### PR TITLE
node:module: make findSourceMap() honor process.setSourceMapsEnabled()

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -229,6 +229,10 @@ pub struct VirtualMachine {
     /// `source_mappings`.
     pub saved_source_map_table: crate::saved_source_map::HashTable,
     pub source_mappings: SavedSourceMap,
+    /// `process.setSourceMapsEnabled()`. Gates `module.findSourceMap()`, which
+    /// Node leaves disabled by default. Bun's own stack remapping never reads
+    /// this: it always uses `source_mappings`.
+    pub source_maps_enabled: bool,
 
     // BACKREF — `&'a mut Arena` in spirit; caller-owned (web_worker) and
     // outlives the VM.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -162,6 +162,7 @@ JSC_DECLARE_HOST_FUNCTION(Process_functionCwd);
 extern "C" uint8_t Bun__getExitCode(void*);
 extern "C" uint8_t Bun__setExitCode(void*, uint8_t);
 extern "C" bool Bun__closeChildIPC(JSGlobalObject*);
+extern "C" void Bun__VM__setSourceMapsEnabled(void*, bool);
 
 extern "C" bool Bun__GlobalObject__connectedIPC(JSGlobalObject*);
 extern "C" bool Bun__GlobalObject__hasIPC(JSGlobalObject*);
@@ -3835,7 +3836,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_setSourceMapsEnabled, (JSC::JSGlobalObject * le
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "enabled"_s, "boolean"_s, arg0);
     }
 
-    globalObject->processObject()->m_sourceMapsEnabled = arg0.toBoolean(globalObject);
+    Bun__VM__setSourceMapsEnabled(globalObject->bunVM(), arg0.asBoolean());
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -50,7 +50,6 @@ public:
     ~Process();
 
     bool m_isExitCodeObservable = false;
-    bool m_sourceMapsEnabled = false;
     // Re-entry guard for dispatchExitInternal. Per-Process (i.e. per-VM): a
     // function-local static would be shared across worker threads, so a
     // worker's exit would suppress the main thread's 'exit' event.

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -313,6 +313,12 @@ pub fn remove_source_provider_source_map(
         .remove_source_provider(opaque_source_provider, slice.slice());
 }
 
+/// `process.setSourceMapsEnabled()`.
+// HOST_EXPORT(Bun__VM__setSourceMapsEnabled, c)
+pub fn set_source_maps_enabled(vm: &mut VirtualMachine, enabled: bool) {
+    vm.source_maps_enabled = enabled;
+}
+
 #[crate::host_fn(export = "Bun__setSyntheticAllocationLimitForTesting")]
 pub fn Bun__setSyntheticAllocationLimitForTesting(
     global: &JSGlobalObject,

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -1,12 +1,11 @@
 //! This implements the JavaScript SourceMap class from Node.js.
 
-use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use bstr::BStr;
 
 use bun_core::{self as bstring, strings};
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, bun_string_jsc};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, URL, bun_string_jsc};
 use bun_sourcemap::{Mapping, Ordinal, ParseResult, ParsedSourceMap, mapping};
 
 // generate-classes.ts does not emit Rust accessors yet, so the
@@ -14,22 +13,54 @@ use bun_sourcemap::{Mapping, Ordinal, ParseResult, ParsedSourceMap, mapping};
 // symbols by hand.
 pub struct JSSourceMap {
     pub sourcemap: Arc<ParsedSourceMap>,
-    pub sources: Box<[bstring::String]>,
-    pub names: Box<[bstring::String]>,
+    /// `bun.String` is `Copy`, so both slices hold `OwnedString`: the `+1` each
+    /// element carries is released by `Drop`, on the GC finalize path and on
+    /// every `?` unwind out of [`JSSourceMap::constructor`].
+    pub sources: Box<[bstring::OwnedString]>,
+    pub names: Box<[bstring::OwnedString]>,
 }
 
