### PR TITLE
websocket: fail the client connection on RSV1 set on a continuation frame

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -709,6 +709,12 @@ impl<const SSL: bool> WebSocket<SSL> {
             return self.recv_failed(ErrorCode::UnsupportedControlFrame);
         }
 
+        // RFC 7692 §6.1: RSV1 marks the start of a compressed message, so only
+        // the first frame of a data message may ever set it.
+        if header.compressed && !matches!(header.opcode, Opcode::Text | Opcode::Binary) {
+            return self.recv_failed(ErrorCode::UnexpectedRsv1);
+        }
+
         if header.compressed && self.deflate.borrow().is_none() {
             return self.recv_failed(ErrorCode::CompressionUnsupported);
         }
@@ -2043,6 +2049,7 @@ pub enum ErrorCode {
     ProxyAuthenticationRequired = 34,
     ProxyConnectionRefused = 35,
     ProxyTunnelFailed = 36,
+    UnexpectedRsv1 = 37,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -2150,7 +2157,8 @@ struct ParsedHeader {
     payload_len: usize,
     is_fragmented: bool,
     is_final: bool,
-    /// RSV1 on a data frame (RFC 7692 per-message deflate).
+    /// The RSV1 bit (RFC 7692 per-message deflate). Validated by the caller:
+    /// only the first frame of a data message may set it.
     compressed: bool,
     next: ReceiveState,
 }
@@ -2183,14 +2191,9 @@ fn parse_websocket_header(bytes: [u8; 2]) -> ParsedHeader {
         payload_len,
         is_fragmented: opcode == Opcode::Continue || !header.final_(),
         is_final: header.final_(),
-        compressed: is_data_frame && header.compressed(),
+        compressed: header.compressed(),
         next: ReceiveState::Fail,
     };
-
-    // RFC 7692: only the first fragment of a data message may set RSV1.
-    if !is_data_frame && opcode != Opcode::Continue && header.compressed() {
-        return parsed;
-    }
 
     // A server must not mask data frames it sends to a client.
     if header.mask() && is_data_frame {
@@ -2198,7 +2201,7 @@ fn parse_websocket_header(bytes: [u8; 2]) -> ParsedHeader {
         return parsed;
     }
 
-    // rsv2 and rsv3 must always be 0 per RFC 6455 (rsv1 is handled above).
+    // rsv2 and rsv3 must always be 0 per RFC 6455 (rsv1 is checked by the caller).
     if header.rsv() != 0 {
         return parsed;
     }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1786,6 +1786,10 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         didReceiveClose(CleanStatus::NotClean, 1002, "Protocol error - unexpected opcode"_s);
         break;
     }
+    case Bun::WebSocketErrorCode::unexpected_rsv1: {
+        didReceiveClose(CleanStatus::NotClean, 1002, "Protocol error - RSV1 must be clear"_s);
+        break;
+    }
     case Bun::WebSocketErrorCode::invalid_utf8: {
         // RFC 6455 7.4.1: 1007 is "invalid frame payload data" (for example,
         // non-UTF-8 in a text message); 1003 would mean an unsupported data type.

--- a/src/jsc/bindings/webcore/WebSocketErrorCode.h
+++ b/src/jsc/bindings/webcore/WebSocketErrorCode.h
@@ -42,6 +42,7 @@ enum class WebSocketErrorCode : int32_t {
     proxy_authentication_required = 34,
     proxy_connection_refused = 35,
     proxy_tunnel_failed = 36,
+    unexpected_rsv1 = 37,
 };
 
 }

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -1,5 +1,6 @@
 import { serve } from "bun";
 import { expect, setDefaultTimeout, test } from "bun:test";
+import { deflateRawSync } from "node:zlib";
 
 // The decompression bomb test needs extra time to compress 150MB of test data
 setDefaultTimeout(30_000);
@@ -334,4 +335,131 @@ test("WebSocket client rejects decompression bombs", async () => {
     }
     await new Promise<void>(resolve => tcpServer.close(() => resolve()));
   }
+});
+
+const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const OPCODE_CONTINUATION = 0x0;
+const OPCODE_TEXT = 0x1;
+const OPCODE_PING = 0x9;
+
+/** Build one unmasked server -> client frame. Payloads must stay under 126 bytes. */
+function frame(opcode: number, payload: Uint8Array, { fin = true, rsv1 = false } = {}): Uint8Array {
+  if (payload.length >= 126) throw new Error("frame() only supports payloads under 126 bytes");
+  const bytes = new Uint8Array(2 + payload.length);
+  bytes[0] = (fin ? 0x80 : 0) | (rsv1 ? 0x40 : 0) | opcode;
+  bytes[1] = payload.length;
+  bytes.set(payload, 2);
+  return bytes;
+}
+
+type Outcome = { code: number; reason: string; messages: unknown[] };
+
+/**
+ * Complete a WebSocket handshake by hand, write `frames`, and report how the
+ * client reacted: either the close it performed, or the first message it
+ * delivered (which for these frames would be a protocol violation).
+ */
+async function sendRawFrames(
+  frames: Uint8Array[],
+  { negotiateDeflate }: { negotiateDeflate: boolean },
+): Promise<Outcome> {
+  let handshake = "";
+  let handshakeComplete = false;
+  const messages: unknown[] = [];
+  let client: WebSocket | undefined;
+
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      // The client fails the connection by resetting it; that is the point of the test.
+      error() {},
+      data(socket, data) {
+        if (handshakeComplete) return;
+        handshake += data.toString();
+        if (!handshake.includes("\r\n\r\n")) return;
+
+        const key = /Sec-WebSocket-Key:\s*(\S+)/i.exec(handshake);
+        if (!key) throw new Error("client did not send Sec-WebSocket-Key");
+        const accept = new Bun.CryptoHasher("sha1").update(key[1] + WEBSOCKET_GUID).digest("base64");
+        handshakeComplete = true;
+
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n` +
+            (negotiateDeflate ? "Sec-WebSocket-Extensions: permessage-deflate\r\n" : "") +
+            "\r\n",
+        );
+        for (const bytes of frames) socket.write(bytes);
+        socket.flush();
+      },
+    },
+  });
+
+  try {
+    const { promise, resolve } = Promise.withResolvers<Outcome>();
+    client = new WebSocket(`ws://127.0.0.1:${server.port}`);
+    // Settle on whichever comes first: a delivered message means the client
+    // accepted frames it should have rejected.
+    client.onmessage = event => {
+      messages.push(event.data);
+      resolve({ code: 0, reason: "<still open>", messages });
+    };
+    client.onerror = () => {};
+    client.onclose = event => resolve({ code: event.code, reason: event.reason, messages });
+    return await promise;
+  } finally {
+    client?.close();
+    server.stop(true);
+  }
+}
+
+// RFC 7692 §6.1: RSV1 marks the start of a compressed message, so only the
+// first frame of a data message may set it.
+test("WebSocket client fails the connection on RSV1 set on a continuation frame", async () => {
+  const compressed = deflateRawSync(Buffer.from("Hello, World!"));
+  const outcome = await sendRawFrames(
+    [
+      frame(OPCODE_TEXT, compressed.subarray(0, 1), { fin: false, rsv1: true }),
+      frame(OPCODE_CONTINUATION, compressed.subarray(1), { fin: true, rsv1: true }),
+    ],
+    { negotiateDeflate: true },
+  );
+
+  expect(outcome).toEqual({ code: 1002, reason: "Protocol error - RSV1 must be clear", messages: [] });
+});
+
+test("WebSocket client fails the connection on RSV1 set on a continuation frame without deflate", async () => {
+  const outcome = await sendRawFrames(
+    [
+      frame(OPCODE_TEXT, Buffer.from("Hel"), { fin: false }),
+      frame(OPCODE_CONTINUATION, Buffer.from("lo"), { fin: true, rsv1: true }),
+    ],
+    { negotiateDeflate: false },
+  );
+
+  expect(outcome).toEqual({ code: 1002, reason: "Protocol error - RSV1 must be clear", messages: [] });
+});
+
+test("WebSocket client fails the connection on RSV1 set on a control frame", async () => {
+  const outcome = await sendRawFrames([frame(OPCODE_PING, Buffer.from("ping"), { rsv1: true })], {
+    negotiateDeflate: true,
+  });
+
+  expect(outcome).toEqual({ code: 1002, reason: "Protocol error - RSV1 must be clear", messages: [] });
+});
+
+test("WebSocket client accepts RSV1 on the first frame of a fragmented compressed message", async () => {
+  const compressed = deflateRawSync(Buffer.from("Hello, World!"));
+  const outcome = await sendRawFrames(
+    [
+      frame(OPCODE_TEXT, compressed.subarray(0, 1), { fin: false, rsv1: true }),
+      frame(OPCODE_CONTINUATION, compressed.subarray(1), { fin: true }),
+    ],
+    { negotiateDeflate: true },
+  );
+
+  expect(outcome).toEqual({ code: 0, reason: "<still open>", messages: ["Hello, World!"] });
 });


