### PR TITLE
Honor `delete Error.prepareStackTrace`

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -152,6 +152,7 @@ using namespace JSC;
     macro(pokePromiseAsHandled) \
     macro(port) \
     macro(post) \
+    macro(prepareStackTrace) \
     macro(preventAbort) \
     macro(preventCancel) \
     macro(preventClose) \

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -120,22 +120,24 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
     return stackStringValue;
 }
 
-static JSValue formatStackTraceToJSValueWithoutPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
+// Error.prepareStackTrace is an ordinary, deletable property of the Error constructor, so it has to
+// be read back every time a stack is formatted. Returns nullptr when the default formatting should
+// run, which includes the property still holding the default formatter: inlining it is cheaper.
+static JSObject* userPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject)
 {
-    JSValue prepareStackTrace = {};
-    if (lexicalGlobalObject->inherits<Zig::GlobalObject>()) {
-        if (auto prepare = globalObject->m_errorConstructorPrepareStackTraceValue.get()) {
-            prepareStackTrace = prepare;
-        }
-    } else {
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
-        auto* errorConstructor = lexicalGlobalObject->m_errorStructure.constructor(globalObject);
-        prepareStackTrace = errorConstructor->getIfPropertyExists(lexicalGlobalObject, JSC::Identifier::fromString(vm, "prepareStackTrace"_s));
-        CLEAR_IF_EXCEPTION(scope);
-    }
+    const auto& propertyName = WebCore::builtinNames(vm).prepareStackTracePublicName();
+    JSValue prepareStackTrace = lexicalGlobalObject->errorConstructor()->getIfPropertyExists(lexicalGlobalObject, propertyName);
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
-    return formatStackTraceToJSValue(vm, globalObject, lexicalGlobalObject, errorObject, callSites, prepareStackTrace);
+    if (!prepareStackTrace || !prepareStackTrace.isCallable())
+        return nullptr;
+
+    if (prepareStackTrace == globalObject->m_errorConstructorPrepareStackTraceInternalValue.get(globalObject))
+        return nullptr;
+
+    return prepareStackTrace.getObject();
 }
 
 WTF::String formatStackTrace(
@@ -529,39 +531,23 @@ static JSValue computeErrorInfoToJSValueWithoutSkipping(JSC::VM& vm, Vector<Stac
 {
     UNUSED_PARAM(bunErrorData);
 
-    Zig::GlobalObject* globalObject = nullptr;
-    JSC::JSGlobalObject* lexicalGlobalObject = nullptr;
-    lexicalGlobalObject = errorInstance->globalObject();
-    globalObject = dynamicDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    JSC::JSGlobalObject* lexicalGlobalObject = errorInstance->globalObject();
+    Zig::GlobalObject* globalObject = dynamicDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Error.prepareStackTrace - https://v8.dev/docs/stack-trace-api#customizing-stack-traces
-    if (!globalObject) {
-        // node:vm will use a different JSGlobalObject
+    // node:vm will use a different JSGlobalObject
+    if (!globalObject)
         globalObject = defaultGlobalObject();
-        if (!globalObject->isInsideErrorPrepareStackTraceCallback) {
-            auto* errorConstructor = lexicalGlobalObject->m_errorStructure.constructor(lexicalGlobalObject);
-            auto prepareStackTrace = errorConstructor->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "prepareStackTrace"_s));
-            RETURN_IF_EXCEPTION(scope, {});
-            if (prepareStackTrace) {
-                if (prepareStackTrace.isCell() && prepareStackTrace.isObject() && prepareStackTrace.isCallable()) {
-                    globalObject->isInsideErrorPrepareStackTraceCallback = true;
-                    auto result = computeErrorInfoWithPrepareStackTrace(vm, globalObject, lexicalGlobalObject, stackTrace, line, column, sourceURL, errorInstance, prepareStackTrace.getObject());
-                    globalObject->isInsideErrorPrepareStackTraceCallback = false;
-                    RELEASE_AND_RETURN(scope, result);
-                }
-            }
-        }
-    } else if (!globalObject->isInsideErrorPrepareStackTraceCallback) {
-        if (JSValue prepareStackTrace = globalObject->m_errorConstructorPrepareStackTraceValue.get()) {
-            if (prepareStackTrace) {
-                if (prepareStackTrace.isCallable()) {
-                    globalObject->isInsideErrorPrepareStackTraceCallback = true;
-                    auto result = computeErrorInfoWithPrepareStackTrace(vm, globalObject, lexicalGlobalObject, stackTrace, line, column, sourceURL, errorInstance, prepareStackTrace.getObject());
-                    globalObject->isInsideErrorPrepareStackTraceCallback = false;
-                    RELEASE_AND_RETURN(scope, result);
-                }
-            }
+
+    // Error.prepareStackTrace - https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+    if (!globalObject->isInsideErrorPrepareStackTraceCallback) {
+        JSObject* prepareStackTrace = userPrepareStackTrace(vm, globalObject, lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (prepareStackTrace) {
+            globalObject->isInsideErrorPrepareStackTraceCallback = true;
+            auto result = computeErrorInfoWithPrepareStackTrace(vm, globalObject, lexicalGlobalObject, stackTrace, line, column, sourceURL, errorInstance, prepareStackTrace);
+            globalObject->isInsideErrorPrepareStackTraceCallback = false;
+            RELEASE_AND_RETURN(scope, result);
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -122,7 +122,8 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
 
 // Error.prepareStackTrace is an ordinary, deletable property of the Error constructor, so it has to
 // be read back every time a stack is formatted. Returns nullptr when the default formatting should
-// run, which includes the property still holding the default formatter: inlining it is cheaper.
+// run. A throwing user getter propagates; computeErrorInfoWrapperToJSValue maps the resulting empty
+// return to jsUndefined() so materializeErrorInfoIfNeeded never stores an empty JSValue.
 static JSObject* userPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -134,6 +135,7 @@ static JSObject* userPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObj
     if (!prepareStackTrace || !prepareStackTrace.isCallable())
         return nullptr;
 
+    // The default formatter is much cheaper to run inline than through a JS call.
     if (prepareStackTrace == globalObject->m_errorConstructorPrepareStackTraceInternalValue.get(globalObject))
         return nullptr;
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1095,34 +1095,6 @@ void GlobalObject::setConsole(void* console)
     this->setConsoleClient(new Bun::ConsoleObject(console));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(errorConstructorPrepareStackTraceGetter,
-    (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue,
-        JSC::PropertyName))
-{
-    Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    if (thisObject->m_errorConstructorPrepareStackTraceValue) {
-        return JSValue::encode(thisObject->m_errorConstructorPrepareStackTraceValue.get());
-    }
-
-    return JSValue::encode(thisObject->m_errorConstructorPrepareStackTraceInternalValue.get(thisObject));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(errorConstructorPrepareStackTraceSetter,
-    (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue encodedValue, JSC::PropertyName property))
-{
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    JSValue value = JSValue::decode(encodedValue);
-    if (value == thisObject->m_errorConstructorPrepareStackTraceInternalValue.get(thisObject)) {
-        thisObject->m_errorConstructorPrepareStackTraceValue.clear();
-    } else {
-        thisObject->m_errorConstructorPrepareStackTraceValue.set(vm, thisObject, value);
-    }
-
-    return true;
-}
-
 #pragma mark - Globals
 
 JSC_DEFINE_CUSTOM_GETTER(globalOnMessage,
@@ -3048,7 +3020,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     JSC::JSObject* errorConstructor = this->errorConstructor();
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "captureStackTrace"_s), 2, errorConstructorFuncCaptureStackTrace, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "appendStackTrace"_s), 2, errorConstructorFuncAppendStackTrace, ImplementationVisibility::Private, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
-    errorConstructor->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "prepareStackTrace"_s), JSC::CustomGetterSetter::create(vm, errorConstructorPrepareStackTraceGetter, errorConstructorPrepareStackTraceSetter), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue);
+    errorConstructor->putDirect(vm, builtinNames.prepareStackTracePublicName(), m_errorConstructorPrepareStackTraceInternalValue.get(this), PropertyAttribute::DontEnum | 0);
 
     JSC::JSObject* consoleObject = this->get(this, JSC::Identifier::fromString(vm, "console"_s)).getObject();
     scope.assertNoExceptionExceptTermination();

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -497,9 +497,6 @@ public:
     /* WriteBarrier<Unknown> m_JSBunDebuggerValue; */                                                        \
     V(private, ThenablesArray, m_thenables)                                                                  \
                                                                                                              \
-    /* Error.prepareStackTrace */                                                                            \
-    V(public, WriteBarrier<JSC::Unknown>, m_errorConstructorPrepareStackTraceValue)                          \
-                                                                                                             \
     /* When a napi module initializes on dlopen, we need to know what the value is */                        \
     V(public, NapiModuleAndExports, m_pendingNapiModuleAndExports)                                           \
                                                                                                              \
@@ -515,11 +512,8 @@ public:
     /* after entry-module evaluation. Stored here (not on globalThis) so user code can't clobber it. */      \
     V(private, WriteBarrier<JSObject>, m_nodeWorkerEntryEvaluatedHook)                                       \
                                                                                                              \
-    /* The original, unmodified Error.prepareStackTrace. */                                                  \
-    /* */                                                                                                    \
-    /* We set a default value for this to mimic Node.js behavior It is a */                                  \
-    /* separate from the user-facing value so that we can tell if the user */                                \
-    /* really set it or if it's just the default value. */                                                   \
+    /* The default value of Error.prepareStackTrace, to mimic Node.js. Comparing the property */             \
+    /* against it is how we tell whether the user really installed a formatter of their own. */              \
     V(public, LazyPropertyOfGlobalObject<JSC::JSFunction>, m_errorConstructorPrepareStackTraceInternalValue) \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<JSObject>, m_nodeErrorCache)                                       \

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1027,3 +1027,50 @@ test("lazy error-info materialization does not store an empty stack value when t
   });
   expect(exitCode).toBe(0);
 });
