### PR TITLE
net: deliver the onread option into the user's buffer, bounded and pausable

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -165,6 +165,8 @@ const kBufferGen = Symbol("kBufferGen");
 // Bytes of an already-read chunk the onread callback has not accepted. Set
 // means reads are stopped, the way Node leaves them unread in the kernel.
 const kBufferPending = Symbol("kBufferPending");
+// A FIN that arrived while those bytes were still held back.
+const kBufferEnded = Symbol("kBufferEnded");
 
 function endNT(socket, callback, err) {
   // Node's _final half-closes the writable side (sends FIN) and leaves the
@@ -1057,8 +1059,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (self[kended]) return;
     self[kended] = true;
     if (!self.allowHalfOpen) self.write = writeAfterFIN;
-    self.push(null);
-    self.read(0);
+    endReadableSide(self);
   },
   // See SocketHandlers.session.
   session(socket, session) {
@@ -1112,8 +1113,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     }
     self[kended] = true;
     if (!self.allowHalfOpen) self.write = writeAfterFIN;
-    self.push(null);
-    self.read(0);
+    endReadableSide(self);
     // A write that was waiting on the native drain can never complete once the
     // socket is gone - fail it so 'finish'/destroy are not stuck behind it
     // (mirrors SocketEmitEndNT).
@@ -1321,12 +1321,12 @@ function onreadQueuePending(self, chunk) {
   const pending = self[kBufferPending];
   if (pending.length === 0) {
     self[kBufferPending] = chunk;
-    return;
+  } else if ($isJSArray(pending)) {
+    ArrayPrototypePush.$call(pending, chunk);
+  } else {
+    // Chunks are concatenated once, on flush, rather than on every arrival.
+    self[kBufferPending] = [pending, chunk];
   }
-  const queued = Buffer.allocUnsafe(pending.length + chunk.length);
-  TypedArrayPrototypeSet.$call(queued, pending);
-  TypedArrayPrototypeSet.$call(queued, chunk, pending.length);
-  self[kBufferPending] = queued;
 }
 
 // Reads restart only once the callback has taken the bytes it left behind.
@@ -1335,8 +1335,28 @@ function onreadFlushPending(self) {
   const pending = self[kBufferPending];
   if (!pending) return true;
   self[kBufferPending] = null;
-  if (pending.length === 0 || self.destroyed) return true;
-  return onreadDeliver(self, pending);
+  const bytes = $isJSArray(pending) ? Buffer.concat(pending) : pending;
+  if (bytes.length !== 0 && !self.destroyed && !onreadDeliver(self, bytes)) return false;
+  // A FIN that landed while the callback was stopped ends the readable side
+  // now that it has everything that arrived before it.
+  if (self[kBufferEnded] && !self.destroyed) {
+    self[kBufferEnded] = false;
+    self.push(null);
+    self.read(0);
+  }
+  return true;
+}
+
+// The peer is done sending. An onread callback that stopped reads has not seen
+// the bytes still held for it, and Node would not have read the FIN behind them
+// yet either, so hold the end of the readable side until resume() drains them.
+function endReadableSide(self) {
+  if (onreadIsPaused(self)) {
+    self[kBufferEnded] = true;
+    return;
+  }
+  self.push(null);
+  self.read(0);
 }
 
 // An onread socket never pushes into its readable side: every chunk is handed
