### PR TITLE
process.memoryUsage: source heapTotal and heapUsed from the same heap

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3665,8 +3665,13 @@ size_t Process::heapUsedBytes(JSC::VM& vm)
     // A full collection's beginMarking() stales every block's mark bits, and the mutator runs
     // through the concurrent part of marking, so a walk there sums a nearly empty heap. Eden
     // leaves the marks alone, so only full marking has to fall back on the last snapshot.
-    if (objectSpace.isMarking() && vm.heap.collectionScope() == JSC::CollectionScope::Full)
+    if (objectSpace.isMarking() && vm.heap.collectionScope() == JSC::CollectionScope::Full) {
+        // With nothing cached, a torn walk still beats claiming an empty heap. Don't latch it:
+        // the version only moves at endMarking(), so it would be served for the whole cycle.
+        if (m_heapUsedVersion == JSC::MarkedSpace::nullVersion)
+            return objectSpace.size();
         return m_heapUsedBytes;
+    }
 
     // MarkedSpace::size() costs a walk of the whole heap but, outside of full marking, only
     // changes when a collection does. Recompute it once per collection, keyed on the
@@ -3706,12 +3711,15 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     //    arrayBuffers: 9386
     // }
 
-    // heapTotal/heapUsed describe the JS object heap only, so both come from the marked
-    // space. That keeps heapUsed <= heapTotal, and leaves the off-heap bytes owned by JS
-    // cells to external/arrayBuffers below.
+    // heapTotal/heapUsed describe the JS object heap only, so both come from the marked space,
+    // leaving the off-heap bytes owned by JS cells to external/arrayBuffers below. The snapshot
+    // heapUsedBytes() falls back on can predate a sweep, so clamp it to the capacity it ships with.
+    size_t heapTotal = vm.heap.objectSpace().capacity();
+    size_t heapUsed = std::min(process->heapUsedBytes(vm), heapTotal);
+
     result->putDirectOffset(vm, 0, JSC::jsNumber(current_rss));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.objectSpace().capacity()));
-    result->putDirectOffset(vm, 2, JSC::jsNumber(process->heapUsedBytes(vm)));
+    result->putDirectOffset(vm, 1, JSC::jsNumber(heapTotal));
+    result->putDirectOffset(vm, 2, JSC::jsNumber(heapUsed));
 
     result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3658,6 +3658,22 @@ err:
 #endif
 }
 
+size_t Process::heapUsedBytes(JSC::VM& vm)
+{
+    auto& objectSpace = vm.heap.objectSpace();
+
+    // MarkedSpace::size() sums the mark bits of every block, so it only changes when a
+    // collection does, but costs a walk of the whole heap. Recompute it once per
+    // collection: newlyAllocatedVersion() advances in MarkedSpace::endMarking().
+    JSC::HeapVersion version = objectSpace.newlyAllocatedVersion();
+    if (m_heapUsedVersion != version) {
+        m_heapUsedVersion = version;
+        m_heapUsedBytes = objectSpace.size();
+    }
+
+    return m_heapUsedBytes;
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3684,12 +3700,12 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     //    arrayBuffers: 9386
     // }
 
+    // heapTotal/heapUsed describe the JS object heap only, so both come from the marked
+    // space. That keeps heapUsed <= heapTotal, and leaves the off-heap bytes owned by JS
+    // cells to external/arrayBuffers below.
     result->putDirectOffset(vm, 0, JSC::jsNumber(current_rss));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.blockBytesAllocated()));