+
+// Deleting the property has to bring the default formatter back, and a formatter assigned
+// afterwards has to take effect. source-map-support, jest and stack-utils all do this.
+// Runs in a subprocess because `delete Error.prepareStackTrace` mutates realm-wide state.
+test("delete Error.prepareStackTrace restores the default formatter", async () => {
+  const fixture = [
+    `const out = {};`,
+    `Error.prepareStackTrace = () => "ONE";`,
+    `out.withFormatter = new Error().stack;`,
+
+    `delete Error.prepareStackTrace;`,
+    `out.typeofAfterDelete = typeof Error.prepareStackTrace;`,
+    `out.headerAfterDelete = new Error("after delete").stack.split("\\n")[0];`,
+    `out.hasFramesAfterDelete = /\\n\\s+at /.test(new Error("after delete").stack);`,
+
+    `Error.prepareStackTrace = () => "TWO";`,
+    `out.afterReassign = new Error().stack;`,
+
+    `delete Error.prepareStackTrace;`,
+    `const captured = new Error("captured");`,
+    `Error.captureStackTrace(captured);`,
+    `out.capturedHeader = captured.stack.split("\\n")[0];`,
+
+    `console.log(JSON.stringify(out));`,
+  ].join("\n");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ out: JSON.parse(stdout || "null"), exitCode }).toEqual({
+    out: {
+      withFormatter: "ONE",
+      typeofAfterDelete: "undefined",
+      headerAfterDelete: "Error: after delete",
+      hasFramesAfterDelete: true,
+      afterReassign: "TWO",
+      capturedHeader: "Error: captured",
+    },
+    exitCode: 0,
+  });
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1113,3 +1113,35 @@ test("an Error.prepareStackTrace accessor installed with defineProperty is honor
     exitCode: 0,
   });
 });
