### PR TITLE
node:fs: keep the last real stat as `previous` when a watched file reappears

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -563,7 +563,9 @@ pub struct StatWatcher {
 
     poll_ref: JsCell<KeepAlive>,
 
-    last_stat: Guarded<PosixStat>,
+    /// The most recent `stat()` result, or `None` when it failed (the file
+    /// does not exist). JS sees a zeroed stat object as `current` for `None`.
+    last_stat: Guarded<Option<PosixStat>>,
 
     scheduler: RefPtr<StatWatcherScheduler>,
 }
@@ -707,18 +709,18 @@ impl StatWatcher {
         self.ctx.event_loop_shared().enqueue_task_concurrent(task);
     }
 
-    /// Copy the last stat by value.
+    /// Copy the last stat by value. `None` when the last `stat()` failed.
     ///
     /// This field is sometimes set from aonther thread, so we should copy by
     /// value instead of referencing by pointer.
-    pub(crate) fn get_last_stat(&self) -> PosixStat {
+    pub(crate) fn get_last_stat(&self) -> Option<PosixStat> {
         let value = self.last_stat.lock();
         *value
         // unlock on Drop of guard
     }
 
-    /// Set the last stat.
-    pub(crate) fn set_last_stat(&self, stat: &PosixStat) {
+    /// Set the last stat. `None` when the `stat()` failed.
+    pub(crate) fn set_last_stat(&self, stat: &Option<PosixStat>) {
         let mut value = self.last_stat.lock();
         *value = *stat;
         // unlock on Drop of guard
@@ -869,8 +871,12 @@ impl StatWatcher {
         // so swallowing it here leaves the VM with an exception pending and
         // the next queued task re-enters JS under a
         // `scope.assertNoException()` RELEASE_ASSERT.
-        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
-            .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
+        let jsvalue = stat_to_js_stats(
+            global_this,
+            &stat_for_js(&this_ref.get_last_stat()),
+            this_ref.bigint,
+        )
+        .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
         js::gc::prev_stat::set(js_this, global_this, jsvalue);
 
         // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
@@ -895,8 +901,12 @@ impl StatWatcher {
             return Ok(());
         };
         let global_this = this_ref.global_this();
-        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
-            .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
+        let jsvalue = stat_to_js_stats(
+            global_this,
+            &stat_for_js(&this_ref.get_last_stat()),
+            this_ref.bigint,
+        )
+        .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
         js::gc::prev_stat::set(js_this, global_this, jsvalue);
 
         let result = js::listener_get_cached(js_this).unwrap().call(
@@ -924,34 +934,15 @@ impl StatWatcher {
     /// Called from any thread
     pub(crate) fn restat(&self) {
         log!("recalling stat");
-        let stat = restat_impl(&self.path);
-        let res = match stat {
-            Ok(res) => res,
-            // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
-            Err(_) => bun_core::ffi::zeroed::<PosixStat>(),
-        };
-
+        let res = restat_impl(&self.path).ok();
         let last_stat = self.get_last_stat();
 
-        // Ignore atime changes when comparing stats
-        // Compare field-by-field to avoid false positives from padding bytes
-        if res.dev == last_stat.dev
-            && res.ino == last_stat.ino
-            && res.mode == last_stat.mode
-            && res.nlink == last_stat.nlink
-            && res.uid == last_stat.uid
-            && res.gid == last_stat.gid
-            && res.rdev == last_stat.rdev
-            && res.size == last_stat.size
-            && res.blksize == last_stat.blksize
-            && res.blocks == last_stat.blocks
-            && res.mtim.sec == last_stat.mtim.sec
-            && res.mtim.nsec == last_stat.mtim.nsec
-            && res.ctim.sec == last_stat.ctim.sec
-            && res.ctim.nsec == last_stat.ctim.nsec
-            && res.birthtim.sec == last_stat.birthtim.sec
-            && res.birthtim.nsec == last_stat.birthtim.nsec
-        {
+        let unchanged = match (&res, &last_stat) {
+            (None, None) => true,
+            (Some(res), Some(last_stat)) => stats_eq(res, last_stat),
+            _ => false,
+        };
+        if unchanged {
             return;
         }
 
@@ -983,10 +974,16 @@ impl StatWatcher {
         };
         let global_this = this_ref.global_this();
         let prev_jsvalue = js::gc::prev_stat::get(js_this).unwrap_or(JSValue::UNDEFINED);
+        let last_stat = this_ref.get_last_stat();
         let current_jsvalue =
-            stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
+            stat_to_js_stats(global_this, &stat_for_js(&last_stat), this_ref.bigint)
                 .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
-        js::gc::prev_stat::set(js_this, global_this, current_jsvalue);
+        // Only a successful stat advances `previous`: a file that disappears
+        // and reappears reports the stat from before it vanished, like libuv
+        // leaving `poll_ctx.statbuf` untouched on a failed stat.
+        if last_stat.is_some() {
+            js::gc::prev_stat::set(js_this, global_this, current_jsvalue);
+        }
 
         // Propagate to the dispatcher: `report_error_or_terminate` reports a
         // regular throw as uncaught and stops the tick loop on termination.
@@ -1044,8 +1041,7 @@ impl StatWatcher {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             // InitStatTask is responsible for setting this
-            // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
-            last_stat: Guarded::init(bun_core::ffi::zeroed::<PosixStat>()),
+            last_stat: Guarded::init(None),
             scheduler: Self::lazy_scheduler(vm),
         });
         let this_ptr = bun_core::heap::into_raw(this);
@@ -1088,6 +1084,33 @@ impl StatWatcher {
 
         Ok(scopeguard::ScopeGuard::into_inner(guard))
     }
+}
+
+/// The stat JS sees: a zeroed stat while the file cannot be stat'd, which is
+/// what node reports as `current` for a missing file.
+fn stat_for_js(last_stat: &Option<PosixStat>) -> PosixStat {
+    last_stat.unwrap_or_else(bun_core::ffi::zeroed)
+}
+
+/// Ignores atime changes, like libuv's `statbuf_eq`.
+/// Compares field-by-field to avoid false positives from padding bytes.
+fn stats_eq(a: &PosixStat, b: &PosixStat) -> bool {
+    a.dev == b.dev
+        && a.ino == b.ino
+        && a.mode == b.mode
+        && a.nlink == b.nlink
+        && a.uid == b.uid
+        && a.gid == b.gid
+        && a.rdev == b.rdev
+        && a.size == b.size
+        && a.blksize == b.blksize
+        && a.blocks == b.blocks
+        && a.mtim.sec == b.mtim.sec
+        && a.mtim.nsec == b.mtim.nsec
+        && a.ctim.sec == b.ctim.sec
+        && a.ctim.nsec == b.ctim.nsec
+        && a.birthtim.sec == b.birthtim.sec
+        && a.birthtim.nsec == b.birthtim.nsec
 }
 
 // Shared by InitialStatTask::work_pool_callback and StatWatcher::restat — identical logic.
@@ -1231,9 +1254,9 @@ impl InitialStatTask {
 
         let stat = restat_impl(&this_ref.path);
         match stat {
-            Ok(ref res) => {
+            Ok(res) => {
                 // we store the stat, but do not call the callback
-                this_ref.set_last_stat(res);
+                this_ref.set_last_stat(&Some(res));
                 this_ref.enqueue_task_concurrent(ConcurrentTask::from_callback(
                     this,
                     StatWatcher::initial_stat_success_on_main_thread,
@@ -1242,8 +1265,7 @@ impl InitialStatTask {
             Err(_) => {
                 // on enoent, eperm, we call cb with two zeroed stat objects
                 // and store previous stat as a zeroed stat object, and then call the callback.
-                // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
-                this_ref.set_last_stat(&bun_core::ffi::zeroed::<PosixStat>());
+                this_ref.set_last_stat(&None);
                 this_ref.enqueue_task_concurrent(ConcurrentTask::from_callback(
                     this,
                     StatWatcher::initial_stat_error_on_main_thread,

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -51,6 +51,62 @@ describe("fs.watchFile", () => {
     expect(entries[0][1].size).toBe(0);
     expect(entries[0][1].mtimeMs).toBe(0);
   });
+
+  // https://nodejs.org/api/fs.html#fswatchfilefilename-options-listener
+  // "When a file being watched by fs.watchFile() disappears and reappears, the
+  // contents of previous in the second callback event (the file's reappearance)
+  // will be the same as the contents of previous in the first callback event
+  // (its disappearance)."
+  test("previous keeps the last real stat when the file disappears and reappears", async () => {
+    const file = path.join(testDir, "reappear.txt");
+    const calls: { curr: fs.Stats; prev: fs.Stats }[] = [];
+    let notify = () => {};
+    // Resolves the next time `predicate` holds, so each step waits on the
+    // watcher instead of on a timer.
+    const until = (predicate: () => boolean) => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      notify = () => {
+        if (predicate()) resolve();
+      };
+      notify();
+      return promise;
+    };
+    const isZeroed = (stats: fs.Stats) => stats.size === 0 && stats.mtimeMs === 0;
+
+    fs.watchFile(file, { interval: 20 }, (curr, prev) => {
+      calls.push({ curr, prev });
+      notify();
+    });
+
+    try {
+      // The file does not exist yet, so the first callback is the zeroed one.
+      await until(() => calls.length > 0);
+      // Create, delete, then recreate it, waiting for each event in turn.
+      updateFile(file, "aaa");
+      await until(() => calls.at(-1)!.curr.size === 3);
+      fs.unlinkSync(file);
+      await until(() => isZeroed(calls.at(-1)!.curr));
+      updateFile(file, "bb");
+      await until(() => calls.at(-1)!.curr.size === 2);
+    } finally {
+      fs.unwatchFile(file);
+    }
+
+    const goneIndex = calls.findIndex((call, i) => i > 0 && isZeroed(call.curr));
+    const gone = calls[goneIndex];
+    const back = calls[goneIndex + 1];
+
+    // Only `current` is zeroed while the file is gone.
+    expect({ size: gone.curr.size, mtimeMs: gone.curr.mtimeMs }).toEqual({ size: 0, mtimeMs: 0 });
+    expect(gone.prev.size).toBe(3);
+    expect(back.curr.size).toBe(2);
+    expect({ ino: back.prev.ino, size: back.prev.size, mtimeMs: back.prev.mtimeMs }).toEqual({
+      ino: gone.prev.ino,
+      size: gone.prev.size,
+      mtimeMs: gone.prev.mtimeMs,
+    });
+  });
+
   test("it watches a file", async () => {
     let { promise, resolve } = Promise.withResolvers<void>();
     let entries: any = [];


### PR DESCRIPTION
### Repro

```js
import fs from "node:fs";
import os from "node:os";
import path from "node:path";

const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wfr-"));
const f = path.join(dir, "g.txt");
fs.writeFileSync(f, "x");

const sleep = ms => new Promise(r => setTimeout(r, ms));
const log = [];
fs.watchFile(f, { interval: 10 }, (cur, prev) => log.push([prev.ino, cur.ino, prev.size, cur.size]));

await sleep(150);
fs.unlinkSync(f); // "gone" callback
await sleep(250);
fs.writeFileSync(f, "yy"); // "back" callback: what is `previous` here?
await sleep(400);
fs.unwatchFile(f);
for (const l of log) console.log(`cb ino ${l[0]}->${l[1]} size ${l[2]}->${l[3]}`);
```

```
node: cb ino 168559930->0 size 1->0   then   cb ino 168559930->168559930 size 1->2
bun : cb ino 168559932->0 size 1->0   then   cb ino 0->168559932          size 0->2
```

On the reappearance callback, `previous` is the zeroed ENOENT placeholder instead of the last real stat. The fs docs pin this exact case: "When a file being watched by `fs.watchFile()` disappears and reappears, the contents of `previous` in the second callback event (the file's reappearance) will be the same as the contents of `previous` in the first callback event (its disappearance)."

Code comparing `previous.ino`/`previous.mtime` across a gone→back transition (checking whether the file was replaced while it was missing, delta-size accounting, debouncers riding out atomic saves) computes against an all-zero baseline on Bun.

### Cause

`StatWatcher` stores the result of each poll in `last_stat`, substituting a zeroed `PosixStat` when the `stat()` fails. `swap_and_call_listener_on_main_thread` then unconditionally copies that value into the `prevStat` cached slot that populates `previous` for the next callback, so a disappearance overwrites the last real stat with zeroes.

libuv's `uv_fs_poll` (what node's StatWatcher is built on) only writes `poll_ctx.statbuf` on a successful stat; on an error it calls back with the untouched `statbuf` as `prev` and a zeroed `statbuf` as `curr`, which is why node's `previous` survives the disappearance.

### Fix

`last_stat` becomes `Option<PosixStat>` (`None` = the stat failed), so "the file is gone" is no longer conflated with "the stat is all zeroes". JS still sees a zeroed stat as `current` while the file is missing, but the cached `previous` only advances on a successful stat. Change detection is unchanged: `None` compares equal to `None`, so a file that stays missing still fires exactly one callback.

### Verification

`test/js/node/watch/fs.watchFile.test.ts` gains a case that watches a nonexistent path, creates the file, deletes it, and recreates it, waiting on the watcher for each event. It asserts `previous` on the reappearance matches `previous` from the disappearance, and that only `current` is zeroed while the file is gone. It fails on `main` with `previous` = `{ ino: 0, size: 0, mtimeMs: 0 }` and passes with the fix; the repro above now prints the same lines as node v26.3.0.