### PR TITLE
Bun.Cookie.parse: don't drop Expires when Max-Age comes first

### DIFF
--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -276,7 +276,7 @@ cookie.httpOnly; // boolean - Accessible only via HTTP (not JavaScript)
 
 #### `isExpired(): boolean`
 
-Checks if the cookie has expired.
+Checks if the cookie has expired. When both `maxAge` and `expires` are set, `maxAge` takes precedence, as required by [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3).
 
 ```ts title="is-expired.ts" icon="/icons/typescript.svg"
 // Expired cookie (Date in the past)
@@ -290,6 +290,10 @@ const validCookie = new Bun.Cookie("name", "value", {
   maxAge: 3600, // 1 hour in seconds
 });
 console.log(validCookie.isExpired()); // false
+
+// A non-positive maxAge expires the cookie immediately
+const deletedCookie = new Bun.Cookie("name", "value", { maxAge: 0 });
+console.log(deletedCookie.isExpired()); // true
 
 // Session cookie (no expiration)
 const sessionCookie = new Bun.Cookie("name", "value");

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -101,7 +101,6 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
     bool httpOnly = false;
     double maxAge = std::numeric_limits<double>::quiet_NaN();
     bool partitioned = false;
-    bool hasMaxAge = false;
     ASSERT(value.isEmpty() || isValidHTTPHeaderValue(value));
     // Parse attributes if there are any
     if (firstSemicolonPos != notFound) {
@@ -122,6 +121,9 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                 attributeValue = emptyString();
             }
 
+            // RFC 6265 5.2: each attribute is recorded independently, last occurrence wins.
+            // Max-Age's precedence over Expires (5.3) governs the computed expiry time, so it
+            // must not drop the Expires attribute, and must not depend on attribute order.
             if (attributeName == "domain"_s) {
                 if (!attributeValue.isEmpty()) {
                     domain = attributeValue.convertToASCIILowercase();
@@ -129,7 +131,7 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
             } else if (attributeName == "path"_s) {
                 if (!attributeValue.isEmpty() && attributeValue.startsWith('/'))
                     path = attributeValue;
-            } else if (attributeName == "expires"_s && !hasMaxAge && !attributeValue.isEmpty()) {
+            } else if (attributeName == "expires"_s && !attributeValue.isEmpty()) {
                 if (!attributeValue.is8Bit()) [[unlikely]] {
                     auto asLatin1 = attributeValue.latin1();
                     double parsed = WTF::parseDate({ reinterpret_cast<const Latin1Character*>(asLatin1.data()), asLatin1.length() });
@@ -146,7 +148,6 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
             } else if (attributeName == "max-age"_s) {
                 if (auto parsed = WTF::parseIntegerAllowingTrailingJunk<int64_t>(attributeValue); parsed.has_value()) {
                     maxAge = static_cast<double>(parsed.value());
-                    hasMaxAge = true;
                 }
             } else if (attributeName == "secure"_s) {
                 secure = true;
@@ -170,6 +171,12 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
 
 bool Cookie::isExpired() const
 {
+    // RFC 6265 5.3: Max-Age takes precedence over Expires when both are present. A
+    // non-positive Max-Age expires the cookie immediately; a positive one is measured
+    // from when the cookie was created, so it is never already expired.
+    if (!std::isnan(m_maxAge))
+        return m_maxAge <= 0;
+
     if (m_expires == Cookie::emptyExpiresAtValue)
         return false; // Session cookie
 

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -131,7 +131,7 @@ private:
     bool m_secure = false;
     CookieSameSite m_sameSite = CookieSameSite::Lax;
     bool m_httpOnly = false;
-    double m_maxAge = 0;
+    double m_maxAge = std::numeric_limits<double>::quiet_NaN();
     bool m_partitioned = false;
 };
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -90,6 +90,21 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(sessionCookie.isExpired()).toBe(false);
   });
 
+  test("Cookie.isExpired() gives Max-Age precedence over Expires", () => {
+    const past = new Date(Date.now() - 1000);
+    const future = new Date(Date.now() + 86_400_000);
+
+    // Max-Age wins over Expires regardless of which one the header listed first.
+    expect(new Bun.Cookie("name", "value", { maxAge: 3600, expires: past }).isExpired()).toBe(false);
+    expect(new Bun.Cookie("name", "value", { maxAge: 0, expires: future }).isExpired()).toBe(true);
+    expect(Bun.Cookie.parse("a=b; Max-Age=3600; Expires=Wed, 21 Oct 2015 07:28:00 GMT").isExpired()).toBe(false);
+    expect(Bun.Cookie.parse("a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Max-Age=3600").isExpired()).toBe(false);
+
+    // A non-positive Max-Age is the "delete this cookie" signal.
+    expect(new Bun.Cookie("name", "value", { maxAge: 0 }).isExpired()).toBe(true);
+    expect(new Bun.Cookie("name", "value", { maxAge: -1 }).isExpired()).toBe(true);
+  });
+
   test("Cookie.parse works with all attributes", () => {
     const cookieStr =
       "name=value; Domain=example.com; Expires=Thu, 13 Mar 2025 12:00:00 GMT; Path=/foo; Max-Age=3600; Secure; HttpOnly; Partitioned; SameSite=Strict";
@@ -105,6 +120,55 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(cookie.expires).toEqual(new Date("Thu, 13 Mar 2025 12:00:00 GMT"));
     expect(cookie.partitioned).toBe(true);
     expect(cookie.sameSite).toBe("strict");
+  });
+
+  test("Cookie.parse keeps Expires when Max-Age comes first", () => {
+    const maxAgeFirst = Bun.Cookie.parse("a=b; Max-Age=60; Expires=Wed, 01 Jan 2031 00:00:00 GMT");
+    const expiresFirst = Bun.Cookie.parse("a=b; Expires=Wed, 01 Jan 2031 00:00:00 GMT; Max-Age=60");
+
+    expect(maxAgeFirst.toJSON()).toEqual({
+      name: "a",
+      value: "b",
+      path: "/",
+      expires: new Date("Wed, 01 Jan 2031 00:00:00 GMT"),
+      maxAge: 60,
+      secure: false,
+      sameSite: "lax",
+      httpOnly: false,
+      partitioned: false,
+    });
+    expect(maxAgeFirst.toJSON()).toEqual(expiresFirst.toJSON());
+    expect(maxAgeFirst.toString()).toBe(expiresFirst.toString());
+  });
+
+  test("Cookie.parse takes the last value of a repeated attribute", () => {
+    const cookie = Bun.Cookie.parse(
+      "a=b; Max-Age=10; Expires=Wed, 01 Jan 2031 00:00:00 GMT; Max-Age=60; Expires=Thu, 02 Jan 2031 00:00:00 GMT",
+    );
+
+    expect(cookie.maxAge).toBe(60);
+    expect(cookie.expires).toEqual(new Date("Thu, 02 Jan 2031 00:00:00 GMT"));
+  });
+
+  test("Cookie.parse reads every attribute in any order", () => {
+    const attributes = [
+      "Max-Age=3600",
+      "Expires=Thu, 13 Mar 2025 12:00:00 GMT",
+      "Domain=example.com",
+      "Path=/foo",
+      "Secure",
+      "HttpOnly",
+      "Partitioned",
+      "SameSite=Strict",
+    ];
+    const expected = Bun.Cookie.parse(`name=value; ${attributes.join("; ")}`).toJSON();
+    expect(expected).toHaveProperty("expires", new Date("Thu, 13 Mar 2025 12:00:00 GMT"));
+
+    // Rotating the attributes must never change the parsed cookie.
+    for (let i = 1; i < attributes.length; i++) {
+      const rotated = [...attributes.slice(i), ...attributes.slice(0, i)];
+      expect(Bun.Cookie.parse(`name=value; ${rotated.join("; ")}`).toJSON()).toEqual(expected);
+    }
   });
 
   test("Cookie.serialize creates cookie string", () => {

--- a/test/js/bun/cookie/cookie-security-fuzz.test.ts
+++ b/test/js/bun/cookie/cookie-security-fuzz.test.ts
@@ -192,20 +192,20 @@ describe("Bun.Cookie.parse security fuzz tests", () => {
     ];
 
     for (const maliciousCase of maliciousCases) {
-      try {
-        const cookie = Bun.Cookie.parse(maliciousCase);
-        expect(cookie).toBeDefined();
-        if (cookie.maxAge !== undefined) {
-          // Max-Age should be a reasonable number, not NaN or Infinity
-          expect(Number.isFinite(cookie.maxAge)).toBe(true);
-        }
-        if (cookie.expires !== undefined) {
-          // Expires should be a reasonable timestamp, not NaN
-          expect(Number.isFinite(cookie.expires)).toBe(true);
-        }
-      } catch (error) {
-        // Some cases might be rejected, which is fine
-        expect(error).toBeDefined();
+      const cookie = Bun.Cookie.parse(maliciousCase);
+      expect(cookie).toBeDefined();
+
+      // Every attribute the header names survives parsing, whichever order it came in.
+      expect(cookie.maxAge !== undefined).toBe(maliciousCase.includes("Max-Age="));
+      expect(cookie.expires !== undefined).toBe(maliciousCase.includes("Expires="));
+
+      if (cookie.maxAge !== undefined) {
+        // Max-Age should be a reasonable number, not NaN or Infinity
+        expect(Number.isFinite(cookie.maxAge)).toBe(true);
+      }
+      if (cookie.expires !== undefined) {
+        // Expires should be a reasonable timestamp, not NaN
+        expect(Number.isFinite(cookie.expires.getTime())).toBe(true);
       }
     }
   });


### PR DESCRIPTION
## Repro

`Bun.Cookie.parse` returns a different cookie depending on the order the attributes appear in:

```js
Bun.Cookie.parse("a=b; Max-Age=60; Expires=Wed, 01 Jan 2031 00:00:00 GMT").expires;
// undefined  <- Expires silently dropped

