### PR TITLE
node:url: serialize an object query with querystring.stringify in url.format

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -30,6 +30,7 @@ const [domainToASCII, domainToUnicode] = $cpp("NodeURL.cpp", "Bun::createNodeURL
 const { urlToHttpOptions } = require("internal/url");
 const { validateString } = require("internal/validators");
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
+let querystringStringify: typeof import("node:querystring").stringify | undefined;
 
 function Url() {
   this.protocol = null;
@@ -513,8 +514,9 @@ Url.prototype.format = function format() {
   }
 
   const thisQuery = this.query;
-  if (thisQuery && typeof thisQuery === "object" && Object.keys(thisQuery).length) {
-    query = new URLSearchParams(thisQuery).toString();
+  if (thisQuery !== null && typeof thisQuery === "object") {
+    querystringStringify ??= require("node:querystring").stringify;
+    query = querystringStringify(thisQuery);
   }
 
   var search = this.search || (query && "?" + query) || "";

--- a/test/js/node/url/url-format.test.js
+++ b/test/js/node/url/url-format.test.js
@@ -302,4 +302,45 @@ describe("url.format", () => {
       "http://example.com/?a=%231",
     );
   });
+
+  // An object `query` is serialized with querystring.stringify(), not
+  // URLSearchParams, which differ on arrays, spaces and non-primitives.
+  describe("serializes an object query with querystring.stringify", () => {
+    const cases = [
+      ["percent-encodes spaces instead of using +", { a: "1 2" }, "/p?a=1%202"],
+      ["expands an array value into repeated keys", { a: ["x", "y"] }, "/p?a=x&a=y"],
+      ["omits keys whose value is an empty array", { a: "1", b: [] }, "/p?a=1"],
+      [
+        "serializes null and undefined as empty values",
+        { a: 1, b: null, c: undefined, d: true },
+        "/p?a=1&b=&c=&d=true",
+      ],
+      ["serializes a symbol value as an empty value", { a: Symbol("s") }, "/p?a="],
+      ["serializes a non-primitive value as an empty value", { a: { b: 1 } }, "/p?a="],
+      ["serializes non-finite numbers as empty values", { a: Infinity, b: NaN }, "/p?a=&b="],
+      ["serializes a bigint value", { a: 10n }, "/p?a=10"],
+      ["serializes non-primitives inside an array", { a: [1, null, undefined, true] }, "/p?a=1&a=&a=&a=true"],
+      ["accepts an array as the whole query object", ["a", "b"], "/p?0=a&1=b"],
+      ["produces no search for an empty query object", {}, "/p"],
+    ];
+
+    for (const [label, query, expected] of cases) {
+      test(label, () => {
+        assert.strictEqual(url.format({ pathname: "/p", query }), expected);
+      });
+    }
+
+    test("an explicit search still takes precedence over query", () => {
+      assert.strictEqual(url.format({ pathname: "/p", search: "?z=9", query: { a: 1 } }), "/p?z=9");
+    });
+
+    test("keeps repeated keys intact across a parse/mutate/format round trip", () => {
+      const parsed = url.parse("http://e.com/p?tag=a&tag=b", true);
+      assert.deepStrictEqual(parsed.query.tag, ["a", "b"]);
+      parsed.query.tag.push("c");
+      parsed.query.note = "q 1";
+      parsed.search = undefined;
+      assert.strictEqual(url.format(parsed), "http://e.com/p?tag=a&tag=b&tag=c&note=q%201");
+    });
+  });
 });


### PR DESCRIPTION
## Repro

```js
import * as nurl from "node:url";

console.log(
  nurl.format({ pathname: "/p", query: { a: "1 2" } }),
  nurl.format({ pathname: "/p", query: { a: ["x", "y"], b: [] } }),
  nurl.format({ pathname: "/p", query: { a: 1, b: null, c: undefined, d: true } }),
);
```

| | Node v26 | Bun 1.4.0 |
|---|---|---|
| `{ a: "1 2" }` | `/p?a=1%202` | `/p?a=1+2` |
| `{ a: ["x","y"], b: [] }` | `/p?a=x&a=y` | `/p?a=x%2Cy&b=` |
| `{ a: 1, b: null, c: undefined, d: true }` | `/p?a=1&b=&c=&d=true` | `/p?a=1&b=null&c=undefined&d=true` |

The array case is the damaging one: two `a` params become one param whose
value is the literal string `x,y`. The round trip that express/proxy
middleware relies on corrupts the query on the way back out:

```js
const u = url.parse("http://e.com/p?tag=a&tag=b", true);
u.query.tag.push("c");
u.search = undefined;
url.format(u);
// node: http://e.com/p?tag=a&tag=b&tag=c
// bun:  http://e.com/p?tag=a%2Cb%2Cc
```

`url.format({ query: ["a", "b"] })` and a symbol value also threw instead of
returning `/p?0=a&1=b` and `/p?a=`.

## Cause

`Url.prototype.format` in `src/js/node/url.ts` serialized an object `query`
with `new URLSearchParams(this.query).toString()`. `URLSearchParams` applies
`application/x-www-form-urlencoded` record semantics: every value goes through
`String(v)` (so an array becomes `"x,y"`, `null` becomes `"null"`) and spaces
serialize as `+`.

Node's `url.format()` is documented to use `querystring.stringify(urlObject.query)`,
which expands array values into repeated keys, skips empty arrays, maps
non-primitives to an empty value, and percent-encodes spaces.

## Fix

Call `querystring.stringify`, which Bun already implements as a faithful port of
Node's. The `require` is lazy (`??=`), matching the existing idiom in
`src/js/node/events.ts`, so only callers that pass an object `query` pay for it.

The parse side (`url.parse(x, true)`) already produced the same shape as
`querystring.parse`, so only the write side needed to change.

## Verification

`test/js/node/url/url-format.test.js` gains 13 cases covering spaces, arrays,
empty arrays, `null`/`undefined`, symbols, non-primitives, non-finite numbers,
bigints, an array as the whole query object, an empty query object, `search`
taking precedence, and the parse/mutate/format round trip. Every expected value
is what node v26.3.0 prints.

10 of the 15 tests in that file fail on `main` and pass with this change; the
rest of `test/js/node/url/` plus the ported `test-url-*` / `test-querystring-*`
suites stay green.

The new path is also faster than the one it replaces, since it no longer
constructs a `URLSearchParams` per call:

```
new URLSearchParams({foo,baz,n}).toString()   1379 ns/op
querystring.stringify({foo,baz,n})             266 ns/op
```
