### PR TITLE
fix(decorators): evaluate member decorator expressions before class decorators

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -2437,16 +2437,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // ── Phase 8: Assemble output ─────────────────────
         if is_expr {
             let mut comma_parts = BumpVec::<Expr>::new_in(bump);
-            if let Some(cda) = class_dec_assign_expr {
-                comma_parts.push(cda);
-            }
             if let Some(ba) = base_assign_expr {
                 comma_parts.push(ba);
             }
 
-            // Can't capture `&mut self` in a closure while also calling
-            // `p.method()`, so inline both call sites against a `&[Stmt]`
-            // slice array.
+            // Member decorator arrays first (per ES spec), then class
+            // decorator arrays, so member decorator expressions are
+            // evaluated before class decorator expressions.
             for stmts_list in [&pre_eval_stmts[..], &prefix_stmts[..]] {
                 for pstmt in stmts_list.iter() {
                     match &pstmt.data {
@@ -2484,6 +2481,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
+            // Class decorator array after member decorator arrays
+            if let Some(cda) = class_dec_assign_expr {
+                comma_parts.push(cda);
+            }
             // _init = __decoratorStart(...)
             comma_parts.push(p.assign_to(init_ref, init_start_expr, loc));
 
@@ -2539,14 +2540,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
 
-        // Statement mode
-        if !matches!(class_dec_stmt.data, js_ast::StmtData::SEmpty(_)) {
-            out.push(class_dec_stmt);
-        }
+        // Statement mode: member decorator arrays first (per ES spec),
+        // then class decorator arrays, so member decorator expressions
+        // are evaluated before class decorator expressions.
         if !matches!(base_decl_stmt.data, js_ast::StmtData::SEmpty(_)) {
             out.push(base_decl_stmt);
         }
         out.extend_from_slice(&pre_eval_stmts);
+        if !matches!(class_dec_stmt.data, js_ast::StmtData::SEmpty(_)) {
+            out.push(class_dec_stmt);
+        }
         out.extend_from_slice(&prefix_stmts);
         out.push(init_decl_stmt);
         out.push(original_stmt.unwrap());


### PR DESCRIPTION
Fixes #33406

## Problem

Per the ES decorator proposal, member decorator expressions must be evaluated before class decorator expressions. Bun was emitting the class decorator array declaration before member decorator array declarations, causing class decorator factories to be called first.

For `@d1 @d2 class C { @d3 x; }`:
- Expected order: d3() factory → d2() factory → d1() factory  
- Actual order: d1() factory → d2() factory → d3() factory

## Fix

In `src/js_parser/lower/lower_decorators.rs` Phase 8 (Assemble output), reorder the emission of class decorator array to come after member decorator arrays:

- **Statement mode**: move `class_dec_stmt` after `pre_eval_stmts`  
- **Expression mode**: move `class_dec_assign_expr` after the `pre_eval_stmts` loop

## Notes

This does not fix other decorator bugs in the same test file:
- `target` binding (expect target === prototype, receives false)
- `propertyKey` serialization (`[object Object]` instead of string)
- `export default class` decorated methods not applied