### PR TITLE
events: make addAbortListener resist stopImmediatePropagation

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -468,6 +468,15 @@ declare interface UnderlyingSource {
   $stream?: ReadableStream;
 }
 
+declare interface AddEventListenerOptions {
+  /**
+   * Private symbol read by the native EventTarget. A listener registered with it still
+   * runs after another listener called `stopImmediatePropagation()`. Mirrors Node.js's
+   * internal `kResistStopPropagation`.
+   */
+  $kResistStopPropagation?: boolean;
+}
+
 declare class OutOfMemoryError {
   constructor();
 }

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -119,6 +119,7 @@ using namespace JSC;
     macro(isUntransferable) \
     macro(join) \
     macro(json) \
+    macro(kResistStopPropagation) \
     macro(key) \
     macro(lazy) \
     macro(lineText) \

--- a/src/js/internal/abort_listener.ts
+++ b/src/js/internal/abort_listener.ts
@@ -1,5 +1,5 @@
 const { validateAbortSignal, validateFunction } = require("internal/validators");
-const { kResistStopPropagation } = require("internal/shared");
+const { resistStopPropagation } = require("internal/shared");
 
 function addAbortListener(signal: AbortSignal, listener: EventListener): Disposable {
   if (signal === undefined) {
@@ -13,16 +13,17 @@ function addAbortListener(signal: AbortSignal, listener: EventListener): Disposa
     queueMicrotask(() => listener());
   } else {
     // TODO(atlowChemi) add { subscription: true } and return directly
-    signal.addEventListener("abort", listener, { once: true, [kResistStopPropagation]: true });
+    signal.addEventListener("abort", listener, resistStopPropagation({ __proto__: null, once: true }));
     removeEventListener = () => {
       signal.removeEventListener("abort", listener);
     };
   }
   return {
+    __proto__: null,
     [Symbol.dispose]() {
       removeEventListener?.();
     },
-  };
+  } as Disposable;
 }
 
 export default {

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -144,6 +144,15 @@ function once(callback, { preserveReturnValue = false } = kEmptyObject) {
 
 const kEmptyObject = ObjectFreeze(Object.create(null));
 
+// Marks an addEventListener() options object so that dispatch still invokes the
+// listener after an unrelated listener called event.stopImmediatePropagation().
+// `$kResistStopPropagation` is a private symbol the native EventTarget reads, so
+// only these internal modules can reach it.
+function resistStopPropagation<T extends object>(options: T): T {
+  (options as AddEventListenerOptions).$kResistStopPropagation = true;
+  return options;
+}
+
 function getLazy<T>(initializer: () => T) {
   let value: T;
   let initialized = false;
@@ -321,6 +330,7 @@ export default {
   ErrnoException,
   once,
   getLazy,
+  resistStopPropagation,
 
   hasObserver,
   startPerf,
@@ -332,7 +342,6 @@ export default {
 
   kHandle: Symbol("kHandle"),
   kAutoDestroyed: Symbol("kAutoDestroyed"),
-  kResistStopPropagation: Symbol("kResistStopPropagation"),
   kWeakHandler: Symbol("kWeak"),
   kGetNativeReadableProto: Symbol("kGetNativeReadableProto"),
   kEmptyObject,

--- a/src/js/internal/streams/operators.ts
+++ b/src/js/internal/streams/operators.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 const { validateAbortSignal, validateFunction, validateInteger, validateObject } = require("internal/validators");
-const { kWeakHandler, kResistStopPropagation } = require("internal/shared");
+const { kWeakHandler, resistStopPropagation } = require("internal/shared");
 const { finished } = require("internal/streams/end-of-stream");
 
 const MathFloor = Math.floor;
@@ -233,7 +233,7 @@ async function reduce(reducer, initialValue, options) {
   const ac = new AbortController();
   const signal = ac.signal;
   if (options?.signal) {
-    const opts = { once: true, [kWeakHandler]: this, [kResistStopPropagation]: true };
+    const opts = resistStopPropagation({ once: true, [kWeakHandler]: this });
     options.signal.addEventListener("abort", () => ac.abort(), opts);
   }
   let gotAnyItemFromStream = false;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -32,6 +32,8 @@ const {
   validateFunction,
   validateString,
 } = require("internal/validators");
+const { addAbortListener } = require("internal/abort_listener");
+const { resistStopPropagation } = require("internal/shared");
 
 const types = require("node:util/types");
 let inspect: typeof import("node:util").inspect | undefined;
@@ -574,7 +576,8 @@ async function once(emitter, type, options = kEmptyObject) {
     }
     resolve(args);
   };
-  eventTargetAgnosticAddListener(emitter, type, resolver, { once: true });
+  const opts = resistStopPropagation({ __proto__: null, once: true });
+  eventTargetAgnosticAddListener(emitter, type, resolver, opts);
   if (type !== "error" && typeof emitter.once === "function") {
     // EventTarget does not have `error` event semantics like Node
     // EventEmitters, we listen to `error` events only on EventEmitters.
@@ -586,7 +589,7 @@ async function once(emitter, type, options = kEmptyObject) {
     reject($makeAbortError(undefined, { cause: signal?.reason }));
   }
   if (signal != null) {
-    eventTargetAgnosticAddListener(signal, "abort", abortListener, { once: true });
+    eventTargetAgnosticAddListener(signal, "abort", abortListener, opts);
   }
 
   return promise;
@@ -873,34 +876,6 @@ function getMaxListeners(emitterOrTarget) {
   throw $ERR_INVALID_ARG_TYPE("emitter", ["EventEmitter", "EventTarget"], emitterOrTarget);
 }
 Object.defineProperty(getMaxListeners, "name", { value: "getMaxListeners" });
-
-// Copy-pasta from Node.js source code
-function addAbortListener(signal, listener) {
-  if (signal === undefined) {
-    throw $ERR_INVALID_ARG_TYPE("signal", "AbortSignal", signal);
-  }
-
-  validateAbortSignal(signal, "signal");
-  if (typeof listener !== "function") {
-    throw $ERR_INVALID_ARG_TYPE("listener", "function", listener);
-  }
-
-  let removeEventListener;
-  if (signal.aborted) {
-    queueMicrotask(() => listener());
-  } else {
-    signal.addEventListener("abort", listener, { __proto__: null, once: true });
-    removeEventListener = () => {
-      signal.removeEventListener("abort", listener);
-    };
-  }
-  return {
-    __proto__: null,
-    [Symbol.dispose]() {
-      removeEventListener?.();
-    },
-  };
-}
 
 let EventEmitterReferencingAsyncResource;
 function lazyLoadAsyncResource() {

--- a/src/js/node/timers.promises.ts
+++ b/src/js/node/timers.promises.ts
@@ -2,6 +2,7 @@
 // https://github.com/niksy/isomorphic-timers-promises/blob/master/index.js
 
 const { validateBoolean, validateAbortSignal, validateObject, validateNumber } = require("internal/validators");
+const { resistStopPropagation } = require("internal/shared");
 
 const symbolAsyncIterator = Symbol.asyncIterator;
 const setImmediateGlobal = globalThis.setImmediate;
@@ -65,7 +66,7 @@ function setTimeout(after = 1, value, options = {}) {
         clearTimeout(timeout);
         reject($makeAbortError(undefined, { cause: signal.reason }));
       };
-      signal.addEventListener("abort", onCancel);
+      signal.addEventListener("abort", onCancel, resistStopPropagation({ __proto__: null }));
     }
   });
   return typeof onCancel !== "undefined"
@@ -104,7 +105,7 @@ function setImmediate(value, options = {}) {
         clearImmediate(immediate);
         reject($makeAbortError(undefined, { cause: signal.reason }));
       };
-      signal.addEventListener("abort", onCancel);
+      signal.addEventListener("abort", onCancel, resistStopPropagation({ __proto__: null }));
     }
   });
   return typeof onCancel !== "undefined"
@@ -187,7 +188,7 @@ function setInterval(after = 1, value, options = {}) {
           callback = undefined;
         }
       };