-/// TODO: when we implement --enable-source-map CLI flag, set this to true.
-// Mutable global; AtomicBool for safe mutation.
-pub(crate) static ENABLE_SOURCE_MAPS: AtomicBool = AtomicBool::new(false);
+/// Node resolves a cached map's `sources` against the generated file's URL
+/// before handing it to `findSourceMap()`; Bun stores them as the map declared
+/// them, so do the same resolution here.
+fn resolve_sources(
+    source_map: &ParsedSourceMap,
+    generated_file: bstring::String,
+    generated_file_utf8: &[u8],
+) -> Box<[bstring::OwnedString]> {
+    // Both arms hand the `+1` to `base`.
+    let base = bstring::OwnedString::new(if strings::contains(generated_file_utf8, b"://") {
+        generated_file.dupe_ref()
+    } else {
+        URL::file_url_from_string(generated_file)
+    });
+
+    // Bun generates a map for every file it transpiles; those carry no
+    // `sources`, because the original source is the file itself.
+    if source_map.external_source_names.is_empty() {
+        return Box::new([base]);
+    }
+
+    source_map
+        .external_source_names
+        .iter()
+        .map(|name| {
+            let joined = URL::join(base.get(), bstring::String::borrow_utf8(name));
+            bstring::OwnedString::new(if joined.is_dead() {
+                bstring::String::clone_utf8(name)
+            } else {
+                joined
+            })
+        })
+        .collect()
+}
 
 #[bun_jsc::host_fn(export = "Bun__JSSourceMap__find")]
 pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    // Node.js doesn't enable source maps by default.
-    // In Bun, we do use them for almost all files since we transpile almost all files
-    // If we enable this by default, we don't have a `payload` object since we don't internally create one.
-    // This causes Next.js to emit errors like the below on start:
-    //       .next/server/chunks/ssr/[root-of-the-server]__012ba519._.js: Invalid source map. Only conformant source maps can be used to filter stack frames. Cause: TypeError: payload is not an Object. (evaluating '"sections" in payload')
-    if !ENABLE_SOURCE_MAPS.load(Ordering::Relaxed) {
+    // Node.js only caches source maps once they're enabled. Bun has a map for
+    // nearly every file it transpiles, so answering unconditionally would break
+    // tooling that reads a hit as "this file came out of a bundler".
+    if !global.bun_vm().source_maps_enabled {
         return Ok(JSValue::UNDEFINED);
     }
 
@@ -38,9 +69,10 @@ pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsR
         return Ok(JSValue::UNDEFINED);
     }
 
