### PR TITLE
url: validate percent-decoding and platform path rules in fileURLToPath

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1872,6 +1872,7 @@ declare module "bun" {
    * Convert a {@link URL} to a filesystem path.
    *
    * @param url The URL to convert.
+   * @param options.windows When `true`, the path is returned in Windows format. Defaults to the current platform.
    * @returns A filesystem path.
    * @throws If `url` is not a valid URL.
    *
@@ -1883,7 +1884,7 @@ declare module "bun" {
    * console.log(path); // "/foo/bar.txt"
    * ```
    */
-  function fileURLToPath(url: URL | string): string;
+  function fileURLToPath(url: URL | string, options?: { windows?: boolean }): string;
 
   /**
    * Fast incremental writer that becomes an {@link ArrayBuffer} on end().

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1401,6 +1401,17 @@ const sqliteProtocols = [
   { prefix: "file:", stripLength: 5 },
 ];
 
+// A file URL's third slash precedes the path but is not part of it when the path is windows-rooted,
+// either a UNC share ("file:///\\\\server\\share\\db") or a drive letter ("file:///C:/db"). A posix
+// path ("file:///tmp/db") keeps the slash it starts with. Mirrors what fileURLToPath itself strips.
+function stripWindowsFileURLSlash(filename: string): string {
+  if (!filename.startsWith("/")) return filename;
+  if (filename.startsWith("/\\")) return filename.slice(1);
+  const letter = filename.charCodeAt(1) | 0x20;
+  if (letter >= 97 && letter <= 122 && filename.charCodeAt(2) === 58) return filename.slice(1);
+  return filename;
+}
+
 function parseDefinitelySqliteUrl(value: string | URL | null): string | null {
   if (value === null) return null;
   const str = value instanceof URL ? value.toString() : value;
@@ -1417,11 +1428,8 @@ function parseDefinitelySqliteUrl(value: string | URL | null): string | null {
         return Bun.fileURLToPath(str);
       } catch {
         // Not a well-formed file URL, so fall back to the text after the scheme and authority.
-        // "file:///\\\\server\\share\\db" is a UNC path written after the URL's third slash, which
-        // is not part of it. A posix path like "file:///tmp/db" keeps the slash it starts with.
         const filename = str.slice(prefix.length);
-        if (process.platform === "win32" && filename.startsWith("/\\")) return filename.slice(1);
-        return filename;
+        return process.platform === "win32" ? stripWindowsFileURLSlash(filename) : filename;
       }
     }
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1417,10 +1417,10 @@ function parseDefinitelySqliteUrl(value: string | URL | null): string | null {
         return Bun.fileURLToPath(str);
       } catch {
         // Not a well-formed file URL, so fall back to the text after the scheme and authority.
-        // On Windows the leading slash of "file:///C:/db" is not part of the path, matching
-        // what fileURLToPath strips when it does accept the URL.
+        // "file:///\\\\server\\share\\db" is a UNC path written after the URL's third slash, which
+        // is not part of it. A posix path like "file:///tmp/db" keeps the slash it starts with.
         const filename = str.slice(prefix.length);
-        if (process.platform === "win32" && filename.startsWith("/")) return filename.slice(1);
+        if (process.platform === "win32" && filename.startsWith("/\\")) return filename.slice(1);
         return filename;
       }
     }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1416,9 +1416,12 @@ function parseDefinitelySqliteUrl(value: string | URL | null): string | null {
       try {
         return Bun.fileURLToPath(str);
       } catch {
-        // if it cant pass it's probably query string, we can just strip it
-        // slicing off the file:// at the beginning
-        return str.slice(7);
+        // Not a well-formed file URL, so fall back to the text after the scheme and authority.
+        // On Windows the leading slash of "file:///C:/db" is not part of the path, matching
+        // what fileURLToPath strips when it does accept the URL.
+        const filename = str.slice(prefix.length);
+        if (process.platform === "win32" && filename.startsWith("/")) return filename.slice(1);
+        return filename;
       }
     }
 

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -893,30 +893,6 @@ Url.prototype.parseHost = function parseHost() {
   if (host) this.hostname = host;
 };
 
-// function fileURLToPath(...args) {
-//   // Since we use WTF::URL::fileSystemPath directly in Bun.fileURLToPath, we don't get invalid windows
-//   // path checking. We patch this in to `node:url` for compatibility. Note that
-//   // this behavior is missing from WATWG URL.
-//   if (process.platform === "win32") {
-//     var url: string;
-//     if ($isObject(args[0]) && args[0] instanceof Url) {
-//       url = (args[0] as { href: string }).href;
-//     } else if (typeof args[0] === "string") {
-//       url = args[0];
-//     } else {
-//       throw $ERR_INVALID_ARG_TYPE("url", ["string", "URL"], args[0]);
-//     }
-
-//     for (var i = 0; i < url.length; i++) {
-//       if (url.charCodeAt(i) === Char.PERCENT && (i + 1) < url.length) {
-//         switch (url.charCodeAt(i + 1)) {
-//         break;
-//       }
-//     }
-//   }
-//   return Bun.fileURLToPath.$call(args);
-// }
-
 /**
  * Add new characters as needed from
  * [here](https://github.com/nodejs/node/blob/main/lib/internal/constants.js).
@@ -933,7 +909,6 @@ const enum Char {
   FORWARD_SLASH = 47,        // /
   HASH = 35,                 // #
   QUESTION_MARK = 63,        // ?
-  PERCENT = 37,              // %
   LEFT_SQUARE_BRACKET = 91,  // [
   RIGHT_SQUARE_BRACKET = 93, // ]
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -8,6 +8,7 @@
 #include "helpers.h"
 #include "IDLTypes.h"
 #include "DOMURL.h"
+#include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSBase.h>
 #include <JavaScriptCore/BuiltinNames.h>
@@ -840,12 +841,75 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(jsonValue));
 }
 
+// ECMA-262 `Decode` with an empty preserve set, which is what decodeURIComponent does.
+// WTF::URL::fileSystemPath() is not usable here: it passes malformed escapes through
+// verbatim and returns a null string for escapes that decode to invalid UTF-8.
+static bool decodeFileURLPath(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, StringView input, String& result)
+{
+    if (!input.contains('%')) {
+        result = input.toString();
+        return true;
+    }
+
+    // The URL parser percent-encodes everything outside of ASCII, so escapes are the
+    // only source of non-ASCII bytes.
+    ASSERT(input.containsOnlyASCII());
+
+    const unsigned length = input.length();
+    Vector<Latin1Character, 256> decoded;
+    decoded.reserveInitialCapacity(length);
+    for (unsigned i = 0; i < length;) {
+        char16_t character = input[i];
+        if (character != '%') {
+            decoded.append(static_cast<Latin1Character>(character));
+            ++i;
+            continue;
+        }
+
+        if (i + 2 >= length || !isASCIIHexDigit(input[i + 1]) || !isASCIIHexDigit(input[i + 2])) {
+            throwException(globalObject, scope, createURIError(globalObject, "URI malformed"_s));
+            return false;
+        }
+
+        decoded.append(toASCIIHexValue(input[i + 1], input[i + 2]));
+        i += 3;
+    }
+
+    result = String::fromUTF8(decoded.span());
+    if (result.isNull()) {
+        throwException(globalObject, scope, createURIError(globalObject, "URI malformed"_s));
+        return false;
+    }
+    return true;
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue arg0 = callFrame->argument(0);
     WTF::URL url;
+
+#if OS(WINDOWS)
+    constexpr bool windowsByDefault = true;
+    constexpr ASCIILiteral platformName = "win32"_s;
+#elif OS(DARWIN)
+    constexpr bool windowsByDefault = false;
+    constexpr ASCIILiteral platformName = "darwin"_s;
+#else
+    constexpr bool windowsByDefault = false;
+    constexpr ASCIILiteral platformName = "linux"_s;
+#endif
+
+    // `options?.windows`, falling back to the host platform when absent.
+    bool windows = windowsByDefault;
+    JSValue options = callFrame->argument(1);
+    if (!options.isUndefinedOrNull()) {
+        JSValue windowsOption = options.get(globalObject, Identifier::fromString(vm, "windows"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!windowsOption.isUndefinedOrNull())
+            windows = windowsOption.toBoolean(globalObject);
+    }
 
     auto path = JSC::JSValue::encode(arg0);
     auto* domURL = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(path);
@@ -867,50 +931,51 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
         return {};
     }
 
-// NOTE: On Windows, WTF::URL::fileSystemPath will handle UNC paths
-// (`file:\\server\share\etc` -> `\\server\share\etc`), so hostname check only
-// needs to happen on posix systems
-#if !OS(WINDOWS)
-    // file://host/path is illegal if `host` is not `localhost`.
-    // Should be `file:///` instead
-    if (url.host().length() > 0 && url.host() != "localhost"_s) [[unlikely]] {
+    const StringView encodedPath = url.path();
+    const StringView host = url.host();
 
-#if OS(DARWIN)
-        Bun::ERR::INVALID_FILE_URL_HOST(scope, globalObject, "darwin"_s);
-        return {};
-#else
-        Bun::ERR::INVALID_FILE_URL_HOST(scope, globalObject, "linux"_s);
-        return {};
-#endif
-    }
-#endif
-
-    // ban url-encoded slashes. '/' on posix, '/' and '\' on windows.
-    const StringView p = url.path();
-    if (p.contains('%')) {
-#if OS(WINDOWS)
-        if (p.contains("%2f"_s) || p.contains("%5c"_s) || p.contains("%2F"_s) || p.contains("%5C"_s)) {
-            Bun::ERR::INVALID_FILE_URL_PATH(scope, globalObject, "must not include encoded \\ or / characters"_s);
+    if (!windows) {
+        // file://host/path is illegal if `host` is not `localhost`.
+        // Should be `file:///` instead
+        if (host.length() > 0 && host != "localhost"_s) [[unlikely]] {
+            Bun::ERR::INVALID_FILE_URL_HOST(scope, globalObject, platformName);
             return {};
         }
-#else
-        if (p.contains("%2f"_s) || p.contains("%2F"_s)) {
+
+        // ban url-encoded slashes.
+        if (encodedPath.contains('%') && (encodedPath.contains("%2f"_s) || encodedPath.contains("%2F"_s))) [[unlikely]] {
             Bun::ERR::INVALID_FILE_URL_PATH(scope, globalObject, "must not include encoded / characters"_s);
             return {};
         }
-#endif
+
+        String decodedPath;
+        if (!decodeFileURLPath(globalObject, scope, encodedPath, decodedPath))
+            return {};
+        return JSC::JSValue::encode(JSC::jsString(vm, decodedPath));
     }
 
-    auto fileSystemPath = url.fileSystemPath();
-
-#if OS(WINDOWS)
-    if (!isAbsolutePath(fileSystemPath)) {
-        Bun::ERR::INVALID_FILE_URL_PATH(scope, globalObject, "must be an absolute path"_s);
+    // ban url-encoded slashes, '/' and '\' on windows.
+    if (encodedPath.contains('%') && (encodedPath.contains("%2f"_s) || encodedPath.contains("%2F"_s) || encodedPath.contains("%5c"_s) || encodedPath.contains("%5C"_s))) [[unlikely]] {
+        Bun::ERR::INVALID_FILE_URL_PATH(scope, globalObject, "must not include encoded \\ or / characters"_s);
         return {};
     }
-#endif
 
-    return JSC::JSValue::encode(JSC::jsString(vm, fileSystemPath));
+    const String separatedPath = makeStringByReplacingAll(encodedPath, '/', '\\');
+    String decodedPath;
+    if (!decodeFileURLPath(globalObject, scope, separatedPath, decodedPath))
+        return {};
+
+    // UNC paths look like '\\server\share\etc', but in a URL they look like 'file://server/share/etc'.
+    if (!host.isEmpty())
+        return JSC::JSValue::encode(JSC::jsString(vm, makeString("\\\\"_s, host, decodedPath)));
+
+    // Otherwise it is a local path, which requires a drive letter: '\C:\etc' -> 'C:\etc'.
+    if (decodedPath.length() < 3 || !isASCIIAlpha(decodedPath[1]) || decodedPath[2] != ':') [[unlikely]] {
+        Bun::ERR::INVALID_FILE_URL_PATH(scope, globalObject, "must be absolute"_s);
+        return {};
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, decodedPath.substring(1)));
 }
 
 /* Source for BunObject.lut.h

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -45,6 +45,7 @@
 #include "BunObjectModule.h"
 #include "JSCookie.h"
 #include "JSCookieMap.h"
+#include "NodeURL.h"
 #include "Secrets.h"
 
 #ifdef WIN32
@@ -966,8 +967,16 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
         return {};
 
     // UNC paths look like '\\server\share\etc', but in a URL they look like 'file://server/share/etc'.
-    if (!host.isEmpty())
-        return JSC::JSValue::encode(JSC::jsString(vm, makeString("\\\\"_s, host, decodedPath)));
+    if (!host.isEmpty()) {
+        // The parser leaves IDN hosts punycode-encoded; node hands the share name back in Unicode.
+        // Bun's parser, unlike node's, accepts hosts that are not decodable; keep those as-is rather
+        // than producing a UNC path with an empty server name.
+        String asciiHost = host.toString();
+        String serverName = Bun::domainToUnicode(asciiHost);
+        if (serverName.isNull())
+            serverName = asciiHost;
+        return JSC::JSValue::encode(JSC::jsString(vm, makeString("\\\\"_s, serverName, decodedPath)));
+    }
 
     // Otherwise it is a local path, which requires a drive letter: '\C:\etc' -> 'C:\etc'.
     if (decodedPath.length() < 3 || !isASCIIAlpha(decodedPath[1]) || decodedPath[2] != ':') [[unlikely]] {

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -71,6 +71,33 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     return JSC::JSValue::encode(jsEmptyString(vm));
 }
 
+WTF::String domainToUnicode(const WTF::String& domain)
+{
+    // this function is only for undoing punycode so its okay if utf-16 text makes it out unchanged.
+    if (!domain.is8Bit())
+        return domain;
+
+    WTF::String utf16Domain = domain;
+    utf16Domain.convertTo16Bit();
+
+    constexpr static int allowedNameToUnicodeErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
+    constexpr static int hostnameBufferLength = 2048;
+
+    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
+    char16_t hostnameBuffer[hostnameBufferLength];
+    UErrorCode error = U_ZERO_ERROR;
+    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
+
+    const auto span = utf16Domain.span16();
+
+    int32_t numCharactersConverted = uidna_nameToUnicode(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
+
+    if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToUnicodeErrors) && numCharactersConverted)
+        return WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) });
+
+    return {};
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -118,27 +145,12 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject,
         return JSC::JSValue::encode(jsEmptyString(vm));
 
     if (!domain.is8Bit())
-        // this function is only for undoing punycode so its okay if utf-16 text makes it out unchanged.
         return JSC::JSValue::encode(arg0);
 
-    domain.convertTo16Bit();
-
-    constexpr static int allowedNameToUnicodeErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
-    constexpr static int hostnameBufferLength = 2048;
-
-    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
-    char16_t hostnameBuffer[hostnameBufferLength];
-    UErrorCode error = U_ZERO_ERROR;
-    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
-
-    const auto span = domain.span16();
-
-    int32_t numCharactersConverted = uidna_nameToUnicode(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
-
-    if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToUnicodeErrors) && numCharactersConverted) {
-        return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
-    }
-    return JSC::JSValue::encode(jsEmptyString(vm));
+    auto unicodeDomain = domainToUnicode(domain);
+    if (unicodeDomain.isNull())
+        return JSC::JSValue::encode(jsEmptyString(vm));
+    return JSC::JSValue::encode(JSC::jsString(vm, unicodeDomain));
 }
 
 JSC::JSValue createNodeURLBinding(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/NodeURL.h
+++ b/src/jsc/bindings/NodeURL.h
@@ -5,4 +5,7 @@ namespace Bun {
 
 JSC::JSValue createNodeURLBinding(Zig::GlobalObject*);
 
+/// Undoes punycode encoding. Returns a null string when `domain` is not a valid IDN.
+WTF::String domainToUnicode(const WTF::String& domain);
+
 } // namespace Bun

--- a/test/js/bun/util/fileUrl.test.js
+++ b/test/js/bun/util/fileUrl.test.js
@@ -21,7 +21,7 @@ describe("pathToFileURL", () => {
 });
 
 describe("fileURLToPath", () => {
-  const absoluteErrorMessage = "File URL path must be an absolute";
+  const absoluteErrorMessage = "File URL path must be absolute";
   it("should convert a file url to a path", () => {
     if (isWindows) {
       expect(() => fileURLToPath("file:///path/to/file.js")).toThrow(absoluteErrorMessage);
@@ -60,5 +60,19 @@ describe("fileURLToPath", () => {
     const url = pathToFileURL(import.meta.path);
     expect(fileURLToPath(url)).toBe(import.meta.path);
     expect(fileURLToPath(import.meta.url)).toBe(import.meta.path);
+  });
+
+  it("should throw on malformed percent-encoding", () => {
+    expect(() => fileURLToPath("file:///%c3%28")).toThrow(URIError);
+    expect(() => fileURLToPath("file:///%")).toThrow(URIError);
+    expect(() => fileURLToPath(new URL("file:///%c3"))).toThrow(URIError);
+  });
+
+  it("should accept a windows option", () => {
+    expect(fileURLToPath("file:///C:/foo", { windows: true })).toBe("C:\\foo");
+    expect(fileURLToPath("file:///foo/bar", { windows: false })).toBe("/foo/bar");
+    expect(() => fileURLToPath("file:///C:/a%5Cb", { windows: true })).toThrow(
+      "File URL path must not include encoded \\ or / characters",
+    );
   });
 });

--- a/test/js/node/url/url-fileurltopath.test.js
+++ b/test/js/node/url/url-fileurltopath.test.js
@@ -203,6 +203,14 @@ describe("url.fileURLToPath", () => {
       );
     });
 
+    test("decodes punycode UNC server names", () => {
+      // The URL parser stores the host punycode-encoded, the UNC path uses the Unicode form.
+      assert.strictEqual(url.fileURLToPath("file://münchen/foo", { windows: true }), "\\\\münchen\\foo");
+      assert.strictEqual(url.fileURLToPath("file://xn--mnchen-3ya/foo", { windows: true }), "\\\\münchen\\foo");
+      assert.strictEqual(url.fileURLToPath("file://xn--e1awd7f.com/x", { windows: true }), "\\\\еріс.com\\x");
+      assert.strictEqual(url.fileURLToPath("file://127.0.0.1/x", { windows: true }), "\\\\127.0.0.1\\x");
+    });
+
     test("rejects encoded separators", () => {
       assert.throws(() => url.fileURLToPath("file:///C:/a%5Cb", { windows: true }), {
         code: "ERR_INVALID_FILE_URL_PATH",

--- a/test/js/node/url/url-fileurltopath.test.js
+++ b/test/js/node/url/url-fileurltopath.test.js
@@ -197,7 +197,10 @@ describe("url.fileURLToPath", () => {
     test("applies win32 path rules regardless of platform", () => {
       assert.strictEqual(url.fileURLToPath("file:///C:/foo", { windows: true }), "C:\\foo");
       assert.strictEqual(url.fileURLToPath("file:///C:/dir/foo%20bar", { windows: true }), "C:\\dir\\foo bar");
-      assert.strictEqual(url.fileURLToPath("file://nas/My%20Docs/File.doc", { windows: true }), "\\\\nas\\My Docs\\File.doc");
+      assert.strictEqual(
+        url.fileURLToPath("file://nas/My%20Docs/File.doc", { windows: true }),
+        "\\\\nas\\My Docs\\File.doc",
+      );
     });
 
     test("rejects encoded separators", () => {

--- a/test/js/node/url/url-fileurltopath.test.js
+++ b/test/js/node/url/url-fileurltopath.test.js
@@ -152,4 +152,95 @@ describe("url.fileURLToPath", () => {
       assert.strictEqual(fromURL, path);
     }
   });
+
+  describe("percent-decoding is validated", () => {
+    // Escape sequences that decodeURIComponent rejects must reject here too, instead of
+    // passing through verbatim or collapsing into the empty string.
+    const malformed = [
+      "file:///%", // truncated escape
+      "file:///%c", // truncated escape
+      "file:///%zz", // not hex digits
+      "file:///%c3", // truncated UTF-8 sequence
+      "file:///%c3%28", // invalid UTF-8 continuation byte
+      "file:///%80", // lone UTF-8 continuation byte
+      "file:///%ff", // never valid in UTF-8
+      "file:///%C0%80", // overlong encoding of U+0000
+      "file:///%ED%A0%80", // UTF-8 encoded surrogate
+      "file:///%F5%80%80%80", // beyond U+10FFFF
+    ];
+
+    for (const input of malformed) {
+      for (const windows of [false, true]) {
+        test(`${input} (windows: ${windows})`, () => {
+          assert.throws(() => url.fileURLToPath(input, { windows }), {
+            name: "URIError",
+            message: "URI malformed",
+          });
+          assert.throws(() => url.fileURLToPath(new URL(input), { windows }), {
+            name: "URIError",
+            message: "URI malformed",
+          });
+        });
+      }
+    }
+
+    test("well-formed escapes still decode", () => {
+      assert.strictEqual(url.fileURLToPath("file:///%41", { windows: false }), "/A");
+      assert.strictEqual(url.fileURLToPath("file:///caf%C3%A9", { windows: false }), "/café");
+      assert.strictEqual(url.fileURLToPath("file:///%F0%9F%9A%80", { windows: false }), "/🚀");
+      // A percent sign that is not an escape sequence has to be encoded, and round-trips.
+      assert.strictEqual(url.fileURLToPath("file:///100%25", { windows: false }), "/100%");
+    });
+  });
+
+  describe("windows option", () => {
+    test("applies win32 path rules regardless of platform", () => {
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", { windows: true }), "C:\\foo");
+      assert.strictEqual(url.fileURLToPath("file:///C:/dir/foo%20bar", { windows: true }), "C:\\dir\\foo bar");
+      assert.strictEqual(url.fileURLToPath("file://nas/My%20Docs/File.doc", { windows: true }), "\\\\nas\\My Docs\\File.doc");
+    });
+
+    test("rejects encoded separators", () => {
+      assert.throws(() => url.fileURLToPath("file:///C:/a%5Cb", { windows: true }), {
+        code: "ERR_INVALID_FILE_URL_PATH",
+        message: "File URL path must not include encoded \\ or / characters",
+      });
+      assert.throws(() => url.fileURLToPath("file:///C:/a%2Fb", { windows: true }), {
+        code: "ERR_INVALID_FILE_URL_PATH",
+        message: "File URL path must not include encoded \\ or / characters",
+      });
+      // On posix only '/' is rejected, '\' is a legal filename character.
+      assert.strictEqual(url.fileURLToPath("file:///a%5Cb", { windows: false }), "/a\\b");
+      assert.throws(() => url.fileURLToPath("file:///a%2Fb", { windows: false }), {
+        code: "ERR_INVALID_FILE_URL_PATH",
+        message: "File URL path must not include encoded / characters",
+      });
+    });
+
+    test("rejects paths without a drive letter", () => {
+      for (const input of ["file:///foo", "file:///", "file:///1:/foo", "file:///C|foo"]) {
+        assert.throws(() => url.fileURLToPath(input, { windows: true }), {
+          code: "ERR_INVALID_FILE_URL_PATH",
+          message: "File URL path must be absolute",
+        });
+      }
+    });
+
+    test("applies posix path rules regardless of platform", () => {
+      assert.strictEqual(url.fileURLToPath("file:///foo/bar", { windows: false }), "/foo/bar");
+      assert.throws(() => url.fileURLToPath("file://host/a", { windows: false }), {
+        code: "ERR_INVALID_FILE_URL_HOST",
+      });
+    });
+
+    test("absent, null and undefined fall back to the platform", () => {
+      const expected = url.fileURLToPath("file:///C:/foo", { windows: isWindows });
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo"), expected);
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", {}), expected);
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", { windows: undefined }), expected);
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", { windows: null }), expected);
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", null), expected);
+      assert.strictEqual(url.fileURLToPath("file:///C:/foo", 5), expected);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #29174. Supersedes #29176, which fixed the percent-decoding half only (and gave the `URIError` a `code` that Node does not set).

## Reproduction

```js
import { fileURLToPath } from "node:url";

fileURLToPath("file:///%c3%28");
// node: URIError: URI malformed
// bun:  "" <- empty path

fileURLToPath("file:///%");
// node: URIError: URI malformed
// bun:  "/%"

fileURLToPath("file:///C:/a%5Cb", { windows: true });
// node: TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must not include encoded \ or / characters
// bun:  "/C:/a\b"
```

Returning `""` instead of throwing turns a malformed URL into "the current directory" for whatever `fs` call receives it, and the unvalidated pass-throughs produce paths containing characters Node's contract guarantees cannot appear.

## Cause

`functionFileURLToPath` handed the URL pathname to `WTF::URL::fileSystemPath()`:

* Its percent-decoder is lenient. `%` not followed by two hex digits is copied through verbatim, and escapes that decode to invalid UTF-8 produce a null `WTF::String` (WebKit's own `FIXME: This returns a null string when we encounter an invalid UTF-8 sequence. Is that OK?`), which surfaces in JS as `""`. Node decodes with `decodeURIComponent`, which throws `URIError: URI malformed` for both.
* It is compiled for the host platform only, so the `windows` option was ignored: the `%5C` check, the drive-letter check, and the `/` -> `\` conversion never ran on POSIX, and the POSIX host check never ran on Windows.

## Fix

Implement Node's `getPathFromURLWin32` / `getPathFromURLPosix` directly in the binding and drop the `fileSystemPath()` call:

* `decodeFileURLPath` decodes the pathname with ECMA-262 `Decode` semantics (the algorithm behind `decodeURIComponent`), throwing `URIError: URI malformed` on a truncated or non-hex escape, and on bytes that are not well-formed UTF-8 (lone continuation bytes, truncated sequences, overlong encodings, encoded surrogates, code points above U+10FFFF).
* `options.windows` selects the platform rules at runtime, defaulting to the host platform, matching `fileURLToPath(path, { windows })`.
* UNC server names go through IDNA-to-Unicode, as Node does. `Bun::domainToUnicode` is factored out of `node:url`'s `domainToUnicode` binding so the two share one implementation.

Error messages and the `ERR_INVALID_FILE_URL_PATH` / `ERR_INVALID_FILE_URL_HOST` codes now match Node exactly, including `File URL path must be absolute` (previously `must be an absolute path`).

Deletes the commented-out `fileURLToPath` shim in `src/js/node/url.ts`, which existed to patch in the Windows path checking the binding now does itself, along with the `Char.PERCENT` constant it was the last reference to.

### One deliberate deviation

Bun's URL parser accepts IDN hosts Node's rejects outright (`new URL("file://xn--/foo")` throws `ERR_INVALID_URL` in Node, parses in Bun), and `uidna_nameToUnicode` cannot decode those. A literal port of Node's `` `\\\\${domainToUnicode(hostname)}${pathname}` `` would emit `\\\foo` for such a host, a UNC path with an empty server name, because Node's `domainToUnicode` returns `''` on failure. The raw host is kept instead. For every host Node can parse, the result is identical to Node.

`pathToFileURL` still ignores `options.windows`. That is a pre-existing gap on `main`, not something this change introduces, and it is left for a separate fix.

### Fallout: a latent sqlite bug this surfaced

`fileURLToPath("file:///\\\\server\\share\\db")` now throws on Windows, because the URL carries no host and the drive-letter check rejects `///server/share/db`. Node throws the same `ERR_INVALID_FILE_URL_PATH`. That throw newly activates a fallback in `parseDefinitelySqliteUrl` (`src/js/internal/sql/shared.ts`) which had never been exercised on any platform, and which sliced off `file://` and returned `/\\server\share\db` with a leading slash no Windows path wants. It now slices the matched prefix and, on Windows only, drops that slash when a windows-rooted path follows it, either a UNC share or a drive letter. Two shapes reach the fallback because this PR made them throw: `file:///\\\\server\\share\\db` (no host, so the drive-letter check rejects it) and `file:///C:/50%off.db` (a literal `%` is now a `URIError`, where the old lenient decoder passed it through and returned `C:\\50%off.db`). Posix-shaped URLs like `file:///tmp/db` reach the same fallback on Windows too, since they carry no drive letter, and they keep the slash they start with. The strip mirrors what `fileURLToPath` itself removes for those paths when it accepts them.

Every `file://` case in `sqlite-url-parsing.test.ts` was simulated under Windows semantics before the change landed, which this PR makes possible: `fileURLToPath(url, { windows: true })` exercises the real win32 branch from any host, and the fallback is pure string arithmetic on top of it.

The fallback is best effort and stays that way. It slices a fixed prefix and so has always ignored the URL's authority: `new SQL("file://localhost/tmp/db")` returned `localhost/tmp/db` on Windows long before this change, because the path is not drive-rooted and `fileURLToPath` rejected it then too. Making `fileURLToPath` stricter widens the set of URLs that reach the fallback, so that pre-existing blind spot is now also reachable for URLs that carry an authority *and* a malformed escape (`file://server/share/50%off.db`). Fixing that properly means giving the sqlite layer its own lenient URL-to-path conversion rather than piggybacking on `fileURLToPath`, which is a separate change; reusing the parsed `pathname` here would break the `file://.hidden.db` cases the suite already asserts. What this PR does fix is the class that is actually unopenable on Windows: a leading slash in front of a drive letter or UNC root.

## Verification

`bun bd test test/js/node/url/url-fileurltopath.test.js test/js/bun/util/fileUrl.test.js` — 50 pass, 0 fail. The new cases all fail on `main`.

Beyond the unit tests, a differential against Node v26 over a generated grammar of file URLs (hosts x path segments x escape sequences x query/fragment x `{windows: true|false}` x string/`URL` input) compared **30,824** cases. Every result is byte-identical to Node except 362 that hinge on `C|`:

<details>
<summary>The <code>C|</code> cases are a pre-existing URL <em>parser</em> divergence, not <code>fileURLToPath</code></summary>

```js
new URL("file:///../C|").pathname           // node: "/C:"     bun: "/C|"
new URL("file://localhost/C|/foo").pathname // node: "/C:/foo" bun: "/C|/foo"
new URL("file:///C|/foo").pathname          // node: "/C:/foo" bun: "/C:/foo"  (agree)
```

WTF's URL parser only applies the WHATWG "normalized windows drive letter" rule in some positions. That reproduces on released Bun and is untouched by this change, so it is left for a separate fix.

</details>
