### PR TITLE
Derive the stack trace header from the error's name and message

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,6 +32,70 @@ using namespace WebCore;
 
 namespace Bun {
 
+// The first line of a stack trace, following V8's ErrorUtils::ToString: an undefined
+// `name` means "Error", an undefined `message` means the empty string, and both are
+// read off the object itself when it is not an ErrorInstance.
+static void getErrorNameAndMessage(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, WTF::String& name, WTF::String& message)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (auto* instance = dynamicDowncast<JSC::ErrorInstance>(errorObject)) {
+        name = instance->sanitizedNameString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, );
+        message = instance->sanitizedMessageString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, );
+        return;
+    }
+
+    // Reading these two properties can run user code. Only a mutator can reach here with a
+    // non-ErrorInstance target: the GC's finalizer path formats with a null errorObject, and
+    // materializeErrorInfoIfNeeded always passes an ErrorInstance, which returned above.
+    ASSERT(vm.heap.worldIsRunning());
+
+    name = "Error"_s;
+
+    JSValue nameValue = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->name);
+    RETURN_IF_EXCEPTION(scope, );
+    if (nameValue && !nameValue.isUndefined()) {
+        name = nameValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+
+    JSValue messageValue = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->message);
+    RETURN_IF_EXCEPTION(scope, );
+    if (messageValue && !messageValue.isUndefined()) {
+        message = messageValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+}
+
+static void appendErrorNameAndMessage(WTF::StringBuilder& sb, const WTF::String& name, const WTF::String& message)
+{
+    if (!name.isEmpty()) {
+        sb.append(name);
+        if (!message.isEmpty()) {
+            sb.append(": "_s);
+            sb.append(message);
+        }
+    } else if (!message.isEmpty()) {
+        sb.append(message);
+    }
+}
+
+// StackFrame holds cells the GC does not scan from the vector itself. Anything that
+// allocates or calls into JS before the frames are formatted can collect them.
+static bool protectStackFrameCells(JSC::MarkedArgumentBuffer& protectedFrameCells, WTF::Vector<JSC::StackFrame>& stackTrace)
+{
+    protectedFrameCells.ensureCapacity(stackTrace.size() * 2);
+    for (auto& frame : stackTrace) {
+        if (auto* callee = frame.callee())
+            protectedFrameCells.append(callee);
+        if (auto* codeBlock = frame.codeBlock())
+            protectedFrameCells.append(codeBlock);
+    }
+    return !protectedFrameCells.hasOverflowed();
+}
+
 static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -41,22 +105,11 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
 
     WTF::StringBuilder sb;
 
-    auto errorMessage = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->message);
+    WTF::String name;
+    WTF::String message;
+    getErrorNameAndMessage(vm, lexicalGlobalObject, errorObject, name, message);
     RETURN_IF_EXCEPTION(scope, {});
