### PR TITLE
fs.watch: release inotify watches for a directory renamed out of a recursive watch

### DIFF
--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -811,6 +811,60 @@ impl Linux {
         });
     }
 
+    /// `subpath` is `rel` itself or sits underneath it. Both are `/`-separated and
+    /// relative to the same watch root.
+    fn in_subtree(subpath: &[u8], rel: &[u8]) -> bool {
+        strings::starts_with(subpath, rel)
+            && (subpath.len() == rel.len() || subpath[rel.len()] == b'/')
+    }
+
+    /// The directory `name` inside `parent_subpath` left this watcher's tree:
+    /// `remove_watch` restricted to it and everything under it, issuing
+    /// `inotify_rm_watch` for each wd left with no owners. Caller holds
+    /// `manager.mutex`.
+    fn remove_subtree(
+        manager: &'static PathWatcherManager,
+        watcher: &mut PathWatcher,
+        parent_subpath: &[u8],
+        name: &[u8],
+    ) {
+        if name.is_empty() {
+            return;
+        }
+        // Built here rather than passed in: joined it is a copy, unjoined it is
+        // `name` from the read buffer. Either way it cannot borrow one of the
+        // `WdOwner.subpath`s dropped below.
+        let mut rel_buf = path::path_buffer_pool::get();
+        let rel: &[u8] = if parent_subpath.is_empty() {
+            name
+        } else {
+            join_string_buf::<platform::Posix>(rel_buf.as_mut_slice(), &[parent_subpath, name])
+        };
+
+        let plat: *mut Linux = manager.platform.get();
+        let fd = manager.inotify_fd();
+        let this = core::ptr::from_mut::<PathWatcher>(watcher).cast_const();
+        // SAFETY: caller holds manager.mutex; exclusive access to `wd_map`.
+        let wd_map = unsafe { &mut (*plat).wd_map };
+        watcher.platform.wds.retain(|&wd| {
+            let Some(owners) = wd_map.get_mut(&wd) else {
+                return true;
+            };
+            let Some(oi) = owners.iter().position(|o| core::ptr::eq(o.watcher, this)) else {
+                return true;
+            };
+            if !Linux::in_subtree(owners[oi].subpath.as_bytes(), rel) {
+                return true;
+            }
+            owners.swap_remove(oi);
+            if owners.is_empty() {
+                wd_map.remove(&wd);
+                sys::linux::inotify_rm_watch(fd.native(), wd);
+            }
+            false
+        });
+    }
+
     /// Caller holds `manager.mutex`. Drops this watcher's ownership of each of its
     /// wds; only issues `inotify_rm_watch` once a wd has no remaining owners.
     fn remove_watch(manager: &'static PathWatcherManager, watcher: &mut PathWatcher) {
@@ -1074,6 +1128,15 @@ impl Linux {
                                 && !watcher_is_file),
                     );
                     let _ = handle_oom(touched.get_or_put(owner_watcher));
+
+                    // Recursive: a directory left this owner's tree. inotify watches
+                    // inodes, not paths, so without this the subtree keeps its wds and
+                    // keeps reporting under its stale subpath until the watcher closes.
+                    // A move that stayed inside the tree is re-added by the matching
+                    // IN_MOVED_TO below.
+                    if watcher_recursive && is_dir_child && (ev.mask & IN::MOVED_FROM != 0) {
+                        Linux::remove_subtree(manager, watcher, owner_subpath, name);
+                    }
 
                     // Recursive: a new directory appeared under this owner's tree —
                     // start watching it so future events inside it are delivered.

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -596,6 +596,111 @@ describe("fs.watch", () => {
     ]);
   });
 
