### PR TITLE
Bun.serve: send Date on bodiless responses, and mirror GET's Content-Type on HEAD

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -41,6 +41,7 @@ pub struct FileRoute {
     has_last_modified_header: bool,
     has_content_length_header: bool,
     has_content_range_header: bool,
+    has_date_header: bool,
 }
 
 pub struct InitOptions<'a> {
@@ -120,6 +121,7 @@ impl FileRoute {
             has_last_modified_header: headers.get(b"last-modified").is_some(),
             has_content_length_header: headers.get(b"content-length").is_some(),
             has_content_range_header: headers.get(b"content-range").is_some(),
+            has_date_header: headers.get(b"date").is_some(),
             blob,
             headers,
             status_code: opts.status_code,
@@ -179,6 +181,7 @@ impl FileRoute {
                     has_last_modified_header: headers.get(b"last-modified").is_some(),
                     has_content_length_header: headers.get(b"content-length").is_some(),
                     has_content_range_header: headers.get(b"content-range").is_some(),
+                    has_date_header: headers.get(b"date").is_some(),
                     blob,
                     headers,
                     status_code,
@@ -203,6 +206,7 @@ impl FileRoute {
                     has_content_length_header: false,
                     has_last_modified_header: false,
                     has_content_range_header: false,
+                    has_date_header: false,
                     status_code: 200,
                     stat_hash: Cell::new(StatHash::default()),
                 }))));
@@ -264,6 +268,12 @@ impl FileRoute {
 
         if self.has_content_length_header {
             resp.mark_wrote_content_length_header();
+        }
+        // A baked Date was written raw above without setting uWS's
+        // HTTP_WROTE_DATE_HEADER; mark it so the terminating writeMark() does not
+        // append a second Date (RFC 9110 5.6.6).
+        if self.has_date_header {
+            resp.mark_wrote_date_header();
         }
     }
 
@@ -485,7 +495,6 @@ impl FileRoute {
         req.set_yield(false);
 
         this.write_status_code(status_code, resp);
-        resp.write_mark();
         this.write_headers(resp);
 
         // Bodiless statuses end before the range switch so a 304 emits no

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2544,8 +2544,10 @@ where
                 } else {
                     resp.write_header_int(b"content-length", size as u64);
                 }
-                this.end_without_body(this.should_close_connection());
+                // Detach before ending: `end_without_body` derefs the context, which at
+                // refcount 1 finalizes it, so `this` must not be touched afterwards.
                 this.blob.detach();
