### PR TITLE
http: closeAllConnections() must not stop the listener

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -362,15 +362,16 @@ Server.prototype.unref = function () {
 };
 
 Server.prototype.closeAllConnections = function () {
-  const server = this[serverSymbol];
-  if (!server) {
+  // Node.js destroys every tracked connection and leaves the listen socket
+  // alone, so the server keeps accepting. It is also the forced half of
+  // close() + closeAllConnections(), which runs once the listener is gone.
+  const connections = this[kTrackedConnections];
+  if (!connections) {
     return;
   }
-  this[serverSymbol] = undefined;
-  clearInterval(this[kConnectionsCheckingInterval]);
-  this.listening = false;
-
-  server.stop(true);
+  for (const socket of connections) {
+    socket.destroy();
+  }
 };
 
 Server.prototype.getConnections = function (callback) {

--- a/test/js/bun/test/parallel/test-http-server.listening-should-work.ts
+++ b/test/js/bun/test/parallel/test-http-server.listening-should-work.ts
@@ -6,5 +6,9 @@ const { expect } = createTest(import.meta.path);
 const server = http.createServer();
 await once(server.listen(0), "listening");
 expect(server.listening).toBe(true);
+// closeAllConnections() destroys the connections, it does not stop listening.
 server.closeAllConnections();
+expect(server.listening).toBe(true);
+server.close();
 expect(server.listening).toBe(false);
+await once(server, "close");

--- a/test/js/bun/test/parallel/test-http-timeout-destruction-should-be-visible-using-kConnectionsCheckingInterval.ts
+++ b/test/js/bun/test/parallel/test-http-timeout-destruction-should-be-visible-using-kConnectionsCheckingInterval.ts
@@ -6,5 +6,10 @@ const { expect } = createTest(import.meta.path);
 const { kConnectionsCheckingInterval } = require("_http_server");
 const server = http.createServer();
 await once(server.listen(0), "listening");
+expect(server[kConnectionsCheckingInterval]._destroyed).toBe(false);
+// Only close() tears the interval down; closeAllConnections() keeps listening.
 server.closeAllConnections();
+expect(server[kConnectionsCheckingInterval]._destroyed).toBe(false);
+server.close();
 expect(server[kConnectionsCheckingInterval]._destroyed).toBe(true);
+await once(server, "close");

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -769,6 +769,7 @@ it("Server should be able to send empty pings", async () => {
       return await promise;
     } finally {
       httpServer.closeAllConnections();
+      httpServer.close();
     }
   }
   {

--- a/test/js/node/http/node-http-close-all-connections.test.ts
+++ b/test/js/node/http/node-http-close-all-connections.test.ts
@@ -30,10 +30,14 @@ test("closeAllConnections() destroys the connections but keeps the server listen
     // Read the response so the connection is idle but still kept alive.
     await once(client, "data");
 
+    // Node destroys the socket object itself, so anything tracking sockets via
+    // 'connection' + socket.on('close') sees them leave.
+    const serverSocketClosed = once(serverSocket, "close");
     const clientClosed = once(client, "close");
     server.closeAllConnections();
 
     expect(serverSocket.destroyed).toBe(true);
+    await serverSocketClosed;
     await clientClosed;
 
     expect(server.listening).toBe(true);

--- a/test/js/node/http/node-http-close-all-connections.test.ts
+++ b/test/js/node/http/node-http-close-all-connections.test.ts
@@ -1,0 +1,115 @@
+// These tests also pass on Node.js. `server.closeAllConnections()` destroys the
+// tracked connections and leaves the listen socket alone, so the server keeps
+// accepting traffic and a later `close(cb)` still completes normally.
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import { connect, type AddressInfo, type Socket } from "node:net";
+
+async function listenAndConnect(server: Server) {
+  const connected = once(server, "connection");
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect(port, "127.0.0.1");
+  client.on("error", () => {});
+  await once(client, "connect");
+  client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  const [serverSocket] = await connected;
+  return { port, client, serverSocket };
+}
+
+test("closeAllConnections() destroys the connections but keeps the server listening", async () => {
+  const server = createServer((req, res) => res.end("ok"));
+  let closeEvents = 0;
+  server.on("close", () => closeEvents++);
+  try {
+    const { port, client, serverSocket } = await listenAndConnect(server);
+    // Read the response so the connection is idle but still kept alive.
+    await once(client, "data");
+
+    const clientClosed = once(client, "close");
+    server.closeAllConnections();
+
+    expect(serverSocket.destroyed).toBe(true);
+    await clientClosed;
+
+    expect(server.listening).toBe(true);
+    expect(closeEvents).toBe(0);
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(await res.text()).toBe("ok");
+    expect(res.status).toBe(200);
+
+    const { promise, resolve } = Promise.withResolvers<Error | undefined>();
+    server.close(resolve);
+    expect(await promise).toBeUndefined();
+    expect(server.listening).toBe(false);
+    expect(closeEvents).toBe(1);
+  } finally {
+    server.closeAllConnections();
+    if (server.listening) server.close();
+  }
+});
+
+test("closeAllConnections() destroys in-flight connections after close()", async () => {
+  const { promise: requestReceived, resolve: onRequest } = Promise.withResolvers<void>();
+  // Never respond: the connection stays in-flight, so close() alone cannot finish.
+  const server = createServer(() => onRequest());
+  try {
+    const { client, serverSocket } = await listenAndConnect(server);
+    await requestReceived;
+
+    const { promise: serverClosed, resolve: onClosed } = Promise.withResolvers<Error | undefined>();
+    const clientClosed = once(client, "close");
+    server.close(onClosed);
+    server.closeAllConnections();
+
+    expect(serverSocket.destroyed).toBe(true);
+    await clientClosed;
+    expect(await serverClosed).toBeUndefined();
+    expect(server.listening).toBe(false);
+  } finally {
+    if (server.listening) server.close();
+  }
+});
+
+test("closeAllConnections() destroys every tracked connection", async () => {
+  const server = createServer((req, res) => res.end("ok"));
+  const serverSockets: Socket[] = [];
+  server.on("connection", socket => serverSockets.push(socket));
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const clients: Socket[] = [];
+    for (let i = 0; i < 4; i++) {
+      const client = connect(port, "127.0.0.1");
+      client.on("error", () => {});
+      await once(client, "connect");
+      client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+      await once(client, "data");
+      clients.push(client);
+    }
+    expect(serverSockets).toHaveLength(4);
+
+    const allClosed = Promise.all(clients.map(client => once(client, "close")));
+    server.closeAllConnections();
+    expect(serverSockets.map(socket => socket.destroyed)).toEqual([true, true, true, true]);
+
+    await allClosed;
+    expect(server.listening).toBe(true);
+  } finally {
+    server.closeAllConnections();
+    if (server.listening) server.close();
+  }
+});
+
+test("closeAllConnections() on a server that never listened does nothing", () => {
+  const server = createServer(() => {});
+  expect(() => server.closeAllConnections()).not.toThrow();
+  expect(server.listening).toBe(false);
+});

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -94,6 +94,7 @@ test.concurrent("should not crash when closing sockets after upgrade", async () 
             http_socket?.destroy();
           });
           server.closeAllConnections();
+          server.close();
           resolve();
         }, 10);
       }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1542,6 +1542,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
     // Close the server if it's still running
     if (server.listening) {
       server.closeAllConnections();
+      server.close();
+      await once(server, "close");
     }
   });
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -85,6 +85,7 @@ test("pre aborted with readable request body", async () => {
     ).rejects.toThrow();
   } finally {
     server.closeAllConnections();
+    server.close();
   }
 });
 
