### PR TITLE
process.on: reject SIGKILL and SIGSTOP with EINVAL like node

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1386,6 +1386,59 @@ __attribute__((noinline)) static void forwardSignal(int signalNumber)
 extern "C" void Bun__MemoryPressure__install(JSC::JSGlobalObject* global);
 extern "C" void Bun__MemoryPressure__uninstall(JSC::JSGlobalObject* global);
 
+#if !OS(WINDOWS)
+// sigaction(2) rejects these two with EINVAL, which is the error Node surfaces
+// from uv_signal_start(). libuv on Windows has no equivalent check, so Node
+// accepts the names there and so do we.
+static bool isUncatchableSignal(int signalNumber)
+{
+    return signalNumber == SIGKILL || signalNumber == SIGSTOP;
+}
+#endif
+
+static bool signalCanBeHandled(int signalNumber)
+{
+#if OS(LINUX)
+    // JSC needs its own handler for the signal it suspends and resumes the JS
+    // thread with, which we must not override.
+    return !isUncatchableSignal(signalNumber) && signalNumber != g_wtfConfig.sigThreadSuspendResume;
+#elif OS(DARWIN) || OS(FREEBSD)
+    return !isUncatchableSignal(signalNumber);
+#elif OS(WINDOWS)
+    // Windows has no SIGSTOP, and nothing ever delivers SIGKILL.
+    return signalNumber != SIGKILL;
+#else
+#error unknown OS
+#endif
+}
+
+#if !OS(WINDOWS)
+// Node starts signal watchers from a `newListener` hook on the main thread, so
+// uv_signal_start()'s EINVAL surfaces before the listener is ever added.
+static bool onWillAddListenerImpl(EventEmitter& eventEmitter, const Identifier& eventName)
+{
+    if (!Bun__isMainThreadVM())
+        return true;
+
+    loadSignalNumberMap();
+    if (!isUncatchableSignal(signalNameToNumberMap->get(eventName.string())))
+        return true;
+
+    auto* globalObject = eventEmitter.scriptExecutionContext()->jsGlobalObject();
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto& names = WebCore::builtinNames(vm);
+
+    // Match Node's ErrnoException: a plain Error with errno/code/syscall.
+    auto* error = JSC::createError(globalObject, "uv_signal_start EINVAL"_s);
+    error->putDirect(vm, names.errnoPublicName(), jsNumber(-EINVAL), 0);
+    error->putDirect(vm, names.codePublicName(), jsString(vm, String("EINVAL"_s)), 0);
+    error->putDirect(vm, names.syscallPublicName(), jsString(vm, String("uv_signal_start"_s)), 0);
+    throwException(globalObject, scope, error);
+    return false;
+}
+#endif
+
 static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& eventName, bool isAdded)
 {
     if (Bun__isMainThreadVM()) {
@@ -1516,20 +1569,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
         }
 
         if (auto signalNumber = signalNameToNumberMap->get(eventName.string())) {
-#if OS(LINUX)
-            // SIGKILL and SIGSTOP cannot be handled, and JSC needs its own signal handler to
-            // suspend and resume the JS thread which we must not override.
-            if (signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume) {
-#elif OS(DARWIN) || OS(FREEBSD)
-            // these signals cannot be handled
-            if (signalNumber != SIGKILL && signalNumber != SIGSTOP) {
-#elif OS(WINDOWS)
-            // windows has no SIGSTOP
-            if (signalNumber != SIGKILL) {
-#else
-#error unknown OS
-#endif
-
+            if (signalCanBeHandled(signalNumber)) {
                 if (isAdded) {
                     if (!signalToContextIdsMap->contains(signalNumber)) {
                         SignalHandleValue signal_handle = {
@@ -4491,6 +4531,9 @@ void Process::finishCreation(JSC::VM& vm)
     Base::finishCreation(vm);
 
     wrapped().onDidChangeListener = &onDidChangeListeners;
+#if !OS(WINDOWS)
+    wrapped().onWillAddListener = &onWillAddListenerImpl;
+#endif
 
     m_cpuUsageStructure.initLater([](const JSC::LazyProperty<Process, JSC::Structure>::Initializer& init) {
         init.set(constructCPUUsageStructure(init.vm, init.owner->globalObject()));

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1451,6 +1451,12 @@ static bool onWillAddListenerImpl(EventEmitter& eventEmitter, const Identifier& 
 
 static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& eventName, bool isAdded)
 {
+    // Comparing an Identifier against a string literal compares characters, so
+    // Symbol("memoryPressure") would match below. None of these events, which
+    // are all keyed by their own Identifier, can ever be named by a Symbol.
+    if (eventName.isSymbol())
+        return;
+
     if (Bun__isMainThreadVM()) {
         if (eventName == "memoryPressure") {
             auto* global = eventEmitter.scriptExecutionContext()->jsGlobalObject();

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1412,6 +1412,17 @@ static bool signalCanBeHandled(int signalNumber)
 #endif
 }
 
+// A Symbol's Identifier hashes and compares by its description, so a plain
+// lookup would match Symbol("SIGKILL"). Only string event names name a signal.
+static int signalNumberForEventName(const Identifier& eventName)
+{
+    if (eventName.isSymbol())
+        return 0;
+
+    loadSignalNumberMap();
+    return signalNameToNumberMap->get(eventName.string());
+}
+
 #if !OS(WINDOWS)
 // Node starts signal watchers from a `newListener` hook on the main thread, so
 // uv_signal_start()'s EINVAL surfaces before the listener is ever added.
@@ -1420,8 +1431,7 @@ static bool onWillAddListenerImpl(EventEmitter& eventEmitter, const Identifier& 
     if (!Bun__isMainThreadVM())
         return true;
 
-    loadSignalNumberMap();
-    if (!isUncatchableSignal(signalNameToNumberMap->get(eventName.string())))
+    if (!isUncatchableSignal(signalNumberForEventName(eventName)))
         return true;
 
     auto* globalObject = eventEmitter.scriptExecutionContext()->jsGlobalObject();
@@ -1480,7 +1490,6 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
         }
 
         // Signal Handlers
-        loadSignalNumberMap();
         static std::once_flag signalNumberToNameMapOnceFlag;
         std::call_once(signalNumberToNameMapOnceFlag, [] {
             auto signalNames = getSignalNames();
@@ -1568,7 +1577,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
             signalToContextIdsMap = new HashMap<int, SignalHandleValue>();
         }
 
-        if (auto signalNumber = signalNameToNumberMap->get(eventName.string())) {
+        if (auto signalNumber = signalNumberForEventName(eventName)) {
             if (signalCanBeHandled(signalNumber)) {
                 if (isAdded) {
                     if (!signalToContextIdsMap->contains(signalNumber)) {

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -25,6 +25,8 @@ Ref<EventEmitter> EventEmitter::create(ScriptExecutionContext& context)
 
 bool EventEmitter::addListener(const Identifier& eventType, Ref<EventListener>&& listener, bool once, bool prepend)
 {
+    if (this->onWillAddListener && !this->onWillAddListener(*this, eventType)) [[unlikely]]
+        return false;
 
     if (prepend) {
         if (!ensureEventEmitterData().eventListenerMap.prepend(eventType, listener.copyRef(), once))

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -69,6 +69,10 @@ public:
 
     WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)> onDidChangeListener = WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)>(nullptr);
 
+    // Runs before the listener is added. Returning false rejects it; the hook
+    // owns throwing the exception the caller will then propagate.
+    WTF::Function<bool(EventEmitter&, const Identifier& eventName)> onWillAddListener = WTF::Function<bool(EventEmitter&, const Identifier& eventName)>(nullptr);
+
     unsigned getMaxListeners() const { return m_maxListeners; };
 
     void setMaxListeners(unsigned count);

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -72,6 +72,42 @@ describe.concurrent("process.on('memoryPressure')", () => {
     expect(exitCode).toBe(0);
   });
 
+  // An Identifier is compared against the "memoryPressure" literal by
+  // characters, so a Symbol of the same description used to enter the branch
+  // and drive the watcher off this event's own, separately keyed, listeners.
+  test("a Symbol of the same description does not arm or disarm the watcher", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { emitMemoryPressure, isMemoryPressureWatcherInstalled } = require("bun:internal-for-testing");
+      const sym = Symbol("memoryPressure");
+      const seen = [];
+      const installed = [];
+      const real = level => seen.push(level);
+      const onSymbol = () => seen.push("symbol listener fired");
+
+      installed.push(isMemoryPressureWatcherInstalled()); // false: no listeners yet
+      process.on(sym, onSymbol);
+      installed.push(isMemoryPressureWatcherInstalled()); // false: a Symbol arms nothing
+      process.on("memoryPressure", real);
+      installed.push(isMemoryPressureWatcherInstalled()); // true: the real listener armed it
+      process.off(sym, onSymbol);
+      installed.push(isMemoryPressureWatcherInstalled()); // true: removing the Symbol must not disarm
+
+      // The real listener is still wired up to the event.
+      emitMemoryPressure("warning");
+
+      process.stdout.write(JSON.stringify({ seen, installed, symbolCount: process.listenerCount(sym) }));
+    `);
+    expect({ stdout, stderr: stderr.trim() }).toEqual({
+      stdout: JSON.stringify({
+        seen: ["warning"],
+        installed: [false, false, true, true],
+        symbolCount: 0,
+      }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("process.once works", async () => {
     const { stdout, exitCode } = await run(/* js */ `
       const { emitMemoryPressure } = require("bun:internal-for-testing");

--- a/test/js/node/process/process-signal-listener-count.test.ts
+++ b/test/js/node/process/process-signal-listener-count.test.ts
@@ -211,8 +211,13 @@ test.skipIf(isWindows)("a Symbol whose description is a signal name installs no 
   const { stdout, stderr, exitCode, signalCode } = await runScript(script);
 
   expect({ stdout, stderr }).toEqual({ stdout: "", stderr: "" });
-  expect(signalCode).toBe("SIGUSR2");
+  // The process is killed by the signal (no handler), so it never reaches the
+  // exit(42) fallback. The specific signal name is not asserted: Bun.spawn maps
+  // the death signal number through a fixed table, and 31 is SIGUSR2 on macOS
+  // but SIGSYS on Linux, so the reported name differs by platform.
+  expect(signalCode).not.toBeNull();
   expect(exitCode).not.toBe(42);
+  expect(exitCode).not.toBe(0);
 });
 
 // Node only starts signal watchers on the main thread, so inside a worker

--- a/test/js/node/process/process-signal-listener-count.test.ts
+++ b/test/js/node/process/process-signal-listener-count.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { Worker } from "node:worker_threads";
 
 // When multiple listeners are registered for the same signal, removing one
 // listener must NOT uninstall the underlying OS signal handler while other
@@ -133,4 +134,97 @@ test.skipIf(isWindows)("re-adding a listener after removing all reinstalls the h
 done"
 `);
   expect(exitCode).toBe(0);
+});
+
+// SIGKILL and SIGSTOP cannot be caught, so Node rejects them at registration
+// time with the EINVAL that uv_signal_start() returns, and adds no listener.
+test.skipIf(isWindows)("listening for SIGKILL or SIGSTOP throws EINVAL and registers nothing", async () => {
+  const script = /*js*/ `
+    const probe = (sig, method) => {
+      try {
+        process[method](sig, () => {});
+        return { registered: true, listenerCount: process.listenerCount(sig) };
+      } catch (e) {
+        return {
+          name: e.name,
+          message: e.message,
+          code: e.code,
+          errno: e.errno,
+          syscall: e.syscall,
+          listenerCount: process.listenerCount(sig),
+        };
+      } finally {
+        process.removeAllListeners(sig);
+      }
+    };
+
+    const result = {};
+    for (const sig of ["SIGKILL", "SIGSTOP"]) {
+      for (const method of ["on", "addListener", "once", "prependListener", "prependOnceListener"]) {
+        result[sig + "." + method] = probe(sig, method);
+      }
+    }
+    result["SIGUSR2.on"] = probe("SIGUSR2", "on");
+    console.log(JSON.stringify(result));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // EINVAL is 22 on every platform Bun builds for; libuv reports it negated.
+  const einval = {
+    name: "Error",
+    message: "uv_signal_start EINVAL",
+    code: "EINVAL",
+    errno: -22,
+    syscall: "uv_signal_start",
+    listenerCount: 0,
+  };
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    "SIGKILL.on": einval,
+    "SIGKILL.addListener": einval,
+    "SIGKILL.once": einval,
+    "SIGKILL.prependListener": einval,
+    "SIGKILL.prependOnceListener": einval,
+    "SIGSTOP.on": einval,
+    "SIGSTOP.addListener": einval,
+    "SIGSTOP.once": einval,
+    "SIGSTOP.prependListener": einval,
+    "SIGSTOP.prependOnceListener": einval,
+    "SIGUSR2.on": { registered: true, listenerCount: 1 },
+  });
+  expect(exitCode).toBe(0);
+});
+
+// Node only starts signal watchers on the main thread, so inside a worker
+// process.on("SIGKILL") is an ordinary event listener and does not throw.
+test.skipIf(isWindows)("listening for SIGKILL inside a worker does not throw", async () => {
+  const source = /*js*/ `
+    const { parentPort } = require("node:worker_threads");
+    try {
+      process.on("SIGKILL", () => {});
+      parentPort.postMessage({ registered: true, listenerCount: process.listenerCount("SIGKILL") });
+    } catch (e) {
+      parentPort.postMessage({ threw: e.message });
+    }
+  `;
+
+  const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+  const worker = new Worker(source, { eval: true });
+  worker.on("message", resolve);
+  worker.on("error", reject);
+  worker.on("exit", code => reject(new Error(`worker exited with code ${code} before posting a message`)));
+
+  try {
+    expect(await promise).toEqual({ registered: true, listenerCount: 1 });
+  } finally {
+    await worker.terminate();
+  }
 });

--- a/test/js/node/process/process-signal-listener-count.test.ts
+++ b/test/js/node/process/process-signal-listener-count.test.ts
@@ -2,6 +2,18 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import { Worker } from "node:worker_threads";
 
+async function runScript(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
 // When multiple listeners are registered for the same signal, removing one
 // listener must NOT uninstall the underlying OS signal handler while other
 // listeners remain.
@@ -41,14 +53,7 @@ test.skipIf(isWindows)("removing one of multiple signal listeners keeps the hand
     console.log("done");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode } = await runScript(script);
 
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
@@ -82,21 +87,14 @@ test.skipIf(isWindows)("removing all signal listeners uninstalls the handler (de
     process.kill(process.pid, "SIGUSR2");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, exitCode, signalCode } = await runScript(script);
 
   expect(stdout).toBe("");
   // Default SIGUSR2 behavior is to terminate the process with a signal.
   // If the handler was correctly uninstalled, the process dies via signal (not exit code 42).
   expect(exitCode).not.toBe(42);
   expect(exitCode).not.toBe(0);
-  expect(proc.signalCode).not.toBeNull();
+  expect(signalCode).not.toBeNull();
 });
 
 // Re-adding a listener after all were removed should reinstall the handler.
@@ -119,14 +117,7 @@ test.skipIf(isWindows)("re-adding a listener after removing all reinstalls the h
     console.log("done");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode } = await runScript(script);
 
   expect(stderr).toBe("");
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
@@ -173,14 +164,7 @@ test.skipIf(isWindows)("listening for SIGKILL or SIGSTOP throws EINVAL and regis
     console.log(JSON.stringify(result));
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode } = await runScript(script);
 
   // EINVAL is 22 on every platform Bun builds for; libuv reports it negated.
   const einval = {
@@ -224,17 +208,10 @@ test.skipIf(isWindows)("a Symbol whose description is a signal name installs no 
     process.kill(process.pid, "SIGUSR2");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode, signalCode } = await runScript(script);
 
   expect({ stdout, stderr }).toEqual({ stdout: "", stderr: "" });
-  expect(proc.signalCode).toBe("SIGUSR2");
+  expect(signalCode).toBe("SIGUSR2");
   expect(exitCode).not.toBe(42);
 });
 

--- a/test/js/node/process/process-signal-listener-count.test.ts
+++ b/test/js/node/process/process-signal-listener-count.test.ts
@@ -165,6 +165,11 @@ test.skipIf(isWindows)("listening for SIGKILL or SIGSTOP throws EINVAL and regis
       }
     }
     result["SIGUSR2.on"] = probe("SIGUSR2", "on");
+
+    // A Symbol is never a signal name, even when its description reads like one.
+    result["Symbol(SIGKILL).on"] = probe(Symbol("SIGKILL"), "on");
+    result["Symbol(SIGSTOP).on"] = probe(Symbol("SIGSTOP"), "on");
+
     console.log(JSON.stringify(result));
   `;
 
@@ -199,8 +204,38 @@ test.skipIf(isWindows)("listening for SIGKILL or SIGSTOP throws EINVAL and regis
     "SIGSTOP.prependListener": einval,
     "SIGSTOP.prependOnceListener": einval,
     "SIGUSR2.on": { registered: true, listenerCount: 1 },
+    "Symbol(SIGKILL).on": { registered: true, listenerCount: 1 },
+    "Symbol(SIGSTOP).on": { registered: true, listenerCount: 1 },
   });
   expect(exitCode).toBe(0);
+});
+
+// An Identifier for a Symbol hashes and compares by its description, so
+// Symbol("SIGUSR2") used to match the signal-name map and install a real OS
+// handler. Node treats it as an ordinary event and lets SIGUSR2 kill us.
+test.skipIf(isWindows)("a Symbol whose description is a signal name installs no handler", async () => {
+  const script = /*js*/ `
+    process.on(Symbol("SIGUSR2"), () => {});
+
+    // Never reached: the default SIGUSR2 action terminates the process. Exists
+    // only so a missing handler-install shows up as 42 rather than a clean exit.
+    setTimeout(() => process.exit(42), 1000);
+
+    process.kill(process.pid, "SIGUSR2");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr }).toEqual({ stdout: "", stderr: "" });
+  expect(proc.signalCode).toBe("SIGUSR2");
+  expect(exitCode).not.toBe(42);
 });
 
 // Node only starts signal watchers on the main thread, so inside a worker


### PR DESCRIPTION
`process.on('SIGKILL', fn)` and `process.on('SIGSTOP', fn)` were silently accepted: the listener registered, `listenerCount` became 1, and it could never fire. Node rejects both at registration time, which is the only feedback a program ever gets that its "SIGKILL cleanup handler" is impossible. It also breaks the `try { process.on('SIGKILL', ...) } catch {}` capability probe some process-manager and signal-shim libraries use to detect uncatchable signals.

## Repro

```js
const attempt = sig => {
  try { process.on(sig, () => {}); return `registered (listenerCount=${process.listenerCount(sig)})`; }
  catch (e) { return `threw ${e.name} ${e.code} ${e.message}`; }
  finally { process.removeAllListeners(sig); }
};
console.log("SIGKILL ->", attempt("SIGKILL"));
console.log("SIGSTOP ->", attempt("SIGSTOP"));
```

```
node v26.3.0:  SIGKILL -> threw Error EINVAL uv_signal_start EINVAL
               SIGSTOP -> threw Error EINVAL uv_signal_start EINVAL
bun 1.4.0   :  SIGKILL -> registered (listenerCount=1)
               SIGSTOP -> registered (listenerCount=1)
```

## Cause

`onDidChangeListeners` in `BunProcess.cpp` guards the `sigaction(2)` call with `if (signalNumber != SIGKILL && signalNumber != SIGSTOP && ...)` and returns without doing anything else. The kernel refuses to install a handler for those two, so the guard is correct, but nothing reports the failure and the listener stays on the process EventEmitter.

Node installs signal watchers from a `newListener` hook, which runs *before* the listener is added. `uv_signal_start()` fails with `EINVAL` (that is `sigaction(2)`'s errno for the uncatchable pair), the hook throws, and the listener is never added, so `listenerCount` stays 0.

## Fix

`EventEmitter` gains an `onWillAddListener` veto hook that runs before the listener is added; returning false rejects it and the hook owns throwing. The process object installs one that throws Node's `ErrnoException` shape for `SIGKILL`/`SIGSTOP` (`Error: uv_signal_start EINVAL`, `code: 'EINVAL'`, `errno: -22`, `syscall: 'uv_signal_start'`). `on`, `addListener`, `once`, `prependListener` and `prependOnceListener` all route through `EventEmitter::addListener`, so every entry point is covered.

The platform-specific guard in `onDidChangeListeners` is factored into `signalCanBeHandled()` so the two questions stay separate: which signals Bun can install a handler for, and which signals Node rejects at registration.

Two places deliberately keep the old behavior, matching Node:

- **Worker threads.** Node's hook is main-thread-only, so a worker's `process.on('SIGKILL')` is an ordinary event listener and does not throw.
- **Windows.** libuv's `uv__signal_start()` only rejects `signum <= 0 || signum >= NSIG`, and `uv/win.h` raises `NSIG` to `SIGWINCH + 1`, so `SIGKILL` (9) passes and Node registers a watcher that never fires. There is no `SIGSTOP` on Windows at all.

## Also fixed: a Symbol event name was treated as a signal name

Found while reviewing the above. An `Identifier` for a Symbol hashes and compares by its description, and `signalNameToNumberMap` is a content-keyed `HashMap<String, int>`, so a Symbol matched the signal entry of the same name. The effect on released Bun:

```js
process.on(Symbol("SIGUSR2"), () => {});
process.kill(process.pid, "SIGUSR2");
setTimeout(() => console.log("SURVIVED"), 300);
```

```
node      -> killed by SIGUSR2
bun 1.4.0 -> SURVIVED      (a real sigaction(2) handler was installed)
```

The new registration hook inherited the same lookup, which would have turned `process.on(Symbol("SIGKILL"), fn)` into a throw. Both lookups now go through `signalNumberForEventName()`, which reports no signal for a Symbol, so the pre-existing handler-install bug is fixed in the same change. Node only ever treats string event names as signals.

## Also fixed: a Symbol event name matched the other `process` event branches

Same bug class as above, found in follow-up review. `onDidChangeListeners` compares the event name against `"memoryPressure"`, `"message"` and `"disconnect"` with `operator==(const Identifier&, const char*)`, which compares characters. The listener map keys Symbols separately, so the branch was entered on a Symbol but read the wrong listener count:

```js
const { isMemoryPressureWatcherInstalled } = require("bun:internal-for-testing");
process.on("memoryPressure", fn1);
process.on(Symbol("memoryPressure"), fn2);
process.off(Symbol-from-above, fn2);
isMemoryPressureWatcherInstalled(); // false, while fn1 is still registered
```

Removing the Symbol listener drove its own count to zero and uninstalled the OS memory-pressure watcher while the real listeners remained, so real memory pressure would never reach them again. An early `if (eventName.isSymbol()) return;` at the top of the function closes all of those sites at once. No Symbol can name any of these events.

## Verification

`bun bd test test/js/node/process/process-signal-listener-count.test.ts test/js/node/process/process-memory-pressure.test.ts` — 12 pass. Three new tests fail against the base `src/` and pass with the fix:

- `listening for SIGKILL or SIGSTOP throws EINVAL and registers nothing` (listeners register instead of throwing)
- `a Symbol whose description is a signal name installs no handler` (the child survives SIGUSR2 instead of dying with `signalCode === "SIGUSR2"`)
- `a Symbol of the same description does not arm or disarm the watcher` (the memory-pressure watcher is uninstalled while a real listener remains)

The three pre-existing tests in that file cover the normal install/uninstall path through the same `addListener` code. Also checked with `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` over a loop of rejected and accepted registrations, and `test/js/node/events/` (67 pass) for the shared `EventEmitter::addListener` change.

