### PR TITLE
net: invoke the pending write callback when a read error destroys the socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -256,17 +256,18 @@ function tlsHandshakeError(verifyError) {
 
 /**
  * A write parked on the native drain can never complete once the socket is
- * gone. Fail it so the caller's write callback runs and 'finish'/destroy are
- * not stuck behind it, the way Node's onWriteComplete does for the write
- * request libuv cancels when the handle closes.
+ * gone. Closing the handle cancels the write request in Node, so its callback
+ * gets errnoException(UV_ECANCELED, 'write') while the error that caused the
+ * close surfaces on 'error'. Failing the write also unsticks the writable side,
+ * so 'finish' and destroy are not queued behind a callback that never fires.
  */
-function failPendingWrite(self, err?) {
+function failPendingWrite(self) {
   const callback = self[kwriteCallback];
   if (!callback) return;
   self._pendingData = null;
   self._pendingEncoding = "";
   self[kwriteCallback] = null;
-  callback(err ?? $ERR_SOCKET_CLOSED());
+  callback(new ErrnoException(UV_ECANCELED, "write"));
 }
 
 const SocketHandlers: SocketHandler = {
@@ -513,7 +514,7 @@ function SocketEmitEndNT(self, _err?) {
       const er = new ErrnoException(errErrno, "read") as Error & { code?: string };
       if (typeof er.code === "string" && /^E[A-Z0-9]+$/.test(er.code)) {
         self.destroy(er);
-        failPendingWrite(self, er);
+        failPendingWrite(self);
         return;
       }
     }
@@ -528,11 +529,11 @@ function SocketEmitEndNT(self, _err?) {
       er.errno = _err.errno ?? (process.platform === "win32" ? -4077 : process.platform === "linux" ? -104 : -54);
       er.syscall = "read";
       self.destroy(er);
-      failPendingWrite(self, er);
+      failPendingWrite(self);
     } else {
       // Any other coded error (ETIMEDOUT, EPIPE, ...) keeps its identity.
       self.destroy(_err);
-      failPendingWrite(self, _err);
+      failPendingWrite(self);
     }
     return;
   }
@@ -550,7 +551,7 @@ function SocketEmitEndNT(self, _err?) {
     self.destroy();
   }
   if (self.destroyed || _err) {
-    failPendingWrite(self, _err);
+    failPendingWrite(self);
   }
 }
 
@@ -1110,7 +1111,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       // the close was driven by a recv() failure (libus close-code enum values
       // are filtered out in NewSocket::on_close).
       self.destroy(er);
-      failPendingWrite(self, er);
+      failPendingWrite(self);
       return;
     }
     self[kended] = true;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -254,6 +254,21 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
