### PR TITLE
node:zlib: accept zstd pledgedSrcSize values of 4 GiB and larger

### DIFF
--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -197,14 +197,18 @@ mod _impl {
                 write_js_callback.with_async_context_if_needed(global),
             );
 
+            // `u64::MAX` is `ZSTD_CONTENTSIZE_UNKNOWN`. `ZSTD_CCtx_setPledgedSrcSize`
+            // takes a u64, so the only bound is what a JS number represents exactly.
             let mut pledged_src_size: u64 = u64::MAX;
             if pledged_src_size_value.is_number() {
-                pledged_src_size = u64::from(validators::validate_uint32(
+                pledged_src_size = u64::try_from(validators::validate_integer(
                     global,
                     pledged_src_size_value,
-                    format_args!("pledgedSrcSize"),
-                    false,
-                )?);
+                    "pledgedSrcSize",
+                    Some(0),
+                    Some(jsc::MAX_SAFE_INTEGER),
+                )?)
+                .expect("infallible: validated range");
             }
 
             let err = self.stream.with_mut(|s| s.init(pledged_src_size));

--- a/test/js/node/zlib/zstd-pledged-src-size.test.ts
+++ b/test/js/node/zlib/zstd-pledged-src-size.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { promisify } from "node:util";
+import * as zlib from "node:zlib";
+
+// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header
+// magic(4) | frame header descriptor(1) | [window descriptor(1)] | [dictionary id] | [frame content size]
+function frameContentSize(frame: Buffer): bigint | null {
+  expect(frame.readUInt32LE(0)).toBe(0xfd2fb528);
+  const descriptor = frame[4];
+  const singleSegment = (descriptor >> 5) & 1;
+  const offset = 5 + (singleSegment ? 0 : 1) + [0, 1, 2, 4][descriptor & 0b11];
+  switch (descriptor >> 6) {
+    case 0:
+      return singleSegment ? BigInt(frame[offset]) : null;
+    case 1:
+      return BigInt(frame.readUInt16LE(offset) + 256);
+    case 2:
+      return BigInt(frame.readUInt32LE(offset));
+    default:
+      return frame.readBigUInt64LE(offset);
+  }
+}
+
+// Finishing with ZSTD_e_flush instead of ZSTD_e_end means zstd never checks the pledged size
+// against what was actually written, so these can pledge 4 GiB without feeding it 4 GiB.
+// The pledge still goes into the frame header.
+const input = Buffer.alloc(64, 0x61);
+const flushOnly = (pledgedSrcSize: number) => ({ pledgedSrcSize, finishFlush: zlib.constants.ZSTD_e_flush });
+
+describe("zstd pledgedSrcSize", () => {
+  it("is written to the frame header unmodified when below 4 GiB", () => {
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(1000)))).toBe(1000n);
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(2 ** 32 - 1)))).toBe(4294967295n);
+  });
+
+  it("accepts 4 GiB and larger", () => {
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(2 ** 32)))).toBe(4294967296n);
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(2 ** 33 + 1)))).toBe(8589934593n);
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(Number.MAX_SAFE_INTEGER)))).toBe(
+      9007199254740991n,
+    );
+  });
+
+  it("accepts 4 GiB and larger when compressing asynchronously", async () => {
+    const compressed = await promisify(zlib.zstdCompress)(input, flushOnly(2 ** 32));
+    expect(frameContentSize(compressed)).toBe(4294967296n);
+  });
+
+  it("accepts 4 GiB and larger when streaming", async () => {
+    const encoder = zlib.createZstdCompress({ pledgedSrcSize: 2 ** 32 });
+    const chunks: Buffer[] = [];
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    encoder.on("data", chunk => chunks.push(chunk));
+    encoder.on("error", reject);
+    encoder.write(input, err => err && reject(err));
+    encoder.flush(() => resolve());
+    await promise;
+    encoder.destroy();
+    expect(frameContentSize(Buffer.concat(chunks))).toBe(4294967296n);
+  });
+
+  it("rejects values that are not a non-negative safe integer", () => {
+    for (const pledgedSrcSize of [Number.MAX_SAFE_INTEGER + 1, -1, 1.5, Infinity]) {
+      expect(() => zlib.createZstdCompress({ pledgedSrcSize })).toThrow(
+        expect.objectContaining({
+          code: "ERR_OUT_OF_RANGE",
+          message: expect.stringContaining('The value of "pledgedSrcSize" is out of range.'),
+        }),
+      );
+    }
+  });
+});

--- a/test/js/node/zlib/zstd-pledged-src-size.test.ts
+++ b/test/js/node/zlib/zstd-pledged-src-size.test.ts
@@ -36,9 +36,7 @@ describe("zstd pledgedSrcSize", () => {
   it("accepts 4 GiB and larger", () => {
     expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(2 ** 32)))).toBe(4294967296n);
     expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(2 ** 33 + 1)))).toBe(8589934593n);
