### PR TITLE
worker_threads: don't abort when terminate() interrupts a lazy property builder

### DIFF
--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -1,6 +1,8 @@
 #pragma once
 // clang-format off
 
+#include <JavaScriptCore/DeferTermination.h>
+
 // --- Getters ---
 #define FOR_EACH_GETTER(macro) \
     macro(Archive) \
@@ -92,8 +94,12 @@ FOR_EACH_CALLBACK(DECLARE_ZIG_BUN_OBJECT_CALLBACK);
 FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 #undef DECLARE_ZIG_BUN_OBJECT_GETTER
 
-// definition of the C++ wrapper to call the Rust function
+// definition of the C++ wrapper to call the Rust function.
+// Lazy property builder: exceptions must not propagate into reifyStaticProperty,
+// which performs no exception check. A TerminationException cannot be cleared,
+// so defer it across the getter.
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
+    JSC::DeferTerminationForAWhile deferTermination(vm); \
     return JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
 } \
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -11,6 +11,7 @@
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSBase.h>
 #include <JavaScriptCore/BuiltinNames.h>
+#include <JavaScriptCore/DeferTermination.h>
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/JSFunction.h>
@@ -359,6 +360,10 @@ JSValue constructBunFetchObject(VM& vm, JSObject* bunObject)
 
 static JSValue constructBunShell(VM& vm, JSObject* bunObject)
 {
+    // Lazy property builder: exceptions must not propagate into
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the call.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(bunObject->globalObject());
     JSFunction* createParsedShellScript = JSFunction::create(vm, bunObject->globalObject(), 2, "createParsedShellScript"_s, BunObject_callback_createParsedShellScript, ImplementationVisibility::Private, NoIntrinsic);
     JSFunction* createShellInterpreterFunction = JSFunction::create(vm, bunObject->globalObject(), 1, "createShellInterpreter"_s, BunObject_callback_createShellInterpreter, ImplementationVisibility::Private, NoIntrinsic);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -317,6 +317,10 @@ static JSValue constructPluginObject(VM& vm, JSObject* bunObject)
 
 static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 {
+    // Lazy property builder: exceptions must not propagate into
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the require.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
@@ -329,6 +333,10 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 
 static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
 {
+    // Lazy property builder: exceptions must not propagate into
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the require.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -16,6 +16,7 @@
 #include "ErrorCode+List.h"
 #include "JavaScriptCore/ArgList.h"
 #include "JavaScriptCore/CallData.h"
+#include "JavaScriptCore/DeferTermination.h"
 #include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
@@ -2652,6 +2653,10 @@ extern "C" void Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(JSC::JSGl
 static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC::JSObject* processObject, int fd)
 {
     auto& vm = JSC::getVM(globalObject);
+    // Lazy property builder: exceptions must not propagate into
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the call.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSC::JSFunction* getStdioWriteStream = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetStdioWriteStreamCodeGenerator(vm), globalObject);
@@ -2715,6 +2720,10 @@ static JSValue constructStderr(VM& vm, JSObject* processObject)
 static JSValue constructStdin(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
+    // Lazy property builder: exceptions must not propagate into
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the call.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSFunction* getStdinStream = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetStdinStreamCodeGenerator(vm), globalObject);
     JSC::MarkedArgumentBuffer args;
@@ -2783,7 +2792,9 @@ static JSValue constructProcessChannel(VM& vm, JSObject* processObject)
     if (Bun__GlobalObject__hasIPC(globalObject)) {
         auto& vm = JSC::getVM(globalObject);
         // Lazy property builder: exceptions must not propagate into
-        // reifyStaticProperty, which performs no exception check.
+        // reifyStaticProperty, which performs no exception check. A
+        // TerminationException cannot be cleared, so defer it across the call.
+        JSC::DeferTerminationForAWhile deferTermination(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
         JSC::JSFunction* getControl = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetChannelCodeGenerator(vm), globalObject);
@@ -3979,7 +3990,9 @@ extern "C" void Bun__Process__queueNextTick2(GlobalObject* globalObject, Encoded
 static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 {
     // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the gets.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(processObject->globalObject());
     auto* bun = globalObject->bunObject();
@@ -4019,7 +4032,9 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
     // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
+    // reifyStaticProperty, which performs no exception check. A
+    // TerminationException cannot be cleared, so defer it across the call.
+    JSC::DeferTerminationForAWhile deferTermination(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) [[unlikely]] {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -131,7 +131,13 @@ test(
                     property + ";",
                 ),
             );
-            const closed = new Promise(resolve => w.addEventListener("close", resolve, { once: true }));
+            const { promise: closed, resolve, reject } = Promise.withResolvers();
+            w.addEventListener("close", resolve, { once: true });
+            // A worker that dies before reaching the property read would still
+            // fire close, and the test would pass having exercised nothing.
+            w.addEventListener("error", event => reject(event.error ?? new Error(property + ": " + event.message)), {
+              once: true,
+            });
             w.addEventListener("message", () => w.terminate(), { once: true });
             return closed;
           }),
@@ -145,9 +151,9 @@ test(
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: `terminated ${lazyProperties.length}\n`,
+    expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toEqual({
       stderr: "",
+      stdout: `terminated ${lazyProperties.length}\n`,
       exitCode: 0,
       signalCode: null,
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -82,6 +82,66 @@ test(
   timeout,
 );
 
+// Regression: `process.nextTick`, `process.mainModule`, `process.stdin` and
+// `Bun.$` are lazily built by JSC's reifyStaticProperty, which performs no
+// exception check. A terminate() that landed while a builder was entering JS
+// left a TerminationException pending (tryClearException() cannot clear one),
+// and the caller's `EXCEPTION_ASSERT(!scope.exception() || !hasSlot)` aborted.
+//
+// Each worker blocks in Bun.sleepSync so terminate() is requested while the
+// thread sits in native code with no JS safepoint ahead of the property read;
+// the builder then runs with the termination trap armed. A blocking call is
+// the point of the test, not a wait for a condition.
+const lazyProperties = ["process.nextTick", "process.mainModule", "process.stdin", "Bun.$"];
+const blockMs = slow ? 600 : 200;
+
+test(
+  "terminate() while a lazy property builder is entering JS does not abort",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const properties = ${JSON.stringify(lazyProperties)};
+        await Promise.all(
+          properties.map(property => {
+            const w = new Worker(
+              "data:text/javascript," +
+                encodeURIComponent(
+                  'postMessage("go");' +
+                    // Blocks the worker thread in native code; terminate() arms the
+                    // termination trap while we are parked here.
+                    "Bun.sleepSync(${blockMs});" +
+                    // First touch of the lazy property: its builder enters JS and is
+                    // terminated mid-call.
+                    property + ";",
+                ),
+            );
+            const closed = new Promise(resolve => w.addEventListener("close", resolve, { once: true }));
+            w.addEventListener("message", () => w.terminate(), { once: true });
+            return closed;
+          }),
+        );
+        console.log("terminated " + properties.length);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: `terminated ${lazyProperties.length}\n`,
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  timeout,
+);
+
 // Regression: WebWorker__dispatchExit deref'd the C++ Worker on the worker
 // thread; if that was the last ref, ~Worker → ~EventTarget ran there and
 // EventListenerMap::releaseAssertOrSetThreadUID tripped because the listener

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -82,17 +82,30 @@ test(
   timeout,
 );
 
-// Regression: `process.nextTick`, `process.mainModule`, `process.stdin` and
-// `Bun.$` are lazily built by JSC's reifyStaticProperty, which performs no
-// exception check. A terminate() that landed while a builder was entering JS
-// left a TerminationException pending (tryClearException() cannot clear one),
-// and the caller's `EXCEPTION_ASSERT(!scope.exception() || !hasSlot)` aborted.
+// Regression: these properties are lazily built by JSC's reifyStaticProperty,
+// which performs no exception check. A terminate() that landed while a builder
+// was entering JS left a TerminationException pending (tryClearException()
+// cannot clear one), so the builder either tripped the caller's
+// `EXCEPTION_ASSERT(!scope.exception() || !hasSlot)` or handed the empty
+// JSValue to putDirect (a null JSCell deref).
 //
 // Each worker blocks in Bun.sleepSync so terminate() is requested while the
 // thread sits in native code with no JS safepoint ahead of the property read;
 // the builder then runs with the termination trap armed. A blocking call is
 // the point of the test, not a wait for a condition.
-const lazyProperties = ["process.nextTick", "process.mainModule", "process.stdin", "Bun.$"];
+//
+// One entry per builder shape: a process.* TopExceptionScope builder, a JS
+// property get, an internal-module require, a JSC::call, and a Rust-backed
+// getter behind the shared wrapper macro.
+const lazyProperties = [
+  "process.nextTick",
+  "process.mainModule",
+  "process.stdin",
+  "Bun.$",
+  "Bun.sql",
+  "Bun.SQL",
+  "Bun.argv",
+];
 const blockMs = slow ? 600 : 200;
 
 test(


### PR DESCRIPTION
Deflakes `test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js`, which has been aborting the whole test process on the `x64-asan` lane (5 of the last 120 failed builds, e.g. builds 68677, 68637, 68564, 68435, 68343):

```
test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js - SIGABRT on 13 x64-asan
ASSERTION FAILED: !scope.exception() || !hasSlot
cache/webkit-c9ad5813fd23bd8b-asan/include/JavaScriptCore/JSCJSValuePropertyInlines.h(51) : JSValue JSC::JSValue::get(JSGlobalObject *, PropertyName, PropertySlot &) const
```

### Repro

The test creates 10 workers and terminates each one on the next `setImmediate`, so `terminate()` lands while the worker is still evaluating its entry module. Deterministically, with no racing:

```js
const w = new Worker(
  "data:text/javascript," +
    encodeURIComponent(`
      postMessage("go");
      Bun.sleepSync(300);   // terminate() arrives while we are parked in native code
      process.nextTick;     // first touch: the lazy builder enters JS
    `),
);
w.addEventListener("message", () => w.terminate());
```

Aborts every time on a debug build. `process.mainModule`, `process.stdin` and `Bun.$` abort the same way (`Bun.$` via `JSCJSValueCell.h:67:34: member call on null pointer of type 'JSC::JSCell'` under UBSAN, because its builder hands the empty JSValue to `putDirect`).

### Cause

`process.nextTick`, `process.mainModule`, `process.stdin`, `process.stdout`, `process.stderr`, `process.channel` and `Bun.$` are `PropertyCallback` entries in a static hash table. JSC reifies them in `reifyStaticProperty` (`Lookup.h`):

```cpp
if (value.attributes() & PropertyAttribute::PropertyCallback) {
    JSValue result = value.lazyPropertyCallback()(vm, &thisObj);
    thisObj.putDirect(vm, propertyName, result, attributesForStructure(value.attributes()));
    return;
}
```

No exception check, and `getPropertySlot` then reports the slot as found. So a builder must never return with an exception pending — the builders know that and say so in a comment:

```cpp
// Lazy property builder: exceptions must not propagate into
// reifyStaticProperty, which performs no exception check.
auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, ...);
if (auto* exception = scope.exception()) [[unlikely]] {
    (void)scope.tryClearException();
    Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
    return JSC::jsUndefined();
}
```

`ExceptionScope::tryClearException()` refuses to clear a `TerminationException` and returns `false`, which nothing checks. When `worker.terminate()` has armed the termination trap, `profiledCall` throws the `TerminationException` at the initializer's entry, the builder leaves it pending, `getPropertySlot` returns `true`, and `JSValue::get`'s `EXCEPTION_ASSERT(!scope.exception() || !hasSlot)` fires. (`JSObject::get` tolerates this exact state — `!scope.exception() || vm.hasPendingTerminationException() || !hasProperty` — but the LLInt's `get_by_id` slow path goes through `JSValue::get`, which does not.)

The window in the vendored test is the straight-line code between the last trap check and the first `process.nextTick` read inside an internal module.

### Fix

Wrap the builders that enter JS in `JSC::DeferTerminationForAWhile`, which is what `JSC::LazyProperty::callFunc` already does for JSC's own lazy properties (`LazyPropertyInlines.h`). The builder runs to completion, no exception is left pending, and the trap refires on scope exit so the worker unwinds at the next safepoint exactly as before.

Applied to every `PropertyCallback` builder that can enter JS:

- `constructNextTickFn`, `constructStdioWriteStream` (`process.stdout`/`process.stderr`), `constructStdin`, `constructProcessChannel`, `constructMainModuleProperty`
- `constructBunShell` (`Bun.$`), `defaultBunSQLObject` (`Bun.sql`/`Bun.postgres`), `constructBunSQLObject` (`Bun.SQL`) — these evaluate a builtin or the `bun:sql` internal module
- `DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER`, the one wrapper behind all 38 Rust-backed `Bun.*` getters

The `Bun.*` builders fail differently today: `RETURN_IF_EXCEPTION(scope, {})` hands the empty JSValue to `putDirect`, so the symptom is `JSCJSValueCell.h:67:34: member call on null pointer of type 'JSC::JSCell'` rather than the assertion. Same contract violation, same fix. (`Bun.argv` and `Bun.embeddedFiles` reach it through the Rust wrapper.)

### Verification

`test/js/web/workers/worker-terminate-lifetime.test.ts` gains a case that terminates one worker per builder shape, each parked in `Bun.sleepSync` so `terminate()` is requested before its first touch of the property.

- `git stash push -- src/ && bun bd test test/js/web/workers/worker-terminate-lifetime.test.ts` → fails with `ASSERTION FAILED: !scope.exception() || !hasSlot`
- `git stash pop && bun bd test test/js/web/workers/worker-terminate-lifetime.test.ts` → 4 pass

Sweeping the repro over all 46 lazy properties on the `Bun` and `process` objects (`Bun.$`, `Bun.sql`, `Bun.SQL`, `Bun.postgres`, `Bun.argv`, `Bun.embeddedFiles`, the 38 Rust-backed getters, `process.nextTick`/`mainModule`/`stdin`/`stdout`/`stderr`/`channel`) reports none crashing; before the change, nine of them did.

The vendored node test also passes, and the previously-crashing timing window (`terminate()` at 400-720 ms into a debug build's worker startup, where it reproduced 2 of 3 runs) is now clean across 16 runs.

<details>
<summary>Adjacent: #33211</summary>

#33211 fixes a different bug in the same `reifyStaticProperty` contract — a `Bun.*` lazy getter that *throws* returns the empty JSValue, which `putDirect` then stores. It touches `constructBunShell`, so these two conflict textually. The `lazyPropertyResult()` guard it introduces uses `tryClearException()` too, so it still needs the `DeferTerminationForAWhile` from this PR for the termination case; whichever lands second should put the defer inside that helper.

</details>

