### PR TITLE
tls: reject secureProtocol combined with minVersion or maxVersion

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -365,6 +365,13 @@ function validateSecureContextOptions(options) {
     dhparam,
     secureProtocol,
   } = options;
+  // A legacy secureProtocol method pins both version bounds, so pairing it with
+  // min/maxVersion is contradictory: honoring one silently drops the other.
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/common.js#L78
+  if (secureProtocol) {
+    if (minVersion != null) throw $ERR_TLS_PROTOCOL_VERSION_CONFLICT(minVersion, secureProtocol);
+    if (maxVersion != null) throw $ERR_TLS_PROTOCOL_VERSION_CONFLICT(maxVersion, secureProtocol);
+  }
   validateSecureProtocol(secureProtocol);
   if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
   if (passphrase !== undefined && passphrase !== null) validateString(passphrase, "options.passphrase");

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -12,6 +12,7 @@
 #include "helpers.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/ErrorInstance.h"
+#include "JavaScriptCore/JSONObject.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/JSType.h"
 #include "JavaScriptCore/Symbol.h"
@@ -2235,11 +2236,10 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
     }
 
     case Bun::ErrorCode::ERR_TLS_PROTOCOL_VERSION_CONFLICT: {
-        auto arg0 = callFrame->argument(1);
-        auto str0 = arg0.toWTFString(globalObject);
+        // Node formats both values with %j, i.e. JSON.stringify.
+        auto str0 = JSC::JSONStringify(globalObject, callFrame->argument(1), 0);
         RETURN_IF_EXCEPTION(scope, {});
-        auto arg1 = callFrame->argument(2);
-        auto str1 = arg1.toWTFString(globalObject);
+        auto str1 = JSC::JSONStringify(globalObject, callFrame->argument(2), 0);
         RETURN_IF_EXCEPTION(scope, {});
         auto message = makeString("TLS protocol version "_s, str0, " conflicts with secureProtocol "_s, str1);
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_TLS_PROTOCOL_VERSION_CONFLICT, message));

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import * as https from "node:https";
+import * as net from "node:net";
 import * as tls from "node:tls";
 
 describe("tls.createSecureContext extra arguments test", () => {
@@ -66,5 +68,131 @@ describe("tls.createSecureContext extra arguments test", () => {
     expect(() => tls.createSecureContext({ privateKeyIdentifier: {} })).toThrow(
       "The property 'options.privateKeyEngine' is invalid. Received undefined",
     );
+  });
+});
+
+describe("secureProtocol conflicts with minVersion/maxVersion", () => {
+  // `secureProtocol` pins both version bounds, so accepting it next to a
+  // minVersion/maxVersion would silently drop the version floor the caller
+  // asked for. Node throws ERR_TLS_PROTOCOL_VERSION_CONFLICT instead.
+  function callAndCleanUp(fn: () => unknown): any {
+    let error: any;
+    let result: any;
+    try {
+      result = fn();
+    } catch (e) {
+      error = e;
+    }
+    // Without the check these calls hand back a socket that connects at the
+    // downgraded version: tear it down so a regression fails on the assertion.
+    if (result && typeof result.on === "function") {
+      result.on("error", () => {});
+      result.destroy?.();
+    }
+    return error;
+  }
+
+  function expectConflict(fn: () => unknown, message: string) {
+    const error = callAndCleanUp(fn);
+    expect(error).toBeInstanceOf(TypeError);
+    expect({ code: error?.code, message: error?.message }).toEqual({
+      code: "ERR_TLS_PROTOCOL_VERSION_CONFLICT",
+      message,
+    });
+  }
+
+  const minConflict = 'TLS protocol version "TLSv1.3" conflicts with secureProtocol "TLSv1_2_method"';
+  const maxConflict = 'TLS protocol version "TLSv1.1" conflicts with secureProtocol "TLSv1_2_method"';
+
+  it("tls.createSecureContext", () => {
+    expectConflict(
+      () => tls.createSecureContext({ secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+    expectConflict(
+      () => tls.createSecureContext({ secureProtocol: "TLSv1_2_method", maxVersion: "TLSv1.1" }),
+      maxConflict,
+    );
+  });
+
+  it("tls.connect", () => {
+    expectConflict(
+      () => tls.connect({ host: "127.0.0.1", port: 1, secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+  });
+
+  it("https.request", () => {
+    expectConflict(
+      () => https.request({ host: "127.0.0.1", port: 1, secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+  });
+
+  it("new tls.TLSSocket", () => {
+    expectConflict(
+      () => new tls.TLSSocket(new net.Socket(), { secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+  });
+
+  it("tls.createServer", () => {
+    expectConflict(() => tls.createServer({ secureProtocol: "TLSv1_2_method", maxVersion: "TLSv1.1" }), maxConflict);
+  });
+
+  it("server.setSecureContext", () => {
+    const server = tls.createServer({});
+    expectConflict(
+      () => server.setSecureContext({ secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+  });
+
+  it("server.addContext", () => {
+    const server = tls.createServer({});
+    expectConflict(
+      () => server.addContext("example.com", { secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" }),
+      minConflict,
+    );
+  });
+
+  it("is checked before the secureProtocol method name and the version strings", () => {
+    // An unknown method and an invalid version are both reported as the conflict.
+    expectConflict(
+      () => tls.createSecureContext({ secureProtocol: "hokey-pokey", minVersion: "TLSv1.3" }),
+      'TLS protocol version "TLSv1.3" conflicts with secureProtocol "hokey-pokey"',
+    );
+    expectConflict(
+      // @ts-expect-error invalid version
+      () => tls.createSecureContext({ secureProtocol: "TLSv1_2_method", minVersion: "fhqwhgads" }),
+      'TLS protocol version "fhqwhgads" conflicts with secureProtocol "TLSv1_2_method"',
+    );
+  });
+
+  it("accepts the options on their own", () => {
+    expect(() => tls.createSecureContext({ secureProtocol: "TLSv1_2_method" })).not.toThrow();
+    expect(() => tls.createSecureContext({ minVersion: "TLSv1.3" })).not.toThrow();
+    expect(() => tls.createSecureContext({ maxVersion: "TLSv1.2", minVersion: "TLSv1.2" })).not.toThrow();
+    // null/undefined mean "not set", so they do not conflict.
+    expect(() =>
+      tls.createSecureContext({ secureProtocol: "TLSv1_2_method", minVersion: undefined, maxVersion: undefined }),
+    ).not.toThrow();
+    expect(() =>
+      // @ts-expect-error node accepts an explicit null here
+      tls.createSecureContext({ secureProtocol: "TLSv1_2_method", minVersion: null, maxVersion: null }),
+    ).not.toThrow();
+  });
+
+  it("an explicit secureContext takes precedence over the conflicting options", () => {
+    const error = callAndCleanUp(() =>
+      tls.connect({
+        host: "127.0.0.1",
+        port: 1,
+        secureProtocol: "TLSv1_2_method",
+        minVersion: "TLSv1.3",
+        secureContext: tls.createSecureContext({}),
+      }),
+    );
+    expect(error).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Repro

```js
const tls = require("node:tls");

tls.connect({
  host, port,
  secureProtocol: "TLSv1_2_method", // legacy: pins the version to TLS 1.2
  minVersion: "TLSv1.3", // floor: refuse anything below TLS 1.3
});
```

Bun connects and negotiates `TLSv1.2`: the `minVersion` floor is silently dropped. Node refuses the contradiction up front:

```
TypeError [ERR_TLS_PROTOCOL_VERSION_CONFLICT]: TLS protocol version "TLSv1.3" conflicts with secureProtocol "TLSv1_2_method"
```

Same for `https.request`, `tls.createSecureContext`, `new tls.TLSSocket`, `tls.createServer`, `server.setSecureContext` and `server.addContext`: Node throws on all seven, Bun accepted all seven.

## Cause

`secureProtocol` is a legacy OpenSSL method name that pins *both* version bounds, so combining it with `minVersion`/`maxVersion` is contradictory. `validateSecureContextOptions` never checked the pair, and the translation that follows gives `secureProtocol` precedence:

```js
const range = secureProtocolToVersionRange(optSecureProtocol);
if (range) {
  minVersion = range[0];
  maxVersion = range[1];
} else {
  minVersion = tlsStringToProtocolVersion(optMinVersion ?? DEFAULT_MIN_VERSION);
  ...
```

So configs that layered a modern `minVersion` over a legacy `secureProtocol` line (common in code ported from Node, which rejects the pair) negotiated the legacy version with no error and nothing in the logs.

## Fix

Reject the pair in `validateSecureContextOptions`, before the method name and the version strings are validated, matching [`lib/internal/tls/common.js#L78`](https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/common.js#L78). Every secure-context construction path in `node:tls` and `node:https` funnels through that validator, so all seven entry points now throw. `null`/`undefined` still mean "not set" and do not conflict, and an explicit `secureContext` still wins over the raw options, as in Node.

`ERR_TLS_PROTOCOL_VERSION_CONFLICT` already existed as an error code with no callers; its message now formats both values with `JSON.stringify`, matching Node's `%j`.

## Verification

Behavior compared against Node v26.3.0 for all 7 entry points, both the `minVersion` and `maxVersion` forms, the two orderings (unknown method / invalid version are both reported as the conflict), the non-conflicting `null`/`undefined`/standalone forms, and the `secureContext` precedence case: each one matches, message included.

The end-to-end downgrade, against a local server that accepts TLS 1.2 and 1.3:

<details>
<summary><code>tls.connect({ secureProtocol: "TLSv1_2_method", minVersion: "TLSv1.3" })</code></summary>

```
node:       threw: ERR_TLS_PROTOCOL_VERSION_CONFLICT - TLS protocol version "TLSv1.3" conflicts with secureProtocol "TLSv1_2_method"
bun 1.4.0:  connected: true protocol: TLSv1.2
this PR:    threw: ERR_TLS_PROTOCOL_VERSION_CONFLICT - TLS protocol version "TLSv1.3" conflicts with secureProtocol "TLSv1_2_method"
```

</details>

- `bun bd test test/js/node/tls/node-tls-create-secure-context-args.test.ts`: 15 pass. The 8 new cases fail on the unfixed build.
- `test/js/node/test/parallel/`: `test-tls-min-max-version`, `test-tls-basic-validations`, `test-tls-getprotocol`, `test-tls-no-sslv23`, `test-https-agent-getname`, `test-tls-secure-session`, `test-tls-alert`, `test-tls-session-cache` all pass.
- The rest of `test/js/node/tls/` is unchanged (3 failures there reproduce on `main` and on the released binary: `NODE_EXTRA_CA_CERTS` timeout, hostname-verification and SNICallback connect failures).

## Note

`https.createServer` does not reach this validator: it ignores every secure-context option today, which #33054 fixes by moving `validateSecureContextOptions` into `src/js/internal/tls.ts`. Whichever lands first, the other rebases on one small hunk, and together they make the https server path throw this error too.
