### PR TITLE
node:http2: send RST_STREAM when a server stream is reset

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3632,7 +3632,10 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode === HTTP_STATUS_NO_CONTENT ||
       statusCode === HTTP_STATUS_RESET_CONTENT ||
       statusCode === HTTP_STATUS_NOT_MODIFIED ||
-      this.headRequest === true
+      this.headRequest === true ||
+      // end() ran before any HEADERS went out, so _final settled the writable without a frame
+      // and nothing else will end the stream (node: SubmitResponse sets EMPTY_PAYLOAD).
+      (this[bunHTTP2StreamStatus] & StreamState.WritableClosed) !== 0
     ) {
       // When endStream is true the HEADERS frame itself carries END_STREAM
       // and the stream moves to HALF_CLOSED_LOCAL inside native request().

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2038,6 +2038,12 @@ enum StreamState {
   // callback). Until then no 'error' listener can exist, so stream errors must not be emitted:
   // node never constructs the JS stream object before a complete header block arrives.
   Delivered = 1 << 8, // 100000000 = 256
+  // close()/destroy() scheduled an RST_STREAM: it replaces the stream's end-of-stream, so
+  // neither _final nor the last DATA frame may put an END_STREAM on the wire ahead of it.
+  RstPending = 1 << 9, // 1000000000 = 512
+  // The RST_STREAM went to the native side. close() and _destroy() each schedule one, and the
+  // native map-miss fallback would write it again once the first has evicted the stream.
+  RstSubmitted = 1 << 10, // 10000000000 = 1024
 }
 // native.writeStream() return-value flag (mirrors WRITE_FLUSHED_WITHOUT_CALLBACK in
 // h2_frame_parser.rs): the chunk was handed to the socket without queueing and the engine did
@@ -2064,7 +2070,8 @@ function isFinalWrite(stream: Http2Stream, pendingLength: number) {
   return (
     (stream._writableState.ending || stream[kEndingWithChunk] === true) &&
     stream.writableLength === pendingLength &&
-    !stream[bunHTTP2WaitForTrailers]
+    !stream[bunHTTP2WaitForTrailers] &&
+    (stream[bunHTTP2StreamStatus] & StreamState.RstPending) === 0
   );
 }
 
@@ -2204,8 +2211,9 @@ function markStreamClosed(stream: Http2Stream) {
     markWritableDone(stream);
   }
 }