-    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(Number.MAX_SAFE_INTEGER)))).toBe(
-      9007199254740991n,
-    );
+    expect(frameContentSize(zlib.zstdCompressSync(input, flushOnly(Number.MAX_SAFE_INTEGER)))).toBe(9007199254740991n);
   });
 
   it("accepts 4 GiB and larger when compressing asynchronously", async () => {

--- a/test/js/node/zlib/zstd-pledged-src-size.test.ts
+++ b/test/js/node/zlib/zstd-pledged-src-size.test.ts
@@ -46,25 +46,27 @@ describe("zstd pledgedSrcSize", () => {
 
   it("accepts 4 GiB and larger when streaming", async () => {
     const encoder = zlib.createZstdCompress({ pledgedSrcSize: 2 ** 32 });
-    const chunks: Buffer[] = [];
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-    encoder.on("data", chunk => chunks.push(chunk));
-    encoder.on("error", reject);
-    encoder.write(input, err => err && reject(err));
-    encoder.flush(() => resolve());
-    await promise;
-    encoder.destroy();
-    expect(frameContentSize(Buffer.concat(chunks))).toBe(4294967296n);
+    try {
+      const chunks: Buffer[] = [];
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      encoder.on("data", chunk => chunks.push(chunk));
+      encoder.on("error", reject);
+      encoder.on("close", () => reject(new Error("encoder closed before the flush completed")));
+      encoder.write(input, err => err && reject(err));
+      encoder.flush(() => resolve());
+      await promise;
+      expect(frameContentSize(Buffer.concat(chunks))).toBe(4294967296n);
+    } finally {
+      encoder.destroy();
+    }
   });
 
-  it("rejects values that are not a non-negative safe integer", () => {
-    for (const pledgedSrcSize of [Number.MAX_SAFE_INTEGER + 1, -1, 1.5, Infinity]) {
-      expect(() => zlib.createZstdCompress({ pledgedSrcSize })).toThrow(
-        expect.objectContaining({
-          code: "ERR_OUT_OF_RANGE",
-          message: expect.stringContaining('The value of "pledgedSrcSize" is out of range.'),
-        }),
-      );
-    }
+  it.each([Number.MAX_SAFE_INTEGER + 1, -1, 1.5, Infinity, NaN])("rejects %p as pledgedSrcSize", pledgedSrcSize => {
+    expect(() => zlib.createZstdCompress({ pledgedSrcSize })).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: expect.stringContaining('The value of "pledgedSrcSize" is out of range.'),
+      }),
+    );
   });
 });


### PR DESCRIPTION
### What's broken

`pledgedSrcSize` is the option you reach for when streaming a file too large to buffer, but pledging 4 GiB or more throws:

```js
const zlib = require("node:zlib");
zlib.createZstdCompress({ pledgedSrcSize: 2 ** 32 });
// RangeError: The value of "pledgedSrcSize" is out of range.
//             It must be >= 0 and <= 4294967295. Received 4294967296
// code: "ERR_OUT_OF_RANGE"
```

Same error from `zstdCompressSync`, `zstdCompress`, and `node:zlib/iter`'s `compressZstd`. Node accepts it: it only rejects negative values, and writes the pledge straight into the frame header.

### Cause

`NativeZstd.init` validated the option with `validate_uint32`, capping it at `2**32 - 1`. Everything downstream of that validator is already 64-bit: `Context.pledged_src_size` is a `u64`, and `ZSTD_CCtx_setPledgedSrcSize` takes a `c_ulonglong`. The zstd frame header's `Frame_Content_Size` field is up to 8 bytes, so sizes above 4 GiB are representable, they just never made it past the validator.

### Fix

Validate it as a non-negative safe integer (`0 ..= Number.MAX_SAFE_INTEGER`, which is the largest integer a JS number holds exactly) and pass the value through unmodified.

### Verification

`test/js/node/zlib/zstd-pledged-src-size.test.ts` pledges 4 GiB through all three compression APIs and reads the frame content size back out of the header, so it checks the value arrives at zstd unmodified rather than just that nothing threw. Finishing with `ZSTD_e_flush` instead of `ZSTD_e_end` skips zstd's pledged-vs-actual check, which is what lets the test pledge 4 GiB without feeding it 4 GiB.

Values below the old cap produce byte-identical output to before (and to node), `Number.MAX_SAFE_INTEGER` is accepted, and one past it, negatives, non-integers and `NaN` still throw `ERR_OUT_OF_RANGE`.

<details>
<summary>before / after</summary>

```
$ bun-1.4.0 test/js/node/zlib/zstd-pledged-src-size.test.ts
(fail) accepts 4 GiB and larger
(fail) accepts 4 GiB and larger when compressing asynchronously
(fail) accepts 4 GiB and larger when streaming
 6 pass, 3 fail

$ bun-debug test/js/node/zlib/zstd-pledged-src-size.test.ts
 9 pass, 0 fail
```

`test/js/node/test/parallel/test-zlib-zstd-pledged-src-size.js`, `test/js/node/test/parallel/test-stream-iter-validation.js`, `test/js/node/zlib/zlib.test.js` and `test/regression/issue/23314/` all still pass.

</details>
