### PR TITLE
js_parser: apply exports.eliminate/replace to function and class declarations

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5283,11 +5283,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Returns whether a part was appended. Statements that are entirely
+    /// eliminated while visiting (dead code, `exports.eliminate`) leave `parts`
+    /// untouched.
     pub fn append_part(
         &mut self,
         parts: &mut ListManaged<'a, js_ast::Part>,
         stmts: &'a mut [Stmt],
-    ) -> Result<(), crate::Error> {
+    ) -> Result<bool, crate::Error> {
         // Reuse the memory if possible
         // This is reusable if the last part turned out to be dead
         self.symbol_uses.clear_retaining_capacity();
@@ -5348,7 +5351,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.relocated_top_level_vars.clear();
         }
 
-        if !part_stmts.is_empty() {
+        let appended = !part_stmts.is_empty();
+        if appended {
             // SAFETY: `into_bump_slice_mut` leaks the BumpVec into the arena and
             // returns the unique `&'a mut [T]` for that allocation. We compute
             // `can_be_removed_if_unused` while the `&mut` is live (reborrowed as
@@ -5405,7 +5409,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.declared_symbols.clear_retaining_capacity();
             self.import_records_for_current_part.clear();
         }
-        Ok(())
+        Ok(appended)
     }
 
     fn binding_can_be_removed_if_unused_without_dce_check(&mut self, binding: Binding) -> bool {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1058,11 +1058,11 @@ impl<'a> Parser<'a> {
                         let should_move = !p.options.bundle && class.class.can_be_moved();
 
                         let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut parts, sliced)?;
+                        let appended = p.append_part(&mut parts, sliced)?;
 
-                        if should_move {
+                        if should_move && appended {
                             // `Part` isn't `Copy`; pop+push instead of last+truncate.
-                            before.push(parts.pop().expect("unreachable"));
+                            before.push(parts.pop().expect("infallible: part was appended"));
                         }
                     }
                     js_ast::StmtData::SExportDefault(value) => {
@@ -1071,10 +1071,10 @@ impl<'a> Parser<'a> {
                         // https://github.com/oven-sh/bun/issues/1961
                         let should_move = !p.options.bundle && value.can_be_moved();
                         let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut parts, sliced)?;
+                        let appended = p.append_part(&mut parts, sliced)?;
 
-                        if should_move {
-                            before.push(parts.pop().expect("unreachable"));
+                        if should_move && appended {
+                            before.push(parts.pop().expect("infallible: part was appended"));
                         }
                     }
                     js_ast::StmtData::SEnum(_) => {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -428,11 +428,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // which is not mutated during the visit pass.
                         let replacer = _ptr.get();
                         if !self.replace_decl_and_possibly_remove(decl, replacer) {
-                            let is_after = self.vis_scope().is_after_const_local_prefix;
-                            self.visit_decl(decl, false, was_const && !is_after, false);
-                        } else {
                             continue 'outer;
                         }
+                        // Replace/Inject gave the decl a value; `visit_decl` requires one.
+                        let is_after = self.vis_scope().is_after_const_local_prefix;
+                        self.visit_decl(decl, false, was_const && !is_after, false);
                     }
                 }
             }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -397,6 +397,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
         }
 
