### PR TITLE
shell: scope `FOO=bar cmd` prefix assignments to that command

### DIFF
--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -71,10 +71,6 @@ impl EnvMap {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
     /// NOTE: This will `.ref()` value, so you should `defer value.deref()` it
     /// before handing it to this function!!!
     pub fn insert(&mut self, key: EnvStr, val: EnvStr) {

--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -71,6 +71,10 @@ impl EnvMap {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     /// NOTE: This will `.ref()` value, so you should `defer value.deref()` it
     /// before handing it to this function!!!
     pub fn insert(&mut self, key: EnvStr, val: EnvStr) {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -582,7 +582,6 @@ impl Interpreter {
                 _buffered_stdout: Bufio::default(),
                 _buffered_stderr: Bufio::default(),
                 shell_env: EnvMap::init(),
-                cmd_local_env: EnvMap::init(),
                 export_env,
                 __prev_cwd: cwd_arr.clone(),
                 __cwd: cwd_arr,
@@ -1787,7 +1786,6 @@ pub struct ShellExecEnv {
     pub _buffered_stdout: Bufio,
     pub _buffered_stderr: Bufio,
     pub shell_env: EnvMap,
-    pub cmd_local_env: EnvMap,
     pub export_env: EnvMap,
     pub __prev_cwd: Vec<u8>,
     pub __cwd: Vec<u8>,
@@ -1830,7 +1828,6 @@ impl ShellExecEnv {
     pub fn memory_cost(&self) -> usize {
         let mut size = core::mem::size_of::<ShellExecEnv>();
         size += self.shell_env.memory_cost();
-        size += self.cmd_local_env.memory_cost();
         size += self.export_env.memory_cost();
         size += self.__cwd.capacity();
         size += self.__prev_cwd.capacity();
@@ -1910,9 +1907,9 @@ impl ShellExecEnv {
 
     /// Heap-allocates a
     /// fresh env for a subshell/pipeline child: dups `cwd_fd`, clones
-    /// `shell_env`/`export_env`, gives it a fresh empty `cmd_local_env`, and
-    /// borrows or owns buffered stdout/stderr per `kind` (subshell/pipeline
-    /// borrow the parent's buffers so output bubbles up; cmd-subst owns).
+    /// `shell_env`/`export_env`, and borrows or owns buffered stdout/stderr per
+    /// `kind` (subshell/pipeline borrow the parent's buffers so output bubbles
+    /// up; cmd-subst owns).
     ///
     /// Caller frees with `ShellExecEnv::deinit_impl(p)`.
     pub fn dupe_for_subshell(
@@ -1952,7 +1949,6 @@ impl ShellExecEnv {
             _buffered_stdout: stdout,
             _buffered_stderr: stderr,
             shell_env: self.shell_env.clone(),
-            cmd_local_env: EnvMap::init(),
             export_env: self.export_env.clone(),
             __prev_cwd: self.__prev_cwd.clone(),
             __cwd: self.__cwd.clone(),
@@ -1999,7 +1995,6 @@ impl ShellExecEnv {
         // EnvMap has a Drop impl; replace with fresh to free now and leave
         // valid state for any later `Drop` of the outer `Interpreter` box.
         self.shell_env = EnvMap::init();
-        self.cmd_local_env = EnvMap::init();
         self.export_env = EnvMap::init();
         self.__cwd = Vec::new();
         self.__prev_cwd = Vec::new();
@@ -2127,23 +2122,6 @@ impl ShellExecEnv {
         self.export_env.insert(EnvStr::init_slice(b"PWD"), pwd);
 
         Ok(())
-    }
-
-    /// Routes `label = value` into one of the three env maps depending on
-    /// where the assignment appeared (`FOO=1 cmd` → cmd-local, bare `FOO=1` →
-    /// shell, `export FOO=1` → exported). NOTE: `EnvMap::insert` `.ref()`s the
-    /// value, so callers should deref `value` after the call.
-    pub fn assign_var(
-        &mut self,
-        label: crate::shell::env_str::EnvStr,
-        value: crate::shell::env_str::EnvStr,
-        assign_ctx: AssignCtx,
-    ) {
-        match assign_ctx {
-            AssignCtx::Cmd => self.cmd_local_env.insert(label, value),
-            AssignCtx::Shell => self.shell_env.insert(label, value),
-            AssignCtx::Exported => self.export_env.insert(label, value),
-        }
     }
 
     /// Looks up `$HOME` (`$USERPROFILE` on Windows) in `shell_env` first, then

--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -144,12 +144,34 @@ impl Assigns {
             merged
         };
 
+        // `EnvMap::insert` `.ref()`s both strings, so the `+1` from
+        // `init_ref_counted` is released below.
         let value_ref = EnvStr::init_ref_counted(value.into_boxed_slice());
-        interp.as_assigns_mut(this).base.shell_mut().assign_var(
-            EnvStr::init_slice(label),
-            value_ref,
-            ctx,
-        );
+        let label_ref = EnvStr::init_slice(label);
+        match ctx {
+            // `FOO=1 cmd` — scoped to that one command, so it lands in the
+            // `Cmd`'s own map (which dies with the command) rather than in the
+            // `ShellExecEnv` shared by every command in this scope.
+            AssignCtx::Cmd => {
+                let parent = interp.as_assigns(this).base.parent;
+                interp
+                    .as_cmd_mut(parent)
+                    .cmd_local_env
+                    .insert(label_ref, value_ref);
+            }
+            AssignCtx::Shell => interp
+                .as_assigns_mut(this)
+                .base
+                .shell_mut()
+                .shell_env
+                .insert(label_ref, value_ref),
+            AssignCtx::Exported => interp
+                .as_assigns_mut(this)
+                .base
+                .shell_mut()
+                .export_env
+                .insert(label_ref, value_ref),
+        }
         value_ref.deref();
 
         Yield::Next(this)

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -435,20 +435,6 @@ impl Cmd {
         Yield::Next(this)
     }
 
-    /// POSIX: when a simple command has no command name, its variable
-    /// assignments affect the current execution environment. Mirrors a bare
-    /// `FOO=bar` statement, which also lands in `shell_env`.
-    fn promote_assigns_to_shell(interp: &Interpreter, this: NodeId) {
-        let cmd = interp.as_cmd_mut(this);
-        if cmd.cmd_local_env.is_empty() {
-            return;
-        }
-        let shell = cmd.base.shell_mut();
-        for (label, value) in cmd.cmd_local_env.iter() {
-            shell.shell_env.insert(*label, *value);
-        }
-    }
-
     /// Resolves argv[0] to a builtin or falls through to subprocess spawn
     /// (still gated).
     fn transition_to_exec(interp: &Interpreter, this: NodeId) -> Yield {
@@ -462,18 +448,19 @@ impl Cmd {
         // Empty/null argv[0] → exit
         // with the exit code from a sole command-substitution (stashed by
         // `child_done` from `Expansion::out_exit_code`), else 0.
-        let first_arg: Option<Vec<u8>> = interp
-            .as_cmd(this)
-            .args
-            .first()
-            // strip the trailing NUL we just added
-            .and_then(|a| (a.len() > 1).then(|| a[..a.len() - 1].to_vec()));
-        let Some(first_arg) = first_arg else {
-            Self::promote_assigns_to_shell(interp, this);
+        let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
-            let exit = me.exit_code.unwrap_or(0);
-            let parent = me.base.parent;
-            return interp.child_done(parent, this, exit);
+            match me.args.first() {
+                Some(a) if a.len() > 1 => {
+                    // strip the trailing NUL we just added
+                    a[..a.len() - 1].to_vec()
+                }
+                _ => {
+                    let exit = me.exit_code.unwrap_or(0);
+                    let parent = me.base.parent;
+                    return interp.child_done(parent, this, exit);
+                }
+            }
         };
 
         if let Some(kind) = BuiltinKind::from_argv0(&first_arg) {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -3,6 +3,7 @@
 //! Execution proceeds: expand assigns → expand redirect → expand argv atoms
 //! → resolve to builtin or spawn subprocess → await exit.
 
+use crate::shell::EnvMap;
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::builtin::{Builtin, Kind as BuiltinKind};
@@ -23,6 +24,10 @@ pub struct Cmd {
     pub io: IO,
     pub state: CmdState,
     pub args: Vec<Vec<u8>>,
+    /// `FOO=bar cmd` prefix assignments. POSIX scopes these to this one
+    /// command, so they live here (freed with the node) instead of in the
+    /// `ShellExecEnv` that every command in the scope shares.
+    pub cmd_local_env: EnvMap,
     pub redirection_file: Vec<u8>,
     pub redirection_fd: Option<*mut CowFd>,
     pub exec: Exec,
@@ -212,6 +217,7 @@ impl Cmd {
             io,
             state: CmdState::Idle,
             args: Vec::new(),
+            cmd_local_env: EnvMap::init(),
             redirection_file: Vec::new(),
             redirection_fd: None,
             exec: Exec::None,
@@ -429,6 +435,20 @@ impl Cmd {
         Yield::Next(this)
     }
 
+    /// POSIX: when a simple command has no command name, its variable
+    /// assignments affect the current execution environment. Mirrors a bare
+    /// `FOO=bar` statement, which also lands in `shell_env`.
+    fn promote_assigns_to_shell(interp: &Interpreter, this: NodeId) {
+        let cmd = interp.as_cmd_mut(this);
+        if cmd.cmd_local_env.is_empty() {
+            return;
+        }
+        let shell = cmd.base.shell_mut();
+        for (label, value) in cmd.cmd_local_env.iter() {
+            shell.shell_env.insert(*label, *value);
+        }
+    }
+
     /// Resolves argv[0] to a builtin or falls through to subprocess spawn
     /// (still gated).
     fn transition_to_exec(interp: &Interpreter, this: NodeId) -> Yield {
@@ -442,19 +462,18 @@ impl Cmd {
         // Empty/null argv[0] → exit
         // with the exit code from a sole command-substitution (stashed by
         // `child_done` from `Expansion::out_exit_code`), else 0.
-        let first_arg: Vec<u8> = {
+        let first_arg: Option<Vec<u8>> = interp
+            .as_cmd(this)
+            .args
+            .first()
+            // strip the trailing NUL we just added
+            .and_then(|a| (a.len() > 1).then(|| a[..a.len() - 1].to_vec()));
+        let Some(first_arg) = first_arg else {
+            Self::promote_assigns_to_shell(interp, this);
             let me = interp.as_cmd(this);
-            match me.args.first() {
-                Some(a) if a.len() > 1 => {
-                    // strip the trailing NUL we just added
-                    a[..a.len() - 1].to_vec()
-                }
-                _ => {
-                    let exit = me.exit_code.unwrap_or(0);
-                    let parent = me.base.parent;
-                    return interp.child_done(parent, this, exit);
-                }
-            }
+            let exit = me.exit_code.unwrap_or(0);
+            let parent = me.base.parent;
+            return interp.child_done(parent, this, exit);
         };
 
         if let Some(kind) = BuiltinKind::from_argv0(&first_arg) {
@@ -538,12 +557,12 @@ impl Cmd {
         resolved.push(0);
         interp.as_cmd_mut(this).args[0] = resolved;
 
-        // Fill env from export_env + cmd_local_env.
+        // Fill env from export_env + this command's prefix assignments.
         {
-            let env = interp.as_cmd_mut(this).base.shell_mut();
-            let mut iter = env.export_env.iterator();
+            let cmd = interp.as_cmd_mut(this);
+            let mut iter = cmd.base.shell_mut().export_env.iterator();
             spawn_args.fill_env::<false>(&mut iter);
-            let mut iter = env.cmd_local_env.iterator();
+            let mut iter = cmd.cmd_local_env.iterator();
             spawn_args.fill_env::<false>(&mut iter);
         }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -951,6 +951,34 @@ booga"
       });
     });
 
+    const printFoo = "console.log(process.env.FOO)";
+
+    test("cmd_local_var does not outlive the command", async () => {
+      const { stdout } = await $`FOO=bar ${BUN} -e ${printFoo}; ${BUN} -e ${printFoo}`;
+      expect(stdout.toString()).toEqual("bar\nundefined\n");
+    });
+
+    test("cmd_local_var does not accumulate across commands", async () => {
+      const printAB = "console.log(JSON.stringify([process.env.A ?? null, process.env.B ?? null]))";
+      const { stdout } = await $`A=1 ${BUN} -e ${"0"}; B=2 ${BUN} -e ${"0"}; ${BUN} -e ${printAB}`;
+      expect(stdout.toString()).toEqual("[null,null]\n");
+    });
+
+    test("cmd_local_var does not outlive a builtin", async () => {
+      const { stdout } = await $`FOO=bar echo hi; ${BUN} -e ${printFoo}`;
+      expect(stdout.toString()).toEqual("hi\nundefined\n");
+    });
+
+    test("cmd_local_var overrides an exported var for one command only", async () => {
+      const { stdout } = await $`export FOO=exported; FOO=local ${BUN} -e ${printFoo}; ${BUN} -e ${printFoo}`;
+      expect(stdout.toString()).toEqual("local\nexported\n");
+    });
+
+    test("assignment with no command word affects the shell", async () => {
+      const { stdout } = await $`empty=; FOO=bar $empty; echo $FOO`;
+      expect(stdout.toString()).toEqual("bar\n");
+    });
+
     test("expand shell var", async () => {
       const { stdout } = await $`FOO=bar BAR=baz; echo $FOO $BAR`;
       const str = stdout.toString();
@@ -981,9 +1009,9 @@ booga"
       let procEnv = JSON.parse(str1);
       expect(procEnv).toEqual({ ...bunEnv, BAZ: "1", FOO: "bar" });
       procEnv = JSON.parse(str2);
+      // `BAZ=1` was scoped to the previous command, so it must not be here.
       expect(procEnv).toEqual({
         ...bunEnv,
-        BAZ: "1",
         FOO: "bar",
         BUN_TEST_VAR: "1",
       });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -974,11 +974,6 @@ booga"
       expect(stdout.toString()).toEqual("local\nexported\n");
     });
 
-    test("assignment with no command word affects the shell", async () => {
-      const { stdout } = await $`empty=; FOO=bar $empty; echo $FOO`;
-      expect(stdout.toString()).toEqual("bar\n");
-    });
-
     test("expand shell var", async () => {
       const { stdout } = await $`FOO=bar BAR=baz; echo $FOO $BAR`;
       const str = stdout.toString();


### PR DESCRIPTION
## Summary

In Bun Shell, a `FOO=bar cmd` prefix assignment is supposed to apply only to
`cmd`'s environment. Instead it persisted for the rest of the script, and
successive prefixes accumulated:

```ts
await $`Q=zz true; printenv Q`;   // bun: "zz"  — bash prints nothing
await $`A=1 true; B=2 true; env`; // bun: both A=1 and B=2 in env
```

This is the idiom for scoping a secret or a flag to one command, so promoting
it to a script-wide export leaks it into every later child:

```ts
await $`AWS_SECRET_ACCESS_KEY=${secret} aws s3 cp ...
        curl https://example.com/webhook`;
// curl inherits AWS_SECRET_ACCESS_KEY; under bash it does not
```

## Cause

`cmd_local_env` lived on `ShellExecEnv`, the object shared by every command in
a scope, and nothing cleared it after a command finished. `Cmd` merged it into
each spawn's environment (`states/Cmd.rs`), so every command after the prefixed
one picked it up. The same aliasing also let two commands sharing a scope (a
backgrounded `cmd &` and its successor) clobber each other's assignments.

## Fix

Move the map onto the `Cmd` state node, which owns it for exactly the lifetime
of the command. `Assigns` routes `AssignCtx::Cmd` into the owning `Cmd` instead
of the shared env; `AssignCtx::Shell`/`Exported` still go to the scope.

## Not covered here

Two adjacent gaps are left alone on purpose, since neither is made worse by this
change and each wants its own fix:

- A prefix assignment that *overrides* an inherited or exported variable still
  appends a second `environ` entry instead of replacing it (#32202). That is a
  separate defect in `SpawnArgs::fill_env`, and #32203 is already open for it.
- POSIX says a simple command with no command name applies its assignments to
  the current execution environment (`FOO=bar $unset; echo $FOO` → `bar` in
  bash). Bun drops them. Implementing that needs a way to tell "no command word"
  from "empty command word", and Bun currently cannot: a quoted empty expansion
  (`"$empty"`) is dropped instead of becoming an empty argv word, so
  `FOO=bar "$empty"` is indistinguishable from `FOO=bar $unset`. bash treats the
  former as naming the empty string, fails command-not-found, and keeps nothing.
  An earlier revision of this PR did the promotion and consequently regressed
  that input; it has been removed.

## Test plan

`test/js/bun/shell/bunshell.test.ts`, `describe("variables")`: the assignment
does not outlive the command (subprocess and builtin), successive prefixes do
not accumulate, and an override of an exported var lasts exactly one command.

The existing `export var` test asserted the leak (it expected `BAZ=1` from an
earlier command to be present in a later command's environment); that
expectation is corrected.

All four new tests and the corrected one fail on `USE_SYSTEM_BUN=1` and pass
with `bun bd`. Full `test/js/bun/shell/bunshell.test.ts` and
`assignments-in-pipeline.test.ts`: 428 pass, 0 fail.
