### PR TITLE
socket: fix use-after-free when upgradeTLS is called inside the socket open handler

### DIFF
--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -451,22 +451,40 @@ pub struct Scope {
 }
 
 impl Scope {
-    /// Returns true if `handlers` was destroyed (client mode, last ref).
-    /// Callers that also hold the pointer in a socket field must null it.
-    ///
-    /// Consumes `self`: a `Scope` is single-use (one `enter` ↔ one `exit`),
-    /// and after a `true` return `self.handlers` is dangling, so no further
-    /// method may touch it.
-    pub fn exit(self) -> bool {
-        // SAFETY: `handlers` is live until `mark_inactive` below (caller
-        // contract of `Handlers::enter`). `event_loop()` returns a non-null
-        // self-pointer into the VM; single JS thread, no aliasing
-        // `&mut EventLoop` outlives this call.
+    /// The event-loop `exit()` half, balancing the `enter()` in
+    /// [`Handlers::enter`]. Split from the `active_connections` bookkeeping
+    /// because draining microtasks here can synchronously reconnect or
+    /// `upgradeTLS` the socket, so the caller must observe the resulting
+    /// `handlers` state before deciding whether to decrement/free. Must be
+    /// followed by exactly one [`mark_inactive`](Self::mark_inactive), or by
+    /// dropping the scope when a new owner took over the handlers.
+    pub fn exit_event_loop(&self) {
+        // SAFETY: no decrement has run yet, so `handlers` is still live (caller
+        // contract of `Handlers::enter`). `event_loop_ref()` returns a non-null
+        // self-pointer into the VM; single JS thread, no aliasing `&mut
+        // EventLoop` outlives this call.
         unsafe { (*self.handlers).vm }.event_loop_ref().exit();
+    }
+
+    /// The `active_connections` half: decrements and, on reaching zero, frees
+    /// the client-mode allocation (or releases the listener, server mode).
+    /// Returns true if the client-mode allocation was destroyed; callers that
+    /// also hold the pointer in a socket field must then null it.
+    ///
+    /// Consumes `self`: a `Scope` is single-use (one `enter` ↔ one exit), and
+    /// after a `true` return `self.handlers` is dangling.
+    pub fn mark_inactive(self) -> bool {
         // SAFETY: `handlers` satisfies `mark_inactive`'s contract by
         // construction in `Handlers::enter` (caller passed the
         // server-embedded / client-heap-root pointer).
         unsafe { Handlers::mark_inactive(self.handlers) }
+    }
+
+    /// Event-loop exit + `mark_inactive` in one step, for callers that cannot
+    /// observe an intervening handlers transfer. Returns true if destroyed.
+    pub fn exit(self) -> bool {
+        self.exit_event_loop();
+        self.mark_inactive()
     }
 }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -925,13 +925,21 @@ impl<const SSL: bool> NewSocket<SSL> {
             .into()
     }
 
-    /// `scope.exit()` drains microtasks, during which a synchronous
-    /// reconnect may repoint `self.handlers` at a fresh allocation; only
-    /// null the cell when it still holds the `Handlers` that `exit` freed.
+    /// The event-loop exit drains microtasks, during which a synchronous
+    /// reconnect may repoint `self.handlers` at a fresh allocation (null the
+    /// cell only when it still holds the `Handlers` the scope freed) or
+    /// `upgradeTLS` may transfer the handlers to the raw TLS twin.
     #[inline]
     fn exit_scope(&self, scope: super::handlers::Scope, entered: bun_ptr::BackRef<Handlers>) {
         let captured = entered.as_ptr();
-        if scope.exit() && self.handlers.get().map(|n| n.as_ptr()) == Some(captured) {
+        scope.exit_event_loop();
+        // `upgradeTLS` can transfer client-mode handlers (and their
+        // `OWNS_HANDLERS` free) to the raw TLS twin from inside this callback,
+        // leaving `handlers` None; the twin frees them, so skip to avoid a double-free.
+        if self.handlers.get().is_none() && self.flags.get().contains(Flags::OWNS_HANDLERS) {
+            return;
+        }
+        if scope.mark_inactive() && self.handlers.get().map(|n| n.as_ptr()) == Some(captured) {
             self.handlers.set(None);
         }
     }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -895,7 +895,7 @@ console.log("completed", done, "cycles without crashing");
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toContain("completed 64 cycles without crashing");
+    expect(stdout.trim()).toBe("completed 64 cycles without crashing");
     expect(exitCode).toBe(0);
   }, 30_000); // subprocess + debug/ASAN startup is slow
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -833,6 +833,71 @@ describe.concurrent("socket", () => {
       client.end();
     }
   });
