### PR TITLE
Stop treating an empty Bun.CookieMap value as a deletion

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -180,19 +180,20 @@ void CookieMap::set(Ref<Cookie> cookie)
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 {
-    removeInternal(options.name);
-
     String name = options.name;
     String domain = options.domain;
     String path = options.path;
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
 
-    // Add the new cookie
+    // Build the removal cookie before touching the map: a rejected name, path or domain
+    // must leave the cookie in place rather than dropping it without a Set-Cookie header.
     auto cookie_exception = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
     if (cookie_exception.hasException()) {
         return cookie_exception.releaseException();
     }
     auto cookie = cookie_exception.releaseReturnValue();
+
+    removeInternal(options.name);
     m_modifiedCookies.append(ModifiedCookie { WTF::move(cookie), true });
     return {};
 }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -54,11 +54,6 @@ CookieMap::CookieMap()
 {
 }
 
-CookieMap::CookieMap(Vector<Ref<Cookie>>&& cookies)
-    : m_modifiedCookies(WTF::move(cookies))
-{
-}
-
 CookieMap::CookieMap(Vector<KeyValuePair<String, String>>&& cookies)
     : m_originalCookies(WTF::move(cookies))
 {
@@ -132,15 +127,14 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
 
 std::optional<String> CookieMap::get(const String& name) const
 {
-    auto modifiedCookieIndex = m_modifiedCookies.findIf([&](auto& cookie) {
-        return cookie->name() == name;
+    auto modifiedCookieIndex = m_modifiedCookies.findIf([&](auto& entry) {
+        return entry.cookie->name() == name;
     });
     if (modifiedCookieIndex != notFound) {
-        // a set cookie with an empty value is treated as not existing, because that is what delete() sets
-        if (m_modifiedCookies[modifiedCookieIndex]->value().isEmpty()) {
+        if (m_modifiedCookies[modifiedCookieIndex].isRemoval) {
             return std::nullopt;
         }
-        return std::optional<String>(m_modifiedCookies[modifiedCookieIndex]->value());
+        return std::optional<String>(m_modifiedCookies[modifiedCookieIndex].cookie->value());
     }
     auto originalCookieIndex = m_originalCookies.findIf([&](auto& cookie) {
         return cookie.key == name;
@@ -151,17 +145,14 @@ std::optional<String> CookieMap::get(const String& name) const
     return std::nullopt;
 }
 
-Vector<KeyValuePair<String, String>> CookieMap::getAll() const
+Vector<Ref<Cookie>> CookieMap::getAllChanges() const
 {
-    Vector<KeyValuePair<String, String>> all;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
-        all.append(KeyValuePair<String, String>(cookie->name(), cookie->value()));
+    Vector<Ref<Cookie>> changes;
+    changes.reserveInitialCapacity(m_modifiedCookies.size());
+    for (const auto& entry : m_modifiedCookies) {
+        changes.append(entry.cookie);
     }
-    for (const auto& cookie : m_originalCookies) {
-        all.append(KeyValuePair<String, String>(cookie.key, cookie.value));
-    }
-    return all;
+    return changes;
 }
 
 bool CookieMap::has(const String& name) const
@@ -175,8 +166,8 @@ void CookieMap::removeInternal(const String& name)
     m_originalCookies.removeAllMatching([&](auto& cookie) {
         return cookie.key == name;
     });
-    m_modifiedCookies.removeAllMatching([&](auto& cookie) {
-        return cookie->name() == name;
+    m_modifiedCookies.removeAllMatching([&](auto& entry) {
+        return entry.cookie->name() == name;
     });
 }
 
@@ -184,7 +175,7 @@ void CookieMap::set(Ref<Cookie> cookie)
 {
     removeInternal(cookie->name());
     // Add the new cookie
-    m_modifiedCookies.append(WTF::move(cookie));
+    m_modifiedCookies.append(ModifiedCookie { WTF::move(cookie), false });
 }
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
@@ -202,7 +193,7 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
         return cookie_exception.releaseException();
     }
     auto cookie = cookie_exception.releaseReturnValue();
-    m_modifiedCookies.append(WTF::move(cookie));
+    m_modifiedCookies.append(ModifiedCookie { WTF::move(cookie), true });
     return {};
 }
 
@@ -218,8 +209,8 @@ size_t
 CookieMap::size() const
 {
     size_t size = 0;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
+    for (const auto& entry : m_modifiedCookies) {
+        if (entry.isRemoval) continue;
         size += 1;
     }
     size += m_originalCookies.size();
@@ -238,10 +229,10 @@ JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
     HashSet<String> seenKeys;
 
     // Add modified cookies to the object
-    for (const auto& cookie : m_modifiedCookies) {
-        if (!cookie->value().isEmpty()) {
-            seenKeys.add(cookie->name());
-            object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie->name()), JSC::jsString(vm, cookie->value()));
+    for (const auto& entry : m_modifiedCookies) {
+        if (!entry.isRemoval) {
+            seenKeys.add(entry.cookie->name());
+            object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, entry.cookie->name()), JSC::jsString(vm, entry.cookie->value()));
             RETURN_IF_EXCEPTION(scope, {});
         }
     }
@@ -265,9 +256,9 @@ size_t CookieMap::memoryCost() const
         cost += cookie.key.sizeInBytes();
         cost += cookie.value.sizeInBytes();
     }
-    for (auto& cookie : m_modifiedCookies) {
-        cost += cookie->name().sizeInBytes();
-        cost += cookie->value().sizeInBytes();
+    for (auto& entry : m_modifiedCookies) {
+        cost += entry.cookie->name().sizeInBytes();
+        cost += entry.cookie->value().sizeInBytes();
     }
     return cost;
 }
@@ -279,12 +270,12 @@ std::optional<KeyValuePair<String, String>> CookieMap::Iterator::next()
             return m_target->m_originalCookies[(m_index++) - m_target->m_modifiedCookies.size()];
         }
 
-        auto result = m_target->m_modifiedCookies[m_index++];
-        if (result->value().isEmpty()) {
-            continue; // deleted; skip
+        const auto& entry = m_target->m_modifiedCookies[m_index++];
+        if (entry.isRemoval) {
+            continue;
         }
 
-        return KeyValuePair<String, String>(result->name(), result->value());
+        return KeyValuePair<String, String>(entry.cookie->name(), entry.cookie->value());
     }
     return std::nullopt;
 }

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -31,8 +31,7 @@ public:
     static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& init, bool throwOnInvalidCookieString = true);
 
     std::optional<String> get(const String& name) const;
