### PR TITLE
repl: interrupt a running evaluation with Ctrl+C

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -32,7 +32,6 @@ unsafe extern "C" {
     safe fn JSC__VM__runGC(vm: &VM, sync: bool) -> usize;
     safe fn JSC__VM__heapSize(vm: &VM) -> usize;
     safe fn JSC__VM__collectAsync(vm: &VM);
-    safe fn JSC__VM__setExecutionForbidden(vm: &VM, forbidden: bool);
     safe fn JSC__VM__setExecutionTimeLimit(vm: &VM, timeout: f64);
     safe fn JSC__VM__clearExecutionTimeLimit(vm: &VM);
     safe fn JSC__VM__executionForbidden(vm: &VM) -> bool;
@@ -128,10 +127,6 @@ impl VM {
 
     pub fn collect_async(&self) {
         JSC__VM__collectAsync(self)
-    }
-
-    pub fn set_execution_forbidden(&self, forbidden: bool) {
-        JSC__VM__setExecutionForbidden(self, forbidden)
     }
 
     pub fn set_execution_time_limit(&self, timeout: f64) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -59,6 +59,7 @@
 #include "NodeValidator.h"
 #include "NodeModuleModule.h"
 #include "JSX509Certificate.h"
+#include "vm/SigintWatcher.h"
 
 #include "AsyncContextFrame.h"
 #include "ErrorCode.h"
@@ -1568,7 +1569,12 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                         sigaddset(&action.sa_mask, signalNumber);
                         action.sa_flags = SA_RESTART;
 
-                        sigaction(signalNumber, &action, nullptr);
+                        // The SIGINT watcher (`node:vm` breakOnSigint, the REPL) holds the
+                        // disposition while the code doing this runs, so hand it the action
+                        // rather than installing over its handler and disarming it.
+                        if (signalNumber != SIGINT || !Bun::SigintWatcher::get().deferSigintDisposition(action)) {
+                            sigaction(signalNumber, &action, nullptr);
+                        }
 #else
                         signal_handle.handle = Bun__UVSignalHandle__init(
                             eventEmitter.scriptExecutionContext()->jsGlobalObject(),
@@ -1585,9 +1591,19 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                     if (signalToContextIdsMap->find(signalNumber) != signalToContextIdsMap->end() && eventEmitter.listenerCount(eventName) == 0) {
 
 #if !OS(WINDOWS)
-                        if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
-                            // Don't uninstall the old handler if it's not the one we installed.
-                            signal(signalNumber, oldHandler);
+                        struct sigaction action;
+                        memset(&action, 0, sizeof(struct sigaction));
+                        action.sa_handler = SIG_DFL;
+                        sigemptyset(&action.sa_mask);
+
+                        // Same as above: while the watcher is armed, the default we want
+                        // back takes effect when it disarms, not now. Without this its
+                        // handler is what `signal()` below would find and reinstate.
+                        if (signalNumber != SIGINT || !Bun::SigintWatcher::get().deferSigintDisposition(action)) {
+                            if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
+                                // Don't uninstall the old handler if it's not the one we installed.
+                                signal(signalNumber, oldHandler);
+                            }
                         }
 #else
                         SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -249,6 +249,14 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         // scope asked for the termination — an outer `timeout`, or the REPL's
         // Ctrl+C watcher. Only that scope can classify it, so re-raise and let
         // it report.
+        //
+        // Returning here instead of falling through to VM_RETURN_IF_EXCEPTION is
+        // load-bearing: that macro would store the VM's singleton
+        // TerminationException on the module, and re-throwing it once the request
+        // is cleared trips `VM::setException`'s
+        // `!isTerminationException(e) || hasTerminationRequest()` assertion.
+        // `reconcileEvaluationState` settles the status instead, wrapping the
+        // error *value* in a fresh Exception that is safe to re-throw.
         if (!getSigintReceived() && timeout == 0) {
             JSC::throwException(globalObject, scope, vm.ensureTerminationException());
             return {};

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -245,19 +245,22 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+        // Neither this module's own SIGINT nor its own timeout: an enclosing
+        // scope asked for the termination — an outer `timeout`, or the REPL's
+        // Ctrl+C watcher. Only that scope can classify it, so re-raise and let
+        // it report.
+        if (!getSigintReceived() && timeout == 0) {
+            JSC::throwException(globalObject, scope, vm.ensureTerminationException());
+            return {};
+        }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         } else {
-            // Terminated by an enclosing scope that armed the watcher itself —
-            // the REPL's Ctrl+C, say. Still a SIGINT, so report it as one
-            // rather than asserting on a reachable state.
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -254,7 +254,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         } else if (timeout != 0) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
+            // Terminated by an enclosing scope that armed the watcher itself —
+            // the REPL's Ctrl+C, say. Still a SIGINT, so report it as one
+            // rather than asserting on a reachable state.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -245,23 +245,16 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        // Neither this module's own SIGINT nor its own timeout: an enclosing
-        // scope asked for the termination — an outer `timeout`, or the REPL's
-        // Ctrl+C watcher. Only that scope can classify it, so re-raise and let
-        // it report.
-        //
-        // Returning here instead of falling through to VM_RETURN_IF_EXCEPTION is
-        // load-bearing: that macro would store the VM's singleton
-        // TerminationException on the module, and re-throwing it once the request
-        // is cleared trips `VM::setException`'s
-        // `!isTerminationException(e) || hasTerminationRequest()` assertion.
-        // `reconcileEvaluationState` settles the status instead, wrapping the
-        // error *value* in a fresh Exception that is safe to re-throw.
+        // An enclosing scope asked for the termination; only it can classify it.
+        // Returning rather than falling through is load-bearing: VM_RETURN_IF_EXCEPTION
+        // would store the singleton TerminationException, whose later re-throw trips
+        // `VM::setException`. `reconcileEvaluationState` settles the status safely.
         if (!getSigintReceived() && timeout == 0) {
             JSC::throwException(globalObject, scope, vm.ensureTerminationException());
             return {};
         }
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
+        // `globalObject` is the NodeVM global when there is one, non-null otherwise.
+        vm.drainMicrotasksForGlobalObject(globalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -253,8 +253,11 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             JSC::throwException(globalObject, scope, vm.ensureTerminationException());
             return {};
         }
-        // `globalObject` is the NodeVM global when there is one, non-null otherwise.
-        vm.drainMicrotasksForGlobalObject(globalObject);
+        // Despite the name this *clears* the queue, so it must stay scoped to the
+        // terminated context's global. `nodeVmGlobalObject` is null when there is
+        // no context, which means there is nothing to clear -- passing the caller's
+        // `globalObject` instead would discard the main thread's microtasks.
+        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -246,17 +246,15 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
         // An enclosing scope asked for the termination; only it can classify it.
-        // Returning rather than falling through is load-bearing: VM_RETURN_IF_EXCEPTION
-        // would store the singleton TerminationException, whose later re-throw trips
-        // `VM::setException`. `reconcileEvaluationState` settles the status safely.
+        // Returning is load-bearing: falling through would store the singleton
+        // TerminationException, whose re-throw later trips `VM::setException`.
         if (!getSigintReceived() && timeout == 0) {
             JSC::throwException(globalObject, scope, vm.ensureTerminationException());
             return {};
         }
-        // Despite the name this *clears* the queue, so it must stay scoped to the
-        // terminated context's global. `nodeVmGlobalObject` is null when there is
-        // no context, which means there is nothing to clear -- passing the caller's
-        // `globalObject` instead would discard the main thread's microtasks.
+        // Despite the name this *clears* the queue, so scope it to the terminated
+        // context. `nodeVmGlobalObject` is null when there is no context (nothing
+        // to clear); passing `globalObject` would discard the main queue.
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -297,7 +297,10 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         } else if (timeout) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
+            // Terminated by an enclosing scope that armed the watcher itself —
+            // the REPL's Ctrl+C, say. Still a SIGINT, so report it as one
+            // rather than asserting on a reachable state.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         }
         return true;
     }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -281,7 +281,7 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
+static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, NodeVMGlobalObject* contextGlobalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (!vm.hasTerminationRequest())
         return false;
@@ -294,7 +294,10 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         return true;
     }
 
-    vm.drainMicrotasksForGlobalObject(globalObject);
+    // Despite the name this *clears* the queue, so scope it to the terminated
+    // context. `runInThisContext` has none of its own (null, nothing to clear);
+    // passing `globalObject` there would discard the caller's microtasks.
+    vm.drainMicrotasksForGlobalObject(contextGlobalObject);
     // The termination may have fired inside an afterEvaluate microtask
     // checkpoint, leaving the termination exception pending; clear it so
     // the ERR_SCRIPT_EXECUTION_* error below replaces it.
@@ -388,7 +391,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, globalObject, scope, script, newLimit)) {
         return {};
     }
 
@@ -453,7 +456,9 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    // `runInThisContext` evaluates in the caller's global, so there is no
+    // contextified global whose microtask queue the termination may clear.
+    if (checkForTermination(vm, globalObject, nullptr, scope, script, newLimit)) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -283,29 +283,32 @@ void NodeVMScript::destroy(JSCell* cell)
 
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            // Terminated by an enclosing scope that armed the watcher itself —
-            // the REPL's Ctrl+C, say. Still a SIGINT, so report it as one
-            // rather than asserting on a reachable state.
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        }
+    if (!vm.hasTerminationRequest())
+        return false;
+
+    // Neither this script's own SIGINT nor its own timeout: an enclosing scope
+    // asked for the termination — an outer `timeout`, or the REPL's Ctrl+C
+    // watcher. Only that scope can classify it, so re-raise and let its own
+    // `checkForTermination` (or `Bun__REPL__evaluate`) report it.
+    if (!script->getSigintReceived() && !timeout) {
+        JSC::throwException(globalObject, scope, vm.ensureTerminationException());
         return true;
     }
 
-    return false;
+    vm.drainMicrotasksForGlobalObject(globalObject);
+    // The termination may have fired inside an afterEvaluate microtask
+    // checkpoint, leaving the termination exception pending; clear it so
+    // the ERR_SCRIPT_EXECUTION_* error below replaces it.
+    if (vm.hasPendingTerminationException())
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    vm.clearHasTerminationRequest();
+    if (script->getSigintReceived()) {
+        script->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    } else {
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
+    }
+    return true;
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -286,10 +286,9 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
     if (!vm.hasTerminationRequest())
         return false;
 