+  // The inode each inotify watch is registered on, as hex, from every inotify fd
+  // the process holds. inotify watches inodes, so a directory renamed out of a
+  // recursive watch keeps its watch unless the backend explicitly drops it.
+  const inotifyWatchedInodes = () => {
+    const inodes = new Set<string>();
+    for (const fd of fs.readdirSync("/proc/self/fd")) {
+      let link: string;
+      try {
+        link = fs.readlinkSync(`/proc/self/fd/${fd}`);
+      } catch {
+        continue; // the readdir snapshot can outlive the fd
+      }
+      if (link !== "anon_inode:inotify") continue;
+      for (const line of fs.readFileSync(`/proc/self/fdinfo/${fd}`, "utf8").split("\n")) {
+        const match = /^inotify wd:[0-9a-f]+ ino:([0-9a-f]+)/.exec(line);
+        if (match) inodes.add(match[1]);
+      }
+    }
+    return inodes;
+  };
+
+  test.skipIf(!isLinux)("recursive watch releases a subdirectory renamed out of the tree", async () => {
+    using dir = tempDir("fs-watch-moved-from", { "root": { "sub": { "nested": {} } }, "outside": {} });
+    const root = path.join(String(dir), "root");
+    const moved = path.join(String(dir), "outside", "sub");
+    const inodeOf = (p: string) => fs.statSync(p, { bigint: true }).ino.toString(16);
+    const subInode = inodeOf(path.join(root, "sub"));
+    const nestedInode = inodeOf(path.join(root, "sub", "nested"));
+
+    const events: [string, string | null][] = [];
+    const sentinel = Promise.withResolvers<void>();
+    let closing = false;
+    const watcher = fs.watch(root, { recursive: true }, (eventType, filename) => {
+      events.push([eventType, filename]);
+      if (filename === "sentinel.txt") sentinel.resolve();
+    });
+    watcher.once("error", err => sentinel.reject(err));
+    watcher.once("close", () => {
+      if (!closing) sentinel.reject(new Error("watcher closed unexpectedly"));
+    });
+    try {
+      const watchedBefore = inotifyWatchedInodes();
+      expect([watchedBefore.has(subInode), watchedBefore.has(nestedInode)]).toEqual([true, true]);
+
+      fs.renameSync(path.join(root, "sub"), moved);
+      fs.writeFileSync(path.join(moved, "f.txt"), "x");
+      fs.writeFileSync(path.join(moved, "nested", "g.txt"), "x");
+      // One ordered queue per inotify fd: anything the two writes above could have
+      // produced is delivered before the sentinel's own event, so no sleep is needed.
+      fs.writeFileSync(path.join(root, "sentinel.txt"), "x");
+      await sentinel.promise;
+
+      // The move itself is reported; nothing underneath the old path is.
+      expect(events).toContainEqual(["rename", "sub"]);
+      expect(events.filter(([, filename]) => filename?.startsWith("sub/"))).toEqual([]);
+
+      const watchedAfter = inotifyWatchedInodes();
+      expect([watchedAfter.has(subInode), watchedAfter.has(nestedInode)]).toEqual([false, false]);
+    } finally {
+      closing = true;
+      watcher.close();
+    }
+  });
+
+  // Dropping the subtree above is self-correcting: the IN_MOVED_TO that brings a
+  // directory back in re-adds a watch for it and every directory under it. This is
+  // also what a rename whose IN_MOVED_FROM and IN_MOVED_TO land in different read()
+  // buffers falls back to, which is why it costs watch descriptors but loses nothing.
+  test.skipIf(!isLinux)("recursive watch re-attaches a subdirectory renamed back into the tree", async () => {
+    using dir = tempDir("fs-watch-moved-back", { "root": { "sub": { "nested": {} } }, "outside": {} });
+    const root = path.join(String(dir), "root");
+    const parked = path.join(String(dir), "outside", "sub");
+
+    const reattached = Promise.withResolvers<void>();
+    const delivered = Promise.withResolvers<[string, string | null]>();
+    let closing = false;
+    const watcher = fs.watch(root, { recursive: true }, (eventType, filename) => {
+      // Emitted while the IN_MOVED_TO branch walks the subtree, so once it reaches
+      // JS the re-added watch on sub2/nested is already registered.
+      if (filename === "sub2/nested") reattached.resolve();
+      if (filename === "sub2/nested/h.txt") delivered.resolve([eventType, filename]);
+    });
+    const fail = (err: unknown) => {
+      reattached.reject(err);
+      delivered.reject(err);
+    };
+    watcher.once("error", fail);
+    watcher.once("close", () => {
+      if (!closing) fail(new Error("watcher closed unexpectedly"));
+    });
+    try {
+      fs.renameSync(path.join(root, "sub"), parked); // drops the subtree's watches
+      fs.renameSync(parked, path.join(root, "sub2")); // must re-add them
+      await reattached.promise;
+
+      // Written only after the walk has been and gone, so nothing but a live watch
+      // on the re-added sub2/nested can report it.
+      fs.writeFileSync(path.join(root, "sub2", "nested", "h.txt"), "x");
+      expect(await delivered.promise).toEqual(["rename", "sub2/nested/h.txt"]);
+    } finally {
+      closing = true;
+      watcher.close();
+    }
+  });
+
   // Past fs.inotify.max_queued_events the kernel drops events and queues one
   // IN_Q_OVERFLOW; Bun reports it as ('change', null) on every watcher sharing
   // the inotify fd, the same shape node uses for overflow on Windows.


