### PR TITLE
Inline lowering helpers when the output can't import bun:wrap

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2429,6 +2429,16 @@ declare module "bun" {
     macro?: MacroMap;
 
     autoImportJSX?: boolean;
+
+    /**
+     * Let the transpiler import its lowering helpers (decorators, `using`) from
+     * `"bun:wrap"` instead of inlining them into the output.
+     *
+     * `"bun:wrap"` only resolves inside Bun, so leave this off (the default)
+     * when the output runs somewhere else.
+     *
+     * @default false
+     */
     allowBunRuntime?: boolean;
     exports?: {
       eliminate?: string[];

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3204,6 +3204,7 @@ pub use lexer_log::LexerLog;
 pub mod lexer_tables;
 pub mod nodes;
 pub mod runtime;
+pub mod runtime_inline;
 
 pub mod ast_result;
 pub mod import_record;

--- a/src/ast/runtime_inline.rs
+++ b/src/ast/runtime_inline.rs
@@ -1,0 +1,287 @@
+//! Self-contained JavaScript source for the runtime helpers that lowering can
+//! emit when no bundling step will inline `bun:wrap` for us.
+//!
+//! `Bun.Transpiler` and `bun build --no-bundle` hand their output to another
+//! runtime, so `import { __using } from "bun:wrap"` is unloadable there. For
+//! those callers the printer emits `var __using_<hash> = <source>;` instead,
+//! using the sources below.
+//!
+//! Each one mirrors its definition in `src/runtime.js` (`__using` /
+//! `__callDispose` mirror `RUNTIME_USING_OTHER` in `src/bundler/ParseTask.rs`,
+//! the variant that does not assume `Symbol.dispose` or `SuppressedError`
+//! exist) with its internal dependencies inlined, so nothing leaks a bare
+//! `__defProp`-style name into the user's scope. Keep them in sync.
+
+/// JavaScript for the value of `name`, or `None` when the helper has no
+/// standalone definition.
+///
+/// Only the helpers that lowering can reach without a bundler need an entry:
+/// legacy/TC39 decorators and `using`. The rest (`__require`, `__export`, …)
+/// are only produced by the bundler, which links the real runtime module.
+pub fn source(name: &[u8]) -> Option<&'static str> {
+    Some(match name {
+        b"__legacyDecorateClassTS" => LEGACY_DECORATE_CLASS_TS,
+        b"__legacyDecorateParamTS" => LEGACY_DECORATE_PARAM_TS,
+        b"__legacyMetadataTS" => LEGACY_METADATA_TS,
+        b"__decoratorStart" => DECORATOR_START,
+        b"__decoratorMetadata" => DECORATOR_METADATA,
+        b"__decorateElement" => DECORATE_ELEMENT,
+        b"__runInitializers" => RUN_INITIALIZERS,
+        b"__privateIn" => PRIVATE_IN,
+        b"__privateGet" => PRIVATE_GET,
+        b"__privateAdd" => PRIVATE_ADD,
+        b"__privateSet" => PRIVATE_SET,
+        b"__privateMethod" => PRIVATE_METHOD,
+        b"__using" => USING,
+        b"__callDispose" => CALL_DISPOSE,
+        _ => return None,
+    })
+}
+
+const LEGACY_DECORATE_CLASS_TS: &str = r#"function (decorators, target, key, desc) {
+  var c = arguments.length,
+    r = c < 3 ? target : desc === null ? (desc = Object.getOwnPropertyDescriptor(target, key)) : desc,
+    d;
+  if (typeof Reflect === "object" && typeof Reflect.decorate === "function")
+    r = Reflect.decorate(decorators, target, key, desc);
+  else
+    for (var i = decorators.length - 1; i >= 0; i--)
+      if ((d = decorators[i])) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+  return (c > 3 && r && Object.defineProperty(target, key, r), r);
+}"#;
+
+const LEGACY_DECORATE_PARAM_TS: &str =
+    "(index, decorator) => (target, key) => decorator(target, key, index)";
+
+const LEGACY_METADATA_TS: &str = r#"(k, v) => {
+  if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+}"#;
+
+const DECORATOR_START: &str = r#"base => [, , , Object.create(base?.[Symbol.metadata || Symbol.for("Symbol.metadata")] ?? null)]"#;
+
+const DECORATOR_METADATA: &str = r#"(array, target) => {
+  var key = Symbol.metadata || Symbol.for("Symbol.metadata");
+  return key in target
+    ? Object.defineProperty(target, key, { enumerable: true, configurable: true, writable: true, value: array[3] })
+    : (target[key] = array[3]);
+}"#;
+
+const RUN_INITIALIZERS: &str = r#"(array, flags, self, value) => {
+  for (var i = 0, fns = array[flags >> 1], n = fns && fns.length; i < n; i++)
+    flags & 1 ? fns[i].call(self) : (value = fns[i].call(self, value));
+  return value;
+}"#;
+
+const PRIVATE_IN: &str = r#"(member, obj) => {
+  if (Object(obj) !== obj) throw TypeError('Cannot use the "in" operator on this value');
+  return member.has(obj);
+}"#;
+
+const PRIVATE_GET: &str = r#"(obj, member, getter) => {
+  if (!member.has(obj)) throw TypeError("Cannot read from private field");
+  return getter ? getter.call(obj) : member.get(obj);
+}"#;
+
+const PRIVATE_ADD: &str = r#"(obj, member, value) => {
+  if (member.has(obj)) throw TypeError("Cannot add the same private member more than once");
+  return member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+}"#;
+
+const PRIVATE_SET: &str = r#"(obj, member, value, setter) => {
+  if (!member.has(obj)) throw TypeError("Cannot write to private field");
+  return setter ? setter.call(obj, value) : member.set(obj, value), value;
+}"#;
+
+const PRIVATE_METHOD: &str = r#"(obj, member, method) => {
+  if (!member.has(obj)) throw TypeError("Cannot access private method");
+  return method;
+}"#;
+
+const USING: &str = r#"(() => {
+  var __dispose = Symbol.dispose || Symbol.for("Symbol.dispose"),
+    __asyncDispose = Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose");
+  return (stack, value, async) => {
+    if (value != null) {
+      if (typeof value !== "object" && typeof value !== "function")
+        throw TypeError('Object expected to be assigned to "using" declaration');
+      var dispose;
+      if (async) dispose = value[__asyncDispose];
+      if (dispose === void 0) dispose = value[__dispose];
+      if (typeof dispose !== "function") throw TypeError("Object not disposable");
+      stack.push([async, dispose, value]);
+    } else if (async) {
+      stack.push([async]);
+    }
+    return value;
+  };
+})()"#;
+
+const CALL_DISPOSE: &str = r#"(stack, error, hasError) => {
+  var E =
+      typeof SuppressedError === "function"
+        ? SuppressedError
+        : function (e, s, m, _) {
+            return (_ = Error(m)), (_.name = "SuppressedError"), (_.error = e), (_.suppressed = s), _;
+          },
+    fail = e =>
+      (error = hasError ? new E(e, error, "An error was suppressed during disposal") : ((hasError = true), e)),
+    next = it => {
+      while ((it = stack.pop())) {
+        try {
+          var result = it[1] && it[1].call(it[2]);
+          if (it[0]) return Promise.resolve(result).then(next, e => (fail(e), next()));
+        } catch (e) {
+          fail(e);
+        }
+      }
+      if (hasError) throw error;
+    };
+  return next();
+}"#;
+
+const DECORATE_ELEMENT: &str = r#"(() => {
+  var __defProp = Object.defineProperty,
+    __getOwnPropDesc = Object.getOwnPropertyDescriptor,
+    __knownSymbol = (name, symbol) => ((symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name)),
+    __typeError = msg => {
+      throw TypeError(msg);
+    },
+    __defNormalProp = (obj, key, value) =>
+      key in obj
+        ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value })
+        : (obj[key] = value),
+    __name = (target, name) => (
+      __defProp(target, "name", { value: name, enumerable: false, configurable: true }), target
+    ),
+    __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg),
+    __privateIn = (member, obj) =>
+      Object(obj) !== obj ? __typeError('Cannot use the "in" operator on this value') : member.has(obj),
+    __privateGet = (obj, member, getter) => (
+      __accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj)
+    ),
+    __privateSet = (obj, member, value, setter) => (
+      __accessCheck(obj, member, "write to private field"),
+      setter ? setter.call(obj, value) : member.set(obj, value),
+      value
+    ),
+    __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method),
+    __decoratorStrings = ["class", "method", "getter", "setter", "accessor", "field", "value", "get", "set"],
+    __expectFn = fn => (fn !== void 0 && typeof fn !== "function" ? __typeError("Function expected") : fn),
+    __decoratorContext = (kind, name, done, metadata, fns) => ({
+      kind: __decoratorStrings[kind],
+      name,
+      metadata,
+      addInitializer: fn => (done._ ? __typeError("Already initialized") : fns.push(__expectFn(fn || null))),
+    }),
+    __decoratorMetadata = (array, target) => __defNormalProp(target, __knownSymbol("metadata"), array[3]);
+  return (array, flags, name, decorators, target, extra) => {
+    var fn,
+      it,
+      done,
+      ctx,
+      access,
+      k = flags & 7,
+      s = !!(flags & 8),
+      p = !!(flags & 16);
+    var j = k > 3 ? array.length + 1 : k ? (s ? 1 : 2) : 0,
+      key = __decoratorStrings[k + 5];
+    var initializers = k > 3 && (array[j - 1] = []),
+      extraInitializers = array[j] || (array[j] = []);
+    var desc =
+      k &&
+      (!p && !s && (target = target.prototype),
+      k < 5 &&
+        (k > 3 || !p) &&
+        __getOwnPropDesc(
+          k < 4
+            ? target
+            : {
+                get [name]() {
+                  return __privateGet(this, extra);
+                },
+                set [name](x) {
+                  __privateSet(this, extra, x);
+                },
+              },
+          name,
+        ));
+    k ? p && k < 4 && __name(extra, (k > 2 ? "set " : k > 1 ? "get " : "") + name) : __name(target, name);
+
+    for (var i = decorators.length - 1; i >= 0; i--) {
+      ctx = __decoratorContext(k, name, (done = {}), array[3], extraInitializers);
+
+      if (k) {
+        ((ctx.static = s),
+          (ctx.private = p),
+          (access = ctx.access = { has: p ? x => __privateIn(target, x) : x => name in x }));
+        if (k ^ 3)
+          access.get = p
+            ? x => (k ^ 1 ? __privateGet : __privateMethod)(x, target, k ^ 4 ? extra : desc.get)
+            : x => x[name];
+        if (k > 2)
+          access.set = p ? (x, y) => __privateSet(x, target, y, k ^ 4 ? extra : desc.set) : (x, y) => (x[name] = y);
+      }
+
+      it = (0, decorators[i])(
+        k ? (k < 4 ? (p ? extra : desc[key]) : k > 4 ? void 0 : { get: desc.get, set: desc.set }) : target,
+        ctx,
+      );
+      done._ = 1;
+
+      if (k ^ 4 || it === void 0)
+        __expectFn(it) && (k > 4 ? initializers.unshift(it) : k ? (p ? (extra = it) : (desc[key] = it)) : (target = it));
+      else if (typeof it !== "object" || it === null) __typeError("Object expected");
+      else
+        (__expectFn((fn = it.get)) && (desc.get = fn),
+          __expectFn((fn = it.set)) && (desc.set = fn),
+          __expectFn((fn = it.init)) && initializers.unshift(fn));
+    }
+
+    return (
+      k || __decoratorMetadata(array, target),
+      desc && __defProp(target, name, desc),
+      p ? (k ^ 4 ? extra : desc) : target
+    );
+  };
+})()"#;
+
+#[cfg(test)]
+mod tests {
+    use super::source;
+
+    /// Every helper legacy/TC39 decorator and `using` lowering can reach
+    /// without a bundler must have a standalone definition, otherwise the
+    /// printer falls back to the unloadable `bun:wrap` import.
+    #[test]
+    fn every_transform_only_helper_has_a_source() {
+        for name in [
+            &b"__legacyDecorateClassTS"[..],
+            b"__legacyDecorateParamTS",
+            b"__legacyMetadataTS",
+            b"__decoratorStart",
+            b"__decoratorMetadata",
+            b"__decorateElement",
+            b"__runInitializers",
+            b"__privateIn",
+            b"__privateGet",
+            b"__privateAdd",
+            b"__privateSet",
+            b"__privateMethod",
+            b"__using",
+            b"__callDispose",
+        ] {
+            assert!(
+                source(name).is_some(),
+                "{} has no inline source",
+                core::str::from_utf8(name).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn bundler_only_helpers_have_no_source() {
+        assert!(source(b"__require").is_none());
+        assert!(source(b"__export").is_none());
+        assert!(source(b"__reExport").is_none());
+    }
+}

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2465,6 +2465,7 @@ impl<'a> Transpiler<'a> {
                 minify_syntax: self.options.minify_syntax,
                 minify_identifiers: self.options.minify_identifiers,
                 transform_only: self.options.transform_only,
+                inline_runtime_helpers: !self.options.allow_runtime,
                 print_dce_annotations: self.options.emit_dce_annotations,
                 runtime_transpiler_cache,
                 hmr_ref: ast.wrapper_ref,
@@ -2500,6 +2501,7 @@ impl<'a> Transpiler<'a> {
             minify_syntax: self.options.minify_syntax,
             minify_identifiers: self.options.minify_identifiers,
             transform_only: self.options.transform_only,
+            inline_runtime_helpers: !self.options.allow_runtime,
             import_meta_ref: ast.import_meta_ref,
             print_dce_annotations: self.options.emit_dce_annotations,
             runtime_transpiler_cache,
@@ -2580,6 +2582,7 @@ impl<'a> Transpiler<'a> {
             minify_syntax: self.options.minify_syntax,
             minify_identifiers: self.options.minify_identifiers,
             transform_only: self.options.transform_only,
+            inline_runtime_helpers: !self.options.allow_runtime,
             module_type: if IS_BUN && self.options.transform_only {
                 // this is for when using `bun build --no-bundle`
                 // it should copy what was passed for the cli

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1289,6 +1289,10 @@ pub struct Options<'a> {
     pub print_dce_annotations: bool,
 
     pub transform_only: bool,
+    /// Print the `bun:wrap` helpers as local `var` declarations instead of an
+    /// import. Set when the output is handed to a runtime that cannot resolve
+    /// `bun:wrap` because no bundling step will inline it.
+    pub inline_runtime_helpers: bool,
     pub inline_require_and_import_errors: bool,
     pub has_run_symbol_renamer: bool,
 
@@ -1365,6 +1369,7 @@ impl<'a> Default for Options<'a> {
             minify_syntax: false,
             print_dce_annotations: true,
             transform_only: false,
+            inline_runtime_helpers: false,
             inline_require_and_import_errors: true,
             has_run_symbol_renamer: false,
             require_or_import_meta_for_source_callback: RequireOrImportMetaCallback::default(),
@@ -1993,6 +1998,43 @@ pub mod __gated_printer {
                 unreachable!();
             }
             self.print_internal_bun_import(import, Some(b"globalThis.Bun"));
+        }
+
+        /// Print `import { __x as __x_hash } from "bun:wrap"` as
+        /// `var __x_hash = <helper source>;`, one declaration per clause item.
+        ///
+        /// Returns false without printing anything when a helper has no
+        /// standalone source, so the caller prints the import statement.
+        fn print_inlined_runtime_helpers(&mut self, import: &S::Import) -> bool {
+            let items = slice_of(import.items);
+            if items.is_empty() || import.default_name.is_some() || !import.star_name_loc.is_empty()
+            {
+                return false;
+            }
+
+            if items
+                .iter()
+                .any(|item| bun_ast::runtime_inline::source(item.alias.slice()).is_none())
+            {
+                return false;
+            }
+
+            for (i, item) in items.iter().enumerate() {
+                let source =
+                    bun_ast::runtime_inline::source(item.alias.slice()).expect("checked above");
+                if i > 0 {
+                    // The caller already printed these for the first declaration.
+                    self.print_indent();
+                    self.print_space_before_identifier();
+                }
+                self.print_semicolon_if_needed();
+                self.print(b"var ");
+                self.print_symbol(item.name.ref_);
+                self.print_equals();
+                self.print(source.as_bytes());
+                self.print_semicolon_after_statement();
+            }
+            true
         }
 
         fn print_internal_bun_import(
@@ -6081,6 +6123,16 @@ pub mod __gated_printer {
                             self.prev_stmt_tag = new_tag;
                             return Ok(());
                         }
+                    }
+
+                    // `generate_import_stmt` is the only producer of the
+                    // `runtime` namespace, so this is the `bun:wrap` import.
+                    if self.options.inline_runtime_helpers
+                        && record.path.namespace == b"runtime"
+                        && self.print_inlined_runtime_helpers(s)
+                    {
+                        self.prev_stmt_tag = new_tag;
+                        return Ok(());
                     }
 
                     if record.path.is_disabled {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -183,6 +183,9 @@ export var __merge = (props, defaultProps) => {
       : __mergeDefaultProps(props, defaultProps);
 };
 
+// The decorator and `using` helpers below are mirrored (with their internal
+// dependencies inlined) in src/ast/runtime_inline.rs, which the printer emits
+// directly when the output cannot import "bun:wrap". Keep both in sync.
 export var __legacyDecorateClassTS = function (decorators, target, key, desc) {
   var c = arguments.length,
     r = c < 3 ? target : desc === null ? (desc = Object.getOwnPropertyDescriptor(target, key)) : desc,

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -98,6 +98,9 @@ impl Default for Config {
             log: bun_ast::Log::default(), // overwritten at construction
             runtime: Runtime::Features {
                 top_level_await: true,
+                // `bun:wrap` only resolves inside Bun, and this output is handed
+                // to another runtime. `allowBunRuntime: true` opts back in.
+                allow_runtime: false,
                 ..Default::default()
             },
             tree_shaking: false,
@@ -337,8 +340,6 @@ impl Config {
                 }
             }
         }
-
-        self.runtime.allow_runtime = false;
 
         if let Some(macros) = object.get_truthy(global, "macro")? {
             'macros: {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1084,6 +1084,10 @@ impl JSTranspiler {
             transpiler.options.minify_identifiers = true;
         }
 
+        // Reads the target-derived default, not `allowBunRuntime`. Assigning
+        // `allow_runtime` first would make this true for every `Bun.Transpiler`,
+        // which flips `module_type` to `output_format` for `target: "bun"` and
+        // stops `import.meta.main` lowering to `require.main == module`.
         transpiler.options.transform_only = !transpiler.options.allow_runtime;
 
         transpiler.options.tree_shaking = config.tree_shaking;

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -1005,24 +1005,27 @@ describe("bundler", () => {
     },
     keepNames: true,
   });
+  // `captureFile` matches its marker as a plain substring, so the decorator is
+  // named `capture` rather than esbuild's `dec`: the latter also matches the
+  // `decorators` / `Reflect.decorate` inside the inlined lowering helpers.
   itBundled("ts/TypeScriptDecoratorScopeESBuildIssue2147", {
     files: {
       "/entry.ts": /* ts */ `
         class Foo {
-          method1(@dec(foo) foo = 2) {}
-          method2(@dec(() => foo) foo = 3) {}
+          method1(@capture(foo) foo = 2) {}
+          method2(@capture(() => foo) foo = 3) {}
         }
 
         class Bar {
           static x = class {
             static y = () => {
-              @dec(bar)
-              @dec(() => bar)
+              @capture(bar)
+              @capture(() => bar)
               class Baz {
-                @dec(bar) method1() {}
-                @dec(() => bar) method2() {}
-                method3(@dec(() => bar) bar) {}
-                method4(@dec(() => bar) bar) {}
+                @capture(bar) method1() {}
+                @capture(() => bar) method2() {}
+                method3(@capture(() => bar) bar) {}
+                method4(@capture(() => bar) bar) {}
               }
               return Baz
             }
@@ -1034,7 +1037,7 @@ describe("bundler", () => {
     },
     bundling: false,
     onAfterBundle(api) {
-      const capturedCalls = api.captureFile("/out.js", "dec");
+      const capturedCalls = api.captureFile("/out.js");
       expect(capturedCalls).toEqual([
         "foo",
         "() => foo",

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -144,7 +144,46 @@ __bun_temp_ref_6$ && await __bun_temp_ref_6$;
 `;
 
 exports[`Bun.Transpiler using top level 1`] = `
-"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+"var __callDispose = (stack, error, hasError) => {
+  var E =
+      typeof SuppressedError === "function"
+        ? SuppressedError
+        : function (e, s, m, _) {
+            return (_ = Error(m)), (_.name = "SuppressedError"), (_.error = e), (_.suppressed = s), _;
+          },
+    fail = e =>
+      (error = hasError ? new E(e, error, "An error was suppressed during disposal") : ((hasError = true), e)),
+    next = it => {
+      while ((it = stack.pop())) {
+        try {
+          var result = it[1] && it[1].call(it[2]);
+          if (it[0]) return Promise.resolve(result).then(next, e => (fail(e), next()));
+        } catch (e) {
+          fail(e);
+        }
+      }
+      if (hasError) throw error;
+    };
+  return next();
+};
+var __using = (() => {
+  var __dispose = Symbol.dispose || Symbol.for("Symbol.dispose"),
+    __asyncDispose = Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose");
+  return (stack, value, async) => {
+    if (value != null) {
+      if (typeof value !== "object" && typeof value !== "function")
+        throw TypeError('Object expected to be assigned to "using" declaration');
+      var dispose;
+      if (async) dispose = value[__asyncDispose];
+      if (dispose === void 0) dispose = value[__dispose];
+      if (typeof dispose !== "function") throw TypeError("Object not disposable");
+      stack.push([async, dispose, value]);
+    } else if (async) {
+      stack.push([async]);
+    }
+    return value;
+  };
+})();
 export function c(e) {
   let __bun_temp_ref_1$ = [];
   try {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4156,6 +4156,19 @@ console.log("boop");
       expect(out).toContain('from "bun:wrap"');
     });
 
+    // A missing options object took an early return past the `allowBunRuntime`
+    // default, so `new Bun.Transpiler()` kept importing the helpers.
+    it.each([
+      ["using", "function f() { using x = a; }"],
+      ["decorators", "function d(x) { return x; }\n@d class Foo { @d m() {} }"],
+    ])("new Bun.Transpiler() inlines %s like new Bun.Transpiler({})", (_, code) => {
+      const noArguments = new Bun.Transpiler().transformSync(code);
+      expect(noArguments).not.toContain("bun:wrap");
+      expect(noArguments).toBe(new Bun.Transpiler({}).transformSync(code));
+      expect(new Bun.Transpiler(undefined).transformSync(code)).toBe(noArguments);
+      expect(new Bun.Transpiler({ allowBunRuntime: true }).transformSync(code)).toContain('from "bun:wrap"');
+    });
+
     it.skipIf(!nodeExe())("transformed output for target node runs under node", async () => {
       const files = {};
       for (const [name, { code, tsconfig }] of Object.entries(cases)) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4070,7 +4070,7 @@ console.log("boop");
     `);
   });
 
-  describe("lowering helpers are inlined instead of imported from bun:wrap", () => {
+  describe.concurrent("lowering helpers are inlined instead of imported from bun:wrap", () => {
     const legacyTsconfig = JSON.stringify({ compilerOptions: { experimentalDecorators: true } });
 
     const cases = {
@@ -4197,6 +4197,152 @@ console.log("boop");
       expect(stderr).not.toContain("error:");
       expect(exitCode).toBe(0);
     });
+
+    // Between them these two exercise every helper in src/ast/runtime_inline.rs,
+    // so a drift from src/runtime.js fails here rather than in someone's output.
+    const equivalenceFixtures = {
+      "legacy decorators": {
+        tsconfig: JSON.stringify({
+          compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+        }),
+        helpers: ["__legacyDecorateClassTS", "__legacyDecorateParamTS", "__legacyMetadataTS"],
+        code: `
+          const order: string[] = [];
+          function cls(target: any) { order.push("cls:" + target.name); return target; }
+          function member(target: any, key: string, desc?: any) { order.push("member:" + key); return desc; }
+          function param(target: any, key: string, i: number) { order.push("param:" + key + ":" + i); }
+          @cls
+          class Legacy {
+            @member prop = 1;
+            @member method(@param arg: number): number { return arg * 2; }
+            @member static staticMethod() { return 3; }
+          }
+          console.log(order.join(","), new Legacy().method(21), Legacy.staticMethod());
+        `,
+      },
+      "tc39 decorators and using": {
+        helpers: [
+          "__callDispose",
+          "__decorateElement",
+          "__decoratorMetadata",
+          "__decoratorStart",
+          "__privateAdd",
+          "__privateGet",
+          "__privateIn",
+          "__privateMethod",
+          "__privateSet",
+          "__runInitializers",
+          "__using",
+        ],
+        code: `
+          const order: string[] = [];
+          let access: any;
+          function dec(value: any, ctx: any) {
+            order.push(ctx.kind + ":" + String(ctx.name) + ":" + !!ctx.private + ":" + !!ctx.static);
+            ctx.metadata.seen = (ctx.metadata.seen ?? 0) + 1;
+            if (ctx.kind === "field") access = ctx.access;
+            if (ctx.kind === "method" && !ctx.private) ctx.addInitializer(function (this: any) { this.tag = "init"; });
+            return value;
+          }
+          class Modern {
+            @dec #field = 1;
+            @dec accessor acc = 2;
+            @dec #priv() { return 3; }
+            @dec get getter() { return 4; }
+            @dec set setter(v: number) {}
+            @dec static stat() { return 5; }
+            @dec method() { return 6; }
+            has(o: any) { return #field in o; }
+            readField() { return this.#field; }
+            writeField(v: number) { this.#field = v; return this.#field; }
+            run() { return this.#priv(); }
+          }
+          const m = new Modern();
+          m.acc = 7;
+          const metadata = (Symbol as any).metadata ?? Symbol.for("Symbol.metadata");
+          console.log(order.join("|"));
+          console.log(m.method(), m.run(), m.getter, m.acc, Modern.stat(), (m as any).tag);
+          console.log(m.has(m), m.has({}), access.get(m), m.readField(), m.writeField(9));
+          console.log(JSON.stringify((Modern as any)[metadata]));
+
+          const log: string[] = [];
+          function make(n: string) { return { [Symbol.dispose]() { log.push(n); } }; }
+          function body() {
+            using a = make("a");
+            using b = make("b");
+            log.push("body");
+          }
+          body();
+          async function asyncBody() {
+            await using a = { async [Symbol.asyncDispose]() { log.push("async-a"); } };
+            log.push("async-body");
+          }
+          await asyncBody();
+          try {
+            (function () {
+              using x = { [Symbol.dispose]() { throw new Error("dispose"); } };
+              throw new Error("body");
+            })();
+          } catch (e: any) {
+            log.push(e.name + ":" + e.error?.message + ":" + e.suppressed?.message);
+          }
+          try {
+            (function () { using x = 5 as any; })();
+          } catch (e: any) {
+            log.push("not-disposable:" + e.constructor.name);
+          }
+          console.log(log.join(","));
+        `,
+      },
+    };
+
+    const importedRuntimeHelpers = out => {
+      const clause = out.match(/^import \{([\s\S]*?)\} from "bun:wrap";/m);
+      if (!clause) return [];
+      return clause[1]
+        .split(",")
+        .map(entry => entry.trim().split(" as ")[0])
+        .filter(Boolean)
+        .sort();
+    };
+
+    const runUnderBun = async file => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", file],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, exitCode, stderr };
+    };
+
+    for (const [name, { code, tsconfig, helpers }] of Object.entries(equivalenceFixtures)) {
+      it.concurrent(`inlined helpers behave like the bun:wrap ones: ${name}`, async () => {
+        const options = { loader: "ts", target: "node", ...(tsconfig ? { tsconfig } : {}) };
+        const reference = new Bun.Transpiler({ ...options, allowBunRuntime: true }).transformSync(code);
+        const inlined = new Bun.Transpiler(options).transformSync(code);
+
+        // If lowering stops needing a helper (or starts needing a new one), this
+        // list is the place to notice before the equivalence check goes stale.
+        expect(importedRuntimeHelpers(reference)).toEqual(helpers);
+        expect(inlined).not.toContain("bun:wrap");
+
+        using dir = tempDir(`inline-runtime-equivalence`, {
+          "reference.mjs": reference,
+          "inlined.mjs": inlined,
+        });
+        const [fromImport, fromInline] = await Promise.all([
+          runUnderBun(join(String(dir), "reference.mjs")),
+          runUnderBun(join(String(dir), "inlined.mjs")),
+        ]);
+
+        expect(fromImport.stdout).not.toBe("");
+        expect(fromImport.exitCode).toBe(0);
+        expect(fromInline.stdout).toBe(fromImport.stdout);
+        expect(fromInline.exitCode).toBe(0);
+      });
+    }
   });
 });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4138,10 +4138,10 @@ console.log("boop");
             stdout: "pipe",
             stderr: "pipe",
           });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect(stdout).toBe(expectedStdout);
-          expect(stderr).not.toContain("error:");
-          expect(exitCode).toBe(0);
+          // stderr is drained so the child cannot block on a full pipe, but not
+          // asserted on: debug and ASAN builds write benign diagnostics to it.
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect({ stdout, exitCode }).toEqual({ stdout: expectedStdout, exitCode: 0 });
         });
       }
     }
