### PR TITLE
Runtime plugins: stop treating a single-letter namespace as a Windows drive

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -66,8 +66,12 @@ pub trait PluginResolver {
 pub struct PluginRunner;
 
 impl PluginRunner {
-    /// Returns the `namespace:` prefix of `specifier`, or `b""` if it has none
-    /// (Windows drive-letter prefixes are not namespaces).
+    /// Returns the `namespace:` prefix of `specifier`, or `b""` if it has none.
+    ///
+    /// A Windows drive root (`C:\` / `C:/`) is a path, never a namespace, and
+    /// only on Windows: everywhere else `q:pp` names the namespace `q`. The
+    /// same rule is spelled out in `isWindowsDriveRoot` (ZigGlobalObject.cpp),
+    /// which decides whether a module key is already plugin-resolved.
     pub fn extract_namespace(specifier: &[u8]) -> &[u8] {
         let Some(colon) = bun_core::strings::index_of_char_usize(specifier, b':') else {
             return b"";
@@ -75,10 +79,9 @@ impl PluginRunner {
         let colon = colon as usize;
         if cfg!(windows)
             && colon == 1
-            && specifier.len() > 3
+            && specifier.len() > 2
+            && bun_paths::resolve_path::is_drive_letter(specifier[0])
             && bun_paths::resolve_path::is_sep_any(specifier[2])
-            && ((specifier[0] > b'a' && specifier[0] < b'z')
-                || (specifier[0] > b'A' && specifier[0] < b'Z'))
         {
             return b"";
         }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3373,6 +3373,22 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject* g
     globalObject->vm().queueMicrotask(WTF::move(task));
 }
 
+// A module key only hides a plugin namespace behind a Windows drive root:
+// "C:\\..." or "C:/...", and only when running on Windows. Anywhere else,
+// "q:pp" names the namespace "q". Keep this in lockstep with
+// `PluginRunner::extract_namespace` (src/bundler/transpiler.rs), which decides
+// the namespace everywhere past this point.
+static bool isWindowsDriveRoot(const WTF::String& key, size_t colon)
+{
+#if OS(WINDOWS)
+    return colon == 1 && key.length() > 2 && isASCIIAlpha(key[0]) && (key[2] == '/' || key[2] == '\\');
+#else
+    UNUSED_PARAM(key);
+    UNUSED_PARAM(colon);
+    return false;
+#endif
+}
+
 JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject,
     JSModuleLoader* loader, JSValue key,
     JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool)
@@ -3421,9 +3437,7 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     // to mark keys it already resolved so we can skip only those.
     if (!globalObject->onLoadPlugins.namespaces.isEmpty()) {
         auto keyStr = keyZ.toWTFString();
-        if (auto colon = keyStr.find(':'); colon != WTF::notFound && !(colon == 1 && isASCIIAlpha(keyStr[0]))) {
-            // colon == 1 with a leading ASCII letter is a Windows drive
-            // ("C:\\..."), never a plugin namespace.
+        if (auto colon = keyStr.find(':'); colon != WTF::notFound && !isWindowsDriveRoot(keyStr, colon)) {
             auto ns = keyStr.left(colon);
             for (const auto& registered : globalObject->onLoadPlugins.namespaces) {
                 if (registered == ns) {

--- a/test/js/bun/plugin/plugin-namespace-drive-letter.test.ts
+++ b/test/js/bun/plugin/plugin-namespace-drive-letter.test.ts
@@ -1,12 +1,13 @@
 // moduleLoaderResolve short-circuits keys whose "ns:" prefix matches a
 // registered onLoad namespace so the C++ loader doesn't re-resolve a key the
-// plugin already produced. A single-letter prefix like "C:" is a Windows
-// drive, never a plugin namespace; resolving "C:\\..." with a one-letter
-// namespace registered must still reach the filesystem resolver.
+// plugin already produced. On Windows a single letter followed by ":" and a
+// separator is a drive root ("C:\\..."), never a namespace, so such a key must
+// still reach the filesystem resolver. Other platforms have no drive roots, so
+// the prefix is the namespace, matching PluginRunner::extract_namespace.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-test("single-letter plugin namespace does not capture Windows drive paths", async () => {
+test("a single-letter namespace never captures a Windows drive root", async () => {
   using dir = tempDir("plugin-ns-drive-letter", {
     "preload.ts": `
       Bun.plugin({
@@ -22,18 +23,16 @@ test("single-letter plugin namespace does not capture Windows drive paths", asyn
       });
     `,
     // Static import of a non-existent absolute Windows path. moduleLoaderResolve
-    // sees the literal "C:\\..." key; the short-circuit must not treat the
-    // single-letter "C" prefix as the registered plugin namespace.
+    // sees the literal "C:\\..." key.
     "uses-drive.mjs": `
       import x from "C:\\\\__definitely_missing__\\\\x.js";
       export default x;
     `,
     "entry.mjs": `
       try {
-        await import("./uses-drive.mjs");
-        console.log("imported");
-      } catch (e) {
-        console.log("rejected:" + (e && e.constructor && e.constructor.name));
+        console.log("loaded:" + (await import("./uses-drive.mjs")).default);
+      } catch {
+        console.log("rejected");
       }
     `,
   });
@@ -45,9 +44,7 @@ test("single-letter plugin namespace does not capture Windows drive paths", asyn
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // Must NOT have produced "imported".
-  expect(stdout.trim().startsWith("rejected:")).toBe(true);
-  expect(stdout).not.toContain("imported");
+
+  expect(stdout.trim() || stderr).toBe(isWindows ? "rejected" : "loaded:from-plugin");
   expect(exitCode).toBe(0);
-  void stderr;
 });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -690,6 +690,74 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
     resolveSync: target,
     importMetaResolve: Bun.pathToFileURL(target).href,
   });
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("onResolve namespaces of any length reach onLoad", async () => {
+  using dir = tempDir("plugin-onresolve-short-namespace", {
+    "entry.js": `
+      const namespaces = ["q", "A", "qq"];
+
+      Bun.plugin({
+        name: "short-namespaces",
+        setup(build) {
+          for (const ns of namespaces) {
+            build.onResolve({ filter: new RegExp("^bare-" + ns + "\\\\.mod$") }, () => ({ path: "pp", namespace: ns }));
+            build.onResolve({ filter: new RegExp("^nested-" + ns + "\\\\.mod$") }, () => ({ path: "sub/pp", namespace: ns }));
+            build.onResolve({ filter: new RegExp("^rooted-" + ns + "\\\\.mod$") }, () => ({ path: "/pp", namespace: ns }));
+            build.onLoad({ filter: /.*/, namespace: ns }, ({ path }) => ({
+              contents: "export const value = " + JSON.stringify(ns + "|" + path) + ";",
+              loader: "js",
+            }));
+          }
+        },
+      });
+
+      async function attempt(specifier) {
+        try {
+          return (await import(specifier)).value;
+        } catch (error) {
+          return "threw: " + error.message;
+        }
+      }
+
+      console.log(
+        JSON.stringify({
+          bare: await attempt("bare-q.mod"),
+          bareUpper: await attempt("bare-A.mod"),
+          bareTwoLetter: await attempt("bare-qq.mod"),
+          nested: await attempt("nested-q.mod"),
+          rootedTwoLetter: await attempt("rooted-qq.mod"),
+          rooted: await attempt("rooted-q.mod"),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fixture catches its own failures, so empty stdout means it crashed.
+  const { rooted, ...rest } = stdout.trim() ? JSON.parse(stdout) : { crashed: stderr };
+  expect(rest).toEqual({
+    bare: "q|pp",
+    bareUpper: "A|pp",
+    bareTwoLetter: "qq|pp",
+    nested: "q|sub/pp",
+    rootedTwoLetter: "qq|/pp",
+  });
+  // "q:/pp" is the one shape a single-letter namespace cannot have on Windows:
+  // it is a drive root there, so it goes to the filesystem resolver instead.
+  if (isWindows) {
+    expect(rooted).toStartWith("threw: ");
+  } else {
+    expect(rooted).toBe("q|/pp");
+  }
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
A runtime `Bun.plugin` `onResolve` result with a single-letter `namespace` silently loses the namespace: the registered `onLoad` never runs and the import fails. Two or more letters work, and the same plugin works under `Bun.build`.

```js
const mk = ns => ({
  name: "p" + ns,
  setup(b) {
    b.onResolve({ filter: new RegExp(`^virt-${ns}\\.mod$`) }, () => ({ path: "pp", namespace: ns }));
    b.onLoad({ filter: /.*/, namespace: ns }, () => ({ contents: `export default ${JSON.stringify("NS-" + ns)}`, loader: "js" }));
  },
});
for (const ns of ["q", "z", "A", "qq"]) {
  Bun.plugin(mk(ns));
  try { console.log(`ns=${ns} ->`, (await import(`virt-${ns}.mod`)).default); }
  catch (e) { console.log(`ns=${ns} -> ERR`, e.message.split("\n")[0]); }
}
```

```
ns=q  -> ERR Cannot find package 'q:pp' from ''
ns=z  -> ERR Cannot find package 'z:pp' from ''
ns=A  -> ERR Cannot find package 'A:pp' from ''
ns=qq -> NS-qq
```

## Cause

`onResolve`'s `{ path, namespace }` is serialized into the module key `"ns:path"`, and the loader re-parses it. Since #29393 the C++ module loader calls `resolve()` a second time on keys that `moduleLoaderImportModule` already resolved, so `moduleLoaderResolve` short-circuits a key whose `"ns:"` prefix names a registered `onLoad` namespace and returns it unchanged.

That short-circuit carved out Windows drive letters with `colon == 1 && isASCIIAlpha(key[0])`, which is true for every single-letter namespace, on every platform. `"q:pp"` was read as drive `q:`, fell through to the filesystem resolver, and failed.

`PluginRunner::extract_namespace`, which decides the namespace everywhere past that point (`Bun__runVirtualModule`, `Zig__GlobalObject__resolve`), already had the correct rule, so the two disagreed about what `"q:pp"` means.

## Fix

`moduleLoaderResolve` now only treats a prefix as a drive when it is an actual Windows drive root (`C:\` or `C:/`) and the process is running on Windows, matching `extract_namespace`.

`extract_namespace` spelled the same carve-out with an exclusive comparison (`specifier[0] > b'a' && specifier[0] < b'z'`), which excluded the `a`, `z`, `A` and `Z` drive letters; it now uses `bun_paths::resolve_path::is_drive_letter` so both sides state the same rule.

No change on non-Windows for `extract_namespace`; on Windows, `a:\x` / `z:\x` / `A:\x` / `Z:\x` and the bare drive root `C:\` are now drives rather than namespaces.

## Behavior change worth a maintainer's eye

One user-visible semantic changes off Windows, and it is the only judgement call in this PR.

With a single-letter namespace registered for `onLoad` and no `onResolve` for it, a specifier shaped like `C:\foo\x.js` now reaches that plugin instead of the filesystem resolver. This is not a new reading of `C:\...`, it is the reading the rest of the runtime already used. On **stock 1.4.0, unpatched, Linux**, an `onResolve` registered for namespace `C` already claims it:

```
onResolve(ns=C) path="\\__definitely_missing__\\x.js"
onLoad(ns=C)    path="\\__definitely_missing__\\x.js"
result: captured
```

`extract_namespace` gates its drive-root carve-out on Windows, so off Windows `C:\foo` has always been the namespace `C` to `Zig__GlobalObject__resolve` and `Bun__runVirtualModule`. `moduleLoaderResolve` was the single site that disagreed. This PR makes it agree.

The platform gate is load-bearing rather than cosmetic. Keeping the carve-out on every platform and only requiring the separator would still drop `{ path: "/pp", namespace: "q" }`, whose key is `q:/pp`. That case and the `C:\...` case are the same shape pulling in opposite directions, so one of them has to lose per platform: drive roots exist only on Windows, so the drive reading wins there and the namespace reading wins everywhere else.

If you would rather keep `C:\...` rejecting off Windows, say so and I will drop the platform gate, at the cost of leaving single-letter namespaces with absolute paths broken.

## Verification

`test/js/bun/plugin/plugins.test.ts` gains `onResolve namespaces of any length reach onLoad`, covering one-letter (`q`, `A`) and two-letter namespaces across bare (`q:pp`), nested (`q:sub/pp`) and rooted (`q:/pp`) paths. `q:/pp` is the one shape a one-letter namespace cannot have on Windows (it is a drive root there), so that case is asserted per platform.

`test/js/bun/plugin/plugin-namespace-drive-letter.test.ts` keeps asserting that a one-letter namespace never captures `C:\...` on Windows, and now asserts the other half of the rule elsewhere: platforms without drive roots read the prefix as the namespace, like `extract_namespace` already did for `onResolve`.

Both fail on `main` and pass with the fix.

The Windows half of the rule is covered on real Windows, not just by inspection: on the previous CI run both files ran on the `windows 2019 x64` lane and passed (`plugins.test.ts` in shard 0/8, `35 pass, 0 fail`; `plugin-namespace-drive-letter.test.ts` in shard 7/8). Before pushing, the `#if OS(WINDOWS)` branch was also compiled and exercised on Linux by forcing the predicate on, which flipped both per-platform assertions to their Windows values as expected.

The red check is infrastructure, not this diff: the latest build expired waiting for agents on every platform and ran zero tests, and the one before it failed a single darwin shard on a 120s artifact-download timeout. Breakdown in the first comment.



