### PR TITLE
js_parser: key exports.eliminate/replace on the exported name

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2440,6 +2440,9 @@ declare module "bun" {
        * Names of exports to remove, matched against the *exported* name.
        *
        * For `export { q as QA }`, that is `"QA"` and not the local `"q"`.
+       *
+       * Any exported name works here, including string-named exports such as
+       * `export { q as "a-b" }`.
        */
       eliminate?: string[];
       /**
@@ -2450,6 +2453,13 @@ declare module "bun" {
        * A `[name, value]` pair exports `value` under `name` instead, so
        * `{ getStaticProps: ["__N_SSG", true] }` turns an exported
        * `getStaticProps` into `export var __N_SSG = true`.
+       *
+       * Keys, and the `name` of a pair, have to be valid ECMAScript
+       * identifiers; anything else throws. That is narrower than `eliminate`,
+       * so `export { q as "a-b" }` can only be eliminated. A replacement is
+       * emitted as `export var <name>`, which a reserved word cannot spell:
+       * `{ default: 1 }` replaces `export default x` but leaves
+       * `export { x as default }` untouched.
        */
       replace?: Record<string, ExportReplacement | [string, ExportReplacement]>;
     };

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2296,6 +2296,11 @@ declare module "bun" {
   type MacroMap = Record<string, Record<string, string>>;
 
   /**
+   * The value an export may be replaced with by {@link TranspilerOptions.exports}.
+   */
+  type ExportReplacement = string | number | boolean | null | undefined;
+
+  /**
    * Hash a string or array buffer using Wyhash
    *
    * This is not a cryptographic hash function.
@@ -2441,8 +2446,12 @@ declare module "bun" {
        * Exports to replace, keyed on the *exported* name.
        *
        * For `export { q as QA }`, that is `"QA"` and not the local `"q"`.
+       *
+       * A `[name, value]` pair exports `value` under `name` instead, so
+       * `{ getStaticProps: ["__N_SSG", true] }` turns an exported
+       * `getStaticProps` into `export var __N_SSG = true`.
        */
-      replace?: Record<string, string>;
+      replace?: Record<string, ExportReplacement | [string, ExportReplacement]>;
     };
     treeShaking?: boolean;
     trimUnusedImports?: boolean;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2431,7 +2431,17 @@ declare module "bun" {
     autoImportJSX?: boolean;
     allowBunRuntime?: boolean;
     exports?: {
+      /**
+       * Names of exports to remove, matched against the *exported* name.
+       *
+       * For `export { q as QA }`, that is `"QA"` and not the local `"q"`.
+       */
       eliminate?: string[];
+      /**
+       * Exports to replace, keyed on the *exported* name.
+       *
+       * For `export { q as QA }`, that is `"QA"` and not the local `"q"`.
+       */
       replace?: Record<string, string>;
     };
     treeShaking?: boolean;

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -5,9 +5,8 @@ use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
 
-use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, can_be_binding_identifier};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -122,21 +121,6 @@ fn class_copy(c: &G::Class) -> G::Class {
         has_decorators: c.has_decorators,
         should_lower_standard_decorators: c.should_lower_standard_decorators,
     }
