### PR TITLE
Test WebKit #272 preview: ICU data package −13.5%

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "c9ad5813fd23bd8b98b0738abc3d037ec716aa92";
+export const WEBKIT_VERSION = "autobuild-preview-pr-272-2bcdcb67";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
**Do not merge** — this pins `WEBKIT_VERSION` to `autobuild-preview-pr-272-2bcdcb67` so Bun's full suite runs against [oven-sh/WebKit#272](https://github.com/oven-sh/WebKit/pull/272) (the ICU data package shrinks **11,578,422 → 10,014,274 B, −13.5%**, no behavior change, no runtime cost; that PR's own CI is 46/46 green and its in-image gates prove the package at the ICU level).

This PR is the bun-level, all-platform proof. Expected effect: **≈ −1.56 MB of `.rodata`** per binary on linux/musl/windows. Once #272 merges, the real `WEBKIT_VERSION` bump replaces this with the `autobuild-<sha>` tag from `main`.