@@ -1512,6 +1532,7 @@ function Socket(options?) {
   this[kBufferCb] = null;
   this[kBufferGen] = null;
   this[kBufferPending] = null;
+  this[kBufferEnded] = false;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
@@ -3844,6 +3865,7 @@ function initSocketHandle(self) {
   // Bytes the onread callback never took belong to the connection they arrived
   // on. Node leaves them unread in the closed fd, so a reconnect starts clean.
   self[kBufferPending] = null;
+  self[kBufferEnded] = false;
 
   // Handle creation may be deferred to bind() or connect() time.
   const handle = self._handle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2140,6 +2140,10 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.resume = function resume() {
+  // Node's delivery is asynchronous, so the stream is already flowing by the
+  // time an onread callback can pause it again. Bun's flush below is
+  // synchronous, so claim the flowing side first or it overwrites that pause.
+  const resumed = Duplex.prototype.resume.$call(this);
   // An onread callback that returned false gets the bytes it left behind before
   // reads restart; if it pauses again, the handle stays stopped.
   if (onreadFlushPending(this)) {
@@ -2155,7 +2159,7 @@ Socket.prototype.resume = function resume() {
       this[kPausedUnref] = false;
     }
   }
-  return Duplex.prototype.resume.$call(this);
+  return resumed;
 };
 
 Socket.prototype.pause = function pause() {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -39,12 +39,14 @@ import type { Socket, SocketHandler, SocketListener } from "bun";
 import type { Server as NetServer, Socket as NetSocket, ServerOpts } from "node:net";
 import type { TLSSocket } from "node:tls";
 const { kTimeout, getTimerDuration } = require("internal/timers");
-const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
+const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString, isUint8Array } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypePush = Array.prototype.push;
+const TypedArrayPrototypeSet = Uint8Array.prototype.set;
+const TypedArrayPrototypeSubarray = Uint8Array.prototype.subarray;
 const MathMax = Math.max;
 
 const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
@@ -154,6 +156,15 @@ const kUserUnrefed = Symbol("kUserUnrefed");
 const kPausedUnref = Symbol("kPausedUnref");
 const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
+// The `onread` option's state: the buffer reads are delivered into, the
+// callback they are handed to, and the optional factory that replaces the
+// buffer after every delivery.
+const kBuffer = Symbol("kBuffer");
+const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
+// Bytes of an already-read chunk the onread callback has not accepted. Set
+// means reads are stopped, the way Node leaves them unread in the kernel.
+const kBufferPending = Symbol("kBufferPending");
 
 function endNT(socket, callback, err) {
   // Node's _final half-closes the writable side (sends FIN) and leaves the
@@ -1221,6 +1232,110 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
 };
 
+// Node's factory form hands over a fresh buffer before the first read and
+// after every delivery; a result that is not a Uint8Array leaves the current
+// buffer in place.
+function onreadNextBuffer(self) {
+  const generate = self[kBufferGen];
+  if (generate === null) return self[kBuffer];
+  const buffer = generate();
+  if (isUint8Array(buffer)) self[kBuffer] = buffer;
+  return self[kBuffer];
+}
+
+// Node reads straight into the user's buffer, so the callback always gets that
+// buffer back holding at most buffer.length bytes. Bun is handed its own chunk,
+// so copy it over in buffer-sized slices instead.
+function onreadDeliver(self, chunk) {
+  const total = chunk.length;
+  let offset = 0;
+  let stopped = false;
+  let failure;
+  let failed = false;
+  try {
+    while (offset < total) {
+      let buffer = self[kBuffer];
+      if (buffer === null) {
+        buffer = onreadNextBuffer(self);
+        // A factory that returned something else leaves nothing to read into.
+        if (buffer === null) {
+          stopped = true;
+          break;
+        }
+      }
+      const remaining = total - offset;
+      const length = buffer.length < remaining ? buffer.length : remaining;
+      // A zero-length buffer can never take a byte: hold the chunk rather than
+      // spin, which is what Node's stopped reads amount to.
+      if (length === 0) {
+        stopped = true;
+        break;
+      }
+      TypedArrayPrototypeSet.$call(
+        buffer,
+        length === total ? chunk : TypedArrayPrototypeSubarray.$call(chunk, offset, offset + length),
+      );
+      offset += length;
+      self.bytesRead += length;
+      const result = self[kBufferCb].$call(self, length, buffer);
+      onreadNextBuffer(self);
+      if (result === false) {
+        stopped = true;
+        break;
+      }
+    }
+  } catch (e) {
+    failure = e;
+    failed = true;
+    stopped = true;
+  }
+  self[kBufferPending] = stopped ? TypedArrayPrototypeSubarray.$call(chunk, offset) : null;
+  if (failed) self.emit("error", failure);
+  return !stopped;
+}
+
+// Node's onStreamRead stops the kernel reads (readStop) without touching the
+// Duplex's flowing state; the unref mirrors pause(), since a stopped socket
+// must not hold the event loop open.
+function onreadStop(self) {
+  if (self.destroyed) return;
+  const handle = self._handle;
+  if (!handle) return;
+  handle.pause?.();
+  handle.unref?.();
+  if (!self[kupgraded] || self[kupgraded] instanceof Socket) {
+    self[kPausedUnref] = true;
+  }
+}
+
+function onreadIsPaused(self) {
+  return !!self[kBufferPending];
+}
+
+// Reads restart only once the callback has taken the bytes it left behind.
+// Returns false when it paused again, so the handle stays stopped.
+function onreadFlushPending(self) {
+  const pending = self[kBufferPending];
+  if (!pending) return true;
+  self[kBufferPending] = null;
+  if (pending.length === 0 || self.destroyed) return true;
+  return onreadDeliver(self, pending);
+}
+
+// An onread socket never pushes into its readable side: every chunk is handed
+// to the callback instead, so no 'data' event is ever emitted.
+const SocketHandlersOnRead: typeof SocketHandlers2 = {
+  ...SocketHandlers2,
+  data(socket, chunk) {
+    $debug("Bun.Socket data (onread)");
+    const { self } = socket.data;
+    if (!self) return;
+    self._unrefTimer();
+    if (self.destroyed) return;
+    if (!onreadDeliver(self, chunk)) onreadStop(self);
+  },
+};
+
 // The same table minus the per-connection callback members: a listener whose
 // config has neither handler never registers the native SNI/ALPN dispatches,
 // so a server without an SNICallback or ALPNCallback does not pay a JS
@@ -1371,6 +1486,10 @@ function Socket(options?) {
   this._parentWrap = null;
   this[kpendingRead] = undefined;
   this[kupgraded] = null;
+  this[kBuffer] = null;
+  this[kBufferCb] = null;
+  this[kBufferGen] = null;
+  this[kBufferPending] = null;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
@@ -1448,27 +1567,20 @@ function Socket(options?) {
   if (socket instanceof Socket) {
     this[ksocket] = socket;
   }
-  if (onread) {
-    if (typeof onread !== "object") {
-      throw new TypeError("onread must be an object");
+  // Node ignores an onread option that does not match the documented shape,
+  // leaving the socket to emit 'data' as usual.
+  if (onread !== null && typeof onread === "object") {
+    const { buffer: onreadBuffer, callback: onreadCallback } = onread;
+    if ((isUint8Array(onreadBuffer) || typeof onreadBuffer === "function") && typeof onreadCallback === "function") {
+      if (typeof onreadBuffer === "function") {
+        this[kBufferGen] = onreadBuffer;
+      } else {
+        this[kBuffer] = onreadBuffer;
+      }
+      this[kBufferCb] = onreadCallback;
+      // when the onread option is specified we use a different handlers object
+      this[khandlers] = SocketHandlersOnRead;
     }
-    if (typeof onread.callback !== "function") {
-      throw new TypeError("onread.callback must be a function");
-    }
-    // when the onread option is specified we use a different handlers object
-    this[khandlers] = {
-      ...SocketHandlers2,
-      data(socket, buffer) {
-        const { self } = socket.data;
-        if (!self) return;
-        self._unrefTimer();
-        try {
-          onread.callback(buffer.length, buffer);
-        } catch (e) {
-          self.emit("error", e);
-        }
-      },
-    };
   }
   if (signal) {
     if (signal.aborted) {
@@ -1982,16 +2094,20 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.resume = function resume() {
-  if (!this.connecting) {
-    this._handle?.resume?.();
-  }
-  // Restore the hold pause() removed - even while still connecting, so the
-  // pause-then-resume sequence is symmetric. Gated on the pause flag so a
-  // socket that was never paused (e.g. a wrapped duplex with no fd) is not
-  // newly pinned to the loop.
-  if (this[kPausedUnref] && !this[kUserUnrefed]) {
-    this._handle?.ref?.();
-    this[kPausedUnref] = false;
+  // An onread callback that returned false gets the bytes it left behind before
+  // reads restart; if it pauses again, the handle stays stopped.
+  if (onreadFlushPending(this)) {
+    if (!this.connecting) {
+      this._handle?.resume?.();
+    }
+    // Restore the hold pause() removed - even while still connecting, so the
+    // pause-then-resume sequence is symmetric. Gated on the pause flag so a
+    // socket that was never paused (e.g. a wrapped duplex with no fd) is not
+    // newly pinned to the loop.
+    if (this[kPausedUnref] && !this[kUserUnrefed]) {
+      this._handle?.ref?.();
+      this[kPausedUnref] = false;
+    }
   }
   return Duplex.prototype.resume.$call(this);
 };
@@ -2063,7 +2179,9 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
 };
 
 Socket.prototype.read = function read(size) {
-  if (!this.connecting) {
+  // The Readable machinery drives this from resume(); it must not undo the stop
+  // an onread callback asked for.
+  if (!this.connecting && !onreadIsPaused(this)) {
     this._handle?.resume?.();
     // Restarting kernel reads makes the handle hold the loop open again;
     // mirror resume()'s re-ref or a paused-then-read() socket waits for
@@ -2080,7 +2198,7 @@ Socket.prototype._read = function _read(size) {
   const socket = this._handle;
   if (this.connecting || !socket) {
     this.once("connect", () => this._read(size));
-  } else {
+  } else if (!onreadIsPaused(this)) {
     socket?.resume?.();
     // See read() above - the Readable machinery's pull path must also
     // restore the handle's hold on the loop.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3841,6 +3841,9 @@ function initSocketHandle(self) {
   self._sockname = null;
   self[kclosed] = false;
   self[kended] = false;
+  // Bytes the onread callback never took belong to the connection they arrived
+  // on. Node leaves them unread in the closed fd, so a reconnect starts clean.
+  self[kBufferPending] = null;
 
   // Handle creation may be deferred to bind() or connect() time.
   const handle = self._handle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -47,6 +47,8 @@ const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypePush = Array.prototype.push;
 const TypedArrayPrototypeSet = Uint8Array.prototype.set;
 const TypedArrayPrototypeSubarray = Uint8Array.prototype.subarray;
+// Marks an onread socket as stopped while holding no bytes back.
+const kEmptyBuffer = Buffer.alloc(0);
 const MathMax = Math.max;
 
 const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
@@ -1279,9 +1281,10 @@ function onreadDeliver(self, chunk) {
       self.bytesRead += length;
       const result = self[kBufferCb].$call(self, length, buffer);
       onreadNextBuffer(self);
-      // The callback runs user JS: it may have destroyed the socket, and the
-      // remaining slices of this chunk must not reach it.
-      if (result === false || self.destroyed) {
+      // The callback runs user JS: it may have destroyed or paused the socket,
+      // and the remaining slices of this chunk must not reach it. Reads are
+      // never stopped on entry, so a set kBufferPending means pause() did it.
+      if (result === false || self.destroyed || onreadIsPaused(self)) {
         stopped = true;
         break;
       }
@@ -2168,6 +2171,12 @@ Socket.prototype.pause = function pause() {
     if (!this[kupgraded] || this[kupgraded] instanceof Socket) {
       this[kPausedUnref] = true;
     }
+  }
+  // Node documents pause() as behaving the way returning false does, and its
+  // readStop() stops the next delivery even mid-chunk. Park an onread socket in
+  // the same state, holding nothing yet, so resume() is what restarts it.
+  if (this[kBufferCb] && !onreadIsPaused(this)) {
+    this[kBufferPending] = kEmptyBuffer;
   }
   return Duplex.prototype.pause.$call(this);
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1314,6 +1314,21 @@ function onreadIsPaused(self) {
   return !!self[kBufferPending];
 }
 
+// The TLS read loops keep decrypting and dispatching without re-checking the
+// socket's pause flag, so bytes still arrive after the callback stopped reads.
+// Hold them behind the ones it has not taken instead of dropping them.
+function onreadQueuePending(self, chunk) {
+  const pending = self[kBufferPending];
+  if (pending.length === 0) {
+    self[kBufferPending] = chunk;
+    return;
+  }
+  const queued = Buffer.allocUnsafe(pending.length + chunk.length);
+  TypedArrayPrototypeSet.$call(queued, pending);
+  TypedArrayPrototypeSet.$call(queued, chunk, pending.length);
+  self[kBufferPending] = queued;
+}
+
 // Reads restart only once the callback has taken the bytes it left behind.
 // Returns false when it paused again, so the handle stays stopped.
 function onreadFlushPending(self) {
@@ -1334,6 +1349,11 @@ const SocketHandlersOnRead: typeof SocketHandlers2 = {
     if (!self) return;
     self._unrefTimer();
     if (self.destroyed) return;
+    if (onreadIsPaused(self)) {
+      onreadQueuePending(self, chunk);
+      onreadStop(self);
+      return;
+    }
     if (!onreadDeliver(self, chunk)) onreadStop(self);
   },
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1279,7 +1279,9 @@ function onreadDeliver(self, chunk) {
       self.bytesRead += length;
       const result = self[kBufferCb].$call(self, length, buffer);
       onreadNextBuffer(self);
-      if (result === false) {
+      // The callback runs user JS: it may have destroyed the socket, and the
+      // remaining slices of this chunk must not reach it.
+      if (result === false || self.destroyed) {
         stopped = true;
         break;
       }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3872,8 +3872,10 @@ function initSocketHandle(self) {
   self[kclosed] = false;
   self[kended] = false;
   // Bytes the onread callback never took belong to the connection they arrived
-  // on. Node leaves them unread in the closed fd, so a reconnect starts clean.
-  self[kBufferPending] = null;
+  // on, so a reconnect drops them the way Node drops whatever it left unread in
+  // the fd it closed. A pause() the user never lifted does carry over, which is
+  // what Node's `if (!socket.isPaused()) socket.read(0)` amounts to.
+  self[kBufferPending] = self[kBufferCb] && self.isPaused() ? kEmptyBuffer : null;
   self[kBufferEnded] = false;
 
   // Handle creation may be deferred to bind() or connect() time.

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1106,6 +1106,12 @@ describe("net.Socket onread", () => {
     }
   }
 
+  const listen = (server: Server | import("node:tls").Server) =>
+    new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port));
+    });
+
   // `fail` races the server's errors against the test body, so a server-side
   // failure surfaces as that error instead of hanging on a promise the server
   // can no longer settle.
@@ -1304,11 +1310,7 @@ describe("net.Socket onread", () => {
     let raw: Socket | undefined;
     let socket: import("node:tls").TLSSocket | undefined;
     try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", resolve);
-      });
-      const { port } = server.address() as import("node:net").AddressInfo;
+      const port = await listen(server);
       raw = connect({ port, host: "127.0.0.1" });
       const proxy = new SocketProxy(raw);
 
@@ -1365,6 +1367,66 @@ describe("net.Socket onread", () => {
     }
   });
 
+  // Same transport: the FIN arrives while the callback is stopped, and ending the
+  // readable side there would strand the bytes queued in front of it.
+  it("delays the end of the readable side until the callback takes the held bytes", async () => {
+    const payload = pattern(4096);
+    const server = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, c => {
+      c.on("error", () => {});
+      c.end(payload); // payload and FIN in one go
+    });
+    let raw: Socket | undefined;
+    let socket: import("node:tls").TLSSocket | undefined;
+    try {
+      const port = await listen(server);
+      raw = connect({ port, host: "127.0.0.1" });
+      const proxy = new SocketProxy(raw);
+
+      const buffer = Buffer.alloc(512);
+      const received: Buffer[] = [];
+      let calls = 0;
+      let ended = false;
+      const firstCall = Promise.withResolvers<void>();
+      const endEvent = Promise.withResolvers<void>();
+      socket = tls.connect({
+        socket: proxy,
+        servername: "localhost",
+        rejectUnauthorized: false,
+        onread: {
+          buffer,
+          callback(nread, buf) {
+            calls++;
+            received.push(Buffer.from(buf.subarray(0, nread)));
+            if (calls === 1) {
+              firstCall.resolve();
+              return false;
+            }
+          },
+        },
+      });
+      socket.on("error", err => {
+        firstCall.reject(err);
+        endEvent.reject(err);
+      });
+      socket.on("end", () => {
+        ended = true;
+        endEvent.resolve();
+      });
+
+      await firstCall.promise;
+      for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+      expect({ ended, calls }).toEqual({ ended: false, calls: 1 });
+
+      socket.resume();
+      await endEvent.promise;
+      expect(Buffer.concat(received)).toEqual(payload);
+    } finally {
+      socket?.destroy();
+      raw?.destroy();
+      server.close();
+    }
+  });
+
   it("stops delivering a chunk the moment the callback destroys the socket", async () => {
     const payload = pattern(4096);
     await withServer(
@@ -1414,11 +1476,6 @@ describe("net.Socket onread", () => {
       c.on("error", () => {});
       c.end(second);
     });
-    const listen = (server: Server) =>
-      new Promise<number>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port));
-      });
     try {
       const [portA, portB] = [await listen(serverA), await listen(serverB)];
       const buffer = Buffer.alloc(64);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1285,7 +1285,13 @@ describe("net.Socket onread", () => {
           });
           await firstCall.promise;
           for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
-          expect({ calls, bytesRead: socket.bytesRead }).toEqual({ calls: 1, bytesRead: buffer.length });
+          // How big that one delivery was is up to how the kernel framed the
+          // payload; that there was exactly one of it, and that it counted
+          // towards bytesRead without overrunning the buffer, is not.
+          expect({
+            calls,
+            bytesOutOfRange: socket.bytesRead < 1 || socket.bytesRead > buffer.length,
+          }).toEqual({ calls: 1, bytesOutOfRange: false });
 
           paused = false;
           socket.resume();

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,7 +1,16 @@
 import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  expectMaxObjectTypeCount,
+  isASAN,
+  isDebug,
+  isWindows,
+  tls as tlsCert,
+  tmpdirSync,
+} from "harness";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import {
@@ -17,6 +26,8 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
+import { Duplex } from "node:stream";
+import tls from "node:tls";
 
 const socket_domain = tmpdirSync();
 
@@ -1070,6 +1081,31 @@ describe("net.Socket onread", () => {
     return buf;
   }
 
+  // A generic Duplex in front of a socket, so tls.connect({ socket }) takes the
+  // TLS-over-Duplex path rather than upgrading the native handle.
+  class SocketProxy extends Duplex {
+    constructor(readonly socket: Socket) {
+      super();
+      socket.on("data", chunk => {
+        if (!this.push(chunk)) socket.pause();
+      });
+      socket.on("end", () => this.push(null));
+      socket.on("close", () => this.push(null));
+      socket.on("error", err => this.destroy(err));
+      socket.on("drain", () => this.emit("drain"));
+    }
+    _read() {
+      if (this.socket.isPaused()) this.socket.resume();
+    }
+    _write(chunk: Buffer, encoding: BufferEncoding, callback: (err?: Error | null) => void) {
+      this.socket.write(chunk, encoding, callback);
+    }
+    _final(callback: (err?: Error | null) => void) {
+      this.socket.end();
+      callback();
+    }
+  }
+
   // `fail` races the server's errors against the test body, so a server-side
   // failure surfaces as that error instead of hanging on a promise the server
   // can no longer settle.
@@ -1124,14 +1160,14 @@ describe("net.Socket onread", () => {
           await promise;
           expect({
             sameBuffer,
-            maxNread: Math.max(...nreads),
-            minNread: Math.min(...nreads),
+            // How many deliveries there are and how big each one is depends on
+            // how the kernel frames the payload; the bound does not.
+            outOfRange: nreads.filter(nread => nread < 1 || nread > buffer.length),
             dataEvents,
             payload: Buffer.concat(received),
           }).toEqual({
             sameBuffer: true,
-            maxNread: buffer.length,
-            minNread: payload.length % buffer.length,
+            outOfRange: [],
             dataEvents: 0,
             payload,
           });
@@ -1193,10 +1229,10 @@ describe("net.Socket onread", () => {
           socket.resume();
           await everything.promise;
           expect({
-            maxNread: Math.max(...nreads),
+            outOfRange: nreads.filter(nread => nread < 1 || nread > buffer.length),
             payload: Buffer.concat(received),
           }).toEqual({
-            maxNread: buffer.length,
+            outOfRange: [],
             payload: Buffer.concat([first, second]),
           });
         } finally {
@@ -1253,6 +1289,82 @@ describe("net.Socket onread", () => {
     );
   });
 
+  // TLS over a generic Duplex decrypts and dispatches without re-checking the
+  // socket's pause flag, so a stopped callback can still be handed more bytes.
+  // Those have to queue up behind the ones it never took.
+  it("queues bytes that arrive after the callback stopped reads", async () => {
+    const first = pattern(4096);
+    const second = Buffer.alloc(4096, 0x5a);
+    const secondWritten = Promise.withResolvers<void>();
+    const server = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, c => {
+      c.on("error", () => secondWritten.reject(new Error("server socket errored")));
+      c.write(first);
+      c.on("data", () => c.write(second, () => secondWritten.resolve()));
+    });
+    let raw: Socket | undefined;
+    let socket: import("node:tls").TLSSocket | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const { port } = server.address() as import("node:net").AddressInfo;
+      raw = connect({ port, host: "127.0.0.1" });
+      const proxy = new SocketProxy(raw);
+
+      const buffer = Buffer.alloc(512);
+      const received: Buffer[] = [];
+      const nreads: number[] = [];
+      let calls = 0;
+      let total = 0;
+      const firstCall = Promise.withResolvers<void>();
+      const everything = Promise.withResolvers<void>();
+      socket = tls.connect({
+        socket: proxy,
+        servername: "localhost",
+        rejectUnauthorized: false,
+        onread: {
+          buffer,
+          callback(nread, buf) {
+            calls++;
+            total += nread;
+            nreads.push(nread);
+            received.push(Buffer.from(buf.subarray(0, nread)));
+            if (calls === 1) {
+              firstCall.resolve();
+              return false;
+            }
+            if (total === first.length + second.length) everything.resolve();
+          },
+        },
+      });
+      socket.on("error", err => {
+        firstCall.reject(err);
+        everything.reject(err);
+      });
+
+      await firstCall.promise;
+      socket.write("go");
+      await secondWritten.promise;
+      for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+      expect(calls).toBe(1);
+
+      socket.resume();
+      await everything.promise;
+      expect({
+        outOfRange: nreads.filter(nread => nread < 1 || nread > buffer.length),
+        payload: Buffer.concat(received),
+      }).toEqual({
+        outOfRange: [],
+        payload: Buffer.concat([first, second]),
+      });
+    } finally {
+      socket?.destroy();
+      raw?.destroy();
+      server.close();
+    }
+  });
+
   it("stops delivering a chunk the moment the callback destroys the socket", async () => {
     const payload = pattern(4096);
     await withServer(
@@ -1280,7 +1392,10 @@ describe("net.Socket onread", () => {
         socket.on("close", () => closed.resolve());
         await closed.promise;
         // The remaining slices of that chunk must not reach a destroyed socket.
-        expect(nreads).toEqual([buffer.length]);
+        expect({
+          deliveries: nreads.length,
+          outOfRange: nreads.filter(nread => nread < 1 || nread > buffer.length),
+        }).toEqual({ deliveries: 1, outOfRange: [] });
       },
     );
   });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1400,6 +1400,78 @@ describe("net.Socket onread", () => {
     );
   });
 
+  // Bytes the callback never took belong to the connection they arrived on:
+  // Node leaves them unread in the fd it is about to close.
+  it("does not replay bytes held back from a previous connection", async () => {
+    const first = pattern(4096);
+    const second = Buffer.alloc(256, 0xbb);
+    const serverA = createServer(c => {
+      // The client destroys mid-stream, so an unflushed write reports ECONNRESET.
+      c.on("error", () => {});
+      c.write(first);
+    });
+    const serverB = createServer(c => {
+      c.on("error", () => {});
+      c.end(second);
+    });
+    const listen = (server: Server) =>
+      new Promise<number>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve((server.address() as import("node:net").AddressInfo).port));
+      });
+    try {
+      const [portA, portB] = [await listen(serverA), await listen(serverB)];
+      const buffer = Buffer.alloc(64);
+      const afterReconnect: Buffer[] = [];
+      let reconnected = false;
+      let calls = 0;
+      const firstCall = Promise.withResolvers<void>();
+      const ended = Promise.withResolvers<void>();
+      const socket = new Socket({
+        onread: {
+          buffer,
+          callback(nread, buf) {
+            calls++;
+            if (reconnected) afterReconnect.push(Buffer.from(buf.subarray(0, nread)));
+            if (calls === 1) {
+              // Holds back the rest of the first connection's chunk.
+              firstCall.resolve();
+              return false;
+            }
+          },
+        },
+      });
+      try {
+        socket.on("error", err => {
+          firstCall.reject(err);
+          ended.reject(err);
+        });
+        socket.connect(portA, "127.0.0.1");
+        await firstCall.promise;
+
+        const closed = Promise.withResolvers<void>();
+        socket.once("close", () => closed.resolve());
+        socket.destroy();
+        await closed.promise;
+
+        reconnected = true;
+        socket.once("end", () => ended.resolve());
+        socket.connect(portB, "127.0.0.1");
+        await ended.promise;
+
+        expect({
+          outOfRange: afterReconnect.map(chunk => chunk.length).filter(length => length > buffer.length),
+          payload: Buffer.concat(afterReconnect),
+        }).toEqual({ outOfRange: [], payload: second });
+      } finally {
+        socket.destroy();
+      }
+    } finally {
+      serverA.close();
+      serverB.close();
+    }
+  });
+
   it("ignores an onread option that does not match Node's shape", async () => {
     // Node only installs onread when buffer is a Uint8Array or a function and
     // callback is a function; anything else leaves the socket emitting 'data'.

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1302,8 +1302,17 @@ describe("net.Socket onread", () => {
     const first = pattern(4096);
     const second = Buffer.alloc(4096, 0x5a);
     const secondWritten = Promise.withResolvers<void>();
+    const firstCall = Promise.withResolvers<void>();
+    const everything = Promise.withResolvers<void>();
+    // Nothing tears the connection down mid-stream here, so a server-side error
+    // is a real failure: surface it instead of hanging on a promise it broke.
+    const fail = (err: Error) => {
+      secondWritten.reject(err);
+      firstCall.reject(err);
+      everything.reject(err);
+    };
     const server = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, c => {
-      c.on("error", () => secondWritten.reject(new Error("server socket errored")));
+      c.on("error", fail);
       c.write(first);
       c.on("data", () => c.write(second, () => secondWritten.resolve()));
     });
@@ -1319,8 +1328,6 @@ describe("net.Socket onread", () => {
       const nreads: number[] = [];
       let calls = 0;
       let total = 0;
-      const firstCall = Promise.withResolvers<void>();
-      const everything = Promise.withResolvers<void>();
       socket = tls.connect({
         socket: proxy,
         servername: "localhost",
@@ -1371,8 +1378,16 @@ describe("net.Socket onread", () => {
   // readable side there would strand the bytes queued in front of it.
   it("delays the end of the readable side until the callback takes the held bytes", async () => {
     const payload = pattern(4096);
+    const firstCall = Promise.withResolvers<void>();
+    const endEvent = Promise.withResolvers<void>();
+    // The client only tears down once the body is finished, so a server-side
+    // error is a real failure rather than the expected mid-stream reset.
+    const fail = (err: Error) => {
+      firstCall.reject(err);
+      endEvent.reject(err);
+    };
     const server = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, c => {
-      c.on("error", () => {});
+      c.on("error", fail);
       c.end(payload); // payload and FIN in one go
     });
     let raw: Socket | undefined;
@@ -1386,8 +1401,6 @@ describe("net.Socket onread", () => {
       const received: Buffer[] = [];
       let calls = 0;
       let ended = false;
-      const firstCall = Promise.withResolvers<void>();
-      const endEvent = Promise.withResolvers<void>();
       socket = tls.connect({
         socket: proxy,
         servername: "localhost",
@@ -1404,10 +1417,7 @@ describe("net.Socket onread", () => {
           },
         },
       });
-      socket.on("error", err => {
-        firstCall.reject(err);
-        endEvent.reject(err);
-      });
+      socket.on("error", fail);
       socket.on("end", () => {
         ended = true;
         endEvent.resolve();
@@ -1467,13 +1477,16 @@ describe("net.Socket onread", () => {
   it("does not replay bytes held back from a previous connection", async () => {
     const first = pattern(4096);
     const second = Buffer.alloc(256, 0xbb);
+    const firstCall = Promise.withResolvers<void>();
+    const ended = Promise.withResolvers<void>();
     const serverA = createServer(c => {
       // The client destroys mid-stream, so an unflushed write reports ECONNRESET.
       c.on("error", () => {});
       c.write(first);
     });
     const serverB = createServer(c => {
-      c.on("error", () => {});
+      // Nothing tears this one down early, so an error here is a real failure.
+      c.on("error", err => ended.reject(err));
       c.end(second);
     });
     try {
@@ -1482,8 +1495,6 @@ describe("net.Socket onread", () => {
       const afterReconnect: Buffer[] = [];
       let reconnected = false;
       let calls = 0;
-      const firstCall = Promise.withResolvers<void>();
-      const ended = Promise.withResolvers<void>();
       const socket = new Socket({
         onread: {
           buffer,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1114,21 +1114,18 @@ describe("net.Socket onread", () => {
 
   // `fail` races the server's errors against the test body, so a server-side
   // failure surfaces as that error instead of hanging on a promise the server
-  // can no longer settle.
+  // can no longer settle. The target carries the host the server bound to, so a
+  // connect can never fall back to resolving "localhost".
   async function withServer(
     onConnection: (c: Socket, fail: (err: Error) => void) => void,
-    run: (port: number) => Promise<void>,
+    run: (target: { port: number; host: string }) => Promise<void>,
   ) {
     const failed = Promise.withResolvers<never>();
     failed.promise.catch(() => {}); // an error after the body finished is not a failure
     const server = createServer(c => onConnection(c, failed.reject));
     try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", resolve);
-      });
-      const { port } = server.address() as import("node:net").AddressInfo;
-      await Promise.race([run(port), failed.promise]);
+      const port = await listen(server);
+      await Promise.race([run({ port, host: "127.0.0.1" }), failed.promise]);
     } finally {
       server.close();
     }
@@ -1141,7 +1138,7 @@ describe("net.Socket onread", () => {
         c.on("error", fail);
         c.end(payload);
       },
-      async port => {
+      async target => {
         const buffer = Buffer.alloc(100);
         const received: Buffer[] = [];
         const nreads: number[] = [];
@@ -1149,7 +1146,7 @@ describe("net.Socket onread", () => {
         let sameBuffer = true;
         const { promise, resolve, reject } = Promise.withResolvers<void>();
         const socket = connect({
-          port,
+          ...target,
           onread: {
             buffer,
             callback(nread, buf) {
@@ -1194,7 +1191,7 @@ describe("net.Socket onread", () => {
         c.write(first);
         c.on("data", () => c.write(second, () => secondWritten.resolve()));
       },
-      async port => {
+      async target => {
         const buffer = Buffer.alloc(512);
         const received: Buffer[] = [];
         const nreads: number[] = [];
@@ -1203,7 +1200,7 @@ describe("net.Socket onread", () => {
         const firstCall = Promise.withResolvers<void>();
         const everything = Promise.withResolvers<void>();
         const socket = connect({
-          port,
+          ...target,
           onread: {
             buffer,
             callback(nread, buf) {
@@ -1255,13 +1252,13 @@ describe("net.Socket onread", () => {
         c.on("error", fail);
         c.end(payload);
       },
-      async port => {
+      async target => {
         const generated: Buffer[] = [];
         const delivered: Buffer[] = [];
         const received: Buffer[] = [];
         const { promise, resolve, reject } = Promise.withResolvers<void>();
         const socket = connect({
-          port,
+          ...target,
           onread: {
             buffer() {
               const buf = Buffer.alloc(512);
@@ -1446,12 +1443,12 @@ describe("net.Socket onread", () => {
         c.on("error", () => {});
         c.end(payload);
       },
-      async port => {
+      async target => {
         const buffer = Buffer.alloc(512);
         const nreads: number[] = [];
         const closed = Promise.withResolvers<void>();
         const socket = connect({
-          port,
+          ...target,
           onread: {
             buffer,
             callback(nread) {
@@ -1552,11 +1549,11 @@ describe("net.Socket onread", () => {
         c.on("error", fail);
         c.end(payload);
       },
-      async port => {
+      async target => {
         const chunks: Buffer[] = [];
         let onreadCalls = 0;
         const { promise, resolve, reject } = Promise.withResolvers<void>();
-        const socket = connect({ port, onread: { callback: () => onreadCalls++ } } as any);
+        const socket = connect({ ...target, onread: { callback: () => onreadCalls++ } } as any);
         try {
           socket.on("data", chunk => chunks.push(chunk));
           socket.on("error", reject);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1062,3 +1062,212 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+describe("net.Socket onread", () => {
+  function pattern(length: number) {
+    const buf = Buffer.alloc(length);
+    for (let i = 0; i < length; i++) buf[i] = i & 0xff;
+    return buf;
+  }
+
+  async function withServer(onConnection: (c: Socket) => void, run: (port: number) => Promise<void>) {
+    const server = createServer(onConnection);
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      await run((server.address() as import("node:net").AddressInfo).port);
+    } finally {
+      server.close();
+    }
+  }
+
+  it("hands the callback the user's own buffer, never more than its length", async () => {
+    const payload = pattern(64 * 1024);
+    await withServer(
+      c => {
+        c.on("error", () => {});
+        c.end(payload);
+      },
+      async port => {
+        const buffer = Buffer.alloc(100);
+        const received: Buffer[] = [];
+        const nreads: number[] = [];
+        let dataEvents = 0;
+        let sameBuffer = true;
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        const socket = connect({
+          port,
+          onread: {
+            buffer,
+            callback(nread, buf) {
+              if (buf !== buffer) sameBuffer = false;
+              nreads.push(nread);
+              received.push(Buffer.from(buf.subarray(0, nread)));
+            },
+          },
+        });
+        try {
+          socket.on("data", () => dataEvents++);
+          socket.on("error", reject);
+          socket.on("end", resolve);
+          await promise;
+          expect({
+            sameBuffer,
+            maxNread: Math.max(...nreads),
+            minNread: Math.min(...nreads),
+            dataEvents,
+            payload: Buffer.concat(received),
+          }).toEqual({
+            sameBuffer: true,
+            maxNread: buffer.length,
+            minNread: payload.length % buffer.length,
+            dataEvents: 0,
+            payload,
+          });
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+
+  it("stops reading when the callback returns false, and resumes on resume()", async () => {
+    const first = pattern(4096);
+    const second = Buffer.alloc(4096, 0x5a);
+    const secondWritten = Promise.withResolvers<void>();
+    await withServer(
+      c => {
+        c.on("error", () => {});
+        c.write(first);
+        c.on("data", () => c.write(second, () => secondWritten.resolve()));
+      },
+      async port => {
+        const buffer = Buffer.alloc(512);
+        const received: Buffer[] = [];
+        const nreads: number[] = [];
+        let calls = 0;
+        let total = 0;
+        const firstCall = Promise.withResolvers<void>();
+        const everything = Promise.withResolvers<void>();
+        const socket = connect({
+          port,
+          onread: {
+            buffer,
+            callback(nread, buf) {
+              calls++;
+              total += nread;
+              nreads.push(nread);
+              received.push(Buffer.from(buf.subarray(0, nread)));
+              if (calls === 1) {
+                firstCall.resolve();
+                return false;
+              }
+              if (total === first.length + second.length) everything.resolve();
+            },
+          },
+        });
+        try {
+          socket.on("error", err => {
+            firstCall.reject(err);
+            everything.reject(err);
+          });
+          await firstCall.promise;
+          // Ask for the second payload, then give the event loop every chance to
+          // deliver it: reads are stopped, so it cannot reach the callback.
+          socket.write("go");
+          await secondWritten.promise;
+          for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+          expect(calls).toBe(1);
+
+          socket.resume();
+          await everything.promise;
+          expect({
+            maxNread: Math.max(...nreads),
+            payload: Buffer.concat(received),
+          }).toEqual({
+            maxNread: buffer.length,
+            payload: Buffer.concat([first, second]),
+          });
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+
+  it("calls the buffer factory before the first read and after every delivery", async () => {
+    const payload = pattern(4096);
+    await withServer(
+      c => {
+        c.on("error", () => {});
+        c.end(payload);
+      },
+      async port => {
+        const generated: Buffer[] = [];
+        const delivered: Buffer[] = [];
+        const received: Buffer[] = [];
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        const socket = connect({
+          port,
+          onread: {
+            buffer() {
+              const buf = Buffer.alloc(512);
+              generated.push(buf);
+              return buf;
+            },
+            callback(nread, buf) {
+              delivered.push(buf);
+              received.push(Buffer.from(buf.subarray(0, nread)));
+            },
+          },
+        });
+        try {
+          socket.on("error", reject);
+          socket.on("end", resolve);
+          await promise;
+          expect({
+            // One call before the first read, one after each delivery.
+            generated: generated.length,
+            freshBufferEachTime: delivered.every((buf, i) => buf === generated[i]),
+            payload: Buffer.concat(received),
+          }).toEqual({
+            generated: delivered.length + 1,
+            freshBufferEachTime: true,
+            payload,
+          });
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+
+  it("ignores an onread option that does not match Node's shape", async () => {
+    // Node only installs onread when buffer is a Uint8Array or a function and
+    // callback is a function; anything else leaves the socket emitting 'data'.
+    expect(() => new Socket({ onread: "not an object" as any })).not.toThrow();
+    expect(() => new Socket({ onread: { buffer: Buffer.alloc(8) } as any })).not.toThrow();
+
+    const payload = pattern(1024);
+    await withServer(
+      c => {
+        c.on("error", () => {});
+        c.end(payload);
+      },
+      async port => {
+        const chunks: Buffer[] = [];
+        let onreadCalls = 0;
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        const socket = connect({ port, onread: { callback: () => onreadCalls++ } } as any);
+        try {
+          socket.on("data", chunk => chunks.push(chunk));
+          socket.on("error", reject);
+          socket.on("end", resolve);
+          await promise;
+          expect({ onreadCalls, payload: Buffer.concat(chunks) }).toEqual({ onreadCalls: 0, payload });
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1304,6 +1304,67 @@ describe("net.Socket onread", () => {
     );
   });
 
+  // A pause() the user never lifted belongs to the socket, not to one handle:
+  // Node's afterConnect only starts reads when the stream isn't paused, and
+  // that flag survives both the first connect() and a later reconnect.
+  it("carries an unlifted pause() across connect() and a reconnect", async () => {
+    const first = pattern(4096);
+    const second = Buffer.alloc(256, 0xbb);
+    const serverA = createServer(c => {
+      // The client destroys mid-stream, so an unflushed write reports ECONNRESET.
+      c.on("error", () => {});
+      c.write(first);
+    });
+    const everything = Promise.withResolvers<void>();
+    const serverB = createServer(c => {
+      c.on("error", err => everything.reject(err));
+      c.write(second);
+    });
+    try {
+      const [portA, portB] = [await listen(serverA), await listen(serverB)];
+      const buffer = Buffer.alloc(64);
+      const received: Buffer[] = [];
+      let calls = 0;
+      const socket = new Socket({
+        onread: {
+          buffer,
+          callback(nread, buf) {
+            calls++;
+            received.push(Buffer.from(buf.subarray(0, nread)));
+            if (Buffer.concat(received).length === second.length) everything.resolve();
+          },
+        },
+      });
+      try {
+        socket.on("error", err => everything.reject(err));
+        socket.pause();
+
+        socket.connect(portA, "127.0.0.1");
+        for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+        expect(calls).toBe(0);
+
+        const closed = Promise.withResolvers<void>();
+        socket.once("close", () => closed.resolve());
+        socket.destroy();
+        await closed.promise;
+
+        socket.connect(portB, "127.0.0.1");
+        for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+        expect(calls).toBe(0);
+
+        // Only the second connection's bytes: the first's were dropped with it.
+        socket.resume();
+        await everything.promise;
+        expect(Buffer.concat(received)).toEqual(second);
+      } finally {
+        socket.destroy();
+      }
+    } finally {
+      serverA.close();
+      serverB.close();
+    }
+  });
+
   it("calls the buffer factory before the first read and after every delivery", async () => {
     const payload = pattern(4096);
     await withServer(

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1070,11 +1070,23 @@ describe("net.Socket onread", () => {
     return buf;
   }
 
-  async function withServer(onConnection: (c: Socket) => void, run: (port: number) => Promise<void>) {
-    const server = createServer(onConnection);
+  // `fail` races the server's errors against the test body, so a server-side
+  // failure surfaces as that error instead of hanging on a promise the server
+  // can no longer settle.
+  async function withServer(
+    onConnection: (c: Socket, fail: (err: Error) => void) => void,
+    run: (port: number) => Promise<void>,
+  ) {
+    const failed = Promise.withResolvers<never>();
+    failed.promise.catch(() => {}); // an error after the body finished is not a failure
+    const server = createServer(c => onConnection(c, failed.reject));
     try {
-      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
-      await run((server.address() as import("node:net").AddressInfo).port);
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const { port } = server.address() as import("node:net").AddressInfo;
+      await Promise.race([run(port), failed.promise]);
     } finally {
       server.close();
     }
@@ -1083,8 +1095,8 @@ describe("net.Socket onread", () => {
   it("hands the callback the user's own buffer, never more than its length", async () => {
     const payload = pattern(64 * 1024);
     await withServer(
-      c => {
-        c.on("error", () => {});
+      (c, fail) => {
+        c.on("error", fail);
         c.end(payload);
       },
       async port => {
@@ -1135,8 +1147,8 @@ describe("net.Socket onread", () => {
     const second = Buffer.alloc(4096, 0x5a);
     const secondWritten = Promise.withResolvers<void>();
     await withServer(
-      c => {
-        c.on("error", () => {});
+      (c, fail) => {
+        c.on("error", fail);
         c.write(first);
         c.on("data", () => c.write(second, () => secondWritten.resolve()));
       },
@@ -1197,8 +1209,8 @@ describe("net.Socket onread", () => {
   it("calls the buffer factory before the first read and after every delivery", async () => {
     const payload = pattern(4096);
     await withServer(
-      c => {
-        c.on("error", () => {});
+      (c, fail) => {
+        c.on("error", fail);
         c.end(payload);
       },
       async port => {
@@ -1241,6 +1253,38 @@ describe("net.Socket onread", () => {
     );
   });
 
+  it("stops delivering a chunk the moment the callback destroys the socket", async () => {
+    const payload = pattern(4096);
+    await withServer(
+      c => {
+        // The client destroys mid-stream, so an unflushed write can surface here
+        // as ECONNRESET/EPIPE; that is the behavior under test, not a failure.
+        c.on("error", () => {});
+        c.end(payload);
+      },
+      async port => {
+        const buffer = Buffer.alloc(512);
+        const nreads: number[] = [];
+        const closed = Promise.withResolvers<void>();
+        const socket = connect({
+          port,
+          onread: {
+            buffer,
+            callback(nread) {
+              nreads.push(nread);
+              socket.destroy();
+            },
+          },
+        });
+        socket.on("error", closed.reject);
+        socket.on("close", () => closed.resolve());
+        await closed.promise;
+        // The remaining slices of that chunk must not reach a destroyed socket.
+        expect(nreads).toEqual([buffer.length]);
+      },
+    );
+  });
+
   it("ignores an onread option that does not match Node's shape", async () => {
     // Node only installs onread when buffer is a Uint8Array or a function and
     // callback is a function; anything else leaves the socket emitting 'data'.
@@ -1249,8 +1293,8 @@ describe("net.Socket onread", () => {
 
     const payload = pattern(1024);
     await withServer(
-      c => {
-        c.on("error", () => {});
+      (c, fail) => {
+        c.on("error", fail);
         c.end(payload);
       },
       async port => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1304,6 +1304,57 @@ describe("net.Socket onread", () => {
     );
   });
 
+  // Node delivers asynchronously, so the stream is already flowing again before
+  // a callback can pause it. Bun flushes the held bytes inside resume(), so the
+  // pause it takes there has to survive resume()'s own tail call.
+  it("keeps a pause() the callback takes during resume()'s flush", async () => {
+    const payload = pattern(4096);
+    await withServer(
+      (c, fail) => {
+        c.on("error", fail);
+        c.write(payload);
+      },
+      async target => {
+        const buffer = Buffer.alloc(64);
+        let calls = 0;
+        const firstCall = Promise.withResolvers<void>();
+        const secondCall = Promise.withResolvers<void>();
+        const socket = connect({
+          ...target,
+          onread: {
+            buffer,
+            callback() {
+              calls++;
+              if (calls === 1) {
+                firstCall.resolve();
+                return false; // hold the rest of the chunk back
+              }
+              this.pause(); // ... and pause from inside the flush it gets handed to
+              secondCall.resolve();
+            },
+          },
+        });
+        try {
+          socket.on("error", err => {
+            firstCall.reject(err);
+            secondCall.reject(err);
+          });
+          await firstCall.promise;
+
+          socket.resume();
+          await secondCall.promise;
+          expect({ calls, isPaused: socket.isPaused() }).toEqual({ calls: 2, isPaused: true });
+
+          // And the pause is real, not just a flag: nothing more is delivered.
+          for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+          expect(calls).toBe(2);
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+
   // A pause() the user never lifted belongs to the socket, not to one handle:
   // Node's afterConnect only starts reads when the stream isn't paused, and
   // that flag survives both the first connect() and a later reconnect.

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1245,6 +1245,59 @@ describe("net.Socket onread", () => {
     );
   });
 
+  // Node documents pause() as behaving the way returning false does, and its
+  // readStop() halts the next delivery even part-way through a chunk.
+  it("stops reading when the callback pauses the socket rather than returning false", async () => {
+    const payload = pattern(4096);
+    await withServer(
+      (c, fail) => {
+        c.on("error", fail);
+        c.write(payload);
+      },
+      async target => {
+        const buffer = Buffer.alloc(64);
+        const received: Buffer[] = [];
+        let calls = 0;
+        let paused = true;
+        const firstCall = Promise.withResolvers<void>();
+        const everything = Promise.withResolvers<void>();
+        const socket = connect({
+          ...target,
+          onread: {
+            buffer,
+            callback(nread, buf) {
+              calls++;
+              received.push(Buffer.from(buf.subarray(0, nread)));
+              if (paused) {
+                // Back-pressure through pause(), not a false return.
+                this.pause();
+                firstCall.resolve();
+              } else if (Buffer.concat(received).length === payload.length) {
+                everything.resolve();
+              }
+            },
+          },
+        });
+        try {
+          socket.on("error", err => {
+            firstCall.reject(err);
+            everything.reject(err);
+          });
+          await firstCall.promise;
+          for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+          expect({ calls, bytesRead: socket.bytesRead }).toEqual({ calls: 1, bytesRead: buffer.length });
+
+          paused = false;
+          socket.resume();
+          await everything.promise;
+          expect(Buffer.concat(received)).toEqual(payload);
+        } finally {
+          socket.destroy();
+        }
+      },
+    );
+  });
+
   it("calls the buffer factory before the first read and after every delivery", async () => {
     const payload = pattern(4096);
     await withServer(


### PR DESCRIPTION
`net.Socket`'s `onread` option is the zero-allocation read path: the callback is supposed to get back the buffer it supplied, holding at most `buffer.length` bytes, and returning `false` is supposed to stop reads. None of that held.

## Repro

```js
const net = require("net");
const buf = Buffer.alloc(64);
let calls = 0;

const server = net.createServer(c => {
  c.write(Buffer.alloc(4096, 0x61));
  const t = setInterval(() => c.write(Buffer.alloc(4096, 0x61)), 5);
  c.on("close", () => clearInterval(t));
});

server.listen(0, () => {
  net.connect({
    port: server.address().port,
    onread: {
      buffer: buf,
      callback(nread, b) {
        console.log({ sameBuffer: b === buf, nread, bounded: nread <= buf.length });
        if (++calls === 3) return false; // should pause
      },
    },
  });
});
```

| | node v26 | bun 1.4.0 |
|---|---|---|
| `b === buf` | `true` | `false` (Bun's internal chunk) |
| `nread <= buf.length` | always | `nread` is 4096 against a 64-byte buffer |
| `buffer` as a factory function | called once before the first read, once per delivery | never called |
| `return false` | stops reads | keeps delivering (55 more chunks in 300ms) |

Code written to the documented contract reads out of range with `buffer.subarray(0, nread)`, never sees its pooled buffers reused, and cannot apply backpressure.

## Cause

`src/js/node/net.ts` installed a `data` handler that forwarded Bun's chunk straight through:

```js
data(socket, buffer) {
  onread.callback(buffer.length, buffer);
}
```

Node instead pushes a `CustomBufferJSListener` that uses the user's buffer as the `uv_buf_t` for every read, so `nread` is bounded by the buffer and the callback's `false` return reaches `readStop()`.

## Fix

Keep Node's per-socket state (buffer, callback, factory) on the socket and emulate the listener in JS:

- each incoming chunk is copied into the user's buffer in buffer-sized slices, one callback per slice, so `nread <= buffer.length` and the callback always gets its own buffer back;
- the factory form is consulted before the first read and again after every delivery, matching `initSocketHandle` + `onStreamRead`;
- a `false` return stops the kernel reads (pause + unref, as `Socket.prototype.pause()` does) and holds the bytes the callback has not taken; `resume()` hands those over first, and reads only restart if the callback accepts them;
- `pause()` parks the socket in that same state, so a callback reaching for backpressure with `this.pause()` stops the rest of the chunk too, the way Node's `readStop()` does. The docs promise it ("pause() and resume() will also behave as expected") and it was taking all 64 slices of a 4096-byte chunk where Node hands it 1;
- `bytesRead` counts bytes delivered to the callback, as Node's native `bytesRead` does.

The acceptance check now matches Node too: an `onread` that is not `{ buffer: Uint8Array | Function, callback: Function }` is ignored (socket keeps emitting `'data'`) instead of throwing `TypeError`.

### Holding bytes back safely

Node never holds undelivered bytes in JS: the user's buffer *is* the `uv_buf_t`, so anything the callback declines simply stays unread in the kernel. Emulating the contract means Bun has to hold them, and that brought four hazards with it. Each is fixed with its own test, and each test fails when its guard is removed:

- **Post-destroy delivery.** The callback runs user JS and can `destroy()` the socket between two slices of the same chunk. `onreadDeliver` re-checks `destroyed` after each callback; without it, 7 more callbacks land on a dead socket.
- **Overwritten on a second dispatch.** The TLS read loops (`openssl.c`'s restart after a full plaintext buffer, `SSLWrapper::handle_reading` when its 64 KB buffer fills) keep decrypting and dispatching without re-checking the socket's pause flag, and `pause()` cannot reach a TLS socket wrapped over a generic `Duplex` at all. A 4096 + 4096 byte exchange delivered 4608 bytes over 9 calls instead of 8192 over 1. Incoming chunks now queue behind the undelivered ones.
- **`'end'` before the drain.** A FIN landing while bytes are held back ended the readable side through the inherited `end`/`close` handlers, which destroyed the socket before `resume()` could deliver them: `c.end(4096 bytes)` produced 512 delivered and 3584 lost. Both handlers go through `endReadableSide()`, which defers `push(null)` until the held bytes drain. Non-onread sockets never have pending bytes (`kBufferPending` is only written behind the `kBufferCb` gate), so `onreadIsPaused()` is always false there and that path is unchanged. The one genuinely shared change is `resume()` now making its `Duplex.prototype.resume` tail call first; see the audit in the comments.
- **Survived a reconnect.** `kBufferPending` is per-connection but `initSocketHandle()` did not clear it, so reusing a `Socket` replayed the old connection's bytes into the new one: 64 callbacks carrying connection A's payload where Node delivers 1.
- **Cleared the pause marker.** Once `pause()` parked a socket by setting `kBufferPending`, that same `initSocketHandle()` clear wiped it, so `s.pause(); s.connect(...)` delivered everything. The marker is now derived from `isPaused()`, which is the gate Node reaches through `if (!socket.isPaused()) socket.read(0)`: held-back bytes still die with their connection, an unlifted pause still belongs to the socket.
- **Wiped the pause a callback took mid-flush.** `resume()` flushed the held bytes before its tail call into `Duplex.prototype.resume`, so a callback that paused during that synchronous flush had its pause overwritten a line later. Node never hits this because its delivery is asynchronous, so the pause lands last. The tail call runs first now; the delivery loop keys off `kBufferPending` rather than the flowing flag, so the flush is unaffected.

## Verification

`bun bd test test/js/node/net/node-net.test.ts -t "net.Socket onread"` — 11 tests covering buffer identity, the `nread` bound, no `'data'` events, pause-on-false and pause-by-method then resume with nothing lost, the factory call pattern, the six holding-bytes cases above, and the ignored-option shape. All 11 fail against `main`'s `net.ts`.

Because `endReadableSide` sits on the shared `end`/`close` path and `resume()` is on every socket's, `test/js/node/net/`, `node-tls-connect.test.ts` and `node-http.test.ts` were run together: 330 pass, no new failures.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->