-      signal.addEventListener("abort", onCancel);
+      signal.addEventListener("abort", onCancel, resistStopPropagation({ __proto__: null, once: true }));
     }
 
     return asyncIterator({

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -4,6 +4,7 @@ const types = require("node:util/types");
 const utl = require("internal/util/inspect");
 const { promisify } = require("internal/promisify");
 const { validateString, validateOneOf, validateBoolean } = require("internal/validators");
+const { resistStopPropagation } = require("internal/shared");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
 const { deprecate } = require("internal/util/deprecate");
 
@@ -275,7 +276,7 @@ function aborted(signal: AbortSignal, resource: object) {
     // Do not leak the current scope into the listener.
     // Instead, create a new function.
     unregisterToken,
-    { once: true },
+    resistStopPropagation({ __proto__: null, once: true }),
   );
 
   if (!lazyAbortedRegistry) {

--- a/src/jsc/bindings/webcore/AddEventListenerOptions.h
+++ b/src/jsc/bindings/webcore/AddEventListenerOptions.h
@@ -43,6 +43,11 @@ struct AddEventListenerOptions : EventListenerOptions {
     std::optional<bool> passive;
     bool once { false };
     RefPtr<AbortSignal> signal;
+
+    // Not part of the DOM standard. Set through a private symbol by Bun's internal
+    // modules, mirroring Node.js's kResistStopPropagation: a listener registered
+    // with it still runs after another listener called stopImmediatePropagation().
+    bool resistStopPropagation { false };
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/EventTarget.cpp
+++ b/src/jsc/bindings/webcore/EventTarget.cpp
@@ -103,7 +103,7 @@ bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListene
     // if (!passive.has_value() && Quirks::shouldMakeEventListenerPassive(*this, eventType, listener.get()))
     //     passive = true;
 
-    auto* registeredListener = ensureEventTargetData().eventListenerMap.add(eventType, listener.copyRef(), { options.capture, passive.value_or(false), options.once });
+    auto* registeredListener = ensureEventTargetData().eventListenerMap.add(eventType, listener.copyRef(), { options.capture, passive.value_or(false), options.once, options.resistStopPropagation });
     if (!registeredListener)
         return false;
 
@@ -316,10 +316,11 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         // if (InspectorInstrumentation::isEventListenerDisabled(*this, event.type(), registeredListener->callback(), registeredListener->useCapture()))
         //     continue;
 
-        // If stopImmediatePropagation has been called, we just break out immediately, without
-        // handling any more events on this target.
-        if (event.immediatePropagationStopped())
-            break;
+        // If stopImmediatePropagation has been called, skip the remaining listeners. Listeners
+        // registered with resistStopPropagation still run: they are how internal modules attach
+        // teardown that unrelated code sharing the event target must not be able to suppress.
+        if (event.immediatePropagationStopped() && !registeredListener->resistsStopPropagation())
+            continue;
 
         // Make sure the JS wrapper and function stay alive until the end of this scope. Otherwise,
         // event listeners with 'once' flag may get collected as soon as they get unregistered below,

--- a/src/jsc/bindings/webcore/JSAddEventListenerOptions.cpp
+++ b/src/jsc/bindings/webcore/JSAddEventListenerOptions.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "JSAddEventListenerOptions.h"
 
+#include "BunClientData.h"
 #include "JSAbortSignal.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertInterface.h"
@@ -85,6 +86,16 @@ template<> AddEventListenerOptions convertDictionary<AddEventListenerOptions>(JS
     if (!signalValue.isUndefined()) {
         result.signal = convert<IDLInterface<AbortSignal>>(lexicalGlobalObject, signalValue);
         RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    // Bun extension, keyed off a private symbol that only internal modules can
+    // reach. See AddEventListenerOptions::resistStopPropagation.
+    if (!isNullOrUndefined) {
+        JSValue resistStopPropagationValue = object->get(&lexicalGlobalObject, builtinNames(vm).kResistStopPropagationPrivateName());
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!resistStopPropagationValue.isUndefined()) {
+            result.resistStopPropagation = convert<IDLBoolean>(lexicalGlobalObject, resistStopPropagationValue);
+            RETURN_IF_EXCEPTION(throwScope, {});
+        }
     }
     return result;
 }

--- a/src/jsc/bindings/webcore/RegisteredEventListener.h
+++ b/src/jsc/bindings/webcore/RegisteredEventListener.h
@@ -36,16 +36,18 @@ class WeakPtrImplWithEventTargetData;
 class RegisteredEventListener : public RefCounted<RegisteredEventListener> {
 public:
     struct Options {
-        Options(bool capture = false, bool passive = false, bool once = false)
+        Options(bool capture = false, bool passive = false, bool once = false, bool resistStopPropagation = false)
             : capture(capture)
             , passive(passive)
             , once(once)
+            , resistStopPropagation(resistStopPropagation)
         {
         }
 
         bool capture;
         bool passive;
         bool once;
+        bool resistStopPropagation;
     };
 
     static Ref<RegisteredEventListener> create(Ref<EventListener>&& listener, const Options& options)
@@ -60,6 +62,7 @@ public:
     bool isPassive() const { return m_isPassive; }
     bool isOnce() const { return m_isOnce; }
     bool wasRemoved() const { return m_wasRemoved; }
+    bool resistsStopPropagation() const { return m_resistStopPropagation; }
 
     void markAsRemoved();
 
@@ -77,6 +80,7 @@ private:
         , m_isPassive(options.passive)
         , m_isOnce(options.once)
         , m_wasRemoved(false)
+        , m_resistStopPropagation(options.resistStopPropagation)
         , m_callback(WTF::move(listener))
     {
     }
@@ -85,6 +89,7 @@ private:
     bool m_isPassive : 1;
     bool m_isOnce : 1;
     bool m_wasRemoved : 1;
+    bool m_resistStopPropagation : 1;
     uint32_t m_abortAlgorithmIdentifier { 0 };
     Ref<EventListener> m_callback;
     WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> m_abortSignal;

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -877,6 +877,85 @@ test("using addAbortListener", async () => {
   expect(mocked).not.toHaveBeenCalled();
 });
 
+describe("addAbortListener resists stopImmediatePropagation", () => {
+  test("runs after an earlier listener stopped propagation", () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const order: string[] = [];
+
+    signal.addEventListener("abort", e => {
+      order.push("stopper");
+      e.stopImmediatePropagation();
+    });
+    EventEmitter.addAbortListener(signal, e => {
+      order.push(`cleanup:${(e as Event).target === signal}`);
+    });
+    signal.addEventListener("abort", () => order.push("plain-after"));
+
+    controller.abort();
+    expect(order).toEqual(["stopper", "cleanup:true"]);
+  });
+
+  test("runs when it was registered before the listener that stops propagation", () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const order: string[] = [];
+
+    EventEmitter.addAbortListener(signal, () => order.push("cleanup"));
+    signal.addEventListener("abort", e => {
+      order.push("stopper");
+      e.stopImmediatePropagation();
+    });
+    signal.addEventListener("abort", () => order.push("plain-after"));
+
+    controller.abort();
+    expect(order).toEqual(["cleanup", "stopper"]);
+  });
+
+  test("is not run once disposed", () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const mocked = mock();
+
+    signal.addEventListener("abort", e => e.stopImmediatePropagation());
+    {
+      using _ = EventEmitter.addAbortListener(signal, mocked);
+    }
+
+    controller.abort();
+    expect(mocked).not.toHaveBeenCalled();
+  });
+
+  test("once(emitter, event, { signal }) still rejects on a suppressed signal", async () => {
+    const emitter = new EventEmitter();
+    const controller = new AbortController();
+    controller.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+
+    const promise = EventEmitter.once(emitter, "never", { signal: controller.signal });
+    expect(emitter.listenerCount("never")).toBe(1);
+    controller.abort();
+
+    // once()'s abort listener detaches the emitter listener and rejects, both synchronously.
+    expect(emitter.listenerCount("never")).toBe(0);
+    expect(await promise.catch(err => err.code)).toBe("ABORT_ERR");
+  });
+
+  test("stopImmediatePropagation still suppresses ordinary listeners", () => {
+    const target = new EventTarget();
+    const order: string[] = [];
+
+    target.addEventListener("x", () => order.push("a"));
+    target.addEventListener("x", e => {
+      order.push("b");
+      e.stopImmediatePropagation();
+    });
+    target.addEventListener("x", () => order.push("c"));
+
+    target.dispatchEvent(new Event("x"));
+    expect(order).toEqual(["a", "b"]);
+  });
+});
+
 test("getMaxListeners", () => {
   const emitter = new EventEmitter();
   expect(emitter.getMaxListeners()).toBe(10);

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { setImmediate, setTimeout } from "node:timers/promises";
+import { setImmediate, setInterval, setTimeout } from "node:timers/promises";
 
 describe("setTimeout", () => {
   it("abort() does not emit global error", async () => {
@@ -37,6 +37,19 @@ describe("setTimeout", () => {
     await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
     expect(abortController.signal.aborted).toBe(true);
   });
+
+  // abort() runs the listener synchronously, so the short delay can never win the
+  // race: it only exists so a build that ignores the abort resolves and fails the
+  // assertion rather than leaving the promise pending forever.
+  it("rejects even when another listener stopped propagation", async () => {
+    const abortController = new AbortController();
+    abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+
+    const promise = setTimeout(1, "not-aborted", { signal: abortController.signal });
+    abortController.abort();
+
+    await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+  });
 });
 
 describe("setImmediate", () => {
@@ -61,5 +74,33 @@ describe("setImmediate", () => {
 
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);
+  });
+
+  it("rejects even when another listener stopped propagation", async () => {
+    const abortController = new AbortController();
+    abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+
+    const promise = setImmediate("not-aborted", { signal: abortController.signal });
+    abortController.abort();
+
+    await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+  });
+});
+
+describe("setInterval", () => {
+  it("ends the iterator even when another listener stopped propagation", async () => {
+    const abortController = new AbortController();
+    abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+
+    const iterator = setInterval(1, "tick", { signal: abortController.signal })[Symbol.asyncIterator]();
+    try {
+      const next = iterator.next();
+      abortController.abort();
+
+      await expect(next).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+    } finally {
+      // On a build that ignores the abort the interval is still armed; clear it.
+      await iterator.return!();
+    }
   });
 });

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -15,6 +15,18 @@ test("aborted works when provided a resource that was already aborted", () => {
   return expect(abortedPromise).resolves.toBeUndefined();
 });
 
+test("aborted resolves even when another listener stopped propagation", async () => {
+  const ac = new AbortController();
+  ac.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+  const abortedPromise = aborted(ac.signal, {});
+  ac.abort();
+
+  // aborted() resolves from a `once: true` listener, synchronously inside abort(),
+  // so by now it has been consumed and only the listener that stopped propagation is left.
+  expect(getEventListeners(ac.signal, "abort")).toHaveLength(1);
+  await expect(abortedPromise).resolves.toBeUndefined();
+});
+
 test("aborted works when provided a resource that was not already aborted", async () => {
   const ac = new AbortController();
   var strong = {};


### PR DESCRIPTION
## Repro

```js
const events = require("node:events");

const controller = new AbortController();
// any library sharing your signal
controller.signal.addEventListener("abort", e => e.stopImmediatePropagation());
// documented to ALWAYS run on abort
events.addAbortListener(controller.signal, () => console.log("cleanup"));
controller.abort();
```

Node prints `cleanup`. Bun prints nothing.

`addAbortListener` is the API Node tells resource owners to use *specifically* so that another consumer of a shared `AbortSignal` cannot suppress their teardown. On Bun it degraded into a plain listener, so it was skipped in exactly the composed-signal scenarios it exists for.

## Cause

`AbortSignal` is a native `EventTarget`, and `EventTarget::innerInvokeEventListeners` left the dispatch loop the moment `stopImmediatePropagation()` had been called:

```cpp
if (event.immediatePropagationStopped())
    break;
```

Node's `EventTarget` is JS, so it can record a per-listener `resistStopPropagation` flag (from its internal `kResistStopPropagation` symbol) and skip only the listeners that lack it.

`internal/abort_listener.ts` already passed `[kResistStopPropagation]: true`, but it was a plain JS symbol that the native dictionary converter never read, so it did nothing. `node:events` shipped a second copy of `addAbortListener` that did not even pass it.

## Fix

- `AddEventListenerOptions` gains `resistStopPropagation`, parsed in `convertDictionary` from `$kResistStopPropagation`, a JSC private symbol only Bun's internal modules can reach. Userland cannot forge it: a string key, an own `Symbol()`, `Symbol.for()` and `Object.prototype` pollution all fail.
- `RegisteredEventListener` carries the flag, and `innerInvokeEventListeners` skips suppressed listeners instead of breaking, so a listener that set it still runs.
- The duplicate `addAbortListener` in `node:events` is gone; it now uses `internal/abort_listener`.
- Same flag wired into the other listeners Node marks `kResistStopPropagation`: `events.once(emitter, type, { signal })` (both listeners), `util.aborted()`, `timers/promises` `setTimeout`/`setImmediate`/`setInterval`, and stream `reduce()`.

On those last paths, a suppressed signal did not merely skip cleanup, it left the promise pending forever:

| with a `stopImmediatePropagation()` listener on the signal | bun 1.4.0 | node | this PR |
| --- | --- | --- | --- |
| `events.addAbortListener(signal, fn)` | `fn` not called | called | called |
| `events.once(emitter, type, { signal })` | never settles | `AbortError` | `AbortError` |
| `util.aborted(signal, resource)` | never settles | resolves | resolves |
| `timers/promises.setTimeout(ms, v, { signal })` | never settles | `AbortError` | `AbortError` |

`stopImmediatePropagation()` still suppresses ordinary listeners, and it still leaves a later `once: true` listener registered.

`fs.promises.watch`'s JS abort listener is deliberately left alone: Bun's native `fs.watch` registers its own abort algorithm, which runs before event dispatch, so marking the redundant JS listener would change nothing.

## Verification

Six new tests across `event-emitter.test.ts`, `timers.promises.test.ts` and `test-aborted.test.ts`. Each fails in under 60ms on a build without the `src/` changes and passes with them:

<details>
<summary>before / after</summary>

```
### test/js/node/events/event-emitter.test.ts            exit=1
(fail) ... > runs after an earlier listener stopped propagation [12.24ms]
(fail) ... > once(emitter, event, { signal }) still rejects on a suppressed signal [14.52ms]
### test/js/node/timers.promises/timers.promises.test.ts  exit=1
(fail) setTimeout > rejects even when another listener stopped propagation [24.65ms]
(fail) setImmediate > rejects even when another listener stopped propagation [17.49ms]
(fail) setInterval > ends the iterator even when another listener stopped propagation [54.02ms]
### test/js/node/util/test-aborted.test.ts                exit=1
(fail) aborted resolves even when another listener stopped propagation [17.41ms]
```

After: all three files pass, plus `test/js/web/events/`, `test/js/node/events/`, `test/js/node/stream/`, `test/js/deno/event/`, and the `test-eventtarget.js` / `test-events-once.js` / `test-events-add-abort-listener.mjs` Node suites.
</details>

`BUN_JSC_validateExceptionChecks=1` reports no violations for the new `get()` in `convertDictionary`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts test/js/node/timers.promises/timers.promises.test.ts test/js/node/util/test-aborted.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4dfe1e876)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [138.23ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [7.32ms]
(pass) setTimeout > should reject promise when AbortController is aborted [7.12ms]
46 |     abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
47 | 
48 |     const promise = setTimeout(1, "not-aborted", { signal: abortController.signal });
49 |     abortController.abort();
50 | 
51 |     await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
              
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [102.85ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [1.37ms]
(pass) setTimeout > should reject promise when AbortController is aborted [0.35ms]
46 |     abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
47 | 
48 |     const promise = setTimeout(1, "not-aborted", { signal: abortController.signal });
49 |     abortController.abort();
50 | 
51 |     await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
                                       ^
error: expect(received).rejects.toThrow(expected)

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }

      at <anonymous> (/workspace/bun/test/js/node/timers.promises/timers.promises.test.ts:51:35)
(fail) setTimeout > rejects even when another listener stopped propagation [1.51ms]
(pass) setImmediate > abort() does not emit global error [101.11ms]
81 |     abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
82 | 
83 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts test/js/node/timers.promises/timers.promises.test.ts test/js/node/util/test-aborted.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4dfe1e876)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [141.57ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [7.19ms]
(pass) setTimeout > should reject promise when AbortController is aborted [7.63ms]
(pass) setTimeout > rejects even when another listener stopped propagation [7.60ms]
(pass) setImmediate > abort() does not emit global error [124.92ms]
(pass) setImmediate > rejects even when another listener stopped propagation [10.48ms]
(pass) setInterval > ends the iterator even when another listener stopped propagation [36.54ms]

test/j
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4dfe1e876b
  features     (none)

22 deps, 106 codegen, 1169 objects in 871ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [30.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1232] gen ErrorCode+*.h
[4/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[5/1232] fetch picohttpparser
[picohttpparser] up to date
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch libjpeg-turbo
[libjpeg-tur
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins.d.ts                               |  9 +++
 src/js/builtins/BunBuiltinNames.h                  |  1 +
 src/js/internal/abort_listener.ts                  |  7 +-
 src/js/internal/shared.ts                          | 11 ++-
 src/js/internal/streams/operators.ts               |  4 +-
 src/js/node/events.ts                              | 35 ++--------
 src/js/node/timers.promises.ts                     |  7 +-
 src/js/node/util.ts                                |  3 +-
 src/jsc/bindings/webcore/AddEventListenerOptions.h |  5 ++
 src/jsc/bindings/webcore/EventTarget.cpp           | 11 +--
 .../bindings/webcore/JSAddEventListenerOptions.cpp | 11 +++
 src/jsc/bindings/webcore/RegisteredEventListener.h |  7 +-
 test/js/node/events/event-emitter.test.ts          | 79 ++++++++++++++++++++++
 .../node/timers.promises/timers.promises.test.ts   | 43 +++++++++++-
 test/js/node/util/test-aborted.test.ts             | 12 ++++
 15 files changed, 198 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/builtins.d.ts                                        1      1      0
src/js/builtins/BunBuiltinNames.h                           1      1      0
src/js/internal/abort_listener.ts                           2      3      0
src/js/internal/shared.ts                                   3      4      0
src/js/internal/streams/operators.ts                        3      5      0
src/js/node/events.ts                                       4      7      0
src/js/node/timers.promises.ts                              2      5      0
src/js/node/util.ts                                         1      2      0
src/jsc/bindings/webcore/AddEventListenerOptions.h          1      2      0
src/jsc/bindings/webcore/EventTarget.cpp                    2      2      0
src/jsc/bindings/webcore/JSAddEventListenerOptions.cpp      1      2      0
src/jsc/bindings/webcore/RegisteredEventListener.h          1      4      0
test/js/node/events/event-emitter.test.ts                   2      2      0
test/js/node/timers.promises/timers.promises.test.ts        4      8      0
test/js/node/util/test-aborted.test.ts                      1      2      0
```

</details>

<!-- robobun:evidence:end -->