### PR TITLE
udp: send every packet of a sendMany() batch larger than one send buffer

### DIFF
--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -52,21 +52,26 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
 
     int total_sent = 0;
     while (total_sent < num) {
-        int count = bsd_udp_setup_sendbuf(buf, LIBUS_SEND_BUFFER_LENGTH, payloads, lengths, addresses, num);
-        payloads += count;
-        lengths += count;
-        addresses += count;
-        num -= count;
-        // TODO nohang flag?
+        /* The send buffer holds a fixed number of mmsghdr slots, so a batch bigger
+         * than that takes several passes, each starting at the first unsent one. */
+        bsd_udp_setup_sendbuf(buf, LIBUS_SEND_BUFFER_LENGTH, payloads + total_sent, lengths + total_sent, addresses + total_sent, num - total_sent);
         int sent = bsd_sendmmsg(fd, buf, MSG_DONTWAIT);
-        if (sent < 0) {
-            return sent;
+        if (sent <= 0) {
+            /* sendmmsg reports "not one datagram could be sent" as -1 with errno,
+             * the sendmsg/sendto fallbacks as 0. Only a full send buffer is
+             * recoverable; every other errno belongs to the caller. */
+            if (sent < 0 && !bsd_would_block()) {
+                return sent;
+            }
+            /* Out of send buffer space: ask for a writable event so the drain
+             * callback fires, and report the datagrams that did go out. */
+            us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+            break;
         }
         total_sent += sent;
-        if (0 <= sent && sent < num) {
-            // if we couldn't send all packets, register a writable event so we can call the drain callback
-            us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
-        }
+        /* A short count means the datagram at index `sent` failed and sendmmsg(2)
+         * dropped its errno. The next pass retries from that datagram, which
+         * surfaces the errno as -1 instead of hiding it in the count. */
     }
     return total_sent;
 }

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -364,6 +364,58 @@ describe("udpSocket()", () => {
     }
   }
 
+  // The send buffer only holds ~204 sendmmsg slots, so a bigger batch needs
+  // several passes. us_udp_socket_send used to subtract the batch size from
+  // `num` before testing it, which ended the loop after the first pass: an
+  // idle socket reported a short count (204 of 300) and never armed the
+  // writable poll, so the documented "if fewer were sent, wait for drain and
+  // resend the rest" protocol had nothing to wait for.
+  describe("sendMany sends every packet of a batch larger than one send buffer", () => {
+    test.each([205, 300, 500])("connected, %i packets", async count => {
+      using server = await udpSocket({ socket: { data() {} } });
+      using client = await udpSocket({
+        connect: { port: server.port, hostname: "127.0.0.1" },
+      });
+
+      const packets = Array.from({ length: count }, (_, i) => `packet ${i}`);
+      expect(client.sendMany(packets)).toBe(count);
+    });
+
+    test("unconnected, 300 packets", async () => {
+      using server = await udpSocket({ socket: { data() {} } });
+      using client = await udpSocket({});
+
+      const packets = Array.from({ length: 300 }, (_, i) => [`packet ${i}`, server.port, "127.0.0.1"]).flat();
+      expect(client.sendMany(packets)).toBe(300);
+    });
+  });
+
+  // sendmmsg(2) reports a datagram that fails mid-batch as a short count and
+  // drops its errno, so an oversized payload used to throw EMSGSIZE at index 0
+  // but come back as backpressure ("1 of 3 sent") anywhere after it.
+  describe("sendMany surfaces a per-packet error whatever its position", () => {
+    for (const connected of [true, false]) {
+      test.each([0, 1, 2])(`${connected ? "connected" : "unconnected"}, oversized packet at index %i`, async index => {
+        using server = await udpSocket({ socket: { data() {} } });
+        using client = await udpSocket(connected ? { connect: { port: server.port, hostname: "127.0.0.1" } } : {});
+
+        // 70000 > the 65507-byte maximum UDP payload, so the kernel always
+        // rejects this one datagram with EMSGSIZE.
+        const payloads: any[] = ["a", "b", "c"];
+        payloads[index] = Buffer.alloc(70000, 1);
+        const packets = connected ? payloads : payloads.flatMap(p => [p, server.port, "127.0.0.1"]);
+
+        let error: any;
+        try {
+          client.sendMany(packets);
+        } catch (e) {
+          error = e;
+        }
+        expect({ code: error?.code, syscall: error?.syscall }).toEqual({ code: "EMSGSIZE", syscall: "send" });
+      });
+    }
+  });
+
   // send()/sendMany() capture a pointer into the payload's backing store and
   // then run user JS (port `valueOf()`, address `toString()`, and for
   // sendMany also array index getters on later iterations). That JS can


