### PR TITLE
FileSystemRouter: strip the URL fragment before parsing the path

### DIFF
--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -47,6 +47,15 @@ impl URLPath {
 // percent-encoded path, which is the rare case.
 
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
+    // The fragment starts at the first '#' and is part of neither the pathname nor
+    // the query (WHATWG URL). Cut it off the raw input, before percent-decoding, so
+    // that an encoded '#' ("%23") still decodes to a literal byte in the pathname.
+    let possibly_encoded_pathname_ =
+        match strings::index_of_char_usize(possibly_encoded_pathname_, b'#') {
+            Some(hash_i) => &possibly_encoded_pathname_[..hash_i],
+            None => possibly_encoded_pathname_,
+        };
+
     let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
     let mut decoded_storage: Option<Box<[u8]>> = None;
     let mut needs_redirect = false;

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -644,6 +644,78 @@ it(".params decodes percent escapes in a route segment exactly once", () => {
   expect(percent.params.id).toBe("100%25");
 });
 
+it("match() drops the URL fragment from the pathname and the query string", () => {
+  // The root "[id]" is what a leaked fragment makes "/about#top" fall through to.
+  const { dir } = make(["index.tsx", "about.tsx", "[id].tsx", "posts/[id].tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
+
+  // The fragment belongs to neither the pathname nor the query string, so each of
+  // these must match what the same URL without its fragment matches.
+  const about = router.match("/about#top")!;
+  expect({ name: about.name, pathname: about.pathname, params: about.params, query: about.query }).toEqual({
+    name: "/about",
+    pathname: "/about",
+    params: {},
+    query: {},
+  });
+
+  const withQuery = router.match("/about?a=1#top")!;
+  expect({ name: withQuery.name, pathname: withQuery.pathname, query: withQuery.query }).toEqual({
+    name: "/about",
+    pathname: "/about?a=1",
+    query: { a: "1" },
+  });
+
+  const dynamic = router.match("/posts/xyz#frag")!;
+  expect({ name: dynamic.name, pathname: dynamic.pathname, params: dynamic.params }).toEqual({
+    name: "/posts/[id]",
+    pathname: "/posts/xyz",
+    params: { id: "xyz" },
+  });
+
+  // Only the first '#' delimits; '?' and '#' after it are part of the fragment.
+  const nested = router.match("/posts/xyz#a?b=2#c")!;
+  expect({ name: nested.name, pathname: nested.pathname, params: nested.params, query: nested.query }).toEqual({
+    name: "/posts/[id]",
+    pathname: "/posts/xyz",
+    params: { id: "xyz" },
+    query: { id: "xyz" },
+  });
+
+  // A fragment on a percent-encoded pathname: the decode still happens, the
+  // fragment still goes away.
+  const encodedPath = router.match("/posts/a%20b#frag")!;
+  expect({ name: encodedPath.name, pathname: encodedPath.pathname, params: encodedPath.params }).toEqual({
+    name: "/posts/[id]",
+    pathname: "/posts/a b",
+    params: { id: "a b" },
+  });
+
+  // "%23" is an escaped '#', not a fragment delimiter.
+  const encodedHash = router.match("/posts/a%23b#frag")!;
+  expect({ name: encodedHash.name, pathname: encodedHash.pathname, params: encodedHash.params }).toEqual({
+    name: "/posts/[id]",
+    pathname: "/posts/a#b",
+    params: { id: "a#b" },
+  });
+
+  expect(router.match("/about#")?.name).toBe("/about");
+  expect(router.match("/#frag")?.name).toBe("/");
+
+  // The absolute-URL form already went through the URL parser; both forms agree.
+  const absolute = router.match("https://example.com/posts/xyz?a=1#top")!;
+  expect({ name: absolute.name, pathname: absolute.pathname, params: absolute.params, query: absolute.query }).toEqual({
+    name: "/posts/[id]",
+    pathname: "/posts/xyz?a=1",
+    params: { id: "xyz" },
+    query: { id: "xyz", a: "1" },
+  });
+});
+
 it("caps the number of parsed query string parameters instead of crashing", async () => {
   // A query string with more parameters than the iterator's fixed-size visited
   // bitset (2048 entries) must not be able to take down the process when

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -706,6 +706,15 @@ it("match() drops the URL fragment from the pathname and the query string", () =
   expect(router.match("/about#")?.name).toBe("/about");
   expect(router.match("/#frag")?.name).toBe("/");
 
+  // Nothing is left of the path once the fragment goes, so these reach the same
+  // empty-pathname guard that a path percent-decoding to nothing does.
+  expect(router.match("#frag")?.name).toBe("/");
+  expect(router.match("#")?.name).toBe("/");
+
+  // A malformed escape inside the fragment is never decoded, so it can no longer
+  // make match() throw DecodingError. This only holds if the cut runs first.
+  expect(router.match("/about#%zz")?.name).toBe("/about");
+
   // The absolute-URL form already went through the URL parser; both forms agree.
   const absolute = router.match("https://example.com/posts/xyz?a=1#top")!;
   expect({ name: absolute.name, pathname: absolute.pathname, params: absolute.params, query: absolute.query }).toEqual({


### PR DESCRIPTION
## What

`Bun.FileSystemRouter.match(pathString)` never stripped the URL fragment, so everything after `#` stayed in the pathname and leaked into the params and the query string. Passing the same URL as an absolute URL string behaved correctly, because that form goes through the URL parser before `URLPath::parse` sees it.

```js
const dir = fs.mkdtempSync(os.tmpdir() + "/fsr-frag-");
fs.writeFileSync(dir + "/about.tsx", "export default 1;\n");
fs.writeFileSync(dir + "/[id].tsx", "export default 1;\n");

const router = new Bun.FileSystemRouter({ style: "nextjs", dir });
for (const p of ["/about#top", "/about?a=1#top", "/xyz#frag", "http://h/about#top"]) {
  const m = router.match(p);
  console.log(p, "->", m && { name: m.name, params: m.params, query: m.query });
}
```

| input | before | after |
| :-- | :-- | :-- |
| `/about#top` | `/[id]`, `params.id === "about#top"` | `/about`, `params === {}` |
| `/about?a=1#top` | `/about`, `query.a === "1#top"` | `/about`, `query.a === "1"` |
| `/xyz#frag` | `params.id === "xyz#frag"` | `params.id === "xyz"` |
| `/about#%zz` | **throws** `DecodingError` | `/about` |
| `http://h/about#top` | `/about` | `/about` (unchanged) |

The first row is the one that bites: a fragment changes *which* route matches, so `/about#top` falls through to the `[id]` catch-all instead of the static `/about` page. Routing and cache keys derived from `m.params` disagree between Bun's own two input forms for the same URL.

## Cause

`URLPath::parse` (`src/http_types/URLPath.rs`) scans for `?`, `.` and `/` and has no `#` case at all, so the fragment bytes stay in `pathname`, in `path` (which is what the route matcher runs against) and in `query_string`.

## Fix

Cut the input at the first `#` at the top of `URLPath::parse`. Per WHATWG URL the fragment is part of neither the pathname nor the query, so everything downstream (`path`, `pathname`, `query_string`, `extname`) then sees a fragment-free slice.

The cut happens on the raw input, *before* percent-decoding: `%23` is an escaped `#`, not a fragment delimiter, so `match("/posts/a%23b")` must keep producing `params.id === "a#b"`. It also means a fragment is never decoded, so a malformed escape inside one (`/about#%zz`) no longer aborts the parse, which the caller used to surface as a thrown `Error` from a method declared to return `MatchedRoute | null`.

`URLPath::parse` has exactly one caller, `FileSystemRouter.match()`.

## Verification

`bun bd test test/js/bun/util/filesystem_router.test.ts` — 28 pass, 0 fail. The new test fails on the released binary and on `main`:

<details>
<summary><code>match() drops the URL fragment from the pathname and the query string</code> before the fix</summary>

```
error: expect(received).toEqual(expected)

  {
-   "name": "/about",
-   "params": {},
-   "pathname": "/about",
-   "query": {},
+   "name": "/[id]",
+   "params": {
+     "id": "about#top",
+   },
+   "pathname": "/about#top",
+   "query": {
+     "id": "about#top",
+   },
  }
```

</details>

It covers the fragment on a static route, on a dynamic route, alongside a query string, an empty fragment, a fragment containing `?` and further `#` (only the first one delimits), a fragment on a percent-encoded pathname, `%23` staying a literal `#`, a malformed escape inside the fragment, a fragment-only input (`"#frag"`, which newly reaches the empty-pathname guard that a path percent-decoding to nothing also hits), and the absolute-URL form agreeing with the path-string form.

## Note on #32850

#32850 (open) rewrites the same function so the path/query split also runs on the raw input. The two changes are independent, but they touch adjacent lines: whichever lands first, the other's rebase is just re-placing the fragment cut at the top of `parse()`, ahead of the `?` split. That PR also fixes the separate `?` bug I noticed here, where the scan takes the *last* `?` instead of the first, so `/about?a=1?b=2` matches `/[id]` with `params.id === "about?a=1"`.