@@ -4187,8 +4187,8 @@ console.log("boop");
           stdout: "pipe",
           stderr: "pipe",
         });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect({ name, stdout, stderr, exitCode }).toEqual({ name, stdout: expectedStdout, stderr: "", exitCode: 0 });
+        const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ name, stdout, exitCode }).toEqual({ name, stdout: expectedStdout, exitCode: 0 });
       }
     });
 
@@ -4204,10 +4204,9 @@ console.log("boop");
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stdout).not.toContain("bun:wrap");
       expect(stdout).toContain("__legacyDecorateClassTS");
-      expect(stderr).not.toContain("error:");
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace, nodeExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -4003,8 +4003,13 @@ console.log("boop");
   const expectCapturePrintedSnapshot = code => {
     const result = parsed(`(async() => {${code}})()`, false, false);
     expect(result).toEndWith("})();\n");
+    // Inlined runtime helpers are printed above the wrapper this test added, so
+    // anchor on the wrapper itself rather than on the first arrow function.
+    const wrapper = "(async () => {";
+    const start = result.lastIndexOf(wrapper);
+    expect(start).toBeGreaterThan(-1);
     const of_relevance = result
-      .slice(result.indexOf("() => {") + 9, result.lastIndexOf("})();") - 1)
+      .slice(start + wrapper.length, result.lastIndexOf("})();") - 1)
       .trim()
       .split("\n")
       .map(x => x.trim())
@@ -4063,6 +4068,135 @@ console.log("boop");
       await using p = await using;
       export var q = r;
     `);
+  });
+
+  describe("lowering helpers are inlined instead of imported from bun:wrap", () => {
+    const legacyTsconfig = JSON.stringify({ compilerOptions: { experimentalDecorators: true } });
+
+    const cases = {
+      "legacy decorators": {
+        tsconfig: legacyTsconfig,
+        code: `
+          const order: string[] = [];
+          function dec(target: any, key?: any, desc?: any) {
+            order.push(key ?? target.name);
+            return desc;
+          }
+          @dec
+          class Legacy {
+            @dec method() { return 21; }
+          }
+          console.log(order.join(","), new Legacy().method() * 2);
+        `,
+        stdout: "method,Legacy 42\n",
+      },
+      "tc39 decorators": {
+        code: `
+          const order: string[] = [];
+          function dec(value: any, ctx: any) {
+            order.push(ctx.kind + ":" + String(ctx.name));
+            return value;
+          }
+          @dec
+          class Modern {
+            @dec accessor field = 1;
+            @dec method() { return 21; }
+          }
+          console.log(order.join(","), new Modern().method() * 2, new Modern().field);
+        `,
+        stdout: "accessor:field,method:method,class:Modern 42 1\n",
+      },
+      "using declarations": {
+        code: `
+          const order: string[] = [];
+          function make(name: string) {
+            return { [Symbol.dispose]() { order.push(name); } };
+          }
+          function body() {
+            using a = make("a");
+            using b = make("b");
+            order.push("body");
+          }
+          body();
+          console.log(order.join(","));
+        `,
+        stdout: "body,b,a\n",
+      },
+    };
+
+    for (const [name, { code, tsconfig, stdout: expectedStdout }] of Object.entries(cases)) {
+      for (const target of ["node", "browser", "bun"]) {
+        it(`${name} (target: ${target})`, async () => {
+          const out = new Bun.Transpiler({ loader: "ts", target, tsconfig }).transformSync(code);
+          expect(out).not.toContain("bun:wrap");
+          expect(out).not.toContain('from "bun:');
+
+          using dir = tempDir(`inline-runtime-${target}`, { "out.mjs": out });
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "run", join(String(dir), "out.mjs")],
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout).toBe(expectedStdout);
+          expect(stderr).not.toContain("error:");
+          expect(exitCode).toBe(0);
+        });
+      }
+    }
+
+    it("allowBunRuntime keeps the bun:wrap import", () => {
+      const out = new Bun.Transpiler({
+        loader: "ts",
+        target: "node",
+        allowBunRuntime: true,
+        tsconfig: legacyTsconfig,
+      }).transformSync(cases["legacy decorators"].code);
+      expect(out).toContain('from "bun:wrap"');
+    });
+
+    it.skipIf(!nodeExe())("transformed output for target node runs under node", async () => {
+      const files = {};
+      for (const [name, { code, tsconfig }] of Object.entries(cases)) {
+        files[`${name.replaceAll(" ", "-")}.mjs`] = new Bun.Transpiler({
+          loader: "ts",
+          target: "node",
+          tsconfig,
+        }).transformSync(code);
+      }
+      using dir = tempDir("inline-runtime-node", files);
+
+      for (const [name, { stdout: expectedStdout }] of Object.entries(cases)) {
+        await using proc = Bun.spawn({
+          cmd: [nodeExe(), join(String(dir), `${name.replaceAll(" ", "-")}.mjs`)],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ name, stdout, stderr, exitCode }).toEqual({ name, stdout: expectedStdout, stderr: "", exitCode: 0 });
+      }
+    });
+
+    it("bun build --no-bundle does not emit a bun:wrap import", async () => {
+      using dir = tempDir("inline-runtime-no-bundle", {
+        "tsconfig.json": legacyTsconfig,
+        "input.ts": cases["legacy decorators"].code,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--no-bundle", "--target=node", "input.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).not.toContain("bun:wrap");
+      expect(stdout).toContain("__legacyDecorateClassTS");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
### What's wrong

`Bun.Transpiler` and `bun build --no-bundle` are the documented way to use Bun's transpiler as a library for code that runs elsewhere. Any input with decorators (NestJS, TypeORM) or a `using` declaration comes back with a `bun:wrap` import, and `bun:wrap` only resolves inside Bun:

```js
const t = new Bun.Transpiler({ loader: "ts", target: "node" });
require("fs").writeFileSync("out.mjs", t.transformSync(`
  function dec(x) { return x; }
  @dec class Foo { @dec m() {} }
`));
```

```js
// out.mjs
import { __legacyDecorateClassTS as __legacyDecorateClassTS_3r173x8m } from "bun:wrap";
...
```

```
$ node out.mjs
TypeError [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported
by the default ESM loader. Received protocol 'bun:'
```

`allowBunRuntime: false` (already the default) does not prevent it, and `bun build --no-bundle --target=node` emits the same import.

### Cause

The parser records every lowering helper it needs in `p.runtime_imports` and then unconditionally synthesizes `import { ... } from "bun:wrap"` for them (`js_parser/parse/parse_entry.rs`, `if p.has_called_runtime`). When bundling, the linker resolves that module and inlines the helpers, so it never reaches the output. Transform-only callers run no linker, so the import survives.

The parser does gate other runtime uses on `allow_runtime` (`transpose_require`, `resolve_common_js_symbols`), just not the ones lowering produces.

### Fix

Add a printer option, `inline_runtime_helpers`, set from `!options.allow_runtime` on the three transform print paths in `bundler/transpiler.rs`. When it's on, the `bun:wrap` import statement prints as one local `var` declaration per clause item instead, with the helper's definition as the initializer:

```js
var __legacyDecorateClassTS_3r173x8m = function (decorators, target, key, desc) { ... };
```

The definitions live in `src/ast/runtime_inline.rs` and mirror `src/runtime.js` (and `RUNTIME_USING_OTHER` in `bundler/ParseTask.rs`, the variant that does not assume `Symbol.dispose` / `SuppressedError` exist) with their internal dependencies inlined, so nothing like a bare `__defProp` lands in the user's scope. The table covers every helper lowering can reach without a bundler:

`__legacyDecorateClassTS` `__legacyDecorateParamTS` `__legacyMetadataTS` `__decoratorStart` `__decoratorMetadata` `__decorateElement` `__runInitializers` `__privateIn` `__privateGet` `__privateAdd` `__privateSet` `__privateMethod` `__using` `__callDispose`

Anything else (`__require`, `__export`, `__reExport`, …) is only produced by the bundler, and the printer falls back to the import if a helper ever shows up without a definition.

`allowBunRuntime: true` keeps the import, which is now a meaningful escape hatch rather than a flag with no effect.

That default also needed moving into `Config::default()`: `Config::from_js` returns early for `undefined`/`null`, so `new Bun.Transpiler()` was skipping the `allow_runtime = false` further down and still emitting the import, while `new Bun.Transpiler({})` inlined. The two forms now produce identical output for every input.

### Blast radius

Only the transform paths change. `allow_runtime` is true for the module loader, `bun run`, `bun test`, and macros; bundling builds its own `js_printer::Options` in `linker_context/postProcessJSChunk.rs` and `LinkerContext.rs`, where the new field defaults to false. The runtime transpiler cache is never attached on an `allow_runtime == false` path, so cached entries stay byte-identical.

### Verification

Added to `test/bundler/transpiler/transpiler.test.js`: legacy decorators, TC39 decorators, and `using` across `target: node | browser | bun`, each asserting the output has no `bun:` import and then running it; `allowBunRuntime: true` still emits the import; the `target: node` output runs under real Node; `bun build --no-bundle --target=node` emits no `bun:wrap`.

Nothing otherwise stops `runtime_inline.rs` from drifting away from `src/runtime.js`, so there is also a differential test: two fixtures are transpiled twice, once with `allowBunRuntime: true` so the helpers come from `bun:wrap` and once inlined, both are run, and their output must be identical. Between them the fixtures pull in every helper in the table (legacy class/method/property/param decorators, `emitDecoratorMetadata`, TC39 class/method/field/accessor/getter/setter decorators on public, private, and static members, `addInitializer`, `ctx.access`, `#x in obj`, `Symbol.metadata`, `using`, `await using`, `SuppressedError` suppression, a non-disposable `using`), and the expected import clause is asserted so a change in what lowering needs surfaces there too. Adding `+ 1` to `__privateGet`'s return makes it fail.

<details>
<summary>Output before and after</summary>

Before:

```js
import { __callDispose as __callDispose_vyva085h, __legacyDecorateClassTS as __legacyDecorateClassTS_3r173x8m, __using as __using_nccbhqtj } from "bun:wrap";
function dec(x) { return x; }
export class Foo { method() {} }
__legacyDecorateClassTS_3r173x8m([dec], Foo.prototype, "method", null);
...
```

After:

```js
var __callDispose_vyva085h = (stack, error, hasError) => {
  var E =
      typeof SuppressedError === "function"
        ? SuppressedError
        : function (e, s, m, _) {
            return (_ = Error(m)), (_.name = "SuppressedError"), (_.error = e), (_.suppressed = s), _;
          },
    ...
};
var __legacyDecorateClassTS_3r173x8m = function (decorators, target, key, desc) {
  var c = arguments.length,
    r = c < 3 ? target : desc === null ? (desc = Object.getOwnPropertyDescriptor(target, key)) : desc,
    d;
  ...
};
var __using_nccbhqtj = (() => { ... })();
function dec(x) { return x; }
export class Foo { method() {} }
__legacyDecorateClassTS_3r173x8m([dec], Foo.prototype, "method", null);
...
```

</details>

### Not changed

`JSTranspiler::constructor` computes `transform_only = !allow_runtime` one line before it assigns `allow_runtime` from `allowBunRuntime`, so it reads the target-derived default. That looks like an ordering bug, but moving the assignment makes `transform_only` true for every `Bun.Transpiler`, which flips `module_type` to `output_format` for `target: "bun"` and stops `import.meta.main` lowering to `require.main == module` in CommonJS input. `transform_only` is otherwise write-only on this path, so I left it alone and added a comment instead of changing behavior nobody asked about.