-    // Neither this script's own SIGINT nor its own timeout: an enclosing scope
-    // asked for the termination — an outer `timeout`, or the REPL's Ctrl+C
-    // watcher. Only that scope can classify it, so re-raise and let its own
-    // `checkForTermination` (or `Bun__REPL__evaluate`) report it.
+    // Neither this script's own SIGINT nor its own timeout, so an enclosing scope
+    // asked for the termination. Only that scope can classify it: re-raise and let
+    // its `checkForTermination` (or `Bun__REPL__evaluate`) report.
     if (!script->getSigintReceived() && !timeout) {
         JSC::throwException(globalObject, scope, vm.ensureTerminationException());
         return true;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -12,9 +12,11 @@
 #include "JavaScriptCore/ErrorType.h"
 #include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/Exception.h"
+#include "JavaScriptCore/VMTraps.h"
 #include "ErrorCode+List.h"
 #include "ErrorCode.h"
 #include "JavaScriptCore/ThrowScope.h"
+#include "../vm/SigintWatcher.h"
 
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSType.h"
@@ -6266,6 +6268,83 @@ CPP_DECL [[ZIG_EXPORT(nothrow)]] unsigned int Bun__CallFrame__getLineNumber(JSC:
     return lineColumn.line;
 }
 
+// Armed around one REPL evaluation. The watcher thread flips the receiver flag
+// before raising the termination trap, and that flag is the only durable record
+// of the signal: JSC clears both the trap bit and `hasTerminationRequest()` by
+// the time the outermost VM entry scope has unwound.
+namespace {
+class ReplSigintScope final : public Bun::SigintReceiver {
+public:
+    explicit ReplSigintScope(JSC::JSGlobalObject* globalObject)
+        : m_holder(Bun::SigintWatcher::hold(globalObject, this))
+    {
+    }
+
+private:
+    Bun::SigintWatcher::GlobalObjectHolder m_holder;
+};
+}
+
+// Drops whatever termination state a SIGINT left behind so the VM can run
+// JavaScript again.
+static void replClearTermination(JSC::VM& vm)
+{
+    vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+    if (vm.hasPendingTerminationException()) {
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    }
+    vm.clearHasTerminationRequest();
+}
+
+// Arms the SIGINT watcher for `globalObject`. While armed, a SIGINT raises a
+// JSC termination trap, which unwinds synchronous JavaScript (`while (true) {}`)
+// the same way node's `breakOnSigint` does. The returned scope must be passed to
+// `Bun__REPL__disarmSigint`.
+extern "C" void* Bun__REPL__armSigint(JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    // Allocate the termination exception up front: the trap handler runs at a
+    // point where allocating one is not allowed.
+    vm.ensureTerminationException();
+    return new ReplSigintScope(globalObject);
+}
+
+extern "C" void Bun__REPL__disarmSigint(JSC::JSGlobalObject* globalObject, void* scope)
+{
+    // Tears down the watcher thread, so no further signal can reach us.
+    delete static_cast<ReplSigintScope*>(scope);
+
+    auto& vm = JSC::getVM(globalObject);
+    // A signal that raced the disarm leaves a trap bit nobody will service;
+    // the next evaluation would terminate the instant it entered the VM.
+    if (vm.traps().hasTrapBit(JSC::VMTraps::NeedTermination)) [[unlikely]] {
+        replClearTermination(vm);
+    }
+}
+
+extern "C" bool Bun__REPL__sigintRequested(void* scope)
+{
+    return scope && static_cast<ReplSigintScope*>(scope)->getSigintReceived();
+}
+
+// Clears the SIGINT termination state and returns the error to report, or an
+// empty JSValue when no interrupt is pending.
+extern "C" JSC::EncodedJSValue Bun__REPL__takeSigintError(JSC::JSGlobalObject* globalObject, void* scope)
+{
+    if (!Bun__REPL__sigintRequested(scope)) {
+        return JSC::JSValue::encode({});
+    }
+
+    auto& vm = JSC::getVM(globalObject);
+    static_cast<ReplSigintScope*>(scope)->setSigintReceived(false);
+    replClearTermination(vm);
+
+    JSC::JSObject* error = Bun::createError(globalObject, Bun::ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED,
+        "Script execution was interrupted by `SIGINT`"_s);
+    globalObject->putDirect(vm, JSC::Identifier::fromString(vm, "_error"_s), error);
+    return JSC::JSValue::encode(error);
+}
+
 // REPL evaluation function - evaluates JavaScript code in the global scope
 // Returns the result value, or undefined if an exception was thrown
 // If an exception is thrown, the exception value is stored in *exception
@@ -6295,6 +6374,14 @@ extern "C" JSC::EncodedJSValue Bun__REPL__evaluate(
 
     WTF::NakedPtr<JSC::Exception> evalException;
     JSC::JSValue result = JSC::evaluate(globalObject, sourceCode, globalObject->globalThis(), evalException);
+
+    // SIGINT unwound the script, and `evalException` is the internal
+    // TerminatedExecutionError. The caller reports
+    // ERR_SCRIPT_EXECUTION_INTERRUPTED via `Bun__REPL__takeSigintError` instead.
+    if (evalException && vm.isTerminationException(evalException.get())) [[unlikely]] {
+        *exception = JSC::JSValue::encode(JSC::jsUndefined());
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
 
     if (evalException) {
         *exception = JSC::JSValue::encode(evalException->value());

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6263,10 +6263,9 @@ CPP_DECL [[ZIG_EXPORT(nothrow)]] unsigned int Bun__CallFrame__getLineNumber(JSC:
     return lineColumn.line;
 }
 
-// Armed around one REPL evaluation. The watcher thread flips the receiver flag
-// before raising the termination trap, and that flag is the only durable record
-// of the signal: JSC clears both the trap bit and `hasTerminationRequest()` by
-// the time the outermost VM entry scope has unwound.
+// Armed around one REPL evaluation. The receiver flag is the only durable record
+// of the signal: JSC clears the trap bit and `hasTerminationRequest()` by the time
+// the outermost VM entry scope has unwound.
 namespace {
 class ReplSigintScope final : public Bun::SigintReceiver {
 public:
@@ -6291,10 +6290,9 @@ static void replClearTermination(JSC::VM& vm)
     vm.clearHasTerminationRequest();
 }
 
-// Arms the SIGINT watcher for `globalObject`. While armed, a SIGINT raises a
-// JSC termination trap, which unwinds synchronous JavaScript (`while (true) {}`)
-// the same way node's `breakOnSigint` does. The returned scope must be passed to
-// `Bun__REPL__disarmSigint`.
+// Arms SIGINT watching for `globalObject`: a SIGINT then raises a JSC termination
+// trap that unwinds synchronous JS, the way node's `breakOnSigint` does. Pass the
+// returned scope to `Bun__REPL__disarmSigint`.
 extern "C" void* Bun__REPL__armSigint(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4831,11 +4831,6 @@ bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
     return vm->hasTerminationRequest();
 }
 
-void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1)
-{
-    (*arg0).setExecutionForbidden();
-}
-
 // These may be called concurrently from another thread.
 void JSC__VM__notifyNeedTermination(JSC::VM* arg0)
 {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -318,7 +318,6 @@ CPP_DECL void JSC__VM__notifyNeedWatchdogCheck(JSC::VM* arg0);
 CPP_DECL void JSC__VM__releaseWeakRefs(JSC::VM* arg0);
 CPP_DECL size_t JSC__VM__runGC(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__setControlFlowProfiler(JSC::VM* arg0, bool arg1);
-CPP_DECL void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__setExecutionTimeLimit(JSC::VM* arg0, double arg1);
 CPP_DECL void JSC__VM__shrinkFootprint(JSC::VM* arg0);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);

--- a/src/jsc/bindings/vm/SigintReceiver.h
+++ b/src/jsc/bindings/vm/SigintReceiver.h
@@ -1,23 +1,27 @@
 #pragma once
 
+#include <atomic>
+
 namespace Bun {
 
+// `m_sigintReceived` is written by the SigintWatcher thread and read by the VM
+// thread, so it has to be atomic.
 class SigintReceiver {
 public:
     SigintReceiver() = default;
 
     void setSigintReceived(bool value = true)
     {
-        m_sigintReceived = value;
+        m_sigintReceived.store(value, std::memory_order_relaxed);
     }
 
-    bool getSigintReceived()
+    bool getSigintReceived() const
     {
-        return m_sigintReceived;
+        return m_sigintReceived.load(std::memory_order_relaxed);
     }
 
 protected:
-    bool m_sigintReceived = false;
+    std::atomic<bool> m_sigintReceived = false;
 };
 
 } // namespace Bun

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -95,9 +95,9 @@ void SigintWatcher::uninstall()
 #if OS(WINDOWS)
         SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        // Undo only our own handler. Code that ran while we were armed may have
-        // installed its own (`process.on("SIGINT")`), and clobbering that would
-        // strand the listener for good: BunProcess installs it exactly once.
+        // Undo only our own handler: a native addon may have installed its own
+        // while we were armed, and clobbering it would strand that handler.
+        // `process.on("SIGINT")` instead routes through deferSigintDisposition.
         struct sigaction current;
         if (sigaction(SIGINT, nullptr, &current) == 0
             && !(current.sa_flags & SA_SIGINFO)
@@ -110,6 +110,26 @@ void SigintWatcher::uninstall()
         m_thread->waitForCompletion();
     }
 }
+
+#if !OS(WINDOWS)
+bool SigintWatcher::deferSigintDisposition(const struct sigaction& action)
+{
+    WTF::Locker locker { m_refCountMutex };
+    if (!m_installed.load()) {
+        return false;
+    }
+
+    struct sigaction current;
+    if (sigaction(SIGINT, nullptr, &current) != 0
+        || (current.sa_flags & SA_SIGINFO)
+        || current.sa_handler != sigintWatcherHandler) {
+        return false;
+    }
+
+    m_previousAction = action;
+    return true;
+}
+#endif
 
 void SigintWatcher::signalReceived()
 {

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -51,7 +51,9 @@ void SigintWatcher::install()
     sigaddset(&action.sa_mask, SIGINT);
     action.sa_flags = 0;
 
-    sigaction(SIGINT, &action, nullptr);
+    // Save what we displace. `ref()` only reaches install() on the 0 -> 1
+    // transition, so this cannot capture our own handler.
+    sigaction(SIGINT, &action, &m_previousAction);
 #endif
 
     if (m_installed.exchange(true)) {
@@ -90,13 +92,10 @@ void SigintWatcher::uninstall()
 #if OS(WINDOWS)
         SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        struct sigaction action;
-        memset(&action, 0, sizeof(struct sigaction));
-        action.sa_handler = Bun__onPosixSignal;
-        sigemptyset(&action.sa_mask);
-        sigaddset(&action.sa_mask, SIGINT);
-        action.sa_flags = SA_RESTART;
-        sigaction(SIGINT, &action, nullptr);
+        // Put back exactly what install() displaced. Hardcoding Bun__onPosixSignal
+        // here would swallow SIGINT for a process that never registered a
+        // listener, clobbering the startup handler that restores the terminal.
+        sigaction(SIGINT, &m_previousAction, nullptr);
 #endif
 
         m_semaphore.signal();
@@ -119,11 +118,9 @@ void SigintWatcher::registerGlobalObject(JSGlobalObject* globalObject)
     }
 
     WTF::Locker lock(m_globalObjectsMutex);
-    // Append unconditionally: `unregisterGlobalObject` removes exactly one
-    // entry, so skipping a duplicate would let a nested holder (an inner
-    // `runInThisContext({ breakOnSigint: true })`) unregister the outer
-    // holder's global on the way out. `signalAll` tolerates duplicates —
-    // `notifyNeedTermination` only re-sets an already-set trap bit.
+    // Append unconditionally so a nested holder unregisters only its own entry.
+    // `signalAll` tolerates duplicates: `notifyNeedTermination` just re-sets an
+    // already-set trap bit.
     m_globalObjects.append(globalObject);
 }
 
@@ -151,7 +148,10 @@ void SigintWatcher::registerReceiver(SigintReceiver* module)
     }
 
     WTF::Locker lock(m_receiversMutex);
-    m_receivers.appendIfNotContains(module);
+    // Append unconditionally, for the same reason as registerGlobalObject:
+    // `unregisterReceiver` removes one entry. `setSigintReceived` is an
+    // idempotent atomic store, so duplicates are harmless to `signalAll`.
+    m_receivers.append(module);
 }
 
 void SigintWatcher::unregisterReceiver(SigintReceiver* module)

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -20,6 +20,11 @@ static BOOL WindowsCtrlHandler(DWORD signal)
 
     return false;
 }
+#else
+static void sigintWatcherHandler(int)
+{
+    SigintWatcher::get().signalReceived();
+}
 #endif
 
 SigintWatcher::SigintWatcher()
@@ -43,9 +48,7 @@ void SigintWatcher::install()
     struct sigaction action;
     memset(&action, 0, sizeof(struct sigaction));
 
-    action.sa_handler = [](int signalNumber) {
-        get().signalReceived();
-    };
+    action.sa_handler = sigintWatcherHandler;
 
     sigemptyset(&action.sa_mask);
     sigaddset(&action.sa_mask, SIGINT);
@@ -92,10 +95,15 @@ void SigintWatcher::uninstall()
 #if OS(WINDOWS)
         SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        // Put back exactly what install() displaced. Hardcoding Bun__onPosixSignal
-        // here would swallow SIGINT for a process that never registered a
-        // listener, clobbering the startup handler that restores the terminal.
-        sigaction(SIGINT, &m_previousAction, nullptr);
+        // Undo only our own handler. Code that ran while we were armed may have
+        // installed its own (`process.on("SIGINT")`), and clobbering that would
+        // strand the listener for good: BunProcess installs it exactly once.
+        struct sigaction current;
+        if (sigaction(SIGINT, nullptr, &current) == 0
+            && !(current.sa_flags & SA_SIGINFO)
+            && current.sa_handler == sigintWatcherHandler) {
+            sigaction(SIGINT, &m_previousAction, nullptr);
+        }
 #endif
 
         m_semaphore.signal();

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -119,7 +119,12 @@ void SigintWatcher::registerGlobalObject(JSGlobalObject* globalObject)
     }
 
     WTF::Locker lock(m_globalObjectsMutex);