+        // `is_control_flow_dead` is only set above for a non-replace entry. The original
+        // value is gone either way, but `inject` still has to emit its renamed export.
+        macro_rules! inject_default_replacement {
+            () => {
+                if mark_for_replace {
+                    let entry = p
+                        .options
+                        .features
+                        .replace_exports
+                        .get_ptr(b"default")
+                        .cloned()
+                        .expect("infallible: mark_for_replace implies an entry");
+                    let _ =
+                        p.inject_replacement_export(stmts, Ref::NONE, bun_ast::Loc::EMPTY, &entry);
+                }
+            };
+        }
+
         match &mut data.value {
             js_ast::StmtOrExpr::Expr(expr) => {
                 let was_anonymous_named_expr = expr.is_anonymous_named();
@@ -425,6 +443,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.decorator_class_name = prev_decorator_class_name;
 
                 if p.is_control_flow_dead {
+                    inject_default_replacement!();
                     restore_dead!();
                     record_on_exit!();
                     return Ok(());
@@ -607,6 +626,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.react_compiler_candidate_name = None;
 
                         if p.is_control_flow_dead {
+                            inject_default_replacement!();
                             p.react_refresh.hook_ctx_storage = prev;
                             restore_dead!();
                             record_on_exit!();
@@ -777,6 +797,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let _ = p.visit_class(s2_loc, &mut class.class, data.default_name.ref_);
 
                         if p.is_control_flow_dead {
+                            inject_default_replacement!();
                             restore_dead!();
                             record_on_exit!();
                             return Ok(());
@@ -794,7 +815,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 replace_expr,
                             ) = entry
                             {
+                                // The class is discarded, so skip lowering it. Lowering
+                                // reassigns `data.value` and would undo the replacement.
                                 data.value = js_ast::StmtOrExpr::Expr(replace_expr);
+                                stmts.push(*stmt);
                             } else {
                                 let _ = p.inject_replacement_export(
                                     stmts,
@@ -802,10 +826,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     bun_ast::Loc::EMPTY,
                                     &entry,
                                 );
-                                restore_dead!();
-                                record_on_exit!();
-                                return Ok(());
                             }
+
+                            restore_dead!();
+                            record_on_exit!();
+                            return Ok(());
                         }
 
                         if !data.default_name.ref_.is_symbol() {
@@ -884,12 +909,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Function,
     ) -> Result<(), Error> {
-        // We mark it as dead, but the value may not actually be dead
-        // We just want to be sure to not increment the usage counts for anything in the function
-        let mark_as_dead = p.options.features.dead_code_elimination
-            && data.func.flags.contains(flags::Function::IsExport)
+        // `replace_exports` targets module-level exports. A function exported from a
+        // namespace becomes a property of the namespace object, not a module export.
+        let should_replace_export = data.func.flags.contains(flags::Function::IsExport)
+            && p.enclosing_namespace_arg_ref.is_none()
             && p.options.features.replace_exports.count() > 0
             && p.is_export_to_eliminate(data.func.name.expect("infallible: name checked").ref_);
+
+        // We mark it as dead, but the value may not actually be dead
+        // We just want to be sure to not increment the usage counts for anything in the function
+        let mark_as_dead = should_replace_export && p.options.features.dead_code_elimination;
         let original_is_dead = p.is_control_flow_dead;
 
         if mark_as_dead {
@@ -940,13 +969,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ),
                 Expr::init_identifier(func_name.ref_, func_name.loc),
             ));
-        } else if !mark_as_dead {
+        } else if !should_replace_export {
             if remove_overwritten {
                 // restore on early return.
                 p.react_refresh.hook_ctx_storage = prev_hook_storage;
-                if mark_as_dead {
-                    p.is_control_flow_dead = original_is_dead;
-                }
                 return Ok(());
             }
 
@@ -980,21 +1006,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             } else {
                 stmts.push(*stmt);
             }
-        } else if mark_as_dead {
-            if let Some(replacement) = p
-                .options
-                .features
-                .replace_exports
-                .get_ptr(original_name)
-                .cloned()
-            {
-                let _ = p.inject_replacement_export(
-                    stmts,
-                    name_ref,
-                    data.func.name.expect("infallible: name checked").loc,
-                    &replacement,
-                );
-            }
+        } else if let Some(replacement) = p
+            .options
+            .features
+            .replace_exports
+            .get_ptr(original_name)
+            .cloned()
+        {
+            let _ = p.inject_replacement_export(
+                stmts,
+                name_ref,
+                data.func.name.expect("infallible: name checked").loc,
+                &replacement,
+            );
         }
 
         let mut rr: Result<(), Error> = Ok(());