### PR DESCRIPTION
### What

Bun's WebSocket client accepted a continuation frame with RSV1 set. The fragments were reassembled, the message was delivered to the application, and the connection stayed open. RFC 7692 §6.1 allows RSV1 only on the first frame of a data message, because the bit is what tells the receiver a new compressed message is starting; a mid-message RSV1 has no meaning and must fail the connection. node's `ws` and browsers fail with 1002 and deliver nothing.

#33001 fixed this rule for `Bun.serve`'s frame parser. The client has its own parser, in Rust, and was never covered.

This also meant RSV1 on a continuation frame was accepted when `permessage-deflate` was never negotiated at all, since the continuation path never looked at the bit.

### Repro

A raw RFC 6455 frame server sends a fragmented message whose continuation frame sets RSV1:

```js
// after a normal 101 handshake (with or without `Sec-WebSocket-Extensions: permessage-deflate`)
socket.write(frame(OPCODE_TEXT, part1, { fin: false, rsv1: true }));
socket.write(frame(OPCODE_CONTINUATION, part2, { fin: true, rsv1: true }));
//                                                           ^^^^^^^^^^ illegal
```

```
bun 1.4.0:  onmessage fires with the reassembled message, connection stays OPEN
ws / chrome: connection fails, close code 1002, nothing delivered
```