-    m_globalObjects.appendIfNotContains(globalObject);
+    // Append unconditionally: `unregisterGlobalObject` removes exactly one
+    // entry, so skipping a duplicate would let a nested holder (an inner
+    // `runInThisContext({ breakOnSigint: true })`) unregister the outer
+    // holder's global on the way out. `signalAll` tolerates duplicates —
+    // `notifyNeedTermination` only re-sets an already-set trap bit.
+    m_globalObjects.append(globalObject);
 }
 
 void SigintWatcher::unregisterGlobalObject(JSGlobalObject* globalObject)

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -88,27 +88,38 @@ void SigintWatcher::install()
 
 void SigintWatcher::uninstall()
 {
-    if (m_installed.exchange(false)) {
-        WTF::Thread* currentThread = WTF::Thread::currentMayBeNull();
-        ASSERT(!currentThread || m_thread->uid() != currentThread->uid());
+    if (!m_installed.load()) {
+        return;
+    }
 
+    WTF::Thread* currentThread = WTF::Thread::currentMayBeNull();
+    ASSERT(!currentThread || m_thread->uid() != currentThread->uid());
+
+    // Hand the disposition back while still armed. Clearing m_installed first
+    // leaves a window where our handler is live but the watcher thread bails out
+    // of `signalAll`, so a signal landing in it reaches nobody at all.
 #if OS(WINDOWS)
-        SetConsoleCtrlHandler(WindowsCtrlHandler, false);
+    SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        // Undo only our own handler: a native addon may have installed its own
-        // while we were armed, and clobbering it would strand that handler.
-        // `process.on("SIGINT")` instead routes through deferSigintDisposition.
-        struct sigaction current;
-        if (sigaction(SIGINT, nullptr, &current) == 0
-            && !(current.sa_flags & SA_SIGINFO)
-            && current.sa_handler == sigintWatcherHandler) {
-            sigaction(SIGINT, &m_previousAction, nullptr);
-        }
+    // Undo only our own handler: a native addon may have installed its own
+    // while we were armed, and clobbering it would strand that handler.
+    // `process.on("SIGINT")` instead routes through deferSigintDisposition.
+    struct sigaction current;
+    if (sigaction(SIGINT, nullptr, &current) == 0
+        && !(current.sa_flags & SA_SIGINFO)
+        && current.sa_handler == sigintWatcherHandler) {
+        sigaction(SIGINT, &m_previousAction, nullptr);
+    }
 #endif
 
-        m_semaphore.signal();
-        m_thread->waitForCompletion();
+    // The restore above is idempotent, so a second caller that lost this race
+    // (only the destructor can, `deref` holds m_refCountMutex) stops here.
+    if (!m_installed.exchange(false)) {
+        return;
     }
+
+    m_semaphore.signal();
+    m_thread->waitForCompletion();
 }
 
 #if !OS(WINDOWS)

--- a/src/jsc/bindings/vm/SigintWatcher.h
+++ b/src/jsc/bindings/vm/SigintWatcher.h
@@ -106,6 +106,10 @@ private:
     WTF::Vector<JSC::JSGlobalObject*> m_globalObjects;
     WTF::Vector<SigintReceiver*> m_receivers;
     uint32_t m_refCount = 0;
+#if !OS(WINDOWS)
+    // The disposition install() displaced, so uninstall() can put it back.
+    struct sigaction m_previousAction {};
+#endif
 
     bool signalAll();
 };

--- a/src/jsc/bindings/vm/SigintWatcher.h
+++ b/src/jsc/bindings/vm/SigintWatcher.h
@@ -20,6 +20,12 @@ public:
     void install();
     void uninstall();
     void signalReceived();
+#if !OS(WINDOWS)
+    /** While armed we own the SIGINT disposition, so anything that wants to change
+     * it (`process.on("SIGINT")` and its removal) hands us the action to apply when
+     * we disarm. Returns false if we are not armed: install it yourself. */
+    bool deferSigintDisposition(const struct sigaction& action);
+#endif
     void registerGlobalObject(JSC::JSGlobalObject* globalObject);
     void unregisterGlobalObject(JSC::JSGlobalObject* globalObject);
     void registerReceiver(SigintReceiver* module);
@@ -107,7 +113,8 @@ private:
     WTF::Vector<SigintReceiver*> m_receivers;
     uint32_t m_refCount = 0;
 #if !OS(WINDOWS)
-    // The disposition install() displaced, so uninstall() can put it back.
+    // What uninstall() puts back: the disposition install() displaced, unless
+    // deferSigintDisposition() has since replaced it. Guarded by m_refCountMutex.
     struct sigaction m_previousAction {};
 #endif
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1392,7 +1392,10 @@ impl<'a> Repl<'a> {
             if !pending(promise) || Self::sigint_requested(sigint) {
                 return;
             }
-            // SIGINT is delivered without SA_RESTART, so this wakes with EINTR.
+            // Non-blocking while the loop is idle, so the flag above is seen
+            // promptly. With live handles this parks in the poller, which every
+            // path in `us_loop_run_bun_tick` re-enters on EINTR, so a Ctrl+C that
+            // lands after the park waits for whatever wakes the loop next.
             vm.as_mut().auto_tick();
         }
     }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -11,8 +11,7 @@
 //!
 //! This replaces the TypeScript-based REPL for faster startup and better integration.
 
-#[cfg(unix)]
-use core::ffi::c_int;
+use core::ffi::c_void;
 use core::fmt::Arguments;
 use std::io::Write as _;
 
@@ -54,6 +53,34 @@ unsafe extern "C" {
         prefixPtr: *const u8,
         prefixLen: usize,
     ) -> JSValue;
+
+    /// Arms the SIGINT watcher; the returned scope must be passed to
+    /// `Bun__REPL__disarmSigint` exactly once.
+    fn Bun__REPL__armSigint(globalObject: *const JSGlobalObject) -> *mut c_void;
+    fn Bun__REPL__disarmSigint(globalObject: *const JSGlobalObject, scope: *mut c_void);
+    fn Bun__REPL__sigintRequested(scope: *mut c_void) -> bool;
+    /// Clears the VM's SIGINT termination state and hands back the error to
+    /// report, or an empty `JSValue` when no interrupt is pending.
+    fn Bun__REPL__takeSigintError(
+        globalObject: *const JSGlobalObject,
+        scope: *mut c_void,
+    ) -> JSValue;
+}
+
+/// Ctrl+C interruption armed for the duration of one evaluation.
+struct SigintScope {
+    scope: *mut c_void,
+}
+
+/// What one REPL evaluation produced.
+enum EvalOutcome {
+    /// The value of the input, already unwrapped from the `{ value: ... }`
+    /// wrapper the REPL transform adds.
+    Value(JSValue),
+    /// A thrown exception, a rejected promise, or a Ctrl+C interrupt.
+    Error(JSValue),
+    /// A top-level await that never settled. Nothing to print.
+    Pending,
 }
 
 // ============================================================================
@@ -967,51 +994,66 @@ impl<'a> Repl<'a> {
         }
     }
 
