### PR TITLE
bake: fix CSS modules with HMR

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -882,6 +882,10 @@ impl<'a> LinkerContext<'a> {
         // has finished pushing wrapper / entry-point parts.
         {
             let loaders = self.parse_graph().input_files.items_loader();
+            let sources = self.parse_graph().input_files.items_source();
+            let targets = self.graph.ast.items_target();
+            let is_bake_dev =
+                self.options.output_format == crate::options::OutputFormat::InternalBakeDev;
             let parts_col = self.graph.ast.items_parts();
             let mut parts_live: Vec<bun_collections::AutoBitSet> =
                 Vec::with_capacity(parts_col.len());
@@ -893,6 +897,16 @@ impl<'a> LinkerContext<'a> {
                 // walks its parts, so seed the bit here to preserve the old
                 // `Part::is_live = true` initializer.
                 if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
+                    bits.set(1);
+                }
+                // Same for a client CSS module's JS stub in the dev format:
+                // tree shaking short-circuits for CSS-repr files, and dev
+                // imports link at runtime, so nothing else marks it live.
+                if is_bake_dev
+                    && parts.len() > 1
+                    && loaders.get(i).is_some_and(|l| l.is_css())
+                    && crate::is_client_css_module(targets[i], sources[i].path.pretty)
+                {
                     bits.set(1);
                 }
                 parts_live.push(bits);
@@ -4008,6 +4022,19 @@ impl<'a> LinkerContext<'a> {
         source_index: crate::IndexInt,
     ) -> Result<(), AllocError> {
         crate::linker_context::generate_code_for_lazy_export::generate_code_for_lazy_export(
+            self,
+            source_index,
+        )
+    }
+
+    /// Thin inherent-method shim; the body lives in
+    /// `linker_context/generateCodeForLazyExport.rs`.
+    #[inline]
+    pub fn populate_css_module_lazy_export(
+        &mut self,
+        source_index: crate::IndexInt,
+    ) -> Result<(), AllocError> {
+        crate::linker_context::generate_code_for_lazy_export::populate_css_module_lazy_export(
             self,
             source_index,
         )

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1163,10 +1163,7 @@ pub mod parse_worker {
                 // `temp_log` is flushed into `log` on every exit path via linear
                 // control flow (scopeguard would alias `log`/`temp_log`).
 
-                const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
-                let enable_css_modules = source.path.pretty.len() > CSS_MODULE_SUFFIX.len()
-                    && &source.path.pretty[source.path.pretty.len() - CSS_MODULE_SUFFIX.len()..]
-                        == CSS_MODULE_SUFFIX;
+                let enable_css_modules = crate::is_css_module_path(source.path.pretty);
                 // `parse_bundler` takes `ParserOptions<'static>` (the
                 // `'a` on `ParserOptions` is PhantomData-only; storage is a raw
                 // `NonNull<Log>`). Construct via `default(None)` to get `'static`,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5132,6 +5132,7 @@ pub mod bv2_impl {
 
             self.dynamic_import_entry_points = ArrayHashMap::new();
             let mut html_files: ArrayHashMap<Index, ()> = ArrayHashMap::new();
+            let mut css_module_stubs: Vec<Index> = Vec::new();
 
             // Separate non-failing files into two lists: JS and CSS
             let js_reachable_files: &[Index] = 'reachable_files: {
@@ -5279,6 +5280,21 @@ pub mod bv2_impl {
                     }
                 }
 
+                // CSS modules also ship their JS stub (the class-name map) as a
+                // real HMR module so `import styles from "./x.module.css"`
+                // resolves in the client. Server-target CSS stays CSS-only.
+                for entry_point in start.css_entry_points.keys() {
+                    let idx = entry_point.get() as usize;
+                    if crate::is_client_css_module(
+                        asts.items_target()[idx],
+                        sources[idx].path.pretty,
+                    ) && asts.items_parts()[idx].len() > 1
+                    {
+                        js_files.push(*entry_point);
+                        css_module_stubs.push(*entry_point);
+                    }
+                }
+
                 // SAFETY: `alloc_slice_copy` returns into the bundler arena which outlives
                 // this function. Erase the `&self` lifetime via `*const` so the borrow on
                 // `self.arena()` does not extend across the `&mut self` calls below
@@ -5318,6 +5334,14 @@ pub mod bv2_impl {
                     .linker
                     .load(bundle_ptr, ep, scbs, js_reachable_files)
                     .map_err(|_| AllocError)?;
+            }
+
+            // Fill in each CSS-module stub's class-name map now; the reduced
+            // dev pipeline skips `generate_code_for_lazy_export`, which
+            // normally populates it during a full link.
+            for source_index in &css_module_stubs {
+                self.linker
+                    .populate_css_module_lazy_export(source_index.get())?;
             }
 
             // HMR skips tree-shaking, so size and seed the part-liveness bitsets

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -39,6 +39,7 @@ pub(crate) use bun_ast::UseDirective;
 pub(crate) use bun_ast::{Part, Ref};
 pub use bun_js_printer::MangledProps;
 pub use options_impl::PathTemplate;
+pub(crate) use options_impl::{is_client_css_module, is_css_module_path};
 
 pub use HTMLImportManifest::html_import_manifest;
 pub use bun_core::cheap_prefix_normalizer;

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -57,19 +57,31 @@ pub fn convert_stmts_for_chunk_for_dev_server<'bump>(
     let input_files = &c.parse_graph().input_files;
     let loaders = input_files.items_loader();
     let sources = input_files.items_source();
-    for record in ast.import_records.as_mut_slice() {
-        if record.path.is_disabled {
-            continue;
-        }
-        if record.source_index.is_valid()
-            && loaders[record.source_index.get() as usize] == Loader::Css
-        {
-            record.path.is_disabled = true;
-            continue;
-        }
-        // Make sure the printer gets the resolved path
-        if record.source_index.is_valid() {
-            record.path = sources[record.source_index.get() as usize].path;
+    // A CSS-module stub's records are the CSS AST's own `@import`/`composes`
+    // records, read concurrently by CSS-chunk codegen tasks; leave them
+    // untouched. The stub has no `SImport` statements to rewrite anyway.
+    if ast.css.is_none() {
+        let targets = c.graph.ast.items_target();
+        for record in ast.import_records.as_mut_slice() {
+            if record.path.is_disabled {
+                continue;
+            }
+            if record.source_index.is_valid()
+                && loaders[record.source_index.get() as usize] == Loader::Css
+            {
+                let idx = record.source_index.get() as usize;
+                // A CSS module has a JS stub module in the dev graph exporting
+                // its class-name map; keep the import so the HMR binding
+                // resolves. Plain CSS is delivered out of band via <link>.
+                if !crate::is_client_css_module(targets[idx], sources[idx].path.pretty) {
+                    record.path.is_disabled = true;
+                    continue;
+                }
+            }
+            // Make sure the printer gets the resolved path
+            if record.source_index.is_valid() {
+                record.path = sources[record.source_index.get() as usize].path;
+            }
         }
     }
 

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -32,24 +32,15 @@ impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for Slic
     }
 }
 
-pub fn generate_code_for_lazy_export(
+/// Populates a CSS-module stub's lazy-export expression with the class-name
+/// map built from `local_scope` and `composes`. No-op for other lazy exports
+/// (JSON, TOML, ...). Called by the full link and by the dev server pipeline.
+pub fn populate_css_module_lazy_export(
     this: &mut LinkerContext,
     source_index: IndexInt,
 ) -> Result<(), AllocError> {
-    let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
-    // The dev server's module format represents lazy-export modules (JSON,
-    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
-    // runtime, so always generate the `module.exports = ...` form below.
-    // The ESM form would synthesize `export` parts that
-    // `print_dev_server_module` cannot represent.
-    if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
-        && exports_kind != bun_ast::ExportsKind::Cjs
-    {
-        exports_kind = bun_ast::ExportsKind::Cjs;
-        this.graph.ast.items_exports_kind_mut()[source_index as usize] = exports_kind;
-    }
     // Take `parts` as a raw pointer *before* the
-    // long-lived immutable `items_css()` borrow below; re-borrowed again later as needed.
+    // long-lived immutable `items_css()` borrow below.
     let parts: *mut [Part] = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();
     // SAFETY: parse_graph backref; raw deref because `all_sources` is held
     // across `&mut *this.log` below (split borrow).
@@ -58,19 +49,17 @@ pub fn generate_code_for_lazy_export(
     let maybe_css_ast: Option<&BundlerStyleSheet> = all_css_asts[source_index as usize].as_deref();
 
     // SAFETY: `parts` is a stable SoA column slice valid for the link pass.
-    if unsafe { (&*parts).len() } < 1 {
-        panic!("Internal error: expected at least one part for lazy export");
+    if unsafe { (&*parts).len() } < 2 {
+        panic!("Internal error: expected a lazy export part");
     }
 
-    // SAFETY: `parts.ptr[1]` — Vec raw indexing; using index 1 here.
+    // SAFETY: `parts.ptr[1]` — Vec raw indexing; length checked above.
     let part: &mut Part = unsafe { &mut (*parts)[1] };
 
     // `Part.stmts: StoreSlice<Stmt>` — safe `Deref` to `&[Stmt]`.
     if part.stmts.is_empty() {
         panic!("Internal error: expected at least one statement in the lazy export");
     }
-
-    let module_ref = this.graph.ast.items_module_ref()[source_index as usize];
 
     // Handle css modules
     //
@@ -385,6 +374,36 @@ pub fn generate_code_for_lazy_export(
             }
         }
     }
+    Ok(())
+}
+
+pub fn generate_code_for_lazy_export(
+    this: &mut LinkerContext,
+    source_index: IndexInt,
+) -> Result<(), AllocError> {
+    let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
+    // The dev server's module format represents lazy-export modules (JSON,
+    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
+    // runtime, so always generate the `module.exports = ...` form below.
+    // The ESM form would synthesize `export` parts that
+    // `print_dev_server_module` cannot represent.
+    if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
+        && exports_kind != bun_ast::ExportsKind::Cjs
+    {
+        exports_kind = bun_ast::ExportsKind::Cjs;
+        this.graph.ast.items_exports_kind_mut()[source_index as usize] = exports_kind;
+    }
+
+    // Validates the part/stmt shape; re-derive `part` afterwards since the
+    // call releases the borrow.
+    populate_css_module_lazy_export(this, source_index)?;
+
+    let parts: *mut [Part] = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();
+    // SAFETY: `parts` is a stable SoA column slice valid for the link pass;
+    // `populate_css_module_lazy_export` verified index 1 exists.
+    let part: &mut Part = unsafe { &mut (*parts)[1] };
+
+    let module_ref = this.graph.ast.items_module_ref()[source_index as usize];
 
     let stmt: Stmt = part.stmts[0];
     let StmtData::SLazyExport(lazy) = stmt.data else {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -111,6 +111,20 @@ pub fn is_node_builtin(str: &[u8]) -> bool {
     bun_resolve_builtins::Alias::has(str, bun_ast::Target::Node, Default::default())
 }
 
+/// Whether this path enables CSS modules, matching the parser gate in
+/// `ParseTask`. A bare `.module.css` basename does not qualify.
+pub(crate) fn is_css_module_path(pretty_path: &[u8]) -> bool {
+    const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
+    pretty_path.len() > CSS_MODULE_SUFFIX.len()
+        && strings::has_suffix_comptime(pretty_path, CSS_MODULE_SUFFIX)
+}
+
+/// A CSS module whose JS stub (class-name map) ships as a dev-server HMR
+/// module. Server-target CSS keeps its CSS-only representation.
+pub(crate) fn is_client_css_module(target: bun_ast::Target, pretty_path: &[u8]) -> bool {
+    target == bun_ast::Target::Browser && is_css_module_path(pretty_path)
+}
+
 const DEFAULT_WILDCARD_PATTERNS: &[(&[u8], &[u8])] = &[
     (b"/bun:", b""),
     // (b"/src:", b""),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3147,12 +3147,7 @@ impl<'a> Transpiler<'a> {
         // this arm, before any other `log_mut()` reborrow above.
         let mut opts = bun_css::ParserOptions::default(None);
         opts.logger = Some(core::ptr::NonNull::new(self.log).unwrap());
-        const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
-        let enable_css_modules = file_path_text.len() > CSS_MODULE_SUFFIX.len()
-            && strings::eql_comptime(
-                &file_path_text[file_path_text.len() - CSS_MODULE_SUFFIX.len()..],
-                CSS_MODULE_SUFFIX,
-            );
+        let enable_css_modules = crate::is_css_module_path(file_path_text);
         if enable_css_modules {
             opts.filename = bun_paths::basename(file_path_text);
             opts.css_modules = Some(bun_css::CssModuleConfig::default());

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4275,6 +4275,11 @@ pub(super) fn finalize_bundle(
     // changed file, removing dependencies. This pass also flags what routes
     // have been modified.
     for part_range in js_chunk.content.javascript().parts_in_chunk_in_order.iter() {
+        // CSS-module stubs have no JS import edges; their records are CSS
+        // @imports attached by the CSS pass below (ProcessMode::Css).
+        if ctx.loaders[part_range.source_index.get() as usize].is_css() {
+            continue;
+        }
         match targets[part_range.source_index.get() as usize].bake_graph() {
             bake::Graph::Server | bake::Graph::Ssr => dev.server_graph.process_chunk_dependencies(
                 &mut ctx,

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -78,6 +78,13 @@ pub enum Content {
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.
     CssRoot(u64),
+    /// A `CssRoot` that is a CSS module: alongside the CSS asset hash it
+    /// carries its JS stub module (the class-name map) so
+    /// `import styles from "./x.module.css"` resolves in the HMR runtime.
+    CssModule {
+        hash: u64,
+        code: Box<[u8]>,
+    },
     CssChild,
 }
 
@@ -86,6 +93,7 @@ impl Content {
     fn js_code(&self) -> Option<&[u8]> {
         match self {
             Content::Js(c) | Content::Asset(c) => Some(c),
+            Content::CssModule { code, .. } => Some(code),
             _ => None,
         }
     }
@@ -95,7 +103,7 @@ impl Content {
             Content::Unknown => FileKind::Unknown,
             Content::Js(_) => FileKind::Js,
             Content::Asset(_) => FileKind::Asset,
-            Content::CssRoot(_) | Content::CssChild => FileKind::Css,
+            Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => FileKind::Css,
         }
     }
 }
@@ -469,7 +477,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             Content::Js(_) | Content::Asset(_) => {
                 // Box<[u8]> dropped here.
             }
-            Content::CssRoot(_) | Content::CssChild => {
+            Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => {
+                // A CssModule's stub Box<[u8]> drops with the matched value.
                 if css == FreeCssMode::UnrefCss {
                     // SAFETY: see `owner()`; touches `assets` sibling only.
                     unsafe { (*self.owner()).assets.unref_by_path(key) };
@@ -641,6 +650,9 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             self.stale_files.unset(file_index.get() as usize);
         }
 
+        // Whether an earlier pass of this same finalize already received a
+        // chunk for this file (the JS pass runs before the CSS pass).
+        let received_this_finalize = *ctx.get_cached_index(SIDE, index) != CachedFileIndex::NONE;
         *ctx.get_cached_index(SIDE, index) =
             CachedFileIndex::from(Some::<FileIndex<SIDE>>(file_index));
 
@@ -649,12 +661,39 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 let mut html_route_bundle_index: Option<route_bundle::Index> = None;
                 let mut is_special_framework_file = false;
 
+                let mut prior_stub_code: Option<Box<[u8]>> = None;
+                let mut same_bundle_stub: Option<(Box<[u8]>, packed_map::Shared)> = None;
                 if found_existing {
                     // Note: take the existing slot out so `free_file_content`
                     // can borrow `&mut self` while we hold the `File` by value.
                     let mut existing = core::mem::take(
                         &mut self.bundled_files.values_mut()[file_index.get() as usize],
                     );
+
+                    // A CSS module receives two chunks per finalize: its JS
+                    // stub (JS pass), whose prior bytes we keep for the
+                    // unchanged-check, then its CSS hash, which adopts the stub.
+                    if let Content::CssModule { code, .. } = &mut existing.content {
+                        match &content {
+                            // Without a JS pass this finalize, the file is no
+                            // longer a client CSS module (e.g. its target
+                            // flipped to server-only) — demote to CssRoot.
+                            ReceiveChunkContent::Css(_) if received_this_finalize => {
+                                same_bundle_stub = Some((
+                                    core::mem::take(code),
+                                    core::mem::replace(
+                                        &mut existing.source_map,
+                                        packed_map::Shared::None,
+                                    ),
+                                ));
+                            }
+                            ReceiveChunkContent::Css(_) => {}
+                            ReceiveChunkContent::Js { .. } => {
+                                prior_stub_code = Some(core::mem::take(code));
+                            }
+                        }
+                    }
+
                     self.free_file_content(key, &mut existing, FreeCssMode::IgnoreCss);
 
                     if existing.failed {
@@ -674,13 +713,26 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 }
 
                 let (new_content, new_source_map, code_len) = match content {
-                    ReceiveChunkContent::Css(css) => {
-                        (Content::CssRoot(css), packed_map::Shared::None, None)
-                    }
+                    ReceiveChunkContent::Css(css) => match same_bundle_stub {
+                        // Merge the CSS hash with the stub received this pass.
+                        Some((code, source_map)) => {
+                            (Content::CssModule { hash: css, code }, source_map, None)
+                        }
+                        None => (Content::CssRoot(css), packed_map::Shared::None, None),
+                    },
                     ReceiveChunkContent::Js { code, source_map } => {
+                        // A byte-identical stub means the class map did not
+                        // change; keep it out of the hot chunk so pure style
+                        // edits stay CSS-only (no importer re-evaluation).
+                        let stub_unchanged =
+                            prior_stub_code.is_some_and(|old| strings::eql(&old, &code));
                         let len = code.len();
                         let kind = if ctx.loaders[index.get() as usize].is_javascript_like() {
                             Content::Js(code)
+                        } else if ctx.loaders[index.get() as usize].is_css() {
+                            // CSS-module stub; the CSS pass always follows in
+                            // this same finalize and merges the real hash.
+                            Content::CssModule { hash: 0, code }
                         } else {
                             Content::Asset(code)
                         };
@@ -697,16 +749,14 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             _ => {
                                 // Must precompute line count so source-map
                                 // concatenation knows how many newlines to skip.
-                                let count = match &kind {
-                                    Content::Js(c) | Content::Asset(c) => {
-                                        strings::count_char(&c[..], b'\n') as u32
-                                    }
-                                    _ => 0,
+                                let count = match kind.js_code() {
+                                    Some(c) => strings::count_char(c, b'\n') as u32,
+                                    None => 0,
                                 };
                                 packed_map::Shared::LineCount(packed_map::LineCount::init(count))
                             }
                         };
-                        (kind, sm, Some(len))
+                        (kind, sm, if stub_unchanged { None } else { Some(len) })
                     }
                 };
 
@@ -1284,6 +1334,22 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             // CSS can't import JS; trace is done.
                             return Ok(());
                         }
+                        Content::CssModule { hash, code } => {
+                            match goal {
+                                TraceImportGoal::FindCss => {
+                                    self.current_css_files.push(*hash);
+                                }
+                                TraceImportGoal::FindClientModules => {
+                                    let len = code.len();
+                                    self.current_chunk_parts.push(file_index);
+                                    self.current_chunk_len += len;
+                                }
+                                _ => {}
+                            }
+                            // The stub imports nothing at runtime; its edges
+                            // are CSS children handled by the CSS trace.
+                            return Ok(());
+                        }
                         _ => {}
                     }
                 }
@@ -1642,10 +1708,10 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             let owned_path = owned_path.slice();
             match SIDE {
                 Side::Client => match &self.bundled_files.values()[index].content {
-                    Content::CssRoot(_) | Content::CssChild => {
+                    Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => {
                         if matches!(
                             self.bundled_files.values()[index].content,
-                            Content::CssRoot(_),
+                            Content::CssRoot(_) | Content::CssModule { .. },
                         ) {
                             entry_points.append_css(owned_path)?;
                         }
@@ -1656,7 +1722,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             self.stale_files.set(dep.get() as usize);
                             if matches!(
                                 self.bundled_files.values()[dep.get() as usize].content,
-                                Content::CssRoot(_),
+                                Content::CssRoot(_) | Content::CssModule { .. },
                             ) {
                                 let k = bun_ptr::RawSlice::new(
                                     &*self.bundled_files.keys()[dep.get() as usize],
@@ -1678,7 +1744,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             let k = k.slice();
                             if matches!(
                                 self.bundled_files.values()[dep.get() as usize].content,
-                                Content::CssRoot(_),
+                                Content::CssRoot(_) | Content::CssModule { .. },
                             ) {
                                 entry_points.append_css(k)?;
                             } else {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -798,14 +798,14 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       }
     }
   } catch (e) {
-    // A synchronous re-eval throw: modules after the thrower never reloaded;
-    // restore their handlers so future updates still treat them as accepting.
-    for (let i = reloadCursor + 1; i < staleReloads.length; i++) {
+    // A synchronous re-eval throw: restore handlers on modules that did not
+    // complete a reload (the thrower included) so future updates still treat
+    // them as accepting. `??=` keeps handlers re-registered mid-eval.
+    for (let i = reloadCursor; i < staleReloads.length; i++) {
       const [mod, selfAccept, depAccepts] = staleReloads[i];
-      if (mod.state === State.Stale) {
-        mod.selfAccept = selfAccept;
-        mod.depAccepts = depAccepts;
-      }
+      if (mod.state !== State.Stale) continue;
+      mod.selfAccept ??= selfAccept;
+      mod.depAccepts ??= depAccepts;
     }
     throw e;
   }

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -803,7 +803,12 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     // them as accepting. `??=` keeps handlers re-registered mid-eval.
     for (let i = reloadCursor; i < staleReloads.length; i++) {
       const [mod, selfAccept, depAccepts] = staleReloads[i];
-      if (mod.state !== State.Stale) continue;
+      // Stale: never reloaded. Error: its eval threw (sync ESM throws land
+      // here via finishLoadModuleAsync). Pending at the cursor is the frame
+      // that threw; later Pending entries are in-flight TLA loads — keep.
+      const restorable =
+        mod.state === State.Stale || mod.state === State.Error || (i === reloadCursor && mod.state === State.Pending);
+      if (!restorable) continue;
       mod.selfAccept ??= selfAccept;
       mod.depAccepts ??= depAccepts;
     }

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -303,6 +303,10 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
         require: mod.require.bind(mod),
       };
       mod.exports = null;
+    } else {
+      // Re-evaluating a stale CJS module: drop the cached ESM view so
+      // importers observe the re-assigned `cjs.exports`.
+      mod.exports = null;
     }
     if (importer) {
       mod.importers.add(importer);
@@ -402,6 +406,10 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         exports: {},
         require: mod.require.bind(mod),
       };
+      mod.exports = null;
+    } else {
+      // Re-evaluating a stale CJS module: drop the cached ESM view so
+      // importers observe the re-assigned `cjs.exports`.
       mod.exports = null;
     }
     if (importer) {
@@ -750,33 +758,63 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Reload all modules
+  // Reload all modules. Mark everything stale up-front so an importer that
+  // reloads ahead of its updated dependency re-evaluates the dependency
+  // inline (with the new code) instead of reading its stale exports.
   const promises: Promise<HMRModule>[] = [];
+  const staleReloads: [HMRModule, HotAcceptFunction | null, HMRModule["depAccepts"]][] = [];
   for (const mod of toReload) {
     mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
+    staleReloads.push([mod, mod.selfAccept, mod.depAccepts]);
     mod.selfAccept = null;
     mod.depAccepts = null;
-
-    const modOrPromise = loadModuleAsync(mod.id, false, null);
-    if (modOrPromise === mod) {
-      if (selfAccept) {
-        selfAccept(getEsmExports(mod));
-      }
-    } else {
-      DEBUG.ASSERT(modOrPromise instanceof Promise);
-      promises.push(
-        (modOrPromise as Promise<HMRModule>).then(mod => {
-          if (selfAccept) {
+  }
+  // Accept callbacks for modules whose inline (top-level-await) re-eval is
+  // still in flight at their own turn; fired after all reloads settle.
+  const pendingAccepts: [HMRModule, HotAcceptFunction][] = [];
+  let reloadCursor = 0;
+  try {
+    for (; reloadCursor < staleReloads.length; reloadCursor++) {
+      const [mod, selfAccept] = staleReloads[reloadCursor];
+      const modOrPromise = loadModuleAsync(mod.id, false, null);
+      if (modOrPromise === mod) {
+        if (selfAccept) {
+          if (mod.state === State.Pending) {
+            pendingAccepts.push([mod, selfAccept]);
+          } else {
             selfAccept(getEsmExports(mod));
           }
-          return mod;
-        }),
-      );
+        }
+      } else {
+        DEBUG.ASSERT(modOrPromise instanceof Promise);
+        promises.push(
+          (modOrPromise as Promise<HMRModule>).then(mod => {
+            if (selfAccept) {
+              selfAccept(getEsmExports(mod));
+            }
+            return mod;
+          }),
+        );
+      }
     }
+  } catch (e) {
+    // A synchronous re-eval throw: modules after the thrower never reloaded;
+    // restore their handlers so future updates still treat them as accepting.
+    for (let i = reloadCursor + 1; i < staleReloads.length; i++) {
+      const [mod, selfAccept, depAccepts] = staleReloads[i];
+      if (mod.state === State.Stale) {
+        mod.selfAccept = selfAccept;
+        mod.depAccepts = depAccepts;
+      }
+    }
+    throw e;
   }
   if (promises.length > 0) {
     await Promise.all(promises);
+  }
+  for (const [mod, selfAccept] of pendingAccepts) {
+    DEBUG.ASSERT(mod.state !== State.Pending);
+    selfAccept(getEsmExports(mod));
   }
   for (const mod of toReload) {
     const { selfAccept } = mod;

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -624,3 +624,231 @@ function extractCssUrl(backgroundImage: string): string {
   }
   return url[2];
 }
+
+devTest("css modules work with hmr (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<h1>Hello</h1>`,
+    }),
+    "styles.module.css": `
+      .title {
+        color: red;
+      }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      document.querySelector("h1").className = styles.title;
+      globalThis.evalCount = (globalThis.evalCount ?? 0) + 1;
+      console.log("class:" + styles.title);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    assert(msg.startsWith("class:title_"), `expected a hashed class name, got ${JSON.stringify(msg)}`);
+    const className = msg.slice("class:".length);
+    await c.style("." + className).color.expect.toBe("red");
+
+    // Class names are hashed from the file path, so a pure style edit is a
+    // CSS-only hot swap: no reload and no importer re-evaluation.
+    await dev.patch("styles.module.css", { find: "red", replace: "blue" });
+    await c.style("." + className).color.expect.toBe("#00f");
+    const [domClass, evalCount] = await c.js<[string, number]>`
+      [document.querySelector("h1").className, globalThis.evalCount]
+    `;
+    expect(domClass).toBe(className);
+    expect(evalCount).toBe(1);
+  },
+});
+devTest("css modules support all import shapes (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<p>shapes</p>`,
+    }),
+    "shapes.module.css": `
+      .a { color: red; }
+      .b { color: blue; }
+    `,
+    "empty.module.css": `/* no local classes */`,
+    "bare.module.css": `
+      body { background-color: green; }
+    `,
+    "index.ts": `
+      import styles, { a } from "./shapes.module.css";
+      import * as ns from "./shapes.module.css";
+      import empty from "./empty.module.css";
+      import "./bare.module.css";
+      console.log(JSON.stringify({
+        namedMatchesDefault: a === styles.a,
+        nsDefault: ns.default.a === a,
+        keys: Object.keys(styles).sort(),
+        empty,
+      }));
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(
+      JSON.stringify({
+        namedMatchesDefault: true,
+        nsDefault: true,
+        keys: ["a", "b"],
+        empty: {},
+      }),
+    );
+    // The bare import's element-selector rule still applies.
+    await c.style("body").backgroundColor.expect.toBe("green");
+  },
+});
+devTest("css module edits propagate new class names to accepting importers (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "styles.module.css": `
+      .a { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      console.log("keys:" + Object.keys(styles).sort().join(","));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("keys:a");
+    await dev.write(
+      "styles.module.css",
+      `
+        .a { color: red; }
+        .b { color: blue; }
+      `,
+    );
+    await c.expectMessage("keys:a,b");
+    await dev.write(
+      "styles.module.css",
+      `
+        .b { color: blue; }
+      `,
+    );
+    await c.expectMessage("keys:b");
+  },
+});
+devTest("two importers share one css module instance (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "styles.module.css": `
+      .shared { color: red; }
+    `,
+    "a.ts": `
+      import styles from "./styles.module.css";
+      export const mapA = styles;
+    `,
+    "b.ts": `
+      import styles from "./styles.module.css";
+      export const mapB = styles;
+    `,
+    "index.ts": `
+      import { mapA } from "./a";
+      import { mapB } from "./b";
+      console.log("same:" + (mapA === mapB) + " " + mapA.shared);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    assert(msg.startsWith("same:true shared_"), msg);
+  },
+});
+devTest("plain css imports stay side-effect only (#18258 regression guard)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "plain.css": `
+      body { color: red; }
+    `,
+    "index.ts": `
+      import "./plain.css";
+      globalThis.evalCount = (globalThis.evalCount ?? 0) + 1;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style("body").color.expect.toBe("red");
+    await dev.patch("plain.css", { find: "red", replace: "blue" });
+    await c.style("body").color.expect.toBe("#00f");
+    expect(await c.js<number>`globalThis.evalCount`).toBe(1);
+  },
+});
+devTest("css module composes across files (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<button>ok</button>`,
+    }),
+    "base.module.css": `
+      .base { font-weight: 700; }
+    `,
+    "button.module.css": `
+      .btn {
+        composes: base from "./base.module.css";
+        color: red;
+      }
+    `,
+    "index.ts": `
+      import styles from "./button.module.css";
+      document.querySelector("button").className = styles.btn;
+      console.log("btn:" + styles.btn);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    const classes = msg.slice("btn:".length).split(" ");
+    expect(classes).toHaveLength(2);
+    const own = classes.find(cls => cls.startsWith("btn_"));
+    assert(own, msg);
+    const composed = classes.find(cls => cls.startsWith("base_"));
+    assert(composed, msg);
+    await c.style("." + own).color.expect.toBe("red");
+    // The composed module's own rule must be delivered too.
+    await c.style("." + composed).fontWeight.expect.toBe("700");
+  },
+});
+
+devTest("emptying a css module removes its styles and class map (#18258)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<h1>Hello</h1>`,
+    }),
+    "styles.module.css": `
+      .title { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      document.querySelector("h1").className = styles.title ?? "";
+      console.log("keys:" + Object.keys(styles).sort().join(","));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("keys:title");
+    const className = await c.js<string>`document.querySelector("h1").className`;
+    await c.style("." + className).color.expect.toBe("red");
+
+    await dev.write("styles.module.css", " ", { dedent: false });
+    await c.expectMessage("keys:");
+    await c.style("." + className).notFound();
+
+    await dev.write("styles.module.css", `.title { color: blue; }`);
+    await c.expectMessage("keys:title");
+    await c.style("." + className).color.expect.toBe("#00f");
+  },
+});

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -105,6 +105,68 @@ devTest("import.meta.hot.accept patches imports", {
     expect(await c.js<string>`callFunction()`).toBe("B!3!6");
   },
 });
+devTest("editing an imported json file updates accepting importers", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "data.json": `{ "value": 1 }`,
+    "index.ts": `
+      import data from "./data.json";
+      console.log("value:" + data.value);
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("value:1");
+    await dev.write("data.json", `{ "value": 2 }`);
+    await c.expectMessage("value:2");
+  },
+});
+devTest("co-edited async dependency fires accept with settled exports", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "data.ts": `
+      export const value = await Promise.resolve(1);
+      import.meta.hot.accept(newModule => {
+        console.log("accept:" + newModule.value);
+      });
+    `,
+    "index.ts": `
+      import { value } from "./data";
+      console.log("index:" + value);
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index:1");
+    {
+      await using batch = await dev.batchChanges();
+      await dev.write(
+        "index.ts",
+        `
+          import { value } from "./data";
+          console.log("index2:" + value);
+          import.meta.hot.accept();
+        `,
+      );
+      await dev.write(
+        "data.ts",
+        `
+          export const value = await Promise.resolve(2);
+          import.meta.hot.accept(newModule => {
+            console.log("accept:" + newModule.value);
+          });
+        `,
+      );
+    }
+    await c.expectMessageInAnyOrder("index2:2", "accept:2");
+  },
+});
 devTest("import.meta.hot.accept specifier", {
   timeoutMultiplier: 3,
   files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -520,9 +520,9 @@ describe("bundler", async () => {
       },
     });
 
-    // CSS imports are delivered out-of-band by the dev server, so the JS
-    // chunk only contains the importing module. This used to panic while
-    // linking the CSS file's lazy-export JS stub.
+    // A CSS module ships both its CSS (delivered out-of-band as an asset)
+    // and a JS stub module exporting the class-name map, referenced by the
+    // importer's dependency tuple.
     itBundled("bake-dev/loader-css-module-import", {
       format: "internal_bake_dev",
       outdir: "/out",
@@ -535,9 +535,16 @@ describe("bundler", async () => {
       },
       onAfterBundle(api) {
         const jsFile = readdirSync(api.outdir).find(x => x.endsWith(".js"))!;
-        expect(api.readFile(join("/out", jsFile))).toContain('"entry.ts"');
+        const js = api.readFile(join("/out", jsFile));
+        expect(js).toContain('"entry.ts"');
+        expect(js).toContain('"styles.module.css", 1, "default"');
+        expect(js).toContain('"styles.module.css"(hmr, module, exports)');
+        const mangled = js.match(/foo_[A-Za-z0-9_-]+/);
+        expect(mangled).toBeTruthy();
         const cssFile = readdirSync(api.outdir).find(x => x.endsWith(".css"))!;
-        expect(api.readFile(join("/out", cssFile))).toContain("color: red");
+        const css = api.readFile(join("/out", cssFile));
+        expect(css).toContain("color: red");
+        expect(css).toContain(`.${mangled![0]}`);
       },
     });
   });


### PR DESCRIPTION
Fixes #18258

### What does this PR do?

CSS modules don't work in the dev server with HMR on. On a fresh `bun init --react` app, adding `import styles from "./styles.module.css"` throws `ReferenceError: import_styles_module is not defined` in the browser. Production builds are fine — it's specific to `Bun.serve` + HTML imports with HMR.

The dev pipeline was dropping the JS half of a CSS module entirely: `finish_from_bake_dev_server` classifies anything with a CSS AST as css-only, and `convertStmtsForChunkForDevServer` disables every import record pointing at CSS, so the importer loses its dep entry while the printed body still references the binding. 

JSON already works in dev through the lazy-export CJS path, and the comment in `generateCodeForLazyExport.rs` from #31948 says CSS modules should be represented the same way, they just weren't wired up.

With this change, a client `.module.css` ships both halves: the css asset as before, plus the class-name-map stub as a real HMR module. While testing I also fixed two pre-existing bugs in `hmr-module.ts` that affect JSON imports today, the cached ESM view of a CJS module survives re-evaluation, and `replaceModules` could reload an importer before its co-updated dependency, so accepting importers saw stale exports.

**Before:**

https://github.com/user-attachments/assets/887520b4-dbff-48c5-b5c1-6d2df0a45ee8

**After:**

https://github.com/user-attachments/assets/85772e94-decb-41e3-91e4-1298f4feec48

### How did you verify your code works?

New dev-server tests in `test/bake/dev/css.test.ts` and `hot.test.ts`: initial load with the hashed class applied, every import shape, color edits with no reload and no importer re-eval, class add/remove propagation, two importers sharing one instance, `composes` across files, classes → empty file → back, plus JSON and top-level-await dependency hot updates. 

All of them fail with `USE_SYSTEM_BUN=1` (the first five with the exact ReferenceError from the issue) and pass on this branch. The `bake-dev/loader-css-module-import` bundler test now asserts the stub module, the dep tuple, and JS/CSS agreeing on the mangled class name.

The full `test/bake/dev` suite is green (107 pass, 0 fail), the production css suites are unchanged, and everything here is gated on `InternalBakeDev`, so `bun build` output is untouched. Also verified end-to-end on a `bun init --react` app as you can see in the recording above.