### PR TITLE
Bun.gzipSync/deflateSync: honor windowBits, memLevel and strategy

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2448,7 +2448,6 @@ pub mod JSZlib {
         is_gzip: bool,
     ) -> JsResult<JSValue> {
         let mut opts = zlib::Options {
-            gzip: is_gzip,
             window_bits: if is_gzip { 31 } else { -15 },
             ..Default::default()
         };
@@ -2524,27 +2523,21 @@ pub mod JSZlib {
 
         match library {
             Library::Zlib => {
-                let mut reader = match zlib::ZlibReaderArrayList::init_with_options(
-                    compressed,
-                    &mut list,
-                    zlib::Options {
-                        window_bits: opts.window_bits,
-                        level: opts.level,
-                        ..Default::default()
-                    },
-                ) {
-                    Ok(r) => r,
-                    Err(err) => {
-                        // `list` is still mutably borrowed by the match
-                        // scrutinee's temporary; it drops on `return` anyway.
-                        if err == zlib::ZlibError::InvalidArgument {
-                            return Err(
-                                global_this.throw(format_args!("Zlib error: Invalid argument"))
-                            );
+                let mut reader =
+                    match zlib::ZlibReaderArrayList::init_with_options(compressed, &mut list, opts)
+                    {
+                        Ok(r) => r,
+                        Err(err) => {
+                            // `list` is still mutably borrowed by the match
+                            // scrutinee's temporary; it drops on `return` anyway.
+                            if err == zlib::ZlibError::InvalidArgument {
+                                return Err(
+                                    global_this.throw(format_args!("Zlib error: Invalid argument"))
+                                );
+                            }
+                            return Err(global_this.throw_error(err.into(), "Zlib error"));
                         }
-                        return Err(global_this.throw_error(err.into(), "Zlib error"));
-                    }
-                };
+                    };
 
                 if reader.read_all(true).is_err() {
                     let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
@@ -2614,13 +2607,32 @@ pub mod JSZlib {
         options_val_: Option<JSValue>,
         is_gzip: bool,
     ) -> JsResult<JSValue> {
-        let mut level: Option<i32> = None;
-        let mut library = Library::Zlib;
-        let mut window_bits: i32 = 0;
+        // `windowBits` selects the container format, so the defaults mirror what
+        // `Bun.gunzipSync`/`Bun.inflateSync` expect: gzip-wrapped for gzipSync,
+        // raw deflate for deflateSync.
+        let mut opts = zlib::Options {
+            window_bits: if is_gzip { 31 } else { -15 },
+            ..Default::default()
+        };
 
+        let mut library = Library::Zlib;
         if let Some(options_val) = options_val_ {
             if let Some(window) = options_val.get(global_this, "windowBits")? {
-                window_bits = window.coerce::<i32>(global_this)?;
+                opts.window_bits = window.coerce::<i32>(global_this)?;
+                library = Library::Zlib;
+            }
+
+            if let Some(level) = options_val.get(global_this, "level")? {
+                opts.level = level.coerce::<i32>(global_this)?;
+            }
+
+            if let Some(mem_level) = options_val.get(global_this, "memLevel")? {
+                opts.mem_level = mem_level.coerce::<i32>(global_this)?;
+                library = Library::Zlib;
+            }
+
+            if let Some(strategy) = options_val.get(global_this, "strategy")? {
+                opts.strategy = strategy.coerce::<i32>(global_this)?;
                 library = Library::Zlib;
             }
 
@@ -2639,13 +2651,6 @@ pub mod JSZlib {
                     }
                 };
             }
-
-            if let Some(level_value) = options_val.get(global_this, "level")? {
-                level = Some(level_value.coerce::<i32>(global_this)?);
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
-            }
         }
 
         if global_this.has_exception() {
@@ -2654,7 +2659,6 @@ pub mod JSZlib {
 
         let buffer = coerce_compress_buffer(global_this, buffer_value)?;
         let compressed = buffer.slice();
-        let _ = window_bits; // unused
 
         match library {
             Library::Zlib => {
@@ -2664,28 +2668,20 @@ pub mod JSZlib {
                     32
                 });
 
-                let mut reader = match zlib::ZlibCompressorArrayList::init(
-                    compressed,
-                    &mut list,
-                    zlib::Options {
-                        window_bits: 15,
-                        gzip: is_gzip,
-                        level: level.unwrap_or(6),
-                        ..Default::default()
-                    },
-                ) {
-                    Ok(r) => r,
-                    Err(err) => {
-                        // `list` is still mutably borrowed by the match
-                        // scrutinee's temporary; it drops on `return` anyway.
-                        if err == zlib::ZlibError::InvalidArgument {
-                            return Err(
-                                global_this.throw(format_args!("Zlib error: Invalid argument"))
-                            );
+                let mut reader =
+                    match zlib::ZlibCompressorArrayList::init(compressed, &mut list, opts) {
+                        Ok(r) => r,
+                        Err(err) => {
+                            // `list` is still mutably borrowed by the match
+                            // scrutinee's temporary; it drops on `return` anyway.
+                            if err == zlib::ZlibError::InvalidArgument {
+                                return Err(
+                                    global_this.throw(format_args!("Zlib error: Invalid argument"))
+                                );
+                            }
+                            return Err(global_this.throw_error(err.into(), "Zlib error"));
                         }
-                        return Err(global_this.throw_error(err.into(), "Zlib error"));
-                    }
-                };
+                    };
 
                 if reader.read_all().is_err() {
                     let msg = reader.error_message().unwrap_or(b"Zlib returned an error");
@@ -2698,8 +2694,7 @@ pub mod JSZlib {
                 leak_list_into_uint8array(global_this, list)
             }
             Library::Libdeflate => {
-                let Some(mut compressor) = bun_libdeflate::OwnedCompressor::new(level.unwrap_or(6))
-                else {
+                let Some(mut compressor) = bun_libdeflate::OwnedCompressor::new(opts.level) else {
                     return Err(global_this.throw_out_of_memory());
                 };
                 let encoding = if is_gzip {

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -585,9 +585,10 @@ impl<'a> ZlibReaderArrayList<'a> {
 
 #[derive(Clone, Copy)]
 pub struct Options {
-    pub gzip: bool,
     pub level: c_int,
     pub method: c_int,
+    /// Passed to `deflateInit2_`/`inflateInit2_` verbatim: the sign and the +16
+    /// offset select the container format (raw / zlib / gzip).
     pub window_bits: c_int,
     pub mem_level: c_int,
     pub strategy: c_int,
@@ -596,7 +597,6 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            gzip: false,
             level: 6,
             method: 8,
             window_bits: 15,
@@ -946,11 +946,7 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 &raw mut zlib_reader.zlib,
                 options.level,
                 options.method,
-                if !options.gzip {
-                    -options.window_bits
-                } else {
-                    options.window_bits + 16
-                },
+                options.window_bits,
                 options.mem_level,
                 options.strategy,
                 zlibVersion().cast::<u8>(),

--- a/test/js/bun/util/bun-zlib.test.ts
+++ b/test/js/bun/util/bun-zlib.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deflateRawSync as nodeDeflateRawSync,
+  gzipSync as nodeGzipSync,
+  inflateSync as nodeInflateSync,
+  constants as zlibConstants,
+} from "node:zlib";
+
+// Semi-compressible bytes: compressible enough that every tuning knob moves the
+// output, incompressible enough that none of them collapse to the same answer.
+function fixture() {
+  const buf = Buffer.alloc(32768);
+  for (let i = 0; i < buf.length; i++) buf[i] = (i % 251 ^ ((i / 7) | 0)) & 0xff;
+  return buf;
+}
+
+const text = Buffer.from("Hello, World! ".repeat(100));
+
+// `Bun.gzipSync` and `node:zlib` share the same linked zlib, so identical
+// deflateInit2 arguments have to produce identical bytes. Bun's `windowBits` is
+// the raw zlib value (the sign and the +16 offset pick the container format),
+// while node derives it from the function name, hence the 16 + n below.
+
+describe("Bun.gzipSync", () => {
+  test("honors windowBits", () => {
+    const input = fixture();
+    const base = Bun.gzipSync(input, { level: 9 });
+    // 28 == 16 + 12: a gzip container around a 4 KiB window.
+    const narrow = Bun.gzipSync(input, { level: 9, windowBits: 28 });
+
+    expect(Buffer.from(narrow)).toEqual(nodeGzipSync(input, { level: 9, windowBits: 12 }));
+    expect(narrow.length).toBeGreaterThan(base.length);
+    expect(Buffer.from(Bun.gunzipSync(narrow))).toEqual(input);
+  });
+
+  test("honors memLevel", () => {
+    const input = fixture();
+    const base = Bun.gzipSync(input, { level: 9 });
+    const lean = Bun.gzipSync(input, { level: 9, memLevel: 1 });
+
+    expect(Buffer.from(lean)).toEqual(nodeGzipSync(input, { level: 9, memLevel: 1 }));
+    expect(lean.length).toBeGreaterThan(base.length);
+    expect(Buffer.from(Bun.gunzipSync(lean))).toEqual(input);
+  });
+
+  test.each([
+    ["Z_FILTERED", zlibConstants.Z_FILTERED],
+    ["Z_HUFFMAN_ONLY", zlibConstants.Z_HUFFMAN_ONLY],
+    ["Z_RLE", zlibConstants.Z_RLE],
+    ["Z_FIXED", zlibConstants.Z_FIXED],
+  ])("honors strategy %s", (_name, strategy) => {
+    const input = fixture();
+    const base = Bun.gzipSync(input, { level: 9 });
+    const tuned = Bun.gzipSync(input, { level: 9, strategy });
+
+    expect(Buffer.from(tuned)).toEqual(nodeGzipSync(input, { level: 9, strategy }));
+    expect(Buffer.from(tuned)).not.toEqual(Buffer.from(base));
+    expect(Buffer.from(Bun.gunzipSync(tuned))).toEqual(input);
+  });
+
+  test("honors strategy with an explicit library: 'zlib'", () => {
+    const input = fixture();
+    const tuned = Bun.gzipSync(input, { level: 9, strategy: zlibConstants.Z_HUFFMAN_ONLY, library: "zlib" });
+
+    expect(Buffer.from(tuned)).toEqual(nodeGzipSync(input, { level: 9, strategy: zlibConstants.Z_HUFFMAN_ONLY }));
+  });
+
+  test("still emits gzip by default", () => {
+    const compressed = Bun.gzipSync(text);
+
+    expect(compressed[0]).toBe(0x1f);
+    expect(compressed[1]).toBe(0x8b);
+    expect(Buffer.from(compressed)).toEqual(nodeGzipSync(text, { level: 6 }));
+    expect(Buffer.from(Bun.gunzipSync(compressed))).toEqual(text);
+  });
+});
+
+describe("Bun.deflateSync", () => {
+  test("honors memLevel and strategy", () => {
+    const input = fixture();
+    const base = Bun.deflateSync(input, { level: 9 });
+    const tuned = Bun.deflateSync(input, { level: 9, memLevel: 1, strategy: zlibConstants.Z_RLE });
+
+    expect(Buffer.from(tuned)).toEqual(
+      nodeDeflateRawSync(input, { level: 9, memLevel: 1, strategy: zlibConstants.Z_RLE }),
+    );
+    expect(Buffer.from(tuned)).not.toEqual(Buffer.from(base));
+    expect(Buffer.from(Bun.inflateSync(tuned))).toEqual(input);
+  });
+
+  test("still emits raw deflate by default", () => {
+    const compressed = Bun.deflateSync(text);
+
+    expect(Buffer.from(compressed)).toEqual(nodeDeflateRawSync(text, { level: 6 }));
+    expect(Buffer.from(Bun.inflateSync(compressed))).toEqual(text);
+  });
+
+  // https://github.com/oven-sh/bun/issues/8886 — windowBits is the raw zlib
+  // value, so it picks the container format just like it does for inflateSync.
+  test("windowBits -15 emits raw deflate", () => {
+    const compressed = Bun.deflateSync(text, { level: 9, windowBits: -15 });
+
+    expect(Buffer.from(compressed)).toEqual(nodeDeflateRawSync(text, { level: 9 }));
+    expect(Buffer.from(Bun.inflateSync(compressed, { windowBits: -15 }))).toEqual(text);
+  });
+
+  test("windowBits 15 emits zlib-wrapped deflate", () => {
+    const compressed = Bun.deflateSync(text, { level: 9, windowBits: 15 });
+
+    expect(compressed[0]).toBe(0x78);
+    expect(((compressed[0] << 8) | compressed[1]) % 31).toBe(0);
+    expect(nodeInflateSync(Buffer.from(compressed))).toEqual(text);
+    expect(Buffer.from(Bun.inflateSync(compressed, { windowBits: 15 }))).toEqual(text);
+  });
+
+  test("windowBits 31 emits gzip", () => {
+    const compressed = Bun.deflateSync(text, { level: 9, windowBits: 31 });
+
+    expect(compressed[0]).toBe(0x1f);
+    expect(compressed[1]).toBe(0x8b);
+    expect(Buffer.from(Bun.gunzipSync(compressed))).toEqual(text);
+  });
+
+  test("round-trips through inflateSync with every option set", () => {
+    const input = fixture();
+    const compressed = Bun.deflateSync(input, {
+      level: 9,
+      windowBits: -12,
+      memLevel: 4,
+      strategy: zlibConstants.Z_RLE,
+    });
+
+    expect(Buffer.from(Bun.inflateSync(compressed, { windowBits: -12 }))).toEqual(input);
+  });
+});
+
+describe("invalid zlib options", () => {
+  // zlib rejects these inside deflateInit2; the published types already exclude them.
+  const outOfRange: [string, object][] = [
+    ["windowBits", { windowBits: 99 }],
+    ["memLevel", { memLevel: 42 }],
+    ["strategy", { strategy: 99 }],
+  ];
+
+  test.each(outOfRange)("gzipSync rejects an out-of-range %s", (_name, options) => {
+    expect(() => Bun.gzipSync(text, options as Bun.ZlibCompressionOptions)).toThrow("Zlib error: Invalid argument");
+  });
+
+  test.each(outOfRange)("deflateSync rejects an out-of-range %s", (_name, options) => {
+    expect(() => Bun.deflateSync(text, options as Bun.ZlibCompressionOptions)).toThrow("Zlib error: Invalid argument");
+  });
+});

--- a/test/js/bun/util/bun-zlib.test.ts
+++ b/test/js/bun/util/bun-zlib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   deflateRawSync as nodeDeflateRawSync,
+  deflateSync as nodeDeflateSync,
   gzipSync as nodeGzipSync,
   inflateSync as nodeInflateSync,
   constants as zlibConstants,
@@ -148,5 +149,17 @@ describe("invalid zlib options", () => {
 
   test.each(outOfRange)("deflateSync rejects an out-of-range %s", (_name, options) => {
     expect(() => Bun.deflateSync(text, options as Bun.ZlibCompressionOptions)).toThrow("Zlib error: Invalid argument");
+  });
+
+  // `node:zlib` rejects windowBits 0 on every compress function too, and accepts
+  // it on inflate, where it means "read the window size from the zlib header".
+  test("windowBits 0 is rejected for compression but accepted by inflateSync", () => {
+    const zero = { windowBits: 0 } as Bun.ZlibCompressionOptions;
+
+    expect(() => Bun.gzipSync(text, zero)).toThrow("Zlib error: Invalid argument");
+    expect(() => Bun.deflateSync(text, zero)).toThrow("Zlib error: Invalid argument");
+    expect(() => nodeGzipSync(text, { windowBits: 0 })).toThrow(/out of range/);
+
+    expect(Buffer.from(Bun.inflateSync(nodeDeflateSync(text), zero))).toEqual(text);
   });
 });


### PR DESCRIPTION
`Bun.gzipSync` and `Bun.deflateSync` silently ignore three of the four documented members of `ZlibCompressionOptions`. Only `level` reaches zlib.

```js
import * as zlib from "node:zlib";

const buf = Buffer.alloc(32768);
for (let i = 0; i < buf.length; i++) buf[i] = ((i % 251) ^ ((i / 7) | 0)) & 0xff;

for (const [name, o] of [
  ["baseline            ", { level: 9 }],
  ["windowBits 12       ", { level: 9, windowBits: 12 }],
  ["memLevel 1          ", { level: 9, memLevel: 1 }],
  ["strategy Z_HUFFMAN  ", { level: 9, strategy: zlib.constants.Z_HUFFMAN_ONLY }],
]) {
  console.log(name, "node:zlib", zlib.gzipSync(buf, o).length, " Bun.gzipSync", Bun.gzipSync(buf, o).length);
}
```

```
baseline             node:zlib 13300  Bun.gzipSync 13300
windowBits 12        node:zlib 18521  Bun.gzipSync 13300   <- ignored
memLevel 1           node:zlib 14396  Bun.gzipSync 13300   <- ignored
strategy Z_HUFFMAN   node:zlib 32798  Bun.gzipSync 13300   <- ignored
```

No error, no warning: a caller asking for `Z_RLE` on prefiltered data, or a bounded window for a memory-limited decoder, quietly gets the default stream. Passing `library: "zlib"` does not help; the bytes are identical with and without the options.

## Cause

`gzip_or_deflate_sync` parses `windowBits` into a local and then throws it away, never reads `memLevel` or `strategy`, and hardcodes `window_bits: 15` when building the compressor:

```rust
let mut window_bits: i32 = 0;
// ...
let _ = window_bits; // unused

zlib::Options { window_bits: 15, gzip: is_gzip, level: level.unwrap_or(6), ..Default::default() }
```

`ZlibCompressorArrayList` then derived the real `deflateInit2` argument from the `gzip` flag (`-15` for deflate, `31` for gzip), so every call produced one of exactly two streams.

## Fix

All four options are now forwarded to `deflateInit2`, matching what `Bun.inflateSync`/`Bun.gunzipSync` already do on the decompress side: they pass `windowBits` to `inflateInit2` verbatim.

`windowBits` is the raw zlib value, as the type declaration documents, so the sign and the `+16` offset select the container format. The defaults reproduce today's output exactly (`31` for `gzipSync`, `-15` for `deflateSync`), and `ZlibCompressionOptions` keeps one meaning across all four functions. The now-unused `gzip` flag on `zlib::Options` is removed.

Two consequences worth calling out:

- Options that used to be ignored now take effect, and out-of-range values now throw `Zlib error: Invalid argument` instead of being dropped, because zlib rejects them in `deflateInit2`. This includes `windowBits: 0`, which is meaningful for `inflateSync` (read the window size from the header) but not for compression (see #28697, which documents it as inflate-only).
- `Bun.deflateSync` can now emit zlib-wrapped (`windowBits: 9..15`) or gzip (`25..31`) output, which was previously unreachable.

`node:zlib` is a separate binding and is untouched. It keeps node's convention, where the function name picks the container and `windowBits` is just the magnitude.

## Verification

`test/js/bun/util/bun-zlib.test.ts`: 21 new tests comparing against `node:zlib` byte-for-byte (both APIs share the same linked zlib, so identical `deflateInit2` arguments must produce identical bytes), plus round-trips, framing checks on the raw/zlib/gzip headers, and the guards that the no-options defaults are unchanged.

```
released 1.3.14  bun test test/js/bun/util/bun-zlib.test.ts   ->  3 pass, 18 fail
bun bd           test test/js/bun/util/bun-zlib.test.ts        -> 21 pass,  0 fail
```

The 3 that pass on the released binary are the "defaults are unchanged" guards.

<details>
<summary>Adjacent suites</summary>

`test/js/node/zlib/zlib.test.js`, `test/js/web/fetch/fetch-gzip.test.ts`, `test/js/web/fetch/fetch-compress.test.ts` and the `18413`/`17793`/`31652` regression tests all pass. Two pre-existing timeouts in `zlib.test.js` (`zlib.brotli > streaming encode doesn't wait for entire input` and the zstd twin) reproduce on `main` with `src/` stashed; they are unrelated debug-build slowness.

Also verified under `BUN_JSC_validateExceptionChecks=1` that throwing getters and `valueOf` on each of the four options propagate rather than leaving a pending exception.
</details>

The new test file overlaps with #28697, which adds a `test/js/bun/util/bun-zlib.test.ts` of its own; whichever lands second is a trivial merge.

Fixes #30276
Fixes #6280