-    /// Temporarily enable SIGINT delivery during blocking promise waits
-    fn enable_signals_during_wait(&mut self) {
-        if let Some(vm) = self.vm {
-            // Cleared in disable_signals_during_wait; Release pairs with the
-            // Acquire load in `sigint_handler`.
-            SIGINT_VM.store(vm.jsc_vm, core::sync::atomic::Ordering::Release);
+    /// Make Ctrl+C interrupt the evaluation that is about to run.
+    ///
+    /// Like node's REPL, hand the terminal back to the line discipline so Ctrl+C
+    /// arrives as SIGINT rather than a byte nobody reads, and arm the watcher so
+    /// the signal raises a JSC termination trap, which unwinds `while (true) {}`.
+    /// `None` when not attached to a terminal: SIGINT keeps killing the process.
+    fn begin_interruptible_eval(&mut self) -> Option<SigintScope> {
+        let global = self.global?;
+        if !self.is_tty {
+            return None;
         }
+
+        // Arm before handing the terminal back, so the window where Ctrl+C still
+        // means "kill the process" stays closed.
+        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; the scope is
+        // released exactly once in `end_interruptible_eval`.
+        let scope = unsafe { Bun__REPL__armSigint(global) };
 
         #[cfg(unix)]
-        {
-            // Switch to normal terminal mode (has ISIG) so Ctrl+C generates SIGINT
-            let _ = self.tty_state.set_mode(0, tty::Mode::Normal);
+        let _ = self.tty_state.set_mode(0, tty::Mode::Normal);
+        // On Windows, ENABLE_PROCESSED_INPUT is already set, so Ctrl+C already
+        // arrives as a console control event.
 
-            // Install SIGINT handler
-            // SAFETY: zeroed `sigaction` is a valid empty mask + null restorer; we set
-            // sa_sigaction/sa_flags below. `act` is valid for the duration of the call.
-            unsafe {
-                let mut act: bun_sys::posix::Sigaction = bun_core::ffi::zeroed();
-                act.sa_sigaction = sigint_handler as *const () as usize;
-                act.sa_flags = 0;
-                bun_sys::posix::sigaction(libc::SIGINT, &raw const act, core::ptr::null_mut());
-            }
-        }
-        // On Windows, ENABLE_PROCESSED_INPUT is already set so Ctrl+C works
+        Some(SigintScope { scope })
     }
 
-    /// Restore raw terminal mode after promise wait
-    fn disable_signals_during_wait(&mut self) {
-        SIGINT_VM.store(core::ptr::null_mut(), core::sync::atomic::Ordering::Release);
+    fn end_interruptible_eval(&mut self, scope: Option<SigintScope>) {
+        let Some(global) = self.global else {
+            return;
+        };
+        let Some(scope) = scope else {
+            return;
+        };
 
         #[cfg(unix)]
-        {
-            // Back to raw mode
-            let _ = self.tty_state.set_mode(0, tty::Mode::Raw);
+        let _ = self.tty_state.set_mode(0, tty::Mode::Raw);
 
-            // Restore default SIGINT handling
-            // SAFETY: zeroed `sigaction` is a valid empty mask + null restorer; SIG_DFL
-            // restores the default disposition. `act` is valid for the duration of the call.
-            unsafe {
-                let mut act: bun_sys::posix::Sigaction = bun_core::ffi::zeroed();
-                act.sa_sigaction = libc::SIG_DFL;
-                act.sa_flags = 0;
-                bun_sys::posix::sigaction(libc::SIGINT, &raw const act, core::ptr::null_mut());
-            }
-        }
+        // SAFETY: `scope.scope` came from `Bun__REPL__armSigint` and is consumed
+        // once; `global` is a live opaque `JSGlobalObject` handle.
+        unsafe { Bun__REPL__disarmSigint(global, scope.scope) };
+    }
+
+    /// Whether a Ctrl+C has asked the VM to stop running JavaScript.
+    fn sigint_requested(scope: Option<&SigintScope>) -> bool {
+        let Some(scope) = scope else {
+            return false;
+        };
+        // SAFETY: `scope.scope` is live until `end_interruptible_eval`.
+        unsafe { Bun__REPL__sigintRequested(scope.scope) }
+    }
+
+    /// Clear the VM's termination state and take the error to report, if the
+    /// evaluation was interrupted by Ctrl+C.
+    fn take_interrupt_error(&self, scope: Option<&SigintScope>) -> Option<JSValue> {
+        let global = self.global?;
+        let scope = scope?;
+        // SAFETY: `global` is a live opaque `JSGlobalObject` handle and
+        // `scope.scope` is live until `end_interruptible_eval`.
+        let error = unsafe { Bun__REPL__takeSigintError(global, scope.scope) };
+        (!error.is_empty()).then_some(error)
     }
 
     fn write(&self, data: &[u8]) {
@@ -1261,6 +1303,98 @@ impl<'a> Repl<'a> {
     // JavaScript Evaluation
     // ========================================================================
 
+    /// Evaluate already-transformed REPL input, resolving the async IIFE the
+    /// transform emits for top-level `await`. Ctrl+C interrupts both the
+    /// synchronous evaluation and the wait for the promise.
+    fn evaluate_transformed(&mut self, code: &[u8]) -> EvalOutcome {
+        let Some(global) = self.global else {
+            return EvalOutcome::Pending;
+        };
+        let Some(vm) = self.vm else {
+            return EvalOutcome::Pending;
+        };
+
+        let sigint = self.begin_interruptible_eval();
+
+        let mut exception: JSValue = JSValue::UNDEFINED;
+        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; slice ptr/len pairs
+        // are valid for the duration of the call; `exception` is a stack local.
+        let result = unsafe {
+            Bun__REPL__evaluate(
+                global,
+                code.as_ptr(),
+                code.len(),
+                b"[repl]".as_ptr(),
+                b"[repl]".len(),
+                &raw mut exception,
+            )
+        };
+
+        let mut outcome = if !exception.is_undefined() && !exception.is_null() {
+            EvalOutcome::Error(exception)
+        } else if let Some(promise) = result.as_promise() {
+            // Mark as handled BEFORE waiting to prevent unhandled rejection output
+            jsc::JSPromise::opaque_mut(promise).set_handled();
+            self.wait_for_promise_interruptible(promise, sigint.as_ref());
+            // SAFETY: `vm.jsc_vm` is the live JSC VM handle for this thread.
+            let jsc_vm_ref = vm.jsc_vm();
+            match jsc::JSPromise::opaque_mut(promise).status() {
+                PromiseStatus::Fulfilled => {
+                    EvalOutcome::Value(jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref))
+                }
+                PromiseStatus::Rejected => {
+                    EvalOutcome::Error(jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref))
+                }
+                PromiseStatus::Pending => EvalOutcome::Pending,
+            }
+        } else {
+            EvalOutcome::Value(result)
+        };
+
+        // A Ctrl+C supersedes whatever the evaluation left behind, and the VM
+        // has to come out of its terminated state before it runs JS again.
+        if let Some(error) = self.take_interrupt_error(sigint.as_ref()) {
+            outcome = EvalOutcome::Error(error);
+        }
+        self.end_interruptible_eval(sigint);
+
+        // Unwrap the `{ value: expr }` wrapper the REPL transform adds. It is a
+        // REPL-built `{ __proto__: null, value: ... }` so getOwn shouldn't throw,
+        // but if it does, propagate as a REPL error.
+        if let EvalOutcome::Value(value) = outcome {
+            if value.is_object() {
+                outcome = match value.get_own(global, &bun_core::String::static_("value")) {
+                    Ok(Some(inner)) => EvalOutcome::Value(inner),
+                    Ok(None) => EvalOutcome::Value(value),
+                    Err(err) => EvalOutcome::Error(global.take_exception(err)),
+                };
+            }
+        }
+        outcome
+    }
+
+    /// Wait for `promise` to settle while running the event loop, returning
+    /// early when Ctrl+C asks the VM to stop.
+    fn wait_for_promise_interruptible(
+        &mut self,
+        promise: *mut jsc::JSPromise,
+        sigint: Option<&SigintScope>,
+    ) {
+        let Some(vm) = self.vm else {
+            return;
+        };
+        let pending =
+            |promise| jsc::JSPromise::opaque_mut(promise).status() == PromiseStatus::Pending;
+        while pending(promise) && !Self::sigint_requested(sigint) {
+            vm.as_mut().tick();
+            if !pending(promise) || Self::sigint_requested(sigint) {
+                return;
+            }
+            // SIGINT is delivered without SA_RESTART, so this wakes with EINTR.
+            vm.as_mut().auto_tick();
+        }
+    }
+
     fn evaluate_and_print(&mut self, code: &[u8]) {
         let Some(global) = self.global else {
             return;
@@ -1276,119 +1410,29 @@ impl<'a> Repl<'a> {
             return;
         };
 
-        // Evaluate the transformed code
-        let mut exception: JSValue = JSValue::UNDEFINED;
-        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; slice ptr/len pairs
-        // are valid for the duration of the call; `exception` is a stack local.
-        let result = unsafe {
-            Bun__REPL__evaluate(
-                global,
-                transformed_code.as_ptr(),
-                transformed_code.len(),
-                b"[repl]".as_ptr(),
-                b"[repl]".len(),
-                &raw mut exception,
-            )
-        };
-
-        // Check for exception
-        if !exception.is_undefined() && !exception.is_null() {
-            self.set_last_error(exception);
-            self.print_js_error(exception);
-            return;
-        }
-
-        // Handle async IIFE results - wait for promise to resolve
-        let mut resolved_result = result;
-        if let Some(promise) = result.as_promise() {
-            // Mark as handled BEFORE waiting to prevent unhandled rejection output
-            jsc::JSPromise::opaque_mut(promise).set_handled();
-
-            // Temporarily re-enable signal delivery so Ctrl+C can interrupt
-            // the blocking waitForPromise call
-            self.enable_signals_during_wait();
-            // Note: reshaped for borrowck — call disable_signals_during_wait() explicitly on each return path below
-
-            // Wait for the promise to settle
-            vm.as_mut()
-                .wait_for_promise(jsc::AnyPromise::Normal(promise));
-
-            // If execution was forbidden by SIGINT, clear it and report
-            if vm.jsc_vm().execution_forbidden() {
-                vm.jsc_vm().set_execution_forbidden(false);
-                global.clear_termination_exception();
-                self.print(format_args!("\n"));
-                self.disable_signals_during_wait();
-                return;
+        match self.evaluate_transformed(&transformed_code) {
+            EvalOutcome::Error(error) => {
+                self.set_last_error(error);
+                let global_this = global.to_js_value();
+                global_this.put(global, b"_error", error);
+                self.print_js_error(error);
             }
-
-            // SAFETY: `vm.jsc_vm` is the live JSC VM handle for this thread.
-            let jsc_vm_ref = vm.jsc_vm();
-            // Check promise status after waiting
-            match jsc::JSPromise::opaque_mut(promise).status() {
-                PromiseStatus::Fulfilled => {
-                    resolved_result = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
-                }
-                PromiseStatus::Rejected => {
-                    let rejection = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
-                    self.set_last_error(rejection);
-                    // Set _error on the global object
-                    let global_this = global.to_js_value();
-                    global_this.put(global, b"_error", rejection);
-                    self.print_js_error(rejection);
-                    self.disable_signals_during_wait();
-                    return;
-                }
-                PromiseStatus::Pending => {
-                    // Interrupted by signal or timed out
-                    self.print(format_args!("\n"));
-                    self.disable_signals_during_wait();
-                    return;
-                }
-            }
-            self.disable_signals_during_wait();
-        }
-
-        // Extract the value from the result wrapper { value: expr }
-        // The REPL transform wraps the last expression in { value: expr }
-        let mut actual_result = resolved_result;
-        if resolved_result.is_object() {
-            // Wrapper is REPL-built { __proto__: null, value: ... } so getOwn shouldn't throw,
-            // but if it does, propagate as a REPL error.
-            let maybe_value =
-                match resolved_result.get_own(global, &bun_core::String::static_("value")) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        let exc = global.take_exception(err);
-                        self.set_last_error(exc);
-                        self.print_js_error(exc);
-                        vm.as_mut().tick();
-                        return;
+            EvalOutcome::Pending => self.print(format_args!("\n")),
+            EvalOutcome::Value(value) => {
+                self.set_last_result(value);
+                if value.is_undefined() {
+                    if self.use_colors {
+                        self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
+                    } else {
+                        self.print(format_args!("undefined\n"));
                     }
-                };
-            if let Some(value) = maybe_value {
-                actual_result = value;
+                } else {
+                    // Set `_` to the last result (only if not undefined)
+                    let global_this = global.to_js_value();
+                    global_this.put(global, b"_", value);
+                    self.print_formatted_value(value);
+                }
             }
-        }
-
-        // Store and print result
-        self.set_last_result(actual_result);
-
-        // Set _ to the last result (only if not undefined)
-        // Use the global object as JSValue and put the property on it
-        if !actual_result.is_undefined() {
-            let global_this = global.to_js_value();
-            global_this.put(global, b"_", actual_result);
-        }
-
-        if actual_result.is_undefined() {
-            if self.use_colors {
-                self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
-            } else {
-                self.print(format_args!("undefined\n"));
-            }
-        } else {
-            self.print_formatted_value(actual_result);
         }
 
         // Tick the event loop to handle any pending work
@@ -1584,90 +1628,24 @@ impl<'a> Repl<'a> {
             return;
         };
 
-        let mut exception: JSValue = JSValue::UNDEFINED;
-        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; slice ptr/len pairs
-        // are valid for the duration of the call; `exception` is a stack local.
-        let result = unsafe {
-            Bun__REPL__evaluate(
-                global,
-                transformed_code.as_ptr(),
-                transformed_code.len(),
-                b"[repl]".as_ptr(),
-                b"[repl]".len(),
-                &raw mut exception,
-            )
-        };
-
-        if !exception.is_undefined() && !exception.is_null() {
-            self.set_last_error(exception);
-            self.print_js_error(exception);
-            return;
-        }
-
-        let mut resolved_result = result;
-        if let Some(promise) = result.as_promise() {
-            // SAFETY: `promise` is a live JSC heap cell; `vm.jsc_vm` is the
-            // owning JSC VM handle for this thread.
-            jsc::JSPromise::opaque_mut(promise).set_handled();
-            self.enable_signals_during_wait();
-            // Note: reshaped for borrowck — disable_signals_during_wait called on each path
-            vm.as_mut()
-                .wait_for_promise(jsc::AnyPromise::Normal(promise));
-            if vm.jsc_vm().execution_forbidden() {
-                vm.jsc_vm().set_execution_forbidden(false);
-                global.clear_termination_exception();
-                self.print(format_args!("\n"));
-                self.disable_signals_during_wait();
-                return;
+        match self.evaluate_transformed(&transformed_code) {
+            EvalOutcome::Error(error) => {
+                self.set_last_error(error);
+                self.print_js_error(error);
             }
-            let jsc_vm_ref = vm.jsc_vm();
-            match jsc::JSPromise::opaque_mut(promise).status() {
-                PromiseStatus::Fulfilled => {
-                    resolved_result = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref)
+            EvalOutcome::Pending => {}
+            EvalOutcome::Value(value) => {
+                self.set_last_result(value);
+                if !value.is_undefined() {
+                    let global_this = global.to_js_value();
+                    global_this.put(global, b"_", value);
                 }
-                PromiseStatus::Rejected => {
-                    let rejection = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
-                    self.set_last_error(rejection);
-                    self.print_js_error(rejection);
-                    self.disable_signals_during_wait();
-                    return;
-                }
-                PromiseStatus::Pending => {
-                    self.disable_signals_during_wait();
-                    return;
+                if let Err(err) = self.copy_value_to_clipboard(value) {
+                    let exc = global.take_exception(err);
+                    self.set_last_error(exc);
+                    self.print_js_error(exc);
                 }
             }
-            self.disable_signals_during_wait();
-        }
-
-        let mut actual_result = resolved_result;
-        if resolved_result.is_object() {
-            let maybe_value =
-                match resolved_result.get_own(global, &bun_core::String::static_("value")) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        let exc = global.take_exception(err);
-                        self.set_last_error(exc);
-                        self.print_js_error(exc);
-                        vm.as_mut().tick();
-                        return;
-                    }
-                };
-            if let Some(value) = maybe_value {
-                actual_result = value;
-            }
-        }
-
-        self.set_last_result(actual_result);
-        if !actual_result.is_undefined() {
-            let global_this = global.to_js_value();
-            global_this.put(global, b"_", actual_result);
-        }
-
-        if let Err(err) = self.copy_value_to_clipboard(actual_result) {
-            let exc = global.take_exception(err);
-            self.set_last_error(exc);
-            self.print_js_error(exc);
         }
         vm.as_mut().tick();
     }
@@ -2432,23 +2410,6 @@ impl<'a> Drop for Repl<'a> {
         self.history.save();
         // line_editor, history, multiline_buffer, editor_buffer, last_result,
         // last_error dropped automatically (ProtectedJSValue unprotects).
-    }
-}
-
-/// Global pointer for signal handler to access the VM.
-// PORTING.md §Global mutable state: read from a signal handler → AtomicPtr.
-// Atomics are async-signal-safe; the previous raw-global `Option<*mut>` was
-// not. `null` encodes `None`.
-static SIGINT_VM: core::sync::atomic::AtomicPtr<jsc::VM> =
-    core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
-
-#[cfg(unix)]
-extern "C" fn sigint_handler(_: c_int) {
-    let vm = SIGINT_VM.load(core::sync::atomic::Ordering::Acquire);
-    if !vm.is_null() {
-        // `vm` was a valid `*mut jsc::VM` when stored (JS thread is
-        // blocked in wait while the handler runs, so it stays valid).
-        jsc::VM::opaque_ref(vm).set_execution_forbidden(true);
     }
 }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1021,16 +1021,18 @@ impl<'a> Repl<'a> {
     }
 
     fn end_interruptible_eval(&mut self, scope: Option<SigintScope>) {
-        let Some(global) = self.global else {
-            return;
-        };
         let Some(scope) = scope else {
             return;
         };
 
+        // Before anything fallible: leaving the prompt in cooked mode is worse
+        // than any error we could hit below.
         #[cfg(unix)]
         let _ = self.tty_state.set_mode(0, tty::Mode::Raw);
 
+        // A scope is only handed out once `begin_interruptible_eval` has seen a
+        // global, and `self.global` is set once per session.
+        let global = self.global.expect("sigint scope armed without a global");
         // SAFETY: `scope.scope` came from `Bun__REPL__armSigint` and is consumed
         // once; `global` is a live opaque `JSGlobalObject` handle.
         unsafe { Bun__REPL__disarmSigint(global, scope.scope) };

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1335,6 +1335,8 @@ impl<'a> Repl<'a> {
         let mut outcome = if !exception.is_undefined() && !exception.is_null() {
             EvalOutcome::Error(exception)
         } else if let Some(promise) = result.as_promise() {
+            // The wait ticks the VM, which can collect; keep the promise rooted.
+            let _rooted = result.protected();
             // Mark as handled BEFORE waiting to prevent unhandled rejection output
             jsc::JSPromise::opaque_mut(promise).set_handled();
             self.wait_for_promise_interruptible(promise, sigint.as_ref());
@@ -1392,10 +1394,14 @@ impl<'a> Repl<'a> {
             if !pending(promise) || Self::sigint_requested(sigint) {
                 return;
             }
-            // Non-blocking while the loop is idle, so the flag above is seen
-            // promptly. With live handles this parks in the poller, which every
-            // path in `us_loop_run_bun_tick` re-enters on EINTR, so a Ctrl+C that
-            // lands after the park waits for whatever wakes the loop next.
+            // With no live handles `auto_tick` never blocks, so nothing can settle
+            // the promise and looping would just burn a core.
+            if !vm.is_event_loop_alive() {
+                return;
+            }
+            // Parks in the poller. Every path in `us_loop_run_bun_tick` re-enters
+            // it on EINTR, so a Ctrl+C landing after the park is only seen once
+            // something else wakes the loop.
             vm.as_mut().auto_tick();
         }
     }
@@ -1636,6 +1642,7 @@ impl<'a> Repl<'a> {
         match self.evaluate_transformed(&transformed_code) {
             EvalOutcome::Error(error) => {
                 self.set_last_error(error);
+                global.to_js_value().put(global, b"_error", error);
                 self.print_js_error(error);
             }
             EvalOutcome::Pending => {}
@@ -1648,6 +1655,7 @@ impl<'a> Repl<'a> {
                 if let Err(err) = self.copy_value_to_clipboard(value) {
                     let exc = global.take_exception(err);
                     self.set_last_error(exc);
+                    global.to_js_value().put(global, b"_error", exc);
                     self.print_js_error(exc);
                 }
             }

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1021,12 +1021,19 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
   // strand the listener for the rest of the session.
   test("a SIGINT listener registered in the REPL survives the evaluation", async () => {
     await withTerminalRepl(async ({ send, waitFor, proc }) => {
-      send("process.on('SIGINT', () => {}); 1 + 1\n");
+      // Split the literal so the echoed input line can't satisfy the wait.
+      send("process.on('SIGINT', () => console.log('CAUGHT_' + 'SIGINT')); 1 + 1\n");
       await waitFor(/\n\s*2\b/);
 
       proc.kill("SIGINT");
-      const outcome = await Promise.race([proc.exited.then(() => "exited"), Bun.sleep(2000).then(() => "alive")]);
-      expect(outcome).toBe("alive");
+      // The loop only runs during an evaluation, so the queued signal is handed
+      // to the listener on the next one. The signal is already pending when the
+      // keystrokes are written, and a handler runs before the read they satisfy
+      // returns to userspace, so the marker can't be missed.
+      send("3 + 4\n");
+      // Getting the marker at all proves the process survived and the listener,
+      // rather than the watcher's handler, is what the disposition points at.
+      await waitFor("CAUGHT_SIGINT");
     });
   });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -51,27 +51,30 @@ async function withTerminalRepl(
   let cursor = 0;
   let resolveWaiter: (() => void) | null = null;
 
-  await using terminal = new Bun.Terminal({
-    cols: 120,
-    rows: 40,
-    data(_term, data) {
-      const str = Buffer.from(data).toString();
-      received.push(str);
-      if (resolveWaiter) {
-        resolveWaiter();
-        resolveWaiter = null;
-      }
-    },
-  });
-
+  // The inline `terminal` option is what makes the child a session leader with
+  // the pty as its controlling terminal, so Ctrl+C reaches it as SIGINT.
+  // Handing `Bun.spawn` an already-created `Bun.Terminal` skips that setup.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "repl"],
-    terminal,
     env: {
       ...bunEnv,
       TERM: "xterm-256color",
     },
+    terminal: {
+      cols: 120,
+      rows: 40,
+      data(_term, data) {
+        const str = Buffer.from(data).toString();
+        received.push(str);
+        if (resolveWaiter) {
+          resolveWaiter();
+          resolveWaiter = null;
+        }
+      },
+    },
   });
+  const terminal = proc.terminal!;
+  using closeTerminal = { [Symbol.dispose]: () => terminal.close() };
 
   const send = (text: string) => terminal.write(text);
 
@@ -91,11 +94,14 @@ async function withTerminalRepl(
           `Timed out waiting for pattern: ${pattern}\nReceived so far:\n${stripAnsi(received.join("").slice(cursor))}`,
         );
       }
-      // Wait for the next chunk of terminal data (or time out).
-
-      await new Promise<void>(resolve => {
-        resolveWaiter = resolve;
-      });
+      // Wait for the next chunk of terminal data, or for the deadline: without
+      // the race this sleeps forever when the child goes quiet.
+      await Promise.race([
+        new Promise<void>(resolve => {
+          resolveWaiter = resolve;
+        }),
+        Bun.sleep(remaining),
+      ]);
       resolveWaiter = null;
     }
   };
@@ -990,6 +996,43 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       terminal.write("\x04"); // Ctrl+D
       const exitCode = await Promise.race([proc.exited, Bun.sleep(3000).then(() => -1)]);
       expect(exitCode).toBe(0);
+    });
+  });
+
+  // The REPL used to stay in raw mode while evaluating, so Ctrl+C was delivered
+  // as a byte nobody read and a synchronous loop could only be escaped by
+  // killing the process (which left the terminal in raw mode).
+  test("Ctrl+C interrupts a synchronous infinite loop", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      // Print from inside the evaluation so the interrupt is sent only once the
+      // loop is actually running. Split the literal so the echoed input line
+      // can't satisfy the wait.
+      send(`process.stdout.write("RUN" + "NING\\n"); while (true) {}\n`);
+      await waitFor("RUNNING");
+      send("\x03"); // Ctrl+C
+      const output = await waitFor(/interrupted/);
+      expect(stripAnsi(output)).toContain("Script execution was interrupted by `SIGINT`");
+
+      // And the session keeps working.
+      send("111 + 222\n");
+      await waitFor(/\n\s*333\b/);
+    });
+  });
+
+  test("Ctrl+C during a never-settling await leaves the REPL usable", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      // The executor runs synchronously, so printing from it marks the point
+      // where the REPL starts waiting. The long timer keeps the loop alive, so
+      // the wait parks in the poller exactly like a real pending `await` would.
+      send(`await new Promise(() => { process.stdout.write("WAIT" + "ING\\n"); setTimeout(() => {}, 600000); })\n`);
+      await waitFor("WAITING");
+      send("\x03"); // Ctrl+C
+      await waitFor(/interrupted/);
+
+      // Interrupting used to leave the VM permanently execution-forbidden,
+      // which silently dropped every microtask from then on.
+      send("await Promise.resolve(1234 * 1000)\n");
+      await waitFor(/\n\s*1234000\b/);
     });
   });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -999,6 +999,23 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
