### PR TITLE
Take each v8 heap snapshot in its own process

### DIFF
--- a/test/js/bun/util/v8-heap-snapshot-fixture.ts
+++ b/test/js/bun/util/v8-heap-snapshot-fixture.ts
@@ -1,0 +1,110 @@
+// Spawned by v8-heap-snapshot.test.ts, one mode per process.
+// v8HeapSnapshot.parseSnapshot() materializes a JS object per node and per edge,
+// and that graph lands inside the next snapshot taken from the same heap, so
+// every mode gets a fresh process with a small heap. For the same reason each
+// mode loads only the modules it needs, and only once it needs them.
+
+// Reports what the snapshot says about itself. The node and edge arrays are
+// flat, so a short one means the snapshot was truncated.
+function describeSnapshot(json: any) {
+  const { meta, node_count, edge_count } = json.snapshot;
+  return {
+    nodeFields: meta.node_fields,
+    edgeFields: meta.edge_fields,
+    nodeCount: node_count > 0,
+    edgeCount: edge_count > 0,
+    nodesComplete: json.nodes.length === node_count * meta.node_fields.length,
+    edgesComplete: json.edges.length === edge_count * meta.edge_fields.length,
+    strings: json.strings.length > 0,
+  };
+}
+
+// Runs the snapshot through a third-party parser, then walks every node and edge.
+async function parseAndWalk(json: unknown) {
+  const v8HeapSnapshot: typeof import("v8-heapsnapshot") = require("v8-heapsnapshot");
+  const parsed = await v8HeapSnapshot.parseSnapshot(json);
+
+  let edgesMissingTo = 0;
+  for (const edge of parsed.edges) {
+    if (!edge.to) edgesMissingTo++;
+  }
+  let undefinedNodes = 0;
+  for (const node of parsed.nodes) {
+    if (!node) undefinedNodes++;
+  }
+
+  return {
+    parsedNodes: parsed.nodes.length > 0,
+    parsedEdges: parsed.edges.length > 0,
+    edgesMissingTo,
+    undefinedNodes,
+  };
+}
+
+const [mode, pathArg] = process.argv.slice(2);
+
+let result: Record<string, unknown>;
+switch (mode) {
+  case "generate-string": {
+    const snapshot = Bun.generateHeapSnapshot("v8");
+    const json = JSON.parse(snapshot);
+    result = { type: typeof snapshot, ...describeSnapshot(json), ...(await parseAndWalk(json)) };
+    break;
+  }
+
+  case "generate-arraybuffer": {
+    const snapshot = Bun.generateHeapSnapshot("v8", "arraybuffer");
+    const json = JSON.parse(new TextDecoder().decode(snapshot));
+    result = {
+      isArrayBuffer: snapshot instanceof ArrayBuffer,
+      hasBytes: snapshot.byteLength > 0,
+      ...describeSnapshot(json),
+      ...(await parseAndWalk(json)),
+    };
+    break;
+  }
+
+  case "compare-formats": {
+    const fromString = JSON.parse(Bun.generateHeapSnapshot("v8"));
+    const fromArrayBuffer = JSON.parse(new TextDecoder().decode(Bun.generateHeapSnapshot("v8", "arraybuffer")));
+    result = { stringMeta: fromString.snapshot.meta, arrayBufferMeta: fromArrayBuffer.snapshot.meta };
+    break;
+  }
+
+  // The three modes below all hand back the same `Bun.generateHeapSnapshot("v8")`
+  // string the modes above already ran through the parser, so they only check
+  // that what came out the other side is a complete snapshot.
+  case "get-heap-snapshot": {
+    const chunks: Buffer[] = [];
+    let emptyChunks = 0;
+    for await (const chunk of require("node:v8").getHeapSnapshot()) {
+      if (chunk.byteLength === 0) emptyChunks++;
+      chunks.push(chunk);
+    }
+    result = {
+      chunks: chunks.length > 0,
+      emptyChunks,
+      ...describeSnapshot(JSON.parse(Buffer.concat(chunks).toString("utf-8"))),
+    };
+    break;
+  }
+
+  case "write-default": {
+    const path = require("node:v8").writeHeapSnapshot();
+    const json = await Bun.file(path).json();
+    require("node:fs").rmSync(path);
+    result = { filename: require("node:path").basename(path), ...describeSnapshot(json) };
+    break;
+  }
+
+  case "write-path": {
+    const returnedPath = require("node:v8").writeHeapSnapshot(pathArg);
+    result = { returnedPath, ...describeSnapshot(await Bun.file(pathArg).json()) };
+    break;
+  }
+
+  default:
+    throw new Error(`Unknown mode: ${mode}`);
+}
+
+console.log(JSON.stringify(result));

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -1,103 +1,87 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
-import * as v8 from "v8";
-import * as v8HeapSnapshot from "v8-heapsnapshot";
+
+const fixture = join(import.meta.dir, "v8-heap-snapshot-fixture.ts");
+
+const NODE_FIELDS = ["type", "name", "id", "self_size", "edge_count", "trace_node_id", "detachedness"];
+const EDGE_FIELDS = ["type", "name_or_index", "to_node"];
+
+// A heap snapshot contains everything that is live, so whatever a test allocates
+// ends up inside the next snapshot taken in the same process. Parsing a snapshot
+// with `v8-heapsnapshot` materializes an object per node and per edge, and two
+// parses in a row grow the snapshot by ~10x, until the process is OOM-killed.
+// Every snapshot therefore gets its own short-lived process.
+async function runFixture(mode: string, { cwd = import.meta.dir, args = [] }: { cwd?: string; args?: string[] } = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, mode, ...args],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`"${mode}" fixture exited with code ${exitCode}\n${stdout}\n${stderr}`);
+  }
+  return JSON.parse(stdout);
+}
+
+// The snapshot is well-formed and complete: the flat node/edge arrays line up
+// with the counts in its header.
+const structure = {
+  nodeFields: NODE_FIELDS,
+  edgeFields: EDGE_FIELDS,
+  nodeCount: true,
+  edgeCount: true,
+  nodesComplete: true,
+  edgesComplete: true,
+  strings: true,
+};
+
+// Every node is defined and every edge resolves to one.
+const walked = {
+  parsedNodes: true,
+  parsedEdges: true,
+  edgesMissingTo: 0,
+  undefinedNodes: 0,
+};
 
 test("v8 heap snapshot", async () => {
-  const snapshot = Bun.generateHeapSnapshot("v8");
-  // Sanity check: run the validations from this library
-  const parsed = await v8HeapSnapshot.parseSnapshot(JSON.parse(snapshot));
-
-  // Loop over all edges and nodes as another sanity check.
-  for (const edge of parsed.edges) {
-    if (!edge.to) {
-      throw new Error("Edge has no 'to' property");
-    }
-  }
-  for (const node of parsed.nodes) {
-    if (!node) {
-      throw new Error("Node is undefined");
-    }
-  }
-
-  expect(parsed.nodes.length).toBeGreaterThan(0);
-  expect(parsed.edges.length).toBeGreaterThan(0);
-});
-
-test("v8.getHeapSnapshot()", async () => {
-  const snapshot = v8.getHeapSnapshot();
-  let chunks = [];
-  for await (const chunk of snapshot) {
-    expect(chunk.byteLength).toBeGreaterThan(0);
-    chunks.push(chunk);
-  }
-  expect(chunks.length).toBeGreaterThan(0);
-});
-
-test("v8.writeHeapSnapshot()", async () => {
-  const path = v8.writeHeapSnapshot();
-  expect(path).toBeDefined();
-  expect(path).toContain("Heap-");
-
-  const snapshot = await Bun.file(path).json();
-  expect(await v8HeapSnapshot.parseSnapshot(snapshot)).toBeDefined();
+  expect(await runFixture("generate-string")).toEqual({ type: "string", ...structure, ...walked });
 });
 
 test("v8 heap snapshot arraybuffer", async () => {
-  const snapshot = Bun.generateHeapSnapshot("v8", "arraybuffer");
-  expect(snapshot).toBeInstanceOf(ArrayBuffer);
-  expect(snapshot.byteLength).toBeGreaterThan(0);
-
-  // Decode the ArrayBuffer as UTF-8 and parse it as JSON
-  const text = new TextDecoder().decode(snapshot);
-  const parsed = JSON.parse(text);
-
-  // Validate structure
-  expect(parsed.snapshot).toBeDefined();
-  expect(parsed.snapshot.meta).toBeDefined();
-  expect(parsed.nodes).toBeInstanceOf(Array);
-  expect(parsed.edges).toBeInstanceOf(Array);
-  expect(parsed.strings).toBeInstanceOf(Array);
-  expect(parsed.nodes.length).toBeGreaterThan(0);
-  expect(parsed.edges.length).toBeGreaterThan(0);
-  expect(parsed.strings.length).toBeGreaterThan(0);
-
-  // Also validate via v8-heapsnapshot library
-  const parsedSnapshot = await v8HeapSnapshot.parseSnapshot(parsed);
-  expect(parsedSnapshot.nodes.length).toBeGreaterThan(0);
-  expect(parsedSnapshot.edges.length).toBeGreaterThan(0);
+  expect(await runFixture("generate-arraybuffer")).toEqual({
+    isArrayBuffer: true,
+    hasBytes: true,
+    ...structure,
+    ...walked,
+  });
 });
 
 test("v8 heap snapshot arraybuffer matches string output", async () => {
-  // The arraybuffer output should produce valid JSON identical in structure to the string output
-  const snapshotBuffer = Bun.generateHeapSnapshot("v8", "arraybuffer");
-  const text = new TextDecoder().decode(snapshotBuffer);
-  const parsed = JSON.parse(text);
+  const { stringMeta, arrayBufferMeta } = await runFixture("compare-formats");
+  expect(arrayBufferMeta).toEqual(stringMeta);
+  expect(arrayBufferMeta.node_fields).toEqual(NODE_FIELDS);
+  expect(arrayBufferMeta.edge_fields).toEqual(EDGE_FIELDS);
+});
 
