### PR TITLE
node:fs: skip symlink cycles in recursive readdir instead of failing with ELOOP

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6612,11 +6612,10 @@ impl NodeFS {
             Err(err) => {
                 if !is_root {
                     match err.get_errno() {
-                        // These things can happen and there's nothing we can do about it.
-                        //
-                        // This is different than what Node does, at the time of writing.
-                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
-                        E::ENOENT | E::ENOTDIR | E::EPERM => return Ok(()),
+                        // The entry can't be descended into: dangling symlink, not a
+                        // directory, unreadable, or a symlink loop. Node's recursive
+                        // walkers skip these instead of failing the whole operation.
+                        E::ENOENT | E::ENOTDIR | E::EPERM | E::ELOOP => return Ok(()),
                         _ => {}
                     }
                     if root_basename.len() + 1 + basename.as_bytes().len() + 1
@@ -6818,11 +6817,10 @@ impl NodeFS {
                         return Err(err.with_path(args.path.slice()));
                     }
                     match err.get_errno() {
-                        // These things can happen and there's nothing we can do about it.
-                        //
-                        // This is different than what Node does, at the time of writing.
-                        // Node doesn't gracefully handle errors like these. It fails the entire operation.
-                        E::ENOENT | E::ENOTDIR | E::EPERM => continue,
+                        // The entry can't be descended into: dangling symlink, not a
+                        // directory, unreadable, or a symlink loop. Node's recursive
+                        // walkers skip these instead of failing the whole operation.
+                        E::ENOENT | E::ENOTDIR | E::EPERM | E::ELOOP => continue,
                         _ => {
                             // TODO: propagate file path (removed previously because it leaked the path)
                             return Err(err);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6613,8 +6613,8 @@ impl NodeFS {
                 if !is_root {
                     match err.get_errno() {
                         // The entry can't be descended into: dangling symlink, not a
-                        // directory, unreadable, or a symlink loop. Node's recursive
-                        // walkers skip these instead of failing the whole operation.
+                        // directory, not permitted, or a symlink loop. EACCES is absent on
+                        // purpose: like Node, an unreadable directory fails the whole walk.
                         E::ENOENT | E::ENOTDIR | E::EPERM | E::ELOOP => return Ok(()),
                         _ => {}
                     }
@@ -6818,8 +6818,8 @@ impl NodeFS {
                     }
                     match err.get_errno() {
                         // The entry can't be descended into: dangling symlink, not a
-                        // directory, unreadable, or a symlink loop. Node's recursive
-                        // walkers skip these instead of failing the whole operation.
+                        // directory, not permitted, or a symlink loop. EACCES is absent on
+                        // purpose: like Node, an unreadable directory fails the whole walk.
                         E::ENOENT | E::ENOTDIR | E::EPERM | E::ELOOP => continue,
                         _ => {
                             // TODO: propagate file path (removed previously because it leaked the path)

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1412,12 +1412,26 @@ it("readdir with { encoding: 'buffer' } returns Buffer entries", async () => {
   ).toEqual(expected);
 });
 
+// The recursive walker skips an entry it cannot open with ENOENT/ENOTDIR/EPERM/ELOOP,
+// so the only errno left to make a subdirectory fail is EACCES. Root bypasses the
+// permission check, so the child drops to an unprivileged uid first.
+const UNPRIVILEGED_UID = 65534;
+const dropPrivileges = `if (process.getuid() === 0) process.setuid(${UNPRIVILEGED_UID});`;
+function makeUnreadableDir(parent: string, name: string) {
+  const dir = join(parent, name);
+  fs.mkdirSync(dir);
+  fs.writeFileSync(join(dir, "hidden.txt"), "hidden");
+  fs.chmodSync(dir, 0o000);
+  // Every ancestor must stay traversable by the unprivileged child.
+  fs.chmodSync(parent, 0o755);
+  return () => fs.chmodSync(dir, 0o755);
+}
+
 // The error cleanup path previously called MarkedArrayBuffer.destroy() on
 // structs stored by-value inside the entries ArrayList, which passed interior
 // ArrayList pointers to the allocator (freeing entries.items.ptr for index 0 and
-// then freeing it again in entries.deinit()). A self-referential symlink makes
-// the recursive walk fail with ELOOP after entries have been collected, exercising
-// that cleanup path.
+// then freeing it again in entries.deinit()). An unreadable subdirectory makes the
+// recursive walk fail after entries have been collected, exercising that cleanup path.
 it.skipIf(isWindows)(
   "readdirSync({encoding: 'buffer', recursive: true}) frees entries safely when a subdir fails to open",
   async () => {
@@ -1426,34 +1440,41 @@ it.skipIf(isWindows)(
       "b.txt": "b",
       "c.txt": "c",
     });
-    fs.symlinkSync("loop", join(String(dir), "loop"));
+    const restore = makeUnreadableDir(String(dir), "unreadable");
 
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const fs = require("fs");
-          let code;
-          for (let i = 0; i < 2; i++) {
-            try {
-              fs.readdirSync(${JSON.stringify(String(dir))}, { encoding: "buffer", recursive: true });
-              throw new Error("expected readdirSync to throw");
-            } catch (e) {
-              code = e.code;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const fs = require("fs");
+            ${dropPrivileges}
+            // Proves the root itself is readable, so the failure below comes from the subdir.
+            console.log(fs.readdirSync(${JSON.stringify(String(dir))}).length);
+            let code;
+            for (let i = 0; i < 2; i++) {
+              try {
+                fs.readdirSync(${JSON.stringify(String(dir))}, { encoding: "buffer", recursive: true });
+                throw new Error("expected readdirSync to throw");
+              } catch (e) {
+                code = e.code;
+              }
             }
-          }
-          console.log(code);
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-    });
+            console.log(code);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ELOOP", exitCode: 0 });
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "4\nEACCES", exitCode: 0 });
+    } finally {
+      restore();
+    }
   },
 );
 
@@ -1464,39 +1485,88 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
   using dir = tempDir("readdir-recursive-multi-error", {
     "keep.txt": "x",
   });
-  // Self-referencing symlinks: opening one with O_DIRECTORY fails with
-  // ELOOP, which is not swallowed by the recursive walker, so every
-  // enqueued subtask hits the pending_err path.
-  for (let i = 0; i < 64; i++) {
-    const link = join(String(dir), `loop${i}`);
-    fs.symlinkSync(link, link);
-  }
+  // Every unreadable subdirectory fails its openat, so every enqueued subtask
+  // hits the pending_err path.
+  const restores = Array.from({ length: 64 }, (_, i) => makeUnreadableDir(String(dir), `unreadable${i}`));
 
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
           const fs = require("fs");
+          ${dropPrivileges}
+          console.log(fs.readdirSync(${JSON.stringify(String(dir))}).length);
           fs.promises.readdir(${JSON.stringify(String(dir))}, { recursive: true }).then(
             r => console.log("resolved", r.length),
             e => console.log("rejected", e.code),
           );
         `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-    timeout: 10_000,
-  });
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      timeout: 10_000,
+    });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-    stdout: "rejected ELOOP",
-    exitCode: 0,
-    signalCode: null,
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "65\nrejected EACCES",
+      exitCode: 0,
+      signalCode: null,
+    });
+  } finally {
+    for (const restore of restores) restore();
+  }
+});
+
+// A symlink cycle anywhere in the tree aborted every recursive listing with ELOOP,
+// even though a dangling symlink (ENOENT) at the same point was already skipped.
+// Node's recursive walkers ignore per-entry stat failures and list the whole tree.
+it.skipIf(isWindows)("recursive readdir skips symlink cycles instead of failing with ELOOP", async () => {
+  using dir = tempDir("readdir-symlink-cycle", {
+    "d1/f": "x",
+    "real/inside.txt": "i",
   });
+  const root = String(dir);
+  mkdirSync(join(root, "d1", "d2"));
+  symlinkSync("missing", join(root, "dangling")); // broken: open fails with ENOENT
+  symlinkSync("lpB", join(root, "lpA")); // two-link cycle: open fails with ELOOP
+  symlinkSync("lpA", join(root, "lpB"));
+  symlinkSync("self", join(root, "self")); // self-referential cycle
+  symlinkSync("real", join(root, "link")); // resolvable: still walked into
+
+  // The cycle must really be a cycle, otherwise everything below passes vacuously.
+  expect(() => readdirSync(join(root, "lpA"))).toThrow(expect.objectContaining({ code: "ELOOP" }));
+
+  const paths = [
+    "d1",
+    "d1/d2",
+    "d1/f",
+    "dangling",
+    "link",
+    "link/inside.txt",
+    "lpA",
+    "lpB",
+    "real",
+    "real/inside.txt",
+    "self",
+  ];
+  const names = ["d1", "d2", "dangling", "f", "inside.txt", "inside.txt", "link", "lpA", "lpB", "real", "self"];
+  const sorted = (entries: (string | Dirent)[]) =>
+    entries.map(entry => (typeof entry === "string" ? entry : entry.name)).sort();
+
+  expect(sorted(readdirSync(root, { recursive: true }))).toEqual(paths);
+  expect(sorted(readdirSync(root, { recursive: true, withFileTypes: true }))).toEqual(names);
+  expect(sorted(await promises.readdir(root, { recursive: true }))).toEqual(paths);
+  expect(sorted(await promises.readdir(root, { recursive: true, withFileTypes: true }))).toEqual(names);
+
+  const drained: string[] = [];
+  using handle = fs.opendirSync(root, { recursive: true });
+  for (let entry: Dirent | null; (entry = handle.readSync()); ) drained.push(entry.name);
+  expect(drained.sort()).toEqual(names);
 });
 
 describe("readSync", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1526,35 +1526,20 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
 // even though a dangling symlink (ENOENT) at the same point was already skipped.
 // Node's recursive walkers ignore per-entry stat failures and list the whole tree.
 it.skipIf(isWindows)("recursive readdir skips symlink cycles instead of failing with ELOOP", async () => {
-  using dir = tempDir("readdir-symlink-cycle", {
-    "d1/f": "x",
-    "real/inside.txt": "i",
-  });
+  using dir = tempDir("readdir-symlink-cycle", { "d1/f": "x" });
   const root = String(dir);
   mkdirSync(join(root, "d1", "d2"));
   symlinkSync("missing", join(root, "dangling")); // broken: open fails with ENOENT
   symlinkSync("lpB", join(root, "lpA")); // two-link cycle: open fails with ELOOP
   symlinkSync("lpA", join(root, "lpB"));
   symlinkSync("self", join(root, "self")); // self-referential cycle
-  symlinkSync("real", join(root, "link")); // resolvable: still walked into
 
   // The cycle must really be a cycle, otherwise everything below passes vacuously.
   expect(() => readdirSync(join(root, "lpA"))).toThrow(expect.objectContaining({ code: "ELOOP" }));
 
-  const paths = [
-    "d1",
-    "d1/d2",
-    "d1/f",
-    "dangling",
-    "link",
-    "link/inside.txt",
-    "lpA",
-    "lpB",
-    "real",
-    "real/inside.txt",
-    "self",
-  ];
-  const names = ["d1", "d2", "dangling", "f", "inside.txt", "inside.txt", "link", "lpA", "lpB", "real", "self"];
+  // Every listing below matches node v26.3.0 on this tree, entry for entry.
+  const paths = ["d1", "d1/d2", "d1/f", "dangling", "lpA", "lpB", "self"];
+  const names = ["d1", "d2", "dangling", "f", "lpA", "lpB", "self"];
   const sorted = (entries: (string | Dirent)[]) =>
     entries.map(entry => (typeof entry === "string" ? entry : entry.name)).sort();
 
@@ -1563,10 +1548,29 @@ it.skipIf(isWindows)("recursive readdir skips symlink cycles instead of failing 
   expect(sorted(await promises.readdir(root, { recursive: true }))).toEqual(paths);
   expect(sorted(await promises.readdir(root, { recursive: true, withFileTypes: true }))).toEqual(names);
 
-  const drained: string[] = [];
-  using handle = fs.opendirSync(root, { recursive: true });
-  for (let entry: Dirent | null; (entry = handle.readSync()); ) drained.push(entry.name);
-  expect(drained.sort()).toEqual(names);
+  const drainedSync: string[] = [];
+  {
+    using handle = fs.opendirSync(root, { recursive: true });
+    for (let entry: Dirent | null; (entry = handle.readSync()); ) drainedSync.push(entry.name);
+  }
+  expect(drainedSync.sort()).toEqual(names);
+
+  const drainedAsync: string[] = [];
+  {
+    await using handle = await promises.opendir(root, { recursive: true });
+    for await (const entry of handle) drainedAsync.push(entry.name);
+  }
+  expect(drainedAsync.sort()).toEqual(names);
+});
+
+// Skipping entries the walker cannot open must not skip the ones it can: a symlink
+// to a real directory is still descended into.
+it.skipIf(isWindows)("recursive readdir still descends into a symlink to a real directory", () => {
+  using dir = tempDir("readdir-symlink-descend", { "real/inside.txt": "i" });
+  const root = String(dir);
+  symlinkSync("real", join(root, "link"));
+
+  expect(readdirSync(root, { recursive: true }).sort()).toEqual(["link", "link/inside.txt", "real", "real/inside.txt"]);
 });
 
 describe("readSync", () => {

--- a/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
+++ b/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
@@ -3,16 +3,20 @@
 // be fully released. Each Dirent owns a ref to both .name and .path; previously
 // only .name was dereferenced on the sync error path, leaking the .path string.
 //
-// This fixture builds a wide, shallow tree under a long path, with a
-// self-referential symlink two levels deep. The recursive walker is
-// breadth-first, so every depth-1 directory is fully scanned (allocating
-// distinct Dirent.path strings) before the depth-2 symlink is opened and fails
-// with ELOOP. It repeats the failing readdirSync many times and asserts RSS
-// growth between a warmed-up baseline and the end of the run stays bounded.
+// This fixture builds a wide, shallow tree under a long path, with an unreadable
+// directory two levels deep. The recursive walker is breadth-first, so every
+// depth-1 directory is fully scanned (allocating distinct Dirent.path strings)
+// before the depth-2 directory is opened and fails with EACCES. It repeats the
+// failing readdirSync many times and asserts RSS growth between a warmed-up
+// baseline and the end of the run stays bounded.
 
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+
+// Root bypasses the permission check that makes the depth-2 directory fail to
+// open. Drop first so the whole tree below is owned by the unprivileged uid.
+if (process.getuid() === 0) process.setuid(65534);
 
 const seg = (ch, n = 220) => Buffer.alloc(n, ch).toString();
 
@@ -32,20 +36,21 @@ for (let i = 0; i < 8; i++) {
   subdirs.push(d);
 }
 
-// Self-referential symlink at depth 2. Opened last (BFS), yields ELOOP, which
-// is not in the silently-skipped set (NOENT/NOTDIR/PERM) and so propagates as
-// an error after all the Dirents above have been collected.
-const loop = path.join(subdirs[0], "zzloop");
-fs.symlinkSync("zzloop", loop);
+// Unreadable directory at depth 2. Opened last (BFS), yields EACCES, which is not
+// in the silently-skipped set (NOENT/NOTDIR/PERM/LOOP) and so propagates as an
+// error after all the Dirents above have been collected.
+const blocked = path.join(subdirs[0], "zzblocked");
+fs.mkdirSync(blocked);
+fs.chmodSync(blocked, 0o000);
 
-// Sanity: confirm the error path actually fires.
-let threw = false;
+// Sanity: confirm the error path actually fires, for the reason we think it does.
+let code;
 try {
   fs.readdirSync(root, { recursive: true, withFileTypes: true });
-} catch {
-  threw = true;
+} catch (e) {
+  code = e.code;
 }
-if (!threw) throw new Error("expected readdirSync to throw (symlink loop not triggering error path)");
+if (code !== "EACCES") throw new Error("expected readdirSync to throw EACCES, got " + code);
 
 // Warmup: saturate allocator working set / ASAN quarantine so the baseline
 // measurement is taken after steady state is reached.
@@ -69,6 +74,7 @@ const deltaMB = Math.round((after - before) / 1024 / 1024);
 console.log("RSS delta", deltaMB, "MB");
 
 try {
+  fs.chmodSync(blocked, 0o755);
   fs.rmSync(base, { recursive: true, force: true });
 } catch {}
 

--- a/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
+++ b/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
 
-// Windows: self-referential symlinks behave differently and the recursive
-// walker takes a different open path there; this leak is posix-specific.
+// Windows: directory permissions and the recursive walker's open path both differ
+// there, so the EACCES the fixture relies on is posix-specific.
 test.skipIf(isWindows)(
   "readdirSync({recursive:true, withFileTypes:true}) error path does not leak Dirent.path",
   async () => {


### PR DESCRIPTION
Every recursive `node:fs` listing API throws `ELOOP` and returns nothing if the tree contains a symlink cycle anywhere: `readdirSync(root, { recursive: true })` (paths and `withFileTypes`), `fs.promises.readdir({ recursive: true })`, and recursive `opendirSync()`. A single `ln -s . x` or a broken package link in `node_modules` is enough to break the whole listing.

## Repro

```js
import fs from "node:fs";
import os from "node:os";

const root = fs.mkdtempSync(os.tmpdir() + "/rd-");
fs.mkdirSync(`${root}/d1/d2`, { recursive: true });
fs.writeFileSync(`${root}/d1/f`, "x");
fs.symlinkSync("missing", `${root}/dangling`); // ENOENT: tolerated by both
fs.symlinkSync("lpB", `${root}/lpA`);          // ELOOP: only bun aborts
fs.symlinkSync("lpA", `${root}/lpB`);

console.log(fs.readdirSync(root, { recursive: true }).length);
```

```
node v26.3.0: 6
bun 1.4.0   : ELOOP: too many symbolic links encountered, scandir '/tmp/rd-XXXXXX'
```

## Cause

The recursive walker opens every symlink and directory entry with `openat(O_DIRECTORY | O_RDONLY)` and treats that open as the "is this a traversable directory" probe. Its tolerated-errno filter only listed `ENOENT | ENOTDIR | EPERM`, so a dangling symlink (`ENOENT`) and a symlink to a file (`ENOTDIR`) were skipped, but a symlink cycle (`ELOOP`) propagated as the error for the entire call. Node's recursive walkers ignore per-entry stat failures and return the complete listing.

## Fix

Add `ELOOP` to the skipped set in both copies of the walker, `readdir_with_entries_recursive_async` and `readdir_with_entries_recursive_sync` in `src/runtime/node/node_fs.rs`. A real directory can never produce `ELOOP`, so this only affects unresolvable symlink entries. `fs.promises.readdir` and recursive `fs.opendir` both route through `readdir`, so all five variants are covered by the one change. `EACCES` still propagates, matching Node (which throws when it tries to read a directory it lacks permission for).

All five variants now return the same entries as Node, in the same count, and a symlink to a real directory is still walked into.

## Tests

`test/js/node/fs/fs.test.ts` gains `recursive readdir skips symlink cycles instead of failing with ELOOP`. The fixture has a two-link cycle, a self-referential symlink and a dangling symlink, and the test asserts the full listing for all six recursive entry points: `readdirSync` (paths and dirents), `promises.readdir` (paths and dirents), `opendirSync` and `promises.opendir`. Every listing matches node v26.3.0 entry for entry. A non-vacuous guard first asserts the fixture's cycle really does open with `ELOOP`.

A second test, `recursive readdir still descends into a symlink to a real directory`, is the negative contract: widening the skipped-errno set must not skip entries the walker can open.

Three existing tests used a self-referential symlink purely as a way to make a subdirectory open fail, which is exactly what this change stops doing. They now use an unreadable directory (`EACCES`), dropping to an unprivileged uid first since root bypasses the permission check, and keep asserting the invariants they were written for:

- `readdirSync({encoding: 'buffer', recursive: true}) frees entries safely when a subdir fails to open`
- `promises.readdir({recursive: true}) settles when multiple subtasks fail`
- `readdirSync-recursive-error-leak-fixture.js` (Dirent.path leak on the sync error path)

<details>
<summary>Verification</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "skips symlink cycles"
(fail) recursive readdir skips symlink cycles instead of failing with ELOOP
ELOOP: too many symbolic links encountered, scandir '/tmp/readdir-symlink-cycle_QseqFu'

$ bun bd test test/js/node/fs/fs.test.ts
 381 pass, 6 skip, 0 fail

$ bun bd test test/js/node/fs/readdirSync-recursive-error-leak.test.ts
 1 pass, 0 fail

$ bun bd test test/js/node/fs/dir.test.ts test/js/node/fs/glob.test.ts
 50 pass, 0 fail
```

`cargo check -p bun_runtime` is clean for `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.

</details>