### PR DESCRIPTION
`Bun.udpSocket().sendMany()` silently drops packets once the batch outgrows the internal `sendmmsg` send buffer (~204 slots), and the documented backpressure protocol has nothing to resume it.

### Repro

```ts
const server = await Bun.udpSocket({ socket: { data() {} } });
const client = await Bun.udpSocket({
  connect: { hostname: "127.0.0.1", port: server.port },
  socket: { drain() { drains++; } },
});

let drains = 0;
const packets = Array.from({ length: 300 }, (_, i) => `packet ${i}`);
console.log(client.sendMany(packets)); // 204 on an idle loopback socket, expected 300
// ...and `drain` never fires, so "wait for drain, resend the rest" never resumes.
```

On 1.4.0: `N=300` returns `204`, `N=500` returns `408` plus one `drain` with no backlog behind it. Anything at or below 204 works, which is why the existing 100-packet tests never caught it.

### Cause

`us_udp_socket_send()` decremented `num` by each pass's batch size *before* the loop condition and the drain guard read it:

```c
num -= count;
int sent = bsd_sendmmsg(fd, buf, MSG_DONTWAIT);
...
total_sent += sent;
if (0 <= sent && sent < num) { /* arm the writable poll */ }
```

For `num = 300`: pass one sends 204, `num` becomes 96, `total_sent < num` is `204 < 96` so the loop exits with 96 packets never handed to the kernel. `sent < num` is `204 < 96` too, so the writable poll is never armed and `drain` never fires. At `num = 500` the same comparison fires the other way in pass one (`204 < 296`) and arms a `drain` for a send that was not actually blocked.

The same guard is what a real short send lands in, so genuine kernel backpressure could not arm `drain` either.

### Fix

Walk the batch with an offset and leave `num` alone, then key backpressure off what `sendmmsg` actually reports:

- `-1` with `EWOULDBLOCK` is the only recoverable outcome: arm the writable poll, return the count that went out.
- any other errno goes straight to the caller, which throws.
- a short count means the datagram at index `sent` failed. `sendmmsg(2)` drops that datagram's errno ("If an error occurs after at least one message has been sent... the error code is lost"), so the next pass retries from it, and the errno comes back as `-1`.

That last part also fixes a sibling bug in the same function: an oversized datagram threw `EMSGSIZE` at index 0 but came back as a short count ("1 of 3 sent") anywhere after it, so an un-sendable packet was indistinguishable from backpressure. It now throws wherever it sits in the batch.

Two behavior changes worth naming:

- A full kernel send buffer used to throw `EAGAIN` out of `send()`/`sendMany()`. It now returns `false` / a short count and arms `drain`, which is what [the docs describe](https://github.com/oven-sh/bun/blob/main/docs/runtime/networking/udp.mdx).
- A fatal errno partway through a batch throws even if earlier datagrams were sent, so the partial count is lost. That matches what already happened when the bad datagram was first, and the alternative (report a short count, surface the error one `drain` later) is what made oversized packets look like backpressure.

### Verification

`test/js/bun/udp/udp_socket.test.ts`: 8 of the 10 new cases fail on the unfixed build (the two "index 0" cases pass both ways on purpose, they are the control for the position dependence).

```
(fail) sendMany sends every packet of a batch larger than one send buffer > connected, 205 packets
(fail) sendMany sends every packet of a batch larger than one send buffer > connected, 300 packets
(fail) sendMany sends every packet of a batch larger than one send buffer > connected, 500 packets
(fail) sendMany sends every packet of a batch larger than one send buffer > unconnected, 300 packets
(fail) sendMany surfaces a per-packet error whatever its position > connected, oversized packet at index 1
(fail) sendMany surfaces a per-packet error whatever its position > connected, oversized packet at index 2
(fail) sendMany surfaces a per-packet error whatever its position > unconnected, oversized packet at index 1
(fail) sendMany surfaces a per-packet error whatever its position > unconnected, oversized packet at index 2
```

All 188 pass with the fix, as do `test/js/bun/udp/dgram.test.ts`, `udp_socket_recv_flags.test.ts`, and every `test/js/node/test/parallel/test-dgram-*.js`. The 500-packet send was run 30 times without a short count.
