### PR TITLE
Implement module.syncBuiltinESMExports()

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -1026,7 +1026,7 @@ static JSValue fetchESMSourceCode(
         auto source = JSC::SourceCode(JSC::SyntheticSourceProvider::create(generateNativeModule_##name, JSC::SourceOrigin(), WTF::move(moduleKey))); \
         RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(vm, WTF::move(source))));                                                     \
     }
-            BUN_FOREACH_ESM_NATIVE_MODULE(CASE)
+            BUN_FOREACH_ESM_ONLY_NATIVE_MODULE(CASE)
 #undef CASE
 
         // CommonJS modules from src/js/*

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -868,6 +868,8 @@ static void syncBuiltinESMExportsForModule(Zig::GlobalObject* globalObject, JSC:
 
     auto* namespaceObject = record->getModuleNamespace(globalObject);
     RETURN_IF_EXCEPTION(scope, );
+    if (!namespaceObject)
+        return;
 
     for (const auto& exportEntry : record->exportEntries()) {
         auto exportName = JSC::Identifier::fromUid(vm, exportEntry.key.get());
@@ -913,6 +915,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinESMExports,
             continue;
         auto* record = entry->record();
         if (!record)
+            continue;
+        // A record exists before it is linked (an in-flight dynamic import), and an
+        // unlinked one has no bindings for anyone to observe yet. getModuleNamespace
+        // requires a linked record, so skip it the way every other registry walker does.
+        if (!record->moduleEnvironmentMayBeNull())
             continue;
 
         WTF::String keyString = moduleKey.string();

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -12,10 +12,14 @@
 #include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/JSModuleNamespaceObject.h>
+#include <JavaScriptCore/ModuleRegistryEntry.h>
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JSCommonJSExtensions.h"
 
+#include "ModuleLoader.h"
 #include "PathInlines.h"
 #include "ZigGlobalObject.h"
 #include "headers.h"
@@ -853,10 +857,79 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPreloadModules,
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
+// Re-binds every named export of an already-imported builtin to the value its
+// CommonJS exports object currently holds. Mirrors node's syncBuiltinESMExports
+// (lib/internal/modules/esm/utils.js): names that were dropped from the exports
+// object become undefined, names added to it afterwards are not new exports, and
+// `default` is left pointing at the exports object itself.
+static void syncBuiltinESMExportsForModule(Zig::GlobalObject* globalObject, JSC::ThrowScope& scope, JSC::AbstractModuleRecord* record, JSC::JSObject* exportsObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+
+    auto* namespaceObject = record->getModuleNamespace(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
+
+    for (const auto& exportEntry : record->exportEntries()) {
+        auto exportName = JSC::Identifier::fromUid(vm, exportEntry.key.get());
+        if (exportName == vm.propertyNames->defaultKeyword)
+            continue;
+
+        JSValue value = jsUndefined();
+        bool hasOwnProperty = exportsObject->hasOwnProperty(globalObject, exportName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (hasOwnProperty) {
+            value = exportsObject->get(globalObject, exportName);
+            RETURN_IF_EXCEPTION(scope, );
+        }
+
+        namespaceObject->overrideExportValue(globalObject, exportName, value);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinESMExports,
-    (JSGlobalObject * globalObject,
+    (JSGlobalObject * lexicalGlobalObject,
         JSC::CallFrame* callFrame))
 {
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* moduleLoader = globalObject->moduleLoader();
+
+    // Snapshot the keys before touching any of them: reading an export can run a
+    // getter, which can load another module and rehash the registry underneath us.
+    Vector<JSC::Identifier, 8> builtinKeys;
+    for (auto& [key, entry] : moduleLoader->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        if (!Bun::isBuiltinModule(String { key.first }))
+            continue;
+        builtinKeys.append(JSC::Identifier::fromUid(vm, key.first));
+    }
+
+    for (const auto& moduleKey : builtinKeys) {
+        auto* entry = moduleLoader->registryEntry(moduleKey);
+        if (!entry)
+            continue;
+        auto* record = entry->record();
+        if (!record)
+            continue;
+
+        WTF::String keyString = moduleKey.string();
+        BunString specifier = Bun::toString(keyString);
+        JSValue exportsValue = Bun::resolveAndFetchBuiltinModule(globalObject, &specifier);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        // Builtins that are real ES modules (bun:wrap, bun:main) have no CommonJS
+        // exports object to read from, so there is nothing to sync.
+        auto* exportsObject = exportsValue ? exportsValue.getObject() : nullptr;
+        if (!exportsObject)
+            continue;
+
+        syncBuiltinESMExportsForModule(globalObject, scope, record, exportsObject);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/jsc/modules/_NativeModule.h
+++ b/src/jsc/modules/_NativeModule.h
@@ -35,11 +35,21 @@
     macro("utf-8-validate"_s, UTF8Validate) \
     macro("abort-controller"_s, AbortControllerModule)
 
-#define BUN_FOREACH_ESM_NATIVE_MODULE(macro) \
-    BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro) \
+// Natives with no CommonJS counterpart in InternalModuleRegistry: require() hands
+// back a canonical singleton (the Module constructor, `process`, the Bun object),
+// so the ESM namespace has to be generated natively off that same singleton.
+// Everything in BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE instead resolves its ESM
+// namespace through InternalModuleRegistry (see generateInternalModuleSourceCode),
+// so that require() and import share one exports object rather than two
+// independent runs of the generator.
+#define BUN_FOREACH_ESM_ONLY_NATIVE_MODULE(macro) \
     macro("node:module"_s, NodeModule)  \
     macro("node:process"_s, NodeProcess) \
     macro("bun"_s, BunObject)
+
+#define BUN_FOREACH_ESM_NATIVE_MODULE(macro) \
+    BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro) \
+    BUN_FOREACH_ESM_ONLY_NATIVE_MODULE(macro)
 
 #define BUN_FOREACH_CJS_NATIVE_MODULE(macro) \
     BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro)

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -301,3 +301,109 @@ describe.concurrent("node-module-module", () => {
     expect(await proc.exited).toBe(0);
   });
 });
+
+// syncBuiltinESMExports() mutates process-global builtin state, so every case
+// runs in its own process. Every value below is reported as a string so that
+// JSON.stringify cannot silently drop an `undefined` and make the check vacuous.
+describe.concurrent("syncBuiltinESMExports", () => {
+  async function runFixture(source) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("propagates a CommonJS patch to the ESM namespace and named imports", async () => {
+    expect(
+      await runFixture(`
+        import { createRequire, syncBuiltinESMExports } from "node:module";
+        import * as fsNamespace from "node:fs";
+        import { readFileSync } from "node:fs";
+
+        const fs = createRequire(import.meta.url)("fs");
+        fs.readFileSync = () => "patched";
+        syncBuiltinESMExports();
+
+        console.log(
+          JSON.stringify({
+            commonjs: String(fs.readFileSync()),
+            namespace: String(fsNamespace.readFileSync()),
+            namedImport: String(readFileSync()),
+            defaultIsExportsObject: fsNamespace.default === fs,
+          }),
+        );
+      `),
+    ).toEqual({
+      commonjs: "patched",
+      namespace: "patched",
+      namedImport: "patched",
+      defaultIsExportsObject: true,
+    });
+  });
+
+  test("does not touch the ESM namespace until it is called", async () => {
+    expect(
+      await runFixture(`
+        import { createRequire } from "node:module";
+        import * as fsNamespace from "node:fs";
+
+        const fs = createRequire(import.meta.url)("fs");
+        const original = fsNamespace.readFileSync;
+        fs.readFileSync = () => "patched";
+
+        console.log(JSON.stringify({ stillOriginal: fsNamespace.readFileSync === original }));
+      `),
+    ).toEqual({ stillOriginal: true });
+  });
+
+  test("deleted exports become undefined, new properties do not become exports", async () => {
+    expect(
+      await runFixture(`
+        import { createRequire, syncBuiltinESMExports } from "node:module";
+        import * as fsNamespace from "node:fs";
+
+        const fs = createRequire(import.meta.url)("fs");
+        delete fs.readFileSync;
+        fs.brandNewExport = 42;
+        syncBuiltinESMExports();
+
+        console.log(
+          JSON.stringify({
+            deletedValue: typeof fsNamespace.readFileSync,
+            deletedStillExported: "readFileSync" in fsNamespace,
+            added: "brandNewExport" in fsNamespace,
+          }),
+        );
+      `),
+    ).toEqual({ deletedValue: "undefined", deletedStillExported: true, added: false });
+  });
+
+  test("syncs builtins implemented as native modules", async () => {
+    expect(
+      await runFixture(`
+        import { createRequire, syncBuiltinESMExports } from "node:module";
+        import * as bufferNamespace from "node:buffer";
+
+        const buffer = createRequire(import.meta.url)("node:buffer");
+        buffer.isUtf8 = () => "patched";
+        syncBuiltinESMExports();
+
+        console.log(JSON.stringify({ namespace: String(bufferNamespace.isUtf8()) }));
+      `),
+    ).toEqual({ namespace: "patched" });
+  });
+
+  test("returns undefined and is a no-op when no builtin was imported", async () => {
+    expect(
+      await runFixture(`
+        const { syncBuiltinESMExports } = require("node:module");
+        console.log(JSON.stringify({ returned: typeof syncBuiltinESMExports() }));
+      `),
+    ).toEqual({ returned: "undefined" });
+  });
+});

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -393,9 +393,44 @@ describe.concurrent("syncBuiltinESMExports", () => {
         buffer.isUtf8 = () => "patched";
         syncBuiltinESMExports();
 
-        console.log(JSON.stringify({ namespace: String(bufferNamespace.isUtf8()) }));
+        console.log(
+          JSON.stringify({
+            namespace: String(bufferNamespace.isUtf8()),
+            // require() and import must resolve to one exports object, otherwise
+            // syncing swaps every export for an identity-different twin.
+            defaultIsExportsObject: bufferNamespace.default === buffer,
+          }),
+        );
       `),
-    ).toEqual({ namespace: "patched" });
+    ).toEqual({ namespace: "patched", defaultIsExportsObject: true });
+  });
+
+  // Without this, an agent that patches only node:fs silently swaps every export
+  // of every other imported builtin for an identity-equal but distinct twin,
+  // breaking ===, WeakMap keys, and spies held against stored references.
+  test("leaves unpatched exports identity-stable", async () => {
+    expect(
+      await runFixture(`
+        import { syncBuiltinESMExports } from "node:module";
+        import * as bufferNamespace from "node:buffer";
+        import { isUtf8 } from "node:buffer";
+        import * as fsNamespace from "node:fs";
+
+        const nativeNamedBefore = isUtf8;
+        const nativeNamespaceBefore = bufferNamespace.isUtf8;
+        const jsBuiltinBefore = fsNamespace.readFileSync;
+
+        syncBuiltinESMExports();  // nothing was patched
+
+        console.log(
+          JSON.stringify({
+            nativeNamedImport: isUtf8 === nativeNamedBefore,
+            nativeNamespace: bufferNamespace.isUtf8 === nativeNamespaceBefore,
+            jsBuiltin: fsNamespace.readFileSync === jsBuiltinBefore,
+          }),
+        );
+      `),
+    ).toEqual({ nativeNamedImport: true, nativeNamespace: true, jsBuiltin: true });
   });
 
   test("returns undefined and is a no-op when no builtin was imported", async () => {


### PR DESCRIPTION
`module.syncBuiltinESMExports()` was a stub that returned `undefined`. A patch applied to a builtin's CommonJS `exports` object (the graceful-fs / APM instrument-and-patch pattern) never reached the ESM namespace bindings that were snapshotted from it at import time. Patch libraries saw a successful call and kept running, while every `import ... from 'node:fs'` consumer in the same process held the unpatched binding.

## Repro

```js
import { createRequire, syncBuiltinESMExports } from "node:module";
import * as fsns from "node:fs";
const cjs = createRequire(import.meta.url)("fs");
const orig = fsns.readFileSync;
cjs.readFileSync = function patched() { return "PATCHED"; };
syncBuiltinESMExports();
console.log(JSON.stringify({
  cjsPatched: String(cjs.readFileSync()),
  esmAfterSync: fsns.readFileSync === orig ? "orig" : String(fsns.readFileSync()),
}));
```

```
node v26.3.0: {"cjsPatched":"PATCHED","esmAfterSync":"PATCHED"}
bun 1.4.0:    {"cjsPatched":"PATCHED","esmAfterSync":"orig"}
```

## Cause

`jsFunctionSyncBuiltinESMExports` in `src/jsc/modules/NodeModuleModule.cpp` was `return jsUndefined();`. Importing a builtin creates a `SyntheticModuleRecord` whose export values are copied out of the builtin's CommonJS exports object once, at instantiation. Nothing re-read them afterwards.

## Fix

Walk the ESM registry for builtin module keys, and for each one fetch the builtin's CommonJS exports object (the same lookup `process.getBuiltinModule()` uses) and re-bind every named export through `JSModuleNamespaceObject::overrideExportValue`, which writes the module environment slot and touches its watchpoint set. That is the same path `mock.module()` and `spyOn()` already use, so both named imports and the namespace object observe the new value.

Semantics follow node's `syncBuiltinESMExports` in `lib/internal/modules/esm/utils.js`:

- exports deleted from the CommonJS object become `undefined` (the export itself stays)
- properties added to the CommonJS object afterwards do not become new exports
- `default` is left pointing at the exports object
- builtins that were never imported as ESM are untouched

Registry keys are snapshotted before any JS runs, because reading an export can invoke a getter that loads another module. Records that have not linked yet are skipped, matching the other registry walkers.

### Prerequisite: one exports object per native builtin

This relies on an invariant node guarantees and bun was violating for nine builtins. `node:buffer`, `node:constants`, `node:string_decoder`, `node:util/types`, `bun:jsc`, `bun:test`, `bun:app`, `utf-8-validate` and `abort-controller` each have a CommonJS entry in `InternalModuleRegistry`, but their ESM namespace was built by running the native generator a *second* time. `INIT_NATIVE_MODULE`'s `putNativeFn` mints a fresh `JSFunction` per run, so `require()` and `import` ended up with distinct-but-equivalent twins. Syncing would then swap every ESM binding for its twin even when nothing had been patched, breaking `===`, `WeakMap` keys, and spies held against stored references.

They all already carry `InternalModuleRegistryFlag`, so they now fall through to `generateInternalModuleSourceCode` (which resolves via `requireId`) instead of being intercepted by the ESM switch. `node:module`, `node:process` and `bun` keep the native generator: their CommonJS value is a canonical singleton rather than a registry entry, and their generators already read off that same singleton.

This also closes a latent divergence:

| | before | after | node |
|---|---|---|---|
| `(await import('node:buffer')).default === require('node:buffer')` | `false` | `true` | `true` |

## Verification

`bun bd test test/js/node/module/node-module-module.test.js` — 36 pass. The six new cases cover the repro, named-import bindings, delete/add semantics, a native builtin, identity stability of unpatched exports, and the untouched-until-called control. Three of the six fail on `USE_SYSTEM_BUN=1`.

The repro now prints node's output byte for byte. Also checked, not in the test file: a throwing getter propagates out of `syncBuiltinESMExports()` exactly as in node, the function works inside workers, and 200 syncs across 10 imported builtins under `Bun.gc(true)` plus a getter that loads a module mid-iteration run clean under `BUN_JSC_validateExceptionChecks=1`.

`bun:test` is one of the rerouted modules and is imported by every test file, so the blast radius got the most attention. Verified all nine now agree with `require()` on export names, export values and `default`, and ran `test/js/bun/test/mock/` + `mock-fn` (95 pass), `test/js/node/module/` (95 pass), `buffer.test.js` (543 pass), `string_decoder/` (86 pass).