### PR TITLE
Bun.FileSystemRouter: expose the assetPrefix getter on the prototype

### DIFF
--- a/src/runtime/api/filesystem_router.classes.ts
+++ b/src/runtime/api/filesystem_router.classes.ts
@@ -28,6 +28,10 @@ export default [
         getter: "getStyle",
         cache: true,
       },
+      assetPrefix: {
+        getter: "getAssetPrefix",
+        cache: true,
+      },
     },
     klass: {},
   }),

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -698,11 +698,14 @@ impl FileSystemRouter {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_asset_prefix(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        if let Some(ref asset_prefix) = this.asset_prefix {
-            return Ok(zs_to_js(asset_prefix.leak(), global_this));
-        }
+        // An omitted `assetPrefix` and `assetPrefix: ""` both store no prefix, so report
+        // the empty string the router actually applies rather than null.
+        let prefix = match this.asset_prefix {
+            Some(ref asset_prefix) => asset_prefix.leak(),
+            None => b"",
+        };
 
-        Ok(JSValue::NULL)
+        Ok(zs_to_js(prefix, global_this))
     }
 
     // Codegen's `host_fn_finalize` calls this via `|b| FileSystemRouter::finalize(b)`

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -314,6 +314,40 @@ it("assetPrefix, src, and origin", async () => {
   }
 });
 
+it("assetPrefix is readable from the router", () => {
+  const { dir } = make(["index.tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+    assetPrefix: "/_next/static/",
+    origin: "https://nextjs.org",
+  });
+
+  const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(router), "assetPrefix");
+  expect(typeof descriptor?.get).toBe("function");
+  expect(descriptor?.set).toBeUndefined();
+  expect(Object.hasOwn(router, "assetPrefix")).toBe(false);
+
+  expect(router.assetPrefix).toBe("/_next/static/");
+
+  // the prefix the router reports is the one it applies to `src`
+  expect(router.match("/")!.src).toBe(`${router.origin}${router.assetPrefix}index.tsx`);
+
+  router.reload();
+  expect(router.assetPrefix).toBe("/_next/static/");
+});
+
+it("assetPrefix is an empty string when unset", () => {
+  const { dir } = make(["index.tsx"]);
+
+  for (const assetPrefix of [undefined, ""]) {
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs", assetPrefix });
+    expect(router.assetPrefix).toBe("");
+    expect(router.match("/")!.src).toBe("index.tsx");
+  }
+});
+
 it(".query works", () => {
   // set up the test
   const { dir } = make(["posts.tsx"]);


### PR DESCRIPTION
`Bun.FileSystemRouter.prototype.assetPrefix` does not exist at runtime. The constructor accepts `assetPrefix`, `bun-types` declares `readonly assetPrefix: string`, and the prefix is demonstrably applied to `match(...).src`, but reading it back off the router returns `undefined`.

## Repro

```js
import { mkdtempSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";

const dir = mkdtempSync(tmpdir() + "/fsr-prefix-");
writeFileSync(`${dir}/index.tsx`, "export default 1;\n");

const router = new Bun.FileSystemRouter({
  style: "nextjs",
  dir,
  origin: "http://o.test",
  assetPrefix: "/pfx/",
});

console.log("prototype keys:", Object.keys(Object.getOwnPropertyDescriptors(Object.getPrototypeOf(router))).sort().join(","));
console.log("assetPrefix:", router.assetPrefix, "| src:", router.match("/").src);
```

Before:

```
prototype keys: constructor,match,origin,reload,routes,style
assetPrefix: undefined | src: http://o.test/pfx/index.tsx
```

## Cause

`getAssetPrefix` has been implemented since `Bun.FileSystemRouter` was introduced in d21aee5143, but it was never listed in `proto` in `filesystem_router.classes.ts`, so the codegen never emitted the accessor. The getter was unreachable dead code, and the only place a consumer can learn the prefix back off the router reported `undefined`.

## Fix

Add `assetPrefix` to the class definition's `proto`, alongside the existing `origin`/`style` getters (same `cache: true` shape; `reload()` preserves the configured prefix, so the cached value stays correct).

The getter now reports the empty string rather than `null` when no prefix is configured. An omitted `assetPrefix` and `assetPrefix: ""` already collapse to the same internal state (`get_truthy` + `is_empty()` both leave it unset), and the empty string is the prefix the router actually applies to `MatchedRoute.src`, so this keeps the declared `readonly assetPrefix: string` type honest. `origin` keeps returning `null` when absent, which is unchanged.

After:

```
prototype keys: assetPrefix,constructor,match,origin,reload,routes,style
assetPrefix: /pfx/ | src: http://o.test/pfx/index.tsx
```

## Verification

Two tests added to `test/js/bun/util/filesystem_router.test.ts`: the accessor exists on the prototype and returns the configured prefix (including across `reload()`, and tied to the prefix applied to `src`), and it is `""` when unset or set to `""`.

Both fail on the released binary and pass with the change; the file's other 27 tests still pass.