+/**
+ * A write parked on the native drain can never complete once the socket is
+ * gone. Fail it so the caller's write callback runs and 'finish'/destroy are
+ * not stuck behind it, the way Node's onWriteComplete does for the write
+ * request libuv cancels when the handle closes.
+ */
+function failPendingWrite(self, err?) {
+  const callback = self[kwriteCallback];
+  if (!callback) return;
+  self._pendingData = null;
+  self._pendingEncoding = "";
+  self[kwriteCallback] = null;
+  callback(err ?? $ERR_SOCKET_CLOSED());
+}
+
 const SocketHandlers: SocketHandler = {
   close(socket, err) {
     const self = socket.data;
@@ -498,6 +513,7 @@ function SocketEmitEndNT(self, _err?) {
       const er = new ErrnoException(errErrno, "read") as Error & { code?: string };
       if (typeof er.code === "string" && /^E[A-Z0-9]+$/.test(er.code)) {
         self.destroy(er);
+        failPendingWrite(self, er);
         return;
       }
     }
@@ -512,9 +528,11 @@ function SocketEmitEndNT(self, _err?) {
       er.errno = _err.errno ?? (process.platform === "win32" ? -4077 : process.platform === "linux" ? -104 : -54);
       er.syscall = "read";
       self.destroy(er);
+      failPendingWrite(self, er);
     } else {
       // Any other coded error (ETIMEDOUT, EPIPE, ...) keeps its identity.
       self.destroy(_err);
+      failPendingWrite(self, _err);
     }
     return;
   }
@@ -531,12 +549,8 @@ function SocketEmitEndNT(self, _err?) {
     // no further events.
     self.destroy();
   }
-  // A write that was waiting on the native drain can never complete once the
-  // socket is gone - fail it so 'finish'/destroy are not stuck behind it.
-  const pendingWrite = self[kwriteCallback];
-  if (pendingWrite && (self.destroyed || _err)) {
-    self[kwriteCallback] = null;
-    pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
+  if (self.destroyed || _err) {
+    failPendingWrite(self, _err);
   }
 }
 
@@ -1082,35 +1096,28 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       // Same late-detach guard as SocketEmitEndNT: the listener seen at
       // close-time can be gone by the deferred 'error' emission.
       self.once("error", () => {});
+      let er = err;
       if (err.code === undefined || err.code === "ECONNRESET") {
         // Shape it like Node's errnoException(UV_ECONNRESET, 'read').
-        const er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
+        er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
         er.errno = err.errno;
         er.syscall = "read";
-        self.destroy(er);
-      } else {
-        // Any other recv errno (ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, ...)
-        // keeps its identity — Node's onStreamRead does
-        // `stream.destroy(errnoException(nread, 'read'))` for any nread that
-        // is not UV_EOF. The native on_close only passes a non-undefined err
-        // when the close was driven by a recv() failure (libus close-code
-        // enum values are filtered out in NewSocket::on_close).
-        self.destroy(err);
       }
+      // Any other recv errno (ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, ...) keeps
+      // its identity — Node's onStreamRead does
+      // `stream.destroy(errnoException(nread, 'read'))` for any nread that is
+      // not UV_EOF. The native on_close only passes a non-undefined err when
+      // the close was driven by a recv() failure (libus close-code enum values
+      // are filtered out in NewSocket::on_close).
+      self.destroy(er);
+      failPendingWrite(self, er);
       return;
     }
     self[kended] = true;
     if (!self.allowHalfOpen) self.write = writeAfterFIN;
     self.push(null);
     self.read(0);
-    // A write that was waiting on the native drain can never complete once the
-    // socket is gone - fail it so 'finish'/destroy are not stuck behind it
-    // (mirrors SocketEmitEndNT).
-    const pendingWrite = self[kwriteCallback];
-    if (pendingWrite) {
-      self[kwriteCallback] = null;
-      pendingWrite($ERR_SOCKET_CLOSED());
-    }
+    failPendingWrite(self);
   },
   handshake(socket, success, verifyError) {
     $debug("Bun.Socket handshake");

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -125,6 +125,9 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     using p = await connectedPair(s => s.on("error", () => {}));
     const serverFd = (p.serverSock as any)._handle.fd;
     expect(serverFd).toBeGreaterThanOrEqual(0);
+    // resetAndDestroy() emits on the resetting socket when terminate() fails; an
+    // unhandled 'error' would crash the run instead of failing an assertion.
+    p.client.on("error", () => {});
 
     fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1, fd: serverFd });
     const written = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -96,6 +96,42 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     expect(received.length).toBe(256);
   });
 