+  it("does not use-after-free when upgradeTLS is called synchronously inside the open handler", async () => {
+    // https://github.com/oven-sh/bun/issues/33387
+    // Calling upgradeTLS from inside the socket's own open callback transfers
+    // the per-connection Handlers (and its OWNS_HANDLERS free) to the raw TLS
+    // twin while the in-flight open scope still holds that same pointer. The
+    // scope used to free it on exit, then the twin double-freed it at GC.
+    using dir = tempDir("upgrade-tls-in-open", {
+      "fixture.mjs": `
+import net from "node:net";
+
+const server = net.createServer(sock => { sock.on("error", () => {}); sock.on("data", () => {}); });
+await new Promise(res => server.listen(0, "127.0.0.1", res));
+const port = server.address().port;
+
+const TLS = {
+  socket: { open() {}, data() {}, error() {}, close() {}, handshake() {}, end() {}, timeout() {}, drain() {} },
+  tls: { rejectUnauthorized: false, servername: "localhost" },
+};
+
+let done = 0;
+// The UAF fires at the first Bun.gc(true) that finalizes a raw twin whose
+// handlers the open scope freed; a small workload triggers it deterministically
+// (the unfixed binary segfaults well before completing).
+const TOTAL = 64, CONCURRENCY = 16;
+
+function oneCycle() {
+  return new Promise(resolve => {
+    let settled = false;
+    const fin = () => { if (settled) return; settled = true; resolve(); };
+    Bun.connect({
+      hostname: "127.0.0.1", port,
+      socket: {
+        open(sock) {
+          try {
+            const result = sock.upgradeTLS(TLS);
+            if (result) { const [raw, tls] = result; try { tls.end(); } catch {} try { raw.end(); } catch {} }
+          } catch {}
+          try { sock.end(); } catch {}
+          fin();
+        },
+        connectError() { fin(); }, error() { fin(); }, close() { fin(); }, data() {},
+      },
+    });
+  });
+}
+async function worker() { while (done < TOTAL) { done++; await oneCycle(); if (done % 8 === 0) Bun.gc(true); } }
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+Bun.gc(true); server.close();
+console.log("completed", done, "cycles without crashing");
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("completed 64 cycles without crashing");
+    expect(exitCode).toBe(0);
+  }, 30_000); // subprocess + debug/ASAN startup is slow
 });
 
 it.skipIf(isWindows)("should not crash when a socket from a file descriptor is closed after opening", async () => {


### PR DESCRIPTION
Fixes #33387.

## Repro

Calling `socket.upgradeTLS()` synchronously from inside the socket's own `open` (or `data`) callback crashes. Deterministic segfault on release, heap-use-after-free under ASAN:

```js
Bun.connect({
  hostname, port,
  socket: {
    open(sock) {
      const [raw, tls] = sock.upgradeTLS({ tls: { rejectUnauthorized: false }, socket: { /* ... */ } });
      tls.end(); raw.end(); sock.end();
    },
  },
});
// loop + Bun.gc(true) -> panic(main thread): Segmentation fault
```

This is the native path Node's `tls.connect({ socket })` takes (upgrade from the underlying socket's `connect`), which is how Claude Code's HTTPS client hit it in the issue.

## Cause

`upgrade_tls` transfers the original TCP socket's per-connection client `Handlers` allocation (and its `OWNS_HANDLERS` free) to the raw TLS twin. But when the upgrade runs while the original socket's `on_open` scope is still live, that scope captured the same `Handlers` pointer and frees it on exit via `Handlers::mark_inactive` (last `active_connections` ref). The raw twin then frees the same allocation again at GC finalize (`deinit_and_destroy`, `OWNS_HANDLERS`), so the two owners double-free / use-after-free it.

On release builds the freed bytes are reused, so `unprotect()` derefs a garbage `VM*` and it surfaces as the reported null deref:

```
panic(main thread): Segmentation fault at address 0x0
  RefPtr<JSC::VM>::refIfNotNull  (JSLock.cpp:55)
  ... JSC::MarkedBlock::Handle::sweep  (finalizing a JSTLSSocket)
```

ASAN pins it exactly:

```
heap-use-after-free in <Handlers>::mark_inactive (Handlers.rs:225)
  <Scope>::exit -> NewSocket<false>::exit_scope -> NewSocket<false>::on_open
freed by: Box<Handlers>::drop <- NewSocket<true>::deinit_and_destroy (socket_body.rs:3140, OWNS_HANDLERS)
allocated by: Box::<Handlers>::new (Listener::connect_inner)
```

## Fix

Split `Scope::exit` into the event-loop `exit()` and the `active_connections` decrement so `exit_scope` can observe the handlers state after the microtask drain. When the handlers were transferred away (`self.handlers` is `None` and the socket owned them via `OWNS_HANDLERS`), run only the event-loop exit and skip the decrement/free, leaving the single free to the raw twin's `deinit_and_destroy`. The event-loop `exit()` still always runs so the `enter()` stays balanced. Server-mode handlers are embedded in the listener (no `OWNS_HANDLERS`, never heap-freed), so they keep the existing path.

## Verification

New regression test in `test/js/bun/net/socket.test.ts` spawns the sync-upgrade loop as a subprocess.

- Unfixed debug build: ASAN heap-use-after-free, test fails.
- Unfixed release (1.4.0): segfault (exit 139), reproduced across repeated runs.
- With the fix: completes cleanly, and the existing `upgradeTLS` tests (client and server-side `isServer` path) still pass.