### PR TITLE
Preserve literal backslashes in fs.realpath on POSIX

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1691,7 +1691,7 @@ pub fn join_abs_string_buf<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> &'a [u8] {
-    _join_abs_string_buf::<false, P>(cwd, buf, parts)
+    _join_abs_string_buf::<false, P, false>(cwd, buf, parts)
 }
 
 /// Like `join_abs_string_buf`, but returns null when the *normalized* result is
@@ -1704,6 +1704,26 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> Option<&'a [u8]> {
+    join_abs_string_buf_checked_impl::<P, false>(cwd, buf, parts)
+}
+
+/// Like `join_abs_string_buf_checked::<Posix>` but normalizes with strict POSIX
+/// separator semantics: `\` stays a literal filename byte instead of acting as
+/// a separator. Use this for real on-disk path resolution (e.g. realpath), not
+/// for module specifiers, which intentionally treat `\` as a separator.
+pub fn join_abs_string_buf_checked_posix<'a>(
+    cwd: &'a [u8],
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a [u8]> {
+    join_abs_string_buf_checked_impl::<platform::Posix, true>(cwd, buf, parts)
+}
+
+fn join_abs_string_buf_checked_impl<'a, P: PlatformT, const STRICT_POSIX: bool>(
+    cwd: &'a [u8],
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a [u8]> {
     debug_assert!(!matches!(P::P, Platform::Nt));
     // Fast path: size check only — don't allocate a JoinScratch here since the
     // inner join_abs_string_buf already has its own (avoids doubling stack usage).
@@ -1712,14 +1732,14 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
         total += p.len() + 1;
     }
     if total < buf.len() {
-        return Some(join_abs_string_buf::<P>(cwd, buf, parts));
+        return Some(_join_abs_string_buf::<false, P, STRICT_POSIX>(cwd, buf, parts));
     }
 
     // Slow path: allocate a large scratch for the result. The inner
     // join_abs_string_buf will heap-allocate its own temp buffer for the concat
     // since `total > MAX_PATH_BYTES * 2 > sfa inline size` is likely here.
     let mut scratch = vec![0u8; total];
-    let joined = join_abs_string_buf::<P>(cwd, &mut scratch, parts);
+    let joined = _join_abs_string_buf::<false, P, STRICT_POSIX>(cwd, &mut scratch, parts);
     if joined.len() > buf.len() {
         return None;
     }
@@ -1733,14 +1753,18 @@ pub fn join_abs_string_buf_z<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> &'a ZStr {
-    let r = _join_abs_string_buf::<true, P>(cwd, buf, parts);
+    let r = _join_abs_string_buf::<true, P, false>(cwd, buf, parts);
     // SAFETY: IS_SENTINEL=true wrote NUL at r.len()
     unsafe { ZStr::from_raw(r.as_ptr(), r.len()) }
 }
 
 // We always return `&[u8]`; when `IS_SENTINEL` a NUL is written
 // at `result.len()` and callers (e.g. `join_abs_string_buf_z`) re-wrap as `ZStr`.
-fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
+// STRICT_POSIX forces the final normalization to split on `/` only, so a
+// backslash stays a literal filename byte (for real on-disk POSIX paths such
+// as realpath). It is only honored on the POSIX branch below; leave it false
+// everywhere else.
+fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT, const STRICT_POSIX: bool>(
     _cwd: &'a [u8],
     buf: &'a mut [u8],
     _parts: &[&[u8]],
@@ -1847,10 +1871,14 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
     // which writes into buf[leading_len..]).
     buf[..leading_len].copy_from_slice(&leading_buf[..leading_len]);
 
-    let result = normalize_string_buf::<false, P, true>(
-        &temp_buf[leading_len..out],
-        &mut buf[leading_len..],
-    );
+    let result = if STRICT_POSIX {
+        normalize_string_posix_buf_t::<u8, false, true>(
+            &temp_buf[leading_len..out],
+            &mut buf[leading_len..],
+        )
+    } else {
+        normalize_string_buf::<false, P, true>(&temp_buf[leading_len..out], &mut buf[leading_len..])
+    };
     let result_len = result.len();
 
     if IS_SENTINEL {
@@ -2024,6 +2052,25 @@ pub(crate) fn normalize_string_loose_buf_t<
         buf,
         T::from_u8(SEP_POSIX),
         is_sep_any_t::<T>,
+    )
+}
+
+// On POSIX `\` is an ordinary filename byte, so unlike the loose normalizer
+// this splits segments on `/` only, leaving backslashes intact.
+pub(crate) fn normalize_string_posix_buf_t<
+    'a,
+    T: PathChar,
+    const ALLOW_ABOVE_ROOT: bool,
+    const PRESERVE_TRAILING_SLASH: bool,
+>(
+    str: &[T],
+    buf: &'a mut [T],
+) -> &'a mut [T] {
+    normalize_string_generic_t::<T, ALLOW_ABOVE_ROOT, PRESERVE_TRAILING_SLASH>(
+        str,
+        buf,
+        T::from_u8(SEP_POSIX),
+        is_sep_posix_t::<T>,
     )
 }
 

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1732,7 +1732,9 @@ fn join_abs_string_buf_checked_impl<'a, P: PlatformT, const STRICT_POSIX: bool>(
         total += p.len() + 1;
     }
     if total < buf.len() {
-        return Some(_join_abs_string_buf::<false, P, STRICT_POSIX>(cwd, buf, parts));
+        return Some(_join_abs_string_buf::<false, P, STRICT_POSIX>(
+            cwd, buf, parts,
+        ));
     }
 
     // Slow path: allocate a large scratch for the result. The inner

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -355,6 +355,19 @@ pub mod fs {
             join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
         }
 
+        /// Like `abs_buf_checked` but with POSIX separator semantics: a
+        /// backslash stays a literal filename byte instead of acting as a path
+        /// separator. Use this for real on-disk path resolution (e.g.
+        /// realpath), not for module specifiers (those want `Loose`).
+        pub fn abs_buf_checked_posix<'b>(
+            &self,
+            parts: &[&[u8]],
+            buf: &'b mut [u8],
+        ) -> Option<&'b [u8]> {
+            use bun_paths::resolve_path::join_abs_string_buf_checked_posix;
+            join_abs_string_buf_checked_posix(self.top_level_dir, buf, parts)
+        }
+
         /// Like `abs_buf` but writes a
         /// NUL sentinel and returns a `ZStr` borrowing `buf`.
         pub fn abs_buf_z<'b>(&self, parts: &[&[u8]], buf: &'b mut [u8]) -> &'b ZStr {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7674,7 +7674,7 @@ impl NodeFS {
             let fs = FileSystem::get();
             let parts = [fs.top_level_dir, path_slice];
             let inbuf_len = inbuf.len();
