### PR TITLE
console: substitute format specifiers in the first argument only

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1414,6 +1414,21 @@ impl FormatOptions {
 // format2
 // ───────────────────────────────────────────────────────────────────────────
 
+/// https://console.spec.whatwg.org/#formatter
+/// Only `vals[0]` is a format string, and only when it is a primitive string.
+/// Later arguments are data: a `%s` inside one of them prints verbatim.
+fn is_format_string(
+    value: JSValue,
+    tag: TagPayload,
+    any_printed: bool,
+    remaining: &[JSValue],
+) -> bool {
+    !any_printed
+        && !remaining.is_empty()
+        && matches!(tag, TagPayload::String)
+        && value.is_string_literal()
+}
+
 pub fn format2(
     level: MessageLevel,
     global: &JSGlobalObject,
@@ -1517,12 +1532,12 @@ pub fn format2(
             if any {
                 let _ = writer.write_all(b" ");
             }
-            any = true;
 
             tag = formatter::Tag::get(this_value, global)?;
-            if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
+            if is_format_string(this_value, tag.tag, any, fmt.remaining()) {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
+            any = true;
 
             fmt.format::<true>(tag, writer, this_value, global)?;
             if fmt.remaining().is_empty() {
@@ -1540,11 +1555,12 @@ pub fn format2(
             if any {
                 let _ = writer.write_all(b" ");
             }
-            any = true;
+
             tag = formatter::Tag::get(this_value, global)?;
-            if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
+            if is_format_string(this_value, tag.tag, any, fmt.remaining()) {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
+            any = true;
 
             fmt.format::<false>(tag, writer, this_value, global)?;
             if fmt.remaining().is_empty() {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -153,6 +153,13 @@ pub struct FormatOptions {
     pub quote_strings: bool,
 }
 
+/// https://console.spec.whatwg.org/#formatter
+/// Only `vals[0]` is a format string, and only when it is a primitive string.
+/// Later arguments are data: a `%s` inside one of them prints verbatim.
+fn is_format_string(value: JSValue, tag: Tag, any_printed: bool, remaining: &[JSValue]) -> bool {
+    !any_printed && !remaining.is_empty() && tag == Tag::String && value.is_string_literal()
+}
+
 impl JestPrettyFormat {
     pub fn format<W: bun_io::Write>(
         level: MessageLevel,
@@ -229,12 +236,12 @@ impl JestPrettyFormat {
                     if any {
                         let _ = writer.write_all(b" ");
                     }
-                    any = true;
 
                     tag = Tag::get(this_value, global)?;
-                    if tag.tag == Tag::String && !fmt.remaining_values.is_empty() {
+                    if is_format_string(this_value, tag.tag, any, fmt.remaining_values) {
                         tag.tag = Tag::StringPossiblyFormatted;
                     }
+                    any = true;
 
                     fmt.format::<W, true>(tag, writer, this_value, global)?;
                     if fmt.remaining_values.is_empty() {
@@ -252,11 +259,12 @@ impl JestPrettyFormat {
                     if any {
                         let _ = writer.write_all(b" ");
                     }
-                    any = true;
+
                     tag = Tag::get(this_value, global)?;
-                    if tag.tag == Tag::String && !fmt.remaining_values.is_empty() {
+                    if is_format_string(this_value, tag.tag, any, fmt.remaining_values) {
                         tag.tag = Tag::StringPossiblyFormatted;
                     }
+                    any = true;
 
                     fmt.format::<W, false>(tag, writer, this_value, global)?;
                     if fmt.remaining_values.is_empty() {

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -150,3 +150,61 @@ it("console.log with SharedArrayBuffer", () => {
   expect(Bun.inspect(new ArrayBuffer(3))).toBe("ArrayBuffer(3) [ 0, 0, 0 ]");
   expect(Bun.inspect(new SharedArrayBuffer(3))).toBe("SharedArrayBuffer(3) [ 0, 0, 0 ]");
 });
+
+// https://console.spec.whatwg.org/#formatter
+// Only the first argument is a format string, and only when it is a primitive
+// string. Later arguments are data: a "%s"/"%d"/"%%" inside them prints
+// verbatim and must not consume the arguments that follow it.
+const formatterCases: [args: string, expected: string][] = [
+  [`"a", "100%foo", 42`, `a 100%foo 42`],
+  [`"q", "/p?x=%ff", 8`, `q /p?x=%ff 8`],
+  [`"l", "%d %s", 1, "t"`, `l %d %s 1 t`],
+  [`"x", "%%", 1`, `x %% 1`],
+  [`"x", "%c", "color:red", "y"`, `x %c color:red y`],
+  [`"%s %s", "a", "b", "%s", "c"`, `a b %s c`],
+  [`1, "%d", 2`, `1 %d 2`],
+  [`/%d/, 1`, `/%d/ 1`],
+  // Still substituted: a primitive string in first position.
+  [`"%d/%s", 7, "k"`, `7/k`],
+  [`"%%d", 1`, `%d 1`],
+];
+
+// The per-argument loop is written twice, once per color mode. Exercise both.
+for (const enableColors of [false, true]) {
+  it(`console.log substitutes format specifiers in the first argument only (colors: ${enableColors})`, async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", formatterCases.map(([args]) => `console.log(${args});`).join("\n")],
+      env: enableColors ? { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" } : bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      lines: Bun.stripANSI(stdout).split("\n").slice(0, -1),
+      // Guards against the colored branch silently not being taken.
+      colored: stdout.includes("\x1b["),
+      exitCode,
+    }).toEqual({
+      lines: formatterCases.map(([, expected]) => expected),
+      colored: enableColors,
+      exitCode: 0,
+    });
+    expect(stderr).not.toContain("error:");
+  });
+}
+
+it("console.log does not treat a String object as a format string", async () => {
+  // typeof new String("%d") is "object", so node's formatter (and ours) skips it.
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", `console.log(new String("%d"), 1); console.log("a", new String("%d"), 1);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // node prints [String: '%d']; bun's inspect quotes with " instead of '.
+  expect({ stdout, exitCode }).toEqual({ stdout: `[String: "%d"] 1\na [String: "%d"] 1\n`, exitCode: 0 });
+  expect(stderr).not.toContain("error:");
+});


### PR DESCRIPTION
## What

`console.log()` (and every other console level) applied `%s`/`%d`/`%f`/`%o`/`%c`/`%%` substitution to **every** top-level string argument, not just `args[0]`. A later argument that merely contained a `%` silently consumed and reformatted the arguments after it, so they disappeared from the output entirely.

```console
$ bun -e 'console.log("a", "100%foo", 42); console.log("q", "/p?x=%ff", 8); console.log("l", "%d %s", 1, "t")'
a 10042oo         # before
q /p?x=8f
l 1 t

a 100%foo 42      # after (matches node)
q /p?x=%ff 8
l %d %s 1 t
```

Logging a URL, a query string, or a percentage as a second argument is a common pattern, and the `42` / `8` above are gone from the line, not just reformatted.

## Root cause

`src/jsc/ConsoleObject.rs`, the per-argument loop in `format2` (both the color and no-color copies):

```rust
tag = formatter::Tag::get(this_value, global)?;
if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
    tag.tag = TagPayload::StringPossiblyFormatted;
}
```

The loop walks every argument through the same body, so every string argument with something after it got promoted to `StringPossiblyFormatted` and ran through `write_with_formatting`, which pulls its substitutions out of `remaining_values`. The promotion is only correct for `vals[0]`.

Two smaller divergences fall out of the same predicate:

- `TagPayload::String` also covers `StringObject` / `DerivedStringObject` / `RegExpObject`, so `console.log(/%d/, 1)` printed `/1/` and `console.log(new String("%d"), 1)` printed `1`. The [WHATWG Formatter](https://console.spec.whatwg.org/#formatter) only treats a primitive string as a format string (node checks `typeof first === 'string'`).
- Consequently `console.log("%s %s", "a", "b", "%s", "c")` printed `a b c` instead of `a b %s c`.

`util.format` is implemented separately in JS and was already correct; only the native console path diverged.

## Fix

Gate the promotion on being the first argument and on that argument being a primitive string, via a shared `is_format_string` helper used by both copies of the loop.

## Sibling site

`src/runtime/test_runner/pretty_format.rs` holds a byte-identical copy of this loop (the jest snapshot/diff formatter, with its own local `Tag` enum). Its multi-value path is unreachable today: all three callers (`test_runner/mod.rs:208`, `test_runner/diff_format.rs:47` and `:56`) pass `core::slice::from_ref(&x)` with `len = 1`, so the `len == 1` branch returns first. The same gate is applied there anyway to keep the two copies from silently diverging. No behavior change, so no test covers it.

## Verification

`test/js/web/console/console-log.test.ts` gains a table of `console.log` calls whose expected output is node's, run through both the color and no-color branches of the loop (with an assertion that the colored branch really is taken), plus the `String` object case.

<details>
<summary>full before/after vs node</summary>

| call | node | bun before | bun after |
| --- | --- | --- | --- |
| `"a", "100%foo", 42` | `a 100%foo 42` | `a 10042oo` | `a 100%foo 42` |
| `"q", "/p?x=%ff", 8` | `q /p?x=%ff 8` | `q /p?x=8f` | `q /p?x=%ff 8` |
| `"l", "%d %s", 1, "t"` | `l %d %s 1 t` | `l 1 t` | `l %d %s 1 t` |
| `"x", "%%", 1` | `x %% 1` | `x % 1` | `x %% 1` |
| `"x", "%c", "color:red", "y"` | `x %c color:red y` | `x  y` | `x %c color:red y` |
| `"%s %s", "a", "b", "%s", "c"` | `a b %s c` | `a b c` | `a b %s c` |
| `1, "%d", 2` | `1 %d 2` | `1 2` | `1 %d 2` |
| `/%d/, 1` | `/%d/ 1` | `/1/` | `/%d/ 1` |
| `new String("%d"), 1` | `[String: '%d'] 1` | `1` | `[String: "%d"] 1` |
| `"%d/%s", 7, "k"` | `7/k` | `7/k` | `7/k` |
| `"%%d", 1` | `%d 1` | `%d 1` | `%d 1` |

</details>

Existing coverage is unchanged: `console-log.expected.txt`, `test/js/bun/console/`, `test/js/bun/util/inspect.test.js`, `test/js/node/util/node-inspect-tests/`, and the `test-console-*.js` node parallel tests all still pass.

