### PR TITLE
bun:sqlite: set code to SQLITE_ERROR for generic errors

### DIFF
--- a/src/jsc/bindings/sqlite/sqlite3_error_codes.h
+++ b/src/jsc/bindings/sqlite/sqlite3_error_codes.h
@@ -657,6 +657,7 @@
 #endif
 
 #define FOR_EACH_SQLITE_ERROR(MACRO)      \
+    MACRO(SQLITE_ERROR)                   \
     MACRO(SQLITE_INTERNAL)                \
     MACRO(SQLITE_PERM)                    \
     MACRO(SQLITE_ABORT)                   \

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1081,34 +1081,29 @@ it("Missing DB throws SQLITE_CANTOPEN", () => {
   }
 });
 
-it("generic errors set code to SQLITE_ERROR", () => {
-  const db = new Database(":memory:");
+it.each([
+  ["query().get() with a syntax error", db => db.query("selecx 1").get()],
+  ["query().all() with an unknown table", db => db.query("SELECT * FROM not_a_table").all()],
+  ["query().all() with an unknown column", db => db.query("SELECT not_a_column FROM foo").all()],
+  ["run() with a syntax error", db => db.run("selecx 1")],
+  ["exec() with a syntax error", db => db.exec("selecx 1")],
+  ["prepare() with a syntax error", db => db.prepare("selecx 1")],
+])("generic errors set code to SQLITE_ERROR: %s", (label, fn) => {
+  using db = new Database(":memory:");
   db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY)");
 
-  const cases = [
-    ["query syntax error", () => db.query("selecx 1").get()],
-    ["query unknown table", () => db.query("SELECT * FROM not_a_table").all()],
-    ["query unknown column", () => db.query("SELECT not_a_column FROM foo").all()],
-    ["run", () => db.run("selecx 1")],
-    ["exec", () => db.exec("selecx 1")],
-    ["prepare", () => db.prepare("selecx 1")],
-  ];
-
-  for (const [label, fn] of cases) {
-    let error;
-    try {
-      fn();
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error).toBeInstanceOf(SQLiteError);
-    expect({ label, code: error.code, errno: error.errno }).toEqual({
-      label,
-      code: "SQLITE_ERROR",
-      errno: 1,
-    });
+  let error;
+  try {
+    fn(db);
+  } catch (e) {
+    error = e;
   }
+
+  expect(error).toBeInstanceOf(SQLiteError);
+  expect({ code: error.code, errno: error.errno }).toEqual({
+    code: "SQLITE_ERROR",
+    errno: 1,
+  });
 });
 
 it("empty blob", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1081,6 +1081,36 @@ it("Missing DB throws SQLITE_CANTOPEN", () => {
   }
 });
 
+it("generic errors set code to SQLITE_ERROR", () => {
+  const db = new Database(":memory:");
+  db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY)");
+
+  const cases = [
+    ["query syntax error", () => db.query("selecx 1").get()],
+    ["query unknown table", () => db.query("SELECT * FROM not_a_table").all()],
+    ["query unknown column", () => db.query("SELECT not_a_column FROM foo").all()],
+    ["run", () => db.run("selecx 1")],
+    ["exec", () => db.exec("selecx 1")],
+    ["prepare", () => db.prepare("selecx 1")],
+  ];
+
+  for (const [label, fn] of cases) {
+    let error;
+    try {
+      fn();
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(SQLiteError);
+    expect({ label, code: error.code, errno: error.errno }).toEqual({
+      label,
+      code: "SQLITE_ERROR",
+      errno: 1,
+    });
+  }
+});
+
 it("empty blob", () => {
   const db = new Database(":memory:");
   db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, blob BLOB)");


### PR DESCRIPTION
### What does this PR do?

`SQLiteError.code` was `undefined` for every generic `SQLITE_ERROR` (primary result code 1): syntax errors, unknown tables, unknown columns. Every other result code gets its name, so `err.code === "SQLITE_..."` dispatch silently fell through for the errors people branch on most.

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
try {
  db.query("selecx 1").get();
} catch (e) {
  e.errno; // 1
  e.code; // undefined   (better-sqlite3: "SQLITE_ERROR")
}
```

**Cause:** `createSQLiteError` maps `sqlite3_extended_errcode()` to a name by switching over `FOR_EACH_SQLITE_ERROR`. That table starts at `SQLITE_INTERNAL` (2) and never listed `SQLITE_ERROR` (1), so the switch had no matching case, `codeStr` stayed empty, and the `code` property was never put on the error. `SQLITE_OK`, `SQLITE_ROW`, and `SQLITE_DONE` are the only other codes missing from the table, and those are correctly excluded since they aren't errors.

**Fix:** add `MACRO(SQLITE_ERROR)` to the table. The value is unique (the extended codes built on it, `SQLITE_ERROR_MISSING_COLLSEQ`/`RETRY`/`SNAPSHOT`, are 257/513/769), so no case collides.

```js
e.errno; // 1
e.code; // "SQLITE_ERROR"
```

### How did you verify your code works?

New `it.each` cases in `test/js/bun/sqlite/sqlite.test.js` assert `code === "SQLITE_ERROR"` and `errno === 1` across `query().get()`, `query().all()`, `run()`, `exec()`, and `prepare()`, covering syntax errors, unknown tables, and unknown columns.

All six fail on main (`code: undefined`) and pass with the fix. The rest of `test/js/bun/sqlite/` and `test/js/sql/sqlite-sql.test.ts` stay green.
