### PR TITLE
tls: report the handshake's own failure when an early write drives it

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1361,6 +1361,13 @@ void us_internal_ssl_detach(struct us_socket_t *s) {
     }
     SSL_free(s_ssl(s));
     s->ssl = NULL;
+    /* Same for a parked handshake reason: no dispatch can claim it now, and a
+     * socket reusing this address would report it as its own failure. */
+    struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+    if (loop_ssl_data && loop_ssl_data->ssl_last_fatal_error_owner == (void *)s) {
+      loop_ssl_data->ssl_last_fatal_error[0] = 0;
+      loop_ssl_data->ssl_last_fatal_error_owner = NULL;
+    }
   }
 }
 
@@ -1440,6 +1447,26 @@ struct us_bun_verify_error_t us_internal_ssl_verify_error(struct us_socket_t *s)
 }
 
 /* ── Handshake state machine ─────────────────────────────────────────────── */
+
+/* Park the fatal OpenSSL reason behind a failed SSL_* call where the
+ * handshake-failure dispatch can find it, then drain the queue and mark the
+ * socket fatal. Only parks while the handshake is unfinished: that dispatch is
+ * the sole consumer, so a later reason would linger and be misreported as some
+ * other socket's handshake failure. */
+static void ssl_park_fatal_reason(struct us_socket_t *s) {
+  struct loop_ssl_data *loop_ssl_data =
+      (struct loop_ssl_data *) s->group->loop->data.ssl_data;
+  if (loop_ssl_data && s->ssl_handshake_state != HANDSHAKE_COMPLETED) {
+    unsigned long ssl_queue_err = ERR_peek_last_error();
+    if (ssl_queue_err != 0) {
+      ERR_error_string_n(ssl_queue_err, loop_ssl_data->ssl_last_fatal_error,
+                         sizeof(loop_ssl_data->ssl_last_fatal_error));
+      loop_ssl_data->ssl_last_fatal_error_owner = s;
+    }
+  }
+  ERR_clear_error();
+  s->ssl_fatal_error = 1;
+}
 
 /* The on_handshake callback runs JS which may us_socket_close(s) — that frees
  * s->ssl. Every caller MUST check ssl_gone(s) immediately after this returns
@@ -1694,16 +1721,7 @@ static void ssl_update_handshake(struct us_socket_t *s) {
     }
     if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
       if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
-        struct loop_ssl_data *loop_ssl_data =
-            (struct loop_ssl_data *) s->group->loop->data.ssl_data;
-        unsigned long ssl_queue_err = ERR_peek_last_error();
-        if (loop_ssl_data && ssl_queue_err != 0) {
-          ERR_error_string_n(ssl_queue_err, loop_ssl_data->ssl_last_fatal_error,
-                             sizeof(loop_ssl_data->ssl_last_fatal_error));
-          loop_ssl_data->ssl_last_fatal_error_owner = s;
-        }
-        ERR_clear_error();
-        s->ssl_fatal_error = 1;
+        ssl_park_fatal_reason(s);
       }
       ssl_trigger_handshake(s, 0);
       return;
@@ -1885,22 +1903,7 @@ restart:
         }
 
         if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
-          /* Only park the reason while the handshake is still pending - that
-           * is the only consumer (the close path's EPROTO dispatch). For a
-           * completed handshake nothing reads it for this socket, and the
-           * ssl_close below runs JS that could tear down a different
-           * mid-handshake socket on this loop, which would then pick up this
-           * socket's reason as its own. */
-          if (s->ssl_handshake_state != HANDSHAKE_COMPLETED) {
-            unsigned long ssl_queue_err = ERR_peek_last_error();
-            if (ssl_queue_err != 0) {
-              ERR_error_string_n(ssl_queue_err, loop_ssl_data->ssl_last_fatal_error,
-                                 sizeof(loop_ssl_data->ssl_last_fatal_error));
-              loop_ssl_data->ssl_last_fatal_error_owner = s;
-            }
-          }
-          ERR_clear_error();
-          s->ssl_fatal_error = 1;
+          ssl_park_fatal_reason(s);
         }
         ssl_close(s, 0, NULL);
         loop_ssl_data->ssl_last_fatal_error[0] = 0;
