### PR TITLE
node:fs: resolve symlinks in cpSync's pre-flight checks

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -157,7 +157,15 @@ function isSrcSubdir(src, dest) {
   return ArrayPrototypeEvery.$call(srcArr, (cur, i) => destArr[i] === cur);
 }
 
-function checkPathsSync(src, dest, opts) {
+// `followSymlinks` is cpSync's pre-flight, which node implements in C++
+// (`cpSyncCheckPaths` in src/node_file.cc): it classifies src with stat(2) and
+// decides src/dest identity with `std::filesystem::equivalent`, i.e. on both
+// resolved paths. So a dangling src reports ENOENT, a symlink cycle reports
+// ELOOP, a symlink to a directory still requires `recursive`, and a dest
+// symlink that resolves to src is a self-copy rather than an overwrite. The
+// walk over directory entries leaves it off, like node's, so symlinks inside a
+// tree are recreated as symlinks.
+function checkPathsSync(src, dest, opts, followSymlinks = false) {
   if (opts.filter) {
     const shouldCopy = opts.filter(src, dest);
     if ($isPromise(shouldCopy)) {
@@ -165,10 +173,16 @@ function checkPathsSync(src, dest, opts) {
     }
     if (!shouldCopy) return { __proto__: null, skipped: true };
   }
+  // `dereference` already makes getStatsSync follow both paths. Stat src
+  // second, so a src that does not exist at all still reports `lstat`, and only
+  // when the lstat found a link to follow.
   const { srcStat, destStat } = getStatsSync(src, dest, opts);
+  const resolving = followSymlinks && !opts.dereference;
+  const srcCheckStat = resolving && srcStat.isSymbolicLink() ? statSync(src, { bigint: true }) : srcStat;
 
   if (destStat) {
-    if (areIdentical(srcStat, destStat)) {
+    const destCheckStat = resolving && destStat.isSymbolicLink() ? (resolveStatSync(dest) ?? destStat) : destStat;
+    if (areIdentical(srcCheckStat, destCheckStat)) {
       throw fsCpEinvalError({
         message: "src and dest cannot be the same",
         path: dest,
@@ -177,7 +191,7 @@ function checkPathsSync(src, dest, opts) {
         code: "EINVAL",
       });
     }
-    if (srcStat.isDirectory() && !destStat.isDirectory()) {
+    if (srcCheckStat.isDirectory() && !destStat.isDirectory()) {
       throw fsCpDirToNonDirError({
         message: `cannot overwrite non-directory ${dest} with directory ${src}`,
         path: dest,
@@ -186,7 +200,7 @@ function checkPathsSync(src, dest, opts) {
         code: "EISDIR",
       });
     }
-    if (!srcStat.isDirectory() && destStat.isDirectory()) {
+    if (!srcCheckStat.isDirectory() && destStat.isDirectory()) {
       throw fsCpNonDirToDirError({
         message: `cannot overwrite directory ${dest} with non-directory ${src}`,
         path: dest,
@@ -197,7 +211,7 @@ function checkPathsSync(src, dest, opts) {
     }
   }
 
-  if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
+  if (srcCheckStat.isDirectory() && isSrcSubdir(src, dest)) {
     throw fsCpEinvalError({
       message: `cannot copy ${src} to a subdirectory of self ${dest}`,
       path: dest,
@@ -206,7 +220,35 @@ function checkPathsSync(src, dest, opts) {
       code: "EINVAL",
     });
   }
-  return { __proto__: null, srcStat, destStat, skipped: false };
+  return { __proto__: null, srcStat, srcCheckStat, destStat, skipped: false };
+}
+
+function cpSyncCheckPaths(src, dest, opts) {
+  return checkPathsSync(src, dest, opts, true);
+}
+
+// A dest that does not resolve (dangling or looping symlink) is not src.
+// node calls `std::filesystem::equivalent` here, which throws instead.
+function resolveStatSync(dest) {
+  try {
+    return statSync(dest, { bigint: true });
+  } catch {
+    return undefined;
+  }
+}
+
+// The tail of node's cpSyncCheckPaths: `recursive` is enforced against the
+// resolved src, so a symlink to a directory is rejected too.
+function checkRecursiveSync(srcCheckStat, src, opts) {
+  if (srcCheckStat.isDirectory() && !opts.recursive) {
+    throw fsEisdirError({
+      message: `${src} is a directory (not copied)`,
+      path: src,
+      syscall: "cp",
+      errno: EISDIR,
+      code: "EISDIR",
+    });
+  }
 }
 
 function getStatsSync(src, dest, opts) {
@@ -279,18 +321,12 @@ function treeContainsOnlyFilesAndDirsSync(root) {
 // node-correct validation before handing off to the native fast path
 // (which performs the copy but does not implement node's cp error codes).
 function tryNativeFastPathSync(src, dest, opts) {
-  const checked = checkPathsSync(src, dest, opts);
-  const { srcStat, destStat } = checked;
-  checkParentPathsSync(src, srcStat, dest);
-  if (srcStat.isDirectory() && !opts.recursive) {
-    throw fsEisdirError({
-      message: `${src} is a directory (not copied)`,
-      path: src,
-      syscall: "cp",
-      errno: EISDIR,
-      code: "EISDIR",
-    });
-  }
+  const checked = cpSyncCheckPaths(src, dest, opts);
+  const { srcStat, srcCheckStat, destStat } = checked;
+  checkParentPathsSync(src, srcCheckStat, dest);
+  checkRecursiveSync(srcCheckStat, src, opts);
+  // `srcStat` is the unresolved stat: a symlink to a directory is copied as a
+  // symlink, so it must not take either native path.
   if (srcStat.isDirectory()) {
     // On macOS the native path clones the whole tree with a single
     // clonefile(). Only take it when the result is indistinguishable from
@@ -311,9 +347,12 @@ function tryNativeFastPathSync(src, dest, opts) {
 function cpSyncFn(src, dest, opts, checked?) {
   // `checked` carries the stats from a preceding tryNativeFastPathSync so the
   // fallback doesn't re-run the same checkPaths/checkParentPaths syscalls.
-  const { srcStat, destStat, skipped } = checked ?? checkPathsSync(src, dest, opts);
+  const { srcCheckStat, destStat, skipped } = checked ?? cpSyncCheckPaths(src, dest, opts);
   if (skipped) return;
-  if (checked === undefined) checkParentPathsSync(src, srcStat, dest);
+  if (checked === undefined) {
+    checkParentPathsSync(src, srcCheckStat, dest);
+    checkRecursiveSync(srcCheckStat, src, opts);
+  }
   return checkParentDir(destStat, src, dest, opts);
 }
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -430,6 +430,133 @@ test("cp with missing callback throws", () => {
   }).toThrow(/"cb"/);
 });
 
+// node runs cpSync's pre-flight in C++ (cpSyncCheckPaths in src/node_file.cc):
+// it classifies src with stat(2) and decides src/dest identity on the resolved
+// paths, so a symlink cannot slip past the existence, recursive, or self-copy
+// guards. The per-entry walk still uses lstat, which the last test here pins.
+describe("fs.cpSync pre-flight resolves symlinks", () => {
+  function cpSyncShouldThrow(...args: Parameters<typeof fs.cpSync>) {
+    try {
+      fs.cpSync(...args);
+    } catch (e: any) {
+      return e;
+    }
+    throw new Error("Expected cpSync() to throw");
+  }
+
+  test("dangling src symlink throws ENOENT", () => {
+    using dir = tempDir("cp-dangling", {});
+    const base = String(dir);
+    fs.symlinkSync("missing", join(base, "link"));
+
+    expect(cpSyncShouldThrow(join(base, "link"), join(base, "out")).code).toBe("ENOENT");
+    expect(fs.readdirSync(base)).toEqual(["link"]);
+  });
+
+  // Windows resolves an unresolvable reparse point to its own error; ELOOP is a
+  // POSIX mapping.
+  test.skipIf(isWindows)("looping src symlink throws ELOOP", () => {
+    using dir = tempDir("cp-loop", {});
+    const base = String(dir);
+    fs.symlinkSync("b", join(base, "a"));
+    fs.symlinkSync("a", join(base, "b"));
+
+    expect(cpSyncShouldThrow(join(base, "a"), join(base, "out")).code).toBe("ELOOP");
+    expect(fs.readdirSync(base).sort()).toEqual(["a", "b"]);
+  });
+
+  test("src symlink to a directory still requires recursive", () => {
+    using dir = tempDir("cp-symlink-dir", { "d/f.txt": "f" });
+    const base = String(dir);
+    fs.symlinkSync(join(base, "d"), join(base, "link"));
+
+    expect(cpSyncShouldThrow(join(base, "link"), join(base, "out")).code).toBe("ERR_FS_EISDIR");
+    expect(fs.readdirSync(base).sort()).toEqual(["d", "link"]);
+
+    // With recursive it is copied as a link, which is what node does.
+    fs.cpSync(join(base, "link"), join(base, "out"), { recursive: true });
+    expect(fs.lstatSync(join(base, "out")).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(join(base, "out"))).toBe(join(base, "d"));
+  });
+
+  test("src symlink to a directory cannot be copied into its own target", () => {
+    using dir = tempDir("cp-symlink-subdir", { "d/f.txt": "f" });
+    const base = String(dir);
+    fs.symlinkSync(join(base, "d"), join(base, "link"));
+
+    // dest under the link itself: caught by the string-prefix check.
+    expect(cpSyncShouldThrow(join(base, "link"), join(base, "link", "sub"), { recursive: true }).code).toBe(
+      "ERR_FS_CP_EINVAL",
+    );
+    // dest under what the link points at: caught by the parent walk.
+    expect(cpSyncShouldThrow(join(base, "link"), join(base, "d", "sub"), { recursive: true }).code).toBe(
+      "ERR_FS_CP_EINVAL",
+    );
+  });
+
+  test.each([{ force: true }, { force: false }])(
+    "dest symlink resolving to src is a self-copy (%o)",
+    (options: object) => {
+      using dir = tempDir("cp-self", { "file.txt": "hello" });
+      const base = String(dir);
+      fs.symlinkSync("file.txt", join(base, "out"));
+
+      expect(cpSyncShouldThrow(join(base, "file.txt"), join(base, "out"), options).code).toBe("ERR_FS_CP_EINVAL");
+      // The link must survive: it used to be replaced by a copy of its own target.
+      expect(fs.lstatSync(join(base, "out")).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(join(base, "out"))).toBe("file.txt");
+    },
+  );
+
+  test("two symlinks to the same file are the same src and dest", () => {
+    using dir = tempDir("cp-same-target", { "file.txt": "hello" });
+    const base = String(dir);
+    fs.symlinkSync("file.txt", join(base, "a"));
+    fs.symlinkSync("file.txt", join(base, "b"));
+
+    expect(cpSyncShouldThrow(join(base, "a"), join(base, "b")).code).toBe("ERR_FS_CP_EINVAL");
+    expect(fs.lstatSync(join(base, "b")).isSymbolicLink()).toBe(true);
+  });
+
+  test("a dangling symlink inside the tree is still copied", () => {
+    using dir = tempDir("cp-tree-dangling", { "from/a.txt": "a" });
+    const base = String(dir);
+    fs.symlinkSync("nope", join(base, "from", "bad"));
+
+    fs.cpSync(join(base, "from"), join(base, "result"), { recursive: true });
+
+    expect(fs.readdirSync(join(base, "result")).sort()).toEqual(["a.txt", "bad"]);
+    expect(fs.lstatSync(join(base, "result", "bad")).isSymbolicLink()).toBe(true);
+  });
+});
+
+// node's async cp is still the lstat-based JS walker (lib/internal/fs/cp/cp.js),
+// so these cases deliberately keep succeeding. Pinned so the sync pre-flight
+// above does not get copied onto the async path.
+describe("fs.promises.cp pre-flight stays on lstat, like node", () => {
+  test("dangling src symlink is copied as a dangling symlink", async () => {
+    using dir = tempDir("cp-async-dangling", {});
+    const base = String(dir);
+    fs.symlinkSync("missing", join(base, "link"));
+
+    await fs.promises.cp(join(base, "link"), join(base, "out"));
+
+    expect(fs.lstatSync(join(base, "out")).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(join(base, "out"))).toBe(join(base, "missing"));
+  });
+
+  test("dest symlink resolving to src is replaced by a copy", async () => {
+    using dir = tempDir("cp-async-self", { "file.txt": "hello" });
+    const base = String(dir);
+    fs.symlinkSync("file.txt", join(base, "out"));
+
+    await fs.promises.cp(join(base, "file.txt"), join(base, "out"));
+
+    expect(fs.lstatSync(join(base, "out")).isFile()).toBe(true);
+    expect(fs.readFileSync(join(base, "out"), "utf8")).toBe("hello");
+  });
+});
+
 // On Windows, _copySingleFileSync's reparse-point branch opens a handle to the
 // source symlink to resolve its target via GetFinalPathNameByHandleW. Previously
 // that handle was never closed, leaking one OS handle per symlink copied. Over a


### PR DESCRIPTION
### What

`fs.cpSync` classified `src` (and `dest`) with `lstat`, so every pre-flight guard could be walked past with a symlink.

```js
import fs from "node:fs";
import os from "node:os";
const mk = () => { const r = fs.mkdtempSync(os.tmpdir() + "/cp-");
  fs.mkdirSync(`${r}/dir`); fs.writeFileSync(`${r}/dir/f`, "x"); fs.writeFileSync(`${r}/file`, "hello");
  fs.symlinkSync("dir", `${r}/s_dir`); fs.symlinkSync("missing", `${r}/s_dangling`);
  fs.symlinkSync("lpB", `${r}/lpA`); fs.symlinkSync("lpA", `${r}/lpB`); return r; };
const T = (src, opts) => { const r = mk(); try { fs.cpSync(`${r}/${src}`, `${r}/out`, opts);
    const s = fs.lstatSync(`${r}/out`); console.log(src, "-> ok", s.isSymbolicLink() ? "symlink" : "REGULAR FILE"); }
  catch (e) { console.log(src, "-> THREW", e.code); } };
T("s_dangling", {}); T("lpA", {}); T("s_dir", {});
const r = mk(); fs.symlinkSync("file", `${r}/out`);           // out -> file (dest resolves to src!)
try { fs.cpSync(`${r}/file`, `${r}/out`, {}); console.log("self-copy ->", fs.lstatSync(`${r}/out`).isSymbolicLink() ? "symlink" : "REGULAR FILE"); }
catch (e) { console.log("self-copy -> THREW", e.code); }
```

| | node 26.3.0 | bun 1.4.0 |
| --- | --- | --- |
| src = dangling symlink | `ENOENT` | ok, manufactures a dangling symlink at dest |
| src = looping symlink | `ELOOP` | ok, copies the loop |
| src = symlink → dir, no `recursive` | `ERR_FS_EISDIR` | ok, the `recursive` guard is bypassed |
| dest = symlink resolving to src | `ERR_FS_CP_EINVAL` | ok, **the dest symlink is replaced by a regular-file copy of its own target** |

The last one is the damaging case: a symlink you own gets clobbered by a real file, and with `force: false` it is a silent no-op.

### Cause

node rewrote `cpSync`'s pre-flight in C++ ([`CpSyncCheckPaths`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L3454)). It classifies `src` with `std::filesystem::status` (follows the link) and decides src/dest identity with `std::filesystem::equivalent`, which resolves both sides. Bun still runs the `lstat`-based JS port that node used before that rewrite, so an unresolvable `src` never errors, a symlink to a directory never looks like a directory, and a `dest` symlink pointing back at `src` never looks identical to it.

### Fix

`checkPathsSync` gains a `followSymlinks` mode, used only by `cpSync`'s pre-flight: it stats `src` and compares src/dest identity on the resolved stats. `recursive` is then enforced against that resolved stat, which is the tail of node's `cpSyncCheckPaths`.

The copy itself is untouched. The per-entry walk keeps `lstat`ing, exactly like node's walker, so a symlink inside a tree (including a broken one) is still recreated as a symlink, and a symlink-to-directory src with `recursive: true` still produces a symlink rather than a cloned tree. Where node's `equivalent()` throws on an unresolvable `dest` (it aborts the process on a dangling dest symlink), the resolve is treated as "not the same file" and the copy proceeds as before.

`fs.cp` / `fs.promises.cp` were **not** part of node's rewrite and still use the `lstat` pre-flight in `lib/internal/fs/cp/cp.js`; all four cases above succeed on node's async path exactly as they do on bun's. The async path is therefore left alone, and two tests pin that asymmetry so it does not get "fixed" into a divergence.

### Verification

All four reported cases now match node, and the residual differences against node are node bugs, not bun's:

* `{ dereference: true }` on a symlink without `recursive` throws `ERR_FS_EISDIR` on node (its `src_is_dir` is `dereference && type == symlink`, and the `dereference ? symlink_status : status` mapping is inverted); bun keeps copying the target, which is what node's own `test-fs-cp-sync-dereference-file` expects.
* A dangling or looping `dest` symlink aborts node outright (`terminate called after throwing an instance of 'std::filesystem::filesystem_error' ... cannot check file equivalence`); bun copies, as it did before.

<details>
<summary>Suites run</summary>

* `test/js/node/fs/cp.test.ts`, `test/js/node/fs/cp-symlink-target.test.ts` — 59 pass, 0 fail
* all 77 vendored `test/js/node/test/parallel/test-fs-cp-*` — 77 pass, 0 fail
* `test/js/node/fs/fs.test.ts` — 379 pass, 0 fail
* a 37-case src/dest/option matrix diffed against node 26.3.0, case-per-process

</details>