@@ -1041,8 +1065,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Class,
     ) -> Result<(), Error> {
-        let mark_as_dead = p.options.features.dead_code_elimination
-            && data.is_export
+        // `replace_exports` targets module-level exports. A class exported from a
+        // namespace becomes a property of the namespace object, not a module export.
+        let should_replace_export = data.is_export
+            && p.enclosing_namespace_arg_ref.is_none()
             && p.options.features.replace_exports.count() > 0
             && p.is_export_to_eliminate(
                 data.class
@@ -1050,6 +1076,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .expect("infallible: name checked")
                     .ref_,
             );
+
+        // We mark it as dead, but the value may not actually be dead
+        // We just want to be sure to not increment the usage counts for anything in the class
+        let mark_as_dead = should_replace_export && p.options.features.dead_code_elimination;
         let original_is_dead = p.is_control_flow_dead;
 
         if mark_as_dead {
@@ -1067,7 +1097,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Lower class field syntax for browsers that don't support it
         let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
 
-        if !mark_as_dead || was_export_inside_namespace {
+        if !should_replace_export {
             // Lower class field syntax for browsers that don't support it
             stmts.extend_from_slice(lowered);
         } else {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1165,10 +1165,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // visit_decls returns the surviving decl count; truncate `data.decls.len` to it.
         let was_const = data.kind == S::Kind::KConst;
-        let new_len = if !(data.is_export && p.options.features.replace_exports.entries.len() > 0) {
-            p.visit_decls::<false>(data.decls.slice_mut(), was_const)
-        } else {
+        // `replace_exports` targets module-level exports. A declaration exported from a
+        // namespace becomes a property of the namespace object, not a module export.
+        let should_replace_export = data.is_export
+            && p.enclosing_namespace_arg_ref.is_none()
+            && p.options.features.replace_exports.entries.len() > 0;
+        let new_len = if should_replace_export {
             p.visit_decls::<true>(data.decls.slice_mut(), was_const)
+        } else {
+            p.visit_decls::<false>(data.decls.slice_mut(), was_const)
         };
         // Drop the whole statement when every decl was
         // eliminated; otherwise we'd emit an empty `var;`/`let;`/`const;`.

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -397,18 +397,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
         }
 
+        macro_rules! default_replacement_entry {
+            () => {
+                p.options
+                    .features
+                    .replace_exports
+                    .get_ptr(b"default")
+                    .cloned()
+                    .expect("infallible: mark_for_replace implies an entry")
+            };
+        }
+
         // `is_control_flow_dead` is only set above for a non-replace entry. The original
         // value is gone either way, but `inject` still has to emit its renamed export.
         macro_rules! inject_default_replacement {
             () => {
                 if mark_for_replace {
-                    let entry = p
-                        .options
-                        .features
-                        .replace_exports
-                        .get_ptr(b"default")
-                        .cloned()
-                        .expect("infallible: mark_for_replace implies an entry");
+                    let entry = default_replacement_entry!();
                     let _ =
                         p.inject_replacement_export(stmts, Ref::NONE, bun_ast::Loc::EMPTY, &entry);
                 }
@@ -567,13 +572,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if mark_for_replace {
-                    let entry = p
-                        .options
-                        .features
-                        .replace_exports
-                        .get_ptr(b"default")
-                        .cloned()
-                        .unwrap();
+                    let entry = default_replacement_entry!();
                     if let crate::parser::Runtime::ReplaceableExport::Replace(replace_expr) = entry
                     {
                         *expr = replace_expr;
@@ -659,13 +658,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if mark_for_replace {
-                            let entry = p
-                                .options
-                                .features
-                                .replace_exports
-                                .get_ptr(b"default")
-                                .cloned()
-                                .unwrap();
+                            let entry = default_replacement_entry!();
                             if let crate::parser::Runtime::ReplaceableExport::Replace(
                                 replace_expr,
                             ) = entry
@@ -804,13 +797,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if mark_for_replace {
-                            let entry = p
-                                .options
-                                .features
-                                .replace_exports
-                                .get_ptr(b"default")
-                                .cloned()
-                                .unwrap();
+                            let entry = default_replacement_entry!();
                             if let crate::parser::Runtime::ReplaceableExport::Replace(
                                 replace_expr,
                             ) = entry

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1551,6 +1551,134 @@ export default class {
     });
   });
 
+  describe("exports.eliminate/replace do not depend on deadCodeElimination", () => {
+    // Each form: [label, source, eliminate: ["f"], replace: { f: 42 }, replace: { f: ["__N_SSG", true] }]
+    const forms = [
+      [
+        "function declaration",
+        "export function f() {}\nexport const keep = 1;",
+        "export const keep = 1;\n",
+        "export var f = 42;\nexport const keep = 1;\n",
+        "export var __N_SSG = true;\nexport const keep = 1;\n",
+      ],
+      [
+        "class declaration",
+        "export class f {}\nexport const keep = 1;",
+        "export const keep = 1;\n",
+        "export var f = 42;\nexport const keep = 1;\n",
+        "export var __N_SSG = true;\nexport const keep = 1;\n",
+      ],
+      [
+        "const declaration",
+        "export const f = () => {};\nexport const keep = 1;",
+        "export const keep = 1;\n",
+        "export const f = 42;\nexport const keep = 1;\n",
+        "export const __N_SSG = true;\nexport const keep = 1;\n",
+      ],
+      [
+        "export clause",
+        "function f() {}\nexport { f };\nexport const keep = 1;",
+        "function f() {}\nexport const keep = 1;\n",
+        "function f() {}\nexport var f = 42;\nexport const keep = 1;\n",
+        "function f() {}\nexport var __N_SSG = true;\nexport const keep = 1;\n",
+      ],
+    ];
+
+    // `export default <value>` — every value form goes down a different branch.
+    const defaultValues = [
+      ["class", "class X {}"],
+      ["function", "function X() {}"],
+      ["expression", "123"],
+    ];
+
+    for (const deadCodeElimination of [true, false]) {
+      describe(`deadCodeElimination: ${deadCodeElimination}`, () => {
+        it.each(forms)("eliminates an exported %s", (_label, code, eliminated) => {
+          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { eliminate: ["f"] } });
+          expect(transpiler.transformSync(code)).toBe(eliminated);
+          expect(transpiler.scan(code).exports).toEqual(["keep"]);
+        });
+
+        it.each(forms)("replaces an exported %s", (_label, code, _elim, replaced) => {
+          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { replace: { f: 42 } } });
+          expect(transpiler.transformSync(code)).toBe(replaced);
+          expect(transpiler.scan(code).exports).toEqual(["f", "keep"]);
+        });
+
+        it("eliminating a class export keeps the other statements in order", () => {
+          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { eliminate: ["f"] } });
+          expect(transpiler.transformSync("export class f {}")).toBe("");
+          expect(transpiler.transformSync('console.log("a");\nconsole.log("b");\nexport class f {}')).toBe(
+            'console.log("a");\nconsole.log("b");\n',
+          );
+        });
+
+        it.each(forms)("injects a renamed export for an exported %s", (_label, code, _elim, _repl, injected) => {
+          const transpiler = new Bun.Transpiler({
+            loader: "ts",
+            deadCodeElimination,
+            exports: { replace: { f: ["__N_SSG", true] } },
+          });
+          expect(transpiler.transformSync(code)).toBe(injected);
+          expect(transpiler.scan(code).exports).toEqual(["__N_SSG", "keep"]);
+        });
+
+        it.each(defaultValues)("eliminates a default-exported %s", (_label, value) => {
+          const transpiler = new Bun.Transpiler({
+            loader: "ts",
+            deadCodeElimination,
+            exports: { eliminate: ["default"] },
+          });
+          expect(transpiler.transformSync(`export default ${value};`)).toBe("");
+          // The eliminated part must not steal an unrelated one: statements stay in order.
+          expect(transpiler.transformSync(`console.log("a");\nconsole.log("b");\nexport default ${value};`)).toBe(
+            'console.log("a");\nconsole.log("b");\n',
+          );
+        });
+
+        it.each(defaultValues)("replaces a default-exported %s", (_label, value) => {
+          const transpiler = new Bun.Transpiler({
+            loader: "ts",
+            deadCodeElimination,
+            exports: { replace: { default: 42 } },
+          });
+          expect(transpiler.transformSync(`export default ${value};\nexport const keep = 1;`)).toBe(
+            "export default 42;\nexport const keep = 1;\n",
+          );
+        });
+
+        it.each(defaultValues)("injects a renamed export for a default-exported %s", (_label, value) => {
+          const transpiler = new Bun.Transpiler({
+            loader: "ts",
+            deadCodeElimination,
+            exports: { replace: { default: ["__N_SSG", true] } },
+          });
+          expect(transpiler.transformSync(`export default ${value};\nexport const keep = 1;`)).toBe(
+            "export var __N_SSG = true;\nexport const keep = 1;\n",
+          );
+        });
+      });
+    }
+
+    it("does not touch a namespace member that happens to share the name", () => {
+      const transpiler = new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["f"] } });
+
+      expect(
+        transpiler.transformSync('import g from "g";\nexport namespace N {\n  export function f() {\n    g();\n  }\n}'),
+      ).toBe(
+        'import g from "g";\nexport var N;\n((N) => {\n  function f() {\n    g();\n  }\n  N.f = f;\n})(N ||= {});\n',
+      );
+
+      expect(
+        transpiler.transformSync(
+          'import g from "g";\nexport namespace N {\n  export class f {\n    m() {\n      g();\n    }\n  }\n}',
+        ),
+      ).toBe(
+        'import g from "g";\nexport var N;\n((N) => {\n\n  class f {\n    m() {\n      g();\n    }\n  }\n  N.f = f;\n})(N ||= {});\n',
+      );
+    });
+  });
+
   const bunTranspiler = new Bun.Transpiler({
     loader: "tsx",
     define: {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1658,7 +1658,7 @@ export default class {
           expect(transpiler.scan(source).exports).toEqual(["__N_SSG", "keep"]);
         });
 
-        it.each(hoistable)("eliminates a leading `%s`", async (source, exports) => {
+        it.concurrent.each(hoistable)("eliminates a leading `%s`", async (source, exports) => {
           await using proc = Bun.spawn({
             cmd: [
               bunExe(),
@@ -1671,7 +1671,8 @@ export default class {
             stderr: "pipe",
           });
           const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect({ stdout, exitCode }).toEqual({ stdout: '""', exitCode: 0 });
+          // stderr is asserted so that an abort surfaces its panic trace on failure.
+          expect({ stdout, stderr, exitCode }).toEqual({ stdout: '""', stderr: "", exitCode: 0 });
         });
 
         it("does not touch a namespace member that happens to share the name", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1592,11 +1592,20 @@ export default class {
     // `export default <value>` — each value form takes a different branch of s_export_default.
     const defaultValues = [["class X {}"], ["function X() {}"], ["123"]];
 
-    // These two shapes put the eliminated export first, where hoisting it used to abort the
-    // process. Spawn so an abort surfaces as a failed child instead of taking the runner down.
-    const hoistable = [
+    // A declaration with no initializer is a separate branch of visit_decls.
+    // [kind, replace: { f: 42 }, replace: { f: ["__N_SSG", true] }]
+    const uninitialized = [
+      ["let", "export let f = 42;\n", "export let __N_SSG = true;\n"],
+      ["var", "export var f = 42;\n", "export var __N_SSG = true;\n"],
+    ];
+
+    // Eliminating any of these aborted the process: the hoistable two popped an empty parts
+    // list, the uninitialized one unwrapped a missing value. Spawn so an abort is reported
+    // as a failed child rather than taking the test runner down with it.
+    const aborting = [
       ["export class f {}", { eliminate: ["f"] }],
       ["export default class X {}", { eliminate: ["default"] }],
+      ["export let f;", { eliminate: ["f"] }],
     ];
 
     for (const deadCodeElimination of [true, false]) {
@@ -1658,7 +1667,28 @@ export default class {
           expect(transpiler.scan(source).exports).toEqual(["__N_SSG", "keep"]);
         });
 
-        it.concurrent.each(hoistable)("eliminates a leading `%s`", async (source, exports) => {
+        it.each(uninitialized)("replaces an uninitialized exported %s declaration", (kind, replaced) => {
+          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { replace: { f: 42 } } });
+          const source = `${lead}export ${kind} f;\nexport const keep = 1;`;
+          expect(transpiler.transformSync(source)).toBe(lead + replaced + "export const keep = 1;\n");
+          expect(transpiler.scan(source).exports).toEqual(["f", "keep"]);
+        });
+
+        it.each(uninitialized)(
+          "injects a renamed export for an uninitialized exported %s declaration",
+          (kind, _repl, injected) => {
+            const transpiler = new Bun.Transpiler({
+              loader: "ts",
+              deadCodeElimination,
+              exports: { replace: { f: ["__N_SSG", true] } },
+            });
+            const source = `${lead}export ${kind} f;\nexport const keep = 1;`;
+            expect(transpiler.transformSync(source)).toBe(lead + injected + "export const keep = 1;\n");
+            expect(transpiler.scan(source).exports).toEqual(["__N_SSG", "keep"]);
+          },
+        );
+
+        it.concurrent.each(aborting)("eliminates a lone `%s`", async (source, exports) => {
           await using proc = Bun.spawn({
             cmd: [
               bunExe(),

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1552,131 +1552,154 @@ export default class {
   });
 
   describe("exports.eliminate/replace do not depend on deadCodeElimination", () => {
-    // Each form: [label, source, eliminate: ["f"], replace: { f: 42 }, replace: { f: ["__N_SSG", true] }]
+    // Every source starts with these two statements. An eliminated export used to steal
+    // an unrelated part while hoisting, so asserting the full output also pins the order.
+    const lead = 'console.log("a");\nconsole.log("b");\n';
+
+    // [label, source after `lead`, eliminate: ["f"], replace: { f: 42 }, replace: { f: ["__N_SSG", true] }]
     const forms = [
       [
         "function declaration",
         "export function f() {}\nexport const keep = 1;",
-        "export const keep = 1;\n",
-        "export var f = 42;\nexport const keep = 1;\n",
-        "export var __N_SSG = true;\nexport const keep = 1;\n",
+        lead + "export const keep = 1;\n",
+        lead + "export var f = 42;\nexport const keep = 1;\n",
+        lead + "export var __N_SSG = true;\nexport const keep = 1;\n",
       ],
       [
+        // A class is hoistable, so its replacement lands above `lead`.
         "class declaration",
         "export class f {}\nexport const keep = 1;",
-        "export const keep = 1;\n",
-        "export var f = 42;\nexport const keep = 1;\n",
-        "export var __N_SSG = true;\nexport const keep = 1;\n",
+        lead + "export const keep = 1;\n",
+        "export var f = 42;\n" + lead + "export const keep = 1;\n",
+        "export var __N_SSG = true;\n" + lead + "export const keep = 1;\n",
       ],
       [
         "const declaration",
         "export const f = () => {};\nexport const keep = 1;",
-        "export const keep = 1;\n",
-        "export const f = 42;\nexport const keep = 1;\n",
-        "export const __N_SSG = true;\nexport const keep = 1;\n",
+        lead + "export const keep = 1;\n",
+        lead + "export const f = 42;\nexport const keep = 1;\n",
+        lead + "export const __N_SSG = true;\nexport const keep = 1;\n",
       ],
       [
         "export clause",
         "function f() {}\nexport { f };\nexport const keep = 1;",
-        "function f() {}\nexport const keep = 1;\n",
-        "function f() {}\nexport var f = 42;\nexport const keep = 1;\n",
-        "function f() {}\nexport var __N_SSG = true;\nexport const keep = 1;\n",
+        lead + "function f() {}\nexport const keep = 1;\n",
+        lead + "function f() {}\nexport var f = 42;\nexport const keep = 1;\n",
+        lead + "function f() {}\nexport var __N_SSG = true;\nexport const keep = 1;\n",
       ],
     ];
 
-    // `export default <value>` — every value form goes down a different branch.
-    const defaultValues = [
-      ["class", "class X {}"],
-      ["function", "function X() {}"],
-      ["expression", "123"],
+    // `export default <value>` — each value form takes a different branch of s_export_default.
+    const defaultValues = [["class X {}"], ["function X() {}"], ["123"]];
+
+    // These two shapes put the eliminated export first, where hoisting it used to abort the
+    // process. Spawn so an abort surfaces as a failed child instead of taking the runner down.
+    const hoistable = [
+      ["export class f {}", { eliminate: ["f"] }],
+      ["export default class X {}", { eliminate: ["default"] }],
     ];
 
     for (const deadCodeElimination of [true, false]) {
       describe(`deadCodeElimination: ${deadCodeElimination}`, () => {
-        it.each(forms)("eliminates an exported %s", (_label, code, eliminated) => {
+        it.each(forms)("eliminates an exported %s", (_label, source, eliminated) => {
           const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { eliminate: ["f"] } });
-          expect(transpiler.transformSync(code)).toBe(eliminated);
-          expect(transpiler.scan(code).exports).toEqual(["keep"]);
+          expect(transpiler.transformSync(lead + source)).toBe(eliminated);
+          expect(transpiler.scan(lead + source).exports).toEqual(["keep"]);
         });
 
-        it.each(forms)("replaces an exported %s", (_label, code, _elim, replaced) => {
+        it.each(forms)("replaces an exported %s", (_label, source, _elim, replaced) => {
           const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { replace: { f: 42 } } });
-          expect(transpiler.transformSync(code)).toBe(replaced);
-          expect(transpiler.scan(code).exports).toEqual(["f", "keep"]);
+          expect(transpiler.transformSync(lead + source)).toBe(replaced);
+          expect(transpiler.scan(lead + source).exports).toEqual(["f", "keep"]);
         });
 
-        it("eliminating a class export keeps the other statements in order", () => {
-          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { eliminate: ["f"] } });
-          expect(transpiler.transformSync("export class f {}")).toBe("");
-          expect(transpiler.transformSync('console.log("a");\nconsole.log("b");\nexport class f {}')).toBe(
-            'console.log("a");\nconsole.log("b");\n',
-          );
-        });
-
-        it.each(forms)("injects a renamed export for an exported %s", (_label, code, _elim, _repl, injected) => {
+        it.each(forms)("injects a renamed export for an exported %s", (_label, source, _elim, _repl, injected) => {
           const transpiler = new Bun.Transpiler({
             loader: "ts",
             deadCodeElimination,
             exports: { replace: { f: ["__N_SSG", true] } },
           });
-          expect(transpiler.transformSync(code)).toBe(injected);
-          expect(transpiler.scan(code).exports).toEqual(["__N_SSG", "keep"]);
+          expect(transpiler.transformSync(lead + source)).toBe(injected);
+          expect(transpiler.scan(lead + source).exports).toEqual(["__N_SSG", "keep"]);
         });
 
-        it.each(defaultValues)("eliminates a default-exported %s", (_label, value) => {
+        it.each(defaultValues)("eliminates `export default %s`", value => {
           const transpiler = new Bun.Transpiler({
             loader: "ts",
             deadCodeElimination,
             exports: { eliminate: ["default"] },
           });
-          expect(transpiler.transformSync(`export default ${value};`)).toBe("");
-          // The eliminated part must not steal an unrelated one: statements stay in order.
-          expect(transpiler.transformSync(`console.log("a");\nconsole.log("b");\nexport default ${value};`)).toBe(
-            'console.log("a");\nconsole.log("b");\n',
-          );
+          const source = `${lead}export default ${value};\nexport const keep = 1;`;
+          expect(transpiler.transformSync(source)).toBe(lead + "export const keep = 1;\n");
+          expect(transpiler.scan(source).exports).toEqual(["keep"]);
         });
 
-        it.each(defaultValues)("replaces a default-exported %s", (_label, value) => {
+        it.each(defaultValues)("replaces `export default %s`", value => {
           const transpiler = new Bun.Transpiler({
             loader: "ts",
             deadCodeElimination,
             exports: { replace: { default: 42 } },
           });
-          expect(transpiler.transformSync(`export default ${value};\nexport const keep = 1;`)).toBe(
-            "export default 42;\nexport const keep = 1;\n",
-          );
+          const source = `${lead}export default ${value};\nexport const keep = 1;`;
+          expect(transpiler.transformSync(source)).toBe("export default 42;\n" + lead + "export const keep = 1;\n");
+          expect(transpiler.scan(source).exports).toEqual(["default", "keep"]);
         });
 
-        it.each(defaultValues)("injects a renamed export for a default-exported %s", (_label, value) => {
+        it.each(defaultValues)("injects a renamed export for `export default %s`", value => {
           const transpiler = new Bun.Transpiler({
             loader: "ts",
             deadCodeElimination,
             exports: { replace: { default: ["__N_SSG", true] } },
           });
-          expect(transpiler.transformSync(`export default ${value};\nexport const keep = 1;`)).toBe(
-            "export var __N_SSG = true;\nexport const keep = 1;\n",
+          const source = `${lead}export default ${value};\nexport const keep = 1;`;
+          expect(transpiler.transformSync(source)).toBe(
+            "export var __N_SSG = true;\n" + lead + "export const keep = 1;\n",
+          );
+          expect(transpiler.scan(source).exports).toEqual(["__N_SSG", "keep"]);
+        });
+
+        it.each(hoistable)("eliminates a leading `%s`", async (source, exports) => {
+          await using proc = Bun.spawn({
+            cmd: [
+              bunExe(),
+              "-e",
+              `const t = new Bun.Transpiler(${JSON.stringify({ loader: "ts", deadCodeElimination, exports })});
+               process.stdout.write(JSON.stringify(t.transformSync(${JSON.stringify(source)})));`,
+            ],
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect({ stdout, exitCode }).toEqual({ stdout: '""', exitCode: 0 });
+        });
+
+        it("does not touch a namespace member that happens to share the name", () => {
+          const transpiler = new Bun.Transpiler({ loader: "ts", deadCodeElimination, exports: { eliminate: ["f"] } });
+
+          expect(
+            transpiler.transformSync(
+              'import g from "g";\nexport namespace N {\n  export function f() {\n    g();\n  }\n}',
+            ),
+          ).toBe(
+            'import g from "g";\nexport var N;\n((N) => {\n  function f() {\n    g();\n  }\n  N.f = f;\n})(N ||= {});\n',
+          );
+
+          expect(
+            transpiler.transformSync(
+              'import g from "g";\nexport namespace N {\n  export class f {\n    m() {\n      g();\n    }\n  }\n}',
+            ),
+          ).toBe(
+            'import g from "g";\nexport var N;\n((N) => {\n\n  class f {\n    m() {\n      g();\n    }\n  }\n  N.f = f;\n})(N ||= {});\n',
+          );
+
+          // s_local took the same shortcut: the member and its initializer both vanished.
+          expect(transpiler.transformSync('import g from "g";\nexport namespace N {\n  export const f = g();\n}')).toBe(
+            'import g from "g";\nexport var N;\n((N) => {\n  N.f = g();\n})(N ||= {});\n',
           );
         });
       });
     }
-
-    it("does not touch a namespace member that happens to share the name", () => {
-      const transpiler = new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["f"] } });
-
-      expect(
-        transpiler.transformSync('import g from "g";\nexport namespace N {\n  export function f() {\n    g();\n  }\n}'),
-      ).toBe(
-        'import g from "g";\nexport var N;\n((N) => {\n  function f() {\n    g();\n  }\n  N.f = f;\n})(N ||= {});\n',
-      );
-
-      expect(
-        transpiler.transformSync(
-          'import g from "g";\nexport namespace N {\n  export class f {\n    m() {\n      g();\n    }\n  }\n}',
-        ),
-      ).toBe(
-        'import g from "g";\nexport var N;\n((N) => {\n\n  class f {\n    m() {\n      g();\n    }\n  }\n  N.f = f;\n})(N ||= {});\n',
-      );
-    });
   });
 
   const bunTranspiler = new Bun.Transpiler({


### PR DESCRIPTION
## Repro

```js
const t = new Bun.Transpiler({
  loader: "ts",
  deadCodeElimination: false,
  exports: { eliminate: ["f"] },
});

t.transformSync(`export function f() {}\nexport const keep = 1;`);
// "export function f() {}\nexport const keep = 1;\n"   <- f survives, silently
t.scan(`export function f() {}\nexport const keep = 1;`).exports;
// ["f", "keep"]
```

`export class f {}` behaves the same. `export const f = () => {}` and `export { f }` are eliminated correctly, and everything works once `deadCodeElimination` is turned on. `exports.replace` is ignored in exactly the same cases.

`exports.eliminate`/`exports.replace` is the API frameworks use to strip server-only exports out of client bundles, so the declaration form deciding whether the strip happens means functions and classes, the exports people most expect to strip, survive into the client artifact whenever a tool turns DCE off.

## Cause

`s_function` and `s_class` fold two unrelated decisions into one `mark_as_dead` flag:

```rust
let mark_as_dead = p.options.features.dead_code_elimination
    && data.func.flags.contains(flags::Function::IsExport)
    && p.options.features.replace_exports.count() > 0
    && p.is_export_to_eliminate(data.func.name.unwrap().ref_);
```

It decides both whether to suppress usage counts while visiting the body **and** whether to eliminate or replace the export at all, and it is `&&`-ed with `dead_code_elimination`. The `export const` path (`visit_decls`) and `s_export_default` already keep those separate: the replacement is unconditional, and only `is_control_flow_dead` is gated on DCE.

## Fix

`should_replace_export` no longer looks at `dead_code_elimination`; `mark_as_dead` becomes `should_replace_export && dead_code_elimination`.

Auditing the sibling sites for the same assumption turned up four more bugs in `replace_exports`, all fixed here.

### Namespace members

`should_replace_export` also requires `enclosing_namespace_arg_ref.is_none()`, in all three sites (`s_function`, `s_class`, `s_local`). A declaration exported from a TypeScript namespace is a property of the namespace object, not a module export, and each site got this wrong in its own way when a member happened to share a name with an eliminate/replace target:

```js
const t = new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["f"] } });

t.transformSync(`import g from "g";\nexport namespace N { export function f() { g(); } }`);
// before: "...((N) => {\n  function f() {}\n  N.f = f;\n})(N ||= {});\n"   <- g() gone

t.transformSync(`import g from "g";\nexport namespace N { export const f = g(); }`);
// before: "...((N) => {})(N ||= {});\n"   <- member and its side effect both gone
```

`s_function`/`s_class` marked the body dead while the namespace branch still emitted the statement, so the body came out empty. `s_local` dropped the declaration outright, taking the initializer with it.

### Declarations with no initializer

`visit_decls` handles a decl without an initializer in a separate branch, and that branch read `replace_decl_and_possibly_remove`'s return value with the opposite polarity of the branch right above it. The helper returns `false` for `Delete` (leaving the decl alone) and `true` for `Replace`/`Inject` (which write a value into it), so:

```js
new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["f"] } })
  .transformSync("export let f;");
// panic: called `Option::unwrap()` on a `None` value   <- aborts the process

new Bun.Transpiler({ loader: "ts", exports: { replace: { f: 42 } } })
  .transformSync("export let f;\nexport const keep = 1;");
// "export const keep = 1;\n"   <- f silently dropped instead of `export let f = 42;`
```

`Delete` fell into `visit_decl`, which unwraps `decl.value`; `Replace`/`Inject` took the `continue` arm and threw the rewritten decl away. Matching the polarity of the initialized branch fixes both.

### `export default`

- `export default class X {}` with a replacement value kept the class. `s_export_default` writes the replacement into `data.value`, then the class lowering below reassigns `data.value` and undoes it. The replaced statement is now pushed and the lowering skipped, the same shape the function branch already uses.
- `export default` with an inject entry (`replace: { default: ["__N_SSG", true] }`) emitted nothing when `deadCodeElimination` was on, because the `is_control_flow_dead` check returns before the injection runs. The injection is `Delete`-safe, so it runs on that path too.

### Hoisting

Eliminating a hoistable export now happens with `deadCodeElimination` off as well, which reaches the `parts.pop().expect("unreachable")` in `_parse` that assumes `append_part` appended a part. Without that, `export class f {}` + `eliminate: ["f"]` aborts the process, and a non-leading one silently steals an unrelated part and reorders the output. This PR carries the identical hunk as #33376 (`append_part` reports whether it appended) because the tests here reach that path; if #33376 lands first, this rebases away cleanly.

## Verification

`bun bd test test/bundler/transpiler/transpiler.test.js` — 229 pass, 0 fail. On `main`, 34 of the new assertions fail, each for the right reason:

| case | on `main` |
| --- | --- |
| `export function f(){}` + `eliminate`, DCE off | `f` survives |
| `export class f {}` + `eliminate`, DCE off | `f` survives |
| lone `export class f {}` + `eliminate` | `panic: unreachable`, child aborts |
| `console.log("a");console.log("b");export class f {}` + `eliminate` | prints `b` before `a` |
| `export let f;` + `eliminate` | `panic: called Option::unwrap() on a None value` |
| `export let f;` + `replace` / inject | export silently dropped |
| `export default class X {}` + `replace: { default: 42 }` | class survives |
| `export default X` + `replace: { default: ["__N_SSG", true] }`, DCE on | nothing emitted |
| `export namespace N { export function f(){ g(); } }` + `eliminate` | body emptied |
| `export namespace N { export const f = g(); }` + `eliminate` | member and `g()` gone |

The new block asserts the full matrix: `deadCodeElimination` in `[true, false]` x 4 initialized declaration forms (function, class, const, export clause) x `eliminate` / `replace` / inject, plus uninitialized `let`/`var`, the three `export default` value forms, and the namespace members. Every source leads with two statements so the assertions pin statement order too; every cell's `transformSync` output and `scan().exports` is now identical across both `deadCodeElimination` settings. The three shapes that abort on `main` run in a spawned child so the failure is reported rather than taking the runner down.

<details>
<summary>Wider suites</summary>

```
test/bundler/transpiler/            3862 pass   0 fail   (4204 tests, 19 files)
bundler_edgecase + decorator_metadata + feature_flag   150 pass   0 fail
cargo check -p bun_js_parser        no warnings
```

`test/bundler/transpiler/macro-test.test.ts` is excluded from that count: on a debug build the whole-directory run trips a pre-existing JSC assertion (`ASSERTION FAILED: !m_topGCOwnedDataScope` in `Heap::clearConcurrentRetainedDataIfPossible`), which reproduces on a pristine `main` checkout and is unrelated to this change. The file passes on its own (11/11).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 34 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (897b7f6cc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.11ms]
(pass) Bun.Transpiler > normalizes \r\n [5.72ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.77ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.94ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.44ms]
(pass) Bun.Transpiler > property access inlining > works [2.02ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.90ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.39ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.58ms]
(pass) B
... (truncated)

release without fix: 34 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.09ms]
(pass) Bun.Transpiler > normalizes \r\n [0.12ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.08ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.25ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.22ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.22ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (897b7f6cc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.85ms]
(pass) Bun.Transpiler > normalizes \r\n [6.00ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.25ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.62ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.57ms]
(pass) Bun.Transpiler > property access inlining > works [2.38ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.54ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.51ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.79ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     897b7f6cc4
  features     (none)

22 deps, 106 codegen, 1168 objects in 815ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1231] gen ErrorCode+*.h
[4/1231] gen bindgenv2
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[6/1231] fetch zlib
[zlib] up to date
[7/1231] fetch picohttpparser
[picohttpparser] up to date
[8/1231] fetch libj
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         |  10 +-
 src/js_parser/parse/parse_entry.rs         |  12 +-
 src/js_parser/visit/mod.rs                 |   6 +-
 src/js_parser/visit/visit_stmt.rs          | 128 +++++++++++---------
 test/bundler/transpiler/transpiler.test.js | 182 +++++++++++++++++++++++++++++
 5 files changed, 273 insertions(+), 65 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              4      1      0
src/js_parser/parse/parse_entry.rs              1      2      0
src/js_parser/visit/mod.rs                      4      1      0
src/js_parser/visit/visit_stmt.rs              14     16      0
test/bundler/transpiler/transpiler.test.js      9     13      0
```

</details>

<!-- robobun:evidence:end -->