+                this.end_without_body(this.should_close_connection());
             }
 
             Body::Value::Blob(blob) => {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2532,8 +2532,11 @@ where
         let body_value = response.get_body_value();
         match body_value {
             Body::Value::InternalBlob(_) | Body::Value::WTFStringImpl(_) => {
-                let mut blob = body_value.use_as_any_blob_allow_non_utf8_string();
-                let size = blob.size();
+                // `render_metadata` derives the Content-Type from `self.blob`, so the body
+                // has to land there (as it does on the GET path) or HEAD advertises the
+                // bodiless default instead of the type GET sends (RFC 9110 §9.3.2).
+                this.blob = body_value.use_as_any_blob_allow_non_utf8_string();
+                let size = this.blob.size();
                 this.render_metadata();
 
                 if size == crate::webcore::blob::MAX_SIZE {
@@ -2542,7 +2545,7 @@ where
                     resp.write_header_int(b"content-length", size as u64);
                 }
                 this.end_without_body(this.should_close_connection());
-                blob.detach();
+                this.blob.detach();
             }
 
             Body::Value::Blob(blob) => {
@@ -2584,6 +2587,11 @@ where
                 // to the socket in between, so the wire output is unchanged.
                 blob.resolve_size();
                 let blob_size = blob.size.get();
+                // `render_metadata` derives the Content-Type from `self.blob`, so the
+                // body must land there (as the GET path does) or HEAD advertises the
+                // bodiless default instead of GET's type. `dupe()` shares the store, so
+                // `blob` keeps its own reference.
+                this.blob = AnyBlob::Blob(blob.dupe());
                 this.render_metadata();
 
                 if blob_size == crate::webcore::blob::MAX_SIZE {

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -490,10 +490,14 @@ impl StaticRoute {
 
         debug_assert_eq!(names.len(), values.len());
         for (name, value) in names.iter().zip(values) {
-            resp.write_header(
-                &buf[name.offset as usize..][..name.length as usize],
-                &buf[value.offset as usize..][..value.length as usize],
-            );
+            let name = &buf[name.offset as usize..][..name.length as usize];
+            resp.write_header(name, &buf[value.offset as usize..][..value.length as usize]);
+            // This baked Date is written raw, which does not set uWS's
+            // HTTP_WROTE_DATE_HEADER; mark it so the terminator's writeMark()
+            // does not append a second Date (RFC 9110 5.6.6).
+            if name.eq_ignore_ascii_case(b"date") {
+                resp.mark_wrote_date_header();
+            }
         }
         if !matches!(resp, AnyResponse::H3(_)) {
             if let Some(srv) = self.server.get() {

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -289,6 +289,10 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
     }
 
+    pub fn mark_wrote_date_header(&mut self) {
+        c::uws_res_mark_wrote_date_header(Self::ssl_flag(), self.as_raw())
+    }
+
     pub fn write_mark(&mut self) {
         c::uws_res_write_mark(Self::ssl_flag(), self.as_raw())
     }
@@ -695,6 +699,10 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.mark_wrote_content_length_header())
     }
 
+    pub fn mark_wrote_date_header(self) {
+        any_dispatch!(self, |r| r.mark_wrote_date_header())
+    }
+
     pub fn write_mark(self) {
         any_dispatch!(self, |r| r.write_mark())
     }
@@ -1032,6 +1040,7 @@ pub mod c {
     // unsafe.
     unsafe extern "C" {
         pub(crate) safe fn uws_res_mark_wrote_content_length_header(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_mark_wrote_date_header(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_write_mark(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn us_socket_mark_needs_more_not_ssl(socket: &mut uws_res);
         pub(crate) safe fn uws_res_state(ssl: c_int, res: &uws_res) -> State;

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -179,6 +179,9 @@ impl Response {
     pub fn mark_wrote_content_length_header(&mut self) {
         c::uws_h3_res_mark_wrote_content_length_header(self)
     }
+    pub fn mark_wrote_date_header(&mut self) {
+        c::uws_h3_res_mark_wrote_date_header(self)
+    }
     pub fn write_continue(&mut self) {
         c::uws_h3_res_write_continue(self)
     }
@@ -718,6 +721,7 @@ mod c {
             v: u64,
         );
         pub(super) safe fn uws_h3_res_mark_wrote_content_length_header(res: &mut Response);
+        pub(super) safe fn uws_h3_res_mark_wrote_date_header(res: &mut Response);
         pub(super) safe fn uws_h3_res_write_mark(res: &mut Response);
         pub(super) safe fn uws_h3_res_flush_headers(res: &mut Response, immediate: bool);
         pub(super) fn uws_h3_res_write(res: *mut Response, p: *const u8, len: *mut usize) -> bool;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1348,6 +1348,10 @@ extern "C"
       }
       if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
       {
+        // Every other termination path reaches writeMark() through internalEnd();
+        // this one hand-rolls the terminator, so Date is written here instead
+        // (RFC 9110 6.6.1). writeMark() is idempotent.
+        uwsRes->writeMark();
         uwsRes->AsyncSocket<true>::write("\r\n", 2);
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
@@ -1368,6 +1372,10 @@ extern "C"
       }
       if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))
       {
+        // Every other termination path reaches writeMark() through internalEnd();
+        // this one hand-rolls the terminator, so Date is written here instead
+        // (RFC 9110 6.6.1). writeMark() is idempotent.
+        uwsRes->writeMark();
         // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
         // If not, they may throw a ConnectionError.
         uwsRes->AsyncSocket<false>::write("\r\n", 2);

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1250,6 +1250,19 @@ extern "C"
     }
   }
 
+  // Mark a Date header as already written, so a later writeMark() (from
+  // internalEnd or uws_res_end_without_body) does not append a second one.
+  // Callers that write Date via the raw writeHeader() path must use this.
+  void uws_res_mark_wrote_date_header(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<true>::HTTP_WROTE_DATE_HEADER;
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<false>::HTTP_WROTE_DATE_HEADER;
+    }
+  }
+
   void uws_res_write_mark(int ssl, uws_res_r res) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -161,6 +161,11 @@ void uws_h3_res_mark_wrote_content_length_header(uws_h3_res_t* res)
     ((Http3Response*)res)->getHttpResponseData()->state |= Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
 }
 
+void uws_h3_res_mark_wrote_date_header(uws_h3_res_t* res)
+{
+    ((Http3Response*)res)->getHttpResponseData()->state |= Http3ResponseData::HTTP_WROTE_DATE_HEADER;
+}
+
 void uws_h3_res_write_mark(uws_h3_res_t* res) { ((Http3Response*)res)->writeMark(); }
 void uws_h3_res_flush_headers(uws_h3_res_t* res, bool) { ((Http3Response*)res)->flushHeaders(); }
 

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -108,4 +108,17 @@ describe("Date header on bodiless responses", () => {
       expectFreshDate(notModified, `${method} 304`);
     }
   });
+
+  // https://github.com/oven-sh/bun/issues/27512
+  test("413 responses carry Date", async () => {
+    using server = Bun.serve({
+      port: 0,
+      maxRequestBodySize: 1,
+      fetch: () => new Response("Hello Bun"),
+    });
+
+    const tooLarge = await drain(server.url.href, { method: "POST", body: "12" });
+    expect(tooLarge.status).toBe(413);
+    expectFreshDate(tooLarge, "413");
+  });
 });

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
 
 test("Date header is not updated every request", async () => {
   const twoSecondsAgo = new Date(Date.now() - 2 * 1000);
@@ -120,5 +122,67 @@ describe.concurrent("Date header on bodiless responses", () => {
     const tooLarge = await drain(server.url.href, { method: "POST", body: "12" });
     expect(tooLarge.status).toBe(413);
     expectFreshDate(tooLarge, "413");
+  });
+});
+
+// RFC 9110 5.6.6: a server must not generate more than one Date field. Static and
+// file routes write their baked headers raw, so a user-supplied Date has to
+// suppress the server's auto-stamp rather than sit next to it.
+describe.concurrent("a route's own Date is not duplicated", () => {
+  const USER_DATE = "Mon, 01 Jan 2024 00:00:00 GMT";
+
+  // fetch() collapses duplicate headers, so read the raw bytes to count them.
+  async function rawDateHeaders(port: number, method: string, pathname: string) {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const chunks: Buffer[] = [];
+    await using socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data: (_s, d) => chunks.push(d),
+        end: () => resolve(Buffer.concat(chunks).toString()),
+        close: () => resolve(Buffer.concat(chunks).toString()),
+        error: (_s, e) => reject(e),
+      },
+    });
+    socket.write(`${method} ${pathname} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+    socket.flush();
+    const head = (await promise).split("\r\n\r\n")[0];
+    return head
+      .split("\r\n")
+      .slice(1)
+      .filter(line => /^date:/i.test(line))
+      .map(line => line.slice(line.indexOf(":") + 1).trim());
+  }
+
+  test.each(["GET", "HEAD"])("static route, %s", async method => {
+    using server = Bun.serve({
+      port: 0,
+      static: { "/s": new Response("S", { headers: { date: USER_DATE } }) },
+      fetch: () => new Response("fallback"),
+    });
+    expect(await rawDateHeaders(server.port, method, "/s")).toEqual([USER_DATE]);
+  });
+
+  test.each(["GET", "HEAD"])("file route, %s", async method => {
+    using dir = tempDir("serve-date-file", { "f.txt": "FILE" });
+    const file = path.join(String(dir), "f.txt");
+    using server = Bun.serve({
+      port: 0,
+      static: { "/f": new Response(Bun.file(file), { headers: { date: USER_DATE } }) },
+      fetch: () => new Response("fallback"),
+    });
+    expect(await rawDateHeaders(server.port, method, "/f")).toEqual([USER_DATE]);
+  });
+
+  test.each(["GET", "HEAD"])("without a user Date, the server stamps exactly one, %s", async method => {
+    using server = Bun.serve({
+      port: 0,
+      static: { "/s": new Response("S") },
+      fetch: () => new Response("fallback"),
+    });
+    const dates = await rawDateHeaders(server.port, method, "/s");
+    expect(dates).toHaveLength(1);
+    expect(Number.isFinite(new Date(dates[0]).getTime())).toBe(true);
   });
 });

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 test("Date header is not updated every request", async () => {
   const twoSecondsAgo = new Date(Date.now() - 2 * 1000);
@@ -52,4 +52,60 @@ test("Date header is not updated every request", async () => {
     expect(stamp).toBeGreaterThan(twoSecondsAgo.getTime());
     expect(stamp).toBeLessThan(Date.now() + 100);
   }
+});
+
+// RFC 9110 6.6.1: an origin server with a clock sends Date in every response.
+// The bodiless ones terminate through a different path than a normal body write,
+// which used to skip it entirely.
+describe("Date header on bodiless responses", () => {
+  async function drain(url: string, init?: RequestInit) {
+    const res = await fetch(url, init);
+    await res.arrayBuffer();
+    return res;
+  }
+
+  function expectFreshDate(res: Response, label: string) {
+    const date = res.headers.get("date");
+    expect(date, `${label} must carry a Date header`).toBeTruthy();
+    const stamp = new Date(date!).getTime();
+    expect(Number.isFinite(stamp), `${label} Date must parse`).toBe(true);
+    // Date has one-second resolution and the server caches it, so allow a window.
+    expect(stamp).toBeGreaterThan(Date.now() - 60_000);
+    expect(stamp).toBeLessThan(Date.now() + 60_000);
+  }
+
+  test("HEAD responses carry Date", async () => {
+    using server = Bun.serve({
+      port: 0,
+      static: { "/static": new Response("hello") },
+      fetch: () => new Response("hello"),
+    });
+
+    const dynamic = await drain(new URL("/dynamic", server.url).href, { method: "HEAD" });
+    expect(dynamic.status).toBe(200);
+    expectFreshDate(dynamic, "dynamic HEAD");
+
+    const staticRoute = await drain(new URL("/static", server.url).href, { method: "HEAD" });
+    expect(staticRoute.status).toBe(200);
+    expectFreshDate(staticRoute, "static HEAD");
+  });
+
+  test("304 responses carry Date", async () => {
+    using server = Bun.serve({
+      port: 0,
+      static: { "/static": new Response("hello") },
+      fetch: () => new Response("fallback"),
+    });
+    const url = new URL("/static", server.url).href;
+
+    const first = await drain(url);
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    for (const method of ["GET", "HEAD"]) {
+      const notModified = await drain(url, { method, headers: { "if-none-match": etag! } });
+      expect(notModified.status).toBe(304);
+      expectFreshDate(notModified, `${method} 304`);
+    }
+  });
 });

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -57,7 +57,7 @@ test("Date header is not updated every request", async () => {
 // RFC 9110 6.6.1: an origin server with a clock sends Date in every response.
 // The bodiless ones terminate through a different path than a normal body write,
 // which used to skip it entirely.
-describe("Date header on bodiless responses", () => {
+describe.concurrent("Date header on bodiless responses", () => {
   async function drain(url: string, init?: RequestInit) {
     const res = await fetch(url, init);
     await res.arrayBuffer();

--- a/test/js/bun/http/bun-serve-head.test.ts
+++ b/test/js/bun/http/bun-serve-head.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 // request as it would have sent had the request been a GET. The representation
 // metadata (Content-Type, Content-Length) is derived from the body that GET
 // would have sent, even though HEAD sends no body bytes.
-describe("HEAD mirrors GET's representation metadata", () => {
+describe.concurrent("HEAD mirrors GET's representation metadata", () => {
   async function metadataOf(url: string, method: string) {
     const res = await fetch(url, { method });
     const body = await res.arrayBuffer();

--- a/test/js/bun/http/bun-serve-head.test.ts
+++ b/test/js/bun/http/bun-serve-head.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
+
+// RFC 9110 9.3.2: the server sends the same header fields in response to a HEAD
+// request as it would have sent had the request been a GET. The representation
+// metadata (Content-Type, Content-Length) is derived from the body that GET
+// would have sent, even though HEAD sends no body bytes.
+describe("HEAD mirrors GET's representation metadata", () => {
+  async function metadataOf(url: string, method: string) {
+    const res = await fetch(url, { method });
+    const body = await res.arrayBuffer();
+    return {
+      status: res.status,
+      contentType: res.headers.get("content-type"),
+      contentLength: res.headers.get("content-length"),
+      bodyLength: body.byteLength,
+    };
+  }
+
+  test.each([
+    ["string body", () => new Response("hello")],
+    ["typed Blob body", () => new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" }))],
+    ["sliced Blob body", () => new Response(new Blob(["abcdef"], { type: "text/html" }).slice(0, 3))],
+    ["Uint8Array body", () => new Response(new Uint8Array([1, 2, 3]))],
+    ["explicit Content-Type", () => new Response("hi", { headers: { "content-type": "text/foo" } })],
+    ["bodiless", () => new Response(null)],
+  ])("%s", async (_label, make) => {
+    using server = Bun.serve({ port: 0, fetch: () => make() });
+    const url = server.url.href;
+
+    const get = await metadataOf(url, "GET");
+    const head = await metadataOf(url, "HEAD");
+
+    // HEAD advertises the same representation, but sends no body bytes.
+    expect(head).toEqual({
+      status: get.status,
+      contentType: get.contentType,
+      contentLength: get.contentLength,
+      bodyLength: 0,
+    });
+  });
+
+  test("Bun.file body", async () => {
+    using dir = tempDir("serve-head", { "page.html": "<h1>hi</h1>" });
+    const file = path.join(String(dir), "page.html");
+
+    using server = Bun.serve({ port: 0, fetch: () => new Response(Bun.file(file)) });
+    const url = server.url.href;
+
+    const get = await metadataOf(url, "GET");
+    const head = await metadataOf(url, "HEAD");
+
+    expect(get.contentType).toBe("text/html;charset=utf-8");
+    expect(head).toEqual({
+      status: get.status,
+      contentType: get.contentType,
+      contentLength: get.contentLength,
+      bodyLength: 0,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #27512

## Repro

```js
const page = new Response("hello");
using server = Bun.serve({
  port: 0,
  static: { "/static": page },
  fetch: () => new Response("hello"),
});
```

| request | `Date` | `Content-Type` |
|---|---|---|
| `GET /dynamic` | yes | `text/plain;charset=utf-8` |
| `HEAD /dynamic` | **missing** | **`application/octet-stream`** |
| `GET /static` | yes | `text/plain;charset=utf-8` |
| `HEAD /static` | **missing** | `text/plain;charset=utf-8` |
| `GET /static` + `If-None-Match` (304) | **missing** | `text/plain;charset=utf-8` |
| a 413 from `maxRequestBodySize` (#27512) | **missing** | n/a |

A cache keyed on `Date` cannot compute freshness, and a `HEAD` that advertises `application/octet-stream` tells a client the resource is a binary download when `GET` would have served text.

## Cause

Two defects, both making a bodiless response describe itself differently than the `GET` it mirrors.

**1. `Date` (RFC 9110 6.6.1).** `uws_res_end_without_body()` hand-rolls the response terminator rather than going through `internalEnd()` — and `internalEnd()` is where `writeMark()` writes `Date`. Every other termination path reaches it; this one never did. `HEAD`, `304` and the bodiless error responses (`413`) terminate this way, so they shipped with no `Date`.

**2. `Content-Type` on `HEAD` (RFC 9110 9.3.2).** The HEAD renderer consumed the body into a local, but `render_metadata()` derives the Content-Type from `self.blob`, so it fell through to the bodiless default. The GET path assigns `self.blob`. Both HEAD arms (in-memory and `Blob` bodies) had this, so a string, a typed `Blob`, a sliced `Blob` and a `Bun.file` body were all affected.

## Fix

- Call `writeMark()` in `uws_res_end_without_body()` before the terminator. `writeMark()` is idempotent.
- Assign `this.blob` in both HEAD arms before `render_metadata()`, as the GET path does. The `Blob` arm shares the store via `dupe()`; detach happens before `end_without_body` (which may finalize the context at refcount 1).

### No duplicate `Date` for routes that set their own (RFC 9110 5.6.6)

Making `writeMark()` run on the bodiless path surfaced a pre-existing class bug: `StaticRoute`/`FileRoute` write baked headers via the raw `write_header()` path, which never sets `HTTP_WROTE_DATE_HEADER`. So a route whose `Response` carried a `Date` got a second one appended — and GET already double-stamped via `internalEnd()`. Before the fix:

| request (route with a user `Date`) | `Date` headers on `main` |
|---|---|
| `GET /static`, `GET /file`, `HEAD /file` | 2 (pre-existing) |
| `HEAD /static` | 1 → would become 2 under this PR |

Added a `mark_wrote_date_header()` shim next to `mark_wrote_content_length_header()` (C + Rust + `AnyResponse` + H3) and call it from both writers when the baked headers include a `Date`. `FileRoute`'s eager `write_mark()` before `write_headers()` is removed so the terminator stamps `Date` once, preferring the user's value; every `FileRoute` exit (bodiless, sendfile body, 304) still reaches a `writeMark`. After the fix, all six cells (static/file × GET/HEAD, with/without a user `Date`) emit exactly one `Date`, and a user-supplied value is preserved verbatim.

`needs_content_length` is already forced false on the HEAD path and `needs_content_range` is only set for file-backed bodies in `do_sendfile`, so assigning `self.blob` changes nothing but the Content-Type derivation.

### node:http is unaffected

`NodeHTTP.cpp` sets `HTTP_WROTE_DATE_HEADER` up front because `ServerResponse` owns the header in JS (honoring `res.sendDate` / `removeHeader("date")`), so `writeMark()` stays a no-op there:

```
                HEAD /      -> 1 Date    GET /204 -> 1 Date
sendDate=false  HEAD /      -> 0 Date    GET /204 -> 0 Date
```

## Verification

`bun-serve-date.test.ts` asserts `Date` on `HEAD` (dynamic + static), `304` (GET + HEAD), the `413` of #27512, and — via raw sockets, since `fetch` collapses duplicate headers — exactly one `Date` for static/file routes × GET/HEAD with and without a user `Date`.

`bun-serve-head.test.ts` (new) asserts `HEAD` reports the same status, Content-Type and Content-Length as `GET` with zero body bytes, across string / typed `Blob` / sliced `Blob` / `Uint8Array` / explicit Content-Type / bodiless / `Bun.file` bodies.

<details>
<summary>Suites run</summary>

| Suite | Result |
|---|---|
| `bun-serve-date`, `bun-serve-head`, `bun-serve-file`, `serve-if-none-match`, `bun-serve-static`, `bun-serve-routes` | 194 pass, 0 fail |
| `serve.test.ts` | 238 pass, same 4 pre-existing container-env failures as `main` |
| `node-http.test.ts` | 127 pass, 1 pre-existing failure (also fails on `main`) |

`cargo clippy` and `cargo fmt` clean on `bun_uws` and `bun_runtime`.
</details>

## Not in scope

HTTP/3 never writes `Date` on any response, not just bodiless ones — `Http3Response` has no `writeMark()` equivalent. A separate gap in a separate code path.
