### PR TITLE
bundler: compose publicPath with the outdir-relative path of the referenced file

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -682,6 +682,12 @@ impl IntermediateOutput {
                     from_chunk_dir = b"";
                 }
 
+                // esbuild's `pathBetweenChunks`: with a public path configured, every
+                // reference is `publicPath + outdir-relative path`. Importer-relative
+                // paths would escape the prefix from chunks in subdirectories.
+                let use_outdir_relative_path =
+                    from_chunk_dir.is_empty() || force_absolute_path || !import_prefix.is_empty();
+
                 let urls_for_css: &[&[u8]] = if standalone_chunk_contents.is_some() {
                     graph.ast.items_url_for_css()
                 } else {
@@ -763,7 +769,7 @@ impl IntermediateOutput {
 
                             let cheap_normalizer = cheap_prefix_normalizer(
                                 import_prefix,
-                                if from_chunk_dir.is_empty() || force_absolute_path {
+                                if use_outdir_relative_path {
                                     file_path
                                 } else {
                                     bun_paths::resolve_path::relative_platform_buf::<
@@ -944,7 +950,7 @@ impl IntermediateOutput {
                             };
                             let cheap_normalizer = cheap_prefix_normalizer(
                                 import_prefix,
-                                if from_chunk_dir.is_empty() || force_absolute_path {
+                                if use_outdir_relative_path {
                                     file_path
                                 } else {
                                     bun_paths::resolve_path::relative_platform_buf::<

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect } from "bun:test";
 import { isBroken, isWindows } from "harness";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
+
+// A public path composes with the referenced file's path relative to the output
+// directory, never relative to the importing chunk (esbuild's semantics).
+const CDN_PUBLIC_PATH = "https://cdn.example/app/";
+const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.example\/[^"]+)"/g)].map(match => match[1]);
 
 describe("bundler", () => {
   itBundled("edgecase/EmptyFile", {
@@ -860,6 +866,94 @@ describe("bundler", () => {
     outdir: "/out",
     publicPath: "/www",
     run: {},
+  });
+  itBundled("edgecase/PublicPathNestedChunkReferences", {
+    files: {
+      "/src/pages/a/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        import logo from "../../logo.svg";
+        console.log(shared(), logo);
+      `,
+      "/src/pages/b/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        console.log(shared());
+      `,
+      "/src/shared.ts": /* ts */ `
+        import icon from "./icon.svg";
+        export const shared = () => icon;
+      `,
+      "/src/icon.svg": `<svg id="icon" />`,
+      "/src/logo.svg": `<svg id="logo" />`,
+    },
+    entryPoints: ["/src/pages/a/entry.ts", "/src/pages/b/entry.ts"],
+    outputPaths: ["/out/pages/a/entry.js", "/out/pages/b/entry.js"],
+    root: "/src",
+    outdir: "/out",
+    splitting: true,
+    publicPath: CDN_PUBLIC_PATH,
+    chunkNaming: "chunk-[hash].[ext]",
+    loader: { ".svg": "file" },
+    onAfterBundle(api) {
+      // The nested entry references the shared chunk and its own asset. Both
+      // must resolve under the public path, not above it.
+      const nested = cdnUrls(api.readFile("out/pages/a/entry.js")).map(url => url.slice(CDN_PUBLIC_PATH.length));
+      expect(nested.sort()).toEqual([
+        expect.stringMatching(/^chunk-[a-z0-9]+\.js$/),
+        expect.stringMatching(/^logo-[a-z0-9]+\.svg$/),
+      ]);
+      for (const rel of nested) {
+        api.assertFileExists(join("out", rel));
+      }
+
+      // The root-level chunk emits the same form in the same build.
+      const chunks = readdirSync(api.outdir).filter(file => file.endsWith(".js"));
+      expect(chunks).toHaveLength(1);
+      const rootLevel = cdnUrls(api.readFile(join("out", chunks[0]))).map(url => url.slice(CDN_PUBLIC_PATH.length));
+      expect(rootLevel).toEqual([expect.stringMatching(/^icon-[a-z0-9]+\.svg$/)]);
+      api.assertFileExists(join("out", rootLevel[0]));
+    },
+  });
+  itBundled("edgecase/PublicPathNestedEntryAsset", {
+    files: {
+      "/src/pages/a/entry.ts": /* ts */ `
+        import logo from "../../logo.svg";
+        console.log(logo);
+      `,
+      "/src/logo.svg": `<svg id="logo" />`,
+    },
+    entryPoints: ["/src/pages/a/entry.ts"],
+    outputPaths: ["/out/pages/a/entry.js"],
+    root: "/src",
+    outdir: "/out",
+    publicPath: CDN_PUBLIC_PATH,
+    loader: { ".svg": "file" },
+    onAfterBundle(api) {
+      const urls = cdnUrls(api.readFile("out/pages/a/entry.js")).map(url => url.slice(CDN_PUBLIC_PATH.length));
+      expect(urls).toEqual([expect.stringMatching(/^logo-[a-z0-9]+\.svg$/)]);
+      api.assertFileExists(join("out", urls[0]));
+    },
+  });
+  itBundled("edgecase/NoPublicPathNestedChunkStaysRelative", {
+    files: {
+      "/src/pages/a/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        console.log(shared());
+      `,
+      "/src/pages/b/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        console.log(shared());
+      `,
+      "/src/shared.ts": `export const shared = () => "shared";`,
+    },
+    entryPoints: ["/src/pages/a/entry.ts", "/src/pages/b/entry.ts"],
+    outputPaths: ["/out/pages/a/entry.js", "/out/pages/b/entry.js"],
+    root: "/src",
+    outdir: "/out",
+    splitting: true,
+    chunkNaming: "chunk-[hash].[ext]",
+    onAfterBundle(api) {
+      api.expectFile("out/pages/a/entry.js").toMatch(/from "\.\.\/\.\.\/chunk-[a-z0-9]+\.js"/);
+    },
   });
   itBundled("edgecase/ImportDefaultInDirectory", {
     files: {


### PR DESCRIPTION
Fixes #9896
Fixes #3322

### Repro

```sh
bun build src/pages/a/entry.ts src/pages/b/entry.ts \
  --outdir=out --root=src --splitting --format=esm --target=browser \
  --public-path=https://cdn.example/app/ --loader=.svg:file
```

Every reference emitted from a chunk that lives in a subdirectory of the output directory escapes the public-path prefix:

```js
// out/pages/a/entry.js
import { shared } from "https://cdn.example/app/../../shared-kza5hj5k.js"; // resolves to /shared-kza5hj5k.js
var logo = "https://cdn.example/app/../../logo-7cr55x2a.svg";              // 404s on the CDN

// out/shared-kza5hj5k.js  (root-level chunk, same build)
var icon = "https://cdn.example/app/icon-2y5dry5d.svg";                    // correct
```

HTML entry points in a subdirectory have the same problem (`href="https://cdn.example/app/../index-vwpfspr7.css"`).

A code-split app deployed under a CDN prefix therefore 404s on its own chunks and file-loader assets, and only for entries in subdirectories. Local testing passes because the relative form happens to resolve correctly from disk.

### Cause

`IntermediateOutput::code` composes the public path with the referenced file's path *relative to the importing chunk's directory* instead of relative to the output directory. Root-level chunks look right only because the importer-relative branch is skipped when the chunk directory is empty:

```rust
cheap_prefix_normalizer(
    import_prefix,
    if from_chunk_dir.is_empty() || force_absolute_path {
        file_path                                    // outdir-relative
    } else {
        relative_platform_buf(.., from_chunk_dir, file_path)  // importer-relative
    },
);
```

esbuild's `pathBetweenChunks` returns `joinWithPublicPath(publicPath, toRelPath)` whenever a public path is set, and only falls back to a relative path when there isn't one.

### Fix

When a public path is configured, compose it with the outdir-relative path unconditionally. Without a public path, references stay importer-relative exactly as before. This covers cross-chunk imports (static and dynamic), file-loader assets, and HTML chunk references, since all three flow through the same piece substitution.

### Verification

`bun build` with the repro above now emits `https://cdn.example/app/shared-kza5hj5k.js`, matching esbuild byte for byte on the same input.

Three tests in `test/bundler/bundler_edgecase.test.ts`:
- `PublicPathNestedChunkReferences` — splitting; the nested entry's chunk import and asset both resolve under the prefix, and each composed URL names a file that actually exists under the outdir. Also asserts the root-level chunk in the same build.
- `PublicPathNestedEntryAsset` — nested entry, no splitting.
- `NoPublicPathNestedChunkStaysRelative` — without a public path, the nested entry still imports `../../chunk-<hash>.js`.

Without the fix the first two produce `"../../chunk-tbnq96f4.js"` / `"../../logo-cdpwa3f7.svg"`; the third passes both ways and guards the default.

<details>
<summary>Suites run</summary>

`bundler_edgecase`, `bundler_splitting`, `bundler_loader`, `bundler_regressions`, `esbuild/loader`, `esbuild/splitting`, `bundler_html`, `bundler_compile`, `bundler_compile_splitting`, `standalone`, `html-import-manifest`, `bundler_naming`, `metafile`, `bun-build-api`, `test/bake`.

Pre-existing failures unrelated to this change (reproduced on the same build with `src/` stashed): the `compile/*Bytecode*` tests assert exact stderr and pick up a debug-build `hintSourcePagesDontNeed: MADV_DONTNEED` warning; `Bun.build can be called thousands of times in one process` times out at 180s under debug+ASAN; `test/bake/dev/production.test.ts` has 5s-timeout flakes whose failing subset shifts between runs.

`--compile` already took the outdir-relative branch via `force_absolute_path`, so it is unaffected. `bun build --app` (Bake) output is byte-for-byte identical before and after, since its client chunks carry an empty public path.
</details>


### Reported symptoms

Both linked issues are this composition bug. Reproduced on stock 1.4.0 and re-run against this branch; the chunk hashes are identical before and after, so only the composition changed:

| Issue | stock 1.4.0 | this PR |
| --- | --- | --- |
| #9896 | `/assets/../index-7apgmy4d.js` | `/assets/index-7apgmy4d.js` |
| #3322 | `http://localhost:3000/../../../../index-57b36qva.js` | `http://localhost:3000/index-57b36qva.js` |

The names and the number of `../` segments differ from the original reports only because chunk naming changed from `chunk-[hash]` to `[name]-[hash]` since 1.1.0, and #3322's tree was one level deeper.

Neither is a regression (the behavior was never correct, and #3322 is filed as a feature request), so the tests live in the bundler's existing edgecase file rather than `test/regression/issue/`.