-    Vector<KeyValuePair<String, String>> getAll() const;
-    Vector<Ref<Cookie>> getAllChanges() const { return m_modifiedCookies; }
+    Vector<Ref<Cookie>> getAllChanges() const;
 
     bool has(const String& name) const;
 
@@ -62,13 +61,20 @@ public:
 
 private:
     CookieMap();
-    CookieMap(Vector<Ref<Cookie>>&& cookies);
     CookieMap(Vector<KeyValuePair<String, String>>&& cookies);
+
+    // A removal is the expired cookie remove() synthesizes: it is written to Set-Cookie
+    // but is absent from the map. An empty value cannot mark one, because set(name, "")
+    // stores a real cookie whose value happens to be empty.
+    struct ModifiedCookie {
+        Ref<Cookie> cookie;
+        bool isRemoval { false };
+    };
 
     void removeInternal(const String& name);
 
     Vector<KeyValuePair<String, String>> m_originalCookies;
-    Vector<Ref<Cookie>> m_modifiedCookies;
+    Vector<ModifiedCookie> m_modifiedCookies;
 };
 
 } // namespace WebCore

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -432,7 +432,7 @@ describe("delete with prefixed cookie names", () => {
     const map = new Bun.CookieMap("__Host-id=1");
     map.delete("__Host-id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Host-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
+      "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
     ]);
   });
 
@@ -440,7 +440,7 @@ describe("delete with prefixed cookie names", () => {
     const map = new Bun.CookieMap("__Secure-id=1");
     map.delete("__Secure-id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Secure-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
+      "__Secure-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
     ]);
   });
 
