### PR TITLE
ipc: reject non-serializable send() messages instead of closing the channel

### DIFF
--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -440,8 +440,7 @@ mod advanced {
 
         let payload_length: usize = size_of::<IPCMessageType>() + size_of::<u32>() + size as usize;
 
-        // Propagate OOM so serializeAndSend
-        // returns `.failure` instead of silently discarding the Result.
+        // Propagate OOM instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(payload_length)
             .map_err(|_| IPCSerializationError::OutOfMemory)?;
@@ -609,8 +608,7 @@ mod json {
             result_len += 1;
         }
 
-        // Propagate OOM so serializeAndSend
-        // returns `.failure` instead of silently discarding the Result.
+        // Propagate OOM instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(result_len)
             .map_err(|_| IPCSerializationError::OutOfMemory)?;

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -284,14 +284,15 @@ pub enum IPCSerializationError {
 }
 
 impl IPCSerializationError {
-    /// `Some(..)` when serialization left an exception pending on `globalThis`
-    /// (cyclic structure, throwing `toJSON`, structured-clone `DataCloneError`).
-    /// Callers must propagate it instead of replacing it with an error of their own.
-    pub fn pending_exception(&self) -> Option<JsError> {
+    /// Everything except [`Self::SerializationFailed`] is a JS-level failure the caller must
+    /// propagate as-is: a pending exception (cyclic structure, throwing `toJSON`,
+    /// `DataCloneError`) or an allocation failure the host-fn shim turns into an OOM error.
+    pub fn as_js_error(&self) -> Option<JsError> {
         match self {
             Self::JSError => Some(JsError::Thrown),
             Self::JSTerminated => Some(JsError::Terminated),
-            Self::SerializationFailed | Self::OutOfMemory => None,
+            Self::OutOfMemory => Some(JsError::OutOfMemory),
+            Self::SerializationFailed => None,
         }
     }
 }
@@ -592,10 +593,9 @@ mod json {
         // `ensure_unused_capacity`, success) releases it.
         let out = bun_core::OwnedString::new(out);
 
-        // `JSON.stringify` returns `undefined` (a null `WTF::String`, which reaches us as
-        // the `Empty` tag) for values it cannot represent. It never returns `""` for a
-        // value it can, so an empty result means the message is not serializable: writing
-        // it anyway produces a zero-length frame that the peer rejects, closing the channel.
+        // `JSON.stringify` yields `undefined` (a null `WTF::String`, reaching us as the `Empty`
+        // tag) for values it cannot represent, and never `""` for ones it can. Writing an empty
+        // result anyway produces a zero-length frame that the peer rejects, closing the channel.
         if out.is_empty() {
             return Err(IPCSerializationError::SerializationFailed);
         }
@@ -1377,13 +1377,14 @@ impl SendQueue {
         handle: Option<Handle>,
     ) -> Result<SerializeAndSendResult, IPCSerializationError> {
         log!("SendQueue#serializeAndSend");
-        let indicate_backoff = self.waiting_for_ack.is_some() && !self.queue.is_empty();
         let mode = self.mode;
         // Serialize before touching the queue: a value that cannot be serialized must not
         // reach the channel, and must leave the queue (and the callback) untouched.
         let mut payload = StreamBuffer::default();
         let payload_length = serialize(mode, &mut payload, global, value, is_internal)?;
         debug_assert!(payload.list.len() == payload_length);
+        // Read the queue state only after serialization, which can run `toJSON` and re-enter.
+        let indicate_backoff = self.waiting_for_ack.is_some() && !self.queue.is_empty();
         let msg = self.start_message(global, callback, handle)?;
         handle_oom(msg.data.write(&payload.list));
         log!("IPC call continueSend() from serializeAndSend");

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -195,7 +195,6 @@ pub enum IsInternal {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum SerializeAndSendResult {
     Success,
-    Failure,
     Backoff,
 }
 
@@ -282,6 +281,29 @@ pub enum IPCSerializationError {
     JSTerminated,
     #[error("OutOfMemory")]
     OutOfMemory,
+}
+
+impl IPCSerializationError {
+    /// `Some(..)` when serialization left an exception pending on `globalThis`
+    /// (cyclic structure, throwing `toJSON`, structured-clone `DataCloneError`).
+    /// Callers must propagate it instead of replacing it with an error of their own.
+    pub fn pending_exception(&self) -> Option<JsError> {
+        match self {
+            Self::JSError => Some(JsError::Thrown),
+            Self::JSTerminated => Some(JsError::Terminated),
+            Self::SerializationFailed | Self::OutOfMemory => None,
+        }
+    }
+}
+
+impl From<JsError> for IPCSerializationError {
+    fn from(e: JsError) -> Self {
+        match e {
+            JsError::Thrown => IPCSerializationError::JSError,
+            JsError::Terminated => IPCSerializationError::JSTerminated,
+            JsError::OutOfMemory => IPCSerializationError::OutOfMemory,
+        }
+    }
 }
 
 mod advanced {
@@ -403,20 +425,14 @@ mod advanced {
         value: JSValue,
         is_internal: IsInternal,
     ) -> Result<usize, IPCSerializationError> {
-        let serialized = value
-            .serialize(
-                global,
-                SerializedFlags {
-                    // IPC sends across process.
-                    for_cross_process_transfer: true,
-                    for_storage: false,
-                },
-            )
-            .map_err(|e| match e {
-                JsError::Thrown => IPCSerializationError::JSError,
-                JsError::Terminated => IPCSerializationError::JSTerminated,
-                JsError::OutOfMemory => IPCSerializationError::OutOfMemory,
-            })?;
+        let serialized = value.serialize(
+            global,
+            SerializedFlags {
+                // IPC sends across process.
+                for_cross_process_transfer: true,
+                for_storage: false,
+            },
+        )?;
         // `serialized` Drops at scope exit (defer serialized.deinit()).
 
         let size: u32 = u32::try_from(serialized.data().len()).expect("int cast");
@@ -569,20 +585,18 @@ mod json {
         let mut out: BunString = BunString::default();
         // Use jsonStringifyFast which passes undefined for the space parameter,
         // triggering JSC's SIMD-optimized FastStringifier code path.
-        value
-            .json_stringify_fast(global, &mut out)
-            .map_err(|e| match e {
-                JsError::Thrown => IPCSerializationError::JSError,
-                JsError::Terminated => IPCSerializationError::JSTerminated,
-                JsError::OutOfMemory => IPCSerializationError::OutOfMemory,
-            })?;
+        value.json_stringify_fast(global, &mut out)?;
         // `bun_core::String` is `Copy` (no `Drop`),
         // so the +1 ref written by `json_stringify_fast` is wrapped in
         // `OwnedString` immediately so every exit path (Dead, OOM in
         // `ensure_unused_capacity`, success) releases it.
         let out = bun_core::OwnedString::new(out);
 
-        if out.tag() == bun_core::Tag::Dead {
+        // `JSON.stringify` returns `undefined` (a null `WTF::String`, which reaches us as
+        // the `Empty` tag) for values it cannot represent. It never returns `""` for a
+        // value it can, so an empty result means the message is not serializable: writing
+        // it anyway produces a zero-length frame that the peer rejects, closing the channel.
+        if out.is_empty() {
             return Err(IPCSerializationError::SerializationFailed);
         }
 
@@ -1361,28 +1375,24 @@ impl SendQueue {
         is_internal: IsInternal,
         callback: JSValue,
         handle: Option<Handle>,
-    ) -> SerializeAndSendResult {
+    ) -> Result<SerializeAndSendResult, IPCSerializationError> {
         log!("SendQueue#serializeAndSend");
         let indicate_backoff = self.waiting_for_ack.is_some() && !self.queue.is_empty();
         let mode = self.mode;
+        // Serialize before touching the queue: a value that cannot be serialized must not
+        // reach the channel, and must leave the queue (and the callback) untouched.
         let mut payload = StreamBuffer::default();
-        let payload_length = match serialize(mode, &mut payload, global, value, is_internal) {
-            Ok(n) => n,
-            Err(_) => return SerializeAndSendResult::Failure,
-        };
+        let payload_length = serialize(mode, &mut payload, global, value, is_internal)?;
         debug_assert!(payload.list.len() == payload_length);
-        let msg = match self.start_message(global, callback, handle) {
-            Ok(m) => m,
-            Err(_) => return SerializeAndSendResult::Failure,
-        };
+        let msg = self.start_message(global, callback, handle)?;
         handle_oom(msg.data.write(&payload.list));
         log!("IPC call continueSend() from serializeAndSend");
         self.continue_send(global, ContinueSendReason::NewMessageAppended);
 
         if indicate_backoff {
-            return SerializeAndSendResult::Backoff;
+            return Ok(SerializeAndSendResult::Backoff);
         }
-        SerializeAndSendResult::Success
+        Ok(SerializeAndSendResult::Success)
     }
 
     fn debug_log_message_queue(&self) {

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -10,10 +10,9 @@
 
 use bun_core::String as BunString;
 use bun_jsc::ipc::{
-    self as IPC, DecodedIPCMessage, Handle, IPCSerializationError, IsInternal, SendQueue,
-    SerializeAndSendResult,
+    self as IPC, DecodedIPCMessage, Handle, IsInternal, SendQueue, SerializeAndSendResult,
 };
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsError, JsResult};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
 
 use crate::api::bun::subprocess::Subprocess;
 use crate::socket::Listener;
@@ -71,9 +70,8 @@ fn do_send_err(
     Err(global_object.throw_value(ex))
 }
 
-/// Node's `target._send` guard: `typeof message` must be one of
-/// `string | object | number | boolean`. `JSValue::is_object()` is JSC's notion of
-/// "is a JSObject", which is also true for functions, so callables are excluded here to
+/// Node's `_send` accepts string/object/number/boolean by `typeof`.
+/// `JSValue::is_object()` also matches functions, so exclude callables to
 /// keep `typeof`-equivalence.
 fn is_sendable_message(message: JSValue) -> bool {
     message.is_string()
@@ -81,14 +79,6 @@ fn is_sendable_message(message: JSValue) -> bool {
         || message.is_boolean()
         || message.is_null()
         || (message.is_object() && !message.is_callable())
-}
-
-fn throw_unsendable_message(global_object: &JSGlobalObject, message: JSValue) -> JsError {
-    global_object.throw_invalid_argument_type_value_one_of(
-        b"message",
-        b"string, object, number, or boolean",
-        message,
-    )
 }
 
 pub(crate) fn do_send(
@@ -132,7 +122,11 @@ pub(crate) fn do_send(
         return Err(global_object.throw_missing_arguments_value(&["message"]));
     }
     if !is_sendable_message(message) {
-        return Err(throw_unsendable_message(global_object, message));
+        return Err(global_object.throw_invalid_argument_type_value_one_of(
+            b"message",
+            b"string, object, number, or boolean",
+            message,
+        ));
     }
     // The handle branch below replaces `message` with a `NODE_HANDLE` wrapper.
     let original_message = message;
@@ -181,22 +175,16 @@ pub(crate) fn do_send(
     ) {
         Ok(status) => status,
         Err(err) => {
-            // Serialization never enqueues, so the channel is still usable. Report the
-            // failure to the caller instead of treating it as a transport failure.
-            if let Some(exception) = err.pending_exception() {
-                return Err(exception);
-            }
-            if matches!(err, IPCSerializationError::SerializationFailed) {
-                return Err(throw_unsendable_message(global_object, original_message));
-            }
-            let ex =
-                global_object.create_type_error_instance(format_args!("process.send() failed"));
-            ex.put(
-                global_object,
-                b"syscall",
-                bun_jsc::bun_string_jsc::to_js(&BunString::static_(b"write"), global_object)?,
-            );
-            return do_send_err(global_object, callback, ex, from);
+            // Serialization never enqueues, so the channel is untouched: report the failure to
+            // the caller rather than treating it as a transport failure. A value the type guard
+            // accepts but JSON cannot represent (`toJSON()` returning undefined) lands here.
+            return Err(err.as_js_error().unwrap_or_else(|| {
+                global_object.throw_invalid_argument_value_custom(
+                    b"message",
+                    original_message,
+                    b"could not be serialized to JSON",
+                )
+            }));
         }
     };
 

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -10,9 +10,10 @@
 
 use bun_core::String as BunString;
 use bun_jsc::ipc::{
-    self as IPC, DecodedIPCMessage, Handle, IsInternal, SendQueue, SerializeAndSendResult,
+    self as IPC, DecodedIPCMessage, Handle, IPCSerializationError, IsInternal, SendQueue,
+    SerializeAndSendResult,
 };
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsError, JsResult};
 
 use crate::api::bun::subprocess::Subprocess;
 use crate::socket::Listener;
@@ -70,6 +71,26 @@ fn do_send_err(
     Err(global_object.throw_value(ex))
 }
 
+/// Node's `target._send` guard: `typeof message` must be one of
+/// `string | object | number | boolean`. `JSValue::is_object()` is JSC's notion of
+/// "is a JSObject", which is also true for functions, so callables are excluded here to
+/// keep `typeof`-equivalence.
+fn is_sendable_message(message: JSValue) -> bool {
+    message.is_string()
+        || message.is_number()
+        || message.is_boolean()
+        || message.is_null()
+        || (message.is_object() && !message.is_callable())
+}
+
+fn throw_unsendable_message(global_object: &JSGlobalObject, message: JSValue) -> JsError {
+    global_object.throw_invalid_argument_type_value_one_of(
+        b"message",
+        b"string, object, number, or boolean",
+        message,
+    )
+}
+
 pub(crate) fn do_send(
     ipc: Option<&mut SendQueue>,
     global_object: &JSGlobalObject,
@@ -110,18 +131,11 @@ pub(crate) fn do_send(
     if message.is_undefined() {
         return Err(global_object.throw_missing_arguments_value(&["message"]));
     }
-    if !message.is_string()
-        && !message.is_object()
-        && !message.is_number()
-        && !message.is_boolean()
-        && !message.is_null()
-    {
-        return Err(global_object.throw_invalid_argument_type_value_one_of(
-            b"message",
-            b"string, object, number, or boolean",
-            message,
-        ));
+    if !is_sendable_message(message) {
+        return Err(throw_unsendable_message(global_object, message));
     }
+    // The handle branch below replaces `message` with a `NODE_HANDLE` wrapper.
+    let original_message = message;
 
     if !handle.is_undefined_or_null() {
         let serialized_array: JSValue = IPC::ipc_serialize(global_object, message, handle)?;
@@ -158,23 +172,33 @@ pub(crate) fn do_send(
         }
     }
 
-    let status = ipc_data.serialize_and_send(
+    let status = match ipc_data.serialize_and_send(
         global_object,
         message,
         IsInternal::External,
         callback,
         zig_handle,
-    );
-
-    if status == SerializeAndSendResult::Failure {
-        let ex = global_object.create_type_error_instance(format_args!("process.send() failed"));
-        ex.put(
-            global_object,
-            b"syscall",
-            bun_jsc::bun_string_jsc::to_js(&BunString::static_(b"write"), global_object)?,
-        );
-        return do_send_err(global_object, callback, ex, from);
-    }
+    ) {
+        Ok(status) => status,
+        Err(err) => {
+            // Serialization never enqueues, so the channel is still usable. Report the
+            // failure to the caller instead of treating it as a transport failure.
+            if let Some(exception) = err.pending_exception() {
+                return Err(exception);
+            }
+            if matches!(err, IPCSerializationError::SerializationFailed) {
+                return Err(throw_unsendable_message(global_object, original_message));
+            }
+            let ex =
+                global_object.create_type_error_instance(format_args!("process.send() failed"));
+            ex.put(
+                global_object,
+                b"syscall",
+                bun_jsc::bun_string_jsc::to_js(&BunString::static_(b"write"), global_object)?,
+            );
+            return do_send_err(global_object, callback, ex, from);
+        }
+    };
 
     // in the success or backoff case, serializeAndSend will handle calling the callback
     Ok(if status == SerializeAndSendResult::Success {

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -123,7 +123,9 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         Ok(good) => good,
         Err(err) => {
             // Nothing was enqueued, so no ack will ever settle the callback registered above.
-            singleton.callbacks.swap_remove(&seq);
+            // Re-borrow rather than holding `singleton` across `serialize_and_send`, which runs
+            // `toJSON` and can re-enter this fn (see `child_singleton`'s aliasing contract).
+            child_singleton().callbacks.swap_remove(&seq);
             if let Some(exception) = err.as_js_error() {
                 return Err(exception);
             }

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -118,18 +118,24 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         None,
     );
 
-    if good == SerializeAndSendResult::Failure {
-        let ex = global.create_type_error_instance(format_args!("sendInternal() failed"));
-        ex.put(
-            global,
-            b"syscall",
-            BunString::static_str("write").to_js(global)?,
-        );
-        let fnvalue =
-            bun_jsc::JSFunction::create(global, "", __jsc_host_impl_, 1, Default::default());
-        JSValue::call_next_tick_1(fnvalue, global, ex)?;
-        return Ok(JSValue::FALSE);
-    }
+    let good = match good {
+        Ok(good) => good,
+        Err(err) => {
+            if let Some(exception) = err.pending_exception() {
+                return Err(exception);
+            }
+            let ex = global.create_type_error_instance(format_args!("sendInternal() failed"));
+            ex.put(
+                global,
+                b"syscall",
+                BunString::static_str("write").to_js(global)?,
+            );
+            let fnvalue =
+                bun_jsc::JSFunction::create(global, "", __jsc_host_impl_, 1, Default::default());
+            JSValue::call_next_tick_1(fnvalue, global, ex)?;
+            return Ok(JSValue::FALSE);
+        }
+    };
 
     Ok(if good == SerializeAndSendResult::Success {
         JSValue::TRUE
@@ -218,6 +224,15 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
     let _ = handle;
     let success =
         ipc_data.serialize_and_send(global, message, IsInternal::Internal, JSValue::NULL, None);
+    let success = match success {
+        Ok(success) => success,
+        Err(err) => {
+            if let Some(exception) = err.pending_exception() {
+                return Err(exception);
+            }
+            return Ok(JSValue::FALSE);
+        }
+    };
     Ok(if success == SerializeAndSendResult::Success {
         JSValue::TRUE
     } else {

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -74,16 +74,17 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         return Err(global.throw_invalid_argument_type_value("message", "object", message));
     }
     let singleton = child_singleton();
+    let seq = singleton.seq;
     if callback.is_function() {
         // TODO: remove this strong. This is expensive and would be an easy way to create a memory leak.
         // These sequence numbers shouldn't exist from JavaScript's perspective at all.
         let _ = singleton
             .callbacks
-            .put(singleton.seq, StrongOptional::create(callback, global));
+            .put(seq, StrongOptional::create(callback, global));
     }
 
     // sequence number for InternalMsgHolder
-    message.put(global, b"seq", JSValue::js_number(singleton.seq as f64));
+    message.put(global, b"seq", JSValue::js_number(seq as f64));
     singleton.seq = singleton.seq.wrapping_add(1);
 
     // similar code as Bun__Process__send
@@ -121,7 +122,9 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
     let good = match good {
         Ok(good) => good,
         Err(err) => {
-            if let Some(exception) = err.pending_exception() {
+            // Nothing was enqueued, so no ack will ever settle the callback registered above.
+            singleton.callbacks.swap_remove(&seq);
+            if let Some(exception) = err.as_js_error() {
                 return Err(exception);
             }
             let ex = global.create_type_error_instance(format_args!("sendInternal() failed"));
@@ -195,19 +198,16 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
     if !message.is_object() {
         return Err(global.throw_invalid_argument_type_value("message", "object", message));
     }
+    let seq = ipc_data.internal_msg_queue.seq;
     if callback.is_function() {
-        let _ = ipc_data.internal_msg_queue.callbacks.put(
-            ipc_data.internal_msg_queue.seq,
-            StrongOptional::create(callback, global),
-        );
+        let _ = ipc_data
+            .internal_msg_queue
+            .callbacks
+            .put(seq, StrongOptional::create(callback, global));
     }
 
     // sequence number for InternalMsgHolder
-    message.put(
-        global,
-        b"seq",
-        JSValue::js_number(ipc_data.internal_msg_queue.seq as f64),
-    );
+    message.put(global, b"seq", JSValue::js_number(seq as f64));
     ipc_data.internal_msg_queue.seq = ipc_data.internal_msg_queue.seq.wrapping_add(1);
 
     // similar code as bun.jsc.Subprocess.doSend
@@ -227,7 +227,9 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
     let success = match success {
         Ok(success) => success,
         Err(err) => {
-            if let Some(exception) = err.pending_exception() {
+            // Nothing was enqueued, so no ack will ever settle the callback registered above.
+            ipc_data.internal_msg_queue.callbacks.swap_remove(&seq);
+            if let Some(exception) = err.as_js_error() {
                 return Err(exception);
             }
             return Ok(JSValue::FALSE);

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -230,7 +230,11 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         Ok(success) => success,
         Err(err) => {
             // Nothing was enqueued, so no ack will ever settle the callback registered above.
-            ipc_data.internal_msg_queue.callbacks.swap_remove(&seq);
+            // Re-borrow rather than holding `ipc_data` across `serialize_and_send`, which runs
+            // `toJSON` and can re-enter (see `Subprocess::ipc`'s aliasing contract).
+            if let Some(ipc_data) = subprocess.ipc() {
+                ipc_data.internal_msg_queue.callbacks.swap_remove(&seq);
+            }
             if let Some(exception) = err.as_js_error() {
                 return Err(exception);
             }

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,5 +1,8 @@
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { fork } from "node:child_process";
+import path from "node:path";
 
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();
@@ -12,4 +15,116 @@ test("child_process ipc", async () => {
     cb ERR_IPC_CHANNEL_CLOSED
     "
   `);
+});
+
+// A message `JSON.stringify` maps to `undefined` must be rejected by `send()` itself. Before,
+// it was serialized to a zero-length frame, which the peer rejects as malformed and responds to
+// by closing the IPC channel: every queued and subsequent message was silently lost.
+const ECHO_CHILD = `
+process.on("message", message => {
+  if (message === "probe-unserializable") {
+    try {
+      process.send(() => {});
+      process.send({ threw: null });
+    } catch (err) {
+      process.send({ threw: { code: err.code, name: err.name, message: err.message } });
+    }
+    return;
+  }
+  process.send({ echo: message });
+});
+`;
+
+function forkEchoChild() {
+  const dir = tempDir("child-process-ipc-serialization", { "echo-child.js": ECHO_CHILD });
+  const child = fork(path.join(String(dir), "echo-child.js"), { env: bunEnv });
+  return { child, [Symbol.dispose]: () => (child.kill(), dir[Symbol.dispose]()) };
+}
+
+/** Resolves with the next `message`, rejects if the IPC channel dies first. */
+function nextMessage(child) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const onMessage = message => (cleanup(), resolve(message));
+  const onDisconnect = () => (cleanup(), reject(new Error("IPC channel closed before a message arrived")));
+  const onError = err => (cleanup(), reject(err));
+  const onExit = code => (cleanup(), reject(new Error(`child exited with code ${code}`)));
+  const cleanup = () => {
+    child.off("message", onMessage);
+    child.off("disconnect", onDisconnect);
+    child.off("error", onError);
+    child.off("exit", onExit);
+  };
+  child.on("message", onMessage);
+  child.on("disconnect", onDisconnect);
+  child.on("error", onError);
+  child.on("exit", onExit);
+  return promise;
+}
+
+/** Round-trips a message through the child, proving the channel is still usable. */
+function echo(child, message) {
+  const received = nextMessage(child);
+  expect(child.send(message)).toBe(true);
+  return received;
+}
+
+test.concurrent("subprocess.send() of a function throws ERR_INVALID_ARG_TYPE", async () => {
+  using forked = forkEchoChild();
+  const { child } = forked;
+
+  let thrown;
+  try {
+    child.send(() => {});
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(TypeError);
+  expect({ code: thrown?.code, message: thrown?.message }).toEqual({
+    code: "ERR_INVALID_ARG_TYPE",
+    message: 'The "message" argument must be one of type string, object, number, or boolean. Received function ',
+  });
+
+  // The channel must be untouched by the rejected message.
+  expect(child.connected).toBe(true);
+  expect(await echo(child, { ping: 1 })).toEqual({ echo: { ping: 1 } });
+});
+
+test.concurrent("process.send() of a function throws ERR_INVALID_ARG_TYPE in the child", async () => {
+  using forked = forkEchoChild();
+  const { child } = forked;
+
+  expect(await echo(child, "probe-unserializable")).toEqual({
+    threw: {
+      code: "ERR_INVALID_ARG_TYPE",
+      name: "TypeError",
+      message: 'The "message" argument must be one of type string, object, number, or boolean. Received function ',
+    },
+  });
+
+  expect(await echo(child, { ping: 2 })).toEqual({ echo: { ping: 2 } });
+});
+
+test.concurrent("subprocess.send() of a value whose toJSON() returns undefined keeps the channel open", async () => {
+  using forked = forkEchoChild();
+  const { child } = forked;
+
+  expect(() => child.send({ toJSON: () => undefined })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+  expect(await echo(child, { ping: 3 })).toEqual({ echo: { ping: 3 } });
+});
+
+test.concurrent("subprocess.send() of a cyclic message rethrows and never reports success", async () => {
+  using forked = forkEchoChild();
+  const { child } = forked;
+
+  const cyclic = {};
+  cyclic.self = cyclic;
+  const callbackArgs = [];
+  expect(() => child.send(cyclic, err => callbackArgs.push(err))).toThrow(TypeError);
+
+  // A full round-trip is a bounded window: a `process.nextTick` callback queued by the failed
+  // send would have run well before the echo comes back.
+  expect(await echo(child, { ping: 4 })).toEqual({ echo: { ping: 4 } });
+  expect(callbackArgs).toEqual([]);
 });

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -108,9 +108,19 @@ test.concurrent("subprocess.send() of a value whose toJSON() returns undefined k
   using forked = forkEchoChild();
   const { child } = forked;
 
-  expect(() => child.send({ toJSON: () => undefined })).toThrow(
-    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-  );
+  // The type guard accepts this (it is an object), so the failure is reported as an invalid
+  // value rather than an invalid type.
+  let thrown;
+  try {
+    child.send({ toJSON: () => undefined });
+  } catch (err) {
+    thrown = err;
+  }
+  expect({ code: thrown?.code, message: thrown?.message }).toEqual({
+    code: "ERR_INVALID_ARG_VALUE",
+    message: 'The "message" argument could not be serialized to JSON. Received an instance of Object',
+  });
+
   expect(await echo(child, { ping: 3 })).toEqual({ echo: { ping: 3 } });
 });
 


### PR DESCRIPTION
## Repro

```js
// repro.mjs — exits 0 on node, 1 on Bun
import cp from "node:child_process";
import { fileURLToPath } from "node:url";
const selfPath = fileURLToPath(import.meta.url);

if (process.argv[2] === "child") {
  process.on("message", m => process.send({ echo: m }));
} else {
  const c = cp.fork(selfPath, ["child"]);
  let delivered = false;
  c.on("message", () => (delivered = true));

  try {
    c.send(() => {});            // node: throws ERR_INVALID_ARG_TYPE. bun: returns true
  } catch {}
  c.send({ ping: 1 });           // node: echoed. bun: never delivered

  setTimeout(() => { c.kill(); process.exit(delivered ? 0 : 1); }, 700);
}
```

`subprocess.send()` of a value `JSON.stringify` maps to `undefined` (a function, a
symbol, a `toJSON()` returning `undefined`) was accepted: it returned `true` and
called the send callback with a `null` error. The IPC channel was then torn down
asynchronously — `'error'` (`ERR_IPC_CHANNEL_CLOSED`) and `'disconnect'` fire, a
well-formed message sent immediately after (while `connected === true`) is never
delivered, and later sends fail. Node throws `ERR_INVALID_ARG_TYPE` synchronously and
the channel keeps working.

Same for `process.send()` in the child, in both `json` and `advanced` serialization.

## Cause

Node's guard lives in `target._send`:

```js
if (typeof message !== 'string' && typeof message !== 'object' &&
    typeof message !== 'number' && typeof message !== 'boolean') {
  throw new ERR_INVALID_ARG_TYPE('message', ['string', 'object', 'number', 'boolean'], message);
}
```

`do_send` mirrors it, but spells `typeof message === "object"` as
`JSValue::is_object()`. That is JSC's *is a `JSObject`* predicate, which is also
true for functions, so callables slip past the guard that exists to stop them.

`json::serialize` then calls `JSON.stringify`, which returns `undefined` for a
function. That reaches Rust as a null `WTF::String`, and `Bun::toStringRef` maps a
null string to the `Empty` tag — not `Dead`, which is the only tag the existing
guard checked. So the value was serialized to a **zero-length JSON frame** (`"\n"`)
and written to the channel.

The peer's decoder rejects an empty payload as `InvalidFormat` and closes the
socket. With a node child on the other end, it dies outright:

```
SyntaxError: Unexpected end of JSON input
    at parseChannelMessages (node:internal/child_process/serialization:157:15)
```

Separately, when serialization *throws* (cyclic structure, throwing `toJSON`,
`DataCloneError` in advanced mode), `serialize_and_send` flattened the error to a
generic `Failure`, and `do_send` built a fresh `TypeError: process.send() failed`
on top of the still-pending exception. The observable result was `send()` throwing
the real error *and* the send callback firing with `null`, i.e. reporting success
for a message that was never sent.

## Fix

- `do_send`: exclude callables from the message type guard, restoring
  `typeof`-equivalence with node. Functions, symbols and bigints now all throw
  `ERR_INVALID_ARG_TYPE` synchronously, in both serialization modes and from both
  `subprocess.send()` and `process.send()`.
- `json::serialize`: treat an empty `JSON.stringify` result as a serialization
  failure. `JSON.stringify` never returns `""` for a value it can represent, so an
  empty result always means the message is not serializable — writing it anyway is
  what poisons the channel.
- `serialize_and_send` returns the `IPCSerializationError` instead of flattening it
  to `Failure`, so `do_send` can report each cause honestly:
  - a pending JS exception propagates unchanged, and the callback is not invoked
  - an OOM propagates as an `OutOfMemoryError` rather than a fake write error
  - a value the type guard accepts but JSON cannot represent (`toJSON()` returning
    `undefined`) throws `ERR_INVALID_ARG_VALUE`: *The "message" argument could not be
    serialized to JSON*

  With every variant now handled, the old `TypeError: process.send() failed` with
  `syscall: "write"` is dead and removed. It was never a transport error in the first
  place: a real write failure closes the socket inside `continue_send` and never
  returns through `serialize_and_send`.

Serialization already ran before anything was enqueued, so a rejected message leaves
the queue, the callback and the channel untouched.

Two adjacent fixes in the same error arm: `node_cluster_binding`'s send helpers
register a `StrongOptional` callback keyed by `seq` *before* serializing, and nothing
removed it when the send failed (no ack arrives for a message that was never
enqueued), so they now release it; and the backoff flag is read after serialization,
which can run `toJSON` and re-enter.

## Verification

`test/js/node/child_process/child_process_ipc.test.js` gains four tests covering
`subprocess.send()`, `process.send()` in the child, `toJSON()` returning `undefined`,
and the false-success callback on a cyclic message. Each asserts the exact error, and
that the channel still round-trips a message afterwards.

All four fail on `main` and pass with the fix:

<details>
<summary><code>USE_SYSTEM_BUN=1 bun test</code> (before)</summary>

```
(fail) subprocess.send() of a function throws ERR_INVALID_ARG_TYPE
(fail) subprocess.send() of a value whose toJSON() returns undefined keeps the channel open
  error: IPC channel closed before a message arrived
(fail) subprocess.send() of a cyclic message rethrows and never reports success
  - []
  + [ null ]
(fail) process.send() of a function throws ERR_INVALID_ARG_TYPE in the child
  error: IPC channel closed before a message arrived
 1 pass
 4 fail
```

</details>

```
$ bun bd test test/js/node/child_process/child_process_ipc.test.js
 5 pass
 0 fail
```

The repro above now exits 0, matching node. `test/js/node/child_process/`,
`test/js/bun/spawn/` IPC tests, `test/js/node/cluster.test.ts` and node's ported
`test-child-process-send-*.js` (including `test-child-process-send-type-error.js`)
are unchanged.
