### PR TITLE
node:async_hooks: only reject an empty AsyncResource type while an init hook is enabled

### DIFF
--- a/src/js/internal/async_hooks.ts
+++ b/src/js/internal/async_hooks.ts
@@ -3,21 +3,31 @@
 // stub whose callbacks never fire; what CAN be tracked honestly is whether
 // any hook is currently enabled, which is all enabledHooksExist() reports.
 let activeHooks = 0;
+// Mirrors node's async_hook_fields[kInit]: only hooks that supply an `init`
+// callback and are currently enabled are counted.
+let activeInitHooks = 0;
 
 function enabledHooksExist() {
   return activeHooks > 0;
 }
 
-function markHookEnabled() {
-  activeHooks += 1;
+function initHooksExist() {
+  return activeInitHooks > 0;
 }
 
-function markHookDisabled() {
+function markHookEnabled(hasInit: boolean) {
+  activeHooks += 1;
+  if (hasInit) activeInitHooks += 1;
+}
+
+function markHookDisabled(hasInit: boolean) {
   if (activeHooks > 0) activeHooks -= 1;
+  if (hasInit && activeInitHooks > 0) activeInitHooks -= 1;
 }
 
 export default {
   enabledHooksExist,
+  initHooksExist,
   markHookEnabled,
   markHookDisabled,
 };

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -269,7 +269,8 @@ class AsyncResource {
         throw $ERR_INVALID_ASYNC_ID("triggerAsyncId", triggerAsyncId);
       }
     }
-    if (hasEnabledCreateHook && type.length === 0) {
+    // Node only validates the type when an `init` hook is currently enabled.
+    if (type.length === 0 && require("internal/async_hooks").initHooksExist()) {
       throw $ERR_ASYNC_TYPE(type);
     }
 
@@ -364,7 +365,6 @@ const createHookNotImpl = createWarning(
   true,
 );
 
-let hasEnabledCreateHook = false;
 const kHookEnabled = Symbol("kHookEnabled");
 function createHook(hook) {
   validateObject(hook, "hook");
@@ -392,10 +392,9 @@ function createHook(hook) {
       if (before !== undefined || after !== undefined || destroy !== undefined || promiseResolve !== undefined) {
         createHookNotImpl(hook);
       }
-      hasEnabledCreateHook = true;
       if (!this[kHookEnabled]) {
         this[kHookEnabled] = true;
-        require("internal/async_hooks").markHookEnabled();
+        require("internal/async_hooks").markHookEnabled(init !== undefined);
       }
       return this;
     },
@@ -408,7 +407,7 @@ function createHook(hook) {
       }
       if (this[kHookEnabled]) {
         this[kHookEnabled] = false;
-        require("internal/async_hooks").markHookDisabled();
+        require("internal/async_hooks").markHookDisabled(init !== undefined);
       }
       return this;
     },

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
+import { bunEnv, bunExe } from "harness";
 
 test("node async_hooks.AsyncLocalStorage enable disable", async done => {
   const asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
@@ -86,4 +87,93 @@ test("AsyncResource.bind", () => {
     fn = AsyncResource.bind(() => localStorage.getStore());
   });
   expect(fn()).toBe(true);
+});
+
+// Node rejects an empty AsyncResource type only while a hook with an `init`
+// callback is currently enabled. Hook counts are process-global, so the whole
+// ordered sequence runs in one child.
+test("new AsyncResource('') only throws while an init hook is enabled", async () => {
+  const fixture = `
+    const ah = require("node:async_hooks");
+    const probe = (type = "") => {
+      try {
+        new ah.AsyncResource(type);
+        return "ok";
+      } catch (e) {
+        return e.code;
+      }
+    };
+    const out = {};
+
+    out.noHookEver = probe();
+
+    const empty = ah.createHook({}).enable();
+    out.emptyHookEnabled = probe();
+    empty.disable();
+
+    const destroyOnly = ah.createHook({ destroy() {} }).enable();
+    out.destroyOnlyEnabled = probe();
+    destroyOnly.disable();
+
+    const initHook = ah.createHook({ init() {} }).enable();
+    out.initHookEnabled = probe();
+    out.initHookEnabledNonEmptyType = probe("resource");
+    initHook.disable();
+    out.initHookDisabled = probe();
+
+    const first = ah.createHook({ init() {} }).enable();
+    const second = ah.createHook({ init() {} }).enable();
+    first.disable();
+    out.oneOfTwoInitHooksLeft = probe();
+    second.disable();
+    out.bothInitHooksDisabled = probe();
+
+    const twice = ah.createHook({ init() {} });
+    twice.enable();
+    twice.enable();
+    twice.disable();
+    out.enabledTwiceDisabledOnce = probe();
+
+    const kept = ah.createHook({ init() {} }).enable();
+    const dropped = ah.createHook({ init() {} }).enable();
+    dropped.disable();
+    dropped.disable();
+    out.doubleDisableKeepsOtherHook = probe();
+    kept.disable();
+    out.afterLastInitHookDisabled = probe();
+
+    const neverEnabled = ah.createHook({ init() {} });
+    neverEnabled.disable();
+    out.disableWithoutEnable = probe();
+
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Surface the child's stderr in the diff if it died before printing anything.
+  const result = stdout ? JSON.parse(stdout) : { crashed: stderr };
+
+  // Expected values are what node v26.3.0 prints for the same script.
+  expect(result).toEqual({
+    noHookEver: "ok",
+    emptyHookEnabled: "ok",
+    destroyOnlyEnabled: "ok",
+    initHookEnabled: "ERR_ASYNC_TYPE",
+    initHookEnabledNonEmptyType: "ok",
+    initHookDisabled: "ok",
+    oneOfTwoInitHooksLeft: "ERR_ASYNC_TYPE",
+    bothInitHooksDisabled: "ok",
+    enabledTwiceDisabledOnce: "ok",
+    doubleDisableKeepsOtherHook: "ERR_ASYNC_TYPE",
+    afterLastInitHookDisabled: "ok",
+    disableWithoutEnable: "ok",
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
const ah = require("node:async_hooks");
const probe = () => { try { new ah.AsyncResource(""); return "ok"; } catch (e) { return e.code; } };

console.log(probe());                 // ok
const h = ah.createHook({}).enable(); // a hook with no callbacks at all
console.log(probe());                 // node: ok      bun: ERR_ASYNC_TYPE
h.disable();
console.log(probe());                 // node: ok      bun: ERR_ASYNC_TYPE
```

Once any `createHook(...).enable()` has run, `new AsyncResource("")` throws `ERR_ASYNC_TYPE` for the rest of the process, even when the hook had no callbacks and even after every hook is disabled again. Loading a dependency that enables a no-op hook (APM agents, `async-listener` shims, some test frameworks) permanently changes what `new AsyncResource("")` does, and the failure shows up far from its cause.

## Cause

`src/js/node/async_hooks.ts` gated the check on a module-level latch:

```js
let hasEnabledCreateHook = false;
// in enable(), unconditionally:
hasEnabledCreateHook = true;
// in the AsyncResource constructor:
if (hasEnabledCreateHook && type.length === 0) throw $ERR_ASYNC_TYPE(type);
```

It was set by every `enable()` regardless of which callbacks the hook supplied, and `disable()` never cleared it.

Node gates the same check on `initHooksExist()`, i.e. `async_hook_fields[kInit] > 0`: the number of *currently enabled* hooks that supply an `init` callback. `enable()` and `disable()` increment and decrement it, and re-enabling a hook that is already active does not count it twice.

## Fix

Replace the latch with an `activeInitHooks` counter in `internal/async_hooks`, maintained alongside the existing `activeHooks` count and only moved when the hook supplies an `init` callback. `AsyncResource` now consults `initHooksExist()`.

## Verification

Added to `test/js/node/async_hooks/async_hooks.node.test.ts`. Hook counts are process-global, so the whole lifecycle runs in one child process. Expected values are what node v26.3.0 prints for the same script (`ERR` = `ERR_ASYNC_TYPE`):

```
                              node   before   after
noHookEver                    ok     ok       ok
emptyHookEnabled              ok     ERR      ok
destroyOnlyEnabled            ok     ERR      ok
initHookEnabled               ERR    ERR      ERR
initHookEnabledNonEmptyType   ok     ok       ok
initHookDisabled              ok     ERR      ok
oneOfTwoInitHooksLeft         ERR    ERR      ERR
bothInitHooksDisabled         ok     ERR      ok
enabledTwiceDisabledOnce      ok     ERR      ok
doubleDisableKeepsOtherHook   ERR    ERR      ERR
afterLastInitHookDisabled     ok     ERR      ok
disableWithoutEnable          ok     ERR      ok
```

The last four cases pin the counter against double-enable, double-disable and disable-without-enable, so it cannot underflow past a hook that is still enabled.

`test/js/node/test/parallel/test-async-hooks-asyncresource-constructor.js` (which registers an `init` hook precisely so the type gets validated) still passes, as do the `test-stream-finished-*` tests that read `enabledHooksExist()` from the same module, and the rest of `test/js/node/async_hooks/` (112 pass, 0 fail).