@@ -449,9 +449,88 @@ describe("delete with prefixed cookie names", () => {
     map.delete("__Host-id");
     map.delete("id");
     expect(map.toSetCookieHeaders()).toEqual([
-      "__Host-id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; Secure; SameSite=Lax",
-      "id=; Path=/; Expires=Fri, 1 Jan 1970 00:00:00 -0000; SameSite=Lax",
+      "__Host-id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Lax",
+      "id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
     ]);
+  });
+});
+
+describe("cookies with an empty value", () => {
+  test("set() with an empty value stores a cookie the map can see", () => {
+    const map = new Bun.CookieMap();
+    map.set("k", "");
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size, entries: [...map] }).toEqual({
+      has: true,
+      get: "",
+      size: 1,
+      entries: [["k", ""]],
+    });
+    expect(map.toJSON()).toEqual({ k: "" });
+    expect(map.toSetCookieHeaders()).toEqual(["k=; Path=/; SameSite=Lax"]);
+  });
+
+  test("an empty value set from a Cookie object is visible", () => {
+    const map = new Bun.CookieMap();
+    map.set(new Bun.Cookie("k", ""));
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size }).toEqual({ has: true, get: "", size: 1 });
+  });
+
+  test("an empty value set from an init object is visible", () => {
+    const map = new Bun.CookieMap();
+    map.set({ name: "k", value: "" });
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size }).toEqual({ has: true, get: "", size: 1 });
+  });
+
+  test("set() with an empty value matches the same cookie parsed from the Cookie header", () => {
+    const fromWire = new Bun.CookieMap("k=");
+    const fromSet = new Bun.CookieMap();
+    fromSet.set("k", "");
+    expect({ has: fromSet.has("k"), get: fromSet.get("k"), size: fromSet.size, entries: [...fromSet] }).toEqual({
+      has: fromWire.has("k"),
+      get: fromWire.get("k"),
+      size: fromWire.size,
+      entries: [...fromWire],
+    });
+  });
+
+  test("delete() still hides the cookie and emits an expiring header", () => {
+    const map = new Bun.CookieMap("k=v");
+    map.delete("k");
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size, entries: [...map] }).toEqual({
+      has: false,
+      get: null,
+      size: 0,
+      entries: [],
+    });
+    expect(map.toJSON()).toEqual({});
+    expect(map.toSetCookieHeaders()).toEqual(["k=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+  });
+
+  test("set() with an empty value after delete() brings the cookie back", () => {
+    const map = new Bun.CookieMap("k=v");
+    map.delete("k");
+    map.set("k", "");
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size }).toEqual({ has: true, get: "", size: 1 });
+    expect(map.toSetCookieHeaders()).toEqual(["k=; Path=/; SameSite=Lax"]);
+  });
+
+  test("delete() after set() with an empty value removes the cookie", () => {
+    const map = new Bun.CookieMap();
+    map.set("k", "");
+    map.delete("k");
+    expect({ has: map.has("k"), get: map.get("k"), size: map.size }).toEqual({ has: false, get: null, size: 0 });
+    expect(map.toSetCookieHeaders()).toEqual(["k=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"]);
+  });
+
+  test("a deleted cookie is skipped while an empty-valued one is kept during iteration", () => {
+    const map = new Bun.CookieMap("keep=1; drop=2");
+    map.set("empty", "");
+    map.delete("drop");
+    expect([...map]).toEqual([
+      ["empty", ""],
+      ["keep", "1"],
+    ]);
+    expect(map.size).toBe(2);
   });
 });
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -414,6 +414,22 @@ test("delete cookie invalid path option", () => {
     `"Invalid cookie name: contains invalid characters"`,
   );
 });
