### PR TITLE
worker_threads: validate execArgv at Worker construction

### DIFF
--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -345,5 +345,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_TRACE_EVENTS_CATEGORY_REQUIRED", TypeError],
   ["ERR_TRACE_EVENTS_UNAVAILABLE", Error],
+  ["ERR_WORKER_INVALID_EXEC_ARGV", Error],
 ];
 export default errors;

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -74,6 +74,10 @@
 #include "JSEnvironmentVariableMap.h"
 #include <JavaScriptCore/JSMap.h>
 
+// Throws ERR_WORKER_INVALID_EXEC_ARGV when an execArgv entry names a flag that
+// cannot apply to a worker thread. See src/runtime/cli/worker_exec_argv.rs.
+extern "C" void Bun__Worker__validateExecArgv(JSC::JSGlobalObject*, WTF::StringImpl** execArgv, size_t execArgvLen);
+
 namespace WebCore {
 using namespace JSC;
 
@@ -329,6 +333,11 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
                 RETURN_IF_EXCEPTION(scope, );
                 execArgv.append(str);
             });
+            RETURN_IF_EXCEPTION(throwScope, {});
+            // Same reinterpret_cast as Worker::create(): a WTF::String is just
+            // its StringImpl*.
+            static_assert(sizeof(WTF::String) == sizeof(WTF::StringImpl*));
+            Bun__Worker__validateExecArgv(lexicalGlobalObject, reinterpret_cast<WTF::StringImpl**>(execArgv.begin()), execArgv.size());
             RETURN_IF_EXCEPTION(throwScope, {});
             options.execArgv.emplace(WTF::move(execArgv));
         }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -313,6 +313,7 @@ pub mod test {
 #[path = "Arguments.rs"]
 pub mod arguments;
 pub use arguments as Arguments;
+pub mod worker_exec_argv;
 // bunfig.toml without a tier-6 dependency. Re-export under the original path so
 // existing `crate::cli::bunfig` / `crate::cli::Bunfig` callers are unaffected.
 pub use bun_bunfig::Bunfig;

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -35,6 +35,12 @@ enum Flag {
 /// Bun flags that configure the process or the JS engine. Node rejects each of
 /// these from `execArgv` too: `--expose-gc` and `--stack-trace-limit` are V8
 /// options there, the rest are per-process options.
+///
+/// `--use-system-ca` shares Bun's CA-store group with `--use-bundled-ca` and
+/// `--use-openssl-ca` but is deliberately absent: Node registers it in
+/// `EnvironmentOptionsParser`, not `PerProcessOptionsParser`, making it the one
+/// of the three Node accepts here.
+/// <https://github.com/nodejs/node/blob/v26.3.0/src/node_options.cc#L1100>
 const PER_PROCESS_LONG: &[&[u8]] = &[
     b"expose-gc",
     b"help",
@@ -474,6 +480,11 @@ mod tests {
         assert_eq!(lookup_long(b"title"), Flag::PerProcess);
         assert_eq!(lookup_long(b"expose-gc"), Flag::PerProcess);
         assert_eq!(lookup_long(b"definitely-not-a-flag"), Flag::Unknown);
+        // Of Bun's three CA-store flags, only the one Node made per-environment
+        // is accepted.
+        assert_eq!(lookup_long(b"use-openssl-ca"), Flag::PerProcess);
+        assert_eq!(lookup_long(b"use-bundled-ca"), Flag::PerProcess);
+        assert_eq!(lookup_long(b"use-system-ca"), Flag::Supported(Values::None));
     }
 
     #[test]

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -71,7 +71,8 @@ const PER_PROCESS_SHORT: &[u8] = b"hv";
 ///
 /// Taken from Node v26.3.0's `PerIsolateOptionsParser` (which folds in
 /// `EnvironmentOptionsParser`); its V8 and per-process options are left out
-/// because Node rejects those too.
+/// because Node rejects those too. A name a later Node adds and this table
+/// misses is rejected rather than ignored, so the drift fails loudly.
 /// <https://github.com/nodejs/node/blob/v26.3.0/src/node_options.cc>
 ///
 /// Sorted — looked up with `binary_search`.

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -195,8 +195,22 @@ const NODE_ONLY_SHORT_WITH_VALUE: &[u8] = b"C";
 
 /// Classify a long flag by the name between `--` and `=`.
 fn lookup_long(name: &[u8]) -> Flag {
+    // Node canonicalises `_` to `-` in a long option's name before looking it
+    // up, so `--no_warnings` names the same option as `--no-warnings`.
+    if name.contains(&b'_') {
+        let canonical: Vec<u8> = name
+            .iter()
+            .map(|&byte| if byte == b'_' { b'-' } else { byte })
+            .collect();
+        return lookup_canonical_long(&canonical);
+    }
+    lookup_canonical_long(name)
+}
+
+/// Look `name` up in the tables verbatim. `None` when no table names it.
+fn lookup_exact(name: &[u8]) -> Option<Flag> {
     if PER_PROCESS_LONG.binary_search(&name).is_ok() {
-        return Flag::PerProcess;
+        return Some(Flag::PerProcess);
     }
     // The same table `process.execArgv`'s re-parser derives its value-consuming
     // set from, so the two agree on what `bun <entrypoint>` accepts.
@@ -204,22 +218,43 @@ fn lookup_long(name: &[u8]) -> Flag {
         .iter()
         .find(|param| param.names.matches_long(name))
     {
-        return Flag::Supported(param.takes_value);
+        return Some(Flag::Supported(param.takes_value));
     }
     if NODE_ONLY_BOOLEAN.binary_search(&name).is_ok() {
-        return Flag::Supported(Values::None);
+        return Some(Flag::Supported(Values::None));
     }
     if NODE_ONLY_WITH_VALUE.binary_search(&name).is_ok() {
-        return Flag::Supported(Values::One);
+        return Some(Flag::Supported(Values::One));
     }
-    // Node's parser strips a leading `no-` and negates the boolean option named
-    // by the rest, so `--no-<boolean>` is valid for every boolean option.
-    if let Some(negated) = name.strip_prefix(b"no-".as_slice()) {
-        return match lookup_long(negated) {
-            Flag::Supported(Values::None) => Flag::Supported(Values::None),
-            Flag::Supported(_) => Flag::InvalidNegation,
-            Flag::Unknown | Flag::InvalidNegation | Flag::PerProcess => Flag::Unknown,
+    None
+}
+
+/// [`lookup_long`] with `_` already canonicalised to `-`.
+fn lookup_canonical_long(name: &[u8]) -> Flag {
+    if let Some(flag) = lookup_exact(name) {
+        return flag;
+    }
+    // Node registers one canonical name per boolean option and derives the
+    // other spelling from it, so `--x` and `--no-x` both name a boolean `x`.
+    // It strips `no-` exactly once, which leaves `--no-no-x` naming nothing.
+    if let Some(base) = name.strip_prefix(b"no-".as_slice()) {
+        if base.starts_with(b"no-") {
+            return Flag::Unknown;
+        }
+        return match lookup_exact(base) {
+            Some(Flag::Supported(Values::None)) => Flag::Supported(Values::None),
+            Some(Flag::Supported(_)) => Flag::InvalidNegation,
+            _ => Flag::Unknown,
         };
+    }
+    // The tables carry the documented spelling of each boolean, which for a
+    // default-true option is the negative one (`--no-warnings`). Derive the
+    // positive spelling Node also accepts.
+    let mut negated = Vec::with_capacity("no-".len() + name.len());
+    negated.extend_from_slice(b"no-");
+    negated.extend_from_slice(name);
+    if matches!(lookup_exact(&negated), Some(Flag::Supported(Values::None))) {
+        return Flag::Supported(Values::None);
     }
     Flag::Unknown
 }
@@ -412,10 +447,31 @@ mod tests {
             Flag::Supported(Values::None)
         );
         assert_eq!(lookup_long(b"no-conditions"), Flag::InvalidNegation);
+        // Both spellings of a boolean, even when only one is documented.
+        assert_eq!(lookup_long(b"warnings"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"addons"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"strip-types"), Flag::Supported(Values::None));
+        // `no-` is stripped exactly once.
+        assert_eq!(lookup_long(b"no-no-addons"), Flag::Unknown);
+        // `_` is canonicalised to `-`.
+        assert_eq!(lookup_long(b"no_warnings"), Flag::Supported(Values::None));
+        assert_eq!(
+            lookup_long(b"experimental_vm_modules"),
+            Flag::Supported(Values::None)
+        );
+        assert_eq!(lookup_long(b"definitely_not_a_flag"), Flag::Unknown);
         // Per-process and unknown.
         assert_eq!(lookup_long(b"title"), Flag::PerProcess);
         assert_eq!(lookup_long(b"expose-gc"), Flag::PerProcess);
         assert_eq!(lookup_long(b"definitely-not-a-flag"), Flag::Unknown);
+    }
+
+    #[test]
+    fn a_repeated_negation_does_not_recurse() {
+        // `lookup_long` must not recurse per `no-`: a pathological entry has to
+        // come back as an ordinary unrecognised flag, not a stack overflow.
+        let name = b"no-".repeat(200_000);
+        assert_eq!(lookup_long(&name), Flag::Unknown);
     }
 
     #[test]

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -9,6 +9,7 @@
 //!
 //! <https://github.com/nodejs/node/blob/v26.3.0/src/node_worker.cc#L181-L213>
 
+use bstr::BStr;
 use bun_clap::Values;
 use bun_core::{WTFStringImpl, WTFStringImplExt as _};
 use bun_jsc::{ErrorCode, JSGlobalObject};
@@ -242,11 +243,11 @@ fn lookup_short(name: u8) -> Flag {
 
 /// The entries Node would name in `ERR_WORKER_INVALID_EXEC_ARGV`, in order.
 /// Empty when `exec_argv` is acceptable.
-fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<String> {
+fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<Vec<u8>> {
     // Node reports parse errors (a flag missing its value) in preference to
     // unrecognised flags, and reports all of whichever list it picks.
-    let mut errors: Vec<String> = Vec::new();
-    let mut invalid: Vec<String> = Vec::new();
+    let mut errors: Vec<Vec<u8>> = Vec::new();
+    let mut invalid: Vec<Vec<u8>> = Vec::new();
 
     let mut index = 0;
     while index < exec_argv.len() {
@@ -275,13 +276,13 @@ fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<String> {
             Flag::Unknown | Flag::PerProcess => {
                 // Node does not know what an unusable flag's value looks like,
                 // so it never consumes the following entry for one.
-                invalid.push(String::from_utf8_lossy(entry).into_owned());
+                invalid.push(entry.to_vec());
                 continue;
             }
             Flag::InvalidNegation => {
-                errors.push(format!(
-                    "{} is an invalid negation because it is not a boolean option",
-                    String::from_utf8_lossy(entry)
+                errors.push(message(
+                    entry,
+                    b" is an invalid negation because it is not a boolean option",
                 ));
                 continue;
             }
@@ -295,14 +296,14 @@ fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<String> {
             // `--flag=` names no value at all.
             Some(value) => {
                 if is_long && value.is_empty() {
-                    errors.push(missing_argument(entry));
+                    errors.push(message(entry, b" requires an argument"));
                 }
             }
             // The value is the next entry, but only when that entry is not
             // itself a flag.
             None => match exec_argv.get(index) {
                 Some(next) if !next.starts_with(b"-") => index += 1,
-                _ => errors.push(missing_argument(entry)),
+                _ => errors.push(message(entry, b" requires an argument")),
             },
         }
     }
@@ -310,8 +311,11 @@ fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<String> {
     if errors.is_empty() { invalid } else { errors }
 }
 
-fn missing_argument(entry: &[u8]) -> String {
-    format!("{} requires an argument", String::from_utf8_lossy(entry))
+fn message(entry: &[u8], suffix: &[u8]) -> Vec<u8> {
+    let mut message = Vec::with_capacity(entry.len() + suffix.len());
+    message.extend_from_slice(entry);
+    message.extend_from_slice(suffix);
+    message
 }
 
 /// Throw `ERR_WORKER_INVALID_EXEC_ARGV` when `exec_argv` names a flag Bun
@@ -355,11 +359,14 @@ pub unsafe extern "C" fn Bun__Worker__validateExecArgv(
         return;
     }
 
-    let flags = invalid.join(", ");
+    let flags = invalid.join(&b", "[..]);
     let _ = global
         .err(
             ErrorCode::WORKER_INVALID_EXEC_ARGV,
-            format_args!("Initiated Worker with invalid execArgv flags: {flags}"),
+            format_args!(
+                "Initiated Worker with invalid execArgv flags: {}",
+                BStr::new(&flags)
+            ),
         )
         .throw();
 }
@@ -367,6 +374,14 @@ pub unsafe extern "C" fn Bun__Worker__validateExecArgv(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `invalid_entries` yields bytes; spell the expectations as text.
+    fn bytes(expected: &[&str]) -> Vec<Vec<u8>> {
+        expected
+            .iter()
+            .map(|entry| entry.as_bytes().to_vec())
+            .collect()
+    }
 
     #[test]
     fn flag_tables_are_sorted() {
@@ -420,17 +435,17 @@ mod tests {
     fn rejects_unknown_and_per_process_flags() {
         assert_eq!(
             invalid_entries(&[b"--definitely-not-a-flag"]),
-            ["--definitely-not-a-flag"]
+            bytes(&["--definitely-not-a-flag"])
         );
-        assert_eq!(invalid_entries(&[b"--title=x"]), ["--title=x"]);
+        assert_eq!(invalid_entries(&[b"--title=x"]), bytes(&["--title=x"]));
         assert_eq!(
             invalid_entries(&[b"--max-old-space-size=64"]),
-            ["--max-old-space-size=64"]
+            bytes(&["--max-old-space-size=64"])
         );
-        assert_eq!(invalid_entries(&[b"-x"]), ["-x"]);
+        assert_eq!(invalid_entries(&[b"-x"]), bytes(&["-x"]));
         assert_eq!(
             invalid_entries(&[b"--definitely-not-a-flag", b"--also-not-a-flag"]),
-            ["--definitely-not-a-flag", "--also-not-a-flag"]
+            bytes(&["--definitely-not-a-flag", "--also-not-a-flag"])
         );
     }
 
@@ -443,7 +458,7 @@ mod tests {
         // An unusable flag's operand is a positional, as in Node.
         assert_eq!(
             invalid_entries(&[b"--title", b"x", b"--definitely-not-a-flag"]),
-            ["--title"]
+            bytes(&["--title"])
         );
     }
 
@@ -452,7 +467,7 @@ mod tests {
         assert!(invalid_entries(&[b"--conditions", b"not-a-flag"]).is_empty());
         assert_eq!(
             invalid_entries(&[b"--conditions", b"foo", b"--definitely-not-a-flag"]),
-            ["--definitely-not-a-flag"]
+            bytes(&["--definitely-not-a-flag"])
         );
     }
 
@@ -460,21 +475,21 @@ mod tests {
     fn reports_a_missing_value() {
         assert_eq!(
             invalid_entries(&[b"--conditions"]),
-            ["--conditions requires an argument"]
+            bytes(&["--conditions requires an argument"])
         );
         assert_eq!(
             invalid_entries(&[b"--conditions="]),
-            ["--conditions= requires an argument"]
+            bytes(&["--conditions= requires an argument"])
         );
         // A value may not itself look like a flag.
         assert_eq!(
             invalid_entries(&[b"--conditions", b"--no-addons"]),
-            ["--conditions requires an argument"]
+            bytes(&["--conditions requires an argument"])
         );
         // Parse errors win over unrecognised flags, as in Node.
         assert_eq!(
             invalid_entries(&[b"--definitely-not-a-flag", b"--conditions"]),
-            ["--conditions requires an argument"]
+            bytes(&["--conditions requires an argument"])
         );
     }
 
@@ -482,7 +497,7 @@ mod tests {
     fn reports_an_invalid_negation() {
         assert_eq!(
             invalid_entries(&[b"--no-conditions"]),
-            ["--no-conditions is an invalid negation because it is not a boolean option"]
+            bytes(&["--no-conditions is an invalid negation because it is not a boolean option"])
         );
     }
 }

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -1,0 +1,488 @@
+//! `new Worker(filename, { execArgv })` flag validation.
+//!
+//! Node parses a worker's `execArgv` with its per-isolate options parser and
+//! throws `ERR_WORKER_INVALID_EXEC_ARGV` for every entry it cannot apply to a
+//! single thread: unrecognised names, V8 options, and per-process options.
+//! Bun reads only `--no-addons` out of `execArgv` and echoes the rest back
+//! through the worker's `process.execArgv`, so without the same check a typo
+//! (or a `--max-old-space-size` that can never take effect) passes silently.
+//!
+//! <https://github.com/nodejs/node/blob/v26.3.0/src/node_worker.cc#L181-L213>
+
+use bun_clap::Values;
+use bun_core::{WTFStringImpl, WTFStringImplExt as _};
+use bun_jsc::{ErrorCode, JSGlobalObject};
+
+use crate::cli::arguments::AUTO_PARAMS;
+
+/// What one `execArgv` entry names.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Flag {
+    /// Neither Bun's CLI nor Node knows this name.
+    Unknown,
+    /// `--no-<x>` where `<x>` is a known option that is not a boolean. Node
+    /// reports these with a message of their own.
+    InvalidNegation,
+    /// May be set per worker.
+    Supported(Values),
+    /// Recognised, but configures the whole process or the JS engine, so it can
+    /// never take effect on one worker thread. Node rejects its equivalents
+    /// from `execArgv` as well.
+    PerProcess,
+}
+
+/// Bun flags that configure the process or the JS engine. Node rejects each of
+/// these from `execArgv` too: `--expose-gc` and `--stack-trace-limit` are V8
+/// options there, the rest are per-process options.
+const PER_PROCESS_LONG: &[&[u8]] = &[
+    b"expose-gc",
+    b"help",
+    b"revision",
+    b"stack-trace-limit",
+    b"title",
+    b"trace-event-categories",
+    b"trace-event-file-pattern",
+    b"trace-events-enabled",
+    b"use-bundled-ca",
+    b"use-openssl-ca",
+    b"version",
+    b"zero-fill-buffers",
+];
+
+/// `-h` / `-v`: the short spellings of [`PER_PROCESS_LONG`] entries.
+const PER_PROCESS_SHORT: &[u8] = b"hv";
+
+/// Node flags Bun's CLI does not implement but still accepts here, because Node
+/// allows them in a worker's `execArgv` and rejecting them would be stricter
+/// than Node. Bun ignores them, exactly as it does on the command line.
+///
+/// Taken from Node v26.3.0's `PerIsolateOptionsParser` (which folds in
+/// `EnvironmentOptionsParser`); its V8 and per-process options are left out
+/// because Node rejects those too.
+/// <https://github.com/nodejs/node/blob/v26.3.0/src/node_options.cc>
+///
+/// Sorted — looked up with `binary_search`.
+const NODE_ONLY_BOOLEAN: &[&[u8]] = &[
+    b"allow-addons",
+    b"allow-child-process",
+    b"allow-ffi",
+    b"allow-inspector",
+    b"allow-net",
+    b"allow-wasi",
+    b"allow-worker",
+    b"build-snapshot",
+    b"check",
+    b"disable-sigusr1",
+    b"enable-network-family-autoselection",
+    b"enable-source-maps",
+    b"entry-url",
+    b"experimental-addon-modules",
+    b"experimental-eventsource",
+    b"experimental-ffi",
+    b"experimental-import-meta-resolve",
+    b"experimental-inspector-network-resource",
+    b"experimental-network-inspection",
+    b"experimental-print-required-tla",
+    b"experimental-storage-inspection",
+    b"experimental-strip-types",
+    b"experimental-test-coverage",
+    b"experimental-test-module-mocks",
+    b"experimental-vm-modules",
+    b"experimental-worker-inspection",
+    b"force-context-aware",
+    b"force-node-api-uncaught-exceptions-policy",
+    b"frozen-intrinsics",
+    b"insecure-http-parser",
+    b"interactive",
+    b"no-async-context-frame",
+    b"no-experimental-detect-module",
+    b"no-experimental-global-navigator",
+    b"no-experimental-repl-await",
+    b"no-experimental-require-module",
+    b"no-experimental-sqlite",
+    b"no-experimental-websocket",
+    b"no-experimental-webstorage",
+    b"no-extra-info-on-fatal-exception",
+    b"no-force-async-hooks-checks",
+    b"no-global-search-paths",
+    b"no-network-family-autoselection",
+    b"no-require-module",
+    b"no-strip-types",
+    b"no-warnings",
+    b"pending-deprecation",
+    b"permission",
+    b"permission-audit",
+    b"prof-process",
+    b"report-exclude-env",
+    b"report-exclude-network",
+    b"report-on-signal",
+    b"report-uncaught-exception",
+    b"require-module",
+    b"test",
+    b"test-force-exit",
+    b"test-only",
+    b"test-randomize",
+    b"test-update-snapshots",
+    b"tls-max-v1.2",
+    b"tls-max-v1.3",
+    b"tls-min-v1.0",
+    b"tls-min-v1.1",
+    b"tls-min-v1.2",
+    b"tls-min-v1.3",
+    b"trace-deprecation",
+    b"trace-promises",
+    b"trace-sync-io",
+    b"trace-tls",
+    b"trace-uncaught",
+    b"trace-warnings",
+    b"track-heap-objects",
+    b"use-env-proxy",
+    b"watch-preserve-output",
+    b"webstorage",
+];
+
+/// Value-taking counterpart of [`NODE_ONLY_BOOLEAN`]. Sorted.
+const NODE_ONLY_WITH_VALUE: &[&[u8]] = &[
+    b"allow-fs-read",
+    b"allow-fs-write",
+    b"build-snapshot-config",
+    b"debug-port",
+    b"diagnostic-dir",
+    b"disable-warning",
+    b"env-file-if-exists",
+    b"experimental-config-file",
+    b"experimental-default-config-file",
+    b"experimental-loader",
+    b"experimental-test-isolation",
+    b"experimental-test-tag-filter",
+    b"heap-prof-interval",
+    b"heapsnapshot-near-heap-limit",
+    b"heapsnapshot-signal",
+    b"input-type",
+    b"inspect-port",
+    b"inspect-publish-uid",
+    b"localstorage-file",
+    b"max-old-space-size-percentage",
+    b"network-family-autoselection-attempt-timeout",
+    b"redirect-warnings",
+    b"report-signal",
+    b"test-concurrency",
+    b"test-coverage-branches",
+    b"test-coverage-exclude",
+    b"test-coverage-functions",
+    b"test-coverage-include",
+    b"test-coverage-lines",
+    b"test-global-setup",
+    b"test-isolation",
+    b"test-name-pattern",
+    b"test-random-seed",
+    b"test-reporter",
+    b"test-reporter-destination",
+    b"test-rerun-failures",
+    b"test-shard",
+    b"test-skip-pattern",
+    b"test-timeout",
+    b"tls-keylog",
+    b"trace-require-module",
+    b"watch-kill-signal",
+    b"watch-path",
+];
+
+/// `-C` is Node's short spelling of `--conditions`; Bun's CLI only has the long
+/// one.
+const NODE_ONLY_SHORT_WITH_VALUE: &[u8] = b"C";
+
+/// Classify a long flag by the name between `--` and `=`.
+fn lookup_long(name: &[u8]) -> Flag {
+    if PER_PROCESS_LONG.binary_search(&name).is_ok() {
+        return Flag::PerProcess;
+    }
+    // The same table `process.execArgv`'s re-parser derives its value-consuming
+    // set from, so the two agree on what `bun <entrypoint>` accepts.
+    if let Some(param) = AUTO_PARAMS
+        .iter()
+        .find(|param| param.names.matches_long(name))
+    {
+        return Flag::Supported(param.takes_value);
+    }
+    if NODE_ONLY_BOOLEAN.binary_search(&name).is_ok() {
+        return Flag::Supported(Values::None);
+    }
+    if NODE_ONLY_WITH_VALUE.binary_search(&name).is_ok() {
+        return Flag::Supported(Values::One);
+    }
+    // Node's parser strips a leading `no-` and negates the boolean option named
+    // by the rest, so `--no-<boolean>` is valid for every boolean option.
+    if let Some(negated) = name.strip_prefix(b"no-".as_slice()) {
+        return match lookup_long(negated) {
+            Flag::Supported(Values::None) => Flag::Supported(Values::None),
+            Flag::Supported(_) => Flag::InvalidNegation,
+            Flag::Unknown | Flag::InvalidNegation | Flag::PerProcess => Flag::Unknown,
+        };
+    }
+    Flag::Unknown
+}
+
+/// Classify a short flag by the character after `-`.
+fn lookup_short(name: u8) -> Flag {
+    if PER_PROCESS_SHORT.contains(&name) {
+        return Flag::PerProcess;
+    }
+    if let Some(param) = AUTO_PARAMS
+        .iter()
+        .find(|param| param.names.short == Some(name))
+    {
+        return Flag::Supported(param.takes_value);
+    }
+    if NODE_ONLY_SHORT_WITH_VALUE.contains(&name) {
+        return Flag::Supported(Values::One);
+    }
+    Flag::Unknown
+}
+
+/// The entries Node would name in `ERR_WORKER_INVALID_EXEC_ARGV`, in order.
+/// Empty when `exec_argv` is acceptable.
+fn invalid_entries(exec_argv: &[&[u8]]) -> Vec<String> {
+    // Node reports parse errors (a flag missing its value) in preference to
+    // unrecognised flags, and reports all of whichever list it picks.
+    let mut errors: Vec<String> = Vec::new();
+    let mut invalid: Vec<String> = Vec::new();
+
+    let mut index = 0;
+    while index < exec_argv.len() {
+        let entry = exec_argv[index];
+        index += 1;
+
+        // Parsing stops at the first entry that is not a flag: `--`, `-`, the
+        // empty string and any other positional leave the rest unvalidated.
+        if entry.len() < 2 || entry[0] != b'-' || entry == b"--" {
+            break;
+        }
+
+        let is_long = entry.starts_with(b"--");
+        let (flag, inline_value) = if is_long {
+            match entry.iter().position(|&byte| byte == b'=') {
+                Some(eq) => (lookup_long(&entry[2..eq]), Some(&entry[eq + 1..])),
+                None => (lookup_long(&entry[2..]), None),
+            }
+        } else {
+            // `-r value`, `-r=value` and `-rvalue` all reach the same flag.
+            let attached = (entry.len() > 2).then(|| &entry[2..]);
+            (lookup_short(entry[1]), attached)
+        };
+
+        let requires_value = match flag {
+            Flag::Unknown | Flag::PerProcess => {
+                // Node does not know what an unusable flag's value looks like,
+                // so it never consumes the following entry for one.
+                invalid.push(String::from_utf8_lossy(entry).into_owned());
+                continue;
+            }
+            Flag::InvalidNegation => {
+                errors.push(format!(
+                    "{} is an invalid negation because it is not a boolean option",
+                    String::from_utf8_lossy(entry)
+                ));
+                continue;
+            }
+            Flag::Supported(values) => matches!(values, Values::One | Values::Many),
+        };
+        if !requires_value {
+            continue;
+        }
+
+        match inline_value {
+            // `--flag=` names no value at all.
+            Some(value) => {
+                if is_long && value.is_empty() {
+                    errors.push(missing_argument(entry));
+                }
+            }
+            // The value is the next entry, but only when that entry is not
+            // itself a flag.
+            None => match exec_argv.get(index) {
+                Some(next) if !next.starts_with(b"-") => index += 1,
+                _ => errors.push(missing_argument(entry)),
+            },
+        }
+    }
+
+    if errors.is_empty() { invalid } else { errors }
+}
+
+fn missing_argument(entry: &[u8]) -> String {
+    format!("{} requires an argument", String::from_utf8_lossy(entry))
+}
+
+/// Throw `ERR_WORKER_INVALID_EXEC_ARGV` when `exec_argv` names a flag Bun
+/// cannot apply to a worker thread. Called from the `Worker` constructor
+/// (`JSWorker.cpp`) before the strings are moved into `WorkerOptions`.
+///
+/// # Safety
+/// `exec_argv` points at `len` live `WTF::StringImpl*` (the `Vector<String>`
+/// the caller still owns) and `global` is the live global the constructor is
+/// running on.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__Worker__validateExecArgv(
+    global: &JSGlobalObject,
+    exec_argv: *const WTFStringImpl,
+    len: usize,
+) {
+    if len == 0 {
+        return;
+    }
+    // SAFETY: per fn contract — `len` live `WTF::StringImpl*` at `exec_argv`.
+    let raw = unsafe { std::slice::from_raw_parts(exec_argv, len) };
+    // Flag names are ASCII, but an entry may be a UTF-16 string, and an invalid
+    // one is echoed back verbatim, so transcode every entry up front.
+    let owned: Vec<Vec<u8>> = raw
+        .iter()
+        .map(|&string_impl| {
+            if string_impl.is_null() {
+                return Vec::new();
+            }
+            // SAFETY: per fn contract — `string_impl` is a live `WTF::StringImpl`.
+            unsafe { &*string_impl }
+                .to_owned_slice_z()
+                .as_bytes()
+                .to_vec()
+        })
+        .collect();
+    let entries: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+    let invalid = invalid_entries(&entries);
+    if invalid.is_empty() {
+        return;
+    }
+
+    let flags = invalid.join(", ");
+    let _ = global
+        .err(
+            ErrorCode::WORKER_INVALID_EXEC_ARGV,
+            format_args!("Initiated Worker with invalid execArgv flags: {flags}"),
+        )
+        .throw();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_tables_are_sorted() {
+        assert!(PER_PROCESS_LONG.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(NODE_ONLY_BOOLEAN.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(
+            NODE_ONLY_WITH_VALUE
+                .windows(2)
+                .all(|pair| pair[0] < pair[1])
+        );
+    }
+
+    #[test]
+    fn classifies_long_flags() {
+        // Bun's own flags, from AUTO_PARAMS.
+        assert_eq!(lookup_long(b"no-addons"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"smol"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"conditions"), Flag::Supported(Values::Many));
+        // Node flags Bun tolerates.
+        assert_eq!(
+            lookup_long(b"experimental-vm-modules"),
+            Flag::Supported(Values::None)
+        );
+        assert_eq!(lookup_long(b"input-type"), Flag::Supported(Values::One));
+        // Node's `--no-` negation of a boolean option.
+        assert_eq!(
+            lookup_long(b"no-experimental-vm-modules"),
+            Flag::Supported(Values::None)
+        );
+        assert_eq!(lookup_long(b"no-conditions"), Flag::InvalidNegation);
+        // Per-process and unknown.
+        assert_eq!(lookup_long(b"title"), Flag::PerProcess);
+        assert_eq!(lookup_long(b"expose-gc"), Flag::PerProcess);
+        assert_eq!(lookup_long(b"definitely-not-a-flag"), Flag::Unknown);
+    }
+
+    #[test]
+    fn accepts_worker_safe_flags() {
+        assert!(invalid_entries(&[]).is_empty());
+        assert!(invalid_entries(&[b"--no-addons"]).is_empty());
+        assert!(
+            invalid_entries(&[b"--no-warnings", b"--no-deprecation", b"--tls-min-v1.2"]).is_empty()
+        );
+        assert!(invalid_entries(&[b"--conditions", b"react-server"]).is_empty());
+        assert!(invalid_entries(&[b"--conditions=react-server"]).is_empty());
+        assert!(invalid_entries(&[b"--inspect"]).is_empty());
+        assert!(invalid_entries(&[b"-r", b"./preload.js"]).is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_and_per_process_flags() {
+        assert_eq!(
+            invalid_entries(&[b"--definitely-not-a-flag"]),
+            ["--definitely-not-a-flag"]
+        );
+        assert_eq!(invalid_entries(&[b"--title=x"]), ["--title=x"]);
+        assert_eq!(
+            invalid_entries(&[b"--max-old-space-size=64"]),
+            ["--max-old-space-size=64"]
+        );
+        assert_eq!(invalid_entries(&[b"-x"]), ["-x"]);
+        assert_eq!(
+            invalid_entries(&[b"--definitely-not-a-flag", b"--also-not-a-flag"]),
+            ["--definitely-not-a-flag", "--also-not-a-flag"]
+        );
+    }
+
+    #[test]
+    fn stops_at_the_first_positional() {
+        assert!(invalid_entries(&[b"foo.js", b"--definitely-not-a-flag"]).is_empty());
+        assert!(invalid_entries(&[b"--", b"--definitely-not-a-flag"]).is_empty());
+        assert!(invalid_entries(&[b"-"]).is_empty());
+        assert!(invalid_entries(&[b""]).is_empty());
+        // An unusable flag's operand is a positional, as in Node.
+        assert_eq!(
+            invalid_entries(&[b"--title", b"x", b"--definitely-not-a-flag"]),
+            ["--title"]
+        );
+    }
+
+    #[test]
+    fn a_flags_value_is_never_validated() {
+        assert!(invalid_entries(&[b"--conditions", b"not-a-flag"]).is_empty());
+        assert_eq!(
+            invalid_entries(&[b"--conditions", b"foo", b"--definitely-not-a-flag"]),
+            ["--definitely-not-a-flag"]
+        );
+    }
+
+    #[test]
+    fn reports_a_missing_value() {
+        assert_eq!(
+            invalid_entries(&[b"--conditions"]),
+            ["--conditions requires an argument"]
+        );
+        assert_eq!(
+            invalid_entries(&[b"--conditions="]),
+            ["--conditions= requires an argument"]
+        );
+        // A value may not itself look like a flag.
+        assert_eq!(
+            invalid_entries(&[b"--conditions", b"--no-addons"]),
+            ["--conditions requires an argument"]
+        );
+        // Parse errors win over unrecognised flags, as in Node.
+        assert_eq!(
+            invalid_entries(&[b"--definitely-not-a-flag", b"--conditions"]),
+            ["--conditions requires an argument"]
+        );
+    }
+
+    #[test]
+    fn reports_an_invalid_negation() {
+        assert_eq!(
+            invalid_entries(&[b"--no-conditions"]),
+            ["--no-conditions is an invalid negation because it is not a boolean option"]
+        );
+    }
+}

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -206,6 +206,13 @@ const NODE_ONLY_WITH_VALUE: &[&[u8]] = &[
 /// one.
 const NODE_ONLY_SHORT_WITH_VALUE: &[u8] = b"C";
 
+/// Bun declares these `<STR>?`, but Node registers them as plain booleans whose
+/// address is a separate implied `--inspect-port`, so they negate like one.
+/// Bun's other `<STR>?` flag, `--config`, really does name a value, and Node
+/// rejects `--no-config` just as it rejects `--no-inspect-port`.
+/// <https://github.com/nodejs/node/blob/v26.3.0/src/node_options.cc#L475>
+const NEGATABLE_WITH_OPTIONAL_VALUE: &[&[u8]] = &[b"inspect", b"inspect-brk", b"inspect-wait"];
+
 /// Classify a long flag by the name between `--` and `=`.
 fn lookup_long(name: &[u8]) -> Flag {
     // Node canonicalises `_` to `-` in a long option's name before looking it
@@ -259,6 +266,11 @@ fn lookup_canonical_long(name: &[u8]) -> Flag {
         }
         return match lookup_exact(base) {
             Some(Flag::Supported(Values::None)) => Flag::Supported(Values::None),
+            Some(Flag::Supported(Values::OneOptional))
+                if NEGATABLE_WITH_OPTIONAL_VALUE.contains(&base) =>
+            {
+                Flag::Supported(Values::None)
+            }
             Some(Flag::Supported(_)) => Flag::InvalidNegation,
             _ => Flag::Unknown,
         };
@@ -454,6 +466,19 @@ mod tests {
             Flag::Supported(Values::None)
         );
         assert_eq!(lookup_long(b"no-conditions"), Flag::InvalidNegation);
+        // `--inspect[=host:port]` is a boolean to Node, so it negates; Bun's
+        // other `<STR>?` flag names a value, so it does not.
+        assert_eq!(lookup_long(b"no-inspect"), Flag::Supported(Values::None));
+        assert_eq!(
+            lookup_long(b"no-inspect-brk"),
+            Flag::Supported(Values::None)
+        );
+        assert_eq!(
+            lookup_long(b"no-inspect-wait"),
+            Flag::Supported(Values::None)
+        );
+        assert_eq!(lookup_long(b"no-inspect-port"), Flag::InvalidNegation);
+        assert_eq!(lookup_long(b"no-config"), Flag::InvalidNegation);
         // Both spellings of a boolean, even when only one is documented.
         assert_eq!(lookup_long(b"warnings"), Flag::Supported(Values::None));
         assert_eq!(lookup_long(b"no-warnings"), Flag::Supported(Values::None));

--- a/src/runtime/cli/worker_exec_argv.rs
+++ b/src/runtime/cli/worker_exec_argv.rs
@@ -57,6 +57,12 @@ const PER_PROCESS_SHORT: &[u8] = b"hv";
 /// allows them in a worker's `execArgv` and rejecting them would be stricter
 /// than Node. Bun ignores them, exactly as it does on the command line.
 ///
+/// Spelled with the name Node registers the option under, which for a
+/// default-true option is the positive one (`warnings`, not `no-warnings`);
+/// [`lookup_canonical_long`] derives the other spelling. `addons` and
+/// `deprecation` are here rather than in `AUTO_PARAMS` because Bun's CLI only
+/// has their `--no-` form.
+///
 /// Taken from Node v26.3.0's `PerIsolateOptionsParser` (which folds in
 /// `EnvironmentOptionsParser`); its V8 and per-process options are left out
 /// because Node rejects those too.
@@ -64,6 +70,7 @@ const PER_PROCESS_SHORT: &[u8] = b"hv";
 ///
 /// Sorted — looked up with `binary_search`.
 const NODE_ONLY_BOOLEAN: &[&[u8]] = &[
+    b"addons",
     b"allow-addons",
     b"allow-child-process",
     b"allow-ffi",
@@ -71,45 +78,43 @@ const NODE_ONLY_BOOLEAN: &[&[u8]] = &[
     b"allow-net",
     b"allow-wasi",
     b"allow-worker",
+    b"async-context-frame",
     b"build-snapshot",
     b"check",
+    b"deprecation",
     b"disable-sigusr1",
     b"enable-network-family-autoselection",
     b"enable-source-maps",
     b"entry-url",
     b"experimental-addon-modules",
+    b"experimental-detect-module",
     b"experimental-eventsource",
     b"experimental-ffi",
+    b"experimental-global-navigator",
     b"experimental-import-meta-resolve",
     b"experimental-inspector-network-resource",
     b"experimental-network-inspection",
     b"experimental-print-required-tla",
+    b"experimental-repl-await",
+    b"experimental-require-module",
+    b"experimental-sqlite",
     b"experimental-storage-inspection",
     b"experimental-strip-types",
     b"experimental-test-coverage",
     b"experimental-test-module-mocks",
     b"experimental-vm-modules",
+    b"experimental-websocket",
+    b"experimental-webstorage",
     b"experimental-worker-inspection",
+    b"extra-info-on-fatal-exception",
+    b"force-async-hooks-checks",
     b"force-context-aware",
     b"force-node-api-uncaught-exceptions-policy",
     b"frozen-intrinsics",
+    b"global-search-paths",
     b"insecure-http-parser",
     b"interactive",
-    b"no-async-context-frame",
-    b"no-experimental-detect-module",
-    b"no-experimental-global-navigator",
-    b"no-experimental-repl-await",
-    b"no-experimental-require-module",
-    b"no-experimental-sqlite",
-    b"no-experimental-websocket",
-    b"no-experimental-webstorage",
-    b"no-extra-info-on-fatal-exception",
-    b"no-force-async-hooks-checks",
-    b"no-global-search-paths",
-    b"no-network-family-autoselection",
-    b"no-require-module",
-    b"no-strip-types",
-    b"no-warnings",
+    b"network-family-autoselection",
     b"pending-deprecation",
     b"permission",
     b"permission-audit",
@@ -119,6 +124,7 @@ const NODE_ONLY_BOOLEAN: &[&[u8]] = &[
     b"report-on-signal",
     b"report-uncaught-exception",
     b"require-module",
+    b"strip-types",
     b"test",
     b"test-force-exit",
     b"test-only",
@@ -138,6 +144,7 @@ const NODE_ONLY_BOOLEAN: &[&[u8]] = &[
     b"trace-warnings",
     b"track-heap-objects",
     b"use-env-proxy",
+    b"warnings",
     b"watch-preserve-output",
     b"webstorage",
 ];
@@ -237,6 +244,9 @@ fn lookup_canonical_long(name: &[u8]) -> Flag {
     // Node registers one canonical name per boolean option and derives the
     // other spelling from it, so `--x` and `--no-x` both name a boolean `x`.
     // It strips `no-` exactly once, which leaves `--no-no-x` naming nothing.
+    //
+    // This only derives the negative spelling, never the positive one: a Bun
+    // flag whose only name is negative (`--no-macros`) has no `--macros`.
     if let Some(base) = name.strip_prefix(b"no-".as_slice()) {
         if base.starts_with(b"no-") {
             return Flag::Unknown;
@@ -246,15 +256,6 @@ fn lookup_canonical_long(name: &[u8]) -> Flag {
             Some(Flag::Supported(_)) => Flag::InvalidNegation,
             _ => Flag::Unknown,
         };
-    }
-    // The tables carry the documented spelling of each boolean, which for a
-    // default-true option is the negative one (`--no-warnings`). Derive the
-    // positive spelling Node also accepts.
-    let mut negated = Vec::with_capacity("no-".len() + name.len());
-    negated.extend_from_slice(b"no-");
-    negated.extend_from_slice(name);
-    if matches!(lookup_exact(&negated), Some(Flag::Supported(Values::None))) {
-        return Flag::Supported(Values::None);
     }
     Flag::Unknown
 }
@@ -449,8 +450,17 @@ mod tests {
         assert_eq!(lookup_long(b"no-conditions"), Flag::InvalidNegation);
         // Both spellings of a boolean, even when only one is documented.
         assert_eq!(lookup_long(b"warnings"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"no-warnings"), Flag::Supported(Values::None));
         assert_eq!(lookup_long(b"addons"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"deprecation"), Flag::Supported(Values::None));
         assert_eq!(lookup_long(b"strip-types"), Flag::Supported(Values::None));
+        // But a Bun flag whose only name is negative has no positive spelling,
+        // in Bun or in Node.
+        assert_eq!(lookup_long(b"no-macros"), Flag::Supported(Values::None));
+        assert_eq!(lookup_long(b"macros"), Flag::Unknown);
+        assert_eq!(lookup_long(b"clear-screen"), Flag::Unknown);
+        assert_eq!(lookup_long(b"orphans"), Flag::Unknown);
+        assert_eq!(lookup_long(b"exit-on-error"), Flag::Unknown);
         // `no-` is stripped exactly once.
         assert_eq!(lookup_long(b"no-no-addons"), Flag::Unknown);
         // `_` is canonicalised to `-`.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -378,6 +378,7 @@ describe("execArgv option", async () => {
       [["--title=blah"], "--title=blah"],
       [["--zero-fill-buffers"], "--zero-fill-buffers"],
       [["--use-openssl-ca"], "--use-openssl-ca"],
+      [["--use-bundled-ca"], "--use-bundled-ca"],
       // Engine flags: these have to be set before the JS engine starts.
       [["--expose-gc"], "--expose-gc"],
       [["--stack-trace-limit=7"], "--stack-trace-limit=7"],
@@ -431,6 +432,8 @@ describe("execArgv option", async () => {
       [["--warnings", "--addons", "--deprecation"]],
       // Node canonicalises `_` to `-` in a long flag's name.
       [["--experimental_vm_modules", "--no_warnings"]],
+      // Unlike its two siblings above, Node made this one per-environment.
+      [["--use-system-ca"]],
       // Everything from the first positional on is a positional, never a flag.
       [["--", "--definitely-not-a-flag"]],
       [["entrypoint.js", "--definitely-not-a-flag"]],

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,9 @@
 import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+
+// A debug build starts a worker VM about an order of magnitude more slowly, so
+// the tests that spawn a subprocess that then builds a chain of workers need
+// headroom past the 5s default to finish under `bun bd`.
+const subprocessTimeout = isDebug ? 60_000 : 20_000;
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -326,10 +331,14 @@ describe("execArgv option", async () => {
     expect(await proc.stdout.text()).toBe(expected);
   }
 
-  it("inherits the parent's execArgv when falsy or unspecified", async () => {
-    await run("null", '["--smol"]\n');
-    await run("0", '["--smol"]\n');
-  });
+  it(
+    "inherits the parent's execArgv when falsy or unspecified",
+    async () => {
+      await run("null", '["--smol"]\n');
+      await run("0", '["--smol"]\n');
+    },
+    subprocessTimeout,
+  );
   it("provides empty execArgv when passed an empty array", async () => {
     // empty array should result in empty execArgv, not inherited from parent thread
     await run("[]", "[]\n");
@@ -626,21 +635,25 @@ describe("environmentData", () => {
     expect(getEnvironmentData("does_not_exist")).toBeUndefined();
   });
 
-  test("is deeply inherited", async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
-      env: bunEnv,
-      cwd: __dirname,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    await proc.exited;
-    const errors = await proc.stderr.text();
-    if (errors.length > 0) throw new Error(errors);
-    expect(proc.exitCode).toBe(0);
-    const out = await proc.stdout.text();
-    expect(out).toBe("foo\n".repeat(5));
-  });
+  test(
+    "is deeply inherited",
+    async () => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "environmentdata-inherit-fixture.js"],
+        env: bunEnv,
+        cwd: __dirname,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      await proc.exited;
+      const errors = await proc.stderr.text();
+      if (errors.length > 0) throw new Error(errors);
+      expect(proc.exitCode).toBe(0);
+      const out = await proc.stdout.text();
+      expect(out).toBe("foo\n".repeat(5));
+    },
+    subprocessTimeout,
+  );
 
   test("can be used if parent thread had not imported worker_threads", async () => {
     const proc = Bun.spawn({
@@ -741,58 +754,70 @@ describe("getHeapSnapshot", () => {
     }
   });
 
-  test("queues while the worker is starting and rejects once it has exited", async () => {
-    const worker = new Worker("require('worker_threads').parentPort.once('message', () => {})", { eval: true });
-    // Called immediately after construction (m_state still Pending): node — and now
-    // bun — queues into m_pendingTasks and resolves once the worker is Running,
-    // instead of racing against dispatchOnline and spuriously rejecting.
-    const pendingCall = worker.getHeapSnapshot();
-    await once(worker, "online");
-    await expect(pendingCall).resolves.toBeDefined();
-    worker.postMessage("done");
-    await once(worker, "exit");
-    // After exit (m_state Closed) it rejects.
-    await expect(worker.getHeapSnapshot()).rejects.toMatchObject({
-      name: "Error",
-      code: "ERR_WORKER_NOT_RUNNING",
-      message: "Worker instance not running",
-    });
-  });
+  // getHeapSnapshot itself is a full V8-format heap dump, which on top of
+  // worker startup time puts it past 5s under a debug build.
+  const heapSnapshotTimeout = isDebug ? 60_000 : 20_000;
 
-  test("resolves to a Stream.Readable with JSON text in V8 format", async () => {
-    const worker = new Worker(
-      /* js */ `
+  test(
+    "queues while the worker is starting and rejects once it has exited",
+    async () => {
+      const worker = new Worker("require('worker_threads').parentPort.once('message', () => {})", { eval: true });
+      // Called immediately after construction (m_state still Pending): node — and now
+      // bun — queues into m_pendingTasks and resolves once the worker is Running,
+      // instead of racing against dispatchOnline and spuriously rejecting.
+      const pendingCall = worker.getHeapSnapshot();
+      await once(worker, "online");
+      await expect(pendingCall).resolves.toBeDefined();
+      worker.postMessage("done");
+      await once(worker, "exit");
+      // After exit (m_state Closed) it rejects.
+      await expect(worker.getHeapSnapshot()).rejects.toMatchObject({
+        name: "Error",
+        code: "ERR_WORKER_NOT_RUNNING",
+        message: "Worker instance not running",
+      });
+    },
+    heapSnapshotTimeout,
+  );
+
+  test(
+    "resolves to a Stream.Readable with JSON text in V8 format",
+    async () => {
+      const worker = new Worker(
+        /* js */ `
         import { parentPort } from "node:worker_threads";
         parentPort.on("message", () => process.exit(0));
       `,
-      { eval: true },
-    );
-    await once(worker, "online");
-    const stream = await worker.getHeapSnapshot();
-    expect(stream).toBeInstanceOf(Readable);
-    expect(stream.constructor.name).toBe("HeapSnapshotStream");
-    const json = await new Promise<string>(resolve => {
-      let json = "";
-      stream.on("data", chunk => {
-        json += chunk;
+        { eval: true },
+      );
+      await once(worker, "online");
+      const stream = await worker.getHeapSnapshot();
+      expect(stream).toBeInstanceOf(Readable);
+      expect(stream.constructor.name).toBe("HeapSnapshotStream");
+      const json = await new Promise<string>(resolve => {
+        let json = "";
+        stream.on("data", chunk => {
+          json += chunk;
+        });
+        stream.on("end", () => {
+          resolve(json);
+        });
       });
-      stream.on("end", () => {
-        resolve(json);
-      });
-    });
-    const object = JSON.parse(json);
-    expect(Object.keys(object).toSorted()).toEqual([
-      "edges",
-      "locations",
-      "nodes",
-      "samples",
-      "snapshot",
-      "strings",
-      "trace_function_infos",
-      "trace_tree",
-    ]);
-    worker.postMessage(0);
-  });
+      const object = JSON.parse(json);
+      expect(Object.keys(object).toSorted()).toEqual([
+        "edges",
+        "locations",
+        "nodes",
+        "samples",
+        "snapshot",
+        "strings",
+        "trace_function_infos",
+        "trace_tree",
+      ]);
+      worker.postMessage(0);
+    },
+    heapSnapshotTimeout,
+  );
 });
 
 test("failed Worker construction restores transferred FileHandles", async () => {
@@ -1470,28 +1495,36 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
 
   // main -> A (snapshot env) -> B (SHARE_ENV) is a tree disjoint from
   // main -> C (SHARE_ENV); values must not cross between them.
-  it("keeps disjoint SHARE_ENV chains isolated", async () => {
-    expect(await run("tree")).toEqual({
-      B_sees_FROM_A: "a",
-      B_sees_FROM_MAIN: "main",
-      A_sees_FROM_B: "b",
-      C_sees_FROM_B: null,
-      C_sees_FROM_MAIN: "main",
-      main_sees_FROM_B: null,
-      main_sees_FROM_C: "c",
-    });
-  });
+  it(
+    "keeps disjoint SHARE_ENV chains isolated",
+    async () => {
+      expect(await run("tree")).toEqual({
+        B_sees_FROM_A: "a",
+        B_sees_FROM_MAIN: "main",
+        A_sees_FROM_B: "b",
+        C_sees_FROM_B: null,
+        C_sees_FROM_MAIN: "main",
+        main_sees_FROM_B: null,
+        main_sees_FROM_C: "c",
+      });
+    },
+    subprocessTimeout,
+  );
 
   // Founding a store must not adopt another tree's value for a key the founding
   // thread already has.
-  it("does not clobber a worker's own env when it founds a store", async () => {
-    expect(await run("clobber")).toEqual({
-      A_SHARED_KEY_before: "from-A",
-      A_SHARED_KEY_after: "from-A",
-      B_sees_SHARED_KEY: "from-A",
-      main_SHARED_KEY: "from-main",
-    });
-  });
+  it(
+    "does not clobber a worker's own env when it founds a store",
+    async () => {
+      expect(await run("clobber")).toEqual({
+        A_SHARED_KEY_before: "from-A",
+        A_SHARED_KEY_after: "from-A",
+        B_sees_SHARED_KEY: "from-A",
+        main_SHARED_KEY: "from-main",
+      });
+    },
+    subprocessTimeout,
+  );
 
   // An accessor installed via defineProperty lands on the base object, but reads hit
   // the store first — so the store entry must go, or the getter is shadowed. (Node
@@ -1574,16 +1607,20 @@ describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide on
 
   // Two SHARE_ENV children of one thread alias a single store: writes, deletes and
   // enumeration cross between them, and a default-env grandchild snapshots it.
-  it("aliases one store across siblings, deletes and enumeration", async () => {
-    expect(await run("siblings")).toEqual({
-      s2_sees_S1_write: "s1",
-      s2_sees_TO_DELETE: null,
-      s2_keys_have_FROM_S1: true,
-      grandchild_sees_S1_write: "s1",
-      main_sees_FROM_S1: "s1",
-      main_sees_TO_DELETE: null,
-    });
-  });
+  it(
+    "aliases one store across siblings, deletes and enumeration",
+    async () => {
+      expect(await run("siblings")).toEqual({
+        s2_sees_S1_write: "s1",
+        s2_sees_TO_DELETE: null,
+        s2_keys_have_FROM_S1: true,
+        grandchild_sees_S1_write: "s1",
+        main_sees_FROM_S1: "s1",
+        main_sees_TO_DELETE: null,
+      });
+    },
+    subprocessTimeout,
+  );
 
   // Founding a tree replaces process.env; Bun.env is reified from the same object
   // at startup and must not be left observing the orphaned pre-swap env.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -338,6 +338,72 @@ describe("execArgv option", async () => {
     await run('["--no-warnings"]', '["--no-warnings"]\n');
   });
   // TODO(@190n) get our handling of non-string array elements in line with Node's
+
+  // https://github.com/nodejs/node/blob/v26.3.0/test/parallel/test-worker-execargv-invalid.js
+  it("throws ERR_INVALID_ARG_TYPE when execArgv is not an array", () => {
+    for (const execArgv of ["hello", 6]) {
+      expect(() => new Worker("", { eval: true, execArgv: execArgv as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
+      );
+    }
+  });
+
+  describe("throws ERR_WORKER_INVALID_EXEC_ARGV for", () => {
+    it.each([
+      // Unknown to both Bun and Node.
+      [["--definitely-not-a-flag"], "--definitely-not-a-flag"],
+      [["-x"], "-x"],
+      // Reported together, in order.
+      [["--definitely-not-a-flag", "--also-not-a-flag"], "--definitely-not-a-flag, --also-not-a-flag"],
+      // Flags that configure the process, not a thread.
+      [["--title=blah"], "--title=blah"],
+      [["--zero-fill-buffers"], "--zero-fill-buffers"],
+      [["--use-openssl-ca"], "--use-openssl-ca"],
+      // Engine flags: these have to be set before the JS engine starts.
+      [["--expose-gc"], "--expose-gc"],
+      [["--stack-trace-limit=7"], "--stack-trace-limit=7"],
+      [["--max-old-space-size=64"], "--max-old-space-size=64"],
+      // A flag whose value is missing.
+      [["--redirect-warnings"], "--redirect-warnings requires an argument"],
+      [["--conditions"], "--conditions requires an argument"],
+      // The value of a flag is consumed, so validation resumes after it.
+      [["--conditions", "react-server", "--definitely-not-a-flag"], "--definitely-not-a-flag"],
+    ])("%p", (execArgv, message) => {
+      expect(() => new Worker("", { eval: true, execArgv })).toThrow(
+        expect.objectContaining({
+          code: "ERR_WORKER_INVALID_EXEC_ARGV",
+          name: "Error",
+          message: `Initiated Worker with invalid execArgv flags: ${message}`,
+        }),
+      );
+    });
+  });
+
+  describe("accepts", () => {
+    it.each([
+      // Bun's own runtime flags.
+      [["--smol"]],
+      [["--no-addons"]],
+      [["--conditions", "react-server"]],
+      // Node flags Bun does not implement: Node accepts them in execArgv, so
+      // rejecting them here would be stricter than Node.
+      [["--experimental-vm-modules"]],
+      [["--no-warnings", "--no-deprecation", "--tls-min-v1.2"]],
+      // Everything from the first positional on is a positional, never a flag.
+      [["--", "--definitely-not-a-flag"]],
+      [["entrypoint.js", "--definitely-not-a-flag"]],
+    ])("%p", async execArgv => {
+      const worker = new Worker("require('worker_threads').parentPort.postMessage(process.execArgv)", {
+        eval: true,
+        execArgv,
+      });
+      try {
+        expect(await once(worker, "message")).toEqual([execArgv]);
+      } finally {
+        await worker.terminate();
+      }
+    });
+  });
 });
 
 test("eval does not leak source code", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -446,8 +446,13 @@ describe("execArgv option", async () => {
         eval: true,
         execArgv,
       });
+      // A worker that fails to start never posts a message, so report its
+      // error rather than waiting out the timeout.
+      const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+      worker.on("message", resolve);
+      worker.on("error", reject);
       try {
-        expect(await once(worker, "message")).toEqual([execArgv]);
+        expect(await promise).toEqual(execArgv);
       } finally {
         await worker.terminate();
       }

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -397,6 +397,8 @@ describe("execArgv option", async () => {
       // spelling, in Bun or in Node.
       [["--macros"], "--macros"],
       [["--clear-screen"], "--clear-screen"],
+      // Only a boolean can be negated.
+      [["--no-inspect-port"], "--no-inspect-port is an invalid negation because it is not a boolean option"],
     ])("%p", async (execArgv, message) => {
       await expectRejected(execArgv, {
         code: "ERR_WORKER_INVALID_EXEC_ARGV",
@@ -434,6 +436,8 @@ describe("execArgv option", async () => {
       [["--experimental_vm_modules", "--no_warnings"]],
       // Unlike its two siblings above, Node made this one per-environment.
       [["--use-system-ca"]],
+      // `--inspect[=host:port]` negates like the boolean Node registers it as.
+      [["--no-inspect", "--no-inspect-brk", "--no-inspect-wait"]],
       // Everything from the first positional on is a positional, never a flag.
       [["--", "--definitely-not-a-flag"]],
       [["entrypoint.js", "--definitely-not-a-flag"]],

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,9 +1,4 @@
 import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
-
-// A debug build starts a worker VM about an order of magnitude more slowly, so
-// the tests that spawn a subprocess that then builds a chain of workers need
-// headroom past the 5s default to finish under `bun bd`.
-const subprocessTimeout = isDebug ? 60_000 : 20_000;
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -26,6 +21,11 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// A debug build starts a worker VM about an order of magnitude more slowly, so
+// the tests that spawn a subprocess that then builds a chain of workers need
+// headroom past the 5s default to finish under `bun bd`.
+const subprocessTimeout = isDebug ? 60_000 : 20_000;
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -340,15 +340,34 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 
   // https://github.com/nodejs/node/blob/v26.3.0/test/parallel/test-worker-execargv-invalid.js
-  it("throws ERR_INVALID_ARG_TYPE when execArgv is not an array", () => {
+  it("throws ERR_INVALID_ARG_TYPE when execArgv is not an array", async () => {
     for (const execArgv of ["hello", 6]) {
-      expect(() => new Worker("", { eval: true, execArgv: execArgv as any })).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
-      );
+      let worker: InstanceType<typeof Worker> | undefined;
+      try {
+        expect(() => {
+          worker = new Worker("", { eval: true, execArgv: execArgv as any });
+        }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }));
+      } finally {
+        await worker?.terminate();
+      }
     }
   });
 
   describe("throws ERR_WORKER_INVALID_EXEC_ARGV for", () => {
+    // A worker is only born when the constructor fails to throw, which is the
+    // bug this suite is about. Clean it up so a failure doesn't then leak a
+    // thread into every test that follows.
+    async function expectRejected(execArgv: string[], expected: Record<string, string>) {
+      let worker: InstanceType<typeof Worker> | undefined;
+      try {
+        expect(() => {
+          worker = new Worker("", { eval: true, execArgv });
+        }).toThrow(expect.objectContaining(expected));
+      } finally {
+        await worker?.terminate();
+      }
+    }
+
     it.each([
       // Unknown to both Bun and Node.
       [["--definitely-not-a-flag"], "--definitely-not-a-flag"],
@@ -368,14 +387,27 @@ describe("execArgv option", async () => {
       [["--conditions"], "--conditions requires an argument"],
       // The value of a flag is consumed, so validation resumes after it.
       [["--conditions", "react-server", "--definitely-not-a-flag"], "--definitely-not-a-flag"],
-    ])("%p", (execArgv, message) => {
-      expect(() => new Worker("", { eval: true, execArgv })).toThrow(
-        expect.objectContaining({
-          code: "ERR_WORKER_INVALID_EXEC_ARGV",
-          name: "Error",
-          message: `Initiated Worker with invalid execArgv flags: ${message}`,
-        }),
-      );
+      // Node strips `no-` exactly once, so a doubled prefix names nothing.
+      [["--no-no-addons"], "--no-no-addons"],
+      // `_` is canonicalised to `-` for the lookup, but the entry is reported
+      // as the user spelled it.
+      [["--definitely_not_a_flag"], "--definitely_not_a_flag"],
+    ])("%p", async (execArgv, message) => {
+      await expectRejected(execArgv, {
+        code: "ERR_WORKER_INVALID_EXEC_ARGV",
+        name: "Error",
+        message: `Initiated Worker with invalid execArgv flags: ${message}`,
+      });
+    });
+
+    // Classifying a flag must not recurse per `no-`, or this overflows the
+    // stack instead of reporting the flag. The message is 600 KB, so only the
+    // error's identity is asserted.
+    it("a pathologically repeated negation, without overflowing the stack", async () => {
+      await expectRejected(["--" + "no-".repeat(200_000)], {
+        code: "ERR_WORKER_INVALID_EXEC_ARGV",
+        name: "Error",
+      });
     });
   });
 
@@ -389,6 +421,11 @@ describe("execArgv option", async () => {
       // rejecting them here would be stricter than Node.
       [["--experimental-vm-modules"]],
       [["--no-warnings", "--no-deprecation", "--tls-min-v1.2"]],
+      // Node registers every boolean under one name and derives the other
+      // spelling, so both are valid even when only one is documented.
+      [["--warnings", "--addons", "--deprecation"]],
+      // Node canonicalises `_` to `-` in a long flag's name.
+      [["--experimental_vm_modules", "--no_warnings"]],
       // Everything from the first positional on is a positional, never a flag.
       [["--", "--definitely-not-a-flag"]],
       [["entrypoint.js", "--definitely-not-a-flag"]],
@@ -406,19 +443,25 @@ describe("execArgv option", async () => {
   });
 });
 
-test("eval does not leak source code", async () => {
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "eval-source-leak-fixture.js"],
-    env: bunEnv,
-    cwd: __dirname,
-    stderr: "pipe",
-    stdout: "ignore",
-  });
-  await proc.exited;
-  const errors = await proc.stderr.text();
-  if (errors.length > 0) throw new Error(errors);
-  expect(proc.exitCode).toBe(0);
-});
+test(
+  "eval does not leak source code",
+  async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "eval-source-leak-fixture.js"],
+      env: bunEnv,
+      cwd: __dirname,
+      stderr: "pipe",
+      stdout: "ignore",
+    });
+    await proc.exited;
+    const errors = await proc.stderr.text();
+    if (errors.length > 0) throw new Error(errors);
+    expect(proc.exitCode).toBe(0);
+  },
+  // The fixture hands 600 MiB of source to six workers; that takes ~30s under a
+  // debug build, well past the 5s default.
+  isDebug ? 120_000 : 20_000,
+);
 
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -392,6 +392,10 @@ describe("execArgv option", async () => {
       // `_` is canonicalised to `-` for the lookup, but the entry is reported
       // as the user spelled it.
       [["--definitely_not_a_flag"], "--definitely_not_a_flag"],
+      // A Bun flag whose only name is negative (`--no-macros`) has no positive
+      // spelling, in Bun or in Node.
+      [["--macros"], "--macros"],
+      [["--clear-screen"], "--clear-screen"],
     ])("%p", async (execArgv, message) => {
       await expectRejected(execArgv, {
         code: "ERR_WORKER_INVALID_EXEC_ARGV",
@@ -413,9 +417,10 @@ describe("execArgv option", async () => {
 
   describe("accepts", () => {
     it.each([
-      // Bun's own runtime flags.
+      // Bun's own runtime flags, including ones it only spells negatively.
       [["--smol"]],
       [["--no-addons"]],
+      [["--no-macros", "--no-clear-screen"]],
       [["--conditions", "react-server"]],
       // Node flags Bun does not implement: Node accepts them in execArgv, so
       // rejecting them here would be stricter than Node.


### PR DESCRIPTION
## Repro

```js
new Worker(f, { execArgv: ["--definitely-not-a-flag", "--title=x"] });
```

Node throws `ERR_WORKER_INVALID_EXEC_ARGV` synchronously. Bun starts the worker and the bogus flags show up verbatim in its `process.execArgv`.

```console
$ node repro.mjs
ERR_WORKER_INVALID_EXEC_ARGV: Initiated Worker with invalid execArgv flags: --definitely-not-a-flag, --title=x

$ bun repro.mjs
ACCEPTED, worker execArgv=["--definitely-not-a-flag","--title=x"]
```

## Cause

`JSWorker.cpp` coerced every `execArgv` entry to a string and stored the array unvalidated. Bun reads only `--no-addons` back out of it ([`parse_worker_exec_argv_allow_addons`](https://github.com/oven-sh/bun/blob/main/src/runtime/jsc_hooks.rs)), so everything else is inert but still echoed back through the worker's `process.execArgv`. Code that relies on the constructor throwing to detect unsupported runtime flags (pools that forward a filtered `process.execArgv`) silently proceeds: the classic "my `--max-old-space-size` isn't being applied in workers" report, with no error anywhere.

## Fix

Validate `execArgv` at construction and throw `ERR_WORKER_INVALID_EXEC_ARGV`, as Node does in [`Worker::New`](https://github.com/nodejs/node/blob/v26.3.0/src/node_worker.cc#L181-L213). Only an explicitly passed `execArgv` is checked; an inherited one is not, matching Node.

New `src/runtime/cli/worker_exec_argv.rs` classifies each entry against:

- Bun's own `AUTO_PARAMS` table — the same table `process.execArgv`'s re-parser derives its value-consuming set from — so every flag `bun <entrypoint>` accepts keeps working.
- A table of Node flags Bun's CLI does not implement (`--experimental-vm-modules`, `--warnings`, `--tls-min-v1.2`, …), taken from Node v26.3.0's `PerIsolateOptionsParser`. Bun ignores them, but Node allows them in `execArgv`, so rejecting them would be stricter than Node.
- A short list of flags that configure the process or the JS engine (`--title`, `--zero-fill-buffers`, `--use-openssl-ca`, `--expose-gc`, `--stack-trace-limit`, …). Node rejects these from `execArgv` too.

Node's parsing rules are reproduced: parsing stops at the first positional; a value-taking flag consumes the next entry only when that entry is not itself a flag; `_` is canonicalised to `-` in a long flag's name; every boolean is registered under one canonical name, with `--no-<name>` derived from it by stripping `no-` exactly once (including `--no-inspect`, which Node registers as a boolean); and parse errors ("`--conditions` requires an argument") are reported in preference to unrecognised names.

Bun-only flags (`--smol`, `--hot`, `--port`, `--no-macros`) stay accepted. Node rejects them only because it has no such flag, and users forward them through `process.execArgv` today.

## Verification

A differential of the validator against real Node v26.3.0 over 105 inputs (the repro, engine flags, per-process flags, both boolean spellings, underscore spellings, doubled `no-` prefixes, negations, missing values, positionals, `--`, short flags) produces zero differences. The remaining deliberate divergences are flags Bun's CLI has and Node does not (`--no-macros`, `--install`, `--no-env-file`, …), and: `["--stack-trace-limit", "7", "--bogus"]` names only `--stack-trace-limit` where Node names both. Both throw the same error.

```console
$ bun bd test test/js/node/worker_threads/worker_threads.test.ts
 121 pass
 0 fail
```

With `src/` reverted to the merge-base, 19 of those fail.

`test/js/web/workers/worker.test.ts`, `test-no-addons-resolution-condition.js` and `test-trace-exit.js` (all of which pass `execArgv` to a `Worker`) still pass.

## Also in this PR

- The `ERR_WORKER_INVALID_EXEC_ARGV` tests terminate the worker that gets born when the constructor fails to throw, so a regression fails the assertion instead of leaking a thread into every test that follows. The accepting tests wire the worker's `error` event to `reject` so a startup failure names itself instead of hanging until the timeout.
- Eight existing tests in `worker_threads.test.ts` get a debug-build timeout. Each spawns a subprocess that builds a chain of workers (or takes a full V8-format heap dump) and needs 5.6-11.2s under `bun bd`, well past the 5s default; they fail identically on clean main. Same treatment as [`fetch-leak.test.ts`](https://github.com/oven-sh/bun/blob/main/test/js/web/fetch/fetch-leak.test.ts). No assertions changed.

## Rebase note

#33947 made `ErrorCode.rs` generated from `ErrorCode.ts`, so the error code is now a one-line append there; no Rust-side edit remains.

## Not covered

Node also throws `ERR_WORKER_INVALID_EXEC_ARGV` for a bad `env.NODE_OPTIONS` passed to a worker. Bun does not read `NODE_OPTIONS` at all, so that half of [`test-worker-execargv-invalid.js`](https://github.com/nodejs/node/blob/v26.3.0/test/parallel/test-worker-execargv-invalid.js) is out of scope here; the `execArgv` cases from that file are covered in `worker_threads.test.ts`.