-  // Verify it has the same meta structure
-  expect(parsed.snapshot.meta.node_fields).toEqual([
-    "type",
-    "name",
-    "id",
-    "self_size",
-    "edge_count",
-    "trace_node_id",
-    "detachedness",
-  ]);
-  expect(parsed.snapshot.meta.edge_fields).toEqual(["type", "name_or_index", "to_node"]);
-  expect(parsed.snapshot.node_count).toBeGreaterThan(0);
-  expect(parsed.snapshot.edge_count).toBeGreaterThan(0);
+test("v8.getHeapSnapshot()", async () => {
+  expect(await runFixture("get-heap-snapshot")).toEqual({ chunks: true, emptyChunks: 0, ...structure });
+});
+
+test("v8.writeHeapSnapshot()", async () => {
+  // Without a path the snapshot is written to the cwd, so give it one we own.
+  using dir = tempDir("v8-heap-snapshot", {});
+  const { filename, ...rest } = await runFixture("write-default", { cwd: String(dir) });
+  expect(filename).toMatch(/^Heap-\d{8}-\d{6}-\d+-\d+\.heapsnapshot$/);
+  expect(rest).toEqual(structure);
 });
 
 test("v8.writeHeapSnapshot() with path", async () => {
-  const dir = tempDirWithFiles("v8-heap-snapshot", {
-    "test.heapsnapshot": "",
-  });
-
-  const path = join(dir, "test.heapsnapshot");
-  v8.writeHeapSnapshot(path);
-
-  const snapshot = await Bun.file(path).json();
-  expect(await v8HeapSnapshot.parseSnapshot(snapshot)).toBeDefined();
+  using dir = tempDir("v8-heap-snapshot", {});
+  const path = join(String(dir), "test.heapsnapshot");
+  expect(await runFixture("write-path", { args: [path] })).toEqual({ returnedPath: path, ...structure });
 });

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -48,6 +48,9 @@ const walked = {
   undefinedNodes: 0,
 };
 
