### PR TITLE
net: fail the write callback when a send error drops queued data

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -556,9 +556,14 @@ struct us_iovec_t {
 int us_socket_raw_writev(us_socket_r s, const struct us_iovec_t *iov, int count) nonnull_fn_decl;
 
 int us_socket_raw_write(us_socket_r s, const char *data, int length);
+/* Reported through *fatal_write_error when send() failed fatally but the
+ * platform could not name the error. */
+#define LIBUS_FATAL_WRITE_ERROR_UNKNOWN (-1)
 /* Like us_socket_write, but additionally reports a fatal (non-would-block)
  * send error through *fatal_write_error so opted-in callers can fail the
- * write instead of retrying forever. TLS sockets fall back to
+ * write instead of retrying forever. 0 means no fatal error; otherwise the
+ * value is the platform's send error (errno on POSIX, a WSA code on Windows)
+ * or LIBUS_FATAL_WRITE_ERROR_UNKNOWN. TLS sockets fall back to
  * us_socket_write (their errors propagate through the SSL layer). */
 int us_socket_write_check_error(us_socket_r s, const char *data, int length, int *fatal_write_error);
 

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -502,8 +502,13 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
         }
         /* Fatal send error (EPIPE/ECONNRESET after the peer vanished): report
          * it to callers that opt in instead of masking it as would-block, and
-         * do not keep polling writable - retrying can never succeed. */
-        if (fatal_write_error) *fatal_write_error = 1;
+         * do not keep polling writable - retrying can never succeed. The code
+         * lets node:net fail the write with the same errno Node surfaces;
+         * bsd_would_block() only reads the error, so it still names the send. */
+        if (fatal_write_error) {
+            int send_error = LIBUS_ERR;
+            *fatal_write_error = send_error ? send_error : LIBUS_FATAL_WRITE_ERROR_UNKNOWN;
+        }
         return 0;
     }
     if (written != length) {

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -200,6 +200,7 @@ using namespace JSC;
     macro(writable) \
     macro(writableType) \
     macro(write) \
+    macro(writeError) \
     macro(writer) \
     macro(written) \
     BUN_ADDITIONAL_BUILTIN_NAMES(macro)

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -254,6 +254,30 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
+/**
+ * A write that was waiting on the native drain can never complete once the
+ * socket is gone - fail it so 'finish'/destroy are not stuck behind it. The
+ * stream turns this into the user's write callback plus destroy(err), so
+ * 'error'/hadError fire and the writable side is never marked finished.
+ */
+function failPendingWrite(self, err?) {
+  const callback = self[kwriteCallback];
+  if (!callback) return;
+  self[kwriteCallback] = null;
+  callback(err ?? $ERR_SOCKET_CLOSED());
+}
+
+/**
+ * A flush that did not complete because send() failed outright (the peer is
+ * gone) has thrown the queued bytes away: they can never reach the wire and no
+ * further drain is coming. Fail the write with that error the way Node's
+ * onWriteComplete does, instead of reporting the dropped bytes as written.
+ */
+function failPendingWriteOnSendError(self, socket) {
+  const writeError = socket.$writeError();
+  if (writeError) failPendingWrite(self, writeError);
+}
+
 const SocketHandlers: SocketHandler = {
   close(socket, err) {
     const self = socket.data;
@@ -283,12 +307,13 @@ const SocketHandlers: SocketHandler = {
       const writeChunk = self._pendingData;
       if (socket.$write(writeChunk || "", self._pendingEncoding || "utf8")) {
         self._pendingData = self[kwriteCallback] = null;
+        self[kBytesWritten] = socket.bytesWritten;
         callback(null);
-      } else {
-        self._pendingData = null;
+        return;
       }
-
+      self._pendingData = null;
       self[kBytesWritten] = socket.bytesWritten;
+      failPendingWriteOnSendError(self, socket);
     }
   },
   end(socket) {
@@ -498,6 +523,7 @@ function SocketEmitEndNT(self, _err?) {
       const er = new ErrnoException(errErrno, "read") as Error & { code?: string };
       if (typeof er.code === "string" && /^E[A-Z0-9]+$/.test(er.code)) {
         self.destroy(er);
+        failPendingWrite(self, er);
         return;
       }
     }
@@ -512,9 +538,11 @@ function SocketEmitEndNT(self, _err?) {
       er.errno = _err.errno ?? (process.platform === "win32" ? -4077 : process.platform === "linux" ? -104 : -54);
       er.syscall = "read";
       self.destroy(er);
+      failPendingWrite(self, er);
     } else {
       // Any other coded error (ETIMEDOUT, EPIPE, ...) keeps its identity.
       self.destroy(_err);
+      failPendingWrite(self, _err);
     }
     return;
   }
@@ -531,12 +559,8 @@ function SocketEmitEndNT(self, _err?) {
     // no further events.
     self.destroy();
   }
-  // A write that was waiting on the native drain can never complete once the
-  // socket is gone - fail it so 'finish'/destroy are not stuck behind it.
-  const pendingWrite = self[kwriteCallback];
-  if (pendingWrite && (self.destroyed || _err)) {
-    self[kwriteCallback] = null;
-    pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
+  if (self.destroyed || _err) {
+    failPendingWrite(self, _err);
   }
 }
 
@@ -1034,10 +1058,11 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
         self[kBytesWritten] = socket.bytesWritten;
         self._pendingData = self[kwriteCallback] = null;
         callback(null);
-      } else {
-        self[kBytesWritten] = socket.bytesWritten;
-        self._pendingData = null;
+        return;
       }
+      self[kBytesWritten] = socket.bytesWritten;
+      self._pendingData = null;
+      failPendingWriteOnSendError(self, socket);
     }
   },
   end(socket) {
@@ -1082,35 +1107,28 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       // Same late-detach guard as SocketEmitEndNT: the listener seen at
       // close-time can be gone by the deferred 'error' emission.
       self.once("error", () => {});
+      let er = err;
       if (err.code === undefined || err.code === "ECONNRESET") {
         // Shape it like Node's errnoException(UV_ECONNRESET, 'read').
-        const er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
+        er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
         er.errno = err.errno;
         er.syscall = "read";
-        self.destroy(er);
-      } else {
-        // Any other recv errno (ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, ...)
-        // keeps its identity — Node's onStreamRead does
-        // `stream.destroy(errnoException(nread, 'read'))` for any nread that
-        // is not UV_EOF. The native on_close only passes a non-undefined err
-        // when the close was driven by a recv() failure (libus close-code
-        // enum values are filtered out in NewSocket::on_close).
-        self.destroy(err);
       }
+      // Any other recv errno (ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, ...) keeps
+      // its identity — Node's onStreamRead does
+      // `stream.destroy(errnoException(nread, 'read'))` for any nread that is
+      // not UV_EOF. The native on_close only passes a non-undefined err when
+      // the close was driven by a recv() failure (libus close-code enum values
+      // are filtered out in NewSocket::on_close).
+      self.destroy(er);
+      failPendingWrite(self, er);
       return;
     }
     self[kended] = true;
     if (!self.allowHalfOpen) self.write = writeAfterFIN;
     self.push(null);
     self.read(0);
