### PR TITLE
FileSystemRouter: reset route params when a candidate route does not match

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1539,12 +1539,31 @@ pub mod pattern {
 
     impl Pattern {
         /// Match a filesystem route pattern to a URL path.
+        ///
+        /// `params` is scratch shared by every candidate route, so a failed match
+        /// restores it to the length it had on entry: parameters pushed while
+        /// probing a route that loses must never reach the route that wins.
         pub fn match_<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
             // `path` must be lowercased and have no leading slash
             path: &'a [u8],
             // case-sensitive, must not have a leading slash
             name: &'a [u8],
             // case-insensitive, must not have a leading slash
+            match_name: &[u8],
+            params: &mut route_param::List<'a>,
+        ) -> bool {
+            let params_len = params.len();
+            if Self::match_inner::<ALLOW_OPTIONAL_CATCH_ALL>(path, name, match_name, params) {
+                return true;
+            }
+
+            params.truncate(params_len);
+            false
+        }
+
+        fn match_inner<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
+            path: &'a [u8],
+            name: &'a [u8],
             match_name: &[u8],
             params: &mut route_param::List<'a>,
         ) -> bool {
@@ -1559,7 +1578,6 @@ pub mod pattern {
                         let segment =
                             &path_[0..path_.iter().position(|&b| b == b'/').unwrap_or(path_.len())];
                         if !str_.eql_bytes(segment) {
-                            params.truncate(0); // shrinkRetainingCapacity(0)
                             return false;
                         }
 
@@ -1582,7 +1600,6 @@ pub mod pattern {
                             path_ = &path_[i + 1..];
 
                             if pattern.is_end(name) {
-                                params.truncate(0); // shrinkRetainingCapacity(0)
                                 return false;
                             }
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -231,6 +231,89 @@ it("should support catch-all routes", () => {
   }
 });
 
+// Pattern.match_ reuses one scratch param list across every candidate route and used
+// to clear it on only some of its failure paths, so params pushed while probing a
+// route that lost still reached the route that won.
+const probedRouteFixtures = [
+  {
+    // The loser's pattern ran out while path segments remained.
+    files: ["[user]/settings.tsx", "help/[...usertopic].tsx"],
+    pathname: "/help/settings/a",
+    name: "/help/[...usertopic]",
+    params: { usertopic: "settings/a" },
+  },
+  {
+    // Same, and both routes name their param the same thing.
+    files: ["[topic]/settings.tsx", "help/[...topic].tsx"],
+    pathname: "/help/settings/a",
+    name: "/help/[...topic]",
+    params: { topic: "settings/a" },
+  },
+  {
+    // The loser reached its catch-all with nothing left to consume.
+    files: ["[c]/b/[...rest].tsx", "[c]/[...d].tsx"],
+    pathname: "/x/b",
+    name: "/[c]/[...d]",
+    params: { c: "x", d: "b" },
+  },
+];
+
+it.each(probedRouteFixtures)(
+  "does not leak params from a probed route into $name",
+  ({ files, pathname, name, params }) => {
+    const { dir } = make(files);
+
+    const router = new Bun.FileSystemRouter({
+      dir,
+      style: "nextjs",
+    });
+
+    const match = router.match(pathname)!;
+    expect({ name: match.name, params: match.params }).toEqual({ name, params });
+  },
+);
+
+it("does not crash reading .params when a probed route's param name is absent from the match", async () => {
+  // A leaked param name that the winning route's name does not contain resolves to a
+  // zero-length property key, which JSC's Identifier::fromString dereferences as null.
+  // Run in a subprocess so the crash is an exit code rather than a dead test runner.
+  using dir = tempDir("fsr-param-leak-crash", {
+    "pattern-ran-out/[user]/settings.tsx": "export default 1;",
+    "pattern-ran-out/help/[...topic].tsx": "export default 1;",
+    "empty-catch-all/[a]/b/[...rest].tsx": "export default 1;",
+    "empty-catch-all/[c]/[...d].tsx": "export default 1;",
+  });
+
+  const code = /* ts */ `
+    import path from "path";
+    const out = {};
+    for (const [subdir, pathname] of [["pattern-ran-out", "/help/settings/a"], ["empty-catch-all", "/x/b"]]) {
+      const router = new Bun.FileSystemRouter({
+        dir: path.join(${JSON.stringify(String(dir))}, subdir),
+        style: "nextjs",
+        fileExtensions: [".tsx"],
+      });
+      const match = router.match(pathname);
+      out[subdir] = match ? { name: match.name, params: match.params } : null;
+    }
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    "pattern-ran-out": { name: "/help/[...topic]", params: { topic: "settings/a" } },
+    "empty-catch-all": { name: "/[c]/[...d]", params: { c: "x", d: "b" } },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("should support index routes", () => {
   // set up the test
   const { dir } = make(["index.tsx", "posts/[id].tsx", "posts.tsx", "posts/hey.tsx"]);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -236,42 +236,69 @@ it("should support catch-all routes", () => {
 // route that lost still reached the route that won.
 const probedRouteFixtures = [
   {
-    // The loser's pattern ran out while path segments remained.
+    label: "a losing pattern that ran out with path segments left over",
     files: ["[user]/settings.tsx", "help/[...usertopic].tsx"],
     pathname: "/help/settings/a",
     name: "/help/[...usertopic]",
     params: { usertopic: "settings/a" },
   },
   {
-    // Same, and both routes name their param the same thing.
+    label: "a losing route that names its param like the winner's",
     files: ["[topic]/settings.tsx", "help/[...topic].tsx"],
     pathname: "/help/settings/a",
     name: "/help/[...topic]",
     params: { topic: "settings/a" },
   },
   {
-    // The loser reached its catch-all with nothing left to consume.
+    label: "a losing route whose catch-all had nothing left to consume",
     files: ["[c]/b/[...rest].tsx", "[c]/[...d].tsx"],
     pathname: "/x/b",
     name: "/[c]/[...d]",
     params: { c: "x", d: "b" },
   },
+  {
+    // https://github.com/oven-sh/bun/issues/12206
+    label: "sibling routes under a shared dynamic segment",
+    files: [
+      "admin/[businessId]/index.tsx",
+      "admin/[businessId]/providers/index.tsx",
+      "admin/[businessId]/providers/create.tsx",
+      "admin/[businessId]/providers/[providerId]/edit.tsx",
+      "admin/[businessId]/providers/[providerId]/delete.tsx",
+    ],
+    pathname: "/admin/6679fbe17b41431a977163fd/providers/create",
+    name: "/admin/[businessId]/providers/create",
+    params: { businessId: "6679fbe17b41431a977163fd" },
+  },
+  {
+    // https://github.com/oven-sh/bun/issues/15554
+    label: "a dynamic leaf next to its own index route",
+    files: ["[a]/index.ts", "[a]/test/index.ts", "[a]/test/[b].ts"],
+    pathname: "/1/test/2",
+    name: "/[a]/test/[b]",
+    params: { a: "1", b: "2" },
+  },
+  {
+    // https://github.com/oven-sh/bun/issues/15554
+    label: "a dynamic leaf that is itself an index route",
+    files: ["[a]/index.ts", "[a]/test/index.ts", "[a]/test/[b]/index.ts"],
+    pathname: "/1/test/2",
+    name: "/[a]/test/[b]",
+    params: { a: "1", b: "2" },
+  },
 ];
 
-it.each(probedRouteFixtures)(
-  "does not leak params from a probed route into $name",
-  ({ files, pathname, name, params }) => {
-    const { dir } = make(files);
+it.each(probedRouteFixtures)("does not leak params from $label", ({ files, pathname, name, params }) => {
+  const { dir } = make(files);
 
-    const router = new Bun.FileSystemRouter({
-      dir,
-      style: "nextjs",
-    });
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
 
-    const match = router.match(pathname)!;
-    expect({ name: match.name, params: match.params }).toEqual({ name, params });
-  },
-);
+  const match = router.match(pathname)!;
+  expect({ name: match.name, params: match.params }).toEqual({ name, params });
+});
 
 it("does not crash reading .params when a probed route's param name is absent from the match", async () => {
   // A leaked param name that the winning route's name does not contain resolves to a


### PR DESCRIPTION
Fixes #12206
Fixes #15554

`Bun.FileSystemRouter` reports parameters belonging to routes that did not match, and segfaults on `.params` for a route tree containing both a `[x]` and a `[...x]` route.

## Repro

```js
import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";

function router(files) {
  const d = mkdtempSync(tmpdir() + "/fsr-");
  for (const f of files) {
    mkdirSync(d + "/" + f.split("/").slice(0, -1).join("/"), { recursive: true });
    writeFileSync(d + "/" + f, "export default 1;\n");
  }
  return new Bun.FileSystemRouter({ style: "nextjs", dir: d });
}

// "user" comes from [user]/settings, which does not match this path
const a = router(["[user]/settings.tsx", "help/[...usertopic].tsx"]).match("/help/settings/a");
console.log(a.name, JSON.stringify(a.params));

// the catch-all's value is prefixed with the losing route's value
const b = router(["[topic]/settings.tsx", "help/[...topic].tsx"]).match("/help/settings/a");
console.log(b.name, JSON.stringify(b.params));

// segfault
const c = router(["[user]/settings.tsx", "help/[...topic].tsx"]).match("/help/settings/a");
console.log(JSON.stringify(c.params));
```

On 1.4.0 and on `main`:

```
/help/[...usertopic] {"user":"help","usertopic":"settings/a"}
/help/[...topic] {"topic":["help","settings/a"]}
panic(main thread): Segmentation fault at address 0x0
```

Under a debug build the same input trips the invariant the crash violates:

```
panic: assertion failed: name_slice.length > 0
<bun_url::Iterator>::next                                    src/url/lib.rs:1314
...QueryObjectCreator as ObjectInitializer>::create          src/runtime/api/filesystem_router.rs:925
<MatchedRoute>::get_params                                   src/runtime/api/filesystem_router.rs:1032
```

## Cause

`Routes::match_dynamic` walks the candidate routes in sort order and hands each one the same `params` scratch list. `Pattern::match_` pushes into that list as it consumes segments, but it only truncated the list on two of its six failure paths:

* the static segment mismatched, and
* a dynamic segment was followed by more path but the pattern had ended.

The other four leave whatever was pushed in place. The repro hits the one where the pattern runs out while path segments remain: `[user]/settings` consumes `help` as `user`, matches `settings`, still has `/a` left over, falls out of the loop and returns `false` with `user=help` still in the list. `help/[...usertopic]` then matches and inherits it. A catch-all reached with nothing left to consume (`[a]/b/[...rest]` against `/x/b`) leaks the same way.

This is also what #12206 and #15554 report. When the losing route and the winning
route happen to name their parameter the same thing, the two values collapse into
one key and `.params` hands back a `string[]` where the docs promise a `string`:
`/admin/[businessId]/providers/create` matched against
`/admin/6679fbe17b41431a977163fd/providers/create` yields
`{ businessId: ["6679fbe17b41431a977163fd", "6679fbe17b41431a977163fd"] }`.

The crash is the downstream consequence. `PathnameScanner` resolves each parameter's name against the *winning* route's name, so a leaked name that the winner does not contain resolves to a zero-length `StringPointer`. `toStringCopy` turns that into a null `WTF::String`, and `JSC__JSObject__putRecord` passes it to `Identifier::fromString`, which dereferences the null `StringImpl`. When the leaked name happens to be a substring of the winner's name (`user` inside `[...usertopic]`) there is no crash, just a bogus parameter.

## Fix

`Pattern::match_` becomes a single-exit wrapper that records `params.len()` on entry and truncates back to it whenever the inner matcher returns `false`. The two scattered `truncate(0)` calls go away, and every failure path is covered by construction rather than by enumeration.

This has been there since the original implementation (the Rust port is faithful to the Zig `Pattern.match`), so it is not a regression; the test lives in the module's own test file.

## Verification

`test/js/bun/util/filesystem_router.test.ts` gains four cases, all of which fail on the unfixed build:

* six in-process cases asserting the full `{ name, params }` shape: one per leaking failure path (pattern exhausted with distinct names, pattern exhausted with the same name, catch-all reached empty), plus the route trees reported in #12206 and both of the ones in #15554;
* one subprocess case for the two route trees whose leaked name is absent from the winner's name, so a crash shows up as an exit code instead of killing the test runner.

<details>
<summary>before / after</summary>

```
$ git stash push -- src/ && bun bd test test/js/bun/util/filesystem_router.test.ts
(fail) does not leak params from a probed route into /help/[...usertopic]
    "params": {
+     "user": "help",
      "usertopic": "settings/a",
(fail) does not leak params from a probed route into /help/[...topic]
-     "topic": "settings/a",
+     "topic": [ "help", "settings/a" ],
(fail) does not leak params from a probed route into /[c]/[...d]
-     "c": "x",
+     "c": [ "x", "x" ],
(fail) does not crash reading .params when a probed route's param name is absent from the match
+ panic: assertion failed: name_slice.length > 0
 27 pass, 4 fail

$ git stash pop && bun bd test test/js/bun/util/filesystem_router.test.ts
 31 pass, 0 fail
```

</details>
