### PR TITLE
node:fs: reject the empty path in native realpath instead of resolving it to the cwd

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7629,6 +7629,17 @@ impl NodeFS {
         args: &args::Realpath,
         variant: RealpathVariant,
     ) -> Maybe<ret::Realpath> {
+        // `realpath(3)` rejects an empty path. Only the emulated variant resolves it
+        // against the cwd, because Node's JS port starts with `path.resolve(path)`.
+        if variant == RealpathVariant::Native && args.path.slice().is_empty() {
+            return Err(sys::Error {
+                errno: E::ENOENT as _,
+                syscall: sys::Tag::realpath,
+                path: args.path.slice().into(),
+                ..Default::default()
+            });
+        }
+
         #[cfg(windows)]
         {
             let mut req = UvFsReq::new();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2364,6 +2364,43 @@ it("realpath async", async () => {
   expect(await promise).toBe(realpathSync(import.meta.path));
 }, 30_000);
 
+// realpath(3) rejects an empty path, and Node surfaces that through the native
+// entry points. Only realpath/realpathSync (Node's JS port, which begins with
+// path.resolve) turn an empty path into the cwd.
+describe("realpath of an empty path", () => {
+  const summarize = (error: any) => ({
+    code: error?.code,
+    syscall: error?.syscall,
+    message: error?.message,
+  });
+  const enoent = { code: "ENOENT", syscall: "realpath", message: "ENOENT: no such file or directory, realpath" };
+
+  it("realpathSync.native throws ENOENT", () => {
+    let error: unknown;
+    try {
+      fs.realpathSync.native("");
+    } catch (e) {
+      error = e;
+    }
+    expect(summarize(error)).toEqual(enoent);
+  });
+
+  it("realpath.native calls back with ENOENT", async () => {
+    const { promise, resolve } = Promise.withResolvers<any>();
+    fs.realpath.native("", (err, resolvedPath) => resolve(err ?? { resolvedPath }));
+    expect(summarize(await promise)).toEqual(enoent);
+  });
+
+  it("realpathSync and realpath resolve it to the cwd, like Node", async () => {
+    const cwd = realpathSync(process.cwd());
+    expect(realpathSync("")).toBe(cwd);
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    fs.realpath("", (err, resolvedPath) => (err ? reject(err) : resolve(resolvedPath)));
+    expect(await promise).toBe(cwd);
+  });
+});
+
 describe("stat", () => {
   it("file metadata is correct", () => {
     const fileStats = statSync(join(import.meta.dir, "fs-stream.js"));


### PR DESCRIPTION
## Problem

`realpath(3)` rejects an empty path with `ENOENT`, and Node surfaces that through
every entry point backed by the syscall. Bun resolved it to the current working
directory instead:

```js
import fs from "node:fs";

fs.realpathSync.native(""); // node: throws ENOENT   bun: "/current/working/dir"
fs.realpath.native("", console.log); // node: ENOENT  bun: null, "/current/working/dir"
```

An empty string is the classic "a variable was unset" bug (`path.dirname("")`, a
missing env var, an optional field). Every other `fs` entry point turns it into a
loud `ENOENT`, but a realpath-first pipeline (resolve, then read/rm/watch) silently
swapped in the cwd.

## Cause

`NodeFS::realpath_inner` (`src/runtime/node/node_fs.rs`) implements both realpath
variants with the same native syscall. On POSIX it joins the argument onto
`FileSystem::top_level_dir` before `open()`:

```rust
let parts = [fs.top_level_dir, path_slice];
let Some(joined) = fs.abs_buf_checked(&parts, ...) else { /* ENAMETOOLONG */ };
```

For an empty path that join yields the cwd, which opens successfully, so the
resolved cwd came back as the result.

That cwd substitution is correct for the *emulated* variant, which stands in for
Node's JS port of `realpath` (it begins with `p = pathModule.resolve(p)`, and
`path.resolve("")` is the cwd). It is not correct for the native variant, which
must behave like the syscall.

## Fix

Reject the empty path with `ENOENT` before the join, for the native variant only.
`fs.realpathSync` / `fs.realpath` keep returning the cwd, matching Node.

## Verification

New tests in `test/js/node/fs/fs.test.ts`:

| | before | after / node v26 |
| --- | --- | --- |
| `fs.realpathSync.native("")` | `"/current/working/dir"` | `ENOENT` (`syscall: "realpath"`) |
| `fs.realpath.native("", cb)` | `"/current/working/dir"` | `ENOENT` (`syscall: "realpath"`) |
| `fs.realpathSync("")` | cwd | cwd (unchanged) |
| `fs.realpath("", cb)` | cwd | cwd (unchanged) |

Two of the three new tests fail on the unfixed build and pass with the fix; the
fourth guards the emulated variant against over-fixing. `test/js/node/fs/fs.test.ts`
(383 pass, 0 fail), `test-fs-realpath.js`, `test-fs-realpath-native.js`,
`test-fs-realpath-buffer-encoding.js`, `test-fs-realpath-pipe.js`,
`test-fs-long-path.js` and `test-fs-null-bytes.js` all pass.
`bun run rust:check-all` is clean across all ten targets.

## Note on `fs.promises.realpath("")`

`fs.promises.realpath("")` also returns the cwd today, but for a second reason: Bun
wires it to the *emulated* binding, while Node routes it to the native one. #32976
already fixes that routing. With both changes applied `fs.promises.realpath("")`
rejects with `ENOENT` too; neither change alone is enough, so the test for it lives
with whichever lands second. If #32976 is not taken, its one-line change can be
folded in here.

Adjacent and deliberately out of scope: an empty `Buffer` path is rejected with
`ERR_INVALID_ARG_TYPE` by every Bun `fs` entry point (`fs.statSync(Buffer.alloc(0))`
too), not just realpath, and `err.path` is dropped from the error object when the
path is empty (same for `fs.statSync("")`). Both are in shared layers.