Bun.Cookie.parse("a=b; Expires=Wed, 01 Jan 2031 00:00:00 GMT; Max-Age=60").expires;
// 2031-01-01T00:00:00.000Z
```

Servers emit `Set-Cookie` attributes in whatever order their framework picks, so code that reads `cookie.expires` to make a persistence decision gets different answers for equivalent headers. `tough-cookie` and `set-cookie-parser` both return the same cookie for the two strings above.

## Cause

`Cookie::parse()` gated the `Expires` branch on a `hasMaxAge` flag set by an earlier `Max-Age` attribute:

```cpp
} else if (attributeName == "expires"_s && !hasMaxAge && !attributeValue.isEmpty()) {
```

That is a positional drop, not the precedence rule it was reaching for. RFC 6265 5.2 records each attribute independently (last occurrence wins); the `Max-Age`-over-`Expires` precedence in 5.3 governs the **computed expiry time**, not which attributes survive parsing.

## Fix

- `Cookie::parse()`: remove the positional gate, so both attributes are recorded whatever order they arrive in.
- `Cookie::isExpired()`: apply the real 5.3 precedence, in the one place Bun computes an effective expiry. Without this, the parse change alone would make `Max-Age=3600; Expires=<past>` report expired, which the spec says it is not.
- `Cookie.h`: `m_maxAge`'s member default was `0` while NaN is the "unset" sentinel used by the constructor, getter, `toJSON`, and serializer. `isExpired()` now reads the field, so `0` would have silently meant "expired".

`isExpired()` behavior changes in two ways, both toward the spec: a non-positive `maxAge` now reports expired (it is the canonical "delete this cookie" signal), and a positive `maxAge` now wins over a past `expires`. The three cases in the `isExpired()` docs are unchanged.

Only `Bun.Cookie`'s `Set-Cookie` attribute parser is affected. The `Cookie:` request-header path (`CookieMap`) parses name/value pairs and has no attributes.

## Verification

```
bun bd test test/js/bun/cookie/ test/regression/issue/22475.test.ts
 160 pass, 0 fail
```

The four new/changed assertions fail on `main` and pass with the fix. Both changed test files fail independently without the `src/` change.

<details>
<summary>Before/after on the repro</summary>

```
# before
maxage first : {"name":"a","value":"b","path":"/","maxAge":60,...}
expires first: {"name":"a","value":"b","path":"/","expires":"2031-01-01T00:00:00.000Z","maxAge":60,...}

# after
maxage first : {"name":"a","value":"b","path":"/","expires":"2031-01-01T00:00:00.000Z","maxAge":60,...}
expires first: {"name":"a","value":"b","path":"/","expires":"2031-01-01T00:00:00.000Z","maxAge":60,...}
equal: true
```

</details>

`test/js/bun/cookie/cookie-security-fuzz.test.ts` covered exactly these `Max-Age` + `Expires` combinations, but its `expires` assertion was `Number.isFinite(cookie.expires)` on a `Date`, which is always `false`, and a surrounding `try`/`catch` swallowed the resulting failure. Since this change routes two more inputs into that branch, it now asserts on `.getTime()` and checks that every attribute named in the header survives parsing.