### PR TITLE
Bun.plugin: don't re-run a virtual module's onLoad when require() follows import()

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -132,7 +132,9 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
         }
       }
 
-      return (mod.exports = namespace["module.exports"] ?? namespace);
+      // A present "module.exports" binding wins even when it holds null, so test for the
+      // binding rather than for a nullish value.
+      return (mod.exports = "module.exports" in namespace ? namespace["module.exports"] : namespace);
     }
   }
 
@@ -356,7 +358,7 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
       }
     }
 
-    this.exports = namespace["module.exports"] ?? namespace;
+    this.exports = "module.exports" in namespace ? namespace["module.exports"] : namespace;
     return;
   }
 }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -461,6 +461,18 @@ JSModuleMock::JSModuleMock(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject
 {
 }
 
+bool BunPlugin::OnLoad::hasModuleMock(const String& specifier) const
+{
+    if (!virtualModules)
+        return false;
+
+    auto it = virtualModules->find(specifier);
+    if (it == virtualModules->end() || !it->value)
+        return false;
+
+    return dynamicDowncast<JSModuleMock>(it->value.get()) != nullptr;
+}
+
 Structure* JSModuleMock::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -77,6 +77,10 @@ public:
 
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
 
+        // True when `specifier` was registered by mock.module(), as opposed to a
+        // Bun.plugin() virtual module.
+        bool hasModuleMock(const String& specifier) const;
+
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 
         ~OnLoad()

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -402,7 +402,12 @@ static JSValue handleVirtualModuleResult(
 
     case OnLoadResultTypeObject: {
         JSC::JSObject* object = onLoadResult.value.object.getObject();
-        if (commonJSModule) {
+        // Only mocks need to unwrap `default` here. For everything else the source code
+        // below carries a "module.exports" binding that require() reads back out, and
+        // going through it is what registers the module so a later import() reuses this
+        // load instead of running the loader a second time. Mocks skip provideFetch, so
+        // they have nothing to read back and still need the shortcut.
+        if (commonJSModule && wasModuleMock) {
             const auto& __esModuleIdentifier = vm.propertyNames->__esModule;
             auto esModuleValue = object->getIfPropertyExists(globalObject, __esModuleIdentifier);
             if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -660,9 +660,21 @@ JSValue fetchCommonJSModule(
 
     bool wasModuleMock = false;
 
+    // require() of a module already in the ESM registry returns that instance (the
+    // jsNumber(-1) below), so re-running a plugin's onLoad() re-executes user code for
+    // a result we discard. The ESM path never re-fetches a registered module either.
+    const bool alreadyLoadedAsESM = [&]() -> bool {
+        auto* entry = globalObject->moduleLoader()->registryEntry(JSC::Identifier::fromString(vm, specifierWtfString));
+        return entry && entry->status() >= JSC::ModuleRegistryEntry::Status::Fetched;
+    }();
+
+    // mock.module() is exempt: it patches the registry entry when it is installed, and
+    // require() relies on running it here so a mocked builtin still beats the real one.
+    const bool shouldRunVirtualModule = !alreadyLoadedAsESM || globalObject->onLoadPlugins.hasModuleMock(specifierWtfString);
+
     // When "bun test" is enabled, allow users to override builtin modules
     // This is important for being able to trivially mock things like the filesystem.
-    if (isBunTest) {
+    if (isBunTest && shouldRunVirtualModule) {
         JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, &specifier, wasModuleMock);
         RETURN_IF_EXCEPTION(scope, {});
         if (virtualModuleResult) {
@@ -717,7 +729,7 @@ JSValue fetchCommonJSModule(
     }
 
     // When "bun test" is NOT enabled, disable users from overriding builtin modules
-    if (!isBunTest) {
+    if (!isBunTest && shouldRunVirtualModule) {
         JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, &specifier, wasModuleMock);
         RETURN_IF_EXCEPTION(scope, {});
         if (virtualModuleResult) {
@@ -760,12 +772,7 @@ JSValue fetchCommonJSModule(
         }
     }
 
-    bool hasAlreadyLoadedESMVersionSoWeShouldntTranspileItTwice = [&]() -> bool {
-        auto* entry = globalObject->moduleLoader()->registryEntry(JSC::Identifier::fromString(vm, specifierWtfString));
-        return entry && entry->status() >= JSC::ModuleRegistryEntry::Status::Fetched;
-    }();
-
-    if (hasAlreadyLoadedESMVersionSoWeShouldntTranspileItTwice) {
+    if (alreadyLoadedAsESM) {
         RELEASE_AND_RETURN(scope, jsNumber(-1));
     }
 

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -37,6 +37,7 @@
 #include "../modules/ObjectModule.h"
 #include "JSCommonJSModule.h"
 #include "IsolatedModuleCache.h"
+#include "isBuiltinModule.h"
 #include "../modules/_NativeModule.h"
 
 #include "JSCommonJSExtensions.h"
@@ -668,9 +669,14 @@ JSValue fetchCommonJSModule(
         return entry && entry->status() >= JSC::ModuleRegistryEntry::Status::Fetched;
     }();
 
-    // mock.module() is exempt: it patches the registry entry when it is installed, and
-    // require() relies on running it here so a mocked builtin still beats the real one.
-    const bool shouldRunVirtualModule = !alreadyLoadedAsESM || globalObject->onLoadPlugins.hasModuleMock(specifierWtfString);
+    // Two exemptions, both because this lookup runs ahead of the builtin one under
+    // `bun test`. Mocks: mock.module() is how a builtin gets shadowed, and it patches
+    // whatever registry entry existed at install time, which carries no "module.exports"
+    // binding for require() to unwrap. Builtins: keep require() of one on the branch it
+    // already takes, rather than having a registered plugin decide that.
+    const bool shouldRunVirtualModule = !alreadyLoadedAsESM
+        || globalObject->onLoadPlugins.hasModuleMock(specifierWtfString)
+        || Bun::isBuiltinModule(specifierWtfString);
 
     // When "bun test" is enabled, allow users to override builtin modules
     // This is important for being able to trivially mock things like the filesystem.

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -21,6 +21,11 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(throwScope, void());
         gcUnprotectNullTolerant(object);
 
+        const JSC::Identifier moduleDotExports = JSC::Identifier::fromString(vm, "module.exports"_s);
+        bool hasESModuleMarker = false;
+        bool hasModuleDotExports = false;
+        JSValue defaultValue;
+
         for (auto& entry : properties.releaseData()->propertyNameVector()) {
             exportNames.append(entry);
 
@@ -31,6 +36,22 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
                 value = jsUndefined();
             }
             exportValues.append(value);
+
+            if (entry == vm.propertyNames->__esModule)
+                hasESModuleMarker = value.toBoolean(globalObject);
+            else if (entry == vm.propertyNames->defaultKeyword)
+                defaultValue = value;
+            else if (entry == moduleDotExports)
+                hasModuleDotExports = true;
+        }
+
+        // require() of this module unwraps `default` when __esModule is set (see the
+        // commonJSModule branch of handleVirtualModuleResult). Publish it under the
+        // name the CJS bridge reads so require() agrees whether or not import() ran
+        // first and already populated the module registry.
+        if (hasESModuleMarker && !hasModuleDotExports && defaultValue && !defaultValue.isUndefined()) {
+            exportNames.append(moduleDotExports);
+            exportValues.append(defaultValue);
         }
     };
 }

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -45,6 +45,20 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
                 hasModuleDotExports = true;
         }
 
+        // Transpilers define __esModule with Object.defineProperty, which leaves it
+        // non-enumerable and therefore absent from the loop above. Fall back to a lookup
+        // so the marker is found wherever handleVirtualModuleResult would have found it.
+        if (!hasESModuleMarker) {
+            JSValue esModuleValue = object->getIfPropertyExists(globalObject, vm.propertyNames->__esModule);
+            RETURN_IF_EXCEPTION(throwScope, void());
+            if (esModuleValue)
+                hasESModuleMarker = esModuleValue.toBoolean(globalObject);
+        }
+        if (hasESModuleMarker && !defaultValue) {
+            defaultValue = object->getIfPropertyExists(globalObject, vm.propertyNames->defaultKeyword);
+            RETURN_IF_EXCEPTION(throwScope, void());
+        }
+
         // require() of this module unwraps `default` when __esModule is set (see the
         // commonJSModule branch of handleVirtualModuleResult). Publish it under the
         // name the CJS bridge reads so require() agrees whether or not import() ran

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -303,6 +303,123 @@ describe("module", () => {
   });
 });
 
+describe("the loader runs once per specifier", () => {
+  it("require() after import() reuses the ESM registry entry", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-import-first", () => {
+          calls++;
+          return { exports: { value: calls }, loader: "object" };
+        });
+      },
+    });
+
+    // @ts-expect-error
+    const imported = await import("load-once-import-first");
+    expect([calls, imported.value]).toEqual([1, 1]);
+
+    const required = require("load-once-import-first");
+    expect([calls, required.value]).toEqual([1, 1]);
+  });
+
+  it("import() after require() reuses the require() load", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-require-first", () => {
+          calls++;
+          return { exports: { value: calls }, loader: "object" };
+        });
+      },
+    });
+
+    const required = require("load-once-require-first");
+    expect([calls, required.value]).toEqual([1, 1]);
+
+    // @ts-expect-error
+    const imported = await import("load-once-require-first");
+    expect([calls, imported.value]).toEqual([1, 1]);
+  });
+
+  it("require() after import() reuses the entry for a namespaced onLoad", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.onResolve({ filter: /.*/, namespace: "load-once-ns" }, ({ path }) => ({
+          path,
+          namespace: "load-once-ns",
+        }));
+        builder.onLoad({ filter: /.*/, namespace: "load-once-ns" }, () => {
+          calls++;
+          return { contents: `export const value = ${calls};`, loader: "js" };
+        });
+      },
+    });
+
+    // @ts-expect-error
+    const imported = await import("load-once-ns:hello");
+    expect([calls, imported.value]).toEqual([1, 1]);
+
+    const required = require("load-once-ns:hello");
+    expect([calls, required.value]).toEqual([1, 1]);
+  });
+
+  it("require() of an async virtual module succeeds once import() has loaded it", async () => {
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-async", async () => {
+          await Bun.sleep(1);
+          return { exports: { value: "async" }, loader: "object" };
+        });
+      },
+    });
+
+    // Nothing has loaded it yet, so require() has no finished module to hand back.
+    expect(() => require("load-once-async")).toThrow(
+      `require() async module "load-once-async" is unsupported. use "await import()" instead.`,
+    );
+
+    // @ts-expect-error
+    const imported = await import("load-once-async");
+    expect(imported.value).toBe("async");
+
+    // The ESM registry holds it now, so require() returns it rather than throwing.
+    expect(require("load-once-async").value).toBe("async");
+  });
+
+  // `bun test` lets plugins shadow builtins, which reorders the virtual module
+  // lookup in fetchCommonJSModule(). Cover the plain-runtime ordering too.
+  it("require() after import() reuses the ESM registry entry outside of `bun test`", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let calls = 0;
+        Bun.plugin({
+          setup(builder) {
+            builder.module("load-once-outside-bun-test", () => {
+              calls++;
+              return { exports: { value: calls }, loader: "object" };
+            });
+          },
+        });
+        const imported = await import("load-once-outside-bun-test");
+        const required = require("load-once-outside-bun-test");
+        console.log(JSON.stringify({ calls, imported: imported.value, required: required.value }));
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(JSON.stringify({ calls: 1, imported: 1, required: 1 }));
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("dynamic import", () => {
   it("SSRs `<h1>Hello world!</h1>` with Svelte", async () => {
     const { default: App }: any = await import("./hello.svelte");

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -400,7 +400,34 @@ describe("the loader runs once per specifier", () => {
 
     // @ts-expect-error
     const imported = await import("load-once-esmodule-require-first");
-    expect(imported.default).toBe("world");
+    expect([calls, imported.default]).toEqual([1, "world"]);
+  });
+
+  // `default: null` is the one value the "module.exports" binding and a nullish check
+  // disagree about, so require() has to read the binding's presence, not its value.
+  it.each([
+    ["null", null],
+    ["false", false],
+    ["0", 0],
+  ])("require() agrees in either order when the __esModule default is %s", async (label, value) => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.module(`load-once-falsy-import-first-${label}`, () => {
+          calls++;
+          return { exports: { __esModule: true, default: value }, loader: "object" };
+        });
+        builder.module(`load-once-falsy-require-first-${label}`, () => ({
+          exports: { __esModule: true, default: value },
+          loader: "object",
+        }));
+      },
+    });
+
+    expect(require(`load-once-falsy-require-first-${label}`)).toBe(value);
+
+    await import(`load-once-falsy-import-first-${label}`);
+    expect([require(`load-once-falsy-import-first-${label}`), calls]).toEqual([value, 1]);
   });
 
   it("a namespaced onLoad object loader unwraps the __esModule default after import()", async () => {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -365,6 +365,66 @@ describe("the loader runs once per specifier", () => {
     expect([calls, required.value]).toEqual([1, 1]);
   });
 
+  // require() unwraps `default` when the object loader sets __esModule. That unwrap has to
+  // survive the registry reuse above, so it must not depend on import() ordering.
+  it("require() after import() unwraps the __esModule default", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-esmodule-import-first", () => {
+          calls++;
+          return { exports: { __esModule: true, default: "world" }, loader: "object" };
+        });
+      },
+    });
+
+    // @ts-expect-error
+    const imported = await import("load-once-esmodule-import-first");
+    expect([calls, imported.default]).toEqual([1, "world"]);
+
+    expect([require("load-once-esmodule-import-first"), calls]).toEqual(["world", 1]);
+  });
+
+  it("require() before import() unwraps the __esModule default", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-esmodule-require-first", () => {
+          calls++;
+          return { exports: { __esModule: true, default: "world" }, loader: "object" };
+        });
+      },
+    });
+
+    expect([require("load-once-esmodule-require-first"), calls]).toEqual(["world", 1]);
+
+    // @ts-expect-error
+    const imported = await import("load-once-esmodule-require-first");
+    expect(imported.default).toBe("world");
+  });
+
+  it("a namespaced onLoad object loader unwraps the __esModule default after import()", async () => {
+    let calls = 0;
+    Bun.plugin({
+      setup(builder) {
+        builder.onResolve({ filter: /.*/, namespace: "load-once-esm-ns" }, ({ path }) => ({
+          path,
+          namespace: "load-once-esm-ns",
+        }));
+        builder.onLoad({ filter: /.*/, namespace: "load-once-esm-ns" }, () => {
+          calls++;
+          return { exports: { __esModule: true, default: "world" }, loader: "object" };
+        });
+      },
+    });
+
+    // @ts-expect-error
+    const imported = await import("load-once-esm-ns:hello");
+    expect([calls, imported.default]).toEqual([1, "world"]);
+
+    expect([require("load-once-esm-ns:hello"), calls]).toEqual(["world", 1]);
+  });
+
   it("require() of an async virtual module succeeds once import() has loaded it", async () => {
     Bun.plugin({
       setup(builder) {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -502,6 +502,39 @@ describe("the loader runs once per specifier", () => {
 
     // The ESM registry holds it now, so require() returns it rather than throwing.
     expect(require("load-once-async").value).toBe("async");
+  });
+
+  // `export *` re-exports every name but "default", so a wrapper around an __esModule
+  // object module inherits its "module.exports" binding and require() of the wrapper
+  // unwraps to the same value. A user-authored `export { X as "module.exports" }` already
+  // propagates that way, so this keeps the two spellings consistent.
+  it("export * from an __esModule object module carries the CJS unwrap", async () => {
+    using dir = tempDir("plugin-star-export", {
+      "preload.ts": `
+        import { plugin } from "bun";
+        plugin({
+          setup(b) {
+            b.module("star-virt", () => ({
+              exports: { __esModule: true, default: "X", helper: 1 },
+              loader: "object",
+            }));
+          },
+        });
+      `,
+      "wrapper.mjs": `export * from "star-virt";\nexport const extra = 2;`,
+      "app.cjs": `console.log(JSON.stringify(require("./wrapper.mjs")));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload.ts", "./app.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(`"X"`);
+    expect(exitCode).toBe(0);
   });
 
   // `bun test` lets plugins shadow builtins, which reorders the virtual module

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -430,6 +430,35 @@ describe("the loader runs once per specifier", () => {
     expect([require(`load-once-falsy-import-first-${label}`), calls]).toEqual([value, 1]);
   });
 
+  // Transpilers emit the marker with Object.defineProperty, leaving it non-enumerable,
+  // so it has to be found by lookup rather than by enumerating the exports object.
+  it("require() unwraps a non-enumerable __esModule default in either order", async () => {
+    let calls = 0;
+    const markedExports = () => {
+      const exports = { default: "world" };
+      Object.defineProperty(exports, "__esModule", { value: true });
+      return exports;
+    };
+    Bun.plugin({
+      setup(builder) {
+        builder.module("load-once-defineprop-import-first", () => {
+          calls++;
+          return { exports: markedExports(), loader: "object" };
+        });
+        builder.module("load-once-defineprop-require-first", () => ({
+          exports: markedExports(),
+          loader: "object",
+        }));
+      },
+    });
+
+    expect(require("load-once-defineprop-require-first")).toBe("world");
+
+    // @ts-expect-error
+    await import("load-once-defineprop-import-first");
+    expect([require("load-once-defineprop-import-first"), calls]).toEqual(["world", 1]);
+  });
+
   it("a namespaced onLoad object loader unwraps the __esModule default after import()", async () => {
     let calls = 0;
     Bun.plugin({

--- a/test/js/node/module/esm_to_cjs_interop_null.mjs
+++ b/test/js/node/module/esm_to_cjs_interop_null.mjs
@@ -1,0 +1,2 @@
+const test = null;
+export { test as "module.exports" };

--- a/test/js/node/module/esm_to_cjs_interop_undefined.mjs
+++ b/test/js/node/module/esm_to_cjs_interop_undefined.mjs
@@ -1,0 +1,2 @@
+let test;
+export { test as "module.exports" };

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -233,6 +233,13 @@ describe.concurrent("node-module-module", () => {
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });
 
+  // A declared "module.exports" export wins on its presence, not on its value, which is
+  // what Node returns here. A nullish binding used to fall through to the namespace.
+  test("require uses a nullish 'module.exports' export verbatim", () => {
+    expect(require("./esm_to_cjs_interop_null.mjs")).toBeNull();
+    expect(require("./esm_to_cjs_interop_undefined.mjs")).toBeUndefined();
+  });
+
   test("Module.runMain", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
`require()` of a `Bun.plugin()` virtual module that was already loaded by `import()` runs the plugin's `onLoad` callback a second time and throws the result away. The first instance is still what comes back, so the only visible effect is that the loader's side effects (file reads, codegen, counters, registration) happen twice, and only when the two forms are used in that order.

## One open decision for a maintainer

The fix splits cleanly in two, and only the first half is strictly needed for the reported bug:

1. **Hoist the ESM-registry check** in `fetchCommonJSModule()` so `require()` after `import()` stops re-running `onLoad`. Small, self-contained, and it never moved across review.
2. **Keep `require()`'s `__esModule` unwrap working** once the loader is skipped, by having the object module publish `default` under the `"module.exports"` export name. This is the part that took five review rounds and three fixes of my own regressions, and it adds a real named export that `export *` observes.

If you would rather not take (2), I can cut this down to (1) alone and leave `{ __esModule: true, default: X }` object loaders on `main`'s behavior (they would keep running the loader twice). The alternative to the synthetic export is new per-global state keyed by specifier, which I judged a wider change than the edge it closes, but that is a call worth a second opinion. Say the word and I will reshape it.

## Repro

```js
import { plugin } from "bun";

let calls = 0;
plugin({
  setup(build) {
    build.module("virt:x", () => {
      calls++;
      return { exports: { v: calls }, loader: "object" };
    });
  },
});

await import("virt:x"); // onLoad runs (1)
require("virt:x"); // onLoad runs AGAIN (2), its result is discarded
console.log(calls); // 2, expected 1
```

Whether a loader runs twice depends on call order elsewhere in the program. Reviewing this turned up a second shape with the same problem in the opposite direction, so both are fixed here and the loader now runs exactly once per specifier either way.

## Cause

`fetchCommonJSModule()` called `Bun::runVirtualModule()` before checking whether the ESM registry already held the module. That check (`hasAlreadyLoadedESMVersionSoWeShouldntTranspileItTwice`) sat below both `runVirtualModule()` call sites, so by the time it short-circuited to the registry entry, the loader had already run and its `SourceCode` had already been handed to an idempotent `provideFetch()` that dropped it.

The ESM path doesn't have this problem: JSC never calls the embedder's fetch hook for a module that is already registered, so `fetchESMSourceCode()` is naturally guarded.

## Fix

Hoist the registry check to the top of `fetchCommonJSModule()` and use it to guard both `runVirtualModule()` call sites.

Two orderings in that function are load-bearing and are preserved:

- The `jsNumber(-1)` short-circuit stays **below** the builtin lookup. `require("bun")` after `import("bun")` must keep returning the `Bun` object rather than the ESM namespace object.
- Under `bun test` the virtual module lookup runs **before** the builtin lookup so `mock.module()` can shadow builtins. Module mocks are therefore exempt from the new guard, and `require()` still runs them so `mock.module("bun:ffi")` wins after an `import("bun:ffi")`. Mocks don't suffer the double-execution bug anyway, because `JSModuleMock::executeOnce()` caches its result. Builtin specifiers are exempt too, so `require()` of a builtin provably cannot change which branch it takes no matter what plugins are registered.

### The `__esModule` object loader

`require()` unwraps `default` when an object loader sets `__esModule`, and that unwrap had to survive the registry reuse above. Two things were in the way.

`generateObjectModuleSourceCode()` emits only the object's own property names, so `{ __esModule: true, default: X }` left no `"module.exports"` binding for the `-1` path's consumer to find, and `require()` returned the namespace instead of `X`. It now publishes `default` under that name when `__esModule` is truthy. `"module.exports"` is Node's `require(esm)` convention, which Bun already honours for user-authored `export { X as "module.exports" }` (see `test/js/node/module/esm_to_cjs_interop.mjs`, read by `CommonJS.ts` in two places), so `require()` picks `default` back up with no extra registry inspection.

Because it is a real named export, `export *` carries it into a wrapper module, and `require()` of that wrapper unwraps to the same value. That already happens on `main` for the user-authored spelling, so the two now agree; `export *` excludes only `"default"`. Recording the unwrap without a named export would mean new per-global state keyed by specifier, which is a wider change than the edge it closes.

The marker itself has to be found by lookup rather than by enumeration, because `Object.defineProperty(exports, "__esModule", { value: true })` leaves it non-enumerable and that is how TypeScript, Babel, SWC and esbuild emit it.

That binding then has to be readable even when `default` is `null`, which `namespace["module.exports"] ?? namespace` could not express. Both read sites in `CommonJS.ts` now test for the binding rather than for a nullish value. Namespace `[[HasProperty]]` consults the [[Exports]] list rather than the binding's value, so this also reaches user-authored `export { x as "module.exports" }`: `require()` of one holding `null` or `undefined` now returns that value instead of the namespace, which is what Node returns and what `main` got wrong. `test/js/node/module/` pins both.

With the binding in place, the `commonJSModule` early-return in `handleVirtualModuleResult()` is only needed for mocks, which skip `provideFetch()` and so have nothing to read back. Everything else now routes through the generated source, which is what registers the module, so `require()` before `import()` stops re-running the loader as well.

### An intentional behavior change

`require()` of an **async** virtual module now succeeds once `import()` has finished loading it, instead of throwing `require() async module "..." is unsupported. use "await import()" instead.`. There is nothing left to await at that point, and it matches what already happens for a virtual module whose source uses top-level await. `require()` of an async virtual module that nothing has loaded yet still throws.

## Verification

Thirteen cases in `test/js/bun/plugin/plugins.test.ts` cover `build.module()` and namespaced `onLoad()` virtual modules in both orders, the `__esModule` unwrap in both orders, a non-enumerable `__esModule` marker, a `default` of `null`/`false`/`0` in both orders, `export *` propagation, the async-loader case, and the non-`bun test` ordering via a subprocess. Eleven of them fail on `main`.

`test/js/bun/plugin/` (45 pass), `test/js/node/module/` (31 pass), `test/js/bun/test/mock/` plus `mock-fn` and `test/js/node/module/` (180 pass), `test/js/bun/resolve/` and `test/cli/run/` were run against the debug build. The only failures are timeouts and an OOM-prone heap-snapshot test that reproduce identically on an unmodified `src/` with the same debug + ASAN build; each was re-checked by reverting `src/` rather than assuming.


