### PR TITLE
Convert the name argument of URLSearchParams and FormData lookups to USVString

### DIFF
--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -373,9 +373,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_getBody(JSC::JS
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto* nameStr = argument0.value().toString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
-    auto name = nameStr->view(lexicalGlobalObject);
+    auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLNullable<IDLUnion<IDLUSVString, IDLInterface<Blob>>>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, impl.get(name))));
 }
@@ -395,9 +393,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_getAllBody(JSC:
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto* nameStr = argument0.value().toString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
-    auto name = nameStr->view(lexicalGlobalObject);
+    auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     auto entries = impl.getAll(name);
     JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -305,9 +305,7 @@ static inline JSC::EncodedJSValue jsURLSearchParamsPrototypeFunction_getBody(JSC
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto* nameString = argument0.value().toString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
-    const auto name = nameString->view(lexicalGlobalObject);
+    auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLNullable<IDLUSVString>>(*lexicalGlobalObject, throwScope, impl.get(name))));
 }
@@ -327,9 +325,7 @@ static inline JSC::EncodedJSValue jsURLSearchParamsPrototypeFunction_getAllBody(
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto* nameString = argument0.value().toString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
-    const auto name = nameString->view(lexicalGlobalObject);
+    auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLSequence<IDLUSVString>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, impl.getAll(name))));
 }
@@ -349,9 +345,7 @@ static inline JSC::EncodedJSValue jsURLSearchParamsPrototypeFunction_hasBody(JSC
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto* nameString = argument0.value().toString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
-    const auto name = nameString->view(lexicalGlobalObject);
+    auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
 
     String value;

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -915,3 +915,50 @@ test("FormData.toJSON merges duplicate numeric field names into an array", async
   expect(stdout.trim().split("\n")).toEqual(['{"0":["a","b","c"],"tag":["x","y"]}', '{"0":["first","second"]}']);
   expect(exitCode).toBe(0);
 });
+
+describe("USVString conversion of lone surrogates", () => {
+  const loneHigh = "a\uD800b";
+  const loneLow = "a\uDC00b";
+  const replaced = "a\uFFFDb";
+
+  it("get/getAll/has find an entry appended under a lone surrogate name", () => {
+    const formData = new FormData();
+    formData.append(loneHigh, "1");
+    formData.append(loneHigh, "2");
+
+    expect([...formData.keys()]).toEqual([replaced, replaced]);
+    expect(formData.has(loneHigh)).toBe(true);
+    expect(formData.get(loneHigh)).toBe("1");
+    expect(formData.getAll(loneHigh)).toEqual(["1", "2"]);
+
+    // the converted spelling names the same entry
+    expect(formData.get(replaced)).toBe("1");
+    expect(formData.getAll(replaced)).toEqual(["1", "2"]);
+  });
+
+  it("lone high and lone low surrogates both convert to U+FFFD", () => {
+    const formData = new FormData();
+    formData.append(loneLow, "low");
+    expect(formData.get(loneLow)).toBe("low");
+    expect(formData.get(loneHigh)).toBe("low");
+  });
+
+  it("finds a Blob entry appended under a lone surrogate name", async () => {
+    const formData = new FormData();
+    formData.append(loneHigh, new Blob(["bar"]), "mynameis.txt");
+
+    const entry = formData.get(loneHigh) as File;
+    expect(entry).toBeInstanceOf(Blob);
+    expect(entry.name).toBe("mynameis.txt");
+    expect(await entry.text()).toBe("bar");
+    expect(formData.getAll(loneHigh)).toHaveLength(1);
+  });
+
+  it("leaves valid surrogate pairs alone", () => {
+    const formData = new FormData();
+    formData.append("\u{1F600}", "emoji");
+    expect(formData.get("\u{1F600}")).toBe("emoji");
+    expect(formData.getAll("\u{1F600}")).toEqual(["emoji"]);
+    expect(formData.get("\uFFFD")).toBeNull();
+  });
+});

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -226,6 +226,78 @@ it(".delete second argument", () => {
   expect(params + "").toBe("a=2");
 });
 
