### PR TITLE
shell: emit a word delimiter after a trailing `**`

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3240,7 +3240,8 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 | TokenTag::Comma
                 | TokenTag::BraceEnd
                 | TokenTag::CmdSubstEnd
-                | TokenTag::Asterisk => true,
+                | TokenTag::Asterisk
+                | TokenTag::DoubleAsterisk => true,
 
                 TokenTag::Pipe
                 | TokenTag::DoublePipe
@@ -3248,7 +3249,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 | TokenTag::DoubleAmpersand
                 | TokenTag::Redirect
                 | TokenTag::Dollar
-                | TokenTag::DoubleAsterisk
                 | TokenTag::Eq
                 | TokenTag::Semicolon
                 | TokenTag::Newline

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -839,6 +839,66 @@ booga"
         .runAsTest("long leading run of injected ! stays literal");
     });
 
+    describe("a word ending in `**` is terminated by the separator after it", () => {
+      // A trailing `**` must not swallow the separator after it: `echo ** x` is
+      // two words, and before an operator the `**` is still its own word.
+      const words = (out: string) => out.trim().replaceAll("\\", "/").split(/\s+/);
+
+      TestBuilder.command`echo ** after`
+        .ensureTempDir()
+        .file("a.txt", "")
+        .directory("sub")
+        .file("sub/b.txt", "")
+        .stdout(out => {
+          expect(words(out).sort()).toEqual(["a.txt", "after", "sub", "sub/b.txt"]);
+          expect(words(out).at(-1)).toBe("after");
+        })
+        .runAsTest("followed by another word");
+
+      TestBuilder.command`echo src/** dst`
+        .ensureTempDir()
+        .directory("src")
+        .file("src/a.txt", "")
+        .stdout(out => {
+          expect(words(out)).toEqual(["src/a.txt", "dst"]);
+        })
+        .runAsTest("at the end of a longer word");
+
+      TestBuilder.command`echo ** | cat`
+        .ensureTempDir()
+        .file("a.txt", "")
+        .directory("sub")
+        .file("sub/b.txt", "")
+        .stdout(out => {
+          expect(words(out).sort()).toEqual(["a.txt", "sub", "sub/b.txt"]);
+        })
+        .runAsTest("before a pipe");
+
+      TestBuilder.command`echo ** && echo done`
+        .ensureTempDir()
+        .file("a.txt", "")
+        .stdout(out => {
+          expect(out.trim().split("\n")).toEqual(["a.txt", "done"]);
+        })
+        .runAsTest("before &&");
+
+      test("copies the whole tree with `cp -r src/** dst/`", async () => {
+        const dir = tempDirWithFiles("glob-double-asterisk-cp", {
+          "src/a.txt": "a",
+          "src/nested/b.txt": "b",
+          "dst/.keep": "",
+        });
+        const dst = join(dir, "dst").replaceAll("\\", "/");
+
+        const { stderr, exitCode } = await $`cp -r src/** ${dst}/`.cwd(dir).quiet().nothrow();
+        expect(stderr.toString()).toBe("");
+        expect(exitCode).toBe(0);
+
+        expect(await Bun.file(join(dst, "a.txt")).text()).toBe("a");
+        expect(await Bun.file(join(dst, "nested", "b.txt")).text()).toBe("b");
+      });
+    });
+
     test("glob on a nonexistent absolute directory does not crash the process", async () => {
       const missing = join(tmpdirSync(), "does-not-exist").replaceAll("\\", "/");
       const script = `

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -895,7 +895,9 @@ booga"
         })
         .runAsTest("before &&");
 
-      test("copies the whole tree with `cp -r src/** dst/`", async () => {
+      // `-R` rather than `-r`: on POSIX `cp` spawns the system binary, which takes
+      // either, but on Windows it is a builtin that only accepts `-R`.
+      test("copies the whole tree with `cp -R src/** dst/`", async () => {
         const dir = tempDirWithFiles("glob-double-asterisk-cp", {
           "src/a.txt": "a",
           "src/nested/b.txt": "b",
@@ -903,7 +905,7 @@ booga"
         });
         const dst = join(dir, "dst").replaceAll("\\", "/");
 
-        const { stderr, exitCode } = await $`cp -r src/** ${dst}/`.cwd(dir).quiet().nothrow();
+        const { stderr, exitCode } = await $`cp -R src/** ${dst}/`.cwd(dir).quiet().nothrow();
         expect(stderr.toString()).toBe("");
         expect(exitCode).toBe(0);
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -864,6 +864,19 @@ booga"
         })
         .runAsTest("at the end of a longer word");
 
+      // https://github.com/oven-sh/bun/issues/18656
+      TestBuilder.command`echo views/** public/**/*.js .env`
+        .ensureTempDir()
+        .directory("views")
+        .file("views/a.html", "")
+        .directory("public/js")
+        .file("public/js/b.js", "")
+        .file(".env", "")
+        .stdout(out => {
+          expect(words(out)).toEqual(["views/a.html", "public/js/b.js", ".env"]);
+        })
+        .runAsTest("two `**` globs and a plain word stay three arguments");
+
       TestBuilder.command`echo ** | cat`
         .ensureTempDir()
         .file("a.txt", "")

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -224,6 +224,65 @@ describe("lex shell", () => {
     expect(result).toEqual(expected);
   });
 
+  test("asterisk ends the word", () => {
+    expect(JSON.parse(lex`echo * foo`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Asterisk": {} },
+      { "Delimit": {} },
+      { "Text": "foo" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+  });
+
+  test("double asterisk ends the word", () => {
+    expect(JSON.parse(lex`echo ** foo`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleAsterisk": {} },
+      { "Delimit": {} },
+      { "Text": "foo" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    expect(JSON.parse(lex`echo src/** dst`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Text": "src/" },
+      { "DoubleAsterisk": {} },
+      { "Delimit": {} },
+      { "Text": "dst" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+  });
+
+  test("double asterisk ends the word before an operator", () => {
+    expect(JSON.parse(lex`echo ** | cat`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleAsterisk": {} },
+      { "Delimit": {} },
+      { "Pipe": {} },
+      { "Text": "cat" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    expect(JSON.parse(lex`echo ** > f`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleAsterisk": {} },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "f" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+  });
+
   test("op_and", () => {
     const expected = [
       { "Text": "echo" },


### PR DESCRIPTION
## Repro

In `Bun.$`, a word ending in `**` swallows the separator that follows it.

```js
import { $ } from "bun";

// a following word gets merged into the glob
await $`echo ** after`;   // bun: no matches found: **after
await $`cp -r src/** dst/`;  // bun: no matches found: src/**dst/

// a following operator drops the `**` entirely: zero arguments, exit 0
await $`echo ** | cat`;   // prints an empty line
await $`echo ** && echo done`;
```

bash (with `globstar`) expands the tree in all four. A single `*` is already
correct in Bun: `echo * after` works, `echo * | cat` works.

## Cause

`break_word_impl` in `src/shell_parser/parse.rs` decides whether to emit a
`Delimit` token when a separator arrives and no text is pending. It does that
by looking at the previous token. `Asterisk` was listed as a token that can end
a word; `DoubleAsterisk` was listed as one that cannot.

```
lex`echo *  foo` -> Text(echo) Delimit Asterisk       Delimit Text(foo) ...
lex`echo ** foo` -> Text(echo) Delimit DoubleAsterisk         Text(foo) ...
lex`echo ** | cat` -> Text(echo) Delimit DoubleAsterisk Pipe Text(cat) ...
```

Without the `Delimit`, the parser keeps accumulating atoms into the same word,
so `**` and the next word become `**foo`. Before an operator there is no next
word and the parser's `delimits()` does not count `Pipe`/`Redirect`/`&&`, so
the `**` atom is discarded and the command runs with zero arguments.

`;`, a newline, and EOF are in `delimits()`, which is why the plain
`echo **` and `rm -rf build/**` forms happened to work.

## Fix

Move `DoubleAsterisk` into the bucket of tokens that can end a word, next to
`Asterisk`. It only takes effect when `**` is the last thing in the word, so
`**/*.txt`, `a**b` and `**{a,b}` keep lexing as single words.

The same bucket fed both `break_word_impl` call sites, so this covers the
whitespace path and the `break_word_operator` path (`|`, `>`, `<`, `&`, and a
closing backtick) at once.

## Verification

`test/js/bun/shell/lex.test.ts` asserts the token stream directly, including
the single-`*` case as a control. `test/js/bun/shell/bunshell.test.ts` covers
the behavior: a following word, `**` at the end of a longer word, before a
pipe, before `&&`, and the `cp -r src/** ${dst}/` shape from the report with
real filesystem assertions.

All seven fail on `main` and pass with the fix. The rest of
`test/js/bun/shell/` is unchanged (the leak/`ls` failures in this container
reproduce identically without the patch: they need a non-root user and a
faster box).

This is not a regression from the Rust rewrite; the Zig lexer had the same
bucket split.


Fixes #18656