-    // A write that was waiting on the native drain can never complete once the
-    // socket is gone - fail it so 'finish'/destroy are not stuck behind it
-    // (mirrors SocketEmitEndNT).
-    const pendingWrite = self[kwriteCallback];
-    if (pendingWrite) {
-      self[kwriteCallback] = null;
-      pendingWrite($ERR_SOCKET_CLOSED());
-    }
+    failPendingWrite(self);
   },
   handshake(socket, success, verifyError) {
     $debug("Bun.Socket handshake");
@@ -2434,6 +2452,14 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
   } else if (this[kwriteCallback]) {
     callback(new Error("overlapping _write()"));
   } else {
+    const writeError = socket.$writeError();
+    if (writeError) {
+      // send() failed outright: the bytes were dropped and no drain follows,
+      // so fail the write like Node's onWriteComplete instead of parking the
+      // callback on an event that can never arrive.
+      process.nextTick(callback, writeError);
+      return false;
+    }
     this[kwriteCallback] = callback;
   }
 };

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -152,6 +152,7 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
             server_name: JsCell::new(None),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
             twin: JsCell::new(None),
         });

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -565,6 +565,7 @@ impl Listener {
             server_name: JsCell::new(None),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
             twin: JsCell::new(None),
         });
@@ -609,6 +610,7 @@ impl Listener {
             server_name: JsCell::new(None),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
             twin: JsCell::new(None),
         });