+test("a delete that throws leaves the cookie in the map", () => {
+  const map = new Bun.CookieMap("a=1; b=2");
+  expect(() => map.delete("a", { path: "\n" })).toThrow("Invalid cookie path: contains invalid characters");
+  expect(() => map.delete("a", { domain: "\n" })).toThrow("Invalid cookie domain: contains invalid characters");
+  // Dropping "a" without emitting an expiring Set-Cookie would desync the map from the client.
+  expect({ has: map.has("a"), get: map.get("a"), size: map.size, entries: [...map] }).toEqual({
+    has: true,
+    get: "1",
+    size: 2,
+    entries: [
+      ["a", "1"],
+      ["b", "2"],
+    ],
+  });
+  expect(map.toSetCookieHeaders()).toEqual([]);
+});
 
 describe("Bun.CookieMap constructor", () => {
   test("throws for invalid array", () => {

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -209,6 +209,25 @@ describe("Bun.serve() cookies", () => {
       ]
     `);
   });
+  test("set cookie to an empty value", async () => {
+    const res = await fetch(server.url + "/tester", {
+      method: "POST",
+      body: JSON.stringify([["test", ""]]),
+    });
+    expect(res.status).toBe(200);
+    // The handler's view of the cookie must match the Set-Cookie header the client receives.
+    const body = await res.json();
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "test": "",
+      }
+    `);
+    expect(res.headers.getAll("Set-Cookie")).toMatchInlineSnapshot(`
+      [
+        "test=; Path=/; SameSite=Lax",
+      ]
+    `);
+  });
   test("request with cookies", async () => {
     const res = await fetch(server.url + "/tester", {
       method: "POST",


### PR DESCRIPTION
## Repro

```js
const m = new Bun.CookieMap();
m.set("k", "");
console.log({ has: m.has("k"), get: m.get("k"), size: m.size, entries: [...m], headers: m.toSetCookieHeaders() });
// { has: false, get: null, size: 0, entries: [], headers: [ "k=; Path=/; SameSite=Lax" ] }

const w = new Bun.CookieMap("k=");
console.log({ has: w.has("k"), get: w.get("k"), size: w.size });
// { has: true, get: "", size: 1 }
```

The map reports the cookie as absent, but `toSetCookieHeaders()` (and the automatic Set-Cookie write for a mutated `request.cookies` in `Bun.serve`) still emits a live, non-expiring `k=; Path=/; SameSite=Lax`. That header is not a deletion, so the browser stores an empty-valued cookie that the map that produced it claims does not exist, and it comes back on the next request. The same cookie parsed off the wire (`new Bun.CookieMap("k=")`) is visible, so the two paths disagree about the same state.

## Cause

`CookieMap::get`/`size`/`toJSON`/`Iterator::next` treated an empty value on a modified cookie as a sentinel meaning "this entry is the removal `delete()` appended":

```cpp
// a set cookie with an empty value is treated as not existing, because that is what delete() sets
if (m_modifiedCookies[modifiedCookieIndex]->value().isEmpty())
    return std::nullopt;
```

`set()` happily creates such an entry, and the Set-Cookie writer (`getAllChanges()`) never checked the sentinel, so an empty-valued `set()` was hidden from every reader while still being written out as a normal cookie. An empty cookie-value is valid and storable per RFC 6265, and `delete()` already distinguishes itself by adding `Expires=<epoch>`.

## Fix

Record removals explicitly instead of inferring them from the value. `m_modifiedCookies` now holds `{ Ref<Cookie> cookie; bool isRemoval; }`; `remove()` sets the flag and every reader skips flagged entries. An empty value is a real cookie again: visible to `get`/`has`/`size`/iteration/`toJSON`, and emitted as-is.

Nothing else changes: `delete()` still hides the cookie and still emits `Expires=Thu, 01 Jan 1970 00:00:00 GMT`, and `toSetCookieHeaders()` output (including ordering) is unchanged for every other case. An empty-valued `set()` now shows up in iteration ahead of the cookies parsed from the request, which is where a `set()` with a non-empty value already appeared.

Two deletions come along, both zero-caller code the change would otherwise have had to carry forward: `CookieMap::getAll()` (never reached JS, and its signature is not the CookieStore `getAll(name)` shape) and the unused `CookieMap(Vector<Ref<Cookie>>&&)` constructor.

A second commit makes `remove()` atomic, which is the same disagreement from the other direction ([review thread](https://github.com/oven-sh/bun/pull/33431#discussion_r3528045631)). It called `removeInternal(name)` before `Cookie::create` validated the name, path and domain, so a rejected path dropped the cookie from the map *and* skipped the expiring `Set-Cookie`:

```js
const map = new Bun.CookieMap("a=1; b=2");
map.delete("a", { path: "\n" }); // throws: Invalid cookie path: contains invalid characters
map.has("a"); // false — "a" is gone, but the client was never told
map.toSetCookieHeaders(); // []
```

It now builds the removal cookie first and only touches the map once `Cookie::create` has accepted every field. Success-path behavior and header ordering are unchanged.

This also updates three assertions in `cookie-map.test.ts` that still expected the pre-#32926 `Expires=Fri, 1 Jan 1970 00:00:00 -0000` spelling; they are failing on `main` today, and the file has to be green for the new tests to mean anything.

## Verification

`test/js/bun/cookie/cookie-map.test.ts` gains a `cookies with an empty value` block covering `set(name, "")` through all three overloads, equality with the same cookie parsed from a `Cookie` header, `delete()` still hiding its entry, `set()`-after-`delete()` and `delete()`-after-`set()`, and iteration keeping the empty-valued entry while skipping the removed one. `test/js/bun/cookie/cookie.test.ts` adds a `Bun.serve` case asserting the handler's view of `request.cookies` matches the `Set-Cookie` header the client receives.

`cookie.test.ts` also gains `a delete that throws leaves the cookie in the map`, asserting the map is untouched after both the invalid-path and invalid-domain throws.

All 9 new tests fail before the change and pass after it. `test/js/bun/cookie/` (171 tests), `bun-serve-cookies.test.ts`, `test/js/bun/util/cookie.test.js`, `test/js/web/fetch/cookies.test.ts`, `test/bake/dev/request-cookies.test.ts` and the `18547`/`23474` cookie regressions are green.