+describe("USVString conversion of lone surrogates", () => {
+  const loneHigh = "a\uD800b";
+  const loneLow = "a\uDC00b";
+  const replaced = "a\uFFFDb";
+
+  it("get/getAll/has find an entry appended under a lone surrogate name", () => {
+    const params = new URLSearchParams();
+    params.append(loneHigh, "1");
+    params.append(loneHigh, "2");
+
+    expect([...params]).toEqual([
+      [replaced, "1"],
+      [replaced, "2"],
+    ]);
+    expect(params.has(loneHigh)).toBe(true);
+    expect(params.get(loneHigh)).toBe("1");
+    expect(params.getAll(loneHigh)).toEqual(["1", "2"]);
+
+    // the converted spelling names the same entry
+    expect(params.has(replaced)).toBe(true);
+    expect(params.get(replaced)).toBe("1");
+    expect(params.getAll(replaced)).toEqual(["1", "2"]);
+  });
+
+  it("lone high and lone low surrogates both convert to U+FFFD", () => {
+    const params = new URLSearchParams();
+    params.append(loneLow, "low");
+    expect(params.get(loneLow)).toBe("low");
+    expect(params.get(loneHigh)).toBe("low");
+    expect(params.has(loneHigh)).toBe(true);
+  });
+
+  it("converts the value argument of .has()", () => {
+    const params = new URLSearchParams();
+    params.append("k", loneHigh);
+    expect(params.get("k")).toBe(replaced);
+    expect(params.has("k", loneHigh)).toBe(true);
+    expect(params.has("k", replaced)).toBe(true);
+  });
+
+  it(".set() and .delete() address the converted entry", () => {
+    const params = new URLSearchParams();
+    params.append(loneHigh, "1");
+    params.set(loneHigh, "2");
+    expect([...params]).toEqual([[replaced, "2"]]);
+    params.delete(loneHigh);
+    expect(params.size).toBe(0);
+  });
+
+  it("serializes and round-trips the converted name", () => {
+    const params = new URLSearchParams();
+    params.append(loneHigh, "1");
+    expect(params.toString()).toBe("a%EF%BF%BDb=1");
+    expect(new URLSearchParams(params.toString()).get(loneHigh)).toBe("1");
+
+    const url = new URL("https://example.com/");
+    url.searchParams.append(loneHigh, "1");
+    expect(url.search).toBe("?a%EF%BF%BDb=1");
+    expect(url.searchParams.get(loneHigh)).toBe("1");
+  });
+
+  it("leaves valid surrogate pairs alone", () => {
+    const params = new URLSearchParams();
+    params.append("\u{1F600}", "emoji");
+    expect(params.has("\u{1F600}")).toBe(true);
+    expect(params.get("\u{1F600}")).toBe("emoji");
+    expect(params.getAll("\u{1F600}")).toEqual(["emoji"]);
+    expect(params.get("\uFFFD")).toBeNull();
+    expect(params.toString()).toBe("%F0%9F%98%80=emoji");
+  });
+});
+
 it(".has second argument", () => {
   const params = new URLSearchParams("a=1&a=2&b=3");
   expect(params.has("a", 1)).toBe(true);


### PR DESCRIPTION
### Repro

A parameter name containing a lone surrogate is stored under its USVString-converted spelling (`U+FFFD`), but the read methods look it up under the original spelling, so the entry is only reachable by iteration.

```js
const p = new URLSearchParams();
const k = "a\uD800b";
p.append(k, "1");

[...p];       // [["a\uFFFDb", "1"]]  (correct, the name was converted on write)
p.has(k);     // node/spec: true   bun: false
p.get(k);     // node/spec: "1"    bun: null
p.getAll(k);  // node/spec: ["1"]  bun: []

const fd = new FormData();
fd.append(k, "1");
fd.get(k);    // node/spec: "1"    bun: null
fd.getAll(k); // node/spec: ["1"]  bun: []
```

Lone surrogates show up in real data whenever a UTF-16 string is sliced at the wrong offset, so this surfaces as "params randomly missing".

### Cause

`URLSearchParams.get/getAll/has` and `FormData.get/getAll` read the `name` argument with `JSValue::toString()` and pass the resulting `StringView` straight to the impl, which compares it against the stored pairs:

```cpp
auto* nameString = argument0.value().toString(lexicalGlobalObject);
RETURN_IF_EXCEPTION(throwScope, {});
const auto name = nameString->view(lexicalGlobalObject);
```

Their write counterparts (`append`, `set`, `delete`, and the `value` argument of `has`) go through `convert<IDLUSVString>`, which runs `replaceUnpairedSurrogatesWithReplacementCharacter`. So the stored key and the lookup key are produced by two different conversions, and they stop agreeing as soon as the name contains an unpaired surrogate.

`FormData.has` and `FormData.delete` already used `convert<IDLUSVString>`, which is why only `get`/`getAll` are wrong there.

### Fix

Use `convert<IDLUSVString>` for those `name` arguments, matching the sibling methods in the same files and the WebIDL declarations (`URLSearchParams`/`FormData` declare every `name` as `USVString`).

This is not a hot-path cost: `valueToUSVString` moves the string through untouched when it has no unpaired surrogates, and `hasUnpairedSurrogate` short-circuits on 8-bit strings. It also removes a `StringView` that borrowed from the argument `JSString` in favour of an owned `String`.

`Headers` is not affected: header names are validated against the HTTP token charset, so a name with a surrogate can never be stored nor looked up.

### Verification

`test/js/web/html/URLSearchParams.test.ts` and `test/js/web/html/FormData.test.ts` gain a `USVString conversion of lone surrogates` block covering `get`/`getAll`/`has`, lone high and lone low surrogates, the `value` argument of `has`, `set`/`delete`, `toString()` round-trip, `url.searchParams`, the `Blob` branch of `FormData.get`, and that valid surrogate pairs are left alone. Every expected value was taken from Node.

Before the fix, 3 tests fail in each file. After, both files pass, along with `test/js/web/url/url.test.ts`, `test/js/bun/http/form-data-set-append.test.js`, `test/js/web/html/FormData-multipart-serialization.test.ts`, and the 12 `test/js/node/test/parallel/test-whatwg-url-custom-searchparams-*.js` tests.
