### PR TITLE
Capture rejections from any thenable in the browser node:events polyfill

### DIFF
--- a/src/node-fallbacks/events.js
+++ b/src/node-fallbacks/events.js
@@ -236,7 +236,8 @@ function overflowWarning(emitter, type, handlers) {
 
 function onceWrapper(type, listener, ...args) {
   this.removeListener(type, listener);
-  listener.apply(this, args);
+  // The return value reaches captureRejections' addCatch, so it must not be swallowed.
+  return listener.apply(this, args);
 }
 
 EventEmitterPrototype.once = function once(type, fn) {

--- a/src/node-fallbacks/events.js
+++ b/src/node-fallbacks/events.js
@@ -65,10 +65,17 @@ function emitError(emitter, args) {
   return true;
 }
 
-function addCatch(emitter, promise, type, args) {
-  promise.then(undefined, function (err) {
-    queueMicrotask(() => emitUnhandledRejectionOrErr(emitter, err, type, args));
-  });
+function addCatch(emitter, value, type, args) {
+  try {
+    // Any thenable is captured, not only native promises. `then` is read once for Promises/A+ compat.
+    const then = value.then;
+    if (typeof then !== "function") return;
+    then.call(value, undefined, function (err) {
+      queueMicrotask(() => emitUnhandledRejectionOrErr(emitter, err, type, args));
+    });
+  } catch (err) {
+    emitter.emit("error", err);
+  }
 }
 
 function emitUnhandledRejectionOrErr(emitter, err, type, args) {
@@ -156,7 +163,8 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = handler.apply(this, args);
         break;
     }
-    if (result !== undefined && typeof result?.then === "function" && result.then === Promise.prototype.then) {
+    // `undefined` is checked first because it is by far the most common result.
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
   }

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -177,6 +177,23 @@ describe("bundler", () => {
       stdout: "captured throwing-then-getter\nemit returned true",
     },
   });
+  itBundled("browser/NodeEventsCaptureRejectionsOnceListener", {
+    files: {
+      "/entry.js": /* js */ `
+        import { EventEmitter } from "node:events";
+        const ee = new EventEmitter({ captureRejections: true });
+        ee.on("error", err => console.log("captured", err.message));
+        ee.once("boom", async () => { throw new Error("once-rejection"); });
+        ee.prependOnceListener("bang", async () => { throw new Error("prepend-once-rejection"); });
+        ee.emit("boom");
+        ee.emit("bang");
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "captured once-rejection\ncaptured prepend-once-rejection",
+    },
+  });
   // TODO: use nodePolyfillList to generate the code in here.
   const NodePolyfills = itBundled("browser/NodePolyfills", {
     files: {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -134,6 +134,49 @@ describe("bundler", () => {
       stdout: "PASS",
     },
   });
+  itBundled("browser/NodeEventsCaptureRejectionsThenable", {
+    files: {
+      "/entry.js": /* js */ `
+        import { EventEmitter } from "node:events";
+        const ee = new EventEmitter({ captureRejections: true });
+        ee.on("error", err => console.log("captured", err.message));
+        ee.on("boom", () => ({
+          then(onFulfilled, onRejected) {
+            console.log("onFulfilled is", typeof onFulfilled);
+            onRejected(new Error("rejected-thenable"));
+          },
+        }));
+        ee.emit("boom");
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "onFulfilled is undefined\ncaptured rejected-thenable",
+    },
+  });
+  itBundled("browser/NodeEventsCaptureRejectionsThrowingThenGetter", {
+    files: {
+      "/entry.js": /* js */ `
+        import { EventEmitter } from "node:events";
+        const ee = new EventEmitter({ captureRejections: true });
+        ee.on("error", err => console.log("captured", err.message));
+        ee.on("boom", () => {
+          const thenable = {};
+          Object.defineProperty(thenable, "then", {
+            get() {
+              throw new Error("throwing-then-getter");
+            },
+          });
+          return thenable;
+        });
+        console.log("emit returned", ee.emit("boom"));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "captured throwing-then-getter\nemit returned true",
+    },
+  });
   // TODO: use nodePolyfillList to generate the code in here.
   const NodePolyfills = itBundled("browser/NodePolyfills", {
     files: {


### PR DESCRIPTION
The `node:events` polyfill used for `--target=browser` only captured rejections from a native, same-realm `Promise`. Any other thenable returned by a listener was dropped silently: no `'error'` event, no `Symbol.for("nodejs.rejection")` hook, no unhandled rejection. `captureRejections` is the safety net for async listeners, so a rejection that disappears is worse than no net at all.

Separately, a rejection from a `.once()` listener was dropped for the same reason, even for a native promise.

## Repro

```js
// bun build --target=browser entry.js
import { EventEmitter } from "node:events";

const ee = new EventEmitter({ captureRejections: true });
ee.on("error", err => console.log("captured", err.message));
ee.on("boom", () => ({ then(_, reject) { reject(new Error("kaboom")); } }));
ee.emit("boom");
// node:  captured kaboom
// bun:   (nothing)

const once = new EventEmitter({ captureRejections: true });
once.on("error", err => console.log("captured", err.message));
once.once("bang", async () => { throw new Error("kaboom"); });
once.emit("bang");
// node:  captured kaboom
// bun:   unhandled rejection, the script dies
```

## Cause

Two independent gaps in `src/node-fallbacks/events.js`, both on the path from a listener's return value to `addCatch`.

`emitWithRejectionCapture` gated on

```js
result !== undefined && typeof result?.then === "function" && result.then === Promise.prototype.then
```

The identity check against `Promise.prototype.then` excludes plain thenables, cross-realm promises, and promise-likes from userland libraries. Node duck-types `.then` on any non-nullish listener return value instead. A second divergence came out of the same line: the `.then` read already happened during the check, so a throwing `then` getter propagated out of `emit()` rather than reaching the `'error'` event, and it could be read twice.

`onceWrapper` never returned its listener's result, so `result` was always `undefined` for a `.once()` or `.prependOnceListener()` listener and the gate was never entered at all. Node's `onceWrapper` and the runtime's own copy (`src/js/node/events.ts:314`) both return it.

## Fix

`addCatch` now reads `.then` once, checks it is callable, and calls it as `then.call(value, undefined, onRejected)`. A throw from the getter or from the call itself is routed to the `'error'` event. The call site gates on `result !== undefined && result !== null`. `onceWrapper` returns the listener's result.

All five behaviors were checked against Node v26.3.0: the `then` getter is read exactly once (Promises/A+ compat), `then` receives `undefined` as `onFulfilled`, a throwing getter emits `'error'` synchronously, `emit()` still returns `true`, and a `.once()` listener's rejection reaches `'error'`.

The runtime's own copy of the `addCatch` bug, `src/js/node/events.ts`, is already fixed in #32814 (reviewed, CI green, awaiting a maintainer), which does not touch the browser polyfill, so that file is left alone here.

## Verification

Three tests in `test/bundler/bundler_browser.test.ts`, all of which fail against main's `src/`:

- `browser/NodeEventsCaptureRejectionsThenable` : a rejecting thenable reaches the `'error'` listener, and `onFulfilled` is `undefined`. Before: no output.
- `browser/NodeEventsCaptureRejectionsThrowingThenGetter` : a throwing `then` getter reaches the `'error'` listener and `emit()` returns `true`. Before: the throw escapes `emit()` and kills the script.
- `browser/NodeEventsCaptureRejectionsOnceListener` : `.once()` and `.prependOnceListener()` rejections reach the `'error'` listener. Before: unhandled rejection, the script dies.

`bun bd test test/bundler/bundler_browser.test.ts` is green (16 pass, 1 skip, 1 todo).