### PR DESCRIPTION
A subdirectory renamed out of a `fs.watch(dir, { recursive: true })` root keeps its inotify watch on Linux. Bun keeps delivering events for the moved-away directory under its stale pre-move relative path until the watcher closes, and the watch descriptors for the moved subtree are never released, so a long-lived watcher leaks them against `fs.inotify.max_user_watches`.

## Repro

```js
const fs = require("node:fs");
fs.mkdirSync(`${root}/sub`);
fs.watch(root, { recursive: true }, (ev, name) => console.log(ev, name));

fs.renameSync(`${root}/sub`, `${outside}/sub`);  // sub is no longer inside the watched tree
fs.writeFileSync(`${outside}/sub/f`, "x");       // node: nothing.  bun: "change sub/f"  ← stale path
```

Watch descriptors held by the process (`/proc/self/fdinfo/<inotify fd>`), for a `root/sub/nested` tree:

| | after `fs.watch` | after the move |
|---|---|---|
| node | 3 | 2 |
| bun (before) | 3 | **3** |
| bun (after) | 3 | 1 |

## Cause

`Linux::thread_main` in `src/runtime/node/path_watcher.rs` keeps one watch descriptor per directory, each with its path relative to the watch root cached in the `wd_map`. It has branches for `IN_CREATE`/`IN_MOVED_TO` (add the new subtree) and `IN_IGNORED` (retire a wd the kernel dropped), but none for `IN_MOVED_FROM` of a directory.

inotify watches inodes, not paths, so nothing retires the wds of a directory that is renamed out of the tree. The cached subpaths for the whole subtree stay at their pre-move values and keep being used to build event filenames. `IN_IGNORED` only covers deletion, where the kernel retires the wd itself.

## Fix

Handle `IN_MOVED_FROM | IN_ISDIR` on a recursive watcher by dropping that watcher's ownership of the wds for the moved directory and everything under it, issuing `inotify_rm_watch` for each one left with no owners. This is `remove_watch` scoped to a subtree, and it is per-owner, so an overlapping `fs.watch` on the moved directory itself keeps its watch.

A directory that only moved *within* the tree is then re-added by its matching `IN_MOVED_TO`, which already walks and re-registers the subtree (that path is what makes `{recursive: true}` pick up new directories at all). So the teardown needs no knowledge of where the directory went: if it stayed, the next event puts it back; if it left, it stays gone.

In-tree renames keep the same watch-descriptor count and, one event aside, the same stream. For `mv root/sub root/sub2`:

```
before  rename sub, rename sub2, rename sub2/nested, rename sub2   ← trailing duplicate
after   rename sub, rename sub2, rename sub2/nested
```

The duplicate came from the `IN_MOVE_SELF` on the wd that is now retired; node does not emit it either. A later write into the renamed subtree still delivers `rename sub2/nested/f.txt` and `change sub2/nested/f.txt`, so the subtree is fully live.

macOS (FSEvents) and Windows (`ReadDirectoryChangesW`) report by path rather than by inode, so neither has this bug.

## Verification

`test/js/node/watch/fs.watch.test.ts` gains `recursive watch releases a subdirectory renamed out of the tree`, which asserts both halves: no event is delivered under the moved-away directory's old path, and its watch descriptors (matched by inode against `/proc/self/fdinfo`) are gone. It needs no sleep: one inotify fd has one ordered queue, so a sentinel write in the watched root cannot be delivered before anything the writes into the moved-away directory would have produced. It fails on `main` with four stale events and passes with the fix.

A second test, `recursive watch re-attaches a subdirectory renamed back into the tree`, pins the other half: after the teardown, the later `IN_MOVED_TO` restores a live watch on the directory and everything under it. It writes into the re-added nested directory only after the re-registering walk has finished, so nothing but a live watch can report it, and it fails if that re-add is stubbed out.

The whole `test/js/node/watch/` suite and all 40 upstream `test-fs-watch*` / `test-fs-promises-watch*` parallel tests pass.

<details>
<summary>Every move/delete shape, measured on the debug build</summary>

`wds` is the process's inotify watch-descriptor count; the probe writes into the subtree afterwards to check it is still live.

```
move root/sub OUT of the tree        wds 3 -> 1   subtree silent   (the bug)
move root/a/b OUT (nested)           wds 4 -> 2   subtree silent
in-tree rename root/sub -> root/sub2 wds 3 -> 3   still watched, delivers rename + change
move root/a -> root/b/a              wds 4 -> 4   still watched, delivers rename + change
move outside/c -> root/c             wds 1 -> 3   still watched, delivers rename + change
rm -rf root/sub                      wds 3 -> 1
```

</details>