-            let Some(joined) = fs.abs_buf_checked(&parts, &mut inbuf[..inbuf_len - 1]) else {
+            let Some(joined) = fs.abs_buf_checked_posix(&parts, &mut inbuf[..inbuf_len - 1]) else {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::realpath,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2094,6 +2094,32 @@ it.skipIf(isWindows)("realpathSync (getFdPath) is implemented on every POSIX tar
   expect(realpathSync(resolved)).toBe(resolved);
 });
 
+// https://github.com/oven-sh/bun/issues/33403
+// On POSIX a backslash is an ordinary filename byte, so realpath must not
+// rewrite it to '/' (that ENOENTs on a directory that exists).
+it.if(isPosix)("realpath preserves a literal backslash in the path", async () => {
+  using dir = tempDir("fs-realpath-backslash", {});
+  const root = realpathSync(String(dir));
+  const backslashDir = `${root}/back\\slash`;
+  mkdirSync(backslashDir);
+  const file = `${backslashDir}/file.txt`;
+  writeFileSync(file, "x");
+
+  // Every other fs call already sees the backslash byte on disk.
+  expect(existsSync(backslashDir)).toBe(true);
+  expect(lstatSync(backslashDir).isDirectory()).toBe(true);
+
+  const realpathCb = promisify(fs.realpath);
+  const realpathNativeCb = promisify(fs.realpath.native);
+  for (const target of [backslashDir, file]) {
+    expect(realpathSync(target)).toBe(target);
+    expect(realpathSync.native(target)).toBe(target);
+    expect(await realpathCb(target)).toBe(target);
+    expect(await realpathNativeCb(target)).toBe(target);
+    expect(await promises.realpath(target)).toBe(target);
+  }
+});
+
 it("readlink", () => {
   const actual = join(tmpdirSync(), "fs-readlink.txt");
   try {


### PR DESCRIPTION
## What

On POSIX a backslash is an ordinary filename character, but `fs.realpathSync` and `fs.realpathSync.native` rewrote `\` to `/` before touching the filesystem, so they threw `ENOENT` on a directory that `existsSync` / `lstatSync` resolve fine in the same process. Fixes #33403.

```js
const fs = require("fs");
const dir = "/tmp/back\\slash"; // one literal backslash in the name
fs.mkdirSync(dir, { recursive: true });
fs.existsSync(dir);                 // true
fs.lstatSync(dir).isDirectory();    // true
fs.realpathSync(dir);               // before: ENOENT: no such file or directory, lstat '/tmp/back\slash'
```

Node v22+ returns `/tmp/back\slash`. `path.normalize` / `resolve` / `join` already preserved the backslash; only realpath was affected.

## Cause

`realpath_inner` (non-Windows) resolves the input through `FileSystem::abs_buf_checked`, which joins with `platform::Loose`. The join's normalizer (`normalize_string_buf_t`) routed `Platform::Posix` through the loose normalizer, whose separator predicate is `is_sep_any` (treats both `/` and `\` as separators). So `back\slash` was split and re-joined as `back/slash`, and the later `openat` targeted the wrong path:

```
access("/tmp/back\\slash", F_OK)           = 0
openat(AT_FDCWD, "/tmp/back/slash", O_RDONLY|O_PATH) = -1 ENOENT
```

Every other `Platform::Posix` separator predicate (`is_separator`, `get_separator_func`, `is_absolute`, `leading_separator_index`) already treats `\` as a literal byte. The normalizer was the single inconsistent spot.

## Fix

Scoped to realpath so no other path consumer shifts behavior:

- Add `normalize_string_posix_buf_t`, a POSIX normalizer that splits on `/` only (vs the loose normalizer's `is_sep_any`, which also splits on `\`).
- Thread a `STRICT_POSIX` const flag through `_join_abs_string_buf`; when set, the final normalization uses the POSIX normalizer. Every existing caller passes `false`, so their output is byte-identical.
- Expose it only through `join_abs_string_buf_checked_posix` / `FileSystem::abs_buf_checked_posix`, and call that from `realpath_inner`. The shared `normalize_string_buf_t` and `abs_buf_checked` (`Loose`) are untouched, so module-specifier resolution and npm lockfile workspace-path folding (both of which intentionally treat `\` as a separator) keep their behavior.

An earlier revision changed `normalize_string_buf_t`'s `Platform::Posix` arm directly; CI showed that broke npm lockfile migration (`packages\pkg1` workspace entries), so the fix was narrowed to realpath only.

## Error shape

The issue also noted the thrown error reported `syscall: "lstat"`. That was a side effect of the wrong path. For a genuinely missing path Bun already matches Node (`lstat` for `fs.realpath`, `realpath` for `.native`, original `path`), so no error-shape change was needed.

## Test

`test/js/node/fs/fs.test.ts` creates a directory with a literal backslash in its name and asserts `realpathSync`, `realpathSync.native`, the promisified callback forms, and `promises.realpath` all return the path with the backslash intact (POSIX only; `\` is a separator on Windows).

## Verification

- Fails before (`USE_SYSTEM_BUN=1`): `realpathSync` throws `ENOENT`.
- Passes after (`bun bd`).
- No regressions: `test/js/node/fs/fs.test.ts` (353 pass), `test/cli/install/migration/migrate.test.ts` (20 pass), `test/js/node/path/` (122 pass), `test/js/bun/resolve/{resolve,require}.test.ts` (53 pass), `test/bundler/bundler_edgecase.test.ts` (107 pass).