### PR TITLE
Propagate errors thrown by a runtime plugin's onResolve callback

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -865,13 +865,15 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
         if (auto* promise = dynamicDowncast<JSPromise>(result)) {
             switch (promise->status()) {
             case JSPromise::Status::Pending: {
+                // Discarded here, so a later rejection must not surface as unhandled.
+                promise->markAsHandled();
                 JSC::throwTypeError(globalObject, scope, "onResolve() doesn't support pending promises yet"_s);
                 return {};
             }
             case JSPromise::Status::Rejected: {
-                promise->setFlags(static_cast<uint16_t>(JSC::JSPromise::Status::Fulfilled));
-                result = promise->result();
-                return JSValue::encode(result);
+                promise->markAsHandled();
+                JSC::throwException(globalObject, scope, promise->result());
+                return {};
             }
             case JSPromise::Status::Fulfilled: {
                 result = promise->result();

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1064,3 +1064,170 @@ it("object loader: an error thrown by a getter on the exports object rejects the
   });
   expect(() => require("object-loader-throwing-esmodule")).toThrow(boom);
 });
+
+describe.concurrent("onResolve failures", () => {
+  // Prints `{ ...result, unhandled }` once the event loop is drained, so an
+  // unhandled rejection queued by the plugin has already been reported.
+  const reporter = `
+    const unhandled = [];
+    let result = null;
+    process.on("unhandledRejection", error => unhandled.push(error?.message ?? String(error)));
+    process.on("exit", () => console.log(JSON.stringify({ ...result, unhandled })));
+  `;
+
+  async function report(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", reporter + source],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    try {
+      return { report: JSON.parse(stdout), exitCode };
+    } catch {
+      throw new Error(`expected JSON on stdout, got:\n${stdout}\n--- stderr ---\n${stderr}`);
+    }
+  }
+
+  it("rejects the import with the error an async onResolve threw", async () => {
+    expect(
+      await report(`
+        Bun.plugin({
+          name: "rejecting resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /^boom$/, namespace: "asyncthrow" }, async () => {
+              throw new Error("config missing");
+            });
+          },
+        });
+        const error = await import("asyncthrow:boom").catch(error => error);
+        result = { name: error.name, message: error.message };
+      `),
+    ).toEqual({
+      report: { name: "Error", message: "config missing", unhandled: [] },
+      exitCode: 0,
+    });
+  });
+
+  it("rejects the import with a non-Error thrown by an async onResolve", async () => {
+    expect(
+      await report(`
+        Bun.plugin({
+          name: "rejecting resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /^boom$/, namespace: "asyncthrowstring" }, async () => {
+              throw "config missing";
+            });
+          },
+        });
+        const error = await import("asyncthrowstring:boom").catch(error => error);
+        result = { thrown: error };
+      `),
+    ).toEqual({
+      report: { thrown: "config missing", unhandled: [] },
+      exitCode: 0,
+    });
+  });
+
+  it("throws the error an async onResolve threw out of require()", async () => {
+    expect(
+      await report(`
+        Bun.plugin({
+          name: "rejecting resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /^boom$/, namespace: "asyncthrowrequire" }, async () => {
+              throw new Error("config missing");
+            });
+          },
+        });
+        try {
+          require("asyncthrowrequire:boom");
+          result = { name: "(nothing was thrown)", message: "(nothing was thrown)" };
+        } catch (error) {
+          result = { name: error.name, message: error.message };
+        }
+      `),
+    ).toEqual({
+      report: { name: "Error", message: "config missing", unhandled: [] },
+      exitCode: 0,
+    });
+  });
+
+  it("throws the error a sync onResolve threw", async () => {
+    expect(
+      await report(`
+        Bun.plugin({
+          name: "throwing resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /^boom$/, namespace: "syncthrow" }, () => {
+              throw new Error("config missing");
+            });
+          },
+        });
+        const error = await import("syncthrow:boom").catch(error => error);
+        result = { name: error.name, message: error.message };
+      `),
+    ).toEqual({
+      report: { name: "Error", message: "config missing", unhandled: [] },
+      exitCode: 0,
+    });
+  });
+
+  it("fails the entry point when onResolve throws while resolving it", async () => {
+    using dir = tempDir("plugin-entry-throw", {
+      "plugin.js": `
+        Bun.plugin({
+          name: "throwing resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /entry\\.js$/ }, () => {
+              throw new Error("config missing");
+            });
+          },
+        });
+      `,
+      "entry.js": `console.log("the entry point ran");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./plugin.js", "./entry.js"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("config missing");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  it("does not leak the rejection of an onResolve promise that settles too late", async () => {
+    expect(
+      await report(`
+        Bun.plugin({
+          name: "pending resolver",
+          setup(builder) {
+            builder.onResolve({ filter: /^boom$/, namespace: "pendingthrow" }, async () => {
+              await Bun.sleep(1);
+              throw new Error("config missing");
+            });
+          },
+        });
+        const error = await import("pendingthrow:boom").catch(error => error);
+        result = { name: error.name, message: error.message };
+      `),
+    ).toEqual({
+      report: {
+        name: "TypeError",
+        message: "onResolve() doesn't support pending promises yet",
+        unhandled: [],
+      },
+      exitCode: 0,
+    });
+  });
+});

--- a/test/regression/issue/22199.test.ts
+++ b/test/regression/issue/22199.test.ts
@@ -101,9 +101,13 @@ test("plugin onResolve with rejected promise should throw error", () => {
     cmd: [bunExe(), "--preload", "./plugin.js", "./index.js"],
     env: bunEnv,
     cwd: String(dir),
+    stdout: "pipe",
     stderr: "pipe",
   });
 
-  expect(result.exitCode).toBe(1);
   expect(result.stderr.toString()).toContain("Custom plugin error");
+  // The error has to fail the resolution, not arrive later as an unhandled
+  // rejection while index.js runs anyway.
+  expect(result.stdout.toString()).toBe("");
+  expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
## Repro

```js
// plugin.js
Bun.plugin({
  name: "p",
  setup(build) {
    build.onResolve({ filter: /^boom$/, namespace: "ns" }, async () => {
      throw new Error("real reason: config missing");
    });
  },
});

// main.js
const error = await import("ns:boom").catch(e => e);
console.log(error.name, "|", error.message);
```

```
$ bun --preload ./plugin.js ./main.js
ResolveMessage | Cannot find package 'ns:boom' from '.../main.js'
error: real reason: config missing        <- leaked as an unhandled rejection
$ echo $?
1
```

The plugin's actual error is lost, the importer gets a generic "cannot resolve" message, and the rejection escapes to the unhandled-rejection queue, which exits the process under the default policy. `Bun.build()` with the same plugin reports the plugin's error correctly.

## Cause

`BunPlugin::OnResolve::run` handled a rejected promise with
`promise->setFlags(static_cast<uint16_t>(JSPromise::Status::Fulfilled))` and then
returned `promise->result()` as if it were the `{ path }` object the callback is
supposed to return.

`JSPromise::setFlags` replaces the whole 16-bit flags word, so rather than marking
the promise as handled it cleared `isHandled` (and `isFirstResolvingFunctionCalled`,
and the inline-reaction bits). The rejection reason was then handed back to the
resolver, which found no `path` property on it and fell through to default
resolution. The promise, still unhandled, surfaced later as an unhandled rejection.

## Fix

`BunPlugin::OnResolve::run`: `markAsHandled()` + `throwException(globalObject, scope, promise->result())` for a rejected promise, matching `ModuleLoader.cpp`'s handling of a rejected virtual module. A still-pending promise is also marked handled, since nothing attaches a handler to it once the existing `onResolve() doesn't support pending promises yet` TypeError is thrown.

## Verification

Six tests in `test/js/bun/plugin/plugins.test.ts` covering `import()`, `require()`, a
non-`Error` throw, a synchronous throw, entry-point resolution, and a promise that
rejects after the resolver has already returned. Each spawns a subprocess that
collects `unhandledRejection` and prints it from `process.on("exit")`, so
`unhandled: []` is an assertion rather than an absence check.

`test/regression/issue/22199.test.ts`'s "onResolve with rejected promise should throw
error" passed for the wrong reason: it asserted only exit code 1 and the message on
stderr, both of which the leaked unhandled rejection satisfied while `index.js` ran to
completion anyway. It now also asserts stdout is empty.

Against current `main` with only this PR's `BunPlugin.cpp` change reverted, the four
async-rejection tests and the tightened 22199 assertion fail (5 fail / 52 pass). With the
change, 57 pass / 0 fail. The synchronous-throw and entry-point tests pass on `main` alone
and stay as regression guards for the resolve path described below.

<details>
<summary>History: this PR also used to fix a segfault in <code>moduleLoaderResolve</code>, since landed by #40234</summary>

Routing a throwing `onResolve` into `moduleLoaderResolve` originally exposed a second bug:
the function left `ErrorableString res` uninitialized and, on `!res.success`, threw
`res.result.err` unconditionally. The Rust resolve hook returns without writing `res`
whenever a JS exception is already pending, which is exactly what a throwing `onResolve`
does, so this read a wild `JSValue` off the stack and segfaulted:

```
$ bun --preload ./plugin.js ./entry.js      # onResolve throws while resolving entry.js
panic(main thread): Segmentation fault at address 0x10
```

This PR carried a fix for that (zero-initialize `res`, check `scope.exception()` before
reading `res.result.err`, mirroring `moduleLoaderImportModule`). #38273 independently hit
the same crash and carried a minimal variant. Then #40234 ("check the scope after module
resolution") rewrote `moduleLoaderResolve` on `main` with `RETURN_IF_EXCEPTION(scope, {})`
immediately after `Zig__GlobalObject__resolve`, which fixes it the same way. On rebase this
PR's `ZigGlobalObject.cpp` hunk was dropped in favor of `main`'s version, per the plan
agreed with #38273. The `fails the entry point when onResolve throws while resolving it`
test here still exercises that path and passes against `main`'s fix.

The invariant that fix relied on (`success == true` never coexists with a pending
exception, because every fallible call in `resolve_maybe_needs_trailing_slash` and
`plugin_runner_on_resolve_jsc` propagates with `?` before `*res` is written) still holds on
current `main` and is what makes #40234's `RETURN_IF_EXCEPTION`-first ordering correct.
Empirically, the `require-cache` file-path leak fixture showed no delta (68 MB vs 70 MB on
`main`) while this PR's version was in.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts "test/regression/issue/22199.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/22199.test.ts:
(pass) plugin onResolve returning undefined should not crash [322.83ms]
(pass) plugin onResolve returning null should not crash [276.00ms]
(pass) plugin onResolve with sync function returning undefined should not crash [274.16ms]
106 |   });
107 | 
108 |   expect(result.stderr.toString()).toContain("Custom plugin error");
109 |   // The error has to fail the resolution, not arrive later as an unhandled
110 |   // rejection while index.js runs anyway.
111 |   expect(result.stdout.toString()).toBe("");
                                         ^
error: expect(received).toBe(expected)

- ""
+ "Hello from index.js
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/22199.test.ts:111:36)
(fail) plugin onResolve with rejected promise should throw error [287.19ms]

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or productio
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/regression/issue/22199.test.ts:
(pass) plugin onResolve returning undefined should not crash [8.27ms]
(pass) plugin onResolve returning null should not crash [6.02ms]
(pass) plugin onResolve with sync function returning undefined should not crash [5.85ms]
106 |   });
107 | 
108 |   expect(result.stderr.toString()).toContain("Custom plugin error");
109 |   // The error has to fail the resolution, not arrive later as an unhandled
110 |   // rejection while index.js runs anyway.
111 |   expect(result.stdout.toString()).toBe("");
                                         ^
error: expect(received).toBe(expected)

- ""
+ "Hello from index.js
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/22199.test.ts:111:36)
(fail) plugin onResolve with rejected promise should throw error [6.42ms]

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) requir
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts "test/regression/issue/22199.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/22199.test.ts:
(pass) plugin onResolve returning undefined should not crash [326.92ms]
(pass) plugin onResolve returning null should not crash [281.82ms]
(pass) plugin onResolve with sync function returning undefined should not crash [277.22ms]
(pass) plugin onResolve with rejected promise should throw error [270.93ms]

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1254.04ms]
(pass) require > beep:boop returns 42 [8.82ms]
(pass) require > object module works [7.64ms]
(pass) module > throws with require() [12.65ms]
(pass) module > async module works with async import [23.42ms]
(pass) module > sync module module works
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     85e5f20c7a
  features     baseline

23 deps, 129 codegen, 1172 objects in 714ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingCo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp      |   8 +-
 test/js/bun/plugin/plugins.test.ts  | 167 ++++++++++++++++++++++++++++++++++++
 test/regression/issue/22199.test.ts |   6 +-
 3 files changed, 177 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/BunPlugin.cpp           3      2      0
test/js/bun/plugin/plugins.test.ts       5      7      0
test/regression/issue/22199.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->