+  // Arming the SIGINT watcher around every evaluation must put the previous
+  // disposition back, or an external SIGINT is swallowed from then on and the
+  // startup handler that restores the terminal never runs.
+  test("an external SIGINT at the prompt still terminates the REPL", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      send("1 + 1\n");
+      await waitFor(/\n\s*2\b/);
+
+      proc.kill("SIGINT");
+      const exited = await Promise.race([
+        proc.exited.then(() => "exited"),
+        Bun.sleep(4000).then(() => "still running"),
+      ]);
+      expect(exited).toBe("exited");
+    });
+  });
+
   // The REPL used to stay in raw mode while evaluating, so Ctrl+C was delivered
   // as a byte nobody read and a synchronous loop could only be escaped by
   // killing the process (which left the terminal in raw mode).
@@ -1021,10 +1038,10 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
 
   test("Ctrl+C during a never-settling await leaves the REPL usable", async () => {
     await withTerminalRepl(async ({ send, waitFor }) => {
-      // The executor runs synchronously, so printing from it marks the point
-      // where the REPL starts waiting. Nothing keeps the loop alive, so the wait
-      // never parks in the poller and the interrupt is picked up immediately.
-      send(`await new Promise(() => { process.stdout.write("WAIT" + "ING\\n"); })\n`);
+      // The executor runs synchronously, so printing from it marks the point where
+      // the REPL starts waiting. The short interval keeps the loop alive, so the
+      // wait parks in the poller but wakes often enough to notice the interrupt.
+      send(`await new Promise(() => { process.stdout.write("WAIT" + "ING\\n"); setInterval(() => {}, 10); })\n`);
       await waitFor("WAITING");
       send("\x03"); // Ctrl+C
       await waitFor(/interrupted/);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1030,6 +1030,41 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
+  // And the mirror: dropping the last listener has to put the default action back.
+  // BunProcess reinstates the watcher's own handler rather than uninstalling it,
+  // so the disarm used to see its handler intact and restore the stale snapshot.
+  test("removing the last SIGINT listener restores the default disposition", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      send("globalThis.h = () => {}; process.on('SIGINT', globalThis.h); 1 + 1\n");
+      await waitFor(/\n\s*2\b/);
+
+      send("process.removeListener('SIGINT', globalThis.h); 3 + 4\n");
+      await waitFor(/\n\s*7\b/);
+
+      proc.kill("SIGINT");
+      const outcome = await Promise.race([
+        proc.exited.then(() => "exited"),
+        Bun.sleep(4000).then(() => "still running"),
+      ]);
+      expect(outcome).toBe("exited");
+    });
+  });
+
+  // Adding a listener used to install over the watcher's handler, downgrading
+  // Ctrl+C to a JS event that the loop it is meant to break out of never drains.
+  test("Ctrl+C interrupts a loop that installed a SIGINT listener first", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send(`process.on("SIGINT", () => {}); process.stdout.write("LOOP" + "ING\\n"); while (true) {}\n`);
+      await waitFor("LOOPING");
+      send("\x03"); // Ctrl+C
+      const output = await waitFor(/interrupted/);
+      expect(stripAnsi(output)).toContain("Script execution was interrupted by `SIGINT`");
+
+      send("111 + 222\n");
+      await waitFor(/\n\s*333\b/);
+    });
+  });
+
   // The REPL used to stay in raw mode while evaluating, so Ctrl+C was delivered
   // as a byte nobody read and a synchronous loop could only be escaped by
   // killing the process (which left the terminal in raw mode).

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1016,6 +1016,20 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
+  // The disarm must not clobber a handler installed while the watcher was armed:
+  // BunProcess registers its SIGINT handler exactly once, so discarding it would
+  // strand the listener for the rest of the session.
+  test("a SIGINT listener registered in the REPL survives the evaluation", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      send("process.on('SIGINT', () => {}); 1 + 1\n");
+      await waitFor(/\n\s*2\b/);
+
+      proc.kill("SIGINT");
+      const outcome = await Promise.race([proc.exited.then(() => "exited"), Bun.sleep(2000).then(() => "alive")]);
+      expect(outcome).toBe("alive");
+    });
+  });
+
   // The REPL used to stay in raw mode while evaluating, so Ctrl+C was delivered
   // as a byte nobody read and a synchronous loop could only be escaped by
   // killing the process (which left the terminal in raw mode).

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1022,9 +1022,9 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
   test("Ctrl+C during a never-settling await leaves the REPL usable", async () => {
     await withTerminalRepl(async ({ send, waitFor }) => {
       // The executor runs synchronously, so printing from it marks the point
-      // where the REPL starts waiting. The long timer keeps the loop alive, so
-      // the wait parks in the poller exactly like a real pending `await` would.
-      send(`await new Promise(() => { process.stdout.write("WAIT" + "ING\\n"); setTimeout(() => {}, 600000); })\n`);
+      // where the REPL starts waiting. Nothing keeps the loop alive, so the wait
+      // never parks in the poller and the interrupt is picked up immediately.
+      send(`await new Promise(() => { process.stdout.write("WAIT" + "ING\\n"); })\n`);
       await waitFor("WAITING");
       send("\x03"); // Ctrl+C
       await waitFor(/interrupted/);
@@ -1033,6 +1033,36 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       // which silently dropped every microtask from then on.
       send("await Promise.resolve(1234 * 1000)\n");
       await waitFor(/\n\s*1234000\b/);
+    });
+  });
+
+  // The inner script's termination reached `checkForTermination` with neither a
+  // SIGINT flag of its own nor a timeout, which used to abort the process.
+  test("Ctrl+C during a nested vm.runInThisContext does not abort", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      // No `\n` escape inside the nested string: the REPL mishandles one there
+      // (pre-existing, reproduces on release bun), and the marker doesn't need it.
+      send(`require('vm').runInThisContext('process.stdout.write("IN"+"NER"); while (true) {}')\n`);
+      await waitFor("INNER");
+      send("\x03"); // Ctrl+C
+      await waitFor(/interrupted/);
+
+      // Reaching a result at all proves the process survived the interrupt.
+      send("111 + 222\n");
+      await waitFor(/\n\s*333\b/);
+    });
+  });
+
+  // The inner `breakOnSigint` holder used to unregister the REPL's own global on
+  // the way out, leaving the rest of the evaluation uninterruptible.
+  test("Ctrl+C still interrupts after a nested breakOnSigint script", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send(
+        `require('vm').runInThisContext('1', { breakOnSigint: true }); process.stdout.write("AFT"+"ER\\n"); while (true) {}\n`,
+      );
+      await waitFor("AFTER");
+      send("\x03"); // Ctrl+C
+      await waitFor(/interrupted/);
     });
   });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -978,10 +978,10 @@ test("a terminated context-less module does not discard the main microtask queue
     const chain = promise.then(() => "survived");
     resolve(); // the continuation is now parked in the main microtask queue
 
-    const guard = setTimeout(() => { console.log("HUNG"); process.exit(3); }, 8000);
-    await m.evaluate({ timeout: 100 }).then(() => console.log("NO_THROW"), e => console.log("threw=" + e.code));
-    console.log("chain=" + (await chain));
-    clearTimeout(guard);
+    m.evaluate({ timeout: 100 }).then(() => console.log("NO_THROW"), e => console.log("threw=" + e.code));
+    // Clearing the queue drops the continuation, so this never prints and the
+    // process exits with nothing left to do.
+    chain.then(v => console.log("chain=" + v));
   `;
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -89,19 +89,26 @@ describe("vm", () => {
 
     // An outer watchdog firing while a nested no-options script is on the stack
     // used to abort the process, and then to report it as a SIGINT. Only the
-    // scope that armed the termination can classify it.
-    test("an outer timeout reports ERR_SCRIPT_EXECUTION_TIMEOUT through a nested script", () => {
-      (globalThis as any).__nestedSpin = () => runInThisContext("while (true) {}");
-      try {
-        expect(() => runInThisContext("__nestedSpin()", { timeout: 100 })).toThrow(
-          expect.objectContaining({
-            code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
-            message: "Script execution timed out after 100ms",
-          }),
-        );
-      } finally {
-        delete (globalThis as any).__nestedSpin;
-      }
+    // scope that armed the termination can classify it. Spawned, so a regression
+    // back to the abort is an attributable failure rather than a dead runner.
+    test("an outer timeout reports ERR_SCRIPT_EXECUTION_TIMEOUT through a nested script", async () => {
+      const fixture = `
+        const vm = require("node:vm");
+        globalThis.__nestedSpin = () => vm.runInThisContext("while (true) {}");
+        try {
+          vm.runInThisContext("__nestedSpin()", { timeout: 100 });
+          console.log("NO_THROW");
+        } catch (e) {
+          console.log(e.code + " " + e.message);
+        }
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      capture(stderr);
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({
+        stdout: "ERR_SCRIPT_EXECUTION_TIMEOUT Script execution timed out after 100ms",
+        exitCode: 0,
+      });
     });
   });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -965,6 +965,33 @@ test("Loader is not defined in vm context", () => {
   expect(runInContext("typeof Loader.registry;", customContext)).toBe("undefined");
 });
 
