### PR TITLE
test: update cookie deletion expectations to IMF-fixdate

### DIFF
--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -432,7 +432,7 @@ describe("delete with prefixed cookie names", () => {
     const map = new Bun.CookieMap("__Host-id=1");
     map.delete("__Host-id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Host-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
+      "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
     ]);
   });
 
@@ -440,7 +440,7 @@ describe("delete with prefixed cookie names", () => {
     const map = new Bun.CookieMap("__Secure-id=1");
     map.delete("__Secure-id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Secure-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
+      "__Secure-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
     ]);
   });
 
@@ -449,8 +449,8 @@ describe("delete with prefixed cookie names", () => {
     map.delete("__Host-id");
     map.delete("id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Host-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
-      "id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
+      "id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
     ]);
   });
 });


### PR DESCRIPTION
### Problem

`main` is red on all 16 `test-bun` lanes:

```
✗ delete with prefixed cookie names > deleting a cookie whose name starts with __Host- emits a Secure expiring cookie
✗ delete with prefixed cookie names > deleting a cookie whose name starts with __Secure- emits a Secure expiring cookie
✗ delete with prefixed cookie names > deleting a cookie without a name prefix emits an expiring cookie without Secure

- "__Host-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax"
+ "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax"
```

### Cause

028f210723 (#32926) changed `Bun.Cookie`'s `Expires` output to an IMF-fixdate and updated the snapshot at `cookie-map.test.ts:265`, but the `describe("delete with prefixed cookie names")` block landed separately and still asserts the old form.

The implementation is the correct side. `Fri, 1 Jan 1970 00:00:00 -0000` is wrong three ways: 1970-01-01 was a **Thursday**, the day is not zero-padded, and RFC 6265's `sane-cookie-date` is an RFC 1123 / IMF-fixdate ending in `GMT`, not `-0000`.

### Fix

Update the four stale expectation strings to match. Test-only; no production change.

### Verification

`bun bd test test/js/bun/cookie/cookie-map.test.ts`

- on unmodified `main`: **3 fail**, 30 pass
- with this change: **33 pass**, 0 fail