### PR TITLE
process.kill: validate numeric signals like node

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4255,20 +4255,27 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill, (JSC::JSGlobalObject * globalObje
 
     JSC::JSValue signalValue = callFrame->argument(1);
     int signal = SIGTERM;
-    if (signalValue.isNumber()) {
-        signal = signalValue.toInt32(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-    } else if (signalValue.isString()) {
+
+    // this is mimicking `if (sig === (sig | 0))`, which preserves the null signal
+    // and rejects numbers that are not an exact int32
+    int32_t signalAsInt32 = signalValue.toInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    bool isExactInt32 = JSC::JSValue::strictEqual(globalObject, signalValue, jsNumber(signalAsInt32));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (isExactInt32) {
+        signal = signalAsInt32;
+    } else if (signalValue.toBoolean(globalObject)) {
+        // this is mimicking `sig ||= 'SIGTERM'` and then `constants[sig]`,
+        // so undefined, null, NaN, false and "" all stay SIGTERM
         loadSignalNumberMap();
-        if (auto num = signalNameToNumberMap->get(signalValue.toWTFString(globalObject))) {
-            signal = num;
-            RETURN_IF_EXCEPTION(scope, {});
-        } else {
+        auto signalName = signalValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto num = signalNameToNumberMap->get(signalName);
+        if (!num) {
             return Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, signalValue);
         }
-        RETURN_IF_EXCEPTION(scope, {});
-    } else if (!signalValue.isUndefinedOrNull()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "signal"_s, "string or number"_s, signalValue);
+        signal = num;
     }
 
     auto global = uncheckedDowncast<Zig::GlobalObject>(globalObject);

--- a/test/js/node/process/process-sleep.js
+++ b/test/js/node/process/process-sleep.js
@@ -1,3 +1,3 @@
 const args = process.argv.slice(2);
-const timeout = parseInt(args[0] || "0", 1);
+const timeout = parseInt(args[0] || "0", 10);
 Bun.sleepSync(timeout * 1000);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -740,6 +740,54 @@ describe.concurrent(() => {
       expect(() => process.kill(2147483640, "SIGPOOP")).toThrow();
       expect(() => process.kill(2147483640, 456)).toThrow();
     });
+
+    it.serial("process.kill(2) rejects signals that are not an exact int32", async () => {
+      await using child = Bun.spawn({
+        cmd: [bunExe(), process_sleep, "1000000"],
+        stdout: "pipe",
+        cwd: import.meta.dir,
+        env: bunEnv,
+        stderr: "inherit",
+      });
+
+      // node only forwards a signal to kill(2) when `sig === (sig | 0)`
+      for (const signal of [9.9, 2 ** 32 + 9, 2 ** 33, 2 ** 31, Infinity, -Infinity, true, {}]) {
+        expect(() => process.kill(child.pid, signal)).toThrow(
+          expect.objectContaining({ code: "ERR_UNKNOWN_SIGNAL", name: "TypeError" }),
+        );
+      }
+
+      // none of those were delivered, so the child is still running to receive this one
+      const prom = child.exited;
+      expect(process.kill(child.pid, "SIGTERM")).toBe(true);
+      await prom;
+      if (isWindows) {
+        expect(child.exitCode).toBe(1);
+      } else {
+        expect(child.signalCode).toBe("SIGTERM");
+      }
+    });
+
+    it("process.kill(2) coerces falsy signals to SIGTERM, like node", async () => {
+      // `process._kill` is monkey-patched, so nothing reaches the OS, and the pid
+      // is one that cannot exist so an unpatched `_kill` would throw instead of signalling
+      const { stdout } = await runInlineFixture(
+        `
+        const sent = [];
+        process._kill = (pid, signal) => (sent.push(signal), 0);
+        const returned = [undefined, null, NaN, false, "", 0, -0, 9, "SIGHUP"].map(signal =>
+          process.kill(2147483640, signal),
+        );
+        console.log(JSON.stringify({ sent, returned }));
+        `,
+      );
+
+      expect(JSON.parse(stdout)).toEqual({
+        // SIGTERM for every falsy signal, int32 signal numbers are passed through untouched
+        sent: [15, 15, 15, 15, 15, 0, 0, 9, 1],
+        returned: Array(9).fill(true),
+      });
+    });
   });
 
   const undefinedStubs = [


### PR DESCRIPTION
### What's wrong

`process.kill(pid, signal)` with a numeric signal did `signal = signalValue.toInt32(...)` and handed the result to `kill(2)` with no validation, so the value silently wrapped or truncated:

```js
import { spawn } from "node:child_process";

const child = spawn("sleep", ["30"], { stdio: "ignore" });
process.kill(child.pid, 9.9); // returns true, child dies with SIGKILL
```

| signal | node | bun before |
| --- | --- | --- |
| `9.9` | throws `ERR_UNKNOWN_SIGNAL` | sends SIGKILL |
| `2 ** 32 + 9` | throws `ERR_UNKNOWN_SIGNAL` | wraps mod 2^32, sends SIGKILL |
| `2 ** 33` | throws `ERR_UNKNOWN_SIGNAL` | truncates to signal 0, returns `true`, signals nothing |
| `NaN` | SIGTERM | truncates to signal 0, returns `true`, signals nothing |

A near-miss numeric signal (arithmetic bug, JSON round trip, user input) therefore either delivers a different signal than intended, up to and including SIGKILL, or is a silent no-op that reports success.

### Cause

`Process_functionKill` in `src/jsc/bindings/BunProcess.cpp` checked `pid != (pid | 0)` for the pid argument, but coerced the signal argument with a bare `toInt32` three lines later. Node requires the signal to round-trip: `sig === (sig | 0)`, and otherwise treats it as a signal name.

### Fix

Mirror node's coercion (`lib/internal/process/per_thread.js`):

- `sig === (sig | 0)` passes the signal straight through, which preserves the null signal and negative values.
- Anything else goes through `sig ||= 'SIGTERM'` and the signal-name lookup, so `undefined`, `null`, `NaN`, `false` and `""` mean SIGTERM, and everything that is not a known signal name throws `ERR_UNKNOWN_SIGNAL` before anything is sent.

This also brings the non-number cases in line with node: `{}`, `true` and `"9"` now throw `ERR_UNKNOWN_SIGNAL` instead of `ERR_INVALID_ARG_TYPE`, and an object with a `toString` returning a signal name is accepted.

### Verification

`test/js/node/process/process.test.js` gains two tests: one spawns a child, asserts each non-int32 signal throws `ERR_UNKNOWN_SIGNAL`, and then proves the child was never signalled by killing it with SIGTERM; the other monkey-patches `process._kill` (as node's own `test-process-kill-pid.js` does) and pins the exact signal number handed to `kill(2)` for the falsy and int32 cases.

Both fail on `main` and pass with the fix. `test/js/node/test/parallel/test-process-kill-pid.js` and `test-process-kill-null.js` still pass.

<details>
<summary>every value of `signal` this PR touches, bun vs node v26.3.0</summary>

```
                                 node v26.3.0                        bun (this PR)
9.9                            threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
2**32+9                        threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
2**33                          threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
2**31                          threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
Infinity                       threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
-Infinity                      threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
0                              signal 0                            signal 0
-0                             signal 0                            signal 0
9                              signal 9                            signal 9
-2**31                         signal -2147483648                  signal -2147483648
NaN                            signal 15                           signal 15
undefined                      signal 15                           signal 15
null                           signal 15                           signal 15
false                          signal 15                           signal 15
''                             signal 15                           signal 15
true                           threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
'SIGKILL'                      signal 9                            signal 9
'sigkill'                      threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
'9'                            threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
{}                             threw ERR_UNKNOWN_SIGNAL            threw ERR_UNKNOWN_SIGNAL
{toString(){return 'SIGKILL'}} signal 9                            signal 9
```

</details>