@@ -2099,8 +2102,12 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     if (err == SSL_ERROR_WANT_READ) {
       s->ssl_write_wants_read = 1;
     } else if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
-      ERR_clear_error();
-      s->ssl_fatal_error = 1;
+      /* SSL_write drives the handshake when it has not finished, so this is
+       * where a handshake-configuration failure (impossible version window,
+       * no shared cipher) surfaces for a caller that wrote before
+       * 'secureConnect'. Park the reason: the handshake dispatch this failure
+       * triggers reports it instead of a bare verification verdict. */
+      ssl_park_fatal_reason(s);
     }
   }
   return 0;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { once } from "events";
 import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
+import https from "https";
 import net from "net";
 import { join } from "path";
 import stream from "stream";
@@ -691,4 +692,58 @@ it("delivers 'session' even when the data handler destroys the socket immediatel
   expect(session).toBe(true);
   server.close();
   await once(server, "close");
+});
+
+it("a write before 'secureConnect' still reports the handshake's own failure", async () => {
+  // An early write drives the handshake from inside SSL_write. The fatal
+  // reason that write hit used to be dropped, so the handshake dispatch had
+  // nothing to report and the dead session looked established: the only error
+  // left was checkServerIdentity's verdict on an empty peer certificate.
+  await using server = tls.createServer({ ...COMMON_CERT_ }, socket => socket.end());
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const client = tlsConnect({
+    port: (server.address() as AddressInfo).port,
+    host: "127.0.0.1",
+    servername: "localhost",
+    ca: COMMON_CERT_.cert,
+    minVersion: "TLSv1.3",
+    maxVersion: "TLSv1.2",
+  });
+  let secureConnect = false;
+  client.on("secureConnect", () => (secureConnect = true));
+  client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  const [error] = await once(client, "error");
+  expect(error.code).toBe("ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED");
+  expect(secureConnect).toBe(false);
+});
+
+it("https.request reports an impossible version window as a TLS error, not a certificate error", async () => {
+  // The http client flushes the request headers as soon as the socket
+  // connects, so every https.request hits the early-write path above.
+  await using server = https.createServer({ ...COMMON_CERT_ }, (_req, res) => res.end("ok"));
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const options = {
+    host: "127.0.0.1",
+    port: (server.address() as AddressInfo).port,
+    servername: "localhost",
+    ca: COMMON_CERT_.cert,
+    agent: false as const,
+  };
+
+  const failing = https.request({ ...options, minVersion: "TLSv1.3", maxVersion: "TLSv1.2" });
+  failing.end();
+  const [error] = await once(failing, "error");
+  expect(error.code).toBe("ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED");
+
+  // A satisfiable window over the same cert/CA/servername still succeeds: the
+  // version range is the only thing that failed above.
+  const ok = https.request({ ...options, minVersion: "TLSv1.2", maxVersion: "TLSv1.3" });
+  ok.end();
+  const [response] = await once(ok, "response");
+  let body = "";
+  response.on("data", (chunk: Buffer) => (body += chunk));
+  await once(response, "end");
+  expect(body).toBe("ok");
 });


### PR DESCRIPTION
### What does this PR do?

Makes a TLS handshake failure report its own reason when the caller wrote to the socket before `'secureConnect'`, instead of falling through to a certificate error.

**Symptom.** An impossible TLS version window (`minVersion > maxVersion`) is reported by `https.request` as a *certificate* problem, pointing at the cert instead of at the configuration that is actually broken. `tls.connect` with the same options already reports it correctly.

