### PR TITLE
Runtime onResolve: return the path unprefixed in the file namespace

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6694,9 +6694,8 @@ pub fn plugin_runner_on_resolve_jsc(
     let user_namespace = scopeguard::guard(user_namespace, |s| s.deref());
 
     // A `file`-namespace result (the default) is a filesystem path, not a new
-    // specifier: hand it back unprefixed so the module loader loads that file.
-    // `bun:`, `node:` and custom namespaces keep the `ns:path` form the loader
-    // dispatches on.
+    // specifier: hand it back unprefixed. Other namespaces keep the `ns:path`
+    // form the module loader dispatches on.
     if user_namespace.eql_comptime(b"file") {
         return Ok(Some(ErrorableString::ok(file_path.into_inner())));
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6693,6 +6693,14 @@ pub fn plugin_runner_on_resolve_jsc(
     // early-return paths.
     let user_namespace = scopeguard::guard(user_namespace, |s| s.deref());
 
+    // A `file`-namespace result (the default) is a filesystem path, not a new
+    // specifier: hand it back unprefixed so the module loader loads that file.
+    // `bun:`, `node:` and custom namespaces keep the `ns:path` form the loader
+    // dispatches on.
+    if user_namespace.eql_comptime(b"file") {
+        return Ok(Some(ErrorableString::ok(file_path.into_inner())));
+    }
+
     // Our slow way of cloning the string into memory owned by JSC.
     use std::io::Write as _;
     let mut combined_string: Vec<u8> = Vec::new();

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -625,7 +625,7 @@ it("recursion throws stack overflow at entry point", () => {
   expect(result.stderr.toString()).toContain("RangeError: Maximum call stack size exceeded.");
 });
 
-it("onResolve can redirect a specifier to a real file in the file namespace", async () => {
+it.concurrent("onResolve can redirect a specifier to a real file in the file namespace", async () => {
   using dir = tempDir("plugin-onresolve-file-namespace", {
     "real.js": `export const value = "redirected";`,
     "entry.js": `
@@ -693,7 +693,7 @@ it("onResolve can redirect a specifier to a real file in the file namespace", as
   expect(exitCode).toBe(0);
 });
 
-it("a no-op onResolve that returns args.path unchanged is transparent", async () => {
+it.concurrent("a no-op onResolve that returns args.path unchanged is transparent", async () => {
   using dir = tempDir("plugin-onresolve-no-op", {
     "preload.js": `
       Bun.plugin({

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -623,4 +623,72 @@ it("recursion throws stack overflow at entry point", () => {
   });
 
   expect(result.stderr.toString()).toContain("RangeError: Maximum call stack size exceeded.");
+});
+
+it("onResolve can redirect a specifier to a real file in the file namespace", async () => {
+  using dir = tempDir("plugin-onresolve-file-namespace", {
+    "real.js": `export const value = "redirected";`,
+    "entry.js": `
+      import { join } from "node:path";
+
+      const target = join(import.meta.dir, "real.js");
+
+      Bun.plugin({
+        name: "redirect-to-file",
+        setup(build) {
+          build.onResolve({ filter: /^implicit\\.mod$/ }, () => ({ path: target }));
+          build.onResolve({ filter: /^explicit\\.mod$/ }, () => ({ path: target, namespace: "file" }));
+          build.onResolve({ filter: /^empty-namespace\\.mod$/ }, () => ({ path: target, namespace: "" }));
+          build.onResolve({ filter: /^custom\\.mod$/ }, () => ({ path: "inner", namespace: "custom" }));
+          build.onLoad({ filter: /.*/, namespace: "custom" }, ({ path }) => ({
+            contents: "export const value = " + JSON.stringify("custom:" + path) + ";",
+            loader: "js",
+          }));
+        },
+      });
+
+      async function attempt(fn) {
+        try {
+          return await fn();
+        } catch (error) {
+          return "threw: " + error.message;
+        }
+      }
+
+      console.log(
+        JSON.stringify({
+          dynamicImport: await attempt(async () => (await import("implicit.mod")).value),
+          explicitFileNamespace: await attempt(async () => (await import("explicit.mod")).value),
+          emptyNamespace: await attempt(async () => (await import("empty-namespace.mod")).value),
+          customNamespace: await attempt(async () => (await import("custom.mod")).value),
+          requireComputed: await attempt(() => require("implicit" + ".mod").value),
+          resolveSync: await attempt(() => Bun.resolveSync("implicit.mod", import.meta.dir)),
+          importMetaResolve: await attempt(() => import.meta.resolve("implicit.mod")),
+        }),
+      );
+    `,
+  });
+
+  const target = resolve(String(dir), "real.js");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fixture catches its own failures, so empty stdout means it crashed.
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    dynamicImport: "redirected",
+    explicitFileNamespace: "redirected",
+    emptyNamespace: "redirected",
+    // A non-file namespace still round-trips through onLoad as "namespace:path".
+    customNamespace: "custom:inner",
+    requireComputed: "redirected",
+    resolveSync: target,
+    importMetaResolve: Bun.pathToFileURL(target).href,
+  });
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -692,3 +692,33 @@ it("onResolve can redirect a specifier to a real file in the file namespace", as
   });
   expect(exitCode).toBe(0);
 });
+
+it("a no-op onResolve that returns args.path unchanged is transparent", async () => {
+  using dir = tempDir("plugin-onresolve-no-op", {
+    "preload.js": `
+      Bun.plugin({
+        name: "no-op",
+        setup(build) {
+          build.onResolve({ filter: /\\.js$/ }, args => ({ path: args.path }));
+          build.onResolve({ filter: /\\.ts$/, namespace: "file" }, args => ({ path: args.path, namespace: "file" }));
+        },
+      });
+    `,
+    "dep.ts": `export const value = "dep";`,
+    "entry.js": `
+      import { value } from "./dep.ts";
+      console.log("entry ran:" + value);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() || stderr).toBe("entry ran:dep");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #5564
Fixes #20637
Fixes #17847

## Repro

```js
// repro.js
Bun.plugin({
  name: "alias",
  setup(build) {
    build.onResolve({ filter: /^virt-.*\.mod$/ }, () => ({ path: "/tmp/x/real.js" })); // exists on disk
  },
});
await import("virt-a.mod");
```

```
$ bun repro.js
error: Cannot find module 'file:/tmp/x/real.js' from ''
```

The same plugin object passed to `Bun.build()` bundles `real.js` fine.

Redirecting a specifier at a real file is the primary documented use of `onResolve` (path aliases, `#internal/` maps, test doubles), and the error points at a `file:`-prefixed *specifier* the loader itself constructed.

## Cause

`plugin_runner_on_resolve_jsc` serialized every plugin result as `"<namespace>:<path>"` before handing it back as the resolved module key. For a custom namespace that is exactly right: `"myns:inner"` is re-dispatched to the `myns` onLoad handler, and `bun:` / `node:` results land on the builtin loaders. But the default namespace is `file`, so an ordinary filesystem path came back as `file:/abs/path.js`, and nothing downstream unwraps that prefix. The loader then tried to resolve the prefixed string as a brand-new specifier, from an empty referrer.

Every runtime entry point that goes through this hook was affected:

| entry point | before |
| --- | --- |
| `await import("virt-a.mod")` | `Cannot find module 'file:/abs/real.js' from ''` |
| `require(computed)` | `ENOENT reading "file:/abs/real.js"` |
| `Bun.resolveSync(...)` | `"file:/abs/real.js"` |
| `import.meta.resolve(...)` | `"file:/abs/real.js"` |

A file-namespace `onLoad` handler could never fire for such a key either: `Bun__runVirtualModule` splits the key on `:` and looks the namespace up with `OnLoad::group("file")`, which returns `nullptr`, because file-namespace handlers live in `fileNamespace` and are found under `""`.

Static `import` and literal `require` were unaffected because their specifiers are resolved at transpile time by a different hook (`PluginRunner::on_resolve`), which keeps the path and the namespace in separate fields of `Fs::Path` rather than concatenating them. That is also why this went unnoticed: the two halves of the same plugin API disagreed.

## Fix

When the resolved namespace is `file` (explicit, empty, or omitted), return the path as-is. Other namespaces keep the `ns:path` form. This also drops a `Vec` allocation and a round-trip through a `JSString` on the common path, since the path is already a WTF-backed string owned by the caller.

Nothing downstream consumed the old `file:`-prefixed form. The only single-slash `file:` check in the tree is in `JSMock__jsModuleMock`, for specifiers the user passes to `mock.module()`. `moduleLoaderResolve`, `moduleLoaderImportModule`, `ImportMetaObject` and `Bun.resolveSync` all test for `file://` (two slashes), and the resolver rejects the prefix outright (`Bun.resolveSync("file:./x.ts", dir)` → `Cannot find module 'file:./x.ts'`). The prefixed key only ever produced errors.

## Verification

`test/js/bun/plugin/plugins.test.ts` gains two tests:

- the three file-namespace result shapes (`{ path }`, `{ path, namespace: "file" }`, `{ path, namespace: "" }`) across dynamic `import()`, computed `require()`, `Bun.resolveSync` and `import.meta.resolve`, plus a custom-namespace case as a control that the `ns:path` form still round-trips through `onLoad`;
- the no-op shape from #5564 / #20637 (`onResolve` returning `args.path` unchanged), which must leave the program running exactly as if the plugin were absent.

<details>
<summary>Before the fix, 6 of the 7 assertions in the first test fail (the custom-namespace control passes)</summary>

```
  {
    "customNamespace": "custom:inner",
-   "dynamicImport": "redirected",
-   "emptyNamespace": "redirected",
-   "explicitFileNamespace": "redirected",
-   "importMetaResolve": "file:///tmp/.../real.js",
-   "requireComputed": "redirected",
-   "resolveSync": "/tmp/.../real.js",
+   "dynamicImport": "threw: Cannot find module 'file:/tmp/.../real.js' from ''",
+   "emptyNamespace": "threw: Cannot find module 'file:/tmp/.../real.js' from ''",
+   "explicitFileNamespace": "threw: Cannot find module 'file:/tmp/.../real.js' from ''",
+   "importMetaResolve": "file:/tmp/.../real.js",
+   "requireComputed": "threw: ENOENT reading \"file:/tmp/.../real.js\"",
+   "resolveSync": "file:/tmp/.../real.js",
  }
```

</details>

<details>
<summary>The three linked issues, each run against stock 1.3.14 and against this branch</summary>

```
#5564  no-op onResolve via preload
 before: error: ENOENT reading "file:/tmp/iss/5564/a.js"
 after : 5564: script ran

#20637 {path: args.path, namespace: 'file'}
 before: error: ENOENT reading "file:/tmp/iss/20637/example.poc.ts"
 after : 20637: script ran

#17847 rewrite an asset path, no namespace
 before: default = "file:/image.png"
 after : default = "/image.png"
```

The secondary complaint in #17847, that a custom namespace with no `onLoad` handler throws `Cannot find module 'bla:/image.png'`, is unchanged and intentional: `Bun.build` rejects the same thing with `Expected onLoad plugin for namespace bla to exist`, and esbuild does likewise. Happy to drop that `Fixes` line if you would rather keep the issue open for it.

</details>

`test/js/bun/plugin/`, `test/bundler/bundler_plugin.test.ts`, `test/bundler/bundler_plugin_chain.test.ts`, `test/bundler/bun-build-api.test.ts`, `test/js/bun/resolve/` and the `mock.module` suites all pass with the debug build.

## Behavior change worth flagging

A non-absolute `file`-namespace path used to fail on the prefix (`Cannot find module 'file:./x.ts' from ''`). It now reaches the resolver, so `{ path: "./x.ts" }` resolves against the key's referrer, which is empty on the dynamic-import path, i.e. the cwd. The static-import path resolves the same value against the importing file. `Bun.build` rejects non-absolute file-namespace paths outright (`onResolve plugin "path" must be absolute when the namespace is "file"`), so an absolute path remains the only well-defined contract. This PR deliberately does not try to define the rest, but I would rather call it out than have it found later.
