### PR TITLE
Bun.plugin: don't leave a failing onLoad cached in the module registry

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -983,6 +983,7 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
     global->onResolvePlugins.fileNamespace.clear();
     global->onLoadPlugins.groups.clear();
     global->onResolvePlugins.namespaces.clear();
+    global->onLoadPlugins.failedModuleKeys.clear();
 
     delete global->onLoadPlugins.virtualModules;
     global->onLoadPlugins.virtualModules = nullptr;

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -4,6 +4,7 @@
 #include "headers-handwritten.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/HashSet.h>
 #include "helpers.h"
 
 BUN_DECLARE_HOST_FUNCTION(jsFunctionBunPlugin);
@@ -78,6 +79,13 @@ public:
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
+
+        // Module keys whose onLoad failed. The entry JSC caches for them must be
+        // dropped before the next import: see dropFailedPluginModuleEntry().
+        WTF::HashSet<String> failedModuleKeys = {};
+
+        void didFailToLoad(const String& moduleKey) { failedModuleKeys.add(moduleKey); }
+        bool takeLoadFailure(const String& moduleKey) { return failedModuleKeys.remove(moduleKey); }
 
         ~OnLoad()
         {

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSMapInlines.h>
+#include <wtf/Scope.h>
 
 #include "../modules/ObjectModule.h"
 #include "JSCommonJSModule.h"
@@ -1250,8 +1251,14 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionOnLoadObjectResultResolve, (JSC::JSGlobalObje
     pendingModule->internalField(1).set(vm, pendingModule, JSC::jsUndefined());
     JSC::JSPromise* promise = pendingModule->internalPromise();
 
+    // Bun::toString(JSGlobalObject*, JSValue) hands over a +1 on the StringImpl
+    // and BunString has no destructor, so these have to be released by hand.
     BunString specifier = Bun::toString(globalObject, specifierString);
     BunString referrer = Bun::toString(globalObject, referrerString);
+    auto derefStrings = WTF::makeScopeExit([&] {
+        specifier.deref();
+        referrer.deref();
+    });
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     bool wasModuleMock = pendingModule->wasModuleMock;
@@ -1278,6 +1285,7 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionOnLoadObjectResultReject, (JSC::JSGlobalObjec
     JSC::JSValue reason = callFrame->argument(0);
     PendingVirtualModuleResult* pendingModule = uncheckedDowncast<PendingVirtualModuleResult>(callFrame->argument(1));
     BunString specifier = Bun::toString(globalObject, pendingModule->internalField(0).get());
+    auto derefSpecifier = WTF::makeScopeExit([&] { specifier.deref(); });
     pendingModule->internalField(0).set(vm, pendingModule, JSC::jsUndefined());
     pendingModule->internalField(1).set(vm, pendingModule, JSC::jsUndefined());
     JSC::JSPromise* promise = pendingModule->internalPromise();

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -330,6 +330,14 @@ static OnLoadResult handleOnLoadResult(Zig::GlobalObject* globalObject, JSC::JSV
     return handleOnLoadResultNotPromise(globalObject, objectValue, specifier, wasModuleMock);
 }
 
+// A rejected fetch promise makes JSC cache the failure in its module registry,
+// which then hands later importers a rebuilt copy of the error. Remember the key
+// so the next import drops the entry (see dropFailedPluginModuleEntry).
+static void didFailToLoadVirtualModule(Zig::GlobalObject* globalObject, BunString* specifier)
+{
+    globalObject->onLoadPlugins.didFailToLoad(specifier->toWTFString());
+}
+
 template<bool allowPromise>
 static JSValue handleVirtualModuleResult(
     Zig::GlobalObject* globalObject,
@@ -348,6 +356,10 @@ static JSValue handleVirtualModuleResult(
 
     const auto reject = [&](JSC::JSValue exception) -> JSValue {
         if constexpr (allowPromise) {
+            // require() turns this rejection back into a throw, so only the ESM
+            // fetch hook hands the failure to the module registry.
+            if (!commonJSModule)
+                didFailToLoadVirtualModule(globalObject, specifier);
             return rejectedInternalPromise(globalObject, exception);
         } else {
             throwException(globalObject, scope, exception);
@@ -369,6 +381,8 @@ static JSValue handleVirtualModuleResult(
         if (auto* exception = scope.exception()) {
             if constexpr (allowPromise) {
                 (void)scope.tryClearException();
+                if (!commonJSModule)
+                    didFailToLoadVirtualModule(globalObject, specifier);
                 RELEASE_AND_RETURN(scope, rejectedInternalPromise(globalObject, exception));
             } else {
                 return exception;
@@ -1247,6 +1261,7 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionOnLoadObjectResultResolve, (JSC::JSGlobalObje
         throwException(globalObject, scope, result);
     }
     if (scope.exception()) [[unlikely]] {
+        didFailToLoadVirtualModule(static_cast<Zig::GlobalObject*>(globalObject), &specifier);
         auto retValue = JSValue::encode(promise->rejectWithCaughtException(vm, scope));
         pendingModule->internalField(2).set(vm, pendingModule, JSC::jsUndefined());
         return retValue;
@@ -1262,9 +1277,12 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionOnLoadObjectResultReject, (JSC::JSGlobalObjec
     auto& vm = JSC::getVM(globalObject);
     JSC::JSValue reason = callFrame->argument(0);
     PendingVirtualModuleResult* pendingModule = uncheckedDowncast<PendingVirtualModuleResult>(callFrame->argument(1));
+    BunString specifier = Bun::toString(globalObject, pendingModule->internalField(0).get());
     pendingModule->internalField(0).set(vm, pendingModule, JSC::jsUndefined());
     pendingModule->internalField(1).set(vm, pendingModule, JSC::jsUndefined());
     JSC::JSPromise* promise = pendingModule->internalPromise();
+
+    didFailToLoadVirtualModule(static_cast<Zig::GlobalObject*>(globalObject), &specifier);
 
     pendingModule->internalField(2).set(vm, pendingModule, JSC::jsUndefined());
     promise->reject(vm, reason);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3373,12 +3373,33 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject* g
     globalObject->vm().queueMicrotask(WTF::move(task));
 }
 
-JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject,
-    JSModuleLoader* loader, JSValue key,
-    JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool)
+// A plugin's onLoad is user code that can succeed on a later import, but JSC
+// caches a failed fetch forever and re-materializes the stored error through
+// JSModuleLoader::duplicateError(), which keeps only the message: `code`,
+// `cause`, the prototype and the identity of the object the plugin threw are all
+// lost. Drop the entry so the next import re-runs the plugin, which is already
+// what a synchronous onLoad throw does.
+static void dropFailedPluginModuleEntry(Zig::GlobalObject* globalObject, const JSC::Identifier& moduleKey)
 {
-    Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
+    if (moduleKey.isNull() || moduleKey.isEmpty() || moduleKey.isSymbol())
+        return;
 
+    if (!globalObject->onLoadPlugins.takeLoadFailure(moduleKey.string()))
+        return;
+
+    auto* loader = globalObject->moduleLoader();
+    auto* entry = loader->registryEntry(moduleKey);
+    if (!entry || entry->status() != JSC::ModuleRegistryEntry::Status::FetchFailed)
+        return;
+
+    // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread
+    // under cellLock(); take the same lock so the removal can't race it.
+    WTF::Locker locker { loader->cellLock() };
+    loader->removeEntry(moduleKey);
+}
+
+static JSC::Identifier resolveModuleSpecifier(Zig::GlobalObject* globalObject, JSValue key, JSValue referrer)
+{
     ErrorableString res;
     res.success = false;
 
@@ -3456,6 +3477,23 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         throwException(scope, res.result.err, globalObject);
         return globalObject->vm().propertyNames->emptyIdentifier;
     }
+}
+
+JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject,
+    JSModuleLoader* loader, JSValue key,
+    JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool)
+{
+    Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
+
+    JSC::Identifier resolved = resolveModuleSpecifier(globalObject, key, referrer);
+
+    // Static and dynamic imports both resolve before they consult the module
+    // registry, so this is the one hook that runs ahead of JSC's cached-failure
+    // short-circuit in JSModuleLoader::loadModule / hostLoadImportedModule.
+    if (!globalObject->onLoadPlugins.failedModuleKeys.isEmpty())
+        dropFailedPluginModuleEntry(globalObject, resolved);
+
+    return resolved;
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
 import { describe, expect, it } from "bun:test";
-import { resolve } from "path";
+import { join, resolve } from "path";
 
 declare global {
   var failingObject: any;
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -542,6 +542,172 @@ describe("errors", () => {
       sleep(2_500),
     ]);
     expect(text).toBe(result);
+  });
+});
+
+describe("a failing onLoad", () => {
+  // Plugins and the module registry are process-global, so each case needs its
+  // own process.
+  async function runFixture(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`expected JSON on stdout.\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`);
+    }
+    expect(exitCode).toBe(0);
+    return parsed;
+  }
+
+  // Imports `failing:mod` three times and reports what each importer received.
+  function importThrice(onLoad: string) {
+    return `
+      const sent = new Error("cfg missing");
+      sent.code = "E_SENT";
+      let calls = 0;
+      Bun.plugin({
+        name: "failing-loader",
+        setup(builder) {
+          builder.onResolve({ filter: /.*/, namespace: "failing" }, ({ path }) => ({ path, namespace: "failing" }));
+          builder.onLoad({ filter: /.*/, namespace: "failing" }, ${onLoad});
+        },
+      });
+      const errors = [];
+      for (let i = 0; i < 3; i++) errors.push(await import("failing:mod").then(() => null, e => e));
+      console.log(
+        JSON.stringify({
+          calls,
+          sameErrorObject: errors.map(e => e === sent),
+          codes: errors.map(e => (e == null ? null : (e.code ?? null))),
+          messages: errors.map(e => (e == null ? null : e.message)),
+        }),
+      );
+    `;
+  }
+
+  // Every way an onLoad can fail has to agree: the loader runs again on the
+  // next import, and importers get the exact error object the loader produced
+  // rather than a copy the module registry rebuilt from its message.
+  const throwingLoaders = {
+    "throws synchronously": `() => { calls++; throw sent; }`,
+    "rejects asynchronously": `async () => { calls++; throw sent; }`,
+    "returns an already-rejected promise": `() => { calls++; return Promise.reject(sent); }`,
+  };
+
+  for (const [how, onLoad] of Object.entries(throwingLoaders)) {
+    it(`is retried and preserves the error object when it ${how}`, async () => {
+      expect(await runFixture(importThrice(onLoad))).toEqual({
+        calls: 3,
+        sameErrorObject: [true, true, true],
+        codes: ["E_SENT", "E_SENT", "E_SENT"],
+        messages: ["cfg missing", "cfg missing", "cfg missing"],
+      });
+    });
+  }
+
+  const invalidLoaders = {
+    "synchronously": `() => { calls++; return { contents: "", loader: "nope" }; }`,
+    "asynchronously": `async () => { calls++; return { contents: "", loader: "nope" }; }`,
+  };
+
+  for (const [how, onLoad] of Object.entries(invalidLoaders)) {
+    it(`is retried when it ${how} returns an invalid loader`, async () => {
+      const expectedMessage = expect.stringContaining("loader");
+      expect(await runFixture(importThrice(onLoad))).toEqual({
+        calls: 3,
+        sameErrorObject: [false, false, false],
+        codes: [null, null, null],
+        messages: [expectedMessage, expectedMessage, expectedMessage],
+      });
+    });
+  }
+
+  it("stops failing once the loader succeeds", async () => {
+    expect(
+      await runFixture(`
+        let calls = 0;
+        Bun.plugin({
+          name: "transient",
+          setup(builder) {
+            builder.onResolve({ filter: /.*/, namespace: "transient" }, ({ path }) => ({ path, namespace: "transient" }));
+            builder.onLoad({ filter: /.*/, namespace: "transient" }, async () => {
+              if (++calls < 3) throw new Error("not ready yet");
+              return { contents: "export default 'recovered';", loader: "js" };
+            });
+          },
+        });
+        const results = [];
+        for (let i = 0; i < 3; i++) results.push(await import("transient:mod").then(m => m.default, e => e.message));
+        console.log(JSON.stringify({ calls, results }));
+      `),
+    ).toEqual({
+      calls: 3,
+      results: ["not ready yet", "not ready yet", "recovered"],
+    });
+  });
+
+  it("is retried for a plugin that loads real files", async () => {
+    using dir = tempDir("plugin-failing-file-loader", { "config.weird": "" });
+    const entry = JSON.stringify(join(String(dir), "config.weird"));
+
+    expect(
+      await runFixture(`
+        const sent = new Error("cfg missing");
+        sent.code = "E_SENT";
+        let calls = 0;
+        Bun.plugin({
+          name: "failing-file-loader",
+          setup(builder) {
+            builder.onLoad({ filter: /\\.weird$/ }, async () => { calls++; throw sent; });
+          },
+        });
+        const errors = [];
+        for (let i = 0; i < 3; i++) errors.push(await import(${entry}).then(() => null, e => e));
+        console.log(
+          JSON.stringify({
+            calls,
+            sameErrorObject: errors.map(e => e === sent),
+            codes: errors.map(e => (e == null ? null : (e.code ?? null))),
+          }),
+        );
+      `),
+    ).toEqual({
+      calls: 3,
+      sameErrorObject: [true, true, true],
+      codes: ["E_SENT", "E_SENT", "E_SENT"],
+    });
+  });
+
+  it("does not make a successful onLoad re-run on every import", async () => {
+    expect(
+      await runFixture(`
+        let calls = 0;
+        Bun.plugin({
+          name: "succeeding",
+          setup(builder) {
+            builder.onResolve({ filter: /.*/, namespace: "ok" }, ({ path }) => ({ path, namespace: "ok" }));
+            builder.onLoad({ filter: /.*/, namespace: "ok" }, async () => {
+              calls++;
+              return { contents: "export default 42;", loader: "js" };
+            });
+          },
+        });
+        const values = [];
+        for (let i = 0; i < 3; i++) values.push((await import("ok:mod")).default);
+        console.log(JSON.stringify({ calls, values }));
+      `),
+    ).toEqual({
+      calls: 1,
+      values: [42, 42, 42],
+    });
   });
 });
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -545,7 +545,7 @@ describe("errors", () => {
   });
 });
 
-describe("a failing onLoad", () => {
+describe.concurrent("a failing onLoad", () => {
   // Plugins and the module registry are process-global, so each case needs its
   // own process.
   async function runFixture(source: string) {


### PR DESCRIPTION
A failing `Bun.plugin` `onLoad` behaves differently depending on whether the callback is sync or async, and the async path corrupts the error on every import after the first.

## Repro

```js
Bun.plugin({
  name: "v",
  setup(b) {
    b.onResolve({ filter: /.*/, namespace: "v" }, a => ({ path: a.path, namespace: "v" }));
    b.onLoad({ filter: /.*/, namespace: "v" }, async () => {
      globalThis.calls = (globalThis.calls ?? 0) + 1;
      const e = new Error("cfg missing");
      e.code = "E_SENT";
      globalThis.sent = e;
      throw e;
    });
  },
});

const errors = [];
for (let i = 0; i < 3; i++) errors.push(await import("v:x").catch(e => e));

console.log("onLoad calls:", globalThis.calls);
console.log("same object: ", errors.map(e => e === globalThis.sent).join(","));
console.log("err.code:    ", errors.map(e => e.code).join(","));
```

```
onLoad calls: 1
same object:  true,false,false
err.code:     E_SENT,,
```

Only the first importer gets the error the loader threw. The other two get a look-alike copy with `code` gone, and the loader is never run again, so a transient failure (a config not written yet, a registry briefly down) is permanent for the life of the process. Making the same `onLoad` synchronous gives `onLoad calls: 3` and `err.code: E_SENT,E_SENT,E_SENT` instead: two different contracts for one API.

## Cause

The two paths report failure to JSC differently.

A **synchronous** `onLoad` throw propagates out of `Bun__runVirtualModule` as a pending exception, which `moduleLoaderFetch` returns through without clearing. `JSModuleLoader::loadModule` then bails at its `RETURN_IF_EXCEPTION` before registering anything, and Bun's `moduleLoaderImportModule` turns the still-pending exception into a rejected promise. No registry entry exists, so the next import re-runs the loader.

An **asynchronous** `onLoad` rejection settles the ESM fetch promise the normal way, so `moduleLoadTopSettled` records a `FetchFailed` `ModuleRegistryEntry`. Every later import short-circuits on that entry in `JSModuleLoader::loadModule`:

```cpp
if (ModuleRegistryEntry* entry = getRegisteredMayBeNull(specifier, type)) {
    JSValue error = entry->error(globalObject);
    if (error)
        return JSPromise::rejectedPromise(globalObject, error);
```

and `ModuleRegistryEntry::error()` does not hand back what was stored:

```cpp
if (m_status == Status::FetchFailed) {
    if (auto* errorInstance = dynamicDowncast<ErrorInstance>(error))
        RELEASE_AND_RETURN(scope, JSModuleLoader::duplicateError(globalObject, errorInstance));
}
```

`duplicateError` rebuilds the error from its message and error type, copying only five loader-internal private properties. `code`, `cause`, any own property, and `Error` subclass prototypes are dropped, and the result is a different object. That behavior exists so that WPT's requirement of distinct error instances for *network fetch* failures can coexist with error caching. JSC's own `maybeDuplicateFetchError` applies it only to errors carrying the `@moduleFetchFailureKind` marker that WebCore's `ScriptModuleLoader` attaches; nothing in Bun ever sets that marker, so a user error thrown from `onLoad` gets rebuilt even though it was never a fetch error.

The visible consequence is easy to reach without plugins too: `await import("./x.node")` rejects with a fresh `TypeError` each time rather than the cached one.

`ModuleRegistryEntry` lives in the prebuilt WebKit this repo consumes, so the fix here is to stop handing it a failure it will misreport.

## Fix

Keep the contract the synchronous path already has: a plugin `onLoad` is user code that may succeed next time, so its failure is not cached.

- `BunPlugin::OnLoad` gains `failedModuleKeys`, recorded whenever a plugin load rejects the ESM fetch promise (`handleVirtualModuleResult`'s reject paths, and the two `PendingVirtualModuleResult` settle handlers). `require()` turns the same rejection back into a throw and never reaches the registry, so it is excluded.
- `moduleLoaderResolve` drops the `FetchFailed` entry for a recorded key before returning. Static imports, dynamic imports and the entry point all resolve before consulting the registry, so this runs ahead of the short-circuit above. The entry is only removed when its status is `FetchFailed`, leaving in-flight (`Fetching`) and successful (`Fetched`) entries alone.

With no plugin failure recorded, the added work per resolve is one `HashSet::isEmpty()` check.

Both `onLoad` failure shapes now agree, and every importer receives the object the loader produced:

```
onLoad calls: 3
same object:  true,true,true
err.code:     E_SENT,E_SENT,E_SENT
```

## Verification

`test/js/bun/plugin/plugins.test.ts` gains a `describe("a failing onLoad")` block covering the matrix: a sync throw, an async throw, an already-rejected promise, and a sync/async invalid return value, each asserting the loader re-runs and the rejection keeps its identity and `code`. It also covers a plugin that loads real files (no `ns:` prefix), a transient failure that recovers once the loader succeeds, and a successful loader that must still only run once.

Six of the eight fail on `main`; the two that pass both ways are the controls (the sync throw already behaved, and the successful load guards against over-eviction).

Existing suites pass: `test/js/bun/plugin/`, `test/bundler/bundler_plugin.test.ts`, `test/js/bun/resolve/`, `test/js/bun/test/mock/`, `test/cli/run/preload.test.ts`.
