### PR TITLE
node:fs: apply cpSync errorOnExist per entry, not to the destination directory

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -421,17 +421,11 @@ function setDestTimestamps(src, dest) {
   return utimesSync(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
 }
 
+// `errorOnExist` is per-file here: an existing destination directory is merged
+// into, and only a colliding entry raises ERR_FS_CP_EEXIST (see mayCopyFile).
+// node's async cp refuses the directory itself; its cpSync does not.
 function onDir(srcStat, destStat, src, dest, opts) {
   if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
-  if (opts.errorOnExist && !opts.force) {
-    throw fsCpEExistError({
-      message: `${dest} already exists`,
-      path: dest,
-      syscall: "cp",
-      errno: EEXIST,
-      code: "EEXIST",
-    });
-  }
   return copyDir(src, dest, opts);
 }
 

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -314,6 +314,9 @@ async function setDestTimestamps(src, dest) {
   return utimes(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
 }
 
+// node's async cp refuses an existing destination directory outright. Its
+// cpSync merges into one and only raises ERR_FS_CP_EEXIST per colliding file,
+// so internal/fs/cp-sync.ts onDir deliberately lacks this branch.
 function onDir(srcStat, destStat, src, dest, opts) {
   if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
   if (opts.errorOnExist && !opts.force) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -423,6 +423,76 @@ for (const [name, copy] of impls) {
   });
 }
 
+// node applies `errorOnExist` per copied entry in cpSync, so an existing
+// destination directory is merged into and only a colliding file raises
+// ERR_FS_CP_EEXIST. node's async cp refuses the directory itself; match both.
+describe("'force: false' + 'errorOnExist: true' on an existing destination directory", () => {
+  test("cpSync merges into it and keeps the entries already there", () => {
+    const basename = tempDirWithFiles("cp", {
+      "from/a.txt": "a",
+      "from/nested/b.txt": "b",
+      "result/other.txt": "keep this",
+      "result/nested/c.txt": "keep this too",
+    });
+    const from = join(basename, "from");
+    const result = join(basename, "result");
+
+    fs.cpSync(from, result, { recursive: true, force: false, errorOnExist: true });
+
+    expect({
+      result: fs.readdirSync(result).sort(),
+      nested: fs.readdirSync(join(result, "nested")).sort(),
+      "a.txt": fs.readFileSync(join(result, "a.txt"), "utf8"),
+      "nested/b.txt": fs.readFileSync(join(result, "nested", "b.txt"), "utf8"),
+      "other.txt": fs.readFileSync(join(result, "other.txt"), "utf8"),
+      "nested/c.txt": fs.readFileSync(join(result, "nested", "c.txt"), "utf8"),
+    }).toEqual({
+      result: ["a.txt", "nested", "other.txt"],
+      nested: ["b.txt", "c.txt"],
+      "a.txt": "a",
+      "nested/b.txt": "b",
+      "other.txt": "keep this",
+      "nested/c.txt": "keep this too",
+    });
+  });
+
+  test("cpSync still throws ERR_FS_CP_EEXIST on a colliding file", () => {
+    const basename = tempDirWithFiles("cp", {
+      "from/nested/a.txt": "lose",
+      "result/nested/a.txt": "win",
+    });
+    const result = join(basename, "result");
+
+    let err: any;
+    try {
+      fs.cpSync(join(basename, "from"), result, { recursive: true, force: false, errorOnExist: true });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ERR_FS_CP_EEXIST");
+    expect(err?.path).toBe(join(result, "nested", "a.txt"));
+    expect(fs.readFileSync(join(result, "nested", "a.txt"), "utf8")).toBe("win");
+  });
+
+  test("promises.cp refuses the destination directory and copies nothing", async () => {
+    const basename = tempDirWithFiles("cp", {
+      "from/a.txt": "a",
+      "result/other.txt": "keep this",
+    });
+    const result = join(basename, "result");
+
+    let err: any;
+    try {
+      await fs.promises.cp(join(basename, "from"), result, { recursive: true, force: false, errorOnExist: true });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ERR_FS_CP_EEXIST");
+    expect(err?.path).toBe(result);
+    expect(fs.readdirSync(result)).toEqual(["other.txt"]);
+  });
+});
+
 test("cp with missing callback throws", () => {
   expect(() => {
     // @ts-expect-error


### PR DESCRIPTION
## Repro

```js
const fs = require("fs");
fs.mkdirSync("out");                        // any prior run, or mkdir -p
fs.cpSync("assets", "out", { recursive: true, force: false, errorOnExist: true });
```

```
node: copies everything; ERR_FS_CP_EEXIST only if an individual dest FILE exists
bun:  SystemError: Target already exists: cp returned EEXIST (out already exists) out
```

`force: false` + `errorOnExist: true` is the "add my files, never clobber the user's" mode, and a destination directory essentially always exists, so every such call fails.

## Cause

`onDir` in `src/js/internal/fs/cp-sync.ts` refused the destination directory itself:

```js
function onDir(srcStat, destStat, src, dest, opts) {
  if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
  if (opts.errorOnExist && !opts.force) {
    throw fsCpEExistError({ message: `${dest} already exists`, ... });
  }
  return copyDir(src, dest, opts);
}
```

node's `lib/internal/fs/cp/cp-sync.js` has no such check: `onDir` merges, and `ERR_FS_CP_EEXIST` comes only from `mayCopyFile`, per colliding file. The branch above is the body of node's **async** `lib/internal/fs/cp/cp.js` `onDir`, which does refuse the directory. It was copied into the sync path in #31830, where only the async half belonged.

## Fix

Drop the check from the sync `onDir`. `src/js/internal/fs/cp.ts` (async) keeps it, because node's async `cp` really is stricter than its `cpSync`. Added a comment on both halves so the asymmetry doesn't read as an oversight.

## Verification

Differential run against node v26.3.0, `{ recursive: true, force: false, errorOnExist: true }`:

| scenario | node `cpSync` | bun `cpSync` before | bun `cpSync` after |
| --- | --- | --- | --- |
| dest missing | copies | copies | copies |
| dest exists, empty | copies | **EEXIST** | copies |
| dest exists, non-colliding file | merges | **EEXIST** | merges |
| dest exists, colliding file | EEXIST | EEXIST (on dest dir) | EEXIST (on the file) |
| dest exists, colliding subdir | merges | **EEXIST** | merges |
| dest subdir w/ colliding file | EEXIST | EEXIST (on dest dir) | EEXIST (on the file) |
| dest subdir w/ other file | merges | **EEXIST** | merges |

`fs.promises.cp` / `fs.cp` match node on every row both before and after (all seven refuse the existing directory), and a test now pins that.

Bun's thrown error is a `SystemError` carrying `path` = the colliding file. node sets `path` only when a `filter` is passed (without one its `copyDir` runs in C++ and drops the field); the `code` and message text are identical either way.

- `bun bd test test/js/node/fs/cp.test.ts` — 50 pass, 0 fail (3 new)
- all 77 `test/js/node/test/parallel/test-fs-cp-*` pass, including `test-fs-cp-async-dir-exists-error-on-exist.mjs` and `test-fs-cp-sync-error-on-exist.mjs`
