### PR TITLE
bun test: make jest.resetAllMocks() reset mocks instead of clearing them

### DIFF
--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -408,6 +408,27 @@ test("clearing all mocks", () => {
 });
 ```
 
+### Reset All Mocks
+
+`jest.resetAllMocks()` (and its `vi.resetAllMocks()` alias) calls `mockFn.mockReset()` on every mock: on top of what `clearAllMocks()` does, it drops the implementations set by `mockImplementation()`, `mockReturnValue()` and friends. It does not restore the original implementation of a spy:
+
+```ts title="test.ts" icon="/icons/typescript.svg"
+import { expect, jest, test } from "bun:test";
+
+const random = jest.fn(() => Math.random());
+
+test("resetting all mocks", () => {
+  random();
+  expect(random).toHaveBeenCalledTimes(1);
+
+  jest.resetAllMocks();
+
+  expect(random).toHaveBeenCalledTimes(0);
+  // unlike clearAllMocks(), the implementation is gone
+  expect(random()).toBeUndefined();
+});
+```
+
 ### Restore All Mocks
 
 `mock.restore()` restores every mock at once, instead of calling `mockFn.mockRestore()` on each one. It does not reset modules overridden with `mock.module()`.

--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -489,6 +489,7 @@ test("vitest compatibility", () => {
   // vi.spyOn
   // vi.mock
   // vi.restoreAllMocks
+  // vi.resetAllMocks
   // vi.clearAllMocks
 });
 ```

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -33,6 +33,7 @@ BUN_DECLARE_HOST_FUNCTION(JSMock__jsNow);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSetSystemTime);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsRestoreAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsClearAllMocks);
+BUN_DECLARE_HOST_FUNCTION(JSMock__jsResetAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSpyOn);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsMockFn);
 
@@ -660,6 +661,29 @@ extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
         // seems similar to what we do in JSMock__resetSpies,
         // but we actually only clear calls, context, instances and results
         spyObject->clear();
+    }
+}
+
+extern "C" void JSMock__resetAllMocks(Zig::GlobalObject* globalObject)
+{
+    if (!globalObject->mockModule.activeMocks) {
+        return;
+    }
+    auto mocksValue = globalObject->mockModule.activeMocks.get();
+
+    ActiveSpySet* activeMocks = uncheckedDowncast<ActiveSpySet>(mocksValue);
+    MarkedArgumentBuffer active;
+    activeMocks->takeSnapshot(active);
+    size_t size = active.size();
+
+    for (size_t i = 0; i < size; ++i) {
+        JSValue mock = active.at(i);
+        if (!mock.isObject())
+            continue;
+
+        // mockReset() on every mock: drops the recorded calls *and* the implementations,
+        // without restoring the original of a spy.
+        uncheckedDowncast<JSMockFunction>(mock)->reset();
     }
 }
 
@@ -1466,6 +1490,12 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globa
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsClearAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     JSMock__clearAllMocks(uncheckedDowncast<Zig::GlobalObject>(globalObject));
+    return JSValue::encode(jsUndefined());
+}
+
+BUN_DEFINE_HOST_FUNCTION(JSMock__jsResetAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    JSMock__resetAllMocks(uncheckedDowncast<Zig::GlobalObject>(globalObject));
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -617,63 +617,17 @@ static SpyWeakHandleOwner& weakValueHandleOwner()
 
 const ClassInfo JSMockFunctionPrototype::s_info = { "Mock"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSMockFunctionPrototype) };
 
-extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
+// The sets are weak, so a mock that has been collected is simply not visited.
+template<typename Functor>
+static void forEachMockInSet(JSC::Strong<JSC::Unknown>& mockSet, const Functor& apply)
 {
-    if (!globalObject->mockModule.activeSpies) {
+    if (!mockSet) {
         return;
     }
-    auto spiesValue = globalObject->mockModule.activeSpies.get();
 
-    ActiveSpySet* activeSpies = uncheckedDowncast<ActiveSpySet>(spiesValue);
+    ActiveSpySet* mocks = uncheckedDowncast<ActiveSpySet>(mockSet.get());
     MarkedArgumentBuffer active;
-    activeSpies->takeSnapshot(active);
-    size_t size = active.size();
-
-    for (size_t i = 0; i < size; ++i) {
-        JSValue spy = active.at(i);
-        if (!spy.isObject())
-            continue;
-
-        auto* spyObject = uncheckedDowncast<JSMockFunction>(spy);
-        spyObject->clearSpy();
-    }
-    globalObject->mockModule.activeSpies.clear();
-}
-
-extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
-{
-    if (!globalObject->mockModule.activeMocks) {
-        return;
-    }
-    auto spiesValue = globalObject->mockModule.activeMocks.get();
-
-    ActiveSpySet* activeSpies = uncheckedDowncast<ActiveSpySet>(spiesValue);
-    MarkedArgumentBuffer active;
-    activeSpies->takeSnapshot(active);
-    size_t size = active.size();
-
-    for (size_t i = 0; i < size; ++i) {
-        JSValue spy = active.at(i);
-        if (!spy.isObject())
-            continue;
-
-        auto* spyObject = uncheckedDowncast<JSMockFunction>(spy);
-        // seems similar to what we do in JSMock__resetSpies,
-        // but we actually only clear calls, context, instances and results
-        spyObject->clear();
-    }
-}
-
-extern "C" void JSMock__resetAllMocks(Zig::GlobalObject* globalObject)
-{
-    if (!globalObject->mockModule.activeMocks) {
-        return;
-    }
-    auto mocksValue = globalObject->mockModule.activeMocks.get();
-
-    ActiveSpySet* activeMocks = uncheckedDowncast<ActiveSpySet>(mocksValue);
-    MarkedArgumentBuffer active;
-    activeMocks->takeSnapshot(active);
+    mocks->takeSnapshot(active);
     size_t size = active.size();
 
     for (size_t i = 0; i < size; ++i) {
@@ -681,10 +635,27 @@ extern "C" void JSMock__resetAllMocks(Zig::GlobalObject* globalObject)
         if (!mock.isObject())
             continue;
 
-        // mockReset() on every mock: drops the recorded calls *and* the implementations,
-        // without restoring the original of a spy.
-        uncheckedDowncast<JSMockFunction>(mock)->reset();
+        apply(uncheckedDowncast<JSMockFunction>(mock));
     }
+}
+
+extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
+{
+    forEachMockInSet(globalObject->mockModule.activeSpies, [](JSMockFunction* spy) { spy->clearSpy(); });
+    globalObject->mockModule.activeSpies.clear();
+}
+
+extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
+{
+    // mockClear() on every mock: only clears calls, contexts, instances and results.
+    forEachMockInSet(globalObject->mockModule.activeMocks, [](JSMockFunction* mock) { mock->clear(); });
+}
+
+extern "C" void JSMock__resetAllMocks(Zig::GlobalObject* globalObject)
+{
+    // mockReset() on every mock: drops the recorded calls *and* the implementations,
+    // without restoring the original of a spy.
+    forEachMockInSet(globalObject->mockModule.activeMocks, [](JSMockFunction* mock) { mock->reset(); });
 }
 
 JSMockModule JSMockModule::create(JSC::JSGlobalObject* globalObject)

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -416,6 +416,7 @@ pub mod Jest {
         let spy_on = jsc::JSFunction::create(global_object, "spyOn", JSMock__jsSpyOn, 2, Default::default());
         let restore_all_mocks = jsc::JSFunction::create(global_object, "restoreAllMocks", JSMock__jsRestoreAllMocks, 2, Default::default());
         let clear_all_mocks = jsc::JSFunction::create(global_object, "clearAllMocks", JSMock__jsClearAllMocks, 2, Default::default());
+        let reset_all_mocks = jsc::JSFunction::create(global_object, "resetAllMocks", JSMock__jsResetAllMocks, 2, Default::default());
         let mock_module_fn = jsc::JSFunction::create(global_object, "module", JSMock__jsModuleMock, 2, Default::default());
         module.put(global_object, b"mock", mock_fn);
         mock_fn.put(global_object, b"module", mock_module_fn);
@@ -428,7 +429,7 @@ pub mod Jest {
         jest.put(global_object, b"spyOn", spy_on);
         jest.put(global_object, b"restoreAllMocks", restore_all_mocks);
         jest.put(global_object, b"clearAllMocks", clear_all_mocks);
-        jest.put(global_object, b"resetAllMocks", clear_all_mocks);
+        jest.put(global_object, b"resetAllMocks", reset_all_mocks);
         jest.put(global_object, b"setSystemTime", set_system_time);
         jest.put(global_object, b"now", jsc::JSFunction::create(global_object, "now", JSMock__jsNow, 0, Default::default()));
         jest.put(global_object, b"setTimeout", jsc::JSFunction::create(global_object, "setTimeout", __jsc_host_js_set_default_timeout, 1, Default::default()));
@@ -442,7 +443,7 @@ pub mod Jest {
         vi.put(global_object, b"mock", mock_module_fn);
         vi.put(global_object, b"spyOn", spy_on);
         vi.put(global_object, b"restoreAllMocks", restore_all_mocks);
-        vi.put(global_object, b"resetAllMocks", clear_all_mocks);
+        vi.put(global_object, b"resetAllMocks", reset_all_mocks);
         vi.put(global_object, b"clearAllMocks", clear_all_mocks);
         module.put(global_object, b"vi", vi);
 
@@ -459,6 +460,7 @@ pub mod Jest {
         pub(crate) fn JSMock__jsSetSystemTime(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsRestoreAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsClearAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
+        pub(crate) fn JSMock__jsResetAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsSpyOn(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
     }
 

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -796,6 +796,60 @@ describe("mock()", () => {
   });
 });
 
+describe("resetAllMocks", () => {
+  test("removes implementations, not just calls", () => {
+    const fn = jest.fn(() => 42);
+    expect(fn()).toBe(42);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    jest.resetAllMocks();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+    expect(fn.mock.results).toEqual([]);
+    expect(fn.getMockImplementation()).toBeUndefined();
+    expect(fn()).toBeUndefined();
+  });
+
+  test("removes mockReturnValue", () => {
+    const fn = jest.fn();
+    fn.mockReturnValue("stubbed");
+    expect(fn()).toBe("stubbed");
+
+    jest.resetAllMocks();
+
+    expect(fn()).toBeUndefined();
+  });
+
+  test("removes a spy's implementation without restoring the original", () => {
+    const obj = {
+      original() {
+        return "original";
+      },
+    };
+    const spy = spyOn(obj, "original");
+    expect(obj.original()).toBe("original");
+
+    jest.resetAllMocks();
+
+    expect(obj.original()).toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+    expect(obj.original()).toBe("original");
+  });
+
+  if (isBun) {
+    test("vi.resetAllMocks removes implementations too", () => {
+      const fn = vi.fn(() => 42);
+      expect(fn()).toBe(42);
+
+      vi.resetAllMocks();
+
+      expect(fn()).toBeUndefined();
+    });
+  }
+});
+
 describe("spyOn", () => {
   test("works on functions", () => {
     var obj = {


### PR DESCRIPTION
### What does this PR do?

`jest.resetAllMocks()` (and `vi.resetAllMocks()`) behaved exactly like `clearAllMocks()`: implementations and `mockReturnValue`s survived a "reset". Tests that use `resetAllMocks()` between tests to drop stubbed behaviour silently kept the stale stubs.

```js
import { expect, jest, test } from "bun:test";

test("reset drops the implementation", () => {
  const fn = jest.fn(() => 42);
  fn();

  jest.resetAllMocks();

  expect(fn()).toBeUndefined(); // actual: 42
});
```

### Cause

Both names were bound to the same native function:

```rust
jest.put(global_object, b"clearAllMocks", clear_all_mocks);
jest.put(global_object, b"resetAllMocks", clear_all_mocks);
```

`JSMock__clearAllMocks` calls `JSMockFunction::clear()` on every active mock, which only resets `calls`, `contexts`, `instances`, `results` and `invocationCallOrder`.

### Fix

Add `JSMock__resetAllMocks`, which calls `JSMockFunction::reset()` (the same thing `mockFn.mockReset()` does: clear the call history *and* drop the implementation list) on every active mock, and bind `jest.resetAllMocks` / `vi.resetAllMocks` to it.

This matches jest, whose `mockReset()` clears the mock and deletes its config, and vitest. Like `mockReset()`, it does not restore the original implementation of a spy, so `mockRestore()` / `mock.restore()` still work afterwards.

### How did you verify your code works?

New tests in `test/js/bun/test/mock-fn.test.js` cover `jest.resetAllMocks()` dropping an implementation, dropping a `mockReturnValue`, resetting a `spyOn` without restoring the original, and the `vi.resetAllMocks` alias. They fail on current bun (the implementation keeps returning `42`) and pass with this change.

`mock-fn.test.js`, `mock-disposable.test.ts`, the `mock/` module-mocking tests and `test/regression/issue/issue-1825-jest-mock-functions.test.ts` all pass with the debug build.