### PR TITLE
console: left-align Console#table cells to match Node

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -198,11 +198,8 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
     for (let i = 0; i < row.length; i++) {
       const cell = row[i];
       const len = getStringWidth(cell);
-      const needed = (columnWidths[i] - len) / 2;
-      // round(needed) + ceil(needed) will always add up to the amount
-      // of spaces we need while also left justifying the output.
-      out +=
-        (StringPrototypeRepeat as any).$call(" ", needed) + cell + StringPrototypeRepeat.$call(" ", Math.ceil(needed));
+      const needed = columnWidths[i] - len;
+      out += cell + StringPrototypeRepeat.$call(" ", needed);
       if (i !== row.length - 1) out += tableChars.middle;
     }
     out += tableChars.right;

--- a/test/js/node/console/console-table-iterators.test.ts
+++ b/test/js/node/console/console-table-iterators.test.ts
@@ -25,16 +25,16 @@ test("console.Console#table renders Map and Set iterators", async () => {
   }
   expect(stdout).toMatchInlineSnapshot(`
     "┌───────────────────┬────────────┐
-    │ (iteration index) │   Values   │
+    │ (iteration index) │ Values     │
     ├───────────────────┼────────────┤
-    │         0         │ [ 'a', 1 ] │
-    │         1         │ [ 'b', 2 ] │
+    │ 0                 │ [ 'a', 1 ] │
+    │ 1                 │ [ 'b', 2 ] │
     └───────────────────┴────────────┘
     ┌───────────────────┬────────┐
     │ (iteration index) │ Values │
     ├───────────────────┼────────┤
-    │         0         │   7    │
-    │         1         │   8    │
+    │ 0                 │ 7      │
+    │ 1                 │ 8      │
     └───────────────────┴────────┘
     "
   `);

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -63,6 +63,50 @@ describe("console.Console", () => {
     expect(await outValue()).toBe("hello world!\n");
     expect(await errValue()).toBe("uh oh!\n");
   });
+
+  describe("table", () => {
+    test("pads cells on the right", async () => {
+      const [stream, value] = writable();
+      const c = new Console({ stdout: stream, stderr: stream, colorMode: false });
+      c.table([
+        { aaaaa: 1, b: "x" },
+        { aaaaa: 22222, c: true },
+      ]);
+      c.table({ a: 1, bbbb: "two" });
+      stream.end();
+      expect(await value()).toMatchInlineSnapshot(`
+        "┌─────────┬───────┬─────┬──────┐
+        │ (index) │ aaaaa │ b   │ c    │
+        ├─────────┼───────┼─────┼──────┤
+        │ 0       │ 1     │ 'x' │      │
+        │ 1       │ 22222 │     │ true │
+        └─────────┴───────┴─────┴──────┘
+        ┌─────────┬────────┐
+        │ (index) │ Values │
+        ├─────────┼────────┤
+        │ a       │ 1      │
+        │ bbbb    │ 'two'  │
+        └─────────┴────────┘
+        "
+      `);
+    });
+
+    test("pads by visible width, not string length", async () => {
+      const [stream, value] = writable();
+      const c = new Console({ stdout: stream, stderr: stream, colorMode: false });
+      c.table([{ name: "日本語" }, { name: "ab" }]);
+      stream.end();
+      expect(await value()).toMatchInlineSnapshot(`
+        "┌─────────┬──────────┐
+        │ (index) │ name     │
+        ├─────────┼──────────┤
+        │ 0       │ '日本語' │
+        │ 1       │ 'ab'     │
+        └─────────┴──────────┘
+        "
+      `);
+    });
+  });
 });
 
 test("console._stdout", () => {


### PR DESCRIPTION
`new Console(stream).table(...)` centers every cell, where Node left-aligns them. The box frame, column widths, and quoting already match Node exactly, so anything that byte-compares `console.table` output against Node (golden files, snapshot tests, doc generators) diverges on intra-cell padding alone.

## Repro

```js
import { Console } from "node:console";
import { Writable } from "node:stream";

let out = "";
const sink = () => new Writable({ decodeStrings: false, write(c, e, cb) { out += c; cb(); } });
new Console({ stdout: sink(), stderr: sink() }).table([{ aaaaa: 1, b: "x" }, { aaaaa: 22222, c: true }]);
process.stdout.write(out);
```

```
node v26.3.0                            bun 1.4.0 (c76d6b216)
┌─────────┬───────┬─────┬──────┐        ┌─────────┬───────┬─────┬──────┐
│ (index) │ aaaaa │ b   │ c    │        │ (index) │ aaaaa │  b  │  c   │
├─────────┼───────┼─────┼──────┤        ├─────────┼───────┼─────┼──────┤
│ 0       │ 1     │ 'x' │      │        │    0    │   1   │ 'x' │      │
│ 1       │ 22222 │     │ true │        │    1    │ 22222 │     │ true │
└─────────┴───────┴─────┴──────┘        └─────────┴───────┴─────┴──────┘
```

## Cause

`renderRow` in `src/js/builtins/ConsoleObject.ts` is a port of Node's old centering implementation:

```js
const needed = (columnWidths[i] - len) / 2;
out += " ".repeat(needed) + cell + " ".repeat(Math.ceil(needed));
```

Node replaced that with right-padding in `lib/internal/cli_table.js`, and has shipped it since v18. The current source (dumped from the v26.3.0 binary) reads:

```js
const needed = (columnWidths[i] - len);
out += cell + StringPrototypeRepeat(' ', MathCeil(needed));
```

(`needed` is already an integer there, so the `MathCeil` is vestigial.) Everything else in Bun's `table()` helper is already identical to Node's, so `renderRow` was the only divergence.

## Fix

Pad on the right only:

```js
const needed = columnWidths[i] - len;
out += cell + StringPrototypeRepeat.$call(" ", needed);
```

This touches the `node:console` `Console` class only. The global `console.table` is a separate native renderer (`src/jsc/ConsoleObject.rs`), which already left-aligns data cells; #32619 addresses its `(index)` column separately. No file overlap between the two.

## Verification

- `test/js/node/console/console.test.ts`: two new cases covering cell padding, the index/key column, absent cells, and wide characters (`日本語`, so the padding is driven by visible width, not `.length`). Expected output was transcribed from node v26.3.0, not captured from Bun.
- `test/js/node/console/console-table-iterators.test.ts`: the existing inline snapshot was recording the centered output; updated to the left-aligned rendering.
- With `src/` stashed, 3 snapshots fail; with the fix, all 10 tests pass.

The repro fixture now produces output byte-identical to node v26.3.0:

<details>
<summary>diff against node</summary>

```console
$ node ./fixture.js > node.out && bun-debug ./fixture.js > bun.out; diff node.out bun.out && echo IDENTICAL
IDENTICAL
```

</details>