@@ -1134,6 +1136,7 @@ impl Listener {
                         ));
                         // Free old resources before reassignment to prevent memory leaks
                         // when sockets are reused for reconnection (common with MongoDB driver)
+                        prev.reset_write_state_for_reuse();
                         prev.connection.set(Some(connection));
                         prev.local_binding.set(local_binding.clone());
                         if prev.flags.get().contains(SocketFlags::OWNED_PROTOS) {
@@ -1162,6 +1165,7 @@ impl Listener {
                             ref_pollref_on_connect: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
+                            fatal_write_error: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
                             twin: JsCell::new(None),
                         })
@@ -1233,6 +1237,7 @@ impl Listener {
                             prev.socket.get().socket,
                             uws::InternalSocket::Detached
                         ));
+                        prev.reset_write_state_for_reuse();
                         // Adopt `connection` (heap-owned for .unix) so the socket's
                         // deinit frees it; matches the TLS arm above and the
                         // non-pipe arm below. Previously `.connection = null`
@@ -1258,6 +1263,7 @@ impl Listener {
                             ref_pollref_on_connect: Cell::new(true),
                             buffered_data_for_node_net: Default::default(),
                             bytes_written: Cell::new(0),
+                            fatal_write_error: Cell::new(0),
                             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
                             twin: JsCell::new(None),
                         })