-    // reshaped for borrowck — `source_url_slice` borrows `source_url_string`;
-    // explicit deref/deinit calls become Drop on reassignment.
-    let mut source_url_string = bun_string_jsc::from_js(source_url_value, global)?;
+    // `source_url_slice` borrows `source_url_string`, so it has to be dropped
+    // before the reassignment below releases the string it points into.
+    let mut source_url_string =
+        bstring::OwnedString::new(bun_string_jsc::from_js(source_url_value, global)?);
     let mut source_url_slice = source_url_string.to_utf8();
 
     {
@@ -55,7 +87,7 @@ pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsR
 
     if let Some(source_url_index) = strings::index_of(source_url_slice.slice(), b"://") {
         if &source_url_slice.slice()[..source_url_index] == b"file" {
-            let path = bun_jsc::URL::path_from_file_url(source_url_string.dupe_ref());
+            let path = URL::path_from_file_url(source_url_string.get());
 
             if path.is_dead() {
                 return Err(global.throw_value(global.err_invalid_url(format_args!(
@@ -66,7 +98,7 @@ pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsR
 
             // Replace the file:// URL with the absolute path.
             drop(source_url_slice);
-            source_url_string = path;
+            source_url_string = bstring::OwnedString::new(path);
             source_url_slice = source_url_string.to_utf8();
         }
     }
@@ -78,14 +110,13 @@ pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsR
     let Some(source_map) = vm.source_mappings().get(source_url) else {
         return Ok(JSValue::UNDEFINED);
     };
-    // Box allocation aborts on OOM (handleOom semantics).
-    let fake_sources_array: Box<[bstring::String]> = Box::new([source_url_string.dupe_ref()]);
+    let sources = resolve_sources(&source_map, source_url_string.get(), source_url);
 
     // `SavedSourceMap::get` hands back a +1 ref as an `Arc<ParsedSourceMap>`;
     // `Drop` on the field releases it — no manual `deref_()` needed.
     let this = Box::new(JSSourceMap {
         sourcemap: source_map,
-        sources: fake_sources_array,
+        sources,
         names: Box::default(),
     });
     Ok(JSSourceMap::to_js(this, global))
@@ -124,15 +155,15 @@ impl JSSourceMap {
 
         let mappings_str = mappings_value.to_utf8();
 
-        // errdefer blocks deleted: Vec<bun_core::String> drops each element (deref) on `?` unwind.
-        let mut names: Vec<bstring::String> = Vec::new();
-        let mut sources: Vec<bstring::String> = Vec::new();
+        // `OwnedString` so the `+1` on each element is released on `?` unwind.
+        let mut names: Vec<bstring::OwnedString> = Vec::new();
+        let mut sources: Vec<bstring::OwnedString> = Vec::new();
 
         if let Some(sources_value) = payload_arg.get_array(global, b"sources")? {
             let mut iter = sources_value.array_iterator(global)?;
             while let Some(source) = iter.next()? {
                 let source_str = source.to_bun_string(global)?;
-                sources.push(source_str);
+                sources.push(bstring::OwnedString::new(source_str));
             }
         }
 
@@ -140,7 +171,7 @@ impl JSSourceMap {
             let mut iter = names_value.array_iterator(global)?;
             while let Some(name) = iter.next()? {
                 let name_str = name.to_bun_string(global)?;
-                names.push(name_str);
+                names.push(bstring::OwnedString::new(name_str));
             }
         }
 
@@ -219,7 +250,7 @@ impl JSSourceMap {
 
     pub fn memory_cost(&self) -> usize {
         core::mem::size_of::<JSSourceMap>()
-            + self.sources.len() * core::mem::size_of::<bstring::String>()
+            + self.sources.len() * core::mem::size_of::<bstring::OwnedString>()
             + self.sourcemap.memory_cost()
     }
 
@@ -227,9 +258,23 @@ impl JSSourceMap {
         self.memory_cost()
     }
 
-    // The cached value should handle this.
-    pub fn get_payload(&self, _global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(JSValue::UNDEFINED)
+    /// Only runs for maps from `module.findSourceMap()`: the constructor caches
+    /// the payload it was handed. Bun keeps the decoded mappings rather than the
+    /// JSON they came from, so re-encode them into a conformant v3 document.
+    pub fn get_payload(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        let sources =
+            JSValue::create_array_from_iter(global, self.sources.iter(), |s| s.to_js(global))?;
+        // `write_vlqs` never emits the optional name index, so `names` stays empty.
+        let names = JSValue::create_empty_array(global, 0)?;
+        let mappings = format!("{}", self.sourcemap.format_vlqs());
+        let mappings = bun_string_jsc::create_utf8_for_js(global, mappings.as_bytes())?;
+
+        let payload = JSValue::create_empty_object(global, 4);
+        payload.put(global, b"version", JSValue::js_number(3.0));
+        payload.put(global, b"sources", sources);
+        payload.put(global, b"names", names);
+        payload.put(global, b"mappings", mappings);
+        Ok(payload)
     }
 
     // The cached value should handle this.

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -246,3 +246,140 @@ test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns
   expect(stdout).toBe("");
   expect(exitCode).toBe(1);
 });
+
+// `module.findSourceMap()` answers only once source maps are enabled, like
+// Node. Each case runs in its own process because the switch is per-VM.
+function fixture(lib, body) {
+  return `
+import { findSourceMap, SourceMap } from "node:module";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+const lib = path.join(import.meta.dirname, ${JSON.stringify(lib)});
+${body}
+`;
+}
+
+async function runFixture(dir) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("findSourceMap returns undefined until process.setSourceMapsEnabled(true)", async () => {
+  using dir = tempDir("findsourcemap-gate", {
+    "lib.ts": "export const q: number = 42;\n",
+    "fixture.mjs": fixture(
+      "lib.ts",
+      `
+await import(lib);
+console.log("disabled:", String(findSourceMap(lib)));
+process.setSourceMapsEnabled(true);
+console.log("enabled:", findSourceMap(lib)?.constructor.name);
+process.setSourceMapsEnabled(false);
+console.log("disabled again:", String(findSourceMap(lib)));
+`,
+    ),
+  });
+
+  expect(await runFixture(dir)).toEqual({
+    stdout: "disabled: undefined\nenabled: SourceMap\ndisabled again: undefined\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("findSourceMap maps a transpiled file back to its original source", async () => {
+  using dir = tempDir("findsourcemap-transpiled", {
+    "lib.ts": "export const q: number = 42;\n",
+    "fixture.mjs": fixture(
+      "lib.ts",
+      `
+process.setSourceMapsEnabled(true);
+await import(lib);
+const sourceMap = findSourceMap(lib);
+console.log(JSON.stringify(sourceMap.findEntry(0, 13)));
+console.log(JSON.stringify(sourceMap.findOrigin(0, 13)));
+// A file:// specifier resolves to the same entry as the path.
+const href = pathToFileURL(lib).href;
+console.log(findSourceMap(href).findEntry(0, 13).originalSource === href);
+// The payload is a conformant v3 document: it round-trips through the public
+// SourceMap constructor and yields the same entry.
+const payload = sourceMap.payload;
+console.log(payload.version, JSON.stringify(payload.sources), JSON.stringify(payload.names));
+console.log(JSON.stringify(new SourceMap(payload).findEntry(0, 13)));
+`,
+    ),
+  });
+
+  const href = Bun.pathToFileURL(`${dir}/lib.ts`).href;
+  const entry = { generatedLine: 0, generatedColumn: 13, originalLine: 0, originalColumn: 13, originalSource: href };
+  const { stdout, stderr, exitCode } = await runFixture(dir);
+  expect(stderr).toBe("");
+  expect(stdout.split("\n")).toEqual([
+    JSON.stringify(entry),
+    JSON.stringify({ line: 0, column: 13, fileName: href }),
+    "true",
+    `3 ${JSON.stringify([href])} []`,
+    JSON.stringify(entry),
+    "",
+  ]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("findSourceMap resolves an inline sourceMappingURL against the module", async () => {
+  const map = { version: 3, sources: ["nested/orig.ts"], names: [], mappings: "AAAA", sourcesContent: ["// orig\n"] };
+  const inline = Buffer.from(JSON.stringify(map)).toString("base64");
+  using dir = tempDir("findsourcemap-inline", {
+    // `// @bun` marks the file as already bundled, so Bun uses the map the file
+    // carries rather than one it generated while transpiling.
+    "lib.mjs": `// @bun\nexport const q = 42;\n//# sourceMappingURL=data:application/json;base64,${inline}\n`,
+    "fixture.mjs": fixture(
+      "lib.mjs",
+      `
+process.setSourceMapsEnabled(true);
+await import(lib);
+const sourceMap = findSourceMap(lib);
+console.log(sourceMap.findEntry(0, 0).originalSource);
+console.log(JSON.stringify(sourceMap.payload));
+`,
+    ),
+  });
+
+  // Relative `sources` resolve against the generated file, exactly as Node does.
+  const original = new URL("nested/orig.ts", Bun.pathToFileURL(`${dir}/lib.mjs`)).href;
+  const { stdout, stderr, exitCode } = await runFixture(dir);
+  expect(stderr).toBe("");
+  expect(stdout.split("\n")).toEqual([
+    original,
+    JSON.stringify({ version: 3, sources: [original], names: [], mappings: "AAAA" }),
+    "",
+  ]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("findSourceMap ignores builtins and specifiers with no map", async () => {
+  using dir = tempDir("findsourcemap-misses", {
+    "lib.ts": "export const q: number = 42;\n",
+    "fixture.mjs": fixture(
+      "lib.ts",
+      `
+process.setSourceMapsEnabled(true);
+await import(lib);
+for (const specifier of ["node:fs", "bun:jsc", "data:text/javascript,0", "nope.ts", 42, undefined]) {
+  console.log(String(findSourceMap(specifier)));
+}
+`,
+    ),
+  });
+
+  const { stdout, stderr, exitCode } = await runFixture(dir);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("undefined\n".repeat(6));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
`module.findSourceMap()` always returns `undefined`, even after `process.setSourceMapsEnabled(true)`, which is accepted and then ignored. Tooling that uses the API Node documents for stack remapping and coverage silently gets no mappings for every module.

```js
import { findSourceMap } from "node:module";
process.setSourceMapsEnabled(true);
await import("./lib.ts");
const sm = findSourceMap(require.resolve("./lib.ts"));
console.log(sm?.constructor.name, sm?.findEntry(0, 13).originalSource);
// node: SourceMap file:///.../lib.ts
// bun:  undefined undefined
```

## Cause

The registry lookup in `find_source_map` was gated on

```rust
/// TODO: when we implement --enable-source-map CLI flag, set this to true.
pub(crate) static ENABLE_SOURCE_MAPS: AtomicBool = AtomicBool::new(false);
```

and nothing ever stored `true`. `process.setSourceMapsEnabled()` wrote to `Process::m_sourceMapsEnabled`, which nothing read.

Flipping the gate alone is not enough: a `SourceMap` from `findSourceMap()` is built from Bun's already-parsed mappings, not from the JSON they came from, so `payload` was `undefined` and the only entry in `sources` was the generated file rather than the original source. That missing payload is why the gate was left off: Next.js reads `sourceMap.payload` on startup and logs `Invalid source map. Only conformant source maps can be used to filter stack frames. Cause: TypeError: payload is not an Object.`

## Fix

- `process.setSourceMapsEnabled()` stores the flag on the `VirtualMachine` (per-VM, like Node's per-Environment flag), and `find_source_map` reads it. Default stays off, matching Node.
- `sources` resolve against the generated file's URL, the same as Node's `sourcesToAbsolute()`, so `findEntry().originalSource` points at the original file.
- `payload` is re-encoded from the parsed map into a conformant v3 document on first access (`version`, `sources`, `names`, `mappings`). It round-trips through `new SourceMap(payload)`.

While in `JSSourceMap`: `sources`/`names` held `bun.String`, which is `Copy` and has no `Drop`, so the `+1` each element carried was never released. They now hold `OwnedString`, which also covers the `?` unwind paths out of the constructor.

### Known gaps, not addressed here

Both predate this PR and are independent of it. Listing them so the tradeoffs are visible:

- Bun does not compose a file's own `//# sourceMappingURL` with the map it generates while transpiling that file, so for a module Bun transpiles, `findSourceMap()` returns Bun's map rather than chaining to the file's. An already-bundled (`// @bun`) file uses its own map, and that case matches Node.
- Maps in `SavedSourceMap` are parsed with `include_names: false` (the only `ParseUrlResultHint::All` construction site, `SavedSourceMap.rs:460`), so `findEntry().name` is already `undefined` on this path no matter what the map declared. `payload.names` is therefore `[]`, which matches the 4-field mappings `write_vlqs` emits. Node returns the names. Making them work means parsing names into the cached map, teaching `write_vlqs` the optional 5th field, and accepting the extra memory on the hot stack-remapping path, so it belongs in its own change.
- `payload` omits `file`, `sourceRoot`, and `sourcesContent`. All three are optional in the v3 spec, and Bun deliberately does not keep source contents resident (see the comment on `ParsedSourceMap::underlying_provider`). Bun's parser has no references to `sourceRoot` anywhere, so stack remapping already ignores it.

## Verification

```
$ bun bd test test/js/node/module/sourcemap.test.js
 18 pass, 0 fail
```

Three of the four new tests fail against the released binary; `bun bd test test/js/node/module/ test/js/bun/sourcemap/` is 120 pass / 0 fail.

<details>
<summary>After the fix</summary>

```
$ bun-debug -e '...' # TS file, transpiled by Bun
entry:   {"generatedLine":0,"generatedColumn":13,"originalLine":0,"originalColumn":13,"originalSource":"file:///tmp/fsm/ts/lib.ts"}
origin:  {"line":0,"column":13,"fileName":"file:///tmp/fsm/ts/lib.ts"}
payload: {"version":3,"sources":["file:///tmp/fsm/ts/lib.ts"],"names":[],"mappings":"AAAO,aAAM,IAAY;..."}
```

</details>

A GC/ASAN stress over 3000 `new SourceMap()` + `findSourceMap()` + `payload` iterations (including the constructor's throwing path) is clean.

