### PR TITLE
require(esm): throw ERR_REQUIRE_ASYNC_MODULE instead of a bare TypeError

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -42,6 +42,7 @@
 #include "JSCommonJSExtensions.h"
 
 #include "BunProcess.h"
+#include "ErrorCode.h"
 
 namespace Bun {
 using namespace JSC;
@@ -67,6 +68,11 @@ public:
 };
 
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
+
+JSC::EncodedJSValue throwRequireAsyncModuleError(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const WTF::String& specifier)
+{
+    return Bun::throwError(globalObject, scope, ErrorCode::ERR_REQUIRE_ASYNC_MODULE, makeString("require() async module \""_s, specifier, "\" is unsupported. use \"await import()\" instead."_s));
+}
 
 static JSC::JSPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
 {
@@ -681,7 +687,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
+                throwRequireAsyncModuleError(globalObject, scope, specifierWtfString);
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Fulfilled: {
@@ -736,7 +742,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
+                throwRequireAsyncModuleError(globalObject, scope, specifierWtfString);
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Fulfilled: {

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -91,6 +91,10 @@ public:
     bool wasModuleMock = false;
 };
 
+// Node's ERR_REQUIRE_ASYNC_MODULE: require() cannot finish loading this module
+// synchronously. Loaders detect the code to fall back to import().
+JSC::EncodedJSValue throwRequireAsyncModuleError(JSC::JSGlobalObject*, JSC::ThrowScope&, const WTF::String& specifier);
+
 JSValue fetchESMSourceCodeSync(
     Zig::GlobalObject* globalObject,
     JSString* spceifierJS,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -811,7 +811,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
         }
-        return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
+        return Bun::throwRequireAsyncModuleError(globalObject, scope, keyString);
     }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -227,8 +227,17 @@ describe("require", () => {
 });
 
 describe("module", () => {
-  it("throws with require()", () => {
-    expect(() => require("my-virtual-module-async")).toThrow();
+  it("throws ERR_REQUIRE_ASYNC_MODULE with require()", () => {
+    let error: any;
+    try {
+      require("my-virtual-module-async");
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+    expect(error.message).toContain("my-virtual-module-async");
   });
 
   it("async module works with async import", async () => {

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -28,7 +28,7 @@ test("require(esm) rejects when a transitive dependency has top-level await", as
       try {
         require("./middle.mjs");
       } catch (e) {
-        threw = e instanceof TypeError && String(e.message).includes("async module");
+        threw = e instanceof Error && e.code === "ERR_REQUIRE_ASYNC_MODULE" && String(e.message).includes("async module");
       }
       if (!threw) throw new Error("expected require(transitive-TLA) to throw");
       console.log("ok");

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -40,6 +40,48 @@ describe("require(specifier)", () => {
     it.todo("require('*.html') synchronously produces a string");
     it.todo("require('*.wasm') produces a WebAssembly.Module");
     it.todo("require('*.db') wraps a sqlite file in a Database object and exports it");
+  });
+
+  describe("when specifier is an ES module whose graph uses top-level await", () => {
+    // Loaders detect `err.code === "ERR_REQUIRE_ASYNC_MODULE"` to fall back to import().
+    // https://nodejs.org/api/errors.html#err_require_async_module
+    it("throws a node-style ERR_REQUIRE_ASYNC_MODULE error", () => {
+      using dir = tempDir("require-tla", {
+        "tla.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
+      });
+      const specifier = path.join(String(dir), "tla.mjs");
+
+      let error: any;
+      try {
+        require(specifier);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(TypeError);
+      expect(error.name).toBe("Error");
+      expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+      expect(error.message).toContain(require.resolve(specifier));
+    });
+
+    it("throws ERR_REQUIRE_ASYNC_MODULE when only a transitive dependency has top-level await", () => {
+      using dir = tempDir("require-transitive-tla", {
+        "leaf.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
+        "middle.mjs": `export { value } from "./leaf.mjs";\n`,
+      });
+      const specifier = path.join(String(dir), "middle.mjs");
+
+      let error: any;
+      try {
+        require(specifier);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+    });
   });
 
   describe("require.main", () => {


### PR DESCRIPTION
`require()` of an ES module whose graph contains top-level await throws a bare `TypeError` with no `.code`:

```js
// tla.mjs
await new Promise(r => setTimeout(r, 1));
export const v = 1;

// app.cjs
try { require("./tla.mjs"); }
catch (e) { console.log({ name: e.constructor.name, code: e.code ?? null }); }
```

```
node: { name: 'Error',     code: 'ERR_REQUIRE_ASYNC_MODULE' }
bun : { name: 'TypeError', code: null }
```

Node documents `ERR_REQUIRE_ASYNC_MODULE` as the signal for "this module needs `import()`", and the ecosystem's `require(esm)` migration path is `try { require(f) } catch (e) { if (e.code === "ERR_REQUIRE_ASYNC_MODULE") return import(f) }`. On Bun that branch never matched, so loaders and shims rethrow instead of falling back.

## Cause

Three sites throw the same `require() async module "..." is unsupported` message, and all three used `throwTypeError` / `throwVMTypeError` directly, which attaches no `code`:

- `functionEsmLoadSync` in `ZigGlobalObject.cpp` — the `require(esm)` path, reached whenever the synchronous module-loader drain leaves the load promise pending (top-level await anywhere in the graph).
- Two copies in `fetchCommonJSModule` in `ModuleLoader.cpp` — `require()` of a virtual module whose plugin `onLoad` is async.

`ERR_REQUIRE_ASYNC_MODULE` was already declared in `src/jsc/bindings/ErrorCode.ts` (as an `Error`, matching Node) but nothing ever used it.

## Fix

A single `Bun::throwRequireAsyncModuleError` helper routes all three sites through `Bun::throwError(..., ErrorCode::ERR_REQUIRE_ASYNC_MODULE, ...)`. The thrown value is now an `Error` with `code === "ERR_REQUIRE_ASYNC_MODULE"`, matching Node's class and code.

The message text is unchanged. Node's wording points at `--experimental-print-required-tla`, a flag Bun does not implement, and Bun's message already names the offending module, so copying it verbatim would be worse. Only the error class and `.code` change.

Note this is a behavior change for anyone matching `e instanceof TypeError` on this throw: it is now `Error`, as in Node. The one in-tree test doing that is updated to assert the code instead.

This is independent of #33249, which makes some TLA graphs load successfully under `require()`; graphs that genuinely need the event loop still throw, and now they throw the right thing.

## Verification

```
$ bun bd test test/js/bun/resolve/require.test.ts \
             test/js/bun/resolve/require-esm-transitive-tla.test.ts \
             test/regression/issue/24387.test.ts \
             test/js/bun/plugin/plugins.test.ts
 49 pass, 0 fail
```

New tests in `test/js/bun/resolve/require.test.ts` (direct and transitive top-level await) and a strengthened assertion in `test/js/bun/plugin/plugins.test.ts` (async plugin module) fail on `main` with `Expected: "ERR_REQUIRE_ASYNC_MODULE" / Received: undefined`.
