### PR TITLE
Minify whitespace in the embedded builtin modules

### DIFF
--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -255,15 +255,20 @@ for (const entrypoint of bundledEntryPoints) {
   let defaultRewrite = false;
   captured =
     captured
-      .replace(/\$\$EXPORT\$\$\((.*?)\)\.\$\$EXPORT_END\$\$;?\s*export\s*\{([^}]*)\}\s*;?/, (_m: string, _dflt: string, names: string) => {
-        // The clause is spliced into an object literal, so only plain
-        // identifier names are representable ("a as b" / "default" are not).
-        if (/[^\w$,\s]/.test(names) || /\bas\b|\bdefault\b/.test(names)) {
-          throw new Error(`Builtin Bundler: unsupported export clause \`{${names}}\` in ${file_path}; export plain names only`);
-        }
-        namedRewrite = true;
-        return `return{${names}}`;
-      })
+      .replace(
+        /\$\$EXPORT\$\$\((.*?)\)\.\$\$EXPORT_END\$\$;?\s*export\s*\{([^}]*)\}\s*;?/,
+        (_m: string, _dflt: string, names: string) => {
+          // The clause is spliced into an object literal, so only plain
+          // identifier names are representable ("a as b" / "default" are not).
+          if (/[^\w$,\s]/.test(names) || /\bas\b|\bdefault\b/.test(names)) {
+            throw new Error(
+              `Builtin Bundler: unsupported export clause \`{${names}}\` in ${file_path}; export plain names only`,
+            );
+          }
+          namedRewrite = true;
+          return `return{${names}}`;
+        },
+      )
       .replace(/\$\$EXPORT\$\$\((.*?)\)\.\$\$EXPORT_END\$\$;?/, (_m: string, dflt: string) => {
         defaultRewrite = true;
         return `return ${dflt}`;

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -204,7 +204,7 @@ const config_cli = [
   process.execPath,
   "build",
   ...bundledEntryPoints,
-  ...(debug ? [] : ["--minify-syntax", "--keep-names"]),
+  ...(debug ? [] : ["--minify-syntax", "--minify-whitespace", "--keep-names"]),
   "--root",
   TMP_DIR,
   "--target",
@@ -243,15 +243,36 @@ for (const entrypoint of bundledEntryPoints) {
   let captured = `(function (){${output.replace("// @bun\n", "").trim()}})`;
   let usesDebug = output.includes("$debug_log");
   let usesAssert = output.includes("$assert");
+  // The module's completion value. `export default` becomes the $$EXPORT$$
+  // marker; a module that also has named ESM exports gets a trailing
+  // `export { ... };` right after it, and its completion value is then the
+  // object of those named exports. Neither rewrite may depend on the
+  // printer's whitespace (the release build minifies it), and each records
+  // that it fired so the checks below can prove the output has no marker
+  // and no orphaned export statement left.
+  const hasNamedExports = /\$\$EXPORT_END\$\$;?\s*export\s*\{/.test(captured);
+  let namedRewrite = false;
+  let defaultRewrite = false;
   captured =
     captured
-      .replace(/\$\$EXPORT\$\$\((.*)\).\$\$EXPORT_END\$\$;/, "return $1")
+      .replace(/\$\$EXPORT\$\$\((.*?)\)\.\$\$EXPORT_END\$\$;?\s*export\s*\{([^}]*)\}\s*;?/, (_m: string, _dflt: string, names: string) => {
+        // The clause is spliced into an object literal, so only plain
+        // identifier names are representable ("a as b" / "default" are not).
+        if (/[^\w$,\s]/.test(names) || /\bas\b|\bdefault\b/.test(names)) {
+          throw new Error(`Builtin Bundler: unsupported export clause \`{${names}}\` in ${file_path}; export plain names only`);
+        }
+        namedRewrite = true;
+        return `return{${names}}`;
+      })
+      .replace(/\$\$EXPORT\$\$\((.*?)\)\.\$\$EXPORT_END\$\$;?/, (_m: string, dflt: string) => {
+        defaultRewrite = true;
+        return `return ${dflt}`;
+      })
       .replace(/]\s*,\s*__(debug|assert)_end__\)/g, ")")
       .replace(/]\s*,\s*__debug_end__\)/g, ")")
       .replace(/import.meta.require\((.*?)\)/g, (expr, specifier) => {
         throw new Error(`Builtin Bundler: do not use import.meta.require() (in ${file_path}))`);
       })