@@ -559,6 +560,7 @@ test("fetching with Request object - issue #1527", async () => {
     expect(await fetch(request)).resolves.pass();
   } finally {
     server.closeAllConnections();
+    server.close();
   }
 });
 

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -246,6 +246,7 @@ describe.concurrent("fetch() with streaming", () => {
         expect(true).toBe(true);
       } finally {
         server?.closeAllConnections();
+        server?.close();
       }
     });
   }


### PR DESCRIPTION
Fixes #31301 (reported by @mxschmitt, who also has a fix in flight as #31302 — see the comparison at the bottom).

## Repro

```js
const http = require("node:http");
const srv = http.createServer((req, res) => res.end("ok"));
srv.on("close", () => console.log("EVENT: close fired"));
srv.listen(0, "127.0.0.1", async () => {
  const port = srv.address().port;
  srv.closeAllConnections();
  console.log("listening:", srv.listening);
  try {
    console.log("status:", (await fetch(`http://127.0.0.1:${port}/`)).status);
  } catch (e) {
    console.log("ERROR:", e.code);
  }
  srv.close(err => console.log("close(cb) err:", err?.code ?? null));
});
```

| | `node` | `bun` (before) | `bun` (after) |
|---|---|---|---|
| `listening` | `true` | `false` | `true` |
| new request | `200` | `ECONNREFUSED` | `200` |
| `'close'` event | not fired | fired | not fired |
| `close(cb)` | `null` | `ERR_SERVER_NOT_RUNNING` | `null` |

## Cause

`Server.prototype.closeAllConnections()` nulled `this[serverSymbol]` and called the native `stop(true)`, which is a full shutdown of the listen socket and every connection:

```js
Server.prototype.closeAllConnections = function () {
  const server = this[serverSymbol];
  if (!server) return;
  this[serverSymbol] = undefined;
  clearInterval(this[kConnectionsCheckingInterval]);
  this.listening = false;
  server.stop(true);
};
```

Node's contract is narrower: destroy the connections, keep accepting. The API exists for a graceful reload/drain, so on Bun the drain step was an outage.

Two consequences beyond the listener dying:

- `listening`, the `'close'` event and `close(cb)` all reported a server that was never asked to stop.
- Because `close()` also clears `this[serverSymbol]`, the standard `close(); closeAllConnections()` teardown was a no-op for the forced half. The `@azure/msal-node` loopback client uses exactly that sequence and hangs on Bun (#30501).

## Fix

Iterate `kTrackedConnections` (the set the `'connection'` event and `getConnections()` already maintain) and `destroy()` each socket, exactly like Node. Nothing else is touched, which is also what makes it work after `close()`.

```js
Server.prototype.closeAllConnections = function () {
  const connections = this[kTrackedConnections];
  if (!connections) return;
  for (const socket of connections) {
    socket.destroy();
  }
};
```

Destroying through the JS socket (rather than closing the underlying uSocket) is what gives the socket object Node's observable state: `socket.destroyed === true` and a `'close'` event. The `server.on("connection", s => set.add(s))` + `s.on("close", () => set.delete(s))` idiom depends on it.

## Verification

`test/js/node/http/node-http-close-all-connections.test.ts` (new, 4 tests, all pass unmodified on Node.js):

- connections destroyed (`destroyed` flag + `'close'` event), listener still accepting, no server `'close'` event, `close(cb)` reports no error
- `close()` then `closeAllConnections()` destroys in-flight sockets so the close callback runs
- every tracked connection is destroyed (4 sockets)
- no-op on a server that never listened

3 of the 4 fail on `main`. `test/js/node/test/parallel/test-http-server-close-all.js` and the other 356 `test-http-*` node parallel tests are unaffected.

Five existing tests used `closeAllConnections()` as a stand-in for `close()`, and two asserted the old behaviour directly (`listening === false`, the connections-checking interval destroyed). Both of those now assert what Node does: `closeAllConnections()` leaves them alone, `close()` changes them.

## Known limitation

A TCP connection that has been accepted but has not yet sent a request head has no JS socket wrapper, so it is not in `kTrackedConnections` and survives `closeAllConnections()`. Node tracks connections from TCP-accept and would destroy it.

This is the same architectural gap already noted on `getConnections()` ("the native server does not surface raw accepts to JS yet") — `'connection'` does not fire for those sockets either, so they are invisible to the whole connection-tracking surface, not just this method. They are still reaped by `headersTimeout`/`requestTimeout`. Closing it properly needs a native "close every socket, keep the listener" primitive, which is what #31302 adds.

## Relationship to #30505 and #31302

Both are open and neither is a duplicate of the other:

- **#31302** (@mxschmitt) fixes this same listener-teardown bug by adding a native `closeAllConnections` primitive through uWS → `libuwsockets.cpp` → `App.rs` → host fn → class registration, and delegating to it. That catches the pre-request sockets above, which this PR does not. But routing only through the native layer leaves the JS socket wrapper stale: bun's existing `closeIdleConnections()` already takes that path, and on it `socket.destroyed` stays `false` and the socket never emits `'close'`, where Node gives `true` / fires. It also still early-returns after `close()`, so it does not address #30501.
- **#30505** fixes the #30501 hang by keeping `this[serverSymbol]` alive past `close()` and teaching the Rust `stop_listening`/`stop_from_js` to force-close the app when the listener is already gone, so `closeAllConnections()` can still reach `stop(true)`. It keeps the full-stop, so the listener-teardown bug remains.

This PR removes the `stop(true)` call instead, which fixes both bugs in 11 lines of JS with no Rust change: the #30501 teardown sequence exits normally on this branch (verified against Node — both exit, `main` hangs).

The complete fix is probably this PR's `socket.destroy()` loop plus #31302's native sweep for the pre-request sockets. Happy to fold that in with credit, or to close this in favour of #31302 plus a small JS change there — whichever reviewers prefer.