-}
-
-/// Whether a context-inferred name (`export default` → "default", object
-/// property keys, assignment targets) can be attached to a lowered anonymous
-/// class expression as its syntactic binding name. Class bodies are always
-/// strict mode code and the output may be a module, so reserved words
-/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
-/// strings would turn `_class = class <name> {}` into a syntax error.
-#[inline]
-fn can_be_class_binding_name(name: &[u8]) -> bool {
-    js_lexer::is_identifier(name)
-        && js_lexer::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"await"
-        && !is_eval_or_arguments(name)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1139,7 +1123,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 class_name_loc = loc;
                 expr_class_is_anonymous = true;
                 if let Some(name) = name_from_context
-                    && can_be_class_binding_name(name)
+                    && can_be_binding_identifier(name)
                 {
                     class.class_name = Some(js_ast::LocRef {
                         ref_: p.new_sym(js_ast::symbol::Kind::Other, name),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6246,8 +6246,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.features.replace_exports.contains(symbol_name)
     }
 
-    /// Whether `declare_symbol` would accept a `var` named `name` here, rather
-    /// than reporting a redeclaration. Asking `can_merge_symbol_kinds` directly
+    /// Whether a `var` named `name` can share this scope with whatever already
+    /// binds it. `can_merge_symbol_kinds` answers that for declarations, and
     /// keeps this in step with what `declare_symbol` goes on to decide.
     fn can_declare_hoisted(&self, name: &[u8]) -> bool {
         let hash = js_ast::Scope::get_member_hash(name);
@@ -6255,6 +6255,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return true;
         };
         let existing = self.symbols[member.ref_.inner_index() as usize].kind;
+        // TypeScript merges a `var` into an import rather than refusing it, since
+        // the import may be type-only. The two still bind the same name, and
+        // `scan_imports` reports that once the import is used as a value.
+        if existing == js_ast::symbol::Kind::Import {
+            return false;
+        }
         !matches!(
             js_ast::Scope::can_merge_symbol_kinds::<TYPESCRIPT>(
                 self.current_scope.kind,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6287,20 +6287,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !replacement.is_replace() {
             return Ok(Some(local_ref));
         }
-        // `Replace` prints `export var <alias> = value`.
-        if !can_be_binding_identifier(alias) {
+        // `Replace` prints `export var <alias> = value`, so the alias has to spell
+        // a binding, and that binding has to be able to share the scope with
+        // whatever already holds the name, renamed or not.
+        if !can_be_binding_identifier(alias) || !self.can_declare_hoisted(alias) {
             return Ok(None);
         }
         // Reusing the local binding only works when there is one. A re-export
         // has no local symbol, just the parse-time name ref.
         if alias == local_name && local_ref.is_symbol() {
             return Ok(Some(local_ref));
-        }
-        // Otherwise bind the alias itself. That merges with a `var` of the same
-        // name, but a lexical one would make `declare_symbol` report a
-        // redeclaration the source never wrote.
-        if !self.can_declare_hoisted(alias) {
-            return Ok(None);
         }
         Ok(Some(self.declare_symbol(
             js_ast::symbol::Kind::Hoisted,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6285,11 +6285,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !can_be_binding_identifier(alias) {
             return Ok(None);
         }
-        if alias == local_name {
+        // Reusing the local binding only works when there is one. A re-export
+        // has no local symbol, just the parse-time name ref.
+        if alias == local_name && local_ref.is_symbol() {
             return Ok(Some(local_ref));
         }
-        // A renamed export binds the alias itself. That merges with a `var` of
-        // the same name, but a lexical one would make `declare_symbol` report a
+        // Otherwise bind the alias itself. That merges with a `var` of the same
+        // name, but a lexical one would make `declare_symbol` report a
         // redeclaration the source never wrote.
         if !self.can_declare_hoisted(alias) {
             return Ok(None);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6246,6 +6246,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.features.replace_exports.contains(symbol_name)
     }
 
+    /// The ref `inject_replacement_export` should bind for a clause item whose
+    /// exported name is `alias`. `Replace` prints `export var <alias> = value`,
+    /// so a renamed export declares a hoisted binding (one a local of the same
+    /// name merges into). `None` means the alias cannot spell a binding, so the
+    /// caller keeps the clause item.
+    pub fn replacement_export_ref(
+        &mut self,
+        replacement: &crate::parser::Runtime::ReplaceableExport,
+        alias: &'a [u8],
+        local_name: &'a [u8],
+        alias_loc: bun_ast::Loc,
+        local_ref: Ref,
+    ) -> Result<Option<Ref>, bun_core::Error> {
+        if !replacement.is_replace() || alias == local_name {
+            return Ok(Some(local_ref));
+        }
+        if !can_bind_exported_name(alias) {
+            return Ok(None);
+        }
+        Ok(Some(self.declare_symbol(
+            js_ast::symbol::Kind::Hoisted,
+            alias_loc,
+            alias,
+        )?))
+    }
+
     pub fn inject_replacement_export(
         &mut self,
         stmts: &mut crate::parser::StmtList<'a>,
@@ -9648,4 +9674,14 @@ pub fn null_value_expr() -> js_ast::ExprData {
 #[inline]
 pub fn false_value_expr() -> js_ast::ExprData {
     js_ast::ExprData::EBoolean(E::Boolean { value: false })
+}
+
+/// Can `name` spell the binding of an `export var <name> = ...` in a module?
+/// `exports.replace` keys only pass `is_identifier`, which accepts every
+/// keyword, so `default` and friends reach here and have no binding form.
+fn can_bind_exported_name(name: &[u8]) -> bool {
+    bun_ast::lexer_tables::keyword(name).is_none()
+        && !js_lexer::is_strict_mode_reserved_word(name)
+        && name != b"eval"
+        && name != b"arguments"
 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -26,8 +26,8 @@ use crate::{
     JSXImport, JSXTransformType, Jest, LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState,
     ParseStatementOptions, ParsedPath, PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap,
     RuntimeImports, ScopeOrder, ScopeOrderList, SideEffects, StrictModeFeature, StringBoolMap,
-    Substitution, TempRef, ThenCatchChain, TransposeState, WrapMode, fs, is_eval_or_arguments,
-    options, statement_cares_about_scope,
+    Substitution, TempRef, ThenCatchChain, TransposeState, WrapMode, can_be_binding_identifier, fs,
+    is_eval_or_arguments, options, statement_cares_about_scope,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -6246,11 +6246,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.features.replace_exports.contains(symbol_name)
     }
 
+    /// Whether `declare_symbol` would accept a `var` named `name` here, rather
+    /// than reporting a redeclaration. Asking `can_merge_symbol_kinds` directly
+    /// keeps this in step with what `declare_symbol` goes on to decide.
+    fn can_declare_hoisted(&self, name: &[u8]) -> bool {
+        let hash = js_ast::Scope::get_member_hash(name);
+        let Some(member) = self.current_scope.get_member_with_hash(name, hash) else {
+            return true;
+        };
+        let existing = self.symbols[member.ref_.inner_index() as usize].kind;
+        !matches!(
+            js_ast::Scope::can_merge_symbol_kinds::<TYPESCRIPT>(
+                self.current_scope.kind,
+                existing,
+                js_ast::symbol::Kind::Hoisted,
+            ),
+            js_ast::scope::SymbolMergeResult::Forbidden
+        )
+    }
+
     /// The ref `inject_replacement_export` should bind for a clause item whose
-    /// exported name is `alias`. `Replace` prints `export var <alias> = value`,
-    /// so a renamed export declares a hoisted binding (one a local of the same
-    /// name merges into). `None` means the alias cannot spell a binding, so the
-    /// caller keeps the clause item.
+    /// exported name is `alias`. `None` means the replacement has no legal
+    /// spelling here, so the caller keeps the clause item untouched.
     pub fn replacement_export_ref(
         &mut self,
         replacement: &crate::parser::Runtime::ReplaceableExport,
@@ -6259,10 +6276,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         alias_loc: bun_ast::Loc,
         local_ref: Ref,
     ) -> Result<Option<Ref>, bun_core::Error> {
-        if !replacement.is_replace() || alias == local_name {
+        // `Delete` drops the item and `Inject` names its own binding, so neither
+        // cares what the alias spells.
+        if !replacement.is_replace() {
             return Ok(Some(local_ref));
         }
-        if !can_bind_exported_name(alias) {
+        // `Replace` prints `export var <alias> = value`.
+        if !can_be_binding_identifier(alias) {
+            return Ok(None);
+        }
+        if alias == local_name {
+            return Ok(Some(local_ref));
+        }
+        // A renamed export binds the alias itself. That merges with a `var` of
+        // the same name, but a lexical one would make `declare_symbol` report a
+        // redeclaration the source never wrote.
+        if !self.can_declare_hoisted(alias) {
             return Ok(None);
         }
         Ok(Some(self.declare_symbol(
@@ -9674,14 +9703,4 @@ pub fn null_value_expr() -> js_ast::ExprData {
 #[inline]
 pub fn false_value_expr() -> js_ast::ExprData {
     js_ast::ExprData::EBoolean(E::Boolean { value: false })
-}
-
-/// Can `name` spell the binding of an `export var <name> = ...` in a module?
-/// `exports.replace` keys only pass `is_identifier`, which accepts every
-/// keyword, so `default` and friends reach here and have no binding form.
-fn can_bind_exported_name(name: &[u8]) -> bool {
-    bun_ast::lexer_tables::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"eval"
-        && name != b"arguments"
 }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1323,6 +1323,19 @@ pub(crate) fn is_eval_or_arguments(name: &[u8]) -> bool {
     name == b"eval" || name == b"arguments"
 }
 
+/// Whether `name` can spell a `BindingIdentifier` in strict-mode code. Class
+/// bodies and modules are always strict, so reserved words ("default", "let",
+/// "await", …), `eval`/`arguments`, and non-identifier strings are all syntax
+/// errors when used as a binding there.
+#[inline]
+pub(crate) fn can_be_binding_identifier(name: &[u8]) -> bool {
+    js_lexer::is_identifier(name)
+        && js_lexer::keyword(name).is_none()
+        && !js_lexer::is_strict_mode_reserved_word(name)
+        && name != b"await"
+        && !is_eval_or_arguments(name)
+}
+
 #[derive(Clone, Copy, Default)]
 pub struct PrependTempRefsOpts {
     pub fn_body_loc: Option<bun_ast::Loc>,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -183,13 +183,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let symbol = p.find_symbol(items[i].alias_loc, name)?;
                 let ref_ = symbol.r#ref;
 
+                // `replace_exports` is keyed on the exported name, so
+                // `export { q as QA }` matches "QA" and never the local "q".
+                let alias: &'a [u8] = items[i].alias.slice();
                 // reshaped for borrowck — get_ptr borrows options; clone the
                 // small enum payload so `inject_replacement_export(&mut self, ...)` can run.
-                if let Some(entry) = p.options.features.replace_exports.get_ptr(name).cloned() {
+                if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
                     if !entry.is_replace() {
-                        p.ignore_usage(symbol.r#ref);
+                        p.ignore_usage(ref_);
                     }
-                    let _ = p.inject_replacement_export(stmts, symbol.r#ref, stmt.loc, &entry);
+                    // `Replace` emits `export var <name> = value`, and the name
+                    // it has to export is the alias. `Hoisted` matches that `var`:
+                    // a local of the same name merges instead of colliding.
+                    let export_ref = if entry.is_replace() && alias != name {
+                        p.declare_symbol(js_ast::symbol::Kind::Hoisted, items[i].alias_loc, alias)?
+                    } else {
+                        ref_
+                    };
+                    let _ = p.inject_replacement_export(stmts, export_ref, stmt.loc, &entry);
                     any_replaced = true;
                     continue;
                 }
@@ -286,10 +297,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let old_ref = items[i].name.ref_;
 
                 // alias is arena-owned (`ArenaStr`), valid for 'a.
-                let alias = items[i].alias.slice();
+                let alias: &'a [u8] = items[i].alias.slice();
                 if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
+                    // `Replace` emits `export var <name> = value`, and the name
+                    // it has to export is the alias, not the re-exported name.
+                    let export_ref = if entry.is_replace()
+                        && alias != items[i].original_name.slice()
+                    {
+                        p.declare_symbol(js_ast::symbol::Kind::Hoisted, items[i].alias_loc, alias)?
+                    } else {
+                        old_ref
+                    };
                     let _ =
-                        p.inject_replacement_export(stmts, old_ref, bun_ast::Loc::EMPTY, &entry);
+                        p.inject_replacement_export(stmts, export_ref, bun_ast::Loc::EMPTY, &entry);
                     continue;
                 }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -34,16 +34,6 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
 }
 
-/// Can `name` spell the binding of an `export var <name> = ...` in a module?
-/// `exports.replace` keys only pass `is_identifier`, which accepts every
-/// keyword, so `default` and friends reach here and have no binding form.
-fn can_bind_exported_name(name: &[u8]) -> bool {
-    js_ast::lexer_tables::keyword(name).is_none()
-        && !js_lexer::is_strict_mode_reserved_word(name)
-        && name != b"eval"
-        && name != b"arguments"
-}
-
 // a direct `impl P` block. The 30+ per-variant `s_*` helpers are private; only
 // `visit_and_append_stmt` is surfaced. Full draft body preserved under  mod _draft below.
 
@@ -199,23 +189,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // reshaped for borrowck — get_ptr borrows options; clone the
                 // small enum payload so `inject_replacement_export(&mut self, ...)` can run.
                 if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
-                    // `Replace` emits `export var <name> = value`, and the name it
-                    // has to export is the alias, so a renamed export needs an alias
-                    // that can bind. `Hoisted` lets a local of that name merge.
-                    let rename = entry.is_replace() && alias != name;
-                    if !rename || can_bind_exported_name(alias) {
+                    if let Some(export_ref) =
+                        p.replacement_export_ref(&entry, alias, name, items[i].alias_loc, ref_)?
+                    {
                         if !entry.is_replace() {
                             p.ignore_usage(ref_);
                         }
-                        let export_ref = if rename {
-                            p.declare_symbol(
-                                js_ast::symbol::Kind::Hoisted,
-                                items[i].alias_loc,
-                                alias,
-                            )?
-                        } else {
-                            ref_
-                        };
                         let _ = p.inject_replacement_export(stmts, export_ref, stmt.loc, &entry);
                         any_replaced = true;
                         continue;
@@ -316,20 +295,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // alias is arena-owned (`ArenaStr`), valid for 'a.
                 let alias: &'a [u8] = items[i].alias.slice();
                 if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
-                    // `Replace` emits `export var <name> = value`, and the name it
-                    // has to export is the alias, not the re-exported name. A
-                    // renamed export therefore needs an alias that can bind.
-                    let rename = entry.is_replace() && alias != items[i].original_name.slice();
-                    if !rename || can_bind_exported_name(alias) {
-                        let export_ref = if rename {
-                            p.declare_symbol(
-                                js_ast::symbol::Kind::Hoisted,
-                                items[i].alias_loc,
-                                alias,
-                            )?
-                        } else {
-                            old_ref
-                        };
+                    // The re-exported name, not the alias, is this item's local name.
+                    let original_name: &'a [u8] = items[i].original_name.slice();
+                    if let Some(export_ref) = p.replacement_export_ref(
+                        &entry,
+                        alias,
+                        original_name,
+                        items[i].alias_loc,
+                        old_ref,
+                    )? {
                         let _ = p.inject_replacement_export(
                             stmts,
                             export_ref,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -34,6 +34,16 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
 }
 
+/// Can `name` spell the binding of an `export var <name> = ...` in a module?
+/// `exports.replace` keys only pass `is_identifier`, which accepts every
+/// keyword, so `default` and friends reach here and have no binding form.
+fn can_bind_exported_name(name: &[u8]) -> bool {
+    js_ast::lexer_tables::keyword(name).is_none()
+        && !js_lexer::is_strict_mode_reserved_word(name)
+        && name != b"eval"
+        && name != b"arguments"
+}
+
 // a direct `impl P` block. The 30+ per-variant `s_*` helpers are private; only
 // `visit_and_append_stmt` is surfaced. Full draft body preserved under  mod _draft below.
 
@@ -189,20 +199,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // reshaped for borrowck — get_ptr borrows options; clone the
                 // small enum payload so `inject_replacement_export(&mut self, ...)` can run.
                 if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
-                    if !entry.is_replace() {
-                        p.ignore_usage(ref_);
+                    // `Replace` emits `export var <name> = value`, and the name it
+                    // has to export is the alias, so a renamed export needs an alias
+                    // that can bind. `Hoisted` lets a local of that name merge.
+                    let rename = entry.is_replace() && alias != name;
+                    if !rename || can_bind_exported_name(alias) {
+                        if !entry.is_replace() {
+                            p.ignore_usage(ref_);
+                        }
+                        let export_ref = if rename {
+                            p.declare_symbol(
+                                js_ast::symbol::Kind::Hoisted,
+                                items[i].alias_loc,
+                                alias,
+                            )?
+                        } else {
+                            ref_
+                        };
+                        let _ = p.inject_replacement_export(stmts, export_ref, stmt.loc, &entry);
+                        any_replaced = true;
+                        continue;
                     }
-                    // `Replace` emits `export var <name> = value`, and the name
-                    // it has to export is the alias. `Hoisted` matches that `var`:
-                    // a local of the same name merges instead of colliding.
-                    let export_ref = if entry.is_replace() && alias != name {
-                        p.declare_symbol(js_ast::symbol::Kind::Hoisted, items[i].alias_loc, alias)?
-                    } else {
-                        ref_
-                    };
-                    let _ = p.inject_replacement_export(stmts, export_ref, stmt.loc, &entry);
-                    any_replaced = true;
-                    continue;
                 }
 
                 if p.symbols[ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound {
@@ -299,18 +316,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // alias is arena-owned (`ArenaStr`), valid for 'a.
                 let alias: &'a [u8] = items[i].alias.slice();
                 if let Some(entry) = p.options.features.replace_exports.get_ptr(alias).cloned() {
-                    // `Replace` emits `export var <name> = value`, and the name
-                    // it has to export is the alias, not the re-exported name.
-                    let export_ref = if entry.is_replace()
-                        && alias != items[i].original_name.slice()
-                    {
-                        p.declare_symbol(js_ast::symbol::Kind::Hoisted, items[i].alias_loc, alias)?
-                    } else {
-                        old_ref
-                    };
-                    let _ =
-                        p.inject_replacement_export(stmts, export_ref, bun_ast::Loc::EMPTY, &entry);
-                    continue;
+                    // `Replace` emits `export var <name> = value`, and the name it
+                    // has to export is the alias, not the re-exported name. A
+                    // renamed export therefore needs an alias that can bind.
+                    let rename = entry.is_replace() && alias != items[i].original_name.slice();
+                    if !rename || can_bind_exported_name(alias) {
+                        let export_ref = if rename {
+                            p.declare_symbol(
+                                js_ast::symbol::Kind::Hoisted,
+                                items[i].alias_loc,
+                                alias,
+                            )?
+                        } else {
+                            old_ref
+                        };
+                        let _ = p.inject_replacement_export(
+                            stmts,
+                            export_ref,
+                            bun_ast::Loc::EMPTY,
+                            &entry,
+                        );
+                        continue;
+                    }
                 }
 
                 let _name = p.load_name_from_ref(old_ref);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1625,7 +1625,20 @@ export default class {
       );
     });
 
+    // The collision rules apply whether or not the clause renames the export.
+    it.each([
+      [`const foo = 1;`, `const foo = 1;`],
+      [`let foo = 1;`, `let foo = 1;`],
+      [`class foo {}`, `class foo {\n}`],
+      [`import { foo } from "./d";`, `import { foo } from "./d";`],
+    ])("leaves an unrenamed export colliding with `%s` alone", (decl, printed) => {
+      expect(transform(`${decl} export { foo };`, { replace: { foo: 9 } })).toBe(`${printed}\nexport { foo };`);
+    });
+
     it("replaces an unrenamed export clause", () => {
+      expect(transform(`function foo() {} export { foo };`, { replace: { foo: 9 } })).toBe(
+        `function foo() {}\nexport var foo = 9;`,
+      );
       expect(transform(`var foo = 1; export { foo };`, { replace: { foo: 9 } })).toBe(
         `var foo = 1;\nexport var foo = 9;`,
       );

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1551,6 +1551,78 @@ export default class {
     });
   });
 
+  describe("exports.eliminate and exports.replace match the exported name", () => {
+    const transform = (code, exports) =>
+      new Bun.Transpiler({ loader: "ts", exports })
+        .transformSync(code)
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean)
+        .join("\n");
+
+    it("eliminates a renamed export clause by its exported name", () => {
+      expect(transform(`const q = 1; export { q as QA };`, { eliminate: ["QA"] })).toBe(`const q = 1;`);
+    });
+
+    it("does not eliminate a renamed export clause by its local name", () => {
+      expect(transform(`const q = 1; export { q as QA };`, { eliminate: ["q"] })).toBe(
+        `const q = 1;\nexport { q as QA };`,
+      );
+    });
+
+    it("eliminates a renamed re-export clause by its exported name", () => {
+      expect(transform(`export { rr as RR } from "./dep";`, { eliminate: ["RR"] })).toBe(`export {  } from "./dep";`);
+      expect(transform(`export { rr as RR } from "./dep";`, { eliminate: ["rr"] })).toBe(
+        `export { rr as RR } from "./dep";`,
+      );
+    });
+
+    it("eliminates an unrenamed export clause", () => {
+      expect(transform(`const foo = 1; export { foo };`, { eliminate: ["foo"] })).toBe(`const foo = 1;`);
+    });
+
+    it("eliminates `export { q as default }` by the exported name", () => {
+      expect(transform(`const q = 1; export { q as default };`, { eliminate: ["default"] })).toBe(`const q = 1;`);
+    });
+
+    it("eliminates a string-named export clause", () => {
+      expect(transform(`const q = 1; export { q as "a-b" };`, { eliminate: ["a-b"] })).toBe(`const q = 1;`);
+    });
+
+    it("replaces a renamed export clause under its exported name", () => {
+      expect(transform(`var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
+        `var q = 1;\nexport var QA = 9;`,
+      );
+      expect(transform(`var q = 1; export { q as QA };`, { replace: { QA: ["INJ", true] } })).toBe(
+        `var q = 1;\nexport var INJ = true;`,
+      );
+    });
+
+    it("replaces a renamed re-export clause under its exported name", () => {
+      expect(transform(`export { rr as RR } from "./dep";`, { replace: { RR: 9 } })).toBe(
+        `export var RR = 9;\nexport {  } from "./dep";`,
+      );
+    });
+
+    it("replaces an unrenamed export clause", () => {
+      expect(transform(`var foo = 1; export { foo };`, { replace: { foo: 9 } })).toBe(
+        `var foo = 1;\nexport var foo = 9;`,
+      );
+    });
+
+    it("replaces a renamed export whose exported name is also a local var", () => {
+      expect(transform(`var QA = 5; var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
+        `var QA = 5;\nvar q = 1;\nexport var QA = 9;`,
+      );
+    });
+
+    it("rejects a non-identifier exports.replace key", () => {
+      expect(() => new Bun.Transpiler({ loader: "ts", exports: { replace: { "a-b": 9 } } })).toThrow(
+        `"a-b" is not a valid ECMAScript identifier`,
+      );
+    });
+  });
+
   const bunTranspiler = new Bun.Transpiler({
     loader: "tsx",
     define: {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1619,22 +1619,45 @@ export default class {
       );
     });
 
-    // `export var default = ...` / `export var class = ...` are syntax errors, so a
-    // `replace` entry keyed on a reserved word has no binding to emit.
-    it.each(["default", "class", "let", "eval"])("leaves `export { q as %s }` alone when replacing", keyword => {
-      expect(transform(`var q = 1; export { q as ${keyword} };`, { replace: { [keyword]: 9 } })).toBe(
-        `var q = 1;\nexport { q as ${keyword} };`,
+    // The injected `export var QA` merges with a `var`, but a lexical binding of
+    // the same name cannot, and the source never declared QA twice.
+    it.each([
+      [`const QA = 5;`, `const QA = 5;`],
+      [`let QA = 5;`, `let QA = 5;`],
+      [`class QA {}`, `class QA {\n}`],
+    ])("leaves a renamed export colliding with `%s` alone", (decl, printed) => {
+      expect(transform(`${decl} var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
+        `${printed}\nvar q = 1;\nexport { q as QA };`,
       );
     });
 
-    it("leaves a renamed re-export of a reserved word alone when replacing", () => {
-      expect(transform(`export { rr as default } from "./d";`, { replace: { default: 9 } })).toBe(
-        `export { rr as default } from "./d";`,
+    // `export var default = ...` / `export var await = ...` are syntax errors, so a
+    // `replace` entry keyed on a reserved word has no binding to emit.
+    it.each(["default", "class", "let", "eval", "await"])(
+      "leaves `export { q as %s }` alone when replacing",
+      keyword => {
+        expect(transform(`var q = 1; export { q as ${keyword} };`, { replace: { [keyword]: 9 } })).toBe(
+          `var q = 1;\nexport { q as ${keyword} };`,
+        );
+      },
+    );
+
+    it.each(["default", "await"])("leaves a renamed re-export of `%s` alone when replacing", keyword => {
+      expect(transform(`export { rr as ${keyword} } from "./d";`, { replace: { [keyword]: 9 } })).toBe(
+        `export { rr as ${keyword} } from "./d";`,
+      );
+    });
+
+    // The exported name is the reserved word even without `as`.
+    it("leaves an unrenamed re-export of a reserved word alone when replacing", () => {
+      expect(transform(`export { default } from "./d";`, { replace: { default: 9 } })).toBe(
+        `export { default } from "./d";`,
       );
     });
 
     it("still eliminates exports named with a reserved word", () => {
       expect(transform(`const q = 1; export { q as class };`, { eliminate: ["class"] })).toBe(`const q = 1;`);
+      expect(transform(`export { default } from "./d";`, { eliminate: ["default"] })).toBe(`export {  } from "./d";`);
     });
 
     it("rejects a non-identifier exports.replace key", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1616,6 +1616,24 @@ export default class {
       );
     });
 
+    // `export var default = ...` / `export var class = ...` are syntax errors, so a
+    // `replace` entry keyed on a reserved word has no binding to emit.
+    it.each(["default", "class", "let", "eval"])("leaves `export { q as %s }` alone when replacing", keyword => {
+      expect(transform(`var q = 1; export { q as ${keyword} };`, { replace: { [keyword]: 9 } })).toBe(
+        `var q = 1;\nexport { q as ${keyword} };`,
+      );
+    });
+
+    it("leaves a renamed re-export of a reserved word alone when replacing", () => {
+      expect(transform(`export { rr as default } from "./d";`, { replace: { default: 9 } })).toBe(
+        `export { rr as default } from "./d";`,
+      );
+    });
+
+    it("still eliminates exports named with a reserved word", () => {
+      expect(transform(`const q = 1; export { q as class };`, { eliminate: ["class"] })).toBe(`const q = 1;`);
+    });
+
     it("rejects a non-identifier exports.replace key", () => {
       expect(() => new Bun.Transpiler({ loader: "ts", exports: { replace: { "a-b": 9 } } })).toThrow(
         `"a-b" is not a valid ECMAScript identifier`,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1635,6 +1635,26 @@ export default class {
       expect(transform(`var QA = 5; var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
         `var QA = 5;\nvar q = 1;\nexport var QA = 9;`,
       );
+      expect(transform(`function QA() {} var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
+        `function QA() {}\nvar q = 1;\nexport var QA = 9;`,
+      );
+    });
+
+    // An unbound name is not a declaration, so the injected `var` still binds it.
+    it("replaces a renamed export whose exported name is unbound", () => {
+      expect(transform(`console.log(QA); var q = 1; export { q as QA };`, { replace: { QA: 9 } })).toBe(
+        `console.log(QA);\nvar q = 1;\nexport var QA = 9;`,
+      );
+    });
+
+    // TypeScript merges a `var` into an import rather than refusing it, but then
+    // both bind the name and `scan_imports` rejects the file.
+    it("leaves a renamed export colliding with an import alone", () => {
+      expect(
+        transform(`import { QA } from "./d"; console.log(QA); var q = 1; export { q as QA };`, {
+          replace: { QA: 9 },
+        }),
+      ).toBe(`import { QA } from "./d";\nconsole.log(QA);\nvar q = 1;\nexport { q as QA };`);
     });
 
     // The injected `export var QA` merges with a `var`, but a lexical binding of

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1607,6 +1607,24 @@ export default class {
       );
     });
 
+    // A re-export has no local binding to reuse, so `Replace` has to declare the
+    // alias even when the clause does not rename it.
+    it("replaces an unrenamed re-export clause", () => {
+      expect(transform(`export { RR } from "./dep";`, { replace: { RR: 9 } })).toBe(
+        `export var RR = 9;\nexport {  } from "./dep";`,
+      );
+      expect(transform(`export { RR } from "./dep";`, { replace: { RR: ["INJ", true] } })).toBe(
+        `export var INJ = true;\nexport {  } from "./dep";`,
+      );
+      expect(transform(`export { RR } from "./dep";`, { eliminate: ["RR"] })).toBe(`export {  } from "./dep";`);
+    });
+
+    it("replaces an unrenamed re-export whose exported name is also a local var", () => {
+      expect(transform(`var RR = 5; export { RR } from "./dep";`, { replace: { RR: 9 } })).toBe(
+        `var RR = 5;\nexport var RR = 9;\nexport {  } from "./dep";`,
+      );
+    });
+
     it("replaces an unrenamed export clause", () => {
       expect(transform(`var foo = 1; export { foo };`, { replace: { foo: 9 } })).toBe(
         `var foo = 1;\nexport var foo = 9;`,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1642,18 +1642,24 @@ export default class {
       },
     );
 
-    it.each(["default", "await"])("leaves a renamed re-export of `%s` alone when replacing", keyword => {
-      expect(transform(`export { rr as ${keyword} } from "./d";`, { replace: { [keyword]: 9 } })).toBe(
-        `export { rr as ${keyword} } from "./d";`,
-      );
-    });
+    it.each(["default", "class", "let", "eval", "await"])(
+      "leaves a renamed re-export of `%s` alone when replacing",
+      keyword => {
+        expect(transform(`export { rr as ${keyword} } from "./d";`, { replace: { [keyword]: 9 } })).toBe(
+          `export { rr as ${keyword} } from "./d";`,
+        );
+      },
+    );
 
-    // The exported name is the reserved word even without `as`.
-    it("leaves an unrenamed re-export of a reserved word alone when replacing", () => {
-      expect(transform(`export { default } from "./d";`, { replace: { default: 9 } })).toBe(
-        `export { default } from "./d";`,
-      );
-    });
+    // A re-export carries the reserved word as its exported name even without `as`.
+    it.each(["default", "class", "let", "eval", "await"])(
+      "leaves an unrenamed re-export of `%s` alone when replacing",
+      keyword => {
+        expect(transform(`export { ${keyword} } from "./d";`, { replace: { [keyword]: 9 } })).toBe(
+          `export { ${keyword} } from "./d";`,
+        );
+      },
+    );
 
     it("still eliminates exports named with a reserved word", () => {
       expect(transform(`const q = 1; export { q as class };`, { eliminate: ["class"] })).toBe(`const q = 1;`);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1602,6 +1602,9 @@ export default class {
       expect(transform(`export { rr as RR } from "./dep";`, { replace: { RR: 9 } })).toBe(
         `export var RR = 9;\nexport {  } from "./dep";`,
       );
+      expect(transform(`export { rr as RR } from "./dep";`, { replace: { RR: ["INJ", true] } })).toBe(
+        `export var INJ = true;\nexport {  } from "./dep";`,
+      );
     });
 
     it("replaces an unrenamed export clause", () => {

--- a/test/integration/bun-types/fixture/transpiler.ts
+++ b/test/integration/bun-types/fixture/transpiler.ts
@@ -37,6 +37,10 @@ new Bun.Transpiler({
   },
 });
 
+// `eliminate` takes any exported name; `replace` keys are identifier-validated
+// at runtime, so a string-named export can only be eliminated.
+new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["a-b"] } });
+
 const transpiler = new Bun.Transpiler({ loader: "ts" });
 expectType(transpiler.transformSync("const q = 1; export { q as QA };")).is<string>();
 expectType(transpiler.scan("export { q as QA };").exports).is<string[]>();

--- a/test/integration/bun-types/fixture/transpiler.ts
+++ b/test/integration/bun-types/fixture/transpiler.ts
@@ -1,0 +1,51 @@
+import { expectType } from "./utilities";
+
+// -- Bun.Transpiler exports.eliminate / exports.replace --
+
+// `eliminate` and `replace` are keyed on the exported name, not the local one.
+new Bun.Transpiler({
+  loader: "ts",
+  exports: {
+    eliminate: ["QA", "getServerSideProps"],
+  },
+});
+
+// Every scalar `exports.replace` accepts.
+new Bun.Transpiler({
+  loader: "ts",
+  exports: {
+    replace: {
+      aString: "bar",
+      aNumber: 9,
+      aBoolean: true,
+      aNull: null,
+      anUndefined: undefined,
+    },
+  },
+});
+
+// The `[name, value]` pair exports `value` under `name` instead.
+new Bun.Transpiler({
+  loader: "ts",
+  exports: {
+    replace: {
+      getStaticProps: ["__N_SSG", true],
+      getServerSideProps: ["__N_SSP", 1],
+      loader: ["__LOADER", "x"],
+      nulled: ["__NULL", null],
+    },
+  },
+});
+
+const transpiler = new Bun.Transpiler({ loader: "ts" });
+expectType(transpiler.transformSync("const q = 1; export { q as QA };")).is<string>();
+expectType(transpiler.scan("export { q as QA };").exports).is<string[]>();
+
+// @ts-expect-error -- an object is not a valid replacement value
+new Bun.Transpiler({ loader: "ts", exports: { replace: { foo: { a: 1 } } } });
+
+// @ts-expect-error -- the pair's value must be a scalar, not an object
+new Bun.Transpiler({ loader: "ts", exports: { replace: { foo: ["NAME", { a: 1 }] } } });
+
+// @ts-expect-error -- `eliminate` takes a list of exported names
+new Bun.Transpiler({ loader: "ts", exports: { eliminate: { foo: true } } });


### PR DESCRIPTION
`Bun.Transpiler`'s `exports.eliminate` / `exports.replace` are keyed on a module's **exported** names: that is the public surface, and it is what the sibling `Bun.Transpiler.scan()` reports. Export clauses matched the **local** name instead, and re-export clauses matched the exported name, so the same build had two opposite conventions and no single name worked for both forms. The miss is silent.

## Repro

```js
new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["QA"] } })
  .transformSync(`const q = 1; export { q as QA };`);
// => "const q = 1;\nexport { q as QA };"   (not eliminated; "q" eliminates it)

new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["RR"] } })
  .transformSync(`export { rr as RR } from "./dep";`);
// => "export {  } from \"./dep\";"          (eliminated; "rr" does not)

new Bun.Transpiler({ loader: "ts" })
  .scan(`const q = 1; export { q as QA }; export { rr as RR } from "./d";`).exports;
// => ["QA", "RR"]
```

## Cause

`s_export_clause` looked the entry up under `load_name_from_ref(item.name.ref_)`, which is the local name being exported, not `item.alias`. `s_export_from` already used `item.alias`, hence the split.

Keying on the alias then exposed a second half of the same defect: a `replace` entry injects `export var <name> = value`, and that name came from the local symbol. `export { rr as RR } from "./dep"` replaced by `{ RR: 9 }` emitted `export var rr = 9` on main, i.e. it matched `RR` but exported `rr`.

## Fix

Match `item.alias` in both clause forms, and name the injected `Replace` binding after the alias when it differs from the local name. `replacement_export_ref` resolves that ref for both forms.

The injected binding is a `var`, so it is declared `Kind::Hoisted` rather than `Kind::Other`. Without this, `var QA = 5; var q = 1; export { q as QA };` under `replace: { QA: 9 }` would report a spurious `"QA" has already been declared` for valid input; as a hoisted `var` it merges, exactly like the `var` that gets printed. A `const`/`let`/`class` of the same name cannot merge, so `replacement_export_ref` asks `can_merge_symbol_kinds` what `declare_symbol` would decide and leaves the clause alone on `Forbidden`. An import is rejected too: TypeScript merges a `var` into it rather than refusing it, since the import may be type-only, but both still bind the name and `scan_imports` then rejects the file. An unbound name is not a declaration, so the injected `var` still binds it. The same check gates the unrenamed clause, where it lands on the local itself: `const foo = 1; export { foo };` and `import { foo } from "./d"; export { foo };` used to print `export var foo = 9` beside the existing binding.

Emitting `export var <alias>` also needs the alias to be spellable as a strict-mode binding, and `exports.replace` keys are only checked with `is_identifier`, which accepts every keyword. The parser already had that predicate as `can_be_class_binding_name` in `lower_decorators.rs`; it now lives in `parser.rs` as `can_be_binding_identifier` and both callers share it. A reserved-word alias keeps its export clause, which is what main does for `export { q as default }`.

That guard runs before the `alias == local_name` fast path, because an unrenamed re-export carries the exported name too. The fast path itself only reuses `local_ref` when it `is_symbol()`: in `s_export_from` that ref is always the parse-time name ref from `store_name_in_ref`, so a re-export has no local binding to reuse and `Replace` has to declare the alias. Without both, `export { default } from "./d"` and `export { RR } from "./dep"` under `replace` reached `inject_replacement_export` with a non-symbol ref: `assertion failed: r#ref.is_symbol()` on a debug build, and on release a symbol table indexed by a name ref, which is what segfaults released bun once several such clauses run in one process.

`Delete` (`eliminate`) declares nothing, so reserved-word and string-named exports (`export { q as default }`, `export { q as "a-b" }`) are still eliminated by their exported name.

`exports.replace` was typed `Record<string, string>` while `JSTranspiler` accepts `string | number | boolean | null | undefined`, plus a `[name, value]` pair. The transpiler tests rely on both, so the documented Next.js config (`{ getStaticProps: ["__N_SSG", true] }`) did not type-check. Widened, with a `bun-types` fixture that pins the accepted space. The JSDoc also records that `replace` keys (and the `name` of a pair) are identifier-validated while `eliminate` is not, so `export { q as "a-b" }` can only be eliminated.

Declaration forms (`export const`/`function`/`class`), `export default`, and `export * as ns` already keyed on the exported name and are unchanged.

## Verification

`test/bundler/transpiler/transpiler.test.js`, `describe("exports.eliminate and exports.replace match the exported name")`: 38 tests covering renamed and unrenamed clauses, renamed and unrenamed re-exports, scalar and array-form `replace`, `as default`, string-named exports, the local-name non-match, the full collision matrix (`var` and `function` merge, `const`/`let`/`class`/import leave the clause alone, unbound binds), and every branch of `can_be_binding_identifier` (`default`, `class`, `let`, `eval`, `await`).

18 of them fail on released bun, and the unrenamed re-export case asserts on any debug build without the `is_symbol()` guard, which I confirmed by reverting just that line. On this branch the describe block is 38 pass / 0 fail, and `test/bundler/transpiler/` + `bundler_decorator_metadata.test.ts` + `bundler_esm.test.ts` + `bundler_edgecase.test.ts` are green at 4317 passing (the decorator suites cover the `lower_decorators.rs` dedup). `test/integration/bun-types/bun-types.test.ts` is 12 pass, 0 fail, and fails on the old `Record<string, string>` annotation, so the new fixture is not vacuous.

Only `Bun.Transpiler` populates `replace_exports`; the bundler always passes an empty map, so nothing else changes behavior.

## Known gaps, not touched here

All pre-existing, none reachable from the forms this PR rewires:

- `s_export_star` declares the alias itself, so `export * as default from "./d"` under `replace: { default: 9 }` still emits an invalid `export var default = 9`, and `var ns = 5; export * as ns from "./d"` under `replace: { ns: 9 }` still reports a redeclaration. Routing it through `replacement_export_ref` would fix both, but it is an untouched path with no reported bug.
- `inject_replacement_export` and `replace_decl_and_possibly_remove` declare their `Inject` name with `Kind::Other`, so `replace: { foo: ["default", true] }` emits an invalid `export var default`, and two entries injecting the same name (the `getStaticProps`/`getStaticPaths` → `__N_SSG` config in this repo's own tests) error. Making those merge raises a separate question about whether a duplicate `Inject` should dedupe.