+// `drainMicrotasksForGlobalObject` *clears* rather than drains, so a terminated
+// module must only clear its own context's global. Passing the caller's global
+// discarded the main thread's pending microtasks and wedged the process.
+test("a terminated context-less module does not discard the main microtask queue", async () => {
+  const fixture = `
+    const vm = require("node:vm");
+    const m = new vm.SourceTextModule("while (true) {}");
+    await m.link(() => {});
+
+    const { promise, resolve } = Promise.withResolvers();
+    const chain = promise.then(() => "survived");
+    resolve(); // the continuation is now parked in the main microtask queue
+
+    const guard = setTimeout(() => { console.log("HUNG"); process.exit(3); }, 8000);
+    await m.evaluate({ timeout: 100 }).then(() => console.log("NO_THROW"), e => console.log("threw=" + e.code));
+    console.log("chain=" + (await chain));
+    clearTimeout(guard);
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  capture(stderr);
+  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    stdout: ["threw=ERR_SCRIPT_EXECUTION_TIMEOUT", "chain=survived"],
+    exitCode: 0,
+  });
+});
+
 // Re-raising an enclosing scope's termination must not hand the VM's singleton
 // TerminationException to the module: storing it and re-throwing it once the
 // request is cleared trips `VM::setException`'s

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -992,6 +992,36 @@ test("a terminated context-less module does not discard the main microtask queue
   });
 });
 
+// Same clear, reached from the script side. `runInThisContext` evaluates in the
+// caller's global, so there is no context queue to clear and the caller's one is
+// not ours to discard. Node keeps the continuation here too.
+test("a timed-out runInThisContext does not discard the main microtask queue", async () => {
+  const fixture = `
+    const vm = require("node:vm");
+
+    const { promise, resolve } = Promise.withResolvers();
+    const chain = promise.then(() => "survived");
+    resolve(); // the continuation is now parked in the main microtask queue
+
+    try {
+      vm.runInThisContext("while (true) {}", { timeout: 100 });
+      console.log("NO_THROW");
+    } catch (e) {
+      console.log("threw=" + e.code);
+    }
+    // Clearing the queue drops the continuation, so this never prints and the
+    // process exits with nothing left to do.
+    chain.then(v => console.log("chain=" + v));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  capture(stderr);
+  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    stdout: ["threw=ERR_SCRIPT_EXECUTION_TIMEOUT", "chain=survived"],
+    exitCode: 0,
+  });
+});
+
 // Re-raising an enclosing scope's termination must not hand the VM's singleton
 // TerminationException to the module: storing it and re-throwing it once the
 // request is cleared trips `VM::setException`'s

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -86,6 +86,23 @@ describe("vm", () => {
       });
       expect(result).toBe(2);
     });
