### PR TITLE
node:v8: use the calendar month in the default heap snapshot filename

### DIFF
--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -114,7 +114,8 @@ function getDefaultHeapSnapshotPath() {
   const thread_id = worker_threads.threadId;
 
   const yyyy = date.getFullYear();
-  const mm = date.getMonth().toString().padStart(2, "0");
+  // getMonth() is 0-based; the filename carries the calendar month.
+  const mm = (date.getMonth() + 1).toString().padStart(2, "0");
   const dd = date.getDate().toString().padStart(2, "0");
   const hh = date.getHours().toString().padStart(2, "0");
   const MM = date.getMinutes().toString().padStart(2, "0");

--- a/test/js/bun/util/v8-heap-snapshot-fixture.ts
+++ b/test/js/bun/util/v8-heap-snapshot-fixture.ts
@@ -19,6 +19,14 @@ function describeSnapshot(json: any) {
   };
 }
 
+// The `yyyymmdd` a default snapshot filename is supposed to carry: local time,
+// 1-based calendar month, the way node writes it.
+function calendarDate(date: Date) {
+  const mm = (date.getMonth() + 1).toString().padStart(2, "0");
+  const dd = date.getDate().toString().padStart(2, "0");
+  return `${date.getFullYear()}${mm}${dd}`;
+}
+
 // Runs the snapshot through a third-party parser, then walks every node and edge.
 async function parseAndWalk(json: unknown) {
   const v8HeapSnapshot: typeof import("v8-heapsnapshot") = require("v8-heapsnapshot");
@@ -90,10 +98,14 @@ switch (mode) {
   }
 
   case "write-default": {
+    // Bracket the call so the caller still knows which date to expect if this
+    // process happens to cross midnight while the snapshot is being written.
+    const dateBefore = calendarDate(new Date());
     const path = require("node:v8").writeHeapSnapshot();
+    const dateAfter = calendarDate(new Date());
     const json = await Bun.file(path).json();
     require("node:fs").rmSync(path);
-    result = { filename: require("node:path").basename(path), ...describeSnapshot(json) };
+    result = { filename: require("node:path").basename(path), dateBefore, dateAfter, ...describeSnapshot(json) };
     break;
   }
 

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -1,6 +1,10 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "node:path";
+
+// Each test boots a fixture that snapshots its whole heap: ~150ms in a release
+// build, but ~4s under debug/ASAN, which leaves no room under the 5s default.
+if (isDebug || isASAN) setDefaultTimeout(60_000);
 
 const fixture = join(import.meta.dir, "v8-heap-snapshot-fixture.ts");
 

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -78,8 +78,11 @@ test("v8.getHeapSnapshot()", async () => {
 test("v8.writeHeapSnapshot()", async () => {
   // Without a path the snapshot is written to the cwd, so give it one we own.
   using dir = tempDir("v8-heap-snapshot", {});
-  const { filename, ...rest } = await runFixture("write-default", { cwd: String(dir) });
-  expect(filename).toMatch(/^Heap-\d{8}-\d{6}-\d+-\d+\.heapsnapshot$/);
+  const { filename, dateBefore, dateAfter, ...rest } = await runFixture("write-default", { cwd: String(dir) });
+  const defaultName = /^Heap-(\d{8})-\d{6}-\d+-\d+\.heapsnapshot$/;
+  expect(filename).toMatch(defaultName);
+  // The date is the calendar date the snapshot was taken on, not a 0-based month.
+  expect([dateBefore, dateAfter]).toContain(filename.match(defaultName)?.[1]);
   expect(rest).toEqual(structure);
 });
 


### PR DESCRIPTION
`v8.writeHeapSnapshot()` with no argument names the file with a 0-based month, so every default-named snapshot is dated one month in the past (and in January the month renders as `00`).

### Repro

```js
import v8 from "node:v8";
import fs from "node:fs";

const p = v8.writeHeapSnapshot();
try { fs.unlinkSync(p); } catch {}
console.log(p);
```

On 2026-07-06:

```
bun  : Heap-20260606-102202-19567-0.heapsnapshot
node : Heap.20260706.102202.19571.0.001.heapsnapshot
```

### Cause

`getDefaultHeapSnapshotPath()` in `src/js/node/v8.ts` builds the `yyyymmdd` field straight from `Date#getMonth()`, which is 0-based.

### Fix

Add the `+ 1`. Nothing else in the filename changes.

### Verification

`test/js/bun/util/v8-heap-snapshot.test.ts` already had a `v8.writeHeapSnapshot()` test, but it only checked the filename shape (`/^Heap-\d{8}-\d{6}-\d+-\d+\.heapsnapshot$/`), which the wrong month satisfies. It now also asserts the 8-digit date equals the calendar date the fixture observed. The fixture records the date on both sides of the `writeHeapSnapshot()` call and the test accepts either, so a run that crosses midnight can't flake.

Against `main` the strengthened test fails with:

```
error: expect(received).toContain(expected)

Expected to contain: "20260606"
Received: [ "20260706", "20260706" ]
```

and passes with the fix (all 6 tests in the file).

### One unrelated test change

`setDefaultTimeout(60_000)` on debug/ASAN builds, in the same file. Every test there boots a fixture that snapshots its whole heap: ~150ms in release, but ~3-5s under `bun bd`, which runs right up against the 5s default and times the file out on a loaded machine. Release runs keep the 5s budget.