@@ -1529,6 +1535,7 @@ fn connect_finish<const IS_SSL: bool>(
             ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: Default::default(),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(crate::socket::NativeCallbacks::None),
             twin: JsCell::new(None),
         })

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -285,6 +285,11 @@ pub struct NewSocket<const SSL: bool> {
     pub server_name: JsCell<Option<Box<[u8]>>>,
     pub buffered_data_for_node_net: JsCell<Vec<u8>>,
     pub bytes_written: Cell<u64>,
+    /// The platform send error of the first fatal (non-would-block) write
+    /// failure, or 0. Once set, everything queued for this socket has been
+    /// dropped and nothing written afterwards can ever reach the peer, so no
+    /// write may report completion.
+    pub fatal_write_error: Cell<c_int>,
 
     pub native_callback: JsCell<NativeCallbacks>,
     /// `upgradeTLS` produces two `TLSSocket` wrappers over one
@@ -1261,8 +1266,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // SAFETY: ext slot is sized for `*mut c_void`; single-threaded.
         unsafe { *ext = core::ptr::null_mut() };
         self.socket.set(SocketHandler::<SSL>::DETACHED);
-        self.buffered_data_for_node_net
-            .with_mut(|b| b.clear_and_free());
+        self.reset_write_state_for_reuse();
         self.detach_native_callback();
         old.close(uws::CloseCode::Failure);
         self.poll_ref.with_mut(|p| p.unref(js_loop_ctx()));
@@ -2404,7 +2408,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let (res, fatal) = socket.write_check_error(buffer);
-        if fatal {
+        if fatal != 0 {
             // The kernel rejected the write outright (EPIPE/ECONNRESET after
             // the peer vanished): fail the write. Do NOT close the socket from
             // inside the write call - a synchronous close dispatches the whole
@@ -2418,6 +2422,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             // dropped by the caller: clearing it here would create a `&mut` of
             // `buffered_data_for_node_net` while `buffer` may still borrow its
             // heap allocation.
+            self.record_fatal_write_error(fatal);
             return -1;
         }
         let uwrote: usize = usize::try_from(res.max(0)).expect("int cast");
@@ -2427,15 +2432,75 @@ impl<const SSL: bool> NewSocket<SSL> {
         res
     }
 
+    /// Latch the first fatal send error. `write_error` hands it to node:net,
+    /// which fails the pending write callback with it.
+    fn record_fatal_write_error(&self, code: c_int) {
+        debug_assert!(code != 0);
+        if self.fatal_write_error.get() == 0 {
+            self.fatal_write_error.set(code);
+        }
+    }
+
+    /// `node:net` permits `socket.connect()` on an already-used Socket, which
+    /// rebinds this wrapper to a fresh native socket. Write state belongs to
+    /// the old connection: a latched fatal error would otherwise make every
+    /// write on the new one fail, and stale buffered bytes would be sent to
+    /// the wrong peer.
+    pub fn reset_write_state_for_reuse(&self) {
+        self.buffered_data_for_node_net
+            .with_mut(|b| b.clear_and_free());
+        self.fatal_write_error.set(0);
+    }
+
+    /// Nothing written to this socket can reach the peer any more: the handle
+    /// is gone, or a fatal send error already discarded everything queued.
+    /// Drops the now-undeliverable buffer and reports that no write on this
+    /// socket may complete.
+    fn discard_writes_if_doomed(&self) -> bool {
+        if self.socket.get().is_detached() || self.fatal_write_error.get() != 0 {
+            self.buffered_data_for_node_net
+                .with_mut(|b| b.clear_and_free());
+            return true;
+        }
+        false
+    }
+
+    /// The fatal send error that discarded this socket's queued bytes, shaped
+    /// like Node's `errnoException(status, 'write')`, or undefined.
+    #[bun_jsc::host_fn(method)]
+    pub fn write_error(
+        this: &Self,
+        global: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let code = this.fatal_write_error.get();
+        if code == 0 {
+            return Ok(JSValue::UNDEFINED);
+        }
+        // `write_check_error` reports the platform's raw send error (errno on
+        // POSIX, a WSA code on Windows, both positive); `sys::Error` stores a
+        // SystemErrno discriminant, so normalize through the errno table. A
+        // failure the platform could not name is reported as a reset.
+        let errno = if code > 0 {
+            sys::SystemErrno::init(code as i64).unwrap_or(sys::SystemErrno::ECONNRESET)
+        } else {
+            sys::SystemErrno::ECONNRESET
+        };
+        let err = sys::Error {
+            errno: errno as _,
+            syscall: sys::Tag::write,
+            ..Default::default()
+        };
+        Ok(<sys::Error as jsc::SysErrorJsc>::to_js(&err, global))
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn write_buffered(
         this: &Self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if this.socket.get().is_detached() {
-            this.buffered_data_for_node_net
-                .with_mut(|b| b.clear_and_free());
+        if this.discard_writes_if_doomed() {
             return Ok(JSValue::FALSE);
         }
 
@@ -2461,9 +2526,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if this.socket.get().is_detached() {
-            this.buffered_data_for_node_net
-                .with_mut(|b| b.clear_and_free());
+        if this.discard_writes_if_doomed() {
             return Ok(JSValue::FALSE);
         }
 
@@ -2841,7 +2904,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         log!("writeOrEnd {}", bytes.len());
         let wrote = self.write_maybe_corked(bytes);
         let uwrote: usize = usize::try_from(wrote.max(0)).expect("int cast");
-        if buffer_unwritten_data {
+        // `wrote < 0` is a fatal send error: no writable event will follow, so
+        // queueing the remainder would park it (and the JS write callback)
+        // forever. The caller fails the write instead.
+        if buffer_unwritten_data && wrote >= 0 {
             let remaining = &bytes[uwrote..];
             if !remaining.is_empty() {
                 let _ = self
@@ -2879,12 +2945,13 @@ impl<const SSL: bool> NewSocket<SSL> {
             && self.buffered_data_for_node_net.get().len() == 0
     }
 
-    /// Returns `false` when a fatal send error dropped the buffered data.
-    /// NOTE: callers currently ignore this (the drain callback is dispatched
-    /// regardless) - skipping the drain on fatal made Windows servers reset
-    /// FIN-terminated responses (see a5e7ba5905). The return value stays so
-    /// the contract can be re-landed once the Windows fatal-write detection
-    /// is verified.
+    /// Returns `false` when a fatal send error dropped the buffered data; the
+    /// error is latched in `fatal_write_error`.
+    /// NOTE: callers ignore the return value on purpose (the drain callback is
+    /// dispatched regardless) - skipping the drain on fatal made Windows
+    /// servers reset FIN-terminated responses (see a5e7ba5905). node:net sees
+    /// the failure through `write_error` instead, so the drain keeps running
+    /// while the pending write still fails.
     fn internal_flush(&self) -> bool {
         // R-2: every mutated field is `Cell`/`JsCell`, so `&self` carries no
         // `noalias` for them and the previous `black_box` launder (which
@@ -2908,15 +2975,14 @@ impl<const SSL: bool> NewSocket<SSL> {
                     .socket
                     .get()
                     .write_check_error(self.buffered_data_for_node_net.get().slice());
-                if fatal {
+                if fatal != 0 {
                     // Same rule as write_maybe_corked: drop the undeliverable
                     // buffer and stop re-arming the writable retry, but do not
                     // close from inside the drain dispatch - the peer reset is
                     // delivered on the read side and tears the socket down on
-                    // a clean stack. Report the failure so callers do not
-                    // dispatch the JS drain callback (the write did NOT
-                    // complete; Node fails the callback instead of succeeding
-                    // it).
+                    // a clean stack. Latching the error is what keeps the
+                    // dropped bytes from being reported as a completed write.
+                    self.record_fatal_write_error(fatal);
                     self.buffered_data_for_node_net
                         .with_mut(|b| b.clear_and_free());
                     return false;
@@ -3492,6 +3558,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
             twin: JsCell::new(None),
         });
@@ -3639,6 +3706,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             ref_pollref_on_connect: Cell::new(true),
             buffered_data_for_node_net: JsCell::new(Vec::new()),
             bytes_written: Cell::new(0),
+            fatal_write_error: Cell::new(0),
             native_callback: JsCell::new(NativeCallbacks::None),
             twin: JsCell::new(None),
         });
@@ -4528,6 +4596,7 @@ pub fn js_upgrade_duplex_to_tls(
         ref_pollref_on_connect: Cell::new(true),
         buffered_data_for_node_net: JsCell::new(Vec::new()),
         bytes_written: Cell::new(0),
+        fatal_write_error: Cell::new(0),
         native_callback: JsCell::new(NativeCallbacks::None),
         twin: JsCell::new(None),
     });

--- a/src/runtime/socket/sockets.classes.ts
+++ b/src/runtime/socket/sockets.classes.ts
@@ -235,6 +235,11 @@ function generate(ssl) {
         length: 2,
         privateSymbol: "write",
       },
+      "writeError": {
+        fn: "writeError",
+        length: 0,
+        privateSymbol: "writeError",
+      },
       "endBuffered": {
         fn: "endBuffered",
         length: 2,

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -260,12 +260,13 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     /// Raw-TCP write that also reports a fatal send error; non-Connected and
     /// TLS-wrapped sockets fall back to the plain write (no fatal signal).
-    pub fn write_check_error(&self, data: &[u8]) -> (i32, bool) {
+    /// The second element is the platform's send error, or 0 when none.
+    pub fn write_check_error(&self, data: &[u8]) -> (i32, c_int) {
         on_socket!(self.socket;
             connected s => s.write_check_error(data),
-            duplex d => (d.encode_and_write(data), false),
-            pipe p => (p.encode_and_write(data), false),
-            else => (0, false),
+            duplex d => (d.encode_and_write(data), 0),
+            pipe p => (p.encode_and_write(data), 0),
+            else => (0, 0),
         )
     }
 

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -100,8 +100,10 @@ impl us_socket_t {
 
     /// Write that also reports a fatal (non-would-block) send error so the
     /// node:net path can fail the pending write instead of waiting forever.
-    pub fn write_check_error(&self, data: &[u8]) -> (i32, bool) {
-        let mut fatal: i32 = 0;
+    /// The second element is the platform's send error (errno on POSIX, a WSA
+    /// code on Windows), or 0 when the write did not fail fatally.
+    pub fn write_check_error(&self, data: &[u8]) -> (i32, c_int) {
+        let mut fatal: c_int = 0;
         // SAFETY: `self` is a live `us_socket_t`; `data` is valid for its length
         // (clamped to i32) and `fatal` outlives the call as the out-parameter.
         let written = unsafe {
@@ -112,7 +114,7 @@ impl us_socket_t {
                 &raw mut fatal,
             )
         };
-        (written, fatal != 0)
+        (written, fatal)
     }
 
     pub fn is_shutdown(&self) -> bool {

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -96,6 +96,100 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     expect(received.length).toBe(256);
   });
 
+  // A send() that fails outright leaves the queued bytes undeliverable. Bun
+  // used to drop them and then report the write as completed, so a caller saw
+  // write-cb(null) + 'finish' + close(hadError=false) for data that never
+  // reached the wire. Node fails the write callback and destroys the socket.
+  test("send → fatal ECONNRESET while flushing buffered data fails the pending write", async () => {
+    using p = await connectedPair(s => s.on("error", () => {}));
+    const clientFd = (p.client as any)._handle.fd;
+    expect(clientFd).toBeGreaterThanOrEqual(0);
+
+    const errors: NodeJS.ErrnoException[] = [];
+    p.client.on("error", e => errors.push(e));
+    // Not events.once(): it would reject on the 'error' this test expects.
+    const closed = Promise.withResolvers<boolean>();
+    p.client.on("close", hadError => closed.resolve(hadError));
+
+    // One EAGAIN parks the payload in the node:net buffer so the write callback
+    // waits on a drain; the drain's retry then hits the fatal reset.
+    fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: 1, fd: clientFd });
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+    p.client.write(Buffer.alloc(256, "x"), err => resolve(err));
+    fault.set({ syscall: "send", action: "errno", errno: "ECONNRESET", repeat: -1, fd: clientFd });
+
+    const writeErr = await promise;
+    const hadError = await closed.promise;
+
+    expect({
+      code: writeErr?.code,
+      syscall: writeErr?.syscall,
+      errorCodes: errors.map(e => e.code),
+      hadError,
+      writableFinished: p.client.writableFinished,
+    }).toEqual({
+      code: "ECONNRESET",
+      syscall: "write",
+      errorCodes: ["ECONNRESET"],
+      hadError: true,
+      writableFinished: false,
+    });
+  });
+
+  // The same failure on the very first send(): no writable event ever follows a
+  // fatal error, so parking the callback on a drain would hang the write.
+  test("send → fatal EPIPE on the first write fails the write callback", async () => {
+    using p = await connectedPair(s => s.on("error", () => {}));
+    const clientFd = (p.client as any)._handle.fd;
+    p.client.on("error", () => {});
+
+    fault.set({ syscall: "send", action: "errno", errno: "EPIPE", repeat: -1, fd: clientFd });
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+    p.client.write(Buffer.alloc(256, "x"), err => resolve(err));
+
+    const writeErr = await promise;
+    expect({ code: writeErr?.code, syscall: writeErr?.syscall }).toEqual({ code: "EPIPE", syscall: "write" });
+    expect(p.client.writableFinished).toBe(false);
+  });
+
+  // The latched error belongs to the connection, not to the Socket wrapper.
+  // node:net lets connect() rebind a still-live handle to a fresh native
+  // socket, and the new connection must be able to write. Writing straight to
+  // the handle is what reaches that state: the handle's own write() reports a
+  // fatal send error without tearing the stream down, so the Socket survives
+  // to be reconnected.
+  test("a reconnected socket is not poisoned by the previous connection's send error", async () => {
+    const echo = net.createServer(s => s.on("data", c => s.write(c)));
+    echo.listen(0, "127.0.0.1");
+    await once(echo, "listening");
+    const port = (echo.address() as net.AddressInfo).port;
+
+    const client = net.connect({ port, host: "127.0.0.1" });
+    client.on("error", () => {});
+    await once(client, "connect");
+    const handle = (client as any)._handle;
+
+    // send-only fault: a read-side error would detach the handle and send the
+    // reconnect down the fresh-handle path instead.
+    fault.set({ syscall: "send", action: "errno", errno: "EPIPE", repeat: -1, fd: handle.fd });
+    expect(handle.write(Buffer.alloc(16, "a"))).toBeLessThan(0);
+    fault.clear();
+
+    // Same Socket, same wrapper, new native socket.
+    expect(client.destroyed).toBe(false);
+    client.connect({ port, host: "127.0.0.1" });
+    await once(client, "connect");
+
+    const echoed = once(client, "data") as Promise<[Buffer]>;
+    const secondWrite = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+    client.write(Buffer.alloc(16, "b"), err => secondWrite.resolve(err));
+
+    expect(await secondWrite.promise).toBeFalsy();
+    expect((await echoed)[0].toString()).toBe(Buffer.alloc(16, "b").toString());
+    client.destroy();
+    echo.close();
+  });
+
   test("send → short writes still deliver complete payload to peer", async () => {
     let received = Buffer.alloc(0);
     using p = await connectedPair(s => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -999,3 +999,55 @@ describe("paused socket whose peer sends RST", () => {
     expect(errors.map(e => e.code)).not.toContain("ENOEXEC");
   });
 });
+
+describe("peer resets while a large write is still in flight", () => {
+  // The undeliverable bytes were dropped and the write then reported success:
+  // write-cb(null), 'finish', close(hadError=false) and writableFinished ===
+  // true, for a payload that mostly never left the process. Node fails the
+  // write callback, emits 'error' and closes with hadError.
+  it("fails the write callback instead of reporting it as flushed", async () => {
+    // Far larger than any socket buffer pair, so the write is still queued when
+    // the peer resets.
+    const payload = Buffer.alloc(32 * 1024 * 1024, 0x61);
+    let received = 0;
+    const server = createServer(c => {
+      c.on("error", () => {});
+      c.on("data", chunk => {
+        received += chunk.length;
+        if (received >= 128 * 1024) c.resetAndDestroy();
+      });
+    });
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const port = (server.address() as import("node:net").AddressInfo).port;
+
+      const errors: NodeJS.ErrnoException[] = [];
+      const writeDone = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+      const closed = Promise.withResolvers<boolean>();
+
+      const c = connect(port, "127.0.0.1", () => {
+        c.write(payload, err => writeDone.resolve(err));
+      });
+      c.on("error", e => errors.push(e));
+      c.on("close", hadError => closed.resolve(hadError));
+
+      const writeErr = await writeDone.promise;
+      const hadError = await closed.promise;
+
+      expect({
+        writeErrored: !!writeErr,
+        errorEvents: errors.length,
+        hadError,
+        writableFinished: c.writableFinished,
+      }).toEqual({ writeErrored: true, errorEvents: 1, hadError: true, writableFinished: false });
+      // A peer that vanished mid-write: ECONNRESET from the reset, or EPIPE if
+      // the kernel already tore the connection down by the time send() ran.
+      expect(writeErr!.code).toMatch(/^(ECONNRESET|EPIPE)$/);
+      // The error is what makes the truncation observable: the peer stopped
+      // reading long before the payload was through.
+      expect(received).toBeLessThan(payload.length);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Symptom

A `node:net` client whose peer resets the connection during a large write is told the write **succeeded**. The write callback gets `null`, the socket emits `drain` → `end` → `finish` → `close(hadError=false)`, and `writableFinished === true` — while only a fraction of the payload ever reached the wire. Silent truncation presented as a clean completion.

Every "did my upload succeed?" check in Node code keys on exactly those signals. Connection resets under load (LB idle kills, peer restarts) are routine, so this is systematic silent data loss.

```js
// peer reads 128 KB, then RSTs
const s = net.connect(port, () => s.write(Buffer.alloc(32 * 1024 * 1024), err => log("cb:", err)));
```

| | write callback | `'error'` | `close` | `writableFinished` |
|---|---|---|---|---|
| node v26 | `ECONNRESET` | yes | `hadError=true` | `false` |
| bun (before) | `null` | never | `hadError=false` | `true` |
| bun (after) | `ECONNRESET` | yes, `syscall: 'write'` | `hadError=true` | `false` |

The same failure on the *first* `send()` had a second face: the callback was parked on a drain that can never arrive, so it was never invoked at all and the write hung forever.

## Cause

Three layers, one missing signal.

1. `us_socket_write_check_error` detects a fatal (non-would-block) `send()` failure and reports it as a bare `1` — the errno is dropped on the floor.
2. `internal_flush` discards the undeliverable `buffered_data_for_node_net` bytes and returns `false`, but `on_writable` ignores that return and dispatches the JS drain handler anyway (deliberately — skipping it previously broke Windows servers resetting FIN-terminated responses).
3. The drain handler probes the flush with `socket.$write("")`. With the native buffer now empty, that returns `true`, which the handler reads as "the pending write completed" → `callback(null)`.

The stream then sets `writableFinished`, which makes `SocketEmitEndNT` classify the real `ECONNRESET` that arrives next as *teardown noise* and swallow it, producing the clean `close(hadError=false)`.

## Fix

Propagate the error instead of inferring success from an empty buffer.

- `us_socket_write_check_error` reports the platform send error (errno / WSA code) through its existing out-parameter. `0` still means "no fatal error", so the detection logic is unchanged.
- `NewSocket` latches it in `fatal_write_error`. Once latched, `$write`/`$end` can never report completion, and `write_or_end` stops queueing a remainder the socket can never flush (no writable event follows a fatal error, so queueing it is what produced the hang).
- A new private-symbol `socket.$writeError()` hands the error to `net.ts`, which fails the pending stream write with it. `Writable`'s `onwriteError` then destroys the socket with that error — the user's write callback gets it, `'error'` fires once, `hadError` is true, `writableFinished` stays false. This is what Node's `onWriteComplete` does.
- The drain callback is still dispatched on a fatal flush, so the Windows FIN-terminated-response teardown keeps its current behavior.

Two sibling gaps in the same class, found while here:

- `SocketEmitEndNT` and `SocketHandlers2.close` returned early on their destroy-with-error paths without ever invoking the pending write callback.
- `connect()` may rebind a still-live handle to a fresh native socket. The latched error belongs to the old connection, so it is cleared on reuse; otherwise every write on the new connection failed with a stale errno.

TLS is unaffected by design: `us_socket_write_check_error` short-circuits to `us_socket_write` when `s->ssl` is set, so TLS sockets never latch an error and their failures keep propagating through the SSL layer.

## Verification

Four tests, each failing on the unfixed tree:

- `node-net.test.ts` — the reported scenario: peer reads 128 KB of a 32 MB write, then `resetAndDestroy()`. Asserts the write callback errors, exactly one `'error'`, `hadError=true`, `writableFinished=false`.
- `net-syscall-fault.test.ts` — a fatal `ECONNRESET` injected into the buffered flush asserts the exact error shape (`code: 'ECONNRESET'`, `syscall: 'write'`).
- a fatal `EPIPE` on the first `send()` (the hang variant).
- a socket reconnected after a fatal send error can still write (without the reset it fails with the stale errno).

<details>
<summary>Regression coverage</summary>

- 141/141 upstream `test/js/node/test/parallel/test-net-*.js` pass, including `test-net-error-twice` and the FIN-terminated-response tests this code path previously regressed.
- All upstream `test-tls-*` pass.
- `test/js/node/net/`, `test/js/node/tls/`, `test/js/bun/net/`, and the upstream `test-http-*` / `test-http2-*` suites show no failures that aren't already failing on `main`.
- `bun run rust:check-all` passes for all 10 targets (the errno normalization is `#[cfg]`-sensitive: POSIX errnos vs. Windows WSA codes).

</details>