+// Deliberately sequential rather than `test.concurrent`: each fixture is
+// single-threaded, so fanning six snapshots out at once buys wall time this file
+// does not need by multiplying the peak RSS this file exists to bound.
 test("v8 heap snapshot", async () => {
   expect(await runFixture("generate-string")).toEqual({ type: "string", ...structure, ...walked });
 });


### PR DESCRIPTION
### What

`test/js/bun/util/v8-heap-snapshot.test.ts` is killed by the OOM killer on the
`:ubuntu: 25.04 x64` and `25.04 x64-baseline` test lanes. 26 builds in the last
400 hit it; no other lane ever does.

```
--- [43/239] test/js/bun/util/v8-heap-snapshot.test.ts - SIGKILL
bun test v1.4.0-canary.1 (07c092948)
....main process killed by SIGKILL but no core file found
```

Four of the six tests passed, then the process died 24s in, well short of the
300s file timeout. The `:penguin:` lanes are 8GB boxes that also host the docker
service containers, so they are the first to notice.

### Cause

A heap snapshot contains everything that is live, and
`v8HeapSnapshot.parseSnapshot()` materializes a JS object per node *and* per
edge, wired with `in_edges` / `out_edges` arrays. The test parses four
snapshots in one process, so each parse's object graph is a candidate to land
inside the next snapshot. When it does, the snapshot grows by an order of
magnitude, and the next parse allocates an order of magnitude more:

