### PR TITLE
Bun.serve: never write a status line for a status outside 100..=999

### DIFF
--- a/src/runtime/server/HTTPStatusText.rs
+++ b/src/runtime/server/HTTPStatusText.rs
@@ -4,6 +4,13 @@ pub const fn is_null_body(code: u16) -> bool {
     matches!(code, 101 | 103 | 204 | 205 | 304)
 }
 
+/// RFC 9112 §4: the status line carries exactly three digits, so anything else
+/// has no serialization. `Response.error()` is status 0, and `fetch` accepts a
+/// malformed `HTTP/1.1 0xx` status line from an upstream server.
+pub const fn is_sendable(code: u16) -> bool {
+    matches!(code, 100..=999)
+}
+
 pub fn get(code: u16) -> Option<&'static [u8]> {
     match code {
         100 => Some(b"100 Continue"),

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -756,8 +756,7 @@ where
             ctx.render_missing_invalid_response(value);
             return;
         };
-        if !HTTPStatusText::is_sendable(response.status_code()) {
-            ctx.reject_unsendable_response(response.status_code());
+        if ctx.reject_unsendable_response(response) {
             return;
         }
         ctx.response_jsvalue = value;
@@ -2649,8 +2648,7 @@ where
         // `response_value` is rooted via ensure_still_alive() / protect()
         // below for the duration of the borrow.
         if let Some(response) = unsafe { as_response(response_value) } {
-            if !HTTPStatusText::is_sendable(response.status_code()) {
-                ctx.reject_unsendable_response(response.status_code());
+            if ctx.reject_unsendable_response(response) {
                 return;
             }
             ctx.response_jsvalue = response_value;
@@ -2724,8 +2722,7 @@ where
                         return;
                     };
 
-                    if !HTTPStatusText::is_sendable(response.status_code()) {
-                        ctx.reject_unsendable_response(response.status_code());
+                    if ctx.reject_unsendable_response(response) {
                         return;
                     }
 
@@ -3351,12 +3348,17 @@ where
         self.run_error_handler_with_status_code(value, 500);
     }
 
-    /// A status outside `100..=999` has no HTTP status line, so the Response
-    /// can never reach the client. Report it like a thrown error instead of
-    /// writing an unparseable status line to the socket.
-    fn reject_unsendable_response(&mut self, status: u16) {
+    /// `false` when the Response can be written. A status outside `100..=999`
+    /// has no HTTP status line, so the Response can never reach the client:
+    /// report it like a thrown error rather than writing an unparseable one.
+    fn reject_unsendable_response(&mut self, response: &Response) -> bool {
+        let status = response.status_code();
+        if HTTPStatusText::is_sendable(status) {
+            return false;
+        }
         let Some(server) = self.server else {
-            return self.render_production_error(500);
+            self.render_production_error(500);
+            return true;
         };
         // SAFETY: BACKREF
         let global_this = (*server).global_this();
@@ -3364,6 +3366,7 @@ where
             "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
         ));
         self.run_error_handler(err);
+        true
     }
 
     fn ensure_pathname(&self) -> PathnameFormatter<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3> {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -756,6 +756,10 @@ where
             ctx.render_missing_invalid_response(value);
             return;
         };
+        if !HTTPStatusText::is_sendable(response.status_code()) {
+            ctx.reject_unsendable_response(response.status_code());
+            return;
+        }
         ctx.response_jsvalue = value;
         debug_assert!(!ctx.flags.response_protected());
         ctx.flags.set_response_protected(true);
@@ -2645,6 +2649,10 @@ where
         // `response_value` is rooted via ensure_still_alive() / protect()
         // below for the duration of the borrow.
         if let Some(response) = unsafe { as_response(response_value) } {
+            if !HTTPStatusText::is_sendable(response.status_code()) {
+                ctx.reject_unsendable_response(response.status_code());
+                return;
+            }
             ctx.response_jsvalue = response_value;
             ctx.response_jsvalue.ensure_still_alive();
             ctx.flags.set_response_protected(false);
@@ -2715,6 +2723,11 @@ where
                         ctx.render_missing_invalid_response(fulfilled_value);
                         return;
                     };
+
+                    if !HTTPStatusText::is_sendable(response.status_code()) {
+                        ctx.reject_unsendable_response(response.status_code());
+                        return;
+                    }
 
                     ctx.response_jsvalue = fulfilled_value;
                     ctx.response_jsvalue.ensure_still_alive();
@@ -3338,6 +3351,21 @@ where
         self.run_error_handler_with_status_code(value, 500);
     }
 
+    /// A status outside `100..=999` has no HTTP status line, so the Response
+    /// can never reach the client. Report it like a thrown error instead of
+    /// writing an unparseable status line to the socket.
+    fn reject_unsendable_response(&mut self, status: u16) {
+        let Some(server) = self.server else {
+            return self.render_production_error(500);
+        };
+        // SAFETY: BACKREF
+        let global_this = (*server).global_this();
+        let err = global_this.create_error_instance(format_args!(
+            "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+        ));
+        self.run_error_handler(err);
+    }
+
     fn ensure_pathname(&self) -> PathnameFormatter<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3> {
         PathnameFormatter { ctx: self }
     }
@@ -3427,8 +3455,12 @@ where
                     // `result` is GC-rooted by `_keep` (EnsureStillAlive)
                     // across the render() call.
                     } else if let Some(response) = unsafe { as_response(result) } {
-                        self.render(response);
-                        return;
+                        // An unsendable Response from the error handler itself
+                        // falls through to the default error page below.
+                        if HTTPStatusText::is_sendable(response.status_code()) {
+                            self.render(response);
+                            return;
+                        }
                     }
                 }
             }