-
-    // heap.size() loops through every cell...
-    // TODO: add a binding for heap.sizeAfterLastCollection()
-    result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
+    result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.objectSpace().capacity()));
+    result->putDirectOffset(vm, 2, JSC::jsNumber(process->heapUsedBytes(vm)));
 
     result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3662,9 +3662,15 @@ size_t Process::heapUsedBytes(JSC::VM& vm)
 {
     auto& objectSpace = vm.heap.objectSpace();
 
-    // MarkedSpace::size() sums the mark bits of every block, so it only changes when a
-    // collection does, but costs a walk of the whole heap. Recompute it once per
-    // collection: newlyAllocatedVersion() advances in MarkedSpace::endMarking().
+    // A full collection's beginMarking() stales every block's mark bits, and the mutator runs
+    // through the concurrent part of marking, so a walk there sums a nearly empty heap. Eden
+    // leaves the marks alone, so only full marking has to fall back on the last snapshot.
+    if (objectSpace.isMarking() && vm.heap.collectionScope() == JSC::CollectionScope::Full)
+        return m_heapUsedBytes;
+
+    // MarkedSpace::size() costs a walk of the whole heap but, outside of full marking, only
+    // changes when a collection does. Recompute it once per collection, keyed on the
+    // version endMarking() publishes.
     JSC::HeapVersion version = objectSpace.newlyAllocatedVersion();
     if (m_heapUsedVersion != version) {
         m_heapUsedVersion = version;

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -33,9 +33,9 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;
 
-    // Cache for heapUsedBytes(). JSC::MarkedSpace::nullVersion (0) is never a live
-    // version, so it doubles as the "not computed yet" sentinel.
-    JSC::HeapVersion m_heapUsedVersion { 0 };
+    // Cache for heapUsedBytes(). MarkedSpace's own version starts at initialVersion and
+    // nextVersion() skips nullVersion, so nullVersion doubles as "not computed yet".
+    JSC::HeapVersion m_heapUsedVersion { JSC::MarkedSpace::nullVersion };
     size_t m_heapUsedBytes { 0 };
 
 public:

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -33,6 +33,11 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;
 
+    // Cache for heapUsedBytes(). JSC::MarkedSpace::nullVersion (0) is never a live
+    // version, so it doubles as the "not computed yet" sentinel.
+    JSC::HeapVersion m_heapUsedVersion { 0 };
+    size_t m_heapUsedBytes { 0 };
+
 public:
     Process(JSC::Structure* structure, WebCore::JSDOMGlobalObject& globalObject, Ref<WebCore::EventEmitter>&& impl)
         : Base(structure, globalObject, WTF::move(impl))
@@ -81,6 +86,9 @@ public:
 
     JSValue getExecArgv(JSGlobalObject* globalObject);
     void setExecArgv(JSGlobalObject* globalObject, JSValue execArgv);
+
+    // Live bytes in the JS object heap, as of the last collection.
+    size_t heapUsedBytes(JSC::VM&);
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject,
         JSC::JSValue prototype)

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -325,24 +325,28 @@ describe("Channel", () => {
   test("references are not leaked", async () => {
     function noop() {}
 
+    const total = 1000;
     const refs: WeakRef<Channel>[] = [];
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < total; i++) {
       const name = `channel7-${i}`;
       subscribe(name, noop);
       unsubscribe(name, noop);
       refs.push(new WeakRef(channel(name)));
     }
 
-    // Once its last subscriber is gone, the registry holds a channel weakly. Constructing
-    // a WeakRef keeps its target alive for the rest of the job, so yield before collecting.
+    // Once its last subscriber is gone, the registry holds a channel weakly. Constructing a
+    // WeakRef keeps its target alive for the rest of the job, so yield before each collection.
     let alive = refs.length;
-    for (let i = 0; i < 10 && alive > 0; i++) {
+    for (let i = 0; i < 20 && alive > 0; i++) {
       await new Promise(resolve => setImmediate(resolve));
       gc(true);
       alive = refs.filter(ref => ref.deref() !== undefined).length;
     }
 
-    expect(alive).toBe(0);
+    // Conservative stack scanning pins whichever channels still have a pointer in a live
+    // stack slot or register, so this asserts they are collectable, not collected. Retaining
+    // a reference the way this test guards against would leave every one of them alive.
+    expect(alive).toBeLessThan(total / 10);
   });
 });
 

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -322,20 +322,27 @@ describe("Channel", () => {
   });
 
   // test-diagnostics-channel-memory-leak.js
-  test("references are not leaked", () => {
+  test("references are not leaked", async () => {
     function noop() {}
 
-    const heapUsedBefore = process.memoryUsage().heapUsed;
+    const refs: WeakRef<Channel>[] = [];
     for (let i = 0; i < 1000; i++) {
       const name = `channel7-${i}`;
       subscribe(name, noop);
       unsubscribe(name, noop);
+      refs.push(new WeakRef(channel(name)));
     }
 
-    gc(true);
-    const heapUsedAfter = process.memoryUsage().heapUsed;
+    // Once its last subscriber is gone, the registry holds a channel weakly. Constructing
+    // a WeakRef keeps its target alive for the rest of the job, so yield before collecting.
+    let alive = refs.length;
+    for (let i = 0; i < 10 && alive > 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+      gc(true);
+      alive = refs.filter(ref => ref.deref() !== undefined).length;
+    }
 
-    expect(heapUsedBefore).toBeGreaterThanOrEqual(heapUsedAfter);
+    expect(alive).toBe(0);
   });
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -647,6 +647,49 @@ describe.concurrent(() => {
     expect(exitCode).toBe(0);
   });
 
+  it("process.memoryUsage() keeps heapUsed <= heapTotal after the heap shrinks", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // Big backing stores: freeing these shrinks capacity through sweepPreciseAllocations().
+        let live = [];
+        for (let i = 0; i < 60; i++) live.push(new Array(60_000).fill(i));
+        Bun.gc(true);
+        const grown = process.memoryUsage();
+
+        // Read it here, not before: an array only written to is dead by the measurement above.
+        const liveCount = live.length;
+        live = null;
+        Bun.gc(true);
+        const shrunk = process.memoryUsage();
+
+        console.log(JSON.stringify({ liveCount, grown, shrunk }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`exited with ${exitCode}\n${stderr}`);
+    const result = JSON.parse(stdout);
+
+    // Dropping the live set hands blocks back, so capacity falls. heapUsed is a snapshot of
+    // the live set, so it has to fall with it rather than outlive the capacity it is paired
+    // with: a stale snapshot reported against a shrunk capacity is how heapUsed > heapTotal.
+    expect(result.liveCount).toBe(60);
+    expect(result.grown.heapTotal).toBeGreaterThan(8 * 1024 * 1024);
+    expect(result.shrunk.heapTotal).toBeLessThan(result.grown.heapTotal);
+    expect(result.shrunk.heapUsed).toBeLessThan(result.grown.heapUsed);
+
+    expect(result.grown.heapUsed).toBeLessThanOrEqual(result.grown.heapTotal);
+    expect(result.shrunk.heapUsed).toBeLessThanOrEqual(result.shrunk.heapTotal);
+    expect(exitCode).toBe(0);
+  });
+
   describe("process.cpuUsage", () => {
     it("works", () => {
       expect(process.cpuUsage()).toEqual({

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -578,6 +578,69 @@ describe.concurrent(() => {
     expect(process.memoryUsage.rss()).toEqual(expect.any(Number));
   });
 
+  it("process.memoryUsage() keeps heapUsed <= heapTotal while off-heap memory grows", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const CHUNK = 4 << 20;
+        const COUNT = 40;
+        const buffers = [];
+        let violations = 0;
+        let worstRatio = 0;
+        for (let i = 0; i < COUNT; i++) {
+          buffers.push(new ArrayBuffer(CHUNK));
+          const sample = process.memoryUsage();
+          if (sample.heapUsed > sample.heapTotal) violations++;
+          worstRatio = Math.max(worstRatio, sample.heapUsed / sample.heapTotal);
+        }
+        const withBuffers = process.memoryUsage();
+
+        Bun.gc(true);
+        const heapUsedBefore = process.memoryUsage().heapUsed;
+        const objects = [];
+        for (let i = 0; i < 200_000; i++) objects.push({ i, next: null });
+        Bun.gc(true);
+        const withObjects = process.memoryUsage();
+
+        console.log(JSON.stringify({
+          violations,
+          worstRatio,
+          allocated: CHUNK * COUNT,
+          withBuffers,
+          heapGrowth: withObjects.heapUsed - heapUsedBefore,
+          withObjectsHeapUsed: withObjects.heapUsed,
+          withObjectsHeapTotal: withObjects.heapTotal,
+          alive: buffers.length + objects.length,
+        }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`exited with ${exitCode}\n${stderr}`);
+    const result = JSON.parse(stdout);
+
+    // heapUsed is a subset of heapTotal, at every sample. ArrayBuffer backing stores
+    // are off-heap, so they must not land in heapUsed.
+    expect(result.violations).toBe(0);
+    expect(result.worstRatio).toBeLessThanOrEqual(1);
+    expect(result.withBuffers.heapUsed).toBeLessThanOrEqual(result.withBuffers.heapTotal);
+    expect(result.withObjectsHeapUsed).toBeLessThanOrEqual(result.withObjectsHeapTotal);
+
+    // ...they are reported in arrayBuffers, which node documents as part of external.
+    expect(result.withBuffers.arrayBuffers).toBeGreaterThanOrEqual(result.allocated);
+    expect(result.withBuffers.external).toBeGreaterThanOrEqual(result.withBuffers.arrayBuffers);
+
+    // ...but heapUsed still tracks JS object allocation.
+    expect(result.heapGrowth).toBeGreaterThan(2 * 1024 * 1024);
+    expect(exitCode).toBe(0);
+  });
+
   describe("process.cpuUsage", () => {
     it("works", () => {
       expect(process.cpuUsage()).toEqual({

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -589,11 +589,13 @@ describe.concurrent(() => {
         const buffers = [];
         let violations = 0;
         let worstRatio = 0;
+        let minHeapUsed = Infinity;
         for (let i = 0; i < COUNT; i++) {
           buffers.push(new ArrayBuffer(CHUNK));
           const sample = process.memoryUsage();
           if (sample.heapUsed > sample.heapTotal) violations++;
           worstRatio = Math.max(worstRatio, sample.heapUsed / sample.heapTotal);
+          minHeapUsed = Math.min(minHeapUsed, sample.heapUsed);
         }
         const withBuffers = process.memoryUsage();
 
@@ -607,6 +609,7 @@ describe.concurrent(() => {
         console.log(JSON.stringify({
           violations,
           worstRatio,
+          minHeapUsed,
           allocated: CHUNK * COUNT,
           withBuffers,
           heapGrowth: withObjects.heapUsed - heapUsedBefore,
@@ -636,7 +639,10 @@ describe.concurrent(() => {
     expect(result.withBuffers.arrayBuffers).toBeGreaterThanOrEqual(result.allocated);
     expect(result.withBuffers.external).toBeGreaterThanOrEqual(result.withBuffers.arrayBuffers);
 
-    // ...but heapUsed still tracks JS object allocation.
+    // ...but heapUsed still tracks JS object allocation, and never reads as an empty heap.
+    // A collection is typically already marking by the first sample, which is exactly where
+    // a too-eager "skip the walk while marking" guard reports zero.
+    expect(result.minHeapUsed).toBeGreaterThan(0);
     expect(result.heapGrowth).toBeGreaterThan(2 * 1024 * 1024);
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
Fixes #20793

### What does this PR do?

Sources `process.memoryUsage()`'s `heapTotal` and `heapUsed` from the same heap, so that `heapUsed <= heapTotal` holds. Today `heapUsed` can exceed `heapTotal` by ~55x.

## Repro

```js
const bufs = Array.from({ length: 40 }, () => new ArrayBuffer(4 << 20));
const m = process.memoryUsage();
m.heapUsed <= m.heapTotal; // node: true   bun: false
```

```
bun : { rss: 36048896, heapTotal:  617472, heapUsed: 33743574, external: 167794054, arrayBuffers: 167776000 }
node: { rss: 40640512, heapTotal: 4853760, heapUsed:  3936832, external: 169332203, arrayBuffers: 167909663 }
```

`heapUsed` exceeds `heapTotal` by ~55x. Anything that divides the two (autoscalers, heap-pressure watchdogs, APM dashboards) gets a meaningless ratio.

## Cause

The two fields came from different accountings.

`heapUsed` was `Heap::sizeAfterLastEdenCollection()`. JSC computes that in `updateAllocationLimits()` as `m_totalBytesVisited + extraMemorySize()`, and `extraMemorySize()` is `m_extraMemorySize + m_deprecatedExtraMemorySize + m_arrayBuffers.size()`. So every ArrayBuffer backing store was counted as JS heap.

`heapTotal` was `Heap::blockBytesAllocated()`, which only counts MarkedBlocks and WeakBlocks, and knows nothing about extra memory. It also misses PreciseAllocations entirely, so large backing stores are invisible to it: 60 arrays of 60k elements commit 28MB and `main` still reports `heapTotal: 554KB`.

A second, quieter problem: `m_sizeAfterLastEdenCollect` is only written by eden collections. A full collection never updates it, so `heapUsed` did not move across `Bun.gc(true)` at all:

```js
bun -e 'const a = process.memoryUsage().heapUsed; Bun.gc(true); const b = process.memoryUsage().heapUsed; console.log(a === b)'
// true
```

## Fix

Take both numbers from the marked space:

- `heapTotal` = `vm.heap.objectSpace().capacity()`
- `heapUsed` = `vm.heap.objectSpace().size()`

`MarkedSpace::size()` sums `markCount() * cellSize()` per block plus marked precise allocations, and `m_capacity` counts `MarkedBlock::blockSize` per block plus every precise allocation's `cellSize()`. So read together, `size() <= capacity()` holds by construction. Off-heap bytes stay in `external`/`arrayBuffers`, which is where node reports them and where they already were.

`heapUsed` is reported as `std::min(heapUsedBytes(), heapTotal)`. The two are read together on the normal path, but the snapshot served during a collection (below) can be several collections old, and `m_capacity` falls in the meantime as `freeBlock()` and `sweepPreciseAllocations()` hand memory back. Live bytes can never exceed committed bytes, so clamping is the honest bound on a value that is a stale approximation by construction. Within one version a cache hit needs no clamp: a sweep only frees blocks whose `markCount()` was 0, and those contributed nothing to the cached `size()`.

### Keeping the read O(1)

`MarkedSpace::size()` walks every block. It is also a sum of mark bits, and outside of marking those only change when a collection does, so caching it per collection returns the identical number for an O(1) read. The key is `objectSpace().newlyAllocatedVersion()`, which advances in `MarkedSpace::endMarking()` on every collection, eden and full. `nullVersion` is 0 and never live, so it doubles as the "not computed yet" sentinel.

The walk has to be skipped while a *full* collection is marking. Its `beginMarking()` bumps `m_markingVersion`, which stales every block's marks (`MarkedBlock::markCount()` then returns 0) and flips every precise allocation, and the mutator keeps running JS through the concurrent part of marking, so a walk there sums a nearly empty heap. Since `newlyAllocatedVersion()` only advances at `endMarking()`, a first read for a given version landing in that window would cache the torn value and serve it for the rest of the collection. Eden collections only bump `m_edenVersion` and leave the marks valid, so they are not skipped: a collection is usually already marking by the first `process.memoryUsage()` call, and blanket-skipping on `isMarking()` makes that first read return zero.

With nothing cached yet the fallback has nothing to serve, so it takes the torn walk rather than claim an empty heap, and deliberately does not latch it.

Release build, `process.memoryUsage()` in a loop:

| heap | before | after | uncached `heap.size()` |
| --- | --- | --- | --- |
| 8 MB | 4.15 us | 4.15 us | 6.0 us |
| 117 MB | 4.15 us | 4.22 us | 116 us |
| 496 MB | 4.16 us | 4.13 us | 883 us |

`process.memoryUsage.rss()`, which is only the `/proc/self/statm` read, is 4.0 us at every size. The heap accounting is free; the syscall is the whole cost, before and after.

### Known limit

`heapUsed` is the live set as of the last collection, so it steps at collections rather than climbing with each allocation the way V8's `used_heap_size` does. JSC does maintain a gross allocation counter (`Heap::totalBytesAllocatedThisCycle()`, private), and it is cheap: the marked-space site is `LocalAllocator::allocateSlowCase`, called once per free-list refill rather than per object. But `Heap::didAllocate()` is also called from `reportExtraMemoryAllocatedSlowCase()` and from `Heap::addReference(cell, ArrayBuffer*)`, so that counter folds in the same off-heap bytes this PR is removing from `heapUsed`. A continuously-climbing `heapUsed` would need a new marked-space-only counter in JSC.

### How did you verify your code works?

`test/js/node/process/process.test.js` samples `process.memoryUsage()` after each of 40 x 4 MiB ArrayBuffer allocations and asserts no sample violates the invariant, that the backing stores show up in `arrayBuffers` (and `external` covers them), that `heapUsed` still tracks JS object allocation, and that no sample reads as an empty heap.

Fails on `main` with 32/40 samples violating, passes here.

A second test drops 60 arrays of 60k elements and checks the pair across the shrink, covering the path where `freeBlock()` and `sweepPreciseAllocations()` pull capacity down (24776KB -> 496KB). It fails on `main` twice over, since `blockBytesAllocated()` never saw those butterflies in the first place.

There is no regression test for the torn read during full marking, nor for the clamp: I could not force that window deterministically, and the guard is one bool read. The mechanism is the JSC source quoted above, plus `BUN_JSC_logGC=1` showing the mutator being handed the world back mid-`FullCollection`.

`test/js/node/diagnostics_channel/diagnostics_channel.test.ts` compared `heapUsed` before the work against `heapUsed` after a `gc(true)`. Since `heapUsed` never moved across a full collection, both reads returned the same byte count and the assertion could not fail. It now asserts directly that unsubscribed channels are only weakly held, which is what the node test it ports approximates. Conservative stack scanning pins whichever ones still have a pointer in a live stack slot, so the assertion is that they are collectable rather than collected: retaining a reference leaves all 1000 alive, against the handful the scan pins. Confirmed both ways by holding a strong reference.

<details>
<summary>Other suites checked</summary>

`test/js/node/test/parallel/test-memory-usage.js`, `test/js/bun/globals.test.js` ("cleans up memory", which was also comparing two identical numbers and now measures a real drop), `test/js/bun/jsc/bun-jsc.test.ts`: all pass.

</details>