```js
const keep = [];
for (let i = 1; i <= 4; i++) {
  const snapshot = Bun.generateHeapSnapshot("v8");
  console.log(`snapshot ${i}: ${(snapshot.length / 1e6).toFixed(2)} MB, rss=${(process.memoryUsage.rss() / 1e6).toFixed(0)}MB`);
  keep.push(await v8HeapSnapshot.parseSnapshot(JSON.parse(snapshot)));
}
```

```
snapshot 1: 0.92 MB, rss=59MB
snapshot 2: 9.62 MB, rss=181MB
snapshot 3: 104.44 MB, rss=615MB
snapshot 4: 1128.65 MB, rss=4480MB      <- peak RSS 12.4GB
```

`Bun.generateHeapSnapshot` runs a full GC before walking the heap, so the
previous graph is usually collected and the test usually passes. Whether it is
collected depends on whether anything still refers to it when that GC runs,
including conservative stack roots, which is exactly why this fires on x64 and
not on aarch64, and why it only fires some of the time. Timing on a failing
lane, with each test's dot: 0.12s, 0.12s, 1.27s, 6.81s, then the kill.

Locally, on the unchanged test, this shows up as a bimodal runtime:

```
run 1: Ran 6 tests across 1 file. [1.82s]
run 2: Ran 6 tests across 1 file. [737.00ms]
run 3: Ran 6 tests across 1 file. [740.00ms]
run 4: Ran 6 tests across 1 file. [1.83s]
```

### Fix

Each snapshot is taken in its own short-lived child process
(`v8-heap-snapshot-fixture.ts`, one mode per process), so every snapshot sees a
small heap and nothing a test allocates can reach another test's snapshot. The
fixture defers its `require`s for the same reason: loading `v8-heapsnapshot`
before taking the snapshot makes the snapshot ~5x more expensive.

Coverage is unchanged other than being stronger in two places:

- `v8.getHeapSnapshot()` now checks that the concatenated stream is a complete
  snapshot, not just that some chunks arrived.
- The two `v8.writeHeapSnapshot()` tests replace `expect(parsed).toBeDefined()`
  with a check that the flat `nodes` / `edges` arrays line up with the counts in
  the file's own header, i.e. that the file is not truncated. They no longer
  re-run `parseSnapshot` on bytes that are the same
  `Bun.generateHeapSnapshot("v8")` string the first two tests already parsed.
- `arraybuffer matches string output` now actually compares the two, instead of
  checking the arraybuffer's meta against a literal.

`v8.writeHeapSnapshot()` with no path writes into the cwd, so the child for that
test runs in a temp dir the test owns. Before this, every CI run left a
multi-MB `Heap-*.heapsnapshot` in the repo checkout.

### Verification

```
$ bun test test/js/bun/util/v8-heap-snapshot.test.ts     # release
before:  6 pass, [737ms - 1.86s], peak RSS 241MB - 1.5GB
after:   6 pass, [418ms - 504ms],  peak RSS 107MB

$ bun bd test test/js/bun/util/v8-heap-snapshot.test.ts  # debug + ASAN, default 5s per-test timeout
before:  3 fail (3 tests over the 5s timeout), 33.7s with --timeout=120000
after:   6 pass, 19.3s - 19.7s over three runs
```

Mutating the fixture so `nodesComplete` is off by one fails 5 of the 6 tests,
so the structural assertions bite.
