### PR TITLE
node:http2: don't emit 'aborted' when respond() ends the stream

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2050,8 +2050,9 @@ enum StreamState {
   // The native side fully closed and freed the stream (state 7 delivered): there is
   // nothing left to send on the wire for it.
   NativeClosed = 1 << 6, // 1000000 = 64
-  // respond() is ending the writable side ahead of a HEADERS frame that carries
-  // END_STREAM, so `_final` must not write an empty DATA frame of its own.
+  // Set only while respond() has a HEADERS frame carrying END_STREAM in flight: the writable
+  // side is finished even though this.end() has not run yet. Read by _destroy, which the native
+  // request() reaches synchronously when that frame closes an already half-closed stream.
   EndStreamOnHeaders = 1 << 7, // 10000000 = 128
 }
 function markWritableDone(stream: Http2Stream) {
@@ -2341,8 +2342,10 @@ class Http2Stream extends Duplex {
     // closed by definition — closing it is not an abort and nothing must be sent on the wire.
     if (!ending && !this[kPush]) {
       // If the writable side of the Http2Stream is still open, emit the
-      // 'aborted' event and set the aborted flag.
-      if (!this.aborted) {
+      // 'aborted' event and set the aborted flag. EndStreamOnHeaders means respond() is
+      // submitting END_STREAM on the HEADERS frame right now and will call end() once the
+      // native call returns, so the response completed - nothing was cut short.
+      if (!this.aborted && (this[bunHTTP2StreamStatus] & StreamState.EndStreamOnHeaders) === 0) {
         this[kAborted] = true;
         this.emit("aborted");
       }
@@ -2424,13 +2427,6 @@ class Http2Stream extends Duplex {
       const native = session[bunHTTP2Native];
       if (native) {
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
-        // respond() is about to submit a HEADERS frame carrying END_STREAM, so there is no DATA
-        // frame left to write. Settle now, like node's _final does for this case; 'finish' is
-        // queued on the next tick, after request() has put the frame on the wire.
-        if ((status & StreamState.EndStreamOnHeaders) !== 0) {
-          callback();
-          return;
-        }
         // When waitForTrailers is active, writing an empty DATA frame with
         // close=true emits a bare empty DATA frame (flags=0) to the wire
         // before the trailer/noTrailers path runs, which then emits ANOTHER
@@ -3126,34 +3122,39 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     const wireHeaders = rawHeadersList !== null ? rawHeadersList : headers;
-    if (endStream) {
-      // node ends the writable side before submitting the HEADERS frame. request() below can
-      // close an already half-closed stream and destroy it synchronously, and _destroy reads a
-      // still-open writable side as a client abort - ending first keeps 'aborted' from firing.
-      this[bunHTTP2StreamStatus] |= StreamState.EndStreamOnHeaders;
-      this.end();
-    }
-    if (typeof options === "undefined") {
-      session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames);
-    } else {
-      session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames, options);
-      // Only track waitForTrailers when the HEADERS frame above did NOT end
-      // the stream. Status codes 204/205/304 and HEAD requests force
-      // endStream=true earlier in this method, which means the native
-      // request() already wrote END_STREAM on the HEADERS frame — driving
-      // the wantTrailers path from `_final` on such a stream would call
-      // `noTrailers`/`emit("wantTrailers")` on an already-half-closed
-      // stream and corrupt state. Use optional chaining: `options` may be
-      // `null` here (typeof null === "object" enters this else branch).
-      if (options?.waitForTrailers && !endStream) {
-        this[bunHTTP2WaitForTrailers] = true;
+    // An END_STREAM HEADERS frame can close an already half-closed stream outright, and the
+    // native request() then destroys it synchronously - before the this.end() below runs. Tell
+    // _destroy the writable side is finished, and clear it again once the frame is out: a
+    // request() that threw submitted nothing, so the writable side is still genuinely open.
+    if (endStream) this[bunHTTP2StreamStatus] |= StreamState.EndStreamOnHeaders;
+    try {
+      if (typeof options === "undefined") {
+        session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames);
+      } else {
+        session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames, options);
+        // Only track waitForTrailers when the HEADERS frame above did NOT end
+        // the stream. Status codes 204/205/304 and HEAD requests force
+        // endStream=true earlier in this method, which means the native
+        // request() already wrote END_STREAM on the HEADERS frame — driving
+        // the wantTrailers path from `_final` on such a stream would call
+        // `noTrailers`/`emit("wantTrailers")` on an already-half-closed
+        // stream and corrupt state. Use optional chaining: `options` may be
+        // `null` here (typeof null === "object" enters this else branch).
+        if (options?.waitForTrailers && !endStream) {
+          this[bunHTTP2WaitForTrailers] = true;
+        }
       }
+    } finally {
+      this[bunHTTP2StreamStatus] &= ~StreamState.EndStreamOnHeaders;
     }
     this.headersSent = true;
     if (onServerStreamFinishChannel.hasSubscribers) {
       onServerStreamFinishChannel.publish({ stream: this, headers, flags: 0 });
     }
     this[bunHTTP2Headers] = headers;
+    if (endStream) {
+      this.end();
+    }
 
     return;
   }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2424,11 +2424,11 @@ class Http2Stream extends Duplex {
       const native = session[bunHTTP2Native];
       if (native) {
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
-        // respond() is about to submit a HEADERS frame carrying END_STREAM, so there is no
-        // DATA frame left to write. Park the callback: the onStreamEnd dispatch that the
-        // native request() makes runs markWritableDone, which invokes it.
+        // respond() is about to submit a HEADERS frame carrying END_STREAM, so there is no DATA
+        // frame left to write. Settle now, like node's _final does for this case; 'finish' is
+        // queued on the next tick, after request() has put the frame on the wire.
         if ((status & StreamState.EndStreamOnHeaders) !== 0) {
-          this[bunHTTP2StreamFinal] = callback;
+          callback();
           return;
         }
         // When waitForTrailers is active, writing an empty DATA frame with
@@ -3148,12 +3148,6 @@ class ServerHttp2Stream extends Http2Stream {
       if (options?.waitForTrailers && !endStream) {
         this[bunHTTP2WaitForTrailers] = true;
       }
-    }
-    if (endStream) {
-      // The onStreamEnd dispatch request() makes normally settles the `_final` callback parked
-      // above. Idempotent here, and it keeps a submit the native layer rejected (no dispatch)
-      // from leaving the writable side hanging.
-      markWritableDone(this);
     }
     this.headersSent = true;
     if (onServerStreamFinishChannel.hasSubscribers) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2050,6 +2050,9 @@ enum StreamState {
   // The native side fully closed and freed the stream (state 7 delivered): there is
   // nothing left to send on the wire for it.
   NativeClosed = 1 << 6, // 1000000 = 64
+  // respond() is ending the writable side ahead of a HEADERS frame that carries
+  // END_STREAM, so `_final` must not write an empty DATA frame of its own.
+  EndStreamOnHeaders = 1 << 7, // 10000000 = 128
 }
 function markWritableDone(stream: Http2Stream) {
   const _final = stream[bunHTTP2StreamFinal];
@@ -2421,6 +2424,13 @@ class Http2Stream extends Duplex {
       const native = session[bunHTTP2Native];
       if (native) {
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
+        // respond() is about to submit a HEADERS frame carrying END_STREAM, so there is no
+        // DATA frame left to write. Park the callback: the onStreamEnd dispatch that the
+        // native request() makes runs markWritableDone, which invokes it.
+        if ((status & StreamState.EndStreamOnHeaders) !== 0) {
+          this[bunHTTP2StreamFinal] = callback;
+          return;
+        }
         // When waitForTrailers is active, writing an empty DATA frame with
         // close=true emits a bare empty DATA frame (flags=0) to the wire
         // before the trailer/noTrailers path runs, which then emits ANOTHER
@@ -3116,6 +3126,13 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     const wireHeaders = rawHeadersList !== null ? rawHeadersList : headers;
+    if (endStream) {
+      // node ends the writable side before submitting the HEADERS frame. request() below can
+      // close an already half-closed stream and destroy it synchronously, and _destroy reads a
+      // still-open writable side as a client abort - ending first keeps 'aborted' from firing.
+      this[bunHTTP2StreamStatus] |= StreamState.EndStreamOnHeaders;
+      this.end();
+    }
     if (typeof options === "undefined") {
       session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames);
     } else {
@@ -3132,14 +3149,17 @@ class ServerHttp2Stream extends Http2Stream {
         this[bunHTTP2WaitForTrailers] = true;
       }
     }
+    if (endStream) {
+      // The onStreamEnd dispatch request() makes normally settles the `_final` callback parked
+      // above. Idempotent here, and it keeps a submit the native layer rejected (no dispatch)
+      // from leaving the writable side hanging.
+      markWritableDone(this);
+    }
     this.headersSent = true;
     if (onServerStreamFinishChannel.hasSubscribers) {
       onServerStreamFinishChannel.publish({ stream: this, headers, flags: 0 });
     }
     this[bunHTTP2Headers] = headers;
-    if (endStream) {
-      this.end();
-    }
 
     return;
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -11,10 +11,12 @@ import { Duplex } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
 const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx } = createTest(import.meta.path);
-// bun-debug ships with ASAN but isn't named bun-asan, so isASAN is false
-// there; the 10k-request maxSessionMemory stress test takes ~90s under
-// debug+ASAN vs ~2s release, so scale for either.
+// bun-debug ships with ASAN but isn't named bun-asan, so isASAN is false there.
 const ASAN_MULTIPLIER = isDebug ? 10 : isASAN ? 3 : 1;
+// The maxSessionMemory stress test costs ~2s for 10k requests in release but ~90s under
+// debug+ASAN, close enough to its timeout that a loaded machine trips it. Shrink the workload
+// rather than the deadline; 1k sequential requests still exercises the memory accounting.
+const MAX_SESSION_MEMORY_REQUESTS = isDebug || isASAN ? 1_000 : 10_000;
 
 function invalidArgTypeHelper(input) {
   if (input === null) return " Received null";
@@ -1874,7 +1876,7 @@ it(
         const client = http2.connect(`http://localhost:${port}`);
 
         function next(i) {
-          if (i === 10000) {
+          if (i === MAX_SESSION_MEMORY_REQUESTS) {
             client.close();
             server.close();
             resolve();
@@ -3277,4 +3279,47 @@ it("http2 server respond() with END_STREAM after the request body does not emit 
   expect(results).toEqual(
     cases.map(({ name, status }) => ({ name, events: ["finish", "close"], aborted: false, status, body: "" })),
   );
+});
+
+it("http2 a respond() that throws on invalid headers leaves the writable side open", async () => {
+  // 304 forces END_STREAM, and the invalid response pseudo-header makes respond() throw. Nothing
+  // was submitted, so the handler can still recover with a fresh respond() + end().
+  const server = http2.createServer();
+  let thrownCode = null;
+  server.on("stream", stream => {
+    try {
+      stream.respond({ ":status": 304, ":path": "/" });
+    } catch (err) {
+      thrownCode = err.code;
+      stream.respond({ ":status": 500 });
+      stream.end("err");
+    }
+  });
+
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  client.on("error", () => {});
+  try {
+    const req = client.request({ ":path": "/" });
+    const headers = await new Promise((resolve, reject) => {
+      req.on("error", reject);
+      req.on("response", resolve);
+      req.end();
+    });
+    const body = [];
+    req.on("data", chunk => body.push(chunk));
+    await new Promise((resolve, reject) => {
+      req.on("error", reject);
+      req.on("end", resolve);
+    });
+
+    expect({
+      thrownCode,
+      status: headers[":status"],
+      body: Buffer.concat(body).toString(),
+    }).toEqual({ thrownCode: "ERR_HTTP2_INVALID_PSEUDOHEADER", status: 500, body: "err" });
+  } finally {
+    client.close();
+    server.close();
+  }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3186,3 +3186,95 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
     server.close();
   }
 });
+
+// Collects the server stream's lifecycle events for one request, plus `stream.aborted` as read
+// from the 'close' handler. 'end' is filtered out: bun and node disagree on whether it lands
+// before or after 'finish', which is unrelated to what these tests assert.
+async function serverStreamLifecycle(onStream, requestHeaders = { ":path": "/" }) {
+  const events = [];
+  let aborted = null;
+  const { promise: streamClosed, resolve: streamDidClose } = Promise.withResolvers();
+
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.on("aborted", () => events.push("aborted"));
+    stream.on("finish", () => events.push("finish"));
+    stream.on("close", () => {
+      aborted = stream.aborted;
+      events.push("close");
+      streamDidClose();
+    });
+    onStream(stream);
+  });
+
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  client.on("error", () => {});
+  try {
+    const req = client.request(requestHeaders);
+    const responseHeaders = await new Promise((resolve, reject) => {
+      req.on("error", reject);
+      req.on("response", resolve);
+      req.end();
+    });
+    const body = [];
+    req.on("data", chunk => body.push(chunk));
+    await new Promise((resolve, reject) => {
+      req.on("error", reject);
+      req.on("end", resolve);
+    });
+    await streamClosed;
+    return { events, aborted, status: responseHeaders[":status"], body: Buffer.concat(body).toString() };
+  } finally {
+    client.close();
+    server.close();
+  }
+}
+
+it("http2 respondWithFile statCheck returning false does not emit a spurious 'aborted'", async () => {
+  // The documented statCheck veto: reply 304 from a cache validator and cancel the file send.
+  // Node treats that as a completed response, so no 'aborted' fires and stream.aborted stays false.
+  const result = await serverStreamLifecycle(stream => {
+    stream.respondWithFile(
+      import.meta.path,
+      { "content-type": "text/plain" },
+      {
+        statCheck() {
+          stream.respond({ ":status": 304 });
+          stream.end();
+          return false;
+        },
+      },
+    );
+  });
+
+  expect(result).toEqual({ events: ["finish", "close"], aborted: false, status: 304, body: "" });
+});
+
+it("http2 server respond() with END_STREAM after the request body does not emit a spurious 'aborted'", async () => {
+  // Any respond() whose HEADERS frame carries END_STREAM (204/205/304, HEAD, endStream: true)
+  // fully closes a stream whose peer already half-closed. That is a completed response, so the
+  // writable side must be ended before the frame is submitted or the teardown looks like an abort.
+  const cases = [
+    { name: "304", status: 304, respond: stream => stream.respond({ ":status": 304 }) },
+    { name: "204", status: 204, respond: stream => stream.respond({ ":status": 204 }) },
+    { name: "205", status: 205, respond: stream => stream.respond({ ":status": 205 }) },
+    { name: "endStream", status: 200, respond: stream => stream.respond({ ":status": 200 }, { endStream: true }) },
+    { name: "head", status: 200, respond: stream => stream.respond({ ":status": 200 }), method: "HEAD" },
+  ];
+
+  const results = [];
+  for (const { name, respond, method } of cases) {
+    // Respond once the request body is fully received, which is when the stream is already
+    // half-closed by the peer and submitting END_STREAM closes it outright.
+    const { events, aborted, status, body } = await serverStreamLifecycle(
+      stream => stream.on("end", () => respond(stream)),
+      method ? { ":path": "/", ":method": method } : { ":path": "/" },
+    );
+    results.push({ name, events, aborted, status, body });
+  }
+
+  expect(results).toEqual(
+    cases.map(({ name, status }) => ({ name, events: ["finish", "close"], aborted: false, status, body: "" })),
+  );
+});


### PR DESCRIPTION
### Repro

A server stream that answers with a body-less status emits a `'aborted'` event and flips `stream.aborted` to `true`, even though nothing aborted and no `RST_STREAM` is exchanged. The reported shape is the documented `statCheck` veto (reply 304 from a cache validator, cancel the file send):

```js
const server = http2.createServer();
server.on("stream", stream => {
  stream.on("aborted", () => console.log("aborted!"));
  stream.on("close", () => console.log("stream.aborted =", stream.aborted));
  stream.respondWithFile(file, { "content-type": "text/plain" }, {
    statCheck() {
      stream.respond({ ":status": 304 });
      stream.end();
      return false; // documented veto: the handler took over
    },
  });
});
```

```
node: events = ["finish", "end", "close"]   stream.aborted = false
bun:  events = ["end", "aborted", "finish", "close"]   stream.aborted = true
```

It is not specific to `statCheck`. Any `respond()` whose HEADERS frame carries `END_STREAM` hits it as long as the request body has already been received:

```js
server.on("stream", stream => stream.on("end", () => stream.respond({ ":status": 304 })));
```

Same for `204`, `205`, a `HEAD` request, and `respond(headers, { endStream: true })`.

### Cause

`ServerHttp2Stream.respond()` ended the writable side *after* the native `request()` call:

```js
session[bunHTTP2Native]?.request(this.id, undefined, wireHeaders, sensitiveNames, options);
// ...
if (endStream) this.end();
```

When the peer has already half-closed, submitting HEADERS with `END_STREAM` moves the stream to `CLOSED` inside `request()`, which dispatches `onStreamEnd(7)` synchronously. That handler calls `stream.destroy()`, and `_destroy()` reads `_writableState.ending` to decide whether the response was cut short:

```js
const { ending } = this._writableState;
if (!ending && !this[kPush]) {
  this[kAborted] = true;
  this.emit("aborted");
  ...
}
```

`this.end()` had not run yet, so `ending` was `false` and the clean close was recorded as a client abort. The synchronous `respond()` case never showed it because there the stream is still `OPEN` when the handler runs, so the `CLOSED` transition lands after `respond()` returns.

Node ends the writable side *before* submitting, in `lib/internal/http2/core.js`:

```js
if (!!options.endStream || statusCode === HTTP_STATUS_NO_CONTENT || ... ) {
  options.endStream = true;
  this.end();
}
const ret = this[kHandle].respond(headersList, streamOptions);
```

### Fix

Copying that ordering does not hold in bun. Node validates headers in JS (`mapToHeaders`) before it ends the writable side, so a bad header throws with the stream untouched. Bun validates inside the native `request()`, so ending first means a throwing `respond()` leaves the writable side already ended, and the documented catch-and-retry recovery silently hangs the client:

```js
try {
  stream.respond({ ":status": 304, ":path": "/" }); // throws ERR_HTTP2_INVALID_PSEUDOHEADER
} catch {
  stream.respond({ ":status": 500 });
  stream.end("err"); // no-ops on the EndedCalled guard: END_STREAM never goes out
}
```

So `this.end()` stays where it was. Instead `respond()` records, on the stream status, that a HEADERS frame carrying `END_STREAM` is in flight, and clears it once the native call returns. `_destroy` reads that bit to tell a completed response apart from a client abort. A `request()` that threw submitted nothing, so the bit is cleared, the writable side is still genuinely open, and the retry works.

`EndStreamOnHeaders` needs to be its own bit rather than reusing `NativeClosed` or `WritableClosed`. Both of those are also set when the peer cancels with `RST_STREAM(NO_ERROR)`, which dispatches `onStreamEnd(CLOSED)` as well (`h2_frame_parser.rs:4335`) - keying off either would swallow a real client cancel.

### Verification

New tests in `test/js/node/http2/node-http2.test.js`:

- the reported `statCheck` veto, and the wider class (`304`, `204`, `205`, `HEAD`, `endStream: true` responding once the request body has been received). Both fail on `main`, asserting `stream.aborted === false` and that no `'aborted'` fires while `'finish'` still does.
- a throwing `respond()` leaves the writable side open, so `respond()` + `end()` recovery still reaches the client.

Genuine aborts were checked to still fire: a client `close(NGHTTP2_CANCEL)` mid-body, a client `close(NGHTTP2_NO_ERROR)` mid-body (the `onStreamEnd(CLOSED)` path), and a server-side `destroy()` mid-body all still emit `'aborted'` with `stream.aborted === true`, matching node.

<details>
<summary>Before / after, and no regressions</summary>

```
$ git checkout main -- src/js/node/http2.ts
$ bun bd test test/js/node/http2/node-http2.test.js
(fail) http2 respondWithFile statCheck returning false does not emit a spurious 'aborted'
(fail) http2 server respond() with END_STREAM after the request body does not emit a spurious 'aborted'
 295 pass, 2 fail

$ git checkout HEAD -- src/js/node/http2.ts
$ bun bd test test/js/node/http2/node-http2.test.js
 297 pass, 6 skip, 0 fail
```

All 293 `test-http2-*` / `test-diagnostics-channel-http2-*` files under `test/js/node/test/parallel/` run against the debug build: 234 pass, 56 fail, an identical failure set before and after the change.

This also shrinks the `maxSessionMemory` stress test to 1k sequential requests under debug+ASAN. At 10k it took ~88s against its own 150s timeout, close enough to fail on a loaded machine; release still runs the full 10k. The file now runs in 45s instead of 140s.

</details>
