### PR TITLE
Bun.serve: keep the Content-Type when a static route is registered

### DIFF
--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -20,9 +20,6 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::headers_ref::any_blob_content_type;
 use crate::webcore::{AnyBlob, FetchHeaders, InternalBlob, Response};
 
-/// The implicit Content-Type of a `new Response(someString)` body.
-const MIME_TEXT_PLAIN: &[u8] = b"text/plain; charset=utf-8";
-
 // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — single-thread refcount.
 // `*StaticRoute` is also passed as uws onAborted/
 // onWritable userdata; the intrusive `ref_count` Cell + `*mut Self` receivers
@@ -221,9 +218,10 @@ impl StaticRoute {
             // the `text/plain` a string body carried. Record it on the response's own
             // headers so re-registering the same `Response` serves the same type.
             if was_string {
+                let text_mime = bun_http_types::MimeType::TEXT;
                 response.get_or_create_headers(global_this)?.put_default(
                     HTTPHeaderName::ContentType,
-                    &bun_core::String::ascii(MIME_TEXT_PLAIN),
+                    &bun_core::String::ascii(text_mime.value.as_ref()),
                     global_this,
                 )?;
             }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -20,6 +20,9 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::headers_ref::any_blob_content_type;
 use crate::webcore::{AnyBlob, FetchHeaders, InternalBlob, Response};
 
+/// The implicit Content-Type of a `new Response(someString)` body.
+const MIME_TEXT_PLAIN: &[u8] = b"text/plain; charset=utf-8";
+
 // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — single-thread refcount.
 // `*StaticRoute` is also passed as uws onAborted/
 // onWritable userdata; the intrusive `ref_count` Cell + `*mut Self` receivers
@@ -214,15 +217,21 @@ impl StaticRoute {
                 h.fast_remove(HTTPHeaderName::ContentLength);
             }
 
-            let mut headers: Headers = if let Some(h) = response.get_init_headers() {
-                bun_http_jsc::headers_jsc::from_fetch_headers(Some(h), any_blob_content_type(&blob))
-            } else {
-                Headers::default()
-            };
-
-            if was_string && headers.get_content_type().is_none() {
-                headers.append(b"Content-Type", b"text/plain; charset=utf-8");
+            // Consuming the body left a plain `Blob` behind, which no longer implies
+            // the `text/plain` a string body carried. Record it on the response's own
+            // headers so re-registering the same `Response` serves the same type.
+            if was_string {
+                response.get_or_create_headers(global_this)?.put_default(
+                    HTTPHeaderName::ContentType,
+                    &bun_core::String::ascii(MIME_TEXT_PLAIN),
+                    global_this,
+                )?;
             }
+
+            let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
+                response.get_init_headers(),
+                any_blob_content_type(&blob),
+            );
 
             // Generate ETag if not already present
             if headers.get(b"etag").is_none() {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -618,7 +618,10 @@ impl Response {
     }
 
     #[allow(clippy::mut_from_ref)]
-    fn get_or_create_headers(&self, global_this: &JSGlobalObject) -> JsResult<&mut HeadersRef> {
+    pub(crate) fn get_or_create_headers(
+        &self,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<&mut HeadersRef> {
         // R-2 escape hatch via `init_mut()` — the returned `&mut HeadersRef`
         // borrows `self.init`; callers (`get_headers`, `construct_*`) do not
         // hold the borrow across calls that re-enter Response host-fns.

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -207,7 +207,7 @@ describe("static route Content-Type", () => {
   // Registering a Response snapshots (and consumes) its body. Doing that must not
   // change the Content-Type the next registration of the same Response produces.
   test.each([
-    ["string body", () => new Response("hello"), "text/plain; charset=utf-8"],
+    ["string body", () => new Response("hello"), "text/plain;charset=utf-8"],
     [
       "typed Blob body",
       () => new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" })),

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -195,3 +195,78 @@ describe.todoIf(isBroken && isMacOS)("static", () => {
     expect(handler.mock.calls.length, "Handler should be called").toBe(previousCallCount + 1);
   });
 });
+
+describe("static route Content-Type", () => {
+  async function contentTypeOf(server: Server, path: string) {
+    const res = await fetch(new URL(path, server.url));
+    expect(res.status).toBe(200);
+    await res.arrayBuffer();
+    return res.headers.get("content-type");
+  }
+
+  // Registering a Response snapshots (and consumes) its body. Doing that must not
+  // change the Content-Type the next registration of the same Response produces.
+  test.each([
+    ["string body", () => new Response("hello"), "text/plain; charset=utf-8"],
+    [
+      "typed Blob body",
+      () => new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" })),
+      "text/html;charset=utf-8",
+    ],
+    ["explicit header", () => new Response("hello", { headers: { "Content-Type": "text/foo" } }), "text/foo"],
+    ["Response.json", () => Response.json({ a: 1 }), "application/json;charset=utf-8"],
+    ["Uint8Array body", () => new Response(new Uint8Array([1, 2, 3])), null],
+  ])("is stable across registrations: %s", async (_label, make, expected) => {
+    const response = make();
+
+    using server = Bun.serve({
+      port: 0,
+      static: { "/a": response, "/b": response },
+      fetch: () => new Response("fallback"),
+    });
+
+    expect({
+      a: await contentTypeOf(server, "/a"),
+      b: await contentTypeOf(server, "/b"),
+    }).toEqual({ a: expected, b: expected });
+
+    // server.reload() re-registers the very same Response object.
+    server.reload({ static: { "/a": response }, fetch: () => new Response("fallback") });
+    expect(await contentTypeOf(server, "/a")).toBe(expected);
+  });
+
+  // Reading .headers materializes a Blob body's implicit Content-Type onto the
+  // Response, which used to be the only way a static route ever saw it.
+  test("does not depend on whether .headers was read first", async () => {
+    const untouched = new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" }));
+    const touched = new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" }));
+    touched.headers;
+
+    using server = Bun.serve({
+      port: 0,
+      static: { "/untouched": untouched, "/touched": touched },
+      fetch: () => new Response("fallback"),
+    });
+
+    expect({
+      untouched: await contentTypeOf(server, "/untouched"),
+      touched: await contentTypeOf(server, "/touched"),
+    }).toEqual({
+      untouched: "text/html;charset=utf-8",
+      touched: "text/html;charset=utf-8",
+    });
+  });
+
+  test("a string body still serves its body bytes unchanged", async () => {
+    const response = new Response("▲");
+
+    using server = Bun.serve({
+      port: 0,
+      static: { "/a": response, "/b": response },
+      fetch: () => new Response("fallback"),
+    });
+
+    expect(await (await fetch(new URL("/a", server.url))).text()).toBe("▲");
+    expect(await (await fetch(new URL("/b", server.url))).text()).toBe("▲");
+  });
+});

--- a/test/regression/issue/24817.test.ts
+++ b/test/regression/issue/24817.test.ts
@@ -21,7 +21,15 @@ test("static routes should handle unicode correctly", async () => {
 
     const staticText = await staticResp.text();
     expect(staticText).toBe("▲");
-    expect(staticResp.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(staticResp.headers.get("content-type")).toBe("text/plain;charset=utf-8");
+  }
+
+  // A static route and a dynamic one must describe the same body the same way.
+  {
+    const dynamicResp = await fetch(`${baseUrl}/dynamic`);
+
+    expect(await dynamicResp.text()).toBe("▲");
+    expect(dynamicResp.headers.get("content-type")).toBe("text/plain;charset=utf-8");
   }
 
   // Test Japanese characters
@@ -30,7 +38,7 @@ test("static routes should handle unicode correctly", async () => {
     const text = await resp.text();
 
     expect(text).toBe("こんにちは世界");
-    expect(resp.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(resp.headers.get("content-type")).toBe("text/plain;charset=utf-8");
   }
 
   // Test emoji
@@ -39,7 +47,7 @@ test("static routes should handle unicode correctly", async () => {
     const text = await resp.text();
 
     expect(text).toBe("🎉🚀✨");
-    expect(resp.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(resp.headers.get("content-type")).toBe("text/plain;charset=utf-8");
   }
 });
 


### PR DESCRIPTION
## Repro

```js
const page = new Response("hello"); // implicit text/plain;charset=utf-8

const server = Bun.serve({ port: 0, static: { "/a": page, "/b": page }, fetch: () => new Response("x") });
//   /a -> "text/plain; charset=utf-8"
//   /b -> null

server.reload({ static: { "/a": page }, fetch: () => new Response("x") });
//   /a -> null

// and, regardless of re-registration:
const html = new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" }));
Bun.serve({ port: 0, static: { "/a": html }, fetch: () => new Response("x") });
//   /a -> null   (unless something read html.headers first)
```

Content-type-less responses make browsers sniff, and break clients that dispatch on the header.

## Cause

`StaticRoute::from_js` has two independent defects.

1. It reads the body destructively: `body_value.use_()` takes the bytes and puts a plain `Blob` back on the `Response`. A string body's implicit `text/plain` lives only in the `was_string` flag of the pre-snapshot body, so the second registration of the same `Response` (a second path, or `server.reload()`) sees a typeless `Blob` and appends nothing.

2. When `response.get_init_headers()` was `None` it built `Headers::default()` and never looked at the blob's content-type, so the body-derived type was threaded in only when the `Response` already had a headers object. That is why reading `Response.headers` before `serve()` appeared to "fix" a typed-`Blob` body: the getter materializes the type onto the response.

## Fix

- Always pass `any_blob_content_type(&blob)` to `from_fetch_headers`, so a body-derived type reaches the snapshot whether or not the `Response` has a headers object yet.
- For a string body, record the implicit `text/plain` on the response's own headers before the snapshot consumes it. Registration is then idempotent: a second path, `server.reload()`, and the first registration all serve the same header.

A `Blob` body keeps its type across `use_()`, so it needs no fixup; non-text bodies (`Uint8Array`) still get no implicit Content-Type, as before.

## Two behavior changes worth calling out

**The served value for a string-body static route changes** from `text/plain; charset=utf-8` to `text/plain;charset=utf-8` (`MimeType::TEXT`). That spelling was a one-off: every other producer of a string body's implicit type, including the `Bun.serve` fetch-handler path, already uses `MimeType::TEXT`, so a static route and a fetch handler served different bytes for the same `Response`. Both spellings are valid per RFC 9110 and parse identically. Now:

```
static : "text/plain;charset=utf-8"
dynamic: "text/plain;charset=utf-8"
```

**After a string-body `Response` is registered, its `.headers` reports `content-type: text/plain;charset=utf-8`.** That is the record that makes re-registration idempotent, and it matches both what is served and what `Response.headers` reports in Node.

## Verification

`test/js/bun/http/bun-serve-static.test.ts` gains a `static route Content-Type` block asserting the served type is identical across two paths and a `server.reload()` for string bodies, typed `Blob` bodies, explicit headers, `Response.json`, and `Uint8Array` bodies, plus that the result no longer depends on whether `.headers` was read first.

`test/regression/issue/24817.test.ts` held the only in-tree assertion on the old spelling; it is updated, and a `/dynamic` case now pins the static and dynamic paths to the same value.

3 of the new tests fail on `main` and pass with this change. `bun-serve-static.test.ts`, `24817.test.ts`, `bun-serve-routes.test.ts`, `bun-serve-headers.test.ts`, and `bun-serve-html-manifest.test.ts` all pass together (100 tests, 0 fail).
