### PR TITLE
diagnostics_channel: add hasSubscribers getter to TracingChannel

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -281,6 +281,16 @@ class TracingChannel {
     }
   }
 
+  get hasSubscribers() {
+    return (
+      this.start.hasSubscribers ||
+      this.end.hasSubscribers ||
+      this.asyncStart.hasSubscribers ||
+      this.asyncEnd.hasSubscribers ||
+      this.error.hasSubscribers
+    );
+  }
+
   subscribe(handlers) {
     for (const name of traceEvents) {
       if (!handlers[name]) continue;

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -1,7 +1,7 @@
 import { gc } from "bun";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { channel, Channel, hasSubscribers, subscribe, unsubscribe } from "node:diagnostics_channel";
+import { channel, Channel, hasSubscribers, subscribe, tracingChannel, unsubscribe } from "node:diagnostics_channel";
 
 describe("Channel", () => {
   // test-diagnostics-channel-has-subscribers.js
@@ -343,6 +343,108 @@ describe("TracingChannel", () => {
   // Port tests from:
   // https://github.com/search?q=repo%3Anodejs%2Fnode+test-diagnostics-channel+AND+%2Ftracing%2F&type=code
   test.todo("TODO");
+
+  test("hasSubscribers is a getter on the prototype", () => {
+    const tc = tracingChannel("tracing-channel1");
+    const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(tc), "hasSubscribers");
+
+    expect(descriptor?.get).toBeFunction();
+    expect(descriptor?.set).toBeUndefined();
+  });
+
+  // test-diagnostics-channel-tracing-channel-has-subscribers.js
+  test("hasSubscribers follows subscribe and unsubscribe", () => {
+    const tc = tracingChannel("tracing-channel2");
+    const handlers = {
+      start: mustNotCall(() => {}),
+      end: mustNotCall(() => {}),
+      asyncStart: mustNotCall(() => {}),
+      asyncEnd: mustNotCall(() => {}),
+      error: mustNotCall(() => {}),
+    };
+
+    expect(tc.hasSubscribers).toBeFalse();
+
+    tc.subscribe(handlers);
+    expect(tc.hasSubscribers).toBeTrue();
+
+    expect(tc.unsubscribe(handlers)).toBeTrue();
+    expect(tc.hasSubscribers).toBeFalse();
+
+    checkCalls();
+  });
+
+  test.each(["start", "end", "asyncStart", "asyncEnd", "error"] as const)(
+    "hasSubscribers is true when only %s has a subscriber",
+    name => {
+      const tc = tracingChannel(`tracing-channel3-${name}`);
+      const subscriber = mustNotCall(() => {});
+
+      expect(tc.hasSubscribers).toBeFalse();
+
+      tc[name].subscribe(subscriber);
+      expect(tc.hasSubscribers).toBeTrue();
+
+      expect(tc[name].unsubscribe(subscriber)).toBeTrue();
+      expect(tc.hasSubscribers).toBeFalse();
+
+      checkCalls();
+    },
+  );
+
+  test("hasSubscribers reads the channels given to tracingChannel()", () => {
+    const tc = tracingChannel({
+      start: channel("tracing-channel4:start"),
+      end: channel("tracing-channel4:end"),
+      asyncStart: channel("tracing-channel4:asyncStart"),
+      asyncEnd: channel("tracing-channel4:asyncEnd"),
+      error: channel("tracing-channel4:error"),
+    });
+    const subscriber = mustNotCall(() => {});
+
+    expect(tc.hasSubscribers).toBeFalse();
+
+    subscribe("tracing-channel4:asyncEnd", subscriber);
+    expect(tc.hasSubscribers).toBeTrue();
+
+    expect(unsubscribe("tracing-channel4:asyncEnd", subscriber)).toBeTrue();
+    expect(tc.hasSubscribers).toBeFalse();
+
+    checkCalls();
+  });
+
+  test("hasSubscribers is true while a store is bound", () => {
+    const tc = tracingChannel("tracing-channel5");
+    const store = new AsyncLocalStorage();
+
+    expect(tc.hasSubscribers).toBeFalse();
+
+    tc.start.bindStore(store);
+    expect(tc.hasSubscribers).toBeTrue();
+
+    expect(tc.start.unbindStore(store)).toBeTrue();
+    expect(tc.hasSubscribers).toBeFalse();
+  });
+
+  test("tracePromise publishes when hasSubscribers is used as a guard", async () => {
+    const tc = tracingChannel("tracing-channel6");
+    const events: string[] = [];
+
+    expect(tc.hasSubscribers).toBeFalse();
+
+    tc.subscribe({
+      start: () => events.push("start"),
+      end: () => events.push("end"),
+      asyncStart: () => events.push("asyncStart"),
+      asyncEnd: () => events.push("asyncEnd"),
+      error: () => events.push("error"),
+    });
+
+    expect(tc.hasSubscribers).toBeTrue();
+    await tc.tracePromise(async () => {});
+
+    expect(events).toEqual(["start", "end", "asyncStart", "asyncEnd"]);
+  });
 });
 
 const mocks = new Map();

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -445,6 +445,28 @@ describe("TracingChannel", () => {
 
     expect(events).toEqual(["start", "end", "asyncStart", "asyncEnd"]);
   });
+
+  // https://github.com/oven-sh/bun/issues/27805
+  test("traceSync publishes when hasSubscribers is used as a guard", () => {
+    const tc = tracingChannel<{ name: string }>("tracing-channel7");
+    const events: string[] = [];
+
+    tc.subscribe({
+      start: ctx => events.push(`start:${ctx.name}`),
+      end: ctx => events.push(`end:${ctx.name}`),
+      asyncStart: () => events.push("asyncStart"),
+      asyncEnd: () => events.push("asyncEnd"),
+      error: () => events.push("error"),
+    });
+
+    let result;
+    if (tc.hasSubscribers) {
+      result = tc.traceSync(() => "ok:demo-success", { name: "demo-success" });
+    }
+
+    expect(result).toBe("ok:demo-success");
+    expect(events).toEqual(["start:demo-success", "end:demo-success"]);
+  });
 });
 
 const mocks = new Map();


### PR DESCRIPTION
Fixes #27805

`diagnostics_channel.tracingChannel(...)` exposes the five per-event channels, but not the aggregate `hasSubscribers` getter Node documents (added in v22.0.0 / v20.13.0). It read `undefined` before and after `subscribe()`.

### Repro

```js
const dc = require("node:diagnostics_channel");

const tc = dc.tracingChannel("repro:tc");
console.log("prototype has hasSubscribers:", "hasSubscribers" in Object.getPrototypeOf(tc));
console.log("before subscribe:", tc.hasSubscribers);
tc.subscribe({ start() {} });
console.log("after  subscribe:", tc.hasSubscribers, "| per-channel getter:", tc.start.hasSubscribers);
```

```
node: prototype has hasSubscribers: true  · before: false     · after: true      · per-channel: true
bun : prototype has hasSubscribers: false · before: undefined · after: undefined · per-channel: true
```

### Cause

`TracingChannel` in `src/js/node/diagnostics_channel.ts` never defined the getter. The documented pattern for skipping the expensive context capture is `if (tc.hasSubscribers) tc.tracePromise(...)`, so on Bun that condition is always falsy and libraries instrumented against Node's docs silently never publish trace events.

### Fix

Add `get hasSubscribers()` to `TracingChannel.prototype`, returning the OR of the five trace channels' own `hasSubscribers`, matching Node's implementation. The per-channel getters already existed, so this is the only missing piece.

### Verification

`bun bd test test/js/node/diagnostics_channel/diagnostics_channel.test.ts` covers the getter's presence on the prototype, the subscribe/unsubscribe round trip, each of the five channels flipping the aggregate on its own, the `tracingChannel({ start, end, ... })` channel-object form, a bound store counting as active (matches Node), and `tracePromise` publishing when the guard is used. The repro from #27805 (the `traceSync` guard) is covered too. All eleven new assertions fail on the current release build and pass with the fix; the ported Node tests under `test/js/node/test/parallel/test-diagnostics-channel-*` still pass.