-    if (errorMessage) {
-        auto* str = errorMessage.toString(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (str->length() > 0) {
-            auto value = str->view(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            sb.append("Error: "_s);
-            sb.append(value.data);
-        } else {
-            sb.append("Error"_s);
-        }
-    } else {
-        sb.append("Error"_s);
-    }
+    appendErrorNameAndMessage(sb, name, message);
 
     for (size_t i = 0; i < framesCount; i++) {
         sb.append("\n    at "_s);
@@ -152,15 +205,7 @@ WTF::String formatStackTrace(
 {
     WTF::StringBuilder sb;
 
-    if (!name.isEmpty()) {
-        sb.append(name);
-        if (!message.isEmpty()) {
-            sb.append(": "_s);
-            sb.append(message);
-        }
-    } else if (!message.isEmpty()) {
-        sb.append(message);
-    }
+    appendErrorNameAndMessage(sb, name, message);
 
     // FIXME: why can size == 6 and capacity == 0?
     // https://discord.com/channels/876711213126520882/1174901590457585765/1174907969419350036
@@ -409,16 +454,13 @@ static String computeErrorInfoWithoutPrepareStackTrace(
     WTF::String message;
 
     if (errorInstance) {
-        // Note that we are not allowed to allocate memory in here. It's called inside a finalizer.
-        if (auto* instance = dynamicDowncast<ErrorInstance>(errorInstance)) {
-            if (!lexicalGlobalObject) {
-                lexicalGlobalObject = errorInstance->globalObject();
-            }
-            name = instance->sanitizedNameString(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            message = instance->sanitizedMessageString(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+        // Note that we are not allowed to allocate memory in here. It's called inside a finalizer,
+        // but only ever with a null errorInstance, so getErrorNameAndMessage is unreachable there.
+        if (!lexicalGlobalObject) {
+            lexicalGlobalObject = errorInstance->globalObject();
         }
+        getErrorNameAndMessage(vm, lexicalGlobalObject, errorInstance, name, message);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     if (!globalObject) [[unlikely]] {
@@ -726,14 +768,7 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
     } else {
         auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
         JSC::MarkedArgumentBuffer protectedFrameCells;
-        protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
-        for (auto& frame : *ownedStackTrace) {
-            if (auto* callee = frame.callee())
-                protectedFrameCells.append(callee);
-            if (auto* codeBlock = frame.codeBlock())
-                protectedFrameCells.append(codeBlock);
-        }
-        if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
+        if (!protectStackFrameCells(protectedFrameCells, *ownedStackTrace)) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return {};
         }
@@ -785,6 +820,11 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
             // a non-null m_stackTrace, causing ASSERT(!m_errorInfoMaterialized) in
             // computeErrorInfo when GC's finalizeUnconditionally finds unmarked frames.
             // Eagerly compute and set the .stack property instead.
+            JSC::MarkedArgumentBuffer protectedFrameCells;
+            if (!protectStackFrameCells(protectedFrameCells, stackTrace)) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return {};
+            }
             OrdinalNumber line;
             OrdinalNumber column;
             String sourceURL;
@@ -806,6 +846,12 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
             instance->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::CustomAccessor | 0);
         }
     } else {
+        // Formatting reads `name` and `message` off the target, which can run a getter.
+        JSC::MarkedArgumentBuffer protectedFrameCells;
+        if (!protectStackFrameCells(protectedFrameCells, stackTrace)) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return {};
+        }
         OrdinalNumber line;
         OrdinalNumber column;
         String sourceURL;

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1021,9 +1021,82 @@ test("lazy error-info materialization does not store an empty stack value when t
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // V8 does not invoke an accessor `.message` when composing the default stack header for
+  // an Error, so the getter does not fire and prepareStackTrace runs. Both reads succeed.
   expect({ stdout: stdout.trim(), signalCode: proc.signalCode }).toEqual({
-    stdout: JSON.stringify({ first: "msg-boom", secondType: "undefined" }),
+    stdout: JSON.stringify({ first: "no-throw", secondType: "string" }),
     signalCode: null,
   });
   expect(exitCode).toBe(0);
+});
+
+test("Error.captureStackTrace on a non-Error target uses its name and message", () => {
+  const cases = [
+    [{ name: "MyThing", message: "it broke" }, "MyThing: it broke"],
+    [{ message: "only-message" }, "Error: only-message"],
+    [{ name: "OnlyName" }, "OnlyName"],
+    [{}, "Error"],
+    [{ name: "", message: "" }, ""],
+    [{ name: 42, message: 7 }, "42: 7"],
+    [{ name: null }, "null"],
+    [{ message: null }, "Error: null"],
+    [{ name: undefined, message: "x" }, "Error: x"],
+    [{ name: "N", message: undefined }, "N"],
+    [
+      {
+        get name() {
+          return "Getter";
+        },
+        get message() {
+          return "gm";
+        },
+      },
+      "Getter: gm",
+    ],
+  ];
+
+  for (const [target, expected] of cases) {
+    Error.captureStackTrace(target);
+    expect(target.stack.split("\n")[0]).toBe(expected);
+  }
+});
+
+test("Error.captureStackTrace reads name and message off the prototype chain", () => {
+  function Base() {}
+  Base.prototype.name = "BaseName";
+  function Derived() {}
+  Derived.prototype = Object.create(Base.prototype);
+  Derived.prototype.message = "derived";
+
+  const target = new Derived();
+  Error.captureStackTrace(target);
+  expect(target.stack.split("\n")[0]).toBe("BaseName: derived");
+});
+
+test("the pre-class custom error idiom labels its stack", () => {
+  function MyError(message) {
+    this.name = "MyError";
+    this.message = message;
+    Error.captureStackTrace(this, MyError);
+  }
+  MyError.prototype = Object.create(Error.prototype);
+
+  const err = new MyError("boom");
+  expect(err.stack.split("\n")[0]).toBe("MyError: boom");
+  expect(err.stack).not.toContain("at new MyError");
+});
+
+test("the default-formatted stack passed to Error.prepareStackTrace is labelled with the error's name", () => {
+  Error.prepareStackTrace = (err, callSites) => err.stack.split("\n")[0];
+
+  expect(new TypeError("boom").stack).toBe("TypeError: boom");
+
+  class SubError extends Error {
+    name = "SubError";
+  }
+  expect(new SubError("boom").stack).toBe("SubError: boom");
+
+  const target = { name: "Plain", message: "pm" };
+  Error.captureStackTrace(target);
+  expect(target.stack).toBe("Plain: pm");
 });


### PR DESCRIPTION
## Repro

```js
const o = { name: "MyThing", message: "it broke" }; Error.captureStackTrace(o);
const m = { message: "only-message" };              Error.captureStackTrace(m);
const n = { name: "OnlyName" };                     Error.captureStackTrace(n);
console.log([o, m, n].map(x => x.stack.split("\n")[0]));

Error.prepareStackTrace = (err, frames) => err.stack.split("\n")[0];
console.log(new TypeError("boom").stack);
```

```
node v26.3.0: [ "MyThing: it broke", "Error: only-message", "OnlyName" ]
              TypeError: boom
bun 1.4.0:    [ "Error",             "Error",               "Error"    ]
              Error: boom
```

`Error.captureStackTrace(obj)` on a non-`Error` target is the canonical pre-`class`
custom-error idiom:

```js
function MyError(msg) {
  this.name = "MyError";
  this.message = msg;
  Error.captureStackTrace(this, MyError);
}
MyError.prototype = Object.create(Error.prototype);
```

Under bun every such error's trace was labelled `Error` and its message was dropped
from the stack string, so logged stacks lost both the error type and what went wrong.

## Cause

The first line of a stack trace was composed from a hardcoded `"Error"` in two places:

- `computeErrorInfoWithoutPrepareStackTrace` only read `name`/`message` when the target
  was an `ErrorInstance` (via `sanitizedNameString`/`sanitizedMessageString`). A plain
  object fell through to the `name = "Error"_s` default with an empty message.
- `formatStackTraceToJSValue`, which builds the default-formatted string that
  `Error.prepareStackTrace` receives as `err.stack`, read `message` off the object but
  hardcoded the name, so even a real `TypeError` was labelled `Error` there.

V8 composes that line with `ErrorUtils::ToString`, which does a `Get(target, "name")` /
`Get(target, "message")` on the object regardless of its type.

## Fix

Both sites now go through one `getErrorNameAndMessage` helper that follows
`ErrorUtils::ToString`: an undefined `name` means `"Error"`, an undefined `message` means
the empty string, the two are joined with `": "` only when both are non-empty, and for a
non-`ErrorInstance` target they are read off the object itself (prototype chain included,
with `ToString` coercion). `ErrorInstance` keeps using the existing sanitized accessors,
which also makes the `prepareStackTrace` default string agree with the non-`prepareStackTrace`
one (what `test/js/node/v8/error-prepare-stack-default-fixture.js` asserts).

Reading those two properties off the target can run a getter, and a `StackFrame` holds
cells the GC does not scan from the vector itself. The captured frames are now rooted in a
`MarkedArgumentBuffer` across formatting, the same way the lazy `.stack` getter already
does; that block is factored into `protectStackFrameCells`.

### Known remaining difference

bun materializes `.stack` eagerly inside `captureStackTrace`, V8 formats it lazily on first
access. So mutating `name`/`message` after the call is still not reflected, and a throwing
`name`/`message` getter throws from `captureStackTrace` rather than from the `.stack` read.
Both are properties of the eager model, which predates this change (`formatStackTraceToJSValue`
already did a full `Get` on `message`); closing them means storing the frames for a plain
object, which is a larger change.


## Rebase note: interaction with #34104

#34104 (merged) asserted that an accessor `.message` which throws while `Error.prepareStackTrace` is set makes the first `.stack` read throw and the second return `undefined`. This PR routes an `ErrorInstance` through the sanitized (VMInquiry) accessors for the header, which skip getters, so that specific repro now matches Node: the getter is never invoked, `prepareStackTrace` runs, and `.stack` is the string it returned. #34104's test assertion is updated accordingly; its regression guard (`signalCode: null`, `exitCode: 0`) is unchanged, and its `if (!result) return jsUndefined()` safeguard stays.

## Verification

`test/js/node/v8/capture-stack-trace.test.js` gains 4 tests, each asserting a value taken from
node v26.3.0: the header cases above plus `{}`, `{name: "", message: ""}`, `{name: 42, message: 7}`,
`null`/`undefined` name and message, accessor-defined name and message, prototype-chain lookup,
the pre-`class` idiom, and the `prepareStackTrace` default string for `TypeError`, an
`Error` subclass, and a plain target.

```
USE_SYSTEM_BUN=1 bun test capture-stack-trace.test.js   # 4 new tests fail
bun bd test capture-stack-trace.test.js                 # 44 pass, 0 fail
```

<details>
<summary>Regression sweep</summary>

`test/js/node/v8/`, `test/js/bun/sourcemap/`, `test/js/bun/util/fuzzy-wuzzy.test.ts`,
`test/js/deno/v8/error.test.ts`, `test/js/node/util/node-inspect-tests/parallel/util-format.test.js`:
8 fail before the diff (4 of them the new tests), 4 fail after. The 4 remaining
(`capture stack trace limit`, the WebSocket call-sites test, the message-getter test,
`construct-subclass ReadStream`) fail identically on unmodified `main` when those files are run
together, and all pass when each directory is run on its own. `test/js/bun/util/error-gc-test.test.js`
times out on unmodified `main` under debug+ASAN too.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d183d1ce)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.82ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [8.98ms]
(pass) capture stack trace [6.42ms]
(pass) capture stack trace with message [7.36ms]
(pass) capture stack trace with constructor [7.37ms]
(pass) capture stack trace limit [26.81ms]
(pass) prepare stack trace [11.12ms]
(pass) capture stack trace second argument [20.49ms]
(pass) capture stack trace edge cases [12.41ms]
(pass) prepare stack trace call sites [16.59ms]
(pass) sanity check [17.40ms]
(pass) CallFrame isEval works as expected [7.41ms]
(pass) CallFrame isTopLevel returns false for Function constructor [10.39ms]
(pass) CallFrame.p.getThisgetFunction: strict/slop
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.14ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.12ms]
(pass) capture stack trace [0.07ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.22ms]
(pass) prepare stack trace [0.13ms]
(pass) capture stack trace second argument [0.17ms]
(pass) capture stack trace edge cases [0.11ms]
(pass) prepare stack trace call sites [0.14ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.12ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.10ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.10ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.04ms]
(pass) return non-strings from Error.prepareStackTrace [0.04ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.34ms]
(pass) Error.prepareStackTrace inside a node:vm works [4.82ms]
(pass) Error.captureStackTrace inside error constructor works [0.12ms]
(pass) Error.prepareStackTrace has 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d183d1ce)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.59ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.39ms]
(pass) capture stack trace [6.29ms]
(pass) capture stack trace with message [7.00ms]
(pass) capture stack trace with constructor [4.93ms]
(pass) capture stack trace limit [22.20ms]
(pass) prepare stack trace [10.49ms]
(pass) capture stack trace second argument [17.42ms]
(pass) capture stack trace edge cases [11.43ms]
(pass) prepare stack trace call sites [13.38ms]
(pass) sanity check [12.79ms]
(pass) CallFrame isEval works as expected [6.81ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.97ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9d183d1ce3
  features     (none)

22 deps, 106 codegen, 1168 objects in 783ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] gen bindgenv2
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1230] gen Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  | 128 +++++++++++++++++++---------
 test/js/node/v8/capture-stack-trace.test.js |  75 +++++++++++++++-
 2 files changed, 161 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       6      8      0
test/js/node/v8/capture-stack-trace.test.js      1      4      0
```

</details>

<!-- robobun:evidence:end -->