@@ -3477,6 +3509,11 @@ where
                     ctx.finish_running_error_handler(value, status);
                     return;
                 };
+
+                if !HTTPStatusText::is_sendable(response.status_code()) {
+                    ctx.finish_running_error_handler(value, status);
+                    return;
+                }
 
                 ctx.response_jsvalue = fulfilled_value;
                 ctx.response_jsvalue.ensure_still_alive();

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -156,6 +156,13 @@ impl StaticRoute {
         // unsafe in `JSValue`); every `Response` accessor used below takes
         // `&self` (interior mutability for `body`), so no `&mut` is needed.
         if let Some(response) = argument.as_class_ref::<Response>() {
+            if !HTTPStatusText::is_sendable(response.status_code()) {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "Cannot use a Response with status {} as a static route. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+                    response.status_code(),
+                )));
+            }
+
             // The user may want to pass in the same Response object multiple endpoints
             // Let's let them do that.
             let body_value = response.get_body_value();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1260,6 +1260,100 @@ it("does not write body bytes for null body statuses", async () => {
   }
 });
 
+// Response.error() is a WHATWG network error: its status is 0, which has no
+// representation in an HTTP status line. It must never be written to the socket.
+describe("Response.error()", () => {
+  const unsendable =
+    "Cannot send a Response with status 0. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).";
+
+  async function rawStatusLine(port: number, method: string): Promise<string> {
+    const received: Buffer[] = [];
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data(socket, data) {
+          received.push(data);
+        },
+        end() {
+          resolve();
+        },
+        error(socket, error) {
+          reject(error);
+        },
+        close() {
+          resolve();
+        },
+      },
+    });
+    connection.write(`${method} / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
+    connection.flush();
+    await promise;
+    return Buffer.concat(received).toString().split("\r\n")[0];
+  }
+
+  describe.each(["GET", "HEAD"])("%s", method => {
+    it.each([
+      ["sync", () => Response.error()],
+      ["async", async () => Response.error()],
+    ])("a %s fetch handler returning it reaches error()", async (_label, fetchImpl) => {
+      const errors: Error[] = [];
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch: fetchImpl,
+        error(error) {
+          errors.push(error);
+          return new Response("handled", { status: 502 });
+        },
+      });
+
+      expect(await rawStatusLine(server.port, method)).toBe("HTTP/1.1 502 Bad Gateway");
+      expect(errors.map(error => error.message)).toEqual([unsendable]);
+    });
+  });
+
+  // Bun reports the synthesized error the same way it reports a thrown one, which
+  // would fail this test process, so the default 500 page is checked in a child.
+  it("responds 500 with no error() handler, and when error() returns it too", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const servers = [
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: () => Response.error() }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: () => Response.error(), error: () => Response.error() }),
+        ];
+        for (const server of servers) {
+          const response = await fetch(server.url);
+          console.log(response.status, await response.text());
+          server.stop(true);
+        }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("500 Something went wrong!\n500 Something went wrong!\n");
+    expect(stderr).toContain(unsendable);
+  });
+
+  it("is rejected when registered as a static route", () => {
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        routes: { "/": Response.error() },
+      }),
+    ).toThrow(
+      "Cannot use a Response with status 0 as a static route. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+    );
+  });
+});
+
 describe("response framing", () => {
   type RawResponse = { statusLine: string; headerNames: string[]; headers: Record<string, string>; body: string };
   // Read the raw response so that `Content-Length: 0` and an absent


### PR DESCRIPTION
### Repro

```js
Bun.serve({
  port: 0,
  routes: { "/x": () => Response.error() },
  error(e) { /* never called */ },
});
// wire: "HTTP/1.1 0 HM\r\n…"  ← invalid status line
// bun's own fetch: "Malformed_HTTP_Response"
```

### Cause

`Response.error()` is a WHATWG network error: its status is `0`. `HTTPStatusText::get` only maps `100..=999`, and both status serializers fall back to `write!(w, "{status} HM", …)` for anything it has no reason phrase for, so status `0` is written verbatim as `HTTP/1.1 0 HM`. RFC 9112 §4 requires three digits, so every client and proxy in front of the server sees protocol garbage on a connection it may want to keep alive.

The same status reaches the wire from four places: a sync handler, an async handler, the `error()` handler itself, and a static route (`routes: { "/x": Response.error() }`). It is also reachable without `Response.error()`: picohttpparser accepts `HTTP/1.1 000 …` from an upstream server as status `0`, so `fetch(upstream)` forwarded straight to the client produces the same bytes.

### Fix

`HTTPStatusText::is_sendable(code)` is the single predicate for "this status has a status line" (`100..=999`). A Response that fails it:

- from a handler (sync, async, or the `error()` handler's own promise) is reported through `error()` like a thrown error, so the server answers `500` by default and the configured handler can respond itself
- registered as a static route is rejected at `Bun.serve()` time

`error()` returning another unsendable Response falls through to the default error page rather than recursing.

### Verification

`bun bd test test/js/bun/http/serve.test.ts -t "Response.error()"` — 6 pass; all 6 fail on the released binary (`USE_SYSTEM_BUN=1`), four of them with the `HTTP/1.1 0 HM` status line and the other two because `fetch` rejects the reply. `bun-serve-static.test.ts`, `bun-serve-routes.test.ts` and `bun-serve-propagate-errors.test.ts` still pass.