+  // EAGAIN forever parks the write callback on a drain that can never arrive,
+  // so the socket's teardown is the only path left to it. Node hands the
+  // cancelled write request's error to the callback; Bun dropped it entirely.
+  test("a peer reset fails a client's parked write callback", async () => {
+    using p = await connectedPair(s => s.on("error", () => {}));
+    const clientFd = (p.client as any)._handle.fd;
+    expect(clientFd).toBeGreaterThanOrEqual(0);
+    p.client.on("error", () => {});
+
+    fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1, fd: clientFd });
+    const written = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+    p.client.write(Buffer.alloc(256, "x"), err => written.resolve(err));
+    p.serverSock.resetAndDestroy();
+
+    const writeErr = await written.promise;
+    expect(writeErr?.code).toBe("ECONNRESET");
+    expect(p.client.writableFinished).toBe(false);
+  });
+
+  // Same gap on the accepted side, which reaches it through SocketEmitEndNT:
+  // a server still writing a response when the client resets.
+  test("a peer reset fails a server socket's parked write callback", async () => {
+    using p = await connectedPair(s => s.on("error", () => {}));
+    const serverFd = (p.serverSock as any)._handle.fd;
+    expect(serverFd).toBeGreaterThanOrEqual(0);
+
+    fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1, fd: serverFd });
+    const written = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+    p.serverSock.write(Buffer.alloc(256, "x"), err => written.resolve(err));
+    p.client.resetAndDestroy();
+
+    const writeErr = await written.promise;
+    expect(writeErr).toBeTruthy();
+    expect(p.serverSock.writableFinished).toBe(false);
+  });
+
   test("send → short writes still deliver complete payload to peer", async () => {
     let received = Buffer.alloc(0);
     using p = await connectedPair(s => {

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -139,6 +139,35 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     expect(p.serverSock.writableFinished).toBe(false);
   });
 
+  // One write parks and the rest queue in the Writable; failing the parked one
+  // is what cascades through that queue. Without it every queued callback is
+  // left pending forever.
+  test("a peer reset settles every queued write callback, not just the parked one", async () => {
+    using p = await connectedPair(s => s.on("error", () => {}));
+    const serverFd = (p.serverSock as any)._handle.fd;
+    p.client.on("error", () => {});
+
+    fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1, fd: serverFd });
+    const N = 32;
+    const settled: string[] = new Array(N).fill("PENDING");
+    const closed = Promise.withResolvers<void>();
+    p.serverSock.on("close", () => closed.resolve());
+    for (let i = 0; i < N; i++) {
+      p.serverSock.write(
+        Buffer.alloc(256, "x"),
+        err => (settled[i] = err ? (err as NodeJS.ErrnoException).code! : "OK"),
+      );
+    }
+    p.client.resetAndDestroy();
+    await closed.promise;
+
+    // Node: the in-flight write gets ECANCELED; the queued ones get the
+    // stream's stored error (ECONNRESET) via errorBuffer.
+    expect(settled.filter(x => x === "PENDING")).toEqual([]);
+    expect(settled[0]).toBe("ECANCELED");
+    expect(new Set(settled.slice(1))).toEqual(new Set(["ECONNRESET"]));
+  });
+
   test("send → short writes still deliver complete payload to peer", async () => {
     let received = Buffer.alloc(0);
     using p = await connectedPair(s => {

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -97,13 +97,14 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
   });
 
   // EAGAIN forever parks the write callback on a drain that can never arrive,
-  // so the socket's teardown is the only path left to it. Node hands the
-  // cancelled write request's error to the callback; Bun dropped it entirely.
+  // so the socket's teardown is the only path left to it. Node cancels the
+  // write request on handle close; Bun dropped the callback entirely.
   test("a peer reset fails a client's parked write callback", async () => {
     using p = await connectedPair(s => s.on("error", () => {}));
     const clientFd = (p.client as any)._handle.fd;
     expect(clientFd).toBeGreaterThanOrEqual(0);
-    p.client.on("error", () => {});
+    const errors: NodeJS.ErrnoException[] = [];
+    p.client.on("error", e => errors.push(e));
 
     fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1, fd: clientFd });
     const written = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
@@ -111,7 +112,10 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     p.serverSock.resetAndDestroy();
 
     const writeErr = await written.promise;
-    expect(writeErr?.code).toBe("ECONNRESET");
+    // The cancelled write and the error that caused it are separate signals,
+    // exactly as Node reports them.
+    expect({ code: writeErr?.code, syscall: writeErr?.syscall }).toEqual({ code: "ECANCELED", syscall: "write" });
+    expect(errors.map(e => e.code)).toEqual(["ECONNRESET"]);
     expect(p.client.writableFinished).toBe(false);
   });
 
@@ -128,7 +132,7 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     p.client.resetAndDestroy();
 
     const writeErr = await written.promise;
-    expect(writeErr).toBeTruthy();
+    expect({ code: writeErr?.code, syscall: writeErr?.syscall }).toEqual({ code: "ECANCELED", syscall: "write" });
     expect(p.serverSock.writableFinished).toBe(false);
   });
 


### PR DESCRIPTION
### What does this PR do?

`socket.write(chunk, cb)` never calls `cb` when the peer resets the connection while the write is still queued. A caller awaiting that callback waits forever.

```js
const c = net.connect(port, () => c.write(bigBuffer, err => log("cb:", err)));
```

What the parked write's callback receives, measured against node v26.3.0:

| teardown | `main` | node v26 | this PR |
|---|---|---|---|
| peer RST | **never called** | `ECANCELED` / `write` | `ECANCELED` / `write` |
| `socket.destroy()` | `ERR_SOCKET_CLOSED` | `ECANCELED` / `write` | `ECANCELED` / `write` |
| `socket.destroy(err)` | `ERR_SOCKET_CLOSED` | `ECANCELED` / `write` | `ECANCELED` / `write` |

#### Cause

A write that cannot be flushed in one go parks its stream callback in `kwriteCallback` and waits for the native drain. When the read side errors first, the socket is destroyed before any writable event arrives, and both teardown paths return early without touching the parked callback:

- `SocketEmitEndNT` (server-accepted sockets, via `ServerHandlers.close`; also the fd-adoption path) calls `self.destroy(er)` and returns, skipping the `pendingWrite` block at the end of the function.
- `SocketHandlers2.close` (client sockets) does the same.

Each already had the right code, just after the early return it never reaches.

The reset is what makes this deterministic rather than rare: the peer never drained anything, so no writable event was ever pending, and the `EPOLLERR` that arrives with the RST makes `loop.c` skip the writable dispatch entirely and close the socket. The read error always wins that race.

#### Fix

Fail the parked write on those paths. Both teardown paths and the tail now share one helper, which also clears the pending chunk the failed write was still holding.

Closing the handle cancels the pending write request in Node, so its callback gets `errnoException(UV_ECANCELED, 'write')` while the error that *caused* the close surfaces on `'error'`. Those are two separate signals, and the helper now mirrors that on every path. Previously Bun handed the causal read error (`ECONNRESET`, `syscall: 'read'`) to the write callback where it fired at all, and `ERR_SOCKET_CLOSED` on the rest.

Failing the stream write is also what lets the writable side finish, so `'finish'` and destroy are no longer queued behind a callback that will never fire.

### How did you verify your code works?

Three tests, all failing on `main`:

- client-side peer reset with one parked write (times out on `main`: the callback never arrives)
- server-side peer reset with one parked write (same)
- server-side peer reset with **32 queued writes**: asserts all 32 settle, with `ECANCELED` on the in-flight one and `ECONNRESET` on the rest (Node's exact distribution). On `main` all 32 stay `PENDING` forever.

All three arm `send → EAGAIN` forever on one socket so the write is guaranteed to park and no flush can ever complete it, leaving the socket's teardown as the only path to the callback. That removes any dependence on kernel buffer sizing.

A deterministic public-API-only repro (server writes 96×64KB to a peer that sets `SO_RCVBUF=2048`, never reads, then RSTs via `SO_LINGER(1,0)`; no fault injection) produces:

```
node v26.3.0:  {"OK":20,"ECANCELED":1,"ECONNRESET":75,"PENDING":0}
bun main:      {"OK":20,"PENDING":76}
this PR:       {"OK":20,"ECANCELED":1,"ECONNRESET":75,"PENDING":0}
```

Failing the one parked write is what settles the rest: it routes through Writable's `onwriteError` → `errorBuffer(state)`, which drains the queue with `state.errored`.

The table at the top is scratch output from running the same program under `node` and under this build, one scenario per teardown path.

<details>
<summary>Regression coverage</summary>

- 141/141 upstream `test-net-*.js` and 151/151 upstream `test-tls-*.js` pass.
- `test/js/node/net/`, `test/js/node/tls/`, and the upstream `test-http-*` / `test-http2-*` suites show no failures that aren't already failing on `main` (56 pre-existing http/http2, 13 pre-existing net/tls).
- `test-http-chunk-problem.js` flaked twice during a loaded sweep; it is unrelated (0/40 on both builds under identical load, and a probe confirms the new code path never runs in it).

</details>

### Relation to #32488

Complementary, not overlapping. #32488 fixes the *other* half of the same report: when the peer drains first, a writable event arrives, the flush hits a fatal `send()`, and the drain handler reports the dropped bytes as a **successful** write. That is the drain path.

This PR is the close path, which #32488 does not touch (its `net.ts` hunks are at `SocketHandlers.drain`, `SocketHandlers2.drain`/`.end`, and `_write`). The two races are mutually exclusive at runtime, so neither fix covers the other, and this one needs no native changes. It should rebase cleanly on top of #32488.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/net-syscall-fault.test.ts

<!-- robobun:evidence:end -->