### PR TITLE
node:url: treat ws: and wss: as slashed protocols

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -95,11 +95,15 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     ftp: true,
     gopher: true,
     file: true,
+    ws: true,
+    wss: true,
     "http:": true,
     "https:": true,
     "ftp:": true,
     "gopher:": true,
     "file:": true,
+    "ws:": true,
+    "wss:": true,
   };
 
 function urlParse(

--- a/src/node-fallbacks/url.js
+++ b/src/node-fallbacks/url.js
@@ -95,11 +95,15 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     ftp: true,
     gopher: true,
     file: true,
+    ws: true,
+    wss: true,
     "http:": true,
     "https:": true,
     "ftp:": true,
     "gopher:": true,
     "file:": true,
+    "ws:": true,
+    "wss:": true,
   };
 
 // https://github.com/Cap32/tiny-querystring/blob/master/tiny-querystring.js

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -134,6 +134,22 @@ describe("bundler", () => {
       stdout: "PASS",
     },
   });
+  itBundled("browser/NodeUrlWebSocketProtocolsAreSlashed", {
+    files: {
+      "/entry.js": /* js */ `
+        import { parse, format, resolve } from "node:url";
+        for (const protocol of ["ws", "wss"]) {
+          console.log(parse(protocol + ":host/p").host);
+          console.log(format({ protocol, host: "h", pathname: "/p" }));
+          console.log(resolve(protocol + "://h/a/b", "../../x"));
+        }
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "null\nws://h/p\nws://h/x\nnull\nwss://h/p\nwss://h/x",
+    },
+  });
   // TODO: use nodePolyfillList to generate the code in here.
   const NodePolyfills = itBundled("browser/NodePolyfills", {
     files: {

--- a/test/js/node/url/url-parse-format.test.js
+++ b/test/js/node/url/url-parse-format.test.js
@@ -925,25 +925,25 @@ describe("url.parse then url.format", () => {
     //   href: "javascript:alert(1);a='@white-listed.com'",
     // },
 
-    // "ws://www.example.com": {
-    //   protocol: "ws:",
-    //   slashes: true,
-    //   hostname: "www.example.com",
-    //   host: "www.example.com",
-    //   pathname: "/",
-    //   path: "/",
-    //   href: "ws://www.example.com/",
-    // },
+    "ws://www.example.com": {
+      protocol: "ws:",
+      slashes: true,
+      hostname: "www.example.com",
+      host: "www.example.com",
+      pathname: "/",
+      path: "/",
+      href: "ws://www.example.com/",
+    },
 
-    // "wss://www.example.com": {
-    //   protocol: "wss:",
-    //   slashes: true,
-    //   hostname: "www.example.com",
-    //   host: "www.example.com",
-    //   pathname: "/",
-    //   path: "/",
-    //   href: "wss://www.example.com/",
-    // },
+    "wss://www.example.com": {
+      protocol: "wss:",
+      slashes: true,
+      hostname: "www.example.com",
+      host: "www.example.com",
+      pathname: "/",
+      path: "/",
+      href: "wss://www.example.com/",
+    },
 
     // "//fhqwhgads@example.com/everybody-to-the-limit": {
     //   protocol: null,

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "url";
+import { format, parse, resolve } from "url";
 
 describe("Url.prototype.parse", () => {
   it("parses URL correctly", () => {
@@ -65,6 +65,68 @@ describe("Url.prototype.parse", () => {
       href: "http://xn--hs8h.net/",
     });
   });
+});
+
+// ws: and wss: are slashed protocols in node, so they always carry an authority.
+describe.each(["ws", "wss"])("%s: is a slashed protocol", protocol => {
+  it("does not invent a host for an authority-less URL", () => {
+    expect(parse(`${protocol}:host/p`)).toEqual({
+      protocol: `${protocol}:`,
+      slashes: null,
+      auth: null,
+      host: null,
+      port: null,
+      hostname: null,
+      hash: null,
+      search: null,
+      query: null,
+      pathname: "host/p",
+      path: "host/p",
+      href: `${protocol}:host/p`,
+    });
+  });
+
+  it("defaults the pathname to / when there is a host", () => {
+    expect(parse(`${protocol}://h`)).toEqual({
+      protocol: `${protocol}:`,
+      slashes: true,
+      auth: null,
+      host: "h",
+      port: null,
+      hostname: "h",
+      hash: null,
+      search: null,
+      query: null,
+      pathname: "/",
+      path: "/",
+      href: `${protocol}://h/`,
+    });
+  });
+
+  it("formats with // even when slashes is absent", () => {
+    expect(format({ protocol, host: "h", pathname: "/p" })).toBe(`${protocol}://h/p`);
+    expect(format({ protocol: `${protocol}:`, host: "h", pathname: "/p" })).toBe(`${protocol}://h/p`);
+    expect(format({ protocol, hostname: "h", port: 8080, pathname: "/p" })).toBe(`${protocol}://h:8080/p`);
+  });
+
+  it("resolve keeps the host instead of taking it from the relative path", () => {
+    expect(resolve(`${protocol}://h/a/b`, "../../x")).toBe(`${protocol}://h/x`);
+    expect(resolve(`${protocol}://h/a/b`, "../../../../x")).toBe(`${protocol}://h/x`);
+    expect(resolve(`${protocol}://127.0.0.1/`, "../x")).toBe(`${protocol}://127.0.0.1/x`);
+    expect(resolve(`${protocol}://h/a/b`, "/c")).toBe(`${protocol}://h/c`);
+    expect(resolve(`${protocol}://h/a/b`, "c")).toBe(`${protocol}://h/a/c`);
+    expect(resolve(`${protocol}://h/a/b`, "")).toBe(`${protocol}://h/a/b`);
+  });
+
+  it("resolve still honors an explicit authority in the relative reference", () => {
+    expect(resolve(`${protocol}://h/a/b`, "//other/c")).toBe(`${protocol}://other/c`);
+    expect(resolve(`http://h/a`, `${protocol}://other/b`)).toBe(`${protocol}://other/b`);
+    expect(resolve(`${protocol}://h/a`, "http://other/b")).toBe("http://other/b");
+  });
+});
+
+it("mailto: keeps crawling up into the host (not a slashed protocol)", () => {
+  expect(resolve("mailto://h/a/b", "../../x")).toBe("mailto://x");
 });
 
 it("URL constructor throws ERR_MISSING_ARGS", () => {


### PR DESCRIPTION
`node:url`'s legacy `slashedProtocol` table is missing `ws:` and `wss:`, so WebSocket URLs are treated like `mailto:` (a scheme with no authority).

## Repro

```js
import * as nurl from "node:url";
const P = s => { const u = nurl.parse(s); return [u.protocol, u.host, u.pathname]; };
console.log(JSON.stringify([
  P("ws:host/p"),
  nurl.format({ protocol: "ws", host: "h", pathname: "/p" }),
  nurl.resolve("ws://h/a/b", "../../x"),
  nurl.resolve("ws://127.0.0.1/", "../x"),
]));
```

```
node v26.3.0:  [["ws:",null,"host/p"],  "ws://h/p",  "ws://h/x",  "ws://127.0.0.1/x"]
bun 1.4.0   :  [["ws:","host","/p"],    "ws:h/p",    "ws://x",    "ws://x"]
                        ^invented host   ^// lost      ^host replaced by the relative path
```

## Cause

`slashedProtocol` in `src/js/node/url.ts` stops at `file:`. Node's set is `{http, https, ftp, gopher, file, ws, wss}`, each with and without the trailing colon. The table feeds three separate decisions:

- `parse` — a non-slashed scheme never parses an authority, so `ws:host/p` invents `host` as a hostname.
- `format` — only slashed schemes get `//` when `slashes` is absent.
- `resolveObject` — the `psychotic` branch is gated on `!slashedProtocol[result.protocol]`. For a non-slashed scheme a relative reference is allowed to crawl up past the path and into the host. With `ws:` missing, resolving a relative reference against a WebSocket base **replaces the host with a segment of that relative path** — so a relative path that reaches the resolver produces a URL pointing at a host the path chose. Allow-lists and routers keyed on `url.parse(x).host` also see hostnames node would never produce.

The same fix repairs `url.resolve("ws://h/a/b", "/c")`, which returned `ws:///c` instead of `ws://h/c`.

## Fix

Add `ws`/`wss` (with and without the trailing colon) to the table. One table, three faces, all fixed together.

The table is copy-pasted into the browser polyfill as well, so both copies are updated:

- `src/js/node/url.ts` — the runtime `node:url`
- `src/node-fallbacks/url.js` — the `--target=browser` polyfill

## Verification

Bun's port of node's `test-url.js` parse/format suite already carried the `ws://www.example.com` and `wss://www.example.com` cases, **commented out** because they failed. They are un-commented and now pass.

New coverage in `test/js/node/url/url.test.ts` for both protocols, asserting values taken from node v26.3.0: parse with and without an authority, `format` from a plain object, and the `resolve` matrix (`../../x`, over-long `../`, `/c`, `c`, `""`, `//other/c`, and protocol switches in both directions). A `mailto:` case pins the crawl-up behavior that non-slashed schemes are supposed to keep. `test/bundler/bundler_browser.test.ts` covers the browser fallback.

Without the src changes, 9 of the new/restored tests fail; with them, the full `test/js/node/url/` suite and node's upstream `test-url-parse-format.js` / `test-url-relative.js` pass. (Two failures in that directory, `pathToFileURL doesn't leak memory` and `URL.canParse > repeatedly called produces same result`, reproduce on a clean tree and are unrelated.)

Output after the fix is byte-identical to node v26.3.0 on the repro above.