### Cause

`parse_websocket_header` in `src/http_jsc/websocket_client.rs` checked RSV1 only for frames that were neither data nor continuation:

```rust
if !is_data_frame && opcode != Opcode::Continue && header.compressed() {
    return parsed; // fail
}
```

so control frames were rejected and continuation frames fell through. On top of that, `ParsedHeader.compressed` was computed as `is_data_frame && header.compressed()`, which zeroed the bit for continuation frames before the "RSV1 without permessage-deflate" check downstream could see it.

### Fix

`ParsedHeader.compressed` now carries the raw RSV1 bit, and `recv_frame_header` validates it against the opcode alongside the other frame checks:

```rust
if header.compressed && !matches!(header.opcode, Opcode::Text | Opcode::Binary) {
    return self.recv_failed(ErrorCode::UnexpectedRsv1);
}
```

Same shape as the server-side fix in #33001 (`packages/bun-uws/src/WebSocketProtocol.h`: only TEXT and BINARY may reach `setCompressed()`), expressed in the client's parser.

`unexpected_rsv1` is a new `WebSocketErrorCode` so the close event reports `1002 "Protocol error - RSV1 must be clear"` instead of the generic control-frame message. Control frames with RSV1 already failed with 1002; only their close reason changes.

### Verification

`test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts`, four new tests against a raw-frame server: RSV1 on a continuation frame with and without `permessage-deflate` negotiated, RSV1 on a control frame, and a fragmented compressed message with RSV1 correctly set on the first frame only (still delivered).

<details>
<summary>before / after</summary>

```
$ USE_SYSTEM_BUN=1 bun test websocket-permessage-deflate-edge-cases.test.ts -t RSV1
(fail) WebSocket client fails the connection on RSV1 set on a continuation frame
  {
  -   "code": 1002,
  -   "messages": [],
  +   "code": 0,
  +   "messages": [ "Hello, World!" ],
  +   "reason": "<still open>",
  }
(fail) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate
(fail) WebSocket client fails the connection on RSV1 set on a control frame
(pass) WebSocket client accepts RSV1 on the first frame of a fragmented compressed message
 1 pass, 3 fail

$ bun bd test websocket-permessage-deflate-edge-cases.test.ts
 9 pass, 0 fail
```

</details>

The rest of `test/js/web/websocket/` is unchanged (the 7 failures in that directory on this container, postman-echo connectivity and a localhost proxy/bind issue, reproduce identically on stock 1.4.0).