-function rstNextTick(id: number, rstCode: number) {
-  const session = this as Http2Session;
+function rstNextTick(this: Http2Stream, session: Http2Session, id: number, rstCode: number) {
+  if ((this[bunHTTP2StreamStatus] & StreamState.RstSubmitted) !== 0) return;
+  this[bunHTTP2StreamStatus] |= StreamState.RstSubmitted;
   session[bunHTTP2Native]?.rstStream(id, rstCode);
 }
 // node streamOnPause/streamOnResume (lib/internal/http2/core.js): the readable's flow state
@@ -2225,7 +2233,7 @@ function streamOnResume(this: Http2Stream) {
 // A close() on a stream that has not been submitted yet (no id): the RST_STREAM has to follow the
 // HEADERS frame, which is sent when the queued request becomes ready (node's finishCloseStream).
 function sendRstOnReady(this: Http2Stream, session: Http2Session, code: number) {
-  setImmediate(rstNextTick.bind(session, this.id, code));
+  setImmediate(rstNextTick.bind(this, session, this.id, code));
 }
 function uncorkNT(stream: Http2Stream) {
   stream.uncork();
@@ -2537,6 +2545,7 @@ class Http2Stream extends Duplex {
         this.push(null);
       }
       const { ending } = this._writableState;
+      this[bunHTTP2StreamStatus] |= StreamState.RstPending;
       if (!ending) {
         // If the writable side of the Http2Stream is still open, emit the
         // 'aborted' event and set the aborted flag.
@@ -2553,9 +2562,9 @@ class Http2Stream extends Duplex {
         // RST_STREAM has to be sent after the HEADERS frame, once the id is assigned.
         this.once("ready", sendRstOnReady.bind(this, session, code));
       } else if (this.writableFinished || code) {
-        setImmediate(rstNextTick.bind(session, this.#id, code));
+        setImmediate(rstNextTick.bind(this, session, this.#id, code));
       } else {
-        this.once("finish", rstNextTick.bind(session, this.#id, code));
+        this.once("finish", rstNextTick.bind(this, session, this.#id, code));
       }
       // node destroys the stream once both halves have finished; without this a stream closed
       // while idle never emits 'close'.
@@ -2582,6 +2591,7 @@ class Http2Stream extends Duplex {
         this[kAborted] = true;
         this.emit("aborted");
       }
+      this[bunHTTP2StreamStatus] |= StreamState.RstPending;
       // at this state destroyed will be true but we need to close the writable side
       this._writableState.destroyed = false;
       this.end();
@@ -2646,7 +2656,7 @@ class Http2Stream extends Duplex {
       // the deferred rstStream would be a guaranteed no-op host call per request.
       (rstCode !== 0 || (this[bunHTTP2StreamStatus] & StreamState.NativeClosed) === 0)
     ) {
-      setImmediate(rstNextTick.bind(session, this.#id, rstCode));
+      setImmediate(rstNextTick.bind(this, session, this.#id, rstCode));
     }
 
     // Diagnostics channels: published after the stream is closed and destroyed, with the same error
@@ -2687,15 +2697,24 @@ class Http2Stream extends Duplex {
     if (session) {
       const native = session[bunHTTP2Native];
       if (native) {
-        if (this instanceof ServerHttp2Stream && !this.headersSent && (this.id & 1) === 0) {
-          // A locally-pushed (even-id) stream ended before respond() (HEAD/endStream pushes): an
-          // empty DATA frame would precede the response HEADERS on the wire. respond() forces
-          // endStream for these streams, so END_STREAM rides on the HEADERS frame and the
-          // onStreamEnd(5) dispatch completes this callback through markWritableDone.
-          this[bunHTTP2StreamFinal] = callback;
+        if (this instanceof ServerHttp2Stream && !this.headersSent) {
+          // RFC 9113 §8.1: a response begins with HEADERS, so DATA here is a connection error.
+          // A pushed stream (even id) stashes the callback for the respond() that follows; a
+          // client-initiated stream just settles the writable, with any reset already scheduled.
+          if ((this.id & 1) === 0) {
+            this[bunHTTP2StreamFinal] = callback;
+          } else {
+            this[bunHTTP2StreamStatus] |= StreamState.FinalCalled | StreamState.WritableClosed;
+            callback();
+          }
           return;
         }
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
+        if ((this[bunHTTP2StreamStatus] & StreamState.RstPending) !== 0) {
+          this[bunHTTP2StreamStatus] |= StreamState.WritableClosed;
+          callback();
+          return;
+        }
         // When waitForTrailers is active, writing an empty DATA frame with
         // close=true emits a bare empty DATA frame (flags=0) to the wire
         // before the trailer/noTrailers path runs, which then emits ANOTHER
@@ -3320,7 +3339,7 @@ class ServerHttp2Stream extends Http2Stream {
   }
 
   respondWithFile(path, headers, options) {
-    if (this.destroyed) {
+    if (this.destroyed || this.closed || this.session === undefined) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
     if (this.headersSent) throw $ERR_HTTP2_HEADERS_SENT();
@@ -3380,7 +3399,7 @@ class ServerHttp2Stream extends Http2Stream {
         throw err;
       }
     }
-    if (this.destroyed) {
+    if (this.destroyed || this.closed || this.session === undefined) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
     if (this.headersSent) throw $ERR_HTTP2_HEADERS_SENT();
@@ -3507,7 +3526,7 @@ class ServerHttp2Stream extends Http2Stream {
     session[bunHTTP2Native]?.request(this.id, undefined, headers, sensitiveNames);
   }
   respond(headers: any, options?: any) {
-    if (this.destroyed || this.session === undefined) {
+    if (this.destroyed || this.closed || this.session === undefined) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4194,6 +4194,13 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 JSValue::UNDEFINED,
                 JSValue::js_number(old_state as f64),
             );
+        } else if code == ErrorCode::NO_ERROR.0 {
+            // A NO_ERROR reset is a clean end of stream: 'end' then 'close', no 'error'.
+            self.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamEnd,
+                stream_ctx,
+                JSValue::js_number(StreamState::CLOSED as u8 as f64),
+            );
         } else {
             self.dispatch_with_extra(
                 JSH2FrameParser::Gc::onStreamError,

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1440,6 +1440,30 @@ describe("server stream reset (RFC 9113 §6.4)", () => {
     }
   });
 
+  test.each([
+    ["in the same tick", (stream: any, respond: () => void) => respond()],
+    ["on a later turn", (stream: any, respond: () => void) => void stream.once("finish", respond)],
+  ])("respond() after end() %s ends the stream on its HEADERS frame", async (_when, schedule) => {
+    // end() first left the stream open with nothing sent, so the HEADERS frame is the only one
+    // that can still carry END_STREAM. Without it the peer gets a response that never finishes.
+    const closed = Promise.withResolvers<void>();
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.on("close", closed.resolve);
+      stream.end();
+      schedule(stream, () => stream.respond({ ":status": 200 }));
+    });
+    try {
+      const headers = await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      expect(headers.flags & 0x1).toBe(0x1);
+      await closed.promise;
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(c.frames.filter(f => f.streamId === 1).map(f => f.type)).toEqual([FrameType.HEADERS]);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("destroy() mid-body sends RST_STREAM(NO_ERROR) rather than a clean end-of-stream", async () => {
     const { c, cleanup } = await resetServer("GET", stream => {
       stream.respond({ ":status": 200 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -8,10 +8,12 @@
 // WINDOW_UPDATE, frame-size and stream-id rules. HPACK/HEADERS cases live in a sibling file.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, gcTick, normalizeBunSnapshot, tempDir } from "harness";
 import { once } from "node:events";
+import fs from "node:fs";
 import http2 from "node:http2";
 import net from "node:net";
+import path from "node:path";
 import { Writable } from "node:stream";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
@@ -1289,6 +1291,302 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   });
 });
 
+describe("server stream reset (RFC 9113 §6.4)", () => {
+  /** A one-shot h2c server plus a raw client that has handshaken and sent one request. */
+  async function resetServer(method: "GET" | "POST", onStream: (stream: any) => void) {
+    const server = http2.createServer();
+    server.on("stream", (stream: any) => {
+      stream.on("error", () => {});
+      onStream(stream);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    // A GET ends the request body, so the server stream is half-closed (remote); a POST leaves it
+    // open. Closing the local half lands them in different states, so both are covered.
+    c.sendFrame(FrameType.HEADERS, method === "GET" ? 0x4 | 0x1 : 0x4, 1, requestHeaderBlock(method));
+    return {
+      c,
+      cleanup() {
+        c.destroy();
+        server.close();
+      },
+    };
+  }
+
+  const endStreamOnStream1 = (f: Frame) => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0;
+
+  test("close(code) mid-body sends RST_STREAM rather than a clean end-of-stream", async () => {
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.respond({ ":status": 200 });
+      stream.write("partial");
+      stream.close(ErrorCode.INTERNAL_ERROR);
+    });
+    try {
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.INTERNAL_ERROR);
+      // An END_STREAM ahead of the reset tells the peer the aborted response completed.
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("close(code) while the request body is still open does not also end the stream cleanly", async () => {
+    const { c, cleanup } = await resetServer("POST", stream => {
+      stream.respond({ ":status": 200 });
+      stream.write("partial");
+      stream.close(ErrorCode.INTERNAL_ERROR);
+    });
+    try {
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.INTERNAL_ERROR);
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("close(code) before respond() sends RST_STREAM and nothing else", async () => {
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.close(ErrorCode.REFUSED_STREAM);
+    });
+    try {
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.REFUSED_STREAM);
+      // A bare DATA frame with no HEADERS ahead of it is not a response, it is a protocol error.
+      expect(c.frames.find(f => f.streamId === 1 && f.type !== FrameType.RST_STREAM)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test.each([
+    [ErrorCode.NO_ERROR, "NO_ERROR"],
+    [ErrorCode.CANCEL, "CANCEL"],
+    [ErrorCode.INTERNAL_ERROR, "INTERNAL_ERROR"],
+  ])("close(%i) before respond() writes the reset exactly once", async code => {
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.close(code);
+    });
+    try {
+      await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      // close() and _destroy each schedule an rstNextTick; the second must not reach the wire via
+      // the native map-miss fallback. A PING round-trip flushes whatever the deferred tick queued.
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      const onStream1 = c.frames.filter(f => f.streamId === 1);
+      expect(onStream1.map(f => ({ type: f.type, code: f.payload.readUInt32BE(0) }))).toEqual([
+        { type: FrameType.RST_STREAM, code },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("close(code) with a chunk still buffered does not end the stream on that chunk", async () => {
+    // The second write is still queued in the Writable when close() runs, so it reaches _write
+    // as the writable's last chunk, which would otherwise carry END_STREAM.
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.respond({ ":status": 200 });
+      stream.write("aaaa");
+      stream.write("bbbb");
+      stream.close(ErrorCode.INTERNAL_ERROR);
+    });
+    try {
+      await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      const resets = c.frames.filter(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(resets.map(f => f.payload.readUInt32BE(0))).toEqual([ErrorCode.INTERNAL_ERROR]);
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("destroy() after close(NO_ERROR) still resets a stream whose body cannot finish", async () => {
+    // close(NO_ERROR) waits for 'finish' before resetting. The body is larger than the flow-control
+    // window the client never reopens, so 'finish' cannot come and destroy() has to send the reset.
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.respond({ ":status": 200 });
+      stream.write(Buffer.alloc(200_000, 0x61));
+      stream.close(ErrorCode.NO_ERROR);
+      stream.destroy();
+    });
+    try {
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("end() without respond() sends nothing on the stream", async () => {
+    // A response MUST begin with a HEADERS frame: _final on a server stream that never sent one
+    // has no frame it is allowed to write. node's shutdown is a no-op in nghttp2 here.
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.end();
+    });
+    try {
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(c.frames.filter(f => f.streamId === 1)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("destroy() mid-body sends RST_STREAM(NO_ERROR) rather than a clean end-of-stream", async () => {
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.respond({ ":status": 200 });
+      stream.write("partial");
+      stream.destroy();
+    });
+    try {
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // `end(body)` with the body larger than the 65535-byte flow-control window leaves DATA queued,
+  // so the writable side is ending but `_final` has not run. Resetting from there must still not
+  // let a clean end-of-stream escape once the queue drains.
+  test.each([
+    ["close", ErrorCode.INTERNAL_ERROR, (stream: any) => stream.close(ErrorCode.INTERNAL_ERROR)],
+    ["destroy", ErrorCode.NO_ERROR, (stream: any) => stream.destroy()],
+  ])("%s after end(body) resets the stream with data still queued", async (_name, expected, reset) => {
+    const { c, cleanup } = await resetServer("GET", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(Buffer.alloc(200_000, 0x61));
+      reset(stream);
+    });
+    try {
+      // The client never sends WINDOW_UPDATE, so the tail of the body stays queued.
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(expected);
+      expect(c.frames.find(endStreamOnStream1)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("every response entry point refuses a closed stream", async () => {
+    using dir = tempDir("h2-closed-stream", { "body.txt": "hello" });
+    const body = path.join(String(dir), "body.txt");
+    const entryPoints: Array<[string, (stream: any) => void]> = [
+      ["respond", stream => stream.respond({ ":status": 200 })],
+      ["respondWithFile", stream => stream.respondWithFile(body, { ":status": 200 })],
+      [
+        "respondWithFD",
+        stream => {
+          const fd = fs.openSync(body, "r");
+          try {
+            stream.respondWithFD(fd, { ":status": 200 });
+          } finally {
+            // The guard throws before respondWithFD takes ownership of the descriptor.
+            fs.closeSync(fd);
+          }
+        },
+      ],
+      ["additionalHeaders", stream => stream.additionalHeaders({ ":status": 103 })],
+    ];
+
+    const codes: Record<string, string | undefined> = {};
+    for (const [name, send] of entryPoints) {
+      const { c, cleanup } = await resetServer("GET", stream => {
+        stream.close(ErrorCode.REFUSED_STREAM);
+        try {
+          send(stream);
+        } catch (e: any) {
+          codes[name] = e.code;
+        }
+      });
+      try {
+        await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+        // The reset is all the peer gets: a closed stream emits no HEADERS and no DATA.
+        expect(c.frames.find(f => f.streamId === 1 && f.type !== FrameType.RST_STREAM)).toBeUndefined();
+      } finally {
+        cleanup();
+      }
+    }
+
+    expect(codes).toEqual({
+      respond: "ERR_HTTP2_INVALID_STREAM",
+      respondWithFile: "ERR_HTTP2_INVALID_STREAM",
+      respondWithFD: "ERR_HTTP2_INVALID_STREAM",
+      additionalHeaders: "ERR_HTTP2_INVALID_STREAM",
+    });
+  });
+
+  test("an inbound RST_STREAM(NO_ERROR) ends the client stream cleanly", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      const events: string[] = [];
+      let error: any;
+      for (const ev of ["end", "close"] as const) req.on(ev, () => events.push(ev));
+      req.on("error", (e: any) => (error = e));
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      // The peer resets the stream with NO_ERROR before any response: a clean close, so the
+      // readable side still ends. Destroying on the reset would swallow 'end' and hang readers.
+      raw.sendFrame(FrameType.RST_STREAM, 0, 1, Buffer.alloc(4));
+      // once() rejects on 'error', which is the point: no error may fire for a NO_ERROR reset.
+      await once(req, "close");
+      expect({ events, code: error?.code, rstCode: req.rstCode }).toEqual({
+        events: ["end", "close"],
+        code: undefined,
+        rstCode: ErrorCode.NO_ERROR,
+      });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a response the server aborted reaches the client as an error, not a complete 200", async () => {
+    const server = http2.createServer();
+    server.on("stream", (stream: any) => {
+      stream.on("error", () => {});
+      stream.respond({ ":status": 200 });
+      stream.write("partial");
+      stream.close(ErrorCode.INTERNAL_ERROR);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      let error: any;
+      let body = "";
+      req.on("error", (e: any) => (error = e));
+      req.on("data", (d: Buffer) => (body += d));
+      // `once()` rejects on 'error', and the error here is the thing under test.
+      await new Promise<void>(resolve => req.on("close", resolve));
+      expect({ code: error?.code, rstCode: req.rstCode, body }).toEqual({
+        code: "ERR_HTTP2_STREAM_ERROR",
+        rstCode: ErrorCode.INTERNAL_ERROR,
+        body: "partial",
+      });
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+});
+
 // A stream nothing references any more can still survive a bounded number of collections: JSC scans
 // the machine stack conservatively and honors interior pointers, so a stale word left in a native
 // frame (seen on x64 as cell+0x84 in the microtask-drain frames; near-deterministic on aarch64) pins
@@ -1418,12 +1716,13 @@ describe("inbound stream lifecycle", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The RST_STREAM(NO_ERROR) closes the stream cleanly, so the later client.destroy() has
+    // nothing left to cancel: no 'error' precedes 'close'.
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
       "wantTrailers id=1
       toString:start
       toString:end
       sendTrailers:returned
-      req error ERR_HTTP2_STREAM_CANCEL
       req close"
     `);
     expect(proc.signalCode).toBeNull();


### PR DESCRIPTION
### Problem

- `stream.close(errorCode)` on a `node:http2` server never sends `RST_STREAM`. The abort goes out as a clean `END_STREAM`, so the client reads an aborted response as complete. For `respond(); write(x); close(INTERNAL_ERROR)`, node sends `HEADERS DATA RST_STREAM(2)`. Bun sends `HEADERS DATA DATA+END_STREAM`.
- `close()` calls `this.end()` before it schedules the reset. The writable side then announces end-of-stream, from `_final` or from `isFinalWrite()` on a buffered chunk. That takes the native stream to `CLOSED`, where the reset is dropped.

### Fix

- `close()` and `_destroy()` set `StreamState.RstPending` first. `_final` then settles without `END_STREAM`, and `isFinalWrite()` does not let a buffered chunk carry it.
- Reset submission is first-wins per stream (`RstSubmitted`). `close()` and `_destroy()` each schedule one and neither stands down, so a `destroy()` that pre-empts `close(NO_ERROR)`'s `'finish'` still resets.
- A server stream that never sent HEADERS writes nothing from `_final`, and a `respond()` after that puts `END_STREAM` on its HEADERS. `respond`, `respondWithFile`, `respondWithFD` throw on a closed stream. An inbound `RST_STREAM(NO_ERROR)` gives the client `'end'` before `'close'`. All as node does.
- Verified: `test/js/node/http2/h2-conformance.test.ts` (17 new tests). The 279 vendored `node:http2` tests pass. Wire output matches node v26.3.0 across 29 scenarios.

### Background

- HTTP/2 ends a stream with `END_STREAM` (complete) or `RST_STREAM` plus an error code (aborted). Without the second, a peer cannot tell a truncated body from a whole one.
- `Http2Stream` is a `Duplex`. `end()` makes the stream machinery call `_final`, where bun writes an empty `DATA+END_STREAM`. `isFinalWrite()` puts the flag on the last real DATA frame instead.
- A server stream for a `GET` starts `HALF_CLOSED_REMOTE`, so `END_STREAM` closes it fully, and `rstStream` on a `CLOSED` native stream is a no-op.

<details><summary>Notes</summary>

**Duplicate reset.** After a reset the native side evicts the stream from its map. `rstStream` for an id it does not know writes the frame directly (that path exists for pushed streams), which is how a second scheduled reset became a second frame on the wire. Hence `RstSubmitted`.

**RFC.** "Writes nothing from `_final`" is RFC 9113 §8.1: a response begins with HEADERS, so a DATA frame there is a connection error on the peer.


**POST streams.** On a stream whose request body is still open the reset did go out before this change, behind a spurious `END_STREAM`. That is why node's own `test-http2-server-rst-stream.js` passes on `main`: its client never ends the body.

**Other suites.** `test/js/node/http2/` is 534 pass plus 5s timeouts in `DATA frame header straddling the cork flush` and, on some runs, the `forEachStream` rehash test. Both fail 3/3 on `main`'s `src/` in the same container, so they are debug+ASAN slowness there. Of the vendored tests, `test-http2-forget-closed-streams.js` (10,000 sequential requests) takes 133 to 148s on a loaded host, against 147 to 155s on `main`'s `src/`.

**A bare `end()` with no `respond()`** leaves the stream open, as in node: nothing on the wire, no `'close'`, and `session.close()` does not complete while it is outstanding. `main` closed it only by writing a DATA frame with no HEADERS ahead of it, which an nghttp2-based peer treats as a connection error. Node supports `end()` followed by `respond()` (`SubmitResponse` sets `EMPTY_PAYLOAD` when the stream is no longer writable), so the stream must stay usable.


**Wire comparison against node v26.3.0** (raw-frame observer, server under test, hand-rolled client). `main` is canary `4ff919377`.

| server does | node | main | this PR |
| --- | --- | --- | --- |
| `write` + `close(2)` | `DATA RST(2)` | `DATA DATA+END_STREAM` | `DATA RST(2)` |
| `write` + `close(2)`, POST | `DATA RST(2)` | `DATA DATA+END_STREAM RST(2)` | `DATA RST(2)` |
| `write` + `close(0)` | `DATA RST(0)` | `DATA DATA+END_STREAM RST(0)` | `DATA RST(0)` |
| `write a` + `write b` + `close(2)` | `DATA RST(2)` | `DATA DATA+END_STREAM` | `DATA DATA RST(2)` |
| `close(2)` before `respond` | `RST(2)` | `DATA+END_STREAM` (no HEADERS) | `RST(2)` |
| `close()` before `respond` | `RST(0)` | `DATA+END_STREAM RST(0)` | `RST(0)` |
| `end()` before `respond` | nothing | `DATA+END_STREAM` (no HEADERS) | nothing |
| `end()` then `respond()` | `HEADERS+END_STREAM` | `DATA+END_STREAM` then `HEADERS`, or `respond()` throws | `HEADERS+END_STREAM` |
| `write` + `destroy()` | `DATA RST(0)` | `DATA RST(0)` | `DATA RST(0)` |
| `write` + `destroy(err)` | `DATA RST(2)` | `DATA RST(2)` | `DATA RST(2)` |
| `write` + `close(2)` + `destroy()` | `DATA RST(2)` | `DATA RST(2)` | `DATA RST(2)` |
| `end(200KB)` + `close(2)` | `DATA(65535) RST(2)` | same | same |
| `end(200KB)` + `destroy()` | `DATA(65535) RST(0)` | same | same |
| `write(200KB)` + `close(0)` + `destroy()` | `DATA(65535) RST(0)` | same | same |
| `end("done")` | `DATA+END_STREAM` | same | same |
| `write` + `end(chunk)` | `DATA DATA+END_STREAM` | same | same |

With two buffered writes node drops the second chunk and bun flushes it before the reset. The reset is what matters to the peer, and it is there.

**Two deliberate divergences from node.**

- `close(code)` with nothing queued to write. Node's `SubmitRstStream` flushes pending DATA before it submits the reset ([nodejs/node#35695](https://github.com/nodejs/node/issues/35695)). When `_final`'s shutdown has already queued the end-of-stream, that flush sends it and nghttp2 then suppresses the reset. So node answers `respond(); close(INTERNAL_ERROR)` with a clean 200 and no reset. Bun sends the reset.
- `stream.end(body); stream.close(INTERNAL_ERROR)` in the same tick still emits the end-of-stream, because `end(body)` has already put `END_STREAM` on its DATA frame. Node defers serialization and can still retract it. This PR does not change that, and the body is complete in that case either way.

**Snapshot change.** The inline snapshot in the re-entrant `toString` fixture loses its `req error ERR_HTTP2_STREAM_CANCEL` line. The fixture feeds the client a `RST_STREAM(NO_ERROR)`, which is now the clean close it should have been, so the later `client.destroy()` has nothing left to cancel. The test still asserts `signalCode` and the exit code, which is the use-after-free property it guards.

**Rebase.** This was rebased across about 1350 commits on `main`, which had reworked the http2 write path (deferred write completion, `EndStreamSent`). `RstPending` moved to `1 << 9`. The `writeHead()` guard left the diff because `main` landed it on its own. The `isFinalWrite()` guard and the first-wins reset are new in the rebase: the first path did not exist before, and the second replaces a dedup that could drop the reset.

**Overlap.** #33375 touches the same `_final` block for a different reason (`respond()` whose HEADERS carries `END_STREAM`). It is still open. Whichever lands second needs a small rebase.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 7 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [572.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [153.51ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [148.68ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [79.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [60.03ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [54.65ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [66.76ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 14 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [11.33ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [3.62ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [3.11ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.57ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.24ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.27ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.26ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.00ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.02ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [606.58ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [207.17ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [157.05ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [73.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [63.87ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [57.04ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [63.39ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 945ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (14778ms)
Bundle modules (87ms)
Postprocesss modules (163ms)
Bundle Functions (594ms)
Generate Code (53ms)

[15.69s] Bundled "src/js" for production
  2596 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  56 +++--
 src/runtime/api/bun/h2_frame_parser.rs    |   7 +
 test/js/node/http2/h2-conformance.test.ts | 327 +++++++++++++++++++++++++++++-
 3 files changed, 371 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          22     19     45
src/runtime/api/bun/h2_frame_parser.rs        10      4     46
test/js/node/http2/h2-conformance.test.ts      4     12     42
```

</details>

<!-- robobun:evidence:end -->