```js
const options = { host, port, ca, servername: "localhost", minVersion: "TLSv1.3", maxVersion: "TLSv1.2" };

tls.connect(options);   // ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED  (correct)
https.request(options); // ERR_TLS_CERT_ALTNAME_INVALID:
                        //   Hostname/IP does not match certificate's altnames: Cert does not contain a DNS name
```

Node reports the configuration error on both (`ERR_SSL_NO_PROTOCOLS_AVAILABLE`, OpenSSL's spelling of the same reason). Misclassified like this, the failure sends people to rotate certificates that are fine, and any retry/allowlist logic keyed on the error code takes the wrong branch.

**Cause.** `SSL_write` drives the handshake while it has not finished, so a caller that writes before `'secureConnect'` discovers the handshake failure from inside `us_internal_ssl_write`. The https client is exactly such a caller: it flushes the request headers as soon as the socket connects, which is the whole difference from the plain `tls.connect` repro above.

That write path dropped the reason:

```c
} else if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
  ERR_clear_error();          // the reason is gone
  s->ssl_fatal_error = 1;     // and is_shut_down() is now true
}
```

`ssl_fatal_error` makes `us_internal_ssl_is_shut_down()` true, so the `ssl_update_handshake()` that follows never reaches `SSL_do_handshake` and dispatches `ssl_trigger_handshake(s, 0)` with nothing parked. `ssl_dispatch_parked_reason()` finds no reason and falls back to the X509 verify verdict, which is empty. `net.ts` then sees `handshake(success=false, verifyError=null)` — the shape of a native hostname-verdict failure — treats the dead session as established, and runs `checkServerIdentity()` against an empty peer certificate, producing `ERR_TLS_CERT_ALTNAME_INVALID`.

Visible directly at the native dispatch, with and without an early write:

```
no-write:      handshake success=false verifyError={ code: "EPROTO", message: "...NO_SUPPORTED_VERSIONS_ENABLED" }
write-on-open: handshake success=false verifyError=null
```

The handshake path and the read path already park the reason before clearing the queue; only the write path did not.

**Fix.** Extract that parking into `ssl_park_fatal_reason()` (handshake, read and write paths now share it) and call it from `us_internal_ssl_write`, so the handshake dispatch that the fatal write triggers reports `EPROTO` plus the OpenSSL reason. `net.ts` already routes that through `tlsHandshakeError()` into `ERR_SSL_<REASON>`.

The helper keeps the existing "only park while the handshake is unfinished" guard: that dispatch is the only consumer, so a reason captured after the handshake completed would linger and be misreported as another socket's failure. For the same reason, a parked reason still owned by a socket being detached is now cleared, mirroring the spill-slot release right above it. The full ownership invariant is written out [in a comment below](https://github.com/oven-sh/bun/pull/33390#issuecomment-4887547120).

This is the `us_socket_t` path. #32929 fixes a different source of the same `verifyError = null` fall-through on the Duplex/`SSLWrapper` path; the two are complementary.

### How did you verify your code works?

`test/js/node/tls/node-tls-connect.test.ts` gains two tests — the mechanism (`tls.connect` + a write before `'secureConnect'`) and the reported symptom (`https.request`), the latter also asserting that a satisfiable window over the same cert/CA/servername still returns a response, so the version range is provably the only thing that failed.

Both fail on the unfixed build with `ERR_TLS_CERT_ALTNAME_INVALID` and pass with the fix:

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/tls/node-tls-connect.test.ts
  Expected: "ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED"
  Received: "ERR_TLS_CERT_ALTNAME_INVALID"
```

The rest of the file (15 pass), `test/js/node/tls/`, `test/js/node/http/`, `test/js/bun/net/` and the fetch/serve TLS suites show no delta against the same build without the patch. Node's `test-tls-min-max-version`, `test-tls-handshake-error`, `test-tls-destroy-whilst-write`, `test-tls-close-error`, `test-tls-close-event-after-write` and `test-tls-server-failed-handshake-emits-clienterror` pass.