-      .replace(/return \$\nexport /, "return")
       .replace(/__intrinsic__/g, "@")
       .replace(/__no_intrinsic__/g, "") + "\n";
   captured = captured.replace(
@@ -268,6 +289,19 @@ for (const entrypoint of bundledEntryPoints) {
   const errors = [...captured.matchAll(/@bundleError\((.*)\)/g)];
   if (errors.length) {
     throw new Error(`Errors in ${entrypoint}:\n${errors.map(x => x[1]).join("\n")}`);
+  }
+  // The rewrites above must actually fire, and the right one: a printer
+  // output shape they no longer recognize would otherwise ship a builtin
+  // that only fails when it is first required (as a SyntaxError inside the
+  // module wrapper).
+  if (!namedRewrite && !defaultRewrite) {
+    throw new Error(`Builtin Bundler: the export marker was not rewritten in ${file_path}`);
+  }
+  if (hasNamedExports && !namedRewrite) {
+    throw new Error(`Builtin Bundler: the named-export clause of ${file_path} was not rewritten`);
+  }
+  if (captured.includes("$$EXPORT$$")) {
+    throw new Error(`Builtin Bundler: an export marker survived in ${file_path}`);
   }
 
   const outputPath = path.join(JS_DIR, file_path);


### PR DESCRIPTION
### What

Release builds now pass `--minify-whitespace` (alongside the existing `--minify-syntax --keep-names`) when bundling the embedded JS builtins in `src/js/**`, and the codegen's export rewrite is made structural instead of whitespace-dependent.

The embedded builtin sources are one of the largest `.rodata` contributors in the binary after the ICU data: they ship syntax-minified but with all whitespace and indentation intact.

| | embedded builtin JS (linux-x64) |
|---|---:|
| before | 1,758,726 B |
| after | 1,392,431 B (**−366,295 B**) |

### The bug this uncovered (fixed here)

The codegen post-processes the bundler's output with regexes that depended on the printer's exact whitespace. For a module with *named* ESM exports, the bundler emits a trailing `export { ... }` after the `$$EXPORT$$` marker, and the old rewrite only recognized the unminified shape (`/return \$\nexport /` — a literal newline and a trailing space). With a whitespace-minified printer that degenerated into `return $export{...}` — a syntax error — in the 7 builtins that have named exports (`internal/http`, `internal/tls`, `internal/linkedlist`, `internal/assert/utils`, `internal/crypto/x509`, `node/_http_incoming`, `internal-for-testing`), each of which would only fail when first `require()`d.

Both rewrites are now one whitespace-independent transform (marker only → `return <default>`; marker + named exports → `return { ...names }`), each records that it fired, and the codegen now **fails the build** if the marker was not rewritten, if a named-export clause was present but not consumed, or if a clause uses a form that cannot be spliced into an object literal (`a as b`, `default`). Previously this whole class of breakage was only observable at runtime, at the first `require()` of the affected builtin.

### Why it's safe

- Bun's error renderer already skips `node:*`/`bun:*` frames when picking a source preview, and the test harness masks frame locations, so nothing in-tree observes builtin line numbers. (User-visible nuance for completeness: builtin frames that appear in `err.stack` strings become `node:x:1:<col>` since each builtin is now one line, and stepping into a builtin in the inspector shows one long line — release builds only, where the source is already syntax-minified.)
- The builtins are already syntax-minified with `--keep-names`, so `Function.name` is unchanged; `Function.prototype.toString()` of a builtin returns the same minified code on one line.
- Debug builds are unchanged (still unminified: they load `build/debug/js/*.js` from disk for hackability).

### Validation

Built with the release minification forced into a debug build, then:
- all 161 generated modules parse and every public builtin `require()`s and evaluates;
- the builtin-heavy suites (`test/js/node/{events,util,path,url,querystring,string_decoder,assert,punycode,readline,os,diagnostics_channel}`, `test/js/web/{console,url,abort}`: 1,954 tests) produce **failure sets identical to an unminified control build** (the same 7 known load-sensitive flakes);
- the release and debug codegen both run clean with the new fired-rewrite assertions;
- a review pass replayed the new rewrite chain over the bundler's real minified and unminified output for all 161 entrypoints and syntax-checked every result.