+
+// Reading the property runs whatever getter is installed on it. If that getter throws,
+// .stack throws that error (as Node does) and a subsequent read returns undefined
+// instead of storing an empty JSValue. https://github.com/oven-sh/bun/issues/34095
+test("a throwing Error.prepareStackTrace getter propagates out of .stack", async () => {
+  const fixture = [
+    `Object.defineProperty(Error, "prepareStackTrace", {`,
+    `  configurable: true,`,
+    `  get() { throw new Error("boom from getter"); },`,
+    `});`,
+
+    `const e = new Error("x");`,
+    `let first = "no-throw";`,
+    `try { void e.stack; } catch (err) { first = err.message; }`,
+    `console.log(JSON.stringify({ first, secondType: typeof e.stack }));`,
+  ].join("\n");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ out: JSON.parse(stdout || "null"), signalCode: proc.signalCode, exitCode }).toEqual({
+    out: { first: "boom from getter", secondType: "undefined" },
+    signalCode: null,
+    exitCode: 0,
+  });
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1074,3 +1074,42 @@ test("delete Error.prepareStackTrace restores the default formatter", async () =
     exitCode: 0,
   });
 });
+
+// https://github.com/oven-sh/bun/issues/23493
+// error-callsites replaces Error.prepareStackTrace with a JS accessor, then depd assigns
+// through that setter and expects its formatter to receive the CallSite array.
+test("an Error.prepareStackTrace accessor installed with defineProperty is honored", async () => {
+  const fixture = [
+    `let installed;`,
+    `Object.defineProperty(Error, "prepareStackTrace", {`,
+    `  configurable: true,`,
+    `  enumerable: true,`,
+    `  get: () => (err, callsites) => installed(err, callsites),`,
+    `  set: fn => { installed = fn; },`,
+    `});`,
+
+    `Error.prepareStackTrace = (err, callsites) => callsites;`,
+    `const obj = {};`,
+    `function captureHere() { Error.captureStackTrace(obj); }`,
+    `captureHere();`,
+
+    `console.log(JSON.stringify({`,
+    `  isArray: Array.isArray(obj.stack),`,
+    `  topFrame: typeof obj.stack?.[0]?.getFunctionName === "function" ? obj.stack[0].getFunctionName() : null,`,
+    `}));`,
+  ].join("\n");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ out: JSON.parse(stdout || "null"), exitCode }).toEqual({
+    out: { isArray: true, topFrame: "captureHere" },
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fixes #23493

## Repro

```js
const one = () => "ONE";
const two = () => "TWO";

Error.prepareStackTrace = one;
new Error().stack; // "ONE"                 — fine

delete Error.prepareStackTrace;
new Error().stack; // node: default stack   — bun: "ONE"

Error.prepareStackTrace = two;
new Error().stack; // node: "TWO"           — bun: "ONE"
```

Once anything deletes the property, stack formatting in the process is frozen on the removed callback and no library can take over. Installing *and removing* `Error.prepareStackTrace` is exactly what `source-map-support`, jest and `stack-utils` do around their work, so the user-visible symptom is "my source maps stopped applying".

## Cause

`prepareStackTrace` was installed on the `Error` constructor as a `CustomValue` accessor. Its setter mirrored the assigned function into `GlobalObject::m_errorConstructorPrepareStackTraceValue`, and the formatter (`computeErrorInfoToJSValueWithoutSkipping`) read only that cached slot.

`delete` removes the accessor from the constructor's structure, but nothing clears the cached slot, so the formatter kept calling the deleted function. Worse, with the accessor gone, the next `Error.prepareStackTrace = fn` just creates a plain data property that nothing ever reads, so the cache can never be brought back in sync. The property and the cache are two sources of truth for one fact, and `delete` can only ever update one of them.

`delete` is one way to desync the two; `Object.defineProperty` is the other. That is how #23493 happens: `error-callsites` (a dependency of `elastic-apm-node`) replaces `Error.prepareStackTrace` with a JS accessor, which drops the `CustomValue` slot, so the custom setter never runs again. `depd` then assigns its own formatter through that accessor and calls `Error.captureStackTrace(obj)`, but the formatter still reads the empty cache and writes a string, so `obj.stack.slice(1)` yields characters instead of CallSites:

```
TypeError: callSite.getFileName is not a function. (In 'callSite.getFileName()', 'callSite.getFileName' is undefined)
      at callSiteLocation (node_modules/depd/index.js:268:23)
```

The property and the cache are two sources of truth for one fact, and neither `delete` nor `defineProperty` can update both.

## Fix

Make the property itself the single source of truth, which is what V8 does (`ErrorUtils::FormatStackTrace` does a plain `Get` on the error constructor every time).

- `Error.prepareStackTrace` is now an ordinary, deletable data property whose initial value is Bun's default formatter, matching the descriptor Node exposes (`{ value: [Function: ErrorPrepareStackTrace], writable: true, enumerable: false, configurable: true }`).
- The formatter reads it back from the `Error` constructor each time a stack is materialized.
- `m_errorConstructorPrepareStackTraceValue` and the custom getter/setter are deleted, along with `formatStackTraceToJSValueWithoutPrepareStackTrace`, which had no callers and only existed to read the removed field.

The fast path is preserved: when the property still holds the default formatter, the C++ formatting runs inline instead of going through a JS call plus a `CallSite[]` allocation. That is what the identity check against `m_errorConstructorPrepareStackTraceInternalValue` is for, and it also keeps `Error.prepareStackTrace = Error.prepareStackTrace` (the common restore idiom) on the fast path.

Reading the property can run a user getter. If that getter throws, we propagate, matching Node and the precedent #34104 set for a throwing `.message` in the same path. #34104 maps the resulting empty return to `jsUndefined()` at the wrapper, so `materializeErrorInfoIfNeeded` never stores an empty `JSValue`. An earlier revision of this PR swallowed the throw instead; that was working around the bug #34104 fixed at the right layer.

## Performance

`bench/snippets/error-capturestack.mjs`, release builds of this branch and of its merge-base, same machine, min of 5 runs (noise only ever adds time):

| | main | this PR | bun 1.4.0 | node 24 |
|---|---|---|---|---|
| `Error.captureStackTrace(err)` | 375 ns | 377 ns | 373 ns | 2454 ns |
| `new Error().stack` | 3468 ns | 3486 ns | 3463 ns | 9873 ns |

About +0.5% (a noisier 11-rep run put it at ≤1.5%), which is the one property lookup. It is this cheap because the identifier comes from `BunBuiltinNames` rather than `Identifier::fromString` per call. Startup is unchanged (`bun -e '0'`, best-of-5 over 40 processes: 10549/10560 µs on main, 10556/10443 µs here), so installing the default formatter eagerly costs nothing measurable.

## Verification

`test/js/node/v8/capture-stack-trace.test.js` gains three subprocess tests:

- the delete → default, delete → reassign, and delete → `captureStackTrace` paths. Fails on `main` with `headerAfterDelete: "ONE"`, `afterReassign: "ONE"`, `capturedHeader: "ONE"`.
- a `prepareStackTrace` accessor installed with `defineProperty`, assigned through, then read back by `captureStackTrace` (the `error-callsites` + `depd` shape). Fails on `main` with `isArray: false`.
- a throwing `prepareStackTrace` getter, which propagates out of `.stack` (as Node does) instead of storing an empty `JSValue`.

End to end on the #23493 reproduction (`elastic-apm-node` + `express`, same `node_modules`):

```
stock bun  TypeError: callSite.getFileName is not a function   exit 1
this PR    express loaded ok                                   exit 0
node       express loaded ok                                   exit 0
```

<details>
<summary>Output parity with Node across the surrounding behaviors</summary>

```
                          bun (before)   bun (after)    node
vm typeof                 undefined      undefined      undefined
default is fn             true           true           true
identity stable           true           true           true
custom formatter          CUSTOM         CUSTOM         CUSTOM
restored to default       true           true           true
after delete              false          true           true
second lib installs       false          true           true
back to default           false          true           true
defineProperty            false          true           true
= null                    Error: n       Error: n       Error: n
= undefined               Error: u       Error: u       Error: u
```

</details>

Also green: `test/js/node/v8/`, `test/js/web/workers`, `test/js/bun/sourcemap`, `test/js/bun/runtime-error.test.ts`, `test/js/bun/test/stack.test.ts`, `test/regression/issue/prepare-stack-trace-crash.test.ts`, `test/regression/issue/fix-bindings-stack-trace.test.ts`, `test/js/node/test/parallel/test-error-prepare-stack-trace.js`, `test/js/node/test/parallel/test-shadow-realm-prepare-stack-trace.js`. The 3 failures in `test/js/node/vm` reproduce on unmodified `main`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a0f2a50e7)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.81ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.31ms]
(pass) capture stack trace [6.24ms]
(pass) capture stack trace with message [6.91ms]
(pass) capture stack trace with constructor [5.18ms]
(pass) capture stack trace limit [21.95ms]
(pass) prepare stack trace [10.85ms]
(pass) capture stack trace second argument [17.09ms]
(pass) capture stack trace edge cases [11.38ms]
(pass) prepare stack trace call sites [13.39ms]
(pass) sanity check [13.10ms]
(pass) CallFrame isEval works as expected [6.61ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.81ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a0f2a50e7)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.50ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.09ms]
(pass) capture stack trace [0.06ms]
(pass) capture stack trace with message [0.09ms]
(pass) capture stack trace with constructor [0.08ms]
(pass) capture stack trace limit [0.20ms]
(pass) prepare stack trace [0.10ms]
(pass) capture stack trace second argument [0.16ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) prepare stack trace call sites [0.10ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.10ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.13ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.10ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.27ms]
(pass) Error.prepareStackTrace inside a node:vm works [5.57ms]
(pass) Error.captureStackTrace inside error constructor works [0.09ms]
(pass) Error.prepareStackTrace has 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a0f2a50e7)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.01ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.61ms]
(pass) capture stack trace [6.72ms]
(pass) capture stack trace with message [7.25ms]
(pass) capture stack trace with constructor [5.32ms]
(pass) capture stack trace limit [23.25ms]
(pass) prepare stack trace [11.10ms]
(pass) capture stack trace second argument [18.11ms]
(pass) capture stack trace edge cases [11.78ms]
(pass) prepare stack trace call sites [13.14ms]
(pass) sanity check [13.62ms]
(pass) CallFrame isEval works as expected [7.00ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.03ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 730ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/118] gen cpp.rs (cppbind)
[2/117] pch pch/root-pch.h.hxx.pch
[3/117] cxx obj/unified/UnifiedSource-src_jsc_bindings_v8_shim-0.cpp.o
[4/117] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[5/117] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[6/117] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[7/117] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/117] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[9/117] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[10/117] cxx obj/unified/UnifiedSource-src_jsc_bindings_v8-0.cpp.o
[11/117] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[12/117] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[13/117] cxx obj/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/BunBuiltinNames.h           |   1 +
 src/jsc/bindings/FormatStackTraceForJS.cpp  |  74 ++++++++---------
 src/jsc/bindings/ZigGlobalObject.cpp        |  30 +------
 src/jsc/bindings/ZigGlobalObject.h          |  10 +--
 test/js/node/v8/capture-stack-trace.test.js | 118 ++++++++++++++++++++++++++++
 5 files changed, 153 insertions(+), 80 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/builtins/BunBuiltinNames.h                1      1      0
src/jsc/bindings/FormatStackTraceForJS.cpp      11      6      0
src/jsc/bindings/ZigGlobalObject.cpp             4      3      0
src/jsc/bindings/ZigGlobalObject.h               2      2      0
test/js/node/v8/capture-stack-trace.test.js      7      9      0
```

</details>

<!-- robobun:evidence:end -->