### PR TITLE
shell: pathname-expand each brace variant instead of appending the patterns

### DIFF
--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -62,8 +62,7 @@ pub enum ExpansionState {
     CmdSubst,
     Glob,
     BraceExpand,
-    /// Globs `brace_words` one variant per re-entry. A word with no brace
-    /// expansion has an empty list, so it falls straight through to `Done`.
+    /// Globs `brace_words` one per re-entry; an empty list falls straight through to `Done`.
     BraceWords,
     Done,
     /// The parent inspects this on
@@ -78,9 +77,8 @@ pub struct BraceWord {
     pub(crate) meta_offsets: Vec<u32>,
 }
 
-/// Brace expansion invalidates `meta_offsets`, so each literal `*` is
-/// prefixed with this byte on the way in and `decode_brace_word` recovers the
-/// offsets on the way out. A data byte equal to it is doubled.
+/// Prefixed to each literal `*` because brace expansion invalidates `meta_offsets`;
+/// `decode_brace_word` rebuilds them. Doubled where it occurs as data.
 const META_TAG: u8 = 0x01;
 
 #[derive(Default)]
@@ -340,8 +338,7 @@ impl Expansion {
         }
         let count = count as usize;
         if count == 0 {
-            // Nothing expanded (`expand` would index `out[0]` of an empty
-            // slice), so the word and its `meta_offsets` are still valid as-is.
+            // `expand` needs `out[0]`; with nothing to expand, word and `meta_offsets` are final.
             if glob_follows {
                 me.brace_words = vec![BraceWord {
                     word: core::mem::take(&mut me.current_out),
@@ -396,8 +393,7 @@ impl Expansion {
         me.state = ExpansionState::Done;
     }
 
-    /// Inverse of the [`META_TAG`] encoding. Decoding only removes bytes, so
-    /// it compacts in place.
+    /// Inverse of [`META_TAG`]; it only removes bytes, so it compacts in place.
     fn decode_brace_word(mut word: Vec<u8>) -> BraceWord {
         let mut meta_offsets: Vec<u32> = Vec::new();
         let (mut read, mut write) = (0usize, 0usize);
@@ -419,8 +415,7 @@ impl Expansion {
         BraceWord { word, meta_offsets }
     }
 
-    /// Stages the next variant in `current_out`/`meta_offsets`. Returns whether
-    /// it needs a glob, or `None` once all variants are consumed.
+    /// Stages the next variant; returns `Some(needs_glob)`, or `None` once all are consumed.
     fn load_next_brace_word(me: &mut Expansion) -> Option<bool> {
         let idx = me.brace_word_idx as usize;
         if idx >= me.brace_words.len() {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -37,6 +37,12 @@ pub struct Expansion {
     /// and must not change the expansion structure or broaden the glob.
     pub(crate) meta_offsets: Vec<u32>,
     pub(crate) child_script: Option<NodeId>,
+    /// Brace-expansion variants still awaiting pathname expansion, in the order
+    /// they must appear in argv. Only populated when the word combines brace
+    /// and glob expansion; see [`ExpansionState::BraceWords`].
+    pub(crate) brace_words: Vec<BraceWord>,
+    /// Index of the next `brace_words` entry to pathname-expand.
+    pub(crate) brace_word_idx: u32,
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
     pub(crate) cmd_subst_quoted: bool,
@@ -59,11 +65,29 @@ pub enum ExpansionState {
     CmdSubst,
     Glob,
     BraceExpand,
+    /// Pathname-expand the pending brace-expansion variants in `brace_words`,
+    /// one per re-entry. The list is empty for every word without brace
+    /// expansion, so the plain glob path falls straight through to `Done`.
+    BraceWords,
     Done,
     /// The parent inspects this on
     /// `child_done(_, 1)` to print the message.
     Err(Box<ShellErr>),
 }
+
+/// One brace-expansion variant, paired with the byte offsets of the glob
+/// metacharacters it inherited from literal `*`/`**` atoms.
+#[derive(Default)]
+pub struct BraceWord {
+    pub(crate) word: Vec<u8>,
+    pub(crate) meta_offsets: Vec<u32>,
+}
+
+/// Marks a literal `*` in the brace lexer's input so `decode_brace_word` can
+/// recover its offset within the expanded variant, where the word's original
+/// `meta_offsets` no longer line up. Data bytes equal to it are doubled, so
+/// the encoding round-trips any input.
+const META_TAG: u8 = 0x01;
 
 #[derive(Default)]
 pub struct ExpansionOut {
@@ -101,6 +125,8 @@ impl Expansion {
             out: ExpansionOut::default(),
             current_out: Vec::new(),
             meta_offsets: Vec::new(),
+            brace_words: Vec::new(),
+            brace_word_idx: 0,
             child_script: None,
             cmd_subst_quoted: false,
             has_quoted_empty: false,
@@ -139,12 +165,21 @@ impl Expansion {
                 }
                 ExpansionState::BraceExpand => {
                     Self::do_brace_expand(me);
-                    // brace + glob composes: after pushing the literal brace
-                    // variants, glob the original pattern. The normal glob path likewise calls
-                    // `transition_to_glob_state` directly (see below).
-                    if matches!(me.state, ExpansionState::Glob) {
+                    continue;
+                }
+                ExpansionState::BraceWords => {
+                    // Pathname expansion runs once per brace-expansion variant,
+                    // in order: a variant carrying a literal `*` is globbed and
+                    // replaced by its matches, every other variant is already
+                    // the final word.
+                    let Some(needs_glob) = Self::load_next_brace_word(me) else {
+                        me.state = ExpansionState::Done;
+                        continue;
+                    };
+                    if needs_glob {
                         return Self::transition_to_glob_state(interp, this);
                     }
+                    Self::push_current_out(me);
                     continue;
                 }
                 ExpansionState::Done | ExpansionState::Err(_) => break,
@@ -270,23 +305,35 @@ impl Expansion {
 
     /// Re-tokenize `current_out` (the
     /// fully-expanded word with `{`/`,`/`}` markers preserved by
-    /// `expand_simple_no_io`) and push each variant as a separate argv word.
+    /// `expand_simple_no_io`) and turn each variant into a separate word.
+    ///
+    /// Brace expansion precedes pathname expansion, so when the word also
+    /// carries a literal `*` the variants are parked in `brace_words` for
+    /// [`ExpansionState::BraceWords`] to glob one by one instead of being
+    /// pushed straight to argv.
     fn do_brace_expand(me: &mut Expansion) {
         use bun_shell_parser::braces;
+        let glob_follows = me.node.get().has_glob_expansion();
         // Only the `{`/`,`/`}` bytes recorded in `meta_offsets` (written
         // by literal BraceBegin/Comma/BraceEnd atoms) are brace-expansion
         // metacharacters. Bytes from Text/Var/cmd-subst expansion — notably JS
         // `${...}` interpolations — are data: backslash-escape them so the
         // brace lexer cannot be steered into emitting extra argv words.
-        // (`meta_offsets` also records literal `*`/`**` positions for the glob
-        // path; those are inert here since `*` is not in the escape set.)
+        // `meta_offsets` also records literal `*`/`**` positions: those are not
+        // brace syntax, but each one is tagged so the variant it lands in keeps
+        // an accurate offset for `neutralize_glob_metachars`.
         let mut escaped: Vec<u8> = Vec::with_capacity(me.current_out.len());
         let mut next_meta = 0usize;
         for (i, &b) in me.current_out.iter().enumerate() {
             if next_meta < me.meta_offsets.len() && me.meta_offsets[next_meta] as usize == i {
                 next_meta += 1;
+                if glob_follows && b == b'*' {
+                    escaped.push(META_TAG);
+                }
             } else if matches!(b, b'{' | b'}' | b',' | b'\\') {
                 escaped.push(b'\\');
+            } else if glob_follows && b == META_TAG {
+                escaped.push(META_TAG);
             }
             escaped.push(b);
         }
@@ -308,12 +355,26 @@ impl Expansion {
             return;
         }
         let count = count as usize;
-        let expanded: Vec<Vec<u8>> = if count == 0 {
+        if count == 0 {
             // No `{...}` group formed an expansion (no top-level comma, or
-            // unbalanced); emit the word unchanged. `expand` would index
-            // `out[0]` of an empty slice here. Keep `current_out` for glob.
-            vec![me.current_out.clone()]
-        } else {
+            // unbalanced), so the word is unchanged and `meta_offsets` still
+            // describes it: hand it on as-is instead of round-tripping through
+            // the tag encoding. `expand` would index `out[0]` of an empty
+            // slice here.
+            if glob_follows {
+                me.brace_words = vec![BraceWord {
+                    word: core::mem::take(&mut me.current_out),
+                    meta_offsets: core::mem::take(&mut me.meta_offsets),
+                }];
+                me.brace_word_idx = 0;
+                me.state = ExpansionState::BraceWords;
+            } else {
+                Self::push_current_out(me);
+                me.state = ExpansionState::Done;
+            }
+            return;
+        }
+        let expanded: Vec<Vec<u8>> = {
             let mut expanded: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
             let arena = bun_alloc::Arena::new();
             if let Err(e) = braces::expand(
@@ -335,6 +396,14 @@ impl Expansion {
             expanded
         };
 
+        me.current_out.clear();
+        me.meta_offsets.clear();
+        if glob_follows {
+            me.brace_words = expanded.into_iter().map(Self::decode_brace_word).collect();
+            me.brace_word_idx = 0;
+            me.state = ExpansionState::BraceWords;
+            return;
+        }
         // Push each variant as its own word; word boundaries are recorded
         // via `bounds`.
         for s in expanded {
@@ -343,19 +412,48 @@ impl Expansion {
             }
             me.out.buf.extend_from_slice(&s);
         }
+        me.state = ExpansionState::Done;
+    }
 
-        let node = me.node;
-        let atom = node.get();
-        if atom.has_glob_expansion() {
-            // brace + glob composes. Keep
-            // `current_out` (the original pattern, e.g. `src/*.{ts,tsx}`) so
-            // the glob walker brace-expands and globs it; its matches are
-            // appended after the literal brace variants already pushed above.
-            me.state = ExpansionState::Glob;
-        } else {
-            me.current_out.clear();
-            me.state = ExpansionState::Done;
+    /// Strip the [`META_TAG`] markers `do_brace_expand` wrote into the brace
+    /// lexer's input, recovering the offsets of the literal `*` bytes within
+    /// this variant. `META_TAG` + `*` is one glob metacharacter; a doubled
+    /// `META_TAG` is one data byte. Decoding only removes bytes, so it compacts
+    /// in place.
+    fn decode_brace_word(mut word: Vec<u8>) -> BraceWord {
+        let mut meta_offsets: Vec<u32> = Vec::new();
+        let (mut read, mut write) = (0usize, 0usize);
+        while read < word.len() {
+            let b = word[read];
+            if b == META_TAG && read + 1 < word.len() && matches!(word[read + 1], b'*' | META_TAG) {
+                if word[read + 1] == b'*' {
+                    meta_offsets.push(write as u32);
+                }
+                word[write] = word[read + 1];
+                read += 2;
+            } else {
+                word[write] = b;
+                read += 1;
+            }
+            write += 1;
         }
+        word.truncate(write);
+        BraceWord { word, meta_offsets }
+    }
+
+    /// Move the next pending brace-expansion variant into `current_out` /
+    /// `meta_offsets`, reporting whether it needs pathname expansion. `None`
+    /// once every variant has been consumed.
+    fn load_next_brace_word(me: &mut Expansion) -> Option<bool> {
+        let idx = me.brace_word_idx as usize;
+        if idx >= me.brace_words.len() {
+            return None;
+        }
+        me.brace_word_idx += 1;
+        let next = core::mem::take(&mut me.brace_words[idx]);
+        me.current_out = next.word;
+        me.meta_offsets = next.meta_offsets;
+        Some(!me.meta_offsets.is_empty())
     }
 
     /// Build the pattern handed to the glob walker from `current_out`,
@@ -672,7 +770,7 @@ impl Expansion {
             let me = interp.as_expansion_mut(this);
             if in_assign {
                 Self::push_current_out(me);
-                me.state = ExpansionState::Done;
+                me.state = ExpansionState::BraceWords;
             } else if let Some(err) = walk_err {
                 let shell_err = match err {
                     ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
@@ -697,7 +795,9 @@ impl Expansion {
                 }
                 me.out.buf.extend_from_slice(&entry);
             }
-            me.state = ExpansionState::Done;
+            me.current_out.clear();
+            me.meta_offsets.clear();
+            me.state = ExpansionState::BraceWords;
         }
         Yield::Next(this).run(interp);
     }
@@ -725,6 +825,7 @@ impl Expansion {
         me.out.buf.clear();
         me.out.bounds.clear();
         me.current_out.clear();
+        me.brace_words.clear();
     }
 
     /// Take the expanded output (called by the parent after `child_done`).

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -37,11 +37,8 @@ pub struct Expansion {
     /// and must not change the expansion structure or broaden the glob.
     pub(crate) meta_offsets: Vec<u32>,
     pub(crate) child_script: Option<NodeId>,
-    /// Brace-expansion variants still awaiting pathname expansion, in the order
-    /// they must appear in argv. Only populated when the word combines brace
-    /// and glob expansion; see [`ExpansionState::BraceWords`].
+    /// Consumed in argv order by [`ExpansionState::BraceWords`].
     pub(crate) brace_words: Vec<BraceWord>,
-    /// Index of the next `brace_words` entry to pathname-expand.
     pub(crate) brace_word_idx: u32,
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
@@ -65,9 +62,8 @@ pub enum ExpansionState {
     CmdSubst,
     Glob,
     BraceExpand,
-    /// Pathname-expand the pending brace-expansion variants in `brace_words`,
-    /// one per re-entry. The list is empty for every word without brace
-    /// expansion, so the plain glob path falls straight through to `Done`.
+    /// Globs `brace_words` one variant per re-entry. A word with no brace
+    /// expansion has an empty list, so it falls straight through to `Done`.
     BraceWords,
     Done,
     /// The parent inspects this on
@@ -75,18 +71,16 @@ pub enum ExpansionState {
     Err(Box<ShellErr>),
 }
 
-/// One brace-expansion variant, paired with the byte offsets of the glob
-/// metacharacters it inherited from literal `*`/`**` atoms.
+/// A brace-expansion variant and the offsets of its literal `*` bytes.
 #[derive(Default)]
 pub struct BraceWord {
     pub(crate) word: Vec<u8>,
     pub(crate) meta_offsets: Vec<u32>,
 }
 
-/// Marks a literal `*` in the brace lexer's input so `decode_brace_word` can
-/// recover its offset within the expanded variant, where the word's original
-/// `meta_offsets` no longer line up. Data bytes equal to it are doubled, so
-/// the encoding round-trips any input.
+/// Brace expansion invalidates `meta_offsets`, so each literal `*` is
+/// prefixed with this byte on the way in and `decode_brace_word` recovers the
+/// offsets on the way out. A data byte equal to it is doubled.
 const META_TAG: u8 = 0x01;
 
 #[derive(Default)]
@@ -168,10 +162,6 @@ impl Expansion {
                     continue;
                 }
                 ExpansionState::BraceWords => {
-                    // Pathname expansion runs once per brace-expansion variant,
-                    // in order: a variant carrying a literal `*` is globbed and
-                    // replaced by its matches, every other variant is already
-                    // the final word.
                     let Some(needs_glob) = Self::load_next_brace_word(me) else {
                         me.state = ExpansionState::Done;
                         continue;
@@ -305,12 +295,8 @@ impl Expansion {
 
     /// Re-tokenize `current_out` (the
     /// fully-expanded word with `{`/`,`/`}` markers preserved by
-    /// `expand_simple_no_io`) and turn each variant into a separate word.
-    ///
-    /// Brace expansion precedes pathname expansion, so when the word also
-    /// carries a literal `*` the variants are parked in `brace_words` for
-    /// [`ExpansionState::BraceWords`] to glob one by one instead of being
-    /// pushed straight to argv.
+    /// `expand_simple_no_io`) into one word per variant: straight to `out`, or
+    /// to `brace_words` when a glob still has to run on each of them.
     fn do_brace_expand(me: &mut Expansion) {
         use bun_shell_parser::braces;
         let glob_follows = me.node.get().has_glob_expansion();
@@ -319,9 +305,7 @@ impl Expansion {
         // metacharacters. Bytes from Text/Var/cmd-subst expansion — notably JS
         // `${...}` interpolations — are data: backslash-escape them so the
         // brace lexer cannot be steered into emitting extra argv words.
-        // `meta_offsets` also records literal `*`/`**` positions: those are not
-        // brace syntax, but each one is tagged so the variant it lands in keeps
-        // an accurate offset for `neutralize_glob_metachars`.
+        // Literal `*` bytes (also in `meta_offsets`) get a `META_TAG` instead.
         let mut escaped: Vec<u8> = Vec::with_capacity(me.current_out.len());
         let mut next_meta = 0usize;
         for (i, &b) in me.current_out.iter().enumerate() {
@@ -356,11 +340,8 @@ impl Expansion {
         }
         let count = count as usize;
         if count == 0 {
-            // No `{...}` group formed an expansion (no top-level comma, or
-            // unbalanced), so the word is unchanged and `meta_offsets` still
-            // describes it: hand it on as-is instead of round-tripping through
-            // the tag encoding. `expand` would index `out[0]` of an empty
-            // slice here.
+            // Nothing expanded (`expand` would index `out[0]` of an empty
+            // slice), so the word and its `meta_offsets` are still valid as-is.
             if glob_follows {
                 me.brace_words = vec![BraceWord {
                     word: core::mem::take(&mut me.current_out),
@@ -415,11 +396,8 @@ impl Expansion {
         me.state = ExpansionState::Done;
     }
 
-    /// Strip the [`META_TAG`] markers `do_brace_expand` wrote into the brace
-    /// lexer's input, recovering the offsets of the literal `*` bytes within
-    /// this variant. `META_TAG` + `*` is one glob metacharacter; a doubled
-    /// `META_TAG` is one data byte. Decoding only removes bytes, so it compacts
-    /// in place.
+    /// Inverse of the [`META_TAG`] encoding. Decoding only removes bytes, so
+    /// it compacts in place.
     fn decode_brace_word(mut word: Vec<u8>) -> BraceWord {
         let mut meta_offsets: Vec<u32> = Vec::new();
         let (mut read, mut write) = (0usize, 0usize);
@@ -441,9 +419,8 @@ impl Expansion {
         BraceWord { word, meta_offsets }
     }
 
-    /// Move the next pending brace-expansion variant into `current_out` /
-    /// `meta_offsets`, reporting whether it needs pathname expansion. `None`
-    /// once every variant has been consumed.
+    /// Stages the next variant in `current_out`/`meta_offsets`. Returns whether
+    /// it needs a glob, or `None` once all variants are consumed.
     fn load_next_brace_word(me: &mut Expansion) -> Option<bool> {
         let idx = me.brace_word_idx as usize;
         if idx >= me.brace_words.len() {

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -128,24 +128,22 @@ console.log(JSON.stringify(Bun.$.braces("{" + inner)));`,
   });
 });
 
-// A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`) was
-// brace-expanded but the resulting `*` patterns were never globbed (the
-// brace-expand state always transitioned to Done instead of re-entering glob).
+// Brace expansion precedes pathname expansion, and each resulting word is
+// globbed on its own. `{d1,d2}/*` used to emit the literal `d1/*` and `d2/*`
+// words *in addition to* their matches, because the brace-expand state pushed
+// every variant to argv and then globbed the un-expanded pattern.
 describe("brace + glob composition", () => {
-  test("src/*.{ts,tsx} globs after brace expansion", async () => {
+  // The glob walker joins matched paths with the native separator on Windows,
+  // and readdir order is not sorted, so normalize before asserting.
+  const words = (out: string) => out.trim().replaceAll("\\", "/").split(" ").sort();
+
+  test("src/*.{ts,tsx} globs each variant and drops the patterns", async () => {
     using dir = tempDir("shell-brace-glob", {
       "src/app.ts": "",
       "src/util.tsx": "",
     });
-    // The glob walker joins matched paths with the native separator on
-    // Windows, so normalize before asserting.
-    const out = (await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
-    const words = out.split(" ");
-    // Zig composes both the literal brace variants and the glob matches.
-    expect(words).toContain("src/app.ts");
-    expect(words).toContain("src/util.tsx");
-    expect(words).toContain("src/*.ts");
-    expect(words).toContain("src/*.tsx");
+    const out = await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["src/app.ts", "src/util.tsx"]);
   });
 
   test("{src,lib}/*.ts composes a brace prefix with a glob", async () => {
@@ -153,10 +151,28 @@ describe("brace + glob composition", () => {
       "src/a.ts": "",
       "lib/b.ts": "",
     });
-    const out = (await $`echo {src,lib}/*.ts`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
-    const words = out.split(" ");
-    expect(words).toContain("src/a.ts");
-    expect(words).toContain("lib/b.ts");
+    const out = await $`echo {src,lib}/*.ts`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["lib/b.ts", "src/a.ts"]);
+  });
+
+  test("a variant without a glob metacharacter stays literal", async () => {
+    using dir = tempDir("shell-brace-glob4", {
+      "aa": "",
+      "ab": "",
+    });
+    // `nope` carries no `*`, so it is a plain word and never reaches the glob
+    // walker (which would fail it as a no-match).
+    const out = await $`echo {a*,nope}`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["aa", "ab", "nope"]);
+  });
+
+  test("a variant with no matches reports the expanded word", async () => {
+    using dir = tempDir("shell-brace-glob5", {
+      "d1/f1": "",
+    });
+    const { stderr, exitCode } = await $`echo {d1,nope}/*`.cwd(String(dir)).quiet().nothrow();
+    expect(stderr.toString()).toBe("bun: no matches found: nope/*\n");
+    expect(exitCode).toBe(1);
   });
 
   test("an interpolated comma inside a brace group is one literal branch", async () => {
@@ -165,15 +181,10 @@ describe("brace + glob composition", () => {
       "x.,foo": "",
       "x.]foo": "",
     });
-    // `echo` rather than `ls`: the literal brace variants (`*.ts`, `*.,foo`)
-    // are also emitted as argv words and do not exist as files.
-    const out = (await $`echo *.{ts,${",foo"}}`.cwd(String(dir)).text()).trim();
-    const words = out.split(" ");
-    expect(words).toContain("x.ts");
-    // The interpolated `,foo` is matched as a single literal branch...
-    expect(words).toContain("x.,foo");
-    // ...and does not split into a spurious `]foo` branch.
-    expect(words).not.toContain("x.]foo");
+    const out = await $`echo *.{ts,${",foo"}}`.cwd(String(dir)).text();
+    // The interpolated `,foo` is matched as a single literal branch, and does
+    // not split into a spurious `]foo` branch.
+    expect(words(out)).toEqual(["x.,foo", "x.ts"]);
   });
 });
 
@@ -331,5 +342,23 @@ describe("comma-less brace group is literal (bash 5.2)", () => {
       stderr: "bun: no matches found: {x},*.txt\n",
       exitCode: 1,
     });
+  });
+
+  test("a comma-less brace group still globs a literal * and keeps interpolated * as data", async () => {
+    // Brace-expand count is 0, so the word skips the tag round-trip and keeps
+    // its original metacharacter offsets. A template `*` still reaches the
+    // glob walker (which reads `{x}` as a one-branch group, hence the `x.*`
+    // fixtures). An interpolated `*` sets no glob hint, so the word is emitted
+    // as the literal text it is.
+    using dir = tempDir("shell-brace-literal-glob2", {
+      "x.a.txt": "",
+      "x.b.txt": "",
+      "x.*.txt": "",
+    });
+    const words = (out: string) => out.trim().split(" ").sort();
+    const globbed = await $`echo {x}.*.txt`.cwd(String(dir)).text();
+    expect(words(globbed)).toEqual(["x.*.txt", "x.a.txt", "x.b.txt"]);
+    const interpolated = await $`echo {x}.${"*"}.txt`.cwd(String(dir)).text();
+    expect(interpolated.trim()).toBe("{x}.*.txt");
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -146,6 +146,19 @@ describe.concurrent("brace + glob composition", () => {
     expect(words(out)).toEqual(["src/app.ts", "src/util.tsx"]);
   });
 
+  test("src/**/*.test.{ts,tsx} keeps both * of a ** through brace expansion", async () => {
+    // `**` records two adjacent metacharacter offsets, so each variant has to
+    // come back out of brace expansion with both of them, or it stops recursing.
+    using dir = tempDir("shell-brace-glob-doublestar", {
+      "src/x.test.ts": "",
+      "src/a/y.test.tsx": "",
+      "src/a/b/z.test.ts": "",
+      "src/skip.ts": "",
+    });
+    const out = await $`echo src/**/*.test.{ts,tsx}`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["src/a/b/z.test.ts", "src/a/y.test.tsx", "src/x.test.ts"]);
+  });
+
   test("{src,lib}/*.ts composes a brace prefix with a glob", async () => {
     using dir = tempDir("shell-brace-glob2", {
       "src/a.ts": "",
@@ -369,21 +382,22 @@ describe("comma-less brace group is literal (bash 5.2)", () => {
     });
   });
 
-  test("a comma-less brace group still globs a literal * and keeps interpolated * as data", async () => {
-    // Brace-expand count is 0, so the word skips the tag round-trip and keeps
-    // its original metacharacter offsets. A template `*` still reaches the
-    // glob walker (which reads `{x}` as a one-branch group, hence the `x.*`
-    // fixtures). An interpolated `*` sets no glob hint, so the word is emitted
-    // as the literal text it is.
+  test("a zero-variant word with a matching glob emits only the matches", async () => {
+    // The trailing comma sets the brace hint (a word needs `{`, `}` and a `,`
+    // anywhere), the lexer then demotes the comma-less `{x}`, and the expand
+    // count is 0. The unchanged word must keep its metacharacter offsets: the
+    // template `*` globs (the walker reads `{x}` as a one-branch group, hence
+    // the `x,` fixtures) and the literal pattern is not emitted next to the
+    // matches. With an interpolated `*` there is no glob hint, so the word is
+    // emitted as the literal text it is.
     using dir = tempDir("shell-brace-literal-glob2", {
-      "x.a.txt": "",
-      "x.b.txt": "",
-      "x.*.txt": "",
+      "x,a.txt": "",
+      "x,b.txt": "",
     });
     const words = (out: string) => out.trim().split(" ").sort();
-    const globbed = await $`echo {x}.*.txt`.cwd(String(dir)).text();
-    expect(words(globbed)).toEqual(["x.*.txt", "x.a.txt", "x.b.txt"]);
-    const interpolated = await $`echo {x}.${"*"}.txt`.cwd(String(dir)).text();
-    expect(interpolated.trim()).toBe("{x}.*.txt");
+    const globbed = await $`echo {x},*.txt`.cwd(String(dir)).text();
+    expect(words(globbed)).toEqual(["x,a.txt", "x,b.txt"]);
+    const interpolated = await $`echo {x},${"*"}.txt`.cwd(String(dir)).text();
+    expect(interpolated.trim()).toBe("{x},*.txt");
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -132,7 +132,7 @@ console.log(JSON.stringify(Bun.$.braces("{" + inner)));`,
 // globbed on its own. `{d1,d2}/*` used to emit the literal `d1/*` and `d2/*`
 // words *in addition to* their matches, because the brace-expand state pushed
 // every variant to argv and then globbed the un-expanded pattern.
-describe("brace + glob composition", () => {
+describe.concurrent("brace + glob composition", () => {
   // The glob walker joins matched paths with the native separator on Windows,
   // and readdir order is not sorted, so normalize before asserting.
   const words = (out: string) => out.trim().replaceAll("\\", "/").split(" ").sort();
@@ -170,7 +170,9 @@ describe("brace + glob composition", () => {
     using dir = tempDir("shell-brace-glob5", {
       "d1/f1": "",
     });
-    const { stderr, exitCode } = await $`echo {d1,nope}/*`.cwd(String(dir)).quiet().nothrow();
+    const { stdout, stderr, exitCode } = await $`echo {d1,nope}/*`.cwd(String(dir)).quiet().nothrow();
+    // The matches `d1/*` already produced never reach argv: the word fails.
+    expect(stdout.toString()).toBe("");
     expect(stderr.toString()).toBe("bun: no matches found: nope/*\n");
     expect(exitCode).toBe(1);
   });
@@ -185,6 +187,29 @@ describe("brace + glob composition", () => {
     // The interpolated `,foo` is matched as a single literal branch, and does
     // not split into a spurious `]foo` branch.
     expect(words(out)).toEqual(["x.,foo", "x.ts"]);
+  });
+
+  test("an interpolated * inside a brace variant is data, not a pattern", async () => {
+    using dir = tempDir("shell-brace-glob6", {
+      "a1.txt": "",
+      "b1.txt": "",
+    });
+    // The template holds no `*`, so no variant is a glob: both stay literal
+    // even though `a1.txt`/`b1.txt` would match.
+    const out = await $`echo {a,b}${"*"}.txt`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["a*.txt", "b*.txt"]);
+  });
+
+  test("a literal * globs a variant while an interpolated metacharacter stays data", async () => {
+    using dir = tempDir("shell-brace-glob7", {
+      "a[c]1.txt": "",
+      "ac1.txt": "",
+      "b[c]2.txt": "",
+    });
+    // Each variant is neutralized on its own, so the recovered metacharacter
+    // offsets must still point at the template `*` and not at the `[c]`.
+    const out = await $`echo {a,b}${"[c]"}*`.cwd(String(dir)).text();
+    expect(words(out)).toEqual(["a[c]1.txt", "b[c]2.txt"]);
   });
 });
 


### PR DESCRIPTION
## Repro

```js
// d1/f1, d1/f2, d2/f3 exist
await Bun.$`printf '%s\n' {d1,d2}/*`;
```

```
bash: d1/f1  d1/f2  d2/f3
bun:  d1/*  d2/*  d2/f3  d1/f1  d1/f2     <- the un-expanded patterns are extra argv words
```

Every command receives the pattern text as additional arguments: `rm {tmp,cache}/*` also gets the literal `tmp/*` and `cache/*`, and a tool that creates its arguments creates files named `tmp/*`.

## Cause

`do_brace_expand` in `src/runtime/shell/states/Expansion.rs` pushed each brace variant straight to argv, then transitioned to `Glob` and globbed the *original* pattern (bun's glob matcher understands brace groups, so it found the matches too). Result: literal variants plus matches.

Brace expansion precedes pathname expansion, and each resulting word is globbed on its own. `{aa*,b}` is not one glob: `aa*` is a pattern, `b` is a plain word that never reaches the walker.

## Fix

The variants are parked in `brace_words`, and a new `BraceWords` state expands them one at a time, in order: a variant carrying a literal `*` is globbed and replaced by its matches, any other variant is already the final word. A no-match variant follows the rule bun already applies to a single glob word (error outside assignments, literal inside them), so the message now names the expanded word (`no matches found: nope/*`) rather than `{d1,nope}/*`.

After brace expansion the word's `meta_offsets` no longer line up, and those offsets are what `neutralize_glob_metachars` uses to tell a `*` written in the template from a `*` that arrived via `${...}` interpolation. Each literal `*` is therefore tagged with a marker byte through the brace lexer and decoded back per variant; data bytes equal to the marker are doubled, so the encoding round-trips any input.

## Verification

`bun bd test test/js/bun/shell/` — the `brace + glob composition` tests in `test/js/bun/shell/brace.test.ts` asserted the old output (`expect(words).toContain("src/*.ts")`) and now assert the exact word list. Five tests cover it, all failing on `main`:

| command | before | after (= bash) |
| --- | --- | --- |
| `echo {d1,d2}/*` | `d1/* d2/* d2/f3 d1/f1 d1/f2` | `d1/f1 d1/f2 d2/f3` |
| `echo src/*.{ts,tsx}` | `src/*.ts src/*.tsx src/app.ts src/util.tsx` | `src/app.ts src/util.tsx` |
| `echo {a*,nope}` | `a* nope aa ab nope` | `aa ab nope` |
| `echo *{1,2}` | `*1 *2 d1 d2` | `d1 d2` |
| `echo {d1,nope}/*` | `d1/* nope/* d1/f1 d1/f2` | `bun: no matches found: nope/*` |

Interpolation stays data: `echo {a,b}${"*"}.txt` still yields the literal words `a*.txt b*.txt`, and the `interpolated values cannot inject glob syntax` suite in `bunshell.test.ts` passes unchanged.

Glob result ordering (bun does not sort matches) and bash's `{a*` unmatched-brace handling are separate pre-existing divergences, untouched here.

## Rebase notes

Rebased onto `main` after #34856 (comma-less `{x}` is literal), #34865, #34882, #36165, #36184 and #37921 landed in the same two files. One conflict needed a real decision, not a textual merge.

#34856 added a `count == 0` path to `do_brace_expand`: when the lexer demotes every group to literal text, the word is emitted unchanged via `vec![current_out.clone()]`. Auto-merge combined that with this PR's tag encoding, so the untagged word would have gone through `decode_brace_word`, come out with no metacharacter offsets, and had its template `*` neutralized. The resolution hands the unchanged word on with its original `meta_offsets` instead of round-tripping it. I checked this by building the auto-merged version: it fails main's own test "a word with a comma-less brace group and a glob keeps its pattern", and the resolved version passes it. A second test pins the path from this side (template `*` globs, interpolated `*` stays data).

New fields and the `BraceWord` struct use `pub(crate)` to match the visibility pass in #36184.

While doing this I found that the brace lexer and the glob matcher now disagree about a comma-less `{x}` (the lexer says literal, the matcher still reads a one-branch group, so `echo {x},*.txt` matches `x,a.txt`). That predates this PR and is fixed separately in #39634. The test "a zero-variant word with a matching glob emits only the matches" documents the current matcher reading on purpose. If #39634 lands first, its two fixtures become `{x},a.txt` and `{x},b.txt` and the expected list changes to match; nothing else in this PR depends on the order.

Verified on the rebased tree: `brace.test.ts` 48 pass, 6 of them fail with `src/` reverted to `main`; `brace.test.ts` + `bunshell.test.ts` together 472 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [1.89ms]
(pass) $.braces > 2 [1.97ms]
(pass) $.braces > 3 [1.84ms]
(pass) $.braces > nested [1.64ms]
(pass) $.braces > nested 2 [1.98ms]
(pass) $.braces > nested sibling product [1.78ms]
(pass) $.braces > nested sibling product with surrounding text [1.42ms]
(pass) $.braces > nested sibling product mixed with variants [1.98ms]
(pass) $.braces > nested sibling product triple [1.74ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.77ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.60ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.47ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.43ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.45ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.43ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.46ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.43ms]
(pass) $.braces > nest
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [0.05ms]
(pass) $.braces > 2 [0.05ms]
(pass) $.braces > 3 [0.02ms]
(pass) $.braces > nested [0.06ms]
(pass) $.braces > nested 2 [0.03ms]
(pass) $.braces > nested sibling product [0.02ms]
(pass) $.braces > nested sibling product with surrounding text [0.01ms]
(pass) $.braces > nested sibling product mixed with variants [0.02ms]
(pass) $.braces > nested sibling product triple [0.02ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [0.02ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.01ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.01ms]
(pass) $.braces > nested with empty variant > {x,{,}}z
(pass) $.braces > nested with empty variant > a{b,c{d,}}e
(pass) $.braces > nested with empty variant > a{b,c{,d}}e
(pass) $.braces > nested with empty variant > {x,{a,,b}}
(pass) $.braces > nested with empty variant > {x,{a,b,}}
(pass) $.braces > nested with empty variant > {{a,},x}
(pass) $.braces > nested with empty variant > p{q,{r,}{s,}}t
(pass) $.braces > very deeply nested [0.04ms]
(pass) $.braces > literal outer group around hundreds of nest
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [1.87ms]
(pass) $.braces > 2 [1.92ms]
(pass) $.braces > 3 [1.91ms]
(pass) $.braces > nested [1.64ms]
(pass) $.braces > nested 2 [2.00ms]
(pass) $.braces > nested sibling product [1.78ms]
(pass) $.braces > nested sibling product with surrounding text [1.41ms]
(pass) $.braces > nested sibling product mixed with variants [2.01ms]
(pass) $.braces > nested sibling product triple [1.75ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.80ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.63ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.45ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.45ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.43ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.46ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.44ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.45ms]
(pass) $.braces > nest
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3bc4773198
  features     baseline

23 deps, 129 codegen, 1172 objects in 720ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] gen ErrorCode+*.h
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1243] fetch zlib
[zlib] up to date
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/states/Expansion.rs | 125 +++++++++++++++++++++++++++-------
 test/js/bun/shell/brace.test.ts       | 122 +++++++++++++++++++++++++--------
 2 files changed, 194 insertions(+), 53 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/shell/states/Expansion.rs      9     29      0
test/js/bun/shell/brace.test.ts            7      9      0
```

</details>

<!-- robobun:evidence:end -->