+
+    // An outer watchdog firing while a nested no-options script is on the stack
+    // used to abort the process, and then to report it as a SIGINT. Only the
+    // scope that armed the termination can classify it.
+    test("an outer timeout reports ERR_SCRIPT_EXECUTION_TIMEOUT through a nested script", () => {
+      (globalThis as any).__nestedSpin = () => runInThisContext("while (true) {}");
+      try {
+        expect(() => runInThisContext("__nestedSpin()", { timeout: 100 })).toThrow(
+          expect.objectContaining({
+            code: "ERR_SCRIPT_EXECUTION_TIMEOUT",
+            message: "Script execution timed out after 100ms",
+          }),
+        );
+      } finally {
+        delete (globalThis as any).__nestedSpin;
+      }
+    });
   });
 
   describe("compileFunction()", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -958,6 +958,52 @@ test("Loader is not defined in vm context", () => {
   expect(runInContext("typeof Loader.registry;", customContext)).toBe("undefined");
 });
 
+// Re-raising an enclosing scope's termination must not hand the VM's singleton
+// TerminationException to the module: storing it and re-throwing it once the
+// request is cleared trips `VM::setException`'s
+// `!isTerminationException(e) || hasTerminationRequest()` assertion.
+test("a module terminated by an enclosing scope ends up errored without aborting", async () => {
+  const fixture = `
+    const vm = require("node:vm");
+    const m = new vm.SourceTextModule("while (true) {}");
+    await m.link(() => {});
+    globalThis.__run = () => {
+      const p = m.evaluate();
+      p.catch(() => {});
+      return p;
+    };
+    try {
+      vm.runInThisContext("__run()", { timeout: 100 });
+      console.log("outer=NO_THROW");
+    } catch (e) {
+      console.log("outer=" + e.code);
+    }
+    console.log("status=" + m.status);
+    try {
+      m.error;
+      console.log("error=readable");
+    } catch (e) {
+      console.log("error=threw:" + e.code);
+    }
+    // Re-evaluating an errored module re-throws the error it stored. That is
+    // where a stored TerminationException trips the assertion.
+    try {
+      const again = m.evaluate();
+      again.catch(() => {});
+      console.log("reeval=ok");
+    } catch (e) {
+      console.log("reeval=threw:" + (e.code ?? e.name));
+    }
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
+    stdout: ["outer=ERR_SCRIPT_EXECUTION_TIMEOUT", "status=errored", "error=readable", "reeval=ok"],
+    exitCode: 0,
+  });
+  capture(stderr);
+});
+
 test("node:vm native Module prototype methods reject non-module receivers", async () => {
   // The native NodeVMModule prototype (reachable via the kNative own-symbol on a
   // vm.SourceTextModule instance) must validate its receiver. Calling its methods

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -997,11 +997,12 @@ test("a module terminated by an enclosing scope ends up errored without aborting
   `;
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Before the assertion: a native abort makes stderr the useful diagnostic.
+  capture(stderr);
   expect({ stdout: stdout.trim().split("\n"), exitCode }).toEqual({
     stdout: ["outer=ERR_SCRIPT_EXECUTION_TIMEOUT", "status=errored", "error=readable", "reeval=ok"],
     exitCode: 0,
   });
-  capture(stderr);
 });
 
 test("node:vm native Module prototype methods reject non-module receivers", async () => {


### PR DESCRIPTION
## Repro

```console
$ bun repl
> while (true) {}
^C ^C            # nothing. the process has to be killed from another terminal,
                 # and it leaves termios in raw mode
```

Node interrupts with `ERR_SCRIPT_EXECUTION_INTERRUPTED` and keeps going.

A second, quieter one: a single Ctrl+C during an `await` leaves the session
silently broken.

```console
$ bun repl
> await new Promise(() => {})
^C
> await Promise.resolve(42)    # never prints 42, and never will again
```

## Cause

The REPL keeps the terminal in raw mode while it evaluates. Raw mode clears
`ISIG`, so Ctrl+C is not a signal, it is byte `0x03` sitting in the tty input
queue with nobody reading it. Nothing can unwind the running script.

Node's REPL hands the terminal back to the line discipline for the duration of a
command (`ISIG`/`ICANON`/`ECHO` all back on), so Ctrl+C arrives as a real SIGINT,
and `runInThisContext({ breakOnSigint: true })` turns that into a V8 termination.

The `await` case went through `Repl.enable_signals_during_wait`, whose handler
called `JSC::VM::setExecutionForbidden()`. That flag is one-way (JSC has no API
to clear it), and `VM::drainMicrotasks` then clears the microtask queue on every
tick, so the session never runs another microtask.

## Fix

`begin_interruptible_eval` puts the terminal back in cooked mode and arms the
`SigintWatcher` already used by `node:vm`'s `breakOnSigint`. The watcher thread
calls `VM::notifyNeedTermination()`, which raises a `VMTraps::NeedTermination`
trap at the next safepoint, so `while (true) {}` unwinds. The REPL then reports
`ERR_SCRIPT_EXECUTION_INTERRUPTED` and returns to the prompt, exactly as node
does. Windows already sets `ENABLE_PROCESSED_INPUT`, so only the watcher is
needed there.

One wrinkle worth recording: `VM::executeEntryScopeServicesOnExit()` clears
`hasTerminationRequest()` once the outermost entry scope unwinds, and the trap
bit is cleared by `handleTraps()` before that. Neither survives the return from
`JSC::evaluate`, so the durable record of the signal is the `SigintReceiver`
flag, which the watcher sets before raising the trap. That flag is written by
the watcher thread and read by the VM thread, so it is now `std::atomic<bool>`
(`node:vm` was reading it across threads too).

The `setExecutionForbidden()` path is gone. The promise wait now polls the
receiver flag and breaks out on it, leaving the VM able to run JavaScript.

`evaluate_and_print` and `evaluate_and_copy` had a duplicated copy of the
evaluate/await/unwrap sequence; they now share `evaluate_transformed`, which is
where the interrupt handling lives.


## Who owns the SIGINT disposition

Arming the watcher around every evaluation also puts it in conflict with
`BunProcess`, which installs its own `forwardSignal` handler for
`process.on("SIGINT")`. Both sides refuse to uninstall a handler they did not
install, and that guard leaves the disposition wrong in both directions.

Adding a listener, `sigaction(SIGINT, forwardSignal)` displaces the watcher's
handler **while it is armed**, so Ctrl+C is downgraded to a JS event that the
loop it is meant to interrupt never drains:

```console
> process.on("SIGINT", () => {}); while (true) {}
^C            # nothing, same as before this PR
```

Removing the last one, `signal(SIGINT, SIG_DFL)` finds the watcher's handler,
does not recognise it, and reinstates it. The disarm then sees its own handler
still installed and restores the snapshot it took at arm time, which is the
forwarder `BunProcess` just asked to drop, so an external `kill -INT` is
silently swallowed from then on.

While the watcher is armed it owns the disposition, so `BunProcess` hands it the
action to apply on disarm (`SigintWatcher::deferSigintDisposition`) instead of
installing over its handler. With nothing armed the method returns false on its
first line and `BunProcess` is unchanged, which is every path outside `node:vm`
and the REPL.

One more ordering bug fell out of the same audit. `uninstall()` cleared
`m_installed` while its own handler was still the disposition, so a signal in
that window ran the handler, posted the semaphore, and the watcher thread bailed
on `if (!m_installed) return;` before forwarding it. Nobody saw the signal, and
`m_waiting` stayed set, which deafens the watcher from then on. The disposition
now goes back first. With the window artificially widened to 50ms, 30 signals
land somewhere accounted for (`fired + interrupted == 30`) on every run; with the
old ordering two vanished outright in the run that finished and the other two
runs never reached the fixture's exit path.

## Tests

The new REPL tests drive a real pty. They needed one harness change: handing
`Bun.spawn` an already-created `Bun.Terminal` skips the `setsid()` +
`ioctl(TIOCSCTTY)` the inline `terminal: {...}` option performs, so the child had
no controlling terminal (`tty_nr: 0`, `tpgid: -1`) and the line discipline had no
foreground process group to signal. `withTerminalRepl` now uses the inline form.
Its `waitFor` also gained the timeout its `deadline` always implied: it used to
sleep forever when the child went quiet, reporting a bare test timeout instead of
the captured output.

```
git checkout main -- src/ && bun bd test test/js/bun/repl/repl.test.ts \
  -t "Ctrl\+C interrupts|never-settling await"
  → 2 fail   "Timed out waiting for pattern: /interrupted/"

bun bd test test/js/bun/repl/repl.test.ts
  → 125 pass, 0 fail
bun bd test test/js/node/vm/vm.test.ts
  → 210 pass, 0 fail
```

Four of the REPL tests pin the SIGINT disposition, one per reachable state: no
listener (an external SIGINT terminates), a listener added (it does not), the
listener then removed (it terminates again), and a listener added in front of the
loop Ctrl+C has to break out of. The last two fail with `deferSigintDisposition`
stubbed to `return false` on the same build.

`node:vm`'s sigint/timeout suites (`test-vm-sigint.js`,
`test-vm-sigint-existing-handler.js`, `test-vm-timeout.js`,
`test-vm-timeout-escape-promise.js`, `test/js/node/vm/vm.test.ts`) still pass,
as does `test/js/bun/terminal/`. `bun run rust:check-all` is clean on all 10
targets.

On Windows the watcher goes through `SetConsoleCtrlHandler`, and the REPL's raw
mode already sets `ENABLE_PROCESSED_INPUT`, so Ctrl+C was already arriving as a
console control event and only the watcher was missing. That path is untested
here: the terminal REPL suite is `describe.todoIf(isWindows)`.

## Bugs this surfaces in `node:vm`

Arming the watcher around every REPL evaluation makes the REPL an outer
`SigintWatcher` holder, which reaches code nothing reached before.

`require('vm').runInThisContext('while(true){}')` + Ctrl+C **aborted the
process**: the inner script's termination hit `checkForTermination` with neither
a SIGINT flag of its own nor a timeout and fell into
`RELEASE_ASSERT_NOT_REACHED("vm.Script terminated due neither to SIGINT nor to
timeout")`.

A nested script can't classify a termination it didn't request; it only knows
its own SIGINT flag and its own timeout. So when neither is set it now re-raises
the termination instead of converting it, and the enclosing scope picks the right
branch with its own limit and receiver flag. That matters beyond the REPL: an
outer `runInThisContext({ timeout: N })` firing while a nested no-options script
is on the stack involves no signal at all, and node reports
`ERR_SCRIPT_EXECUTION_TIMEOUT` there.

```js
const vm = require("vm");
globalThis.inner = () => vm.runInThisContext("while (true) {}");
vm.runInThisContext("inner()", { timeout: 100 });
// before this PR: abort (RELEASE_ASSERT)
// first attempt:  ERR_SCRIPT_EXECUTION_INTERRUPTED, "interrupted by `SIGINT`"
// now, and node:  ERR_SCRIPT_EXECUTION_TIMEOUT,     "timed out after 100ms"
```

`NodeVMModule` had the identical shape.

`require('vm').runInThisContext('1', {breakOnSigint:true}); while(true){}` +
Ctrl+C **hung**: `registerGlobalObject` used `appendIfNotContains` while
`unregisterGlobalObject` removes one entry unconditionally, so the inner holder
carried the outer holder's registration out with it. Appending unconditionally
balances the two; `signalAll` tolerates duplicates.

A third one, pre-existing rather than surfaced, shares a line with the above.
`drainMicrotasksForGlobalObject` *clears* rather than drains, so a terminated
script may only clear the queue of the context it ran in. `runInThisContext` has
no context of its own and `checkForTermination` was handing it the caller's
global, discarding everything the caller had parked:

```js
const { promise, resolve } = Promise.withResolvers();
const chain = promise.then(() => "survived");
resolve();
try { vm.runInThisContext("while (true) {}", { timeout: 100 }); } catch {}
chain.then(v => console.log(v));   // never prints; node prints "survived"
```

The contextified global is now a parameter of its own: `runInContext` passes its
`NodeVMGlobalObject`, `runInThisContext` passes null. `clearForGlobalObject`
early-returns on null, so that path clears nothing.

## Known gap: nested `vm` timeout classification

The re-raise guard asks whether this scope *configured* a timeout, not whether its
watchdog actually *fired*. So an inner `runInThisContext(src, { timeout: N })` with
no `breakOnSigint`, terminated by an enclosing SIGINT before N elapses, still
reports its own `ERR_SCRIPT_EXECUTION_TIMEOUT`.

Pre-existing: the old `else if (timeout)` was byte-identical, and the non-REPL
shape (outer `breakOnSigint` + inner `timeout`) already behaved this way. The REPL
prints the right thing regardless, because `take_interrupt_error` supersedes off
the sticky receiver flag; it only leaks to a caller that wraps the nested call in
its own `try`/`catch`.

Not fixed here because the obvious discriminator is unsafe: comparing a monotonic
deadline would, on a false "didn't fire" at the *outermost* scope, re-raise an
uncatchable `TerminationException` into user JS instead of the catchable
`ERR_SCRIPT_EXECUTION_TIMEOUT` that `test-vm-timeout.js` asserts on. Doing it right
means tracking fired-state the way node's `Watchdog` carries `timed_out_`, and
`setupWatchdog`'s `enteredVM()` already resets an enclosing deadline, and that
bookkeeping wants its own change.

## Known gap: a parked event loop

`wait_for_promise_interruptible` is only prompt because an idle loop polls
without blocking. Once something keeps the loop alive it parks in
`epoll_pwait2`/`kevent64`, and **every** path in `us_loop_run_bun_tick` re-enters
the poll on `EINTR`, so a signal alone never returns from it. A Ctrl+C landing
after the park waits for whatever wakes the loop next.

This is not a regression (the old `sigint_handler` → `wait_for_promise` →
`auto_tick` path had the same gap), and the `while (true) {}` case in #27558 is
unaffected because that thread is running JS, not parked. Closing it properly
means waking the loop from the watcher thread the way
`WebWorker__notifyNeedTermination` does: `notify_need_termination()` followed by
`event_loop().wakeup()`. That can't be done blindly in `signalAll()`, because
`NodeVMGlobalObject` derives from `Bun::GlobalScope`, not `Zig::GlobalObject`, so
it has no `bunVM()` to reach a loop through. Left for a follow-up rather than
bolted on here. The never-settling-await test is written against the idle loop so
it is deterministic rather than racing the park.

## Not in scope

The related complaint that the JS event loop does not run while the REPL waits
at the prompt (timers, servers and `fetch`es frozen between commands) is already
covered by #30560, so this PR leaves `read_byte` alone.

#33237 (`Bun.spawn({ terminal })` gives the child no controlling terminal) is a
real bug that this PR ran into, but does not fix: the spawn path is untouched,
only the REPL's own test harness moves to the inline `terminal: {...}` option,
which already does the `setsid()` + `ioctl(TIOCSCTTY)`. Confirmed while
debugging, for whoever picks it up: with a pre-created `Bun.Terminal` the child
comes up `tty_nr: 0` / `tpgid: -1`, with the inline option it gets the pty.

Fixes #27558

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->