### PR TITLE
websocket: close() with no code sends an empty close payload

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -62,6 +62,10 @@ const MAX_CONTROL_PAYLOAD: usize = 125;
 const MAX_CLOSE_REASON: usize = MAX_CONTROL_PAYLOAD - 2;
 /// Outgoing control frame prefix: 2-byte header + 4-byte masking key.
 const CONTROL_HEADER_SIZE: usize = 6;
+/// RFC 6455 §7.4.1: reserved, never valid on the wire. C++ passes it to
+/// [`WebSocket::close`] for a `ws.close()` with no code: send a Close frame with
+/// no payload, which §7.1.5 says both ends report as 1005 "no status received".
+const CLOSE_CODE_NOT_SPECIFIED: u16 = 1005;
 
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = Self::deinit)]
@@ -900,7 +904,11 @@ impl<const SSL: bool> WebSocket<SSL> {
         if payload_len >= 2 {
             let received_code = u16::from_be_bytes([payload[0], payload[1]]);
             let (echo_code, dispatch_code) = received_close_codes(received_code);
-            self.send_close_with_body(echo_code, Some(dispatch_code), &payload[2..payload_len]);
+            self.send_close_with_body(
+                Some(echo_code),
+                Some(dispatch_code),
+                &payload[2..payload_len],
+            );
         } else {
             self.send_close();
         }
@@ -910,7 +918,7 @@ impl<const SSL: bool> WebSocket<SSL> {
     pub fn send_close(&self) {
         // Received a bodyless Close: echo a normal-closure frame on the wire,
         // but report 1005 ("no status received") to JS per RFC 6455 §7.1.5.
-        self.send_close_with_body(1000, Some(1005), &[]);
+        self.send_close_with_body(Some(1000), Some(CLOSE_CODE_NOT_SPECIFIED), &[]);
     }
 
     fn enqueue_encoded_bytes(&self, bytes: &[u8]) -> bool {
@@ -1152,13 +1160,21 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.enqueue_encoded_bytes(&ping_frame_bytes[..CONTROL_HEADER_SIZE + ping_len])
     }
 
-    /// `code` is the status code written to the wire frame. `dispatch_code`
-    /// overrides the code reported to JS (`CloseEvent.code`) when it differs
-    /// from the wire code — e.g. a received bodyless Close echoes 1000 but
-    /// reports 1005; when `None`, JS sees `code`.
-    fn send_close_with_body(&self, code: u16, dispatch_code: Option<u16>, body: &[u8]) {
-        let body_len = body.len().min(MAX_CLOSE_REASON);
-        log!("Sending close with code {}", code);
+    /// `code` is the status code written to the wire frame; `None` sends the
+    /// bodyless Close frame RFC 6455 §5.5.1 allows (`body` is then unused, as a
+    /// reason cannot be framed without a code). `dispatch_code` overrides the
+    /// code reported to JS (`CloseEvent.code`) when it differs from the wire
+    /// code — e.g. a received bodyless Close echoes 1000 but reports 1005; when
+    /// `None`, JS sees `code`.
+    fn send_close_with_body(&self, code: Option<u16>, dispatch_code: Option<u16>, body: &[u8]) {
+        let body_len = if code.is_some() {
+            body.len().min(MAX_CLOSE_REASON)
+        } else {
+            0
+        };
+        // 2-byte status code + reason, or nothing at all.
+        let payload_len = if code.is_some() { 2 + body_len } else { 0 };
+        log!("Sending close with code {:?}", code);
         if self.has_pending_close_dispatch() {
             // A close is already mid-flush (user-initiated ws.close() under
             // backpressure); don't enqueue a second close frame on top of it.
@@ -1175,10 +1191,12 @@ impl<const SSL: bool> WebSocket<SSL> {
         // → terminate → cancel(Failure) would RST and discard the buffered
         // frame.
         let mut frame = [0u8; CONTROL_HEADER_SIZE + 2 + MAX_CLOSE_REASON];
-        let header = WebsocketHeader::new(((body_len + 2) & 0x7F) as u8, true, Opcode::Close);
+        let header = WebsocketHeader::new((payload_len & 0x7F) as u8, true, Opcode::Close);
         frame[..2].copy_from_slice(&header.slice());
         // the 4-byte masking key lives at frame[2..6]
-        frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
+        if let Some(code) = code {
+            frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
+        }
 
         let mut reason = bun_core::String::empty();
         if body_len > 0 {
@@ -1193,17 +1211,17 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
 
         // we must mask the code (and the reason, if any)
-        let frame_len = CONTROL_HEADER_SIZE + 2 + body_len;
+        let frame_len = CONTROL_HEADER_SIZE + payload_len;
         {
             let (head, payload) = frame.split_at_mut(CONTROL_HEADER_SIZE);
             let mask_buf: &mut [u8; 4] = (&mut head[2..CONTROL_HEADER_SIZE])
                 .try_into()
                 .expect("infallible: size matches");
-            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..2 + body_len]);
+            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..payload_len]);
         }
 
         if self.enqueue_encoded_bytes(&frame[..frame_len]) {
-            let dispatch_code = dispatch_code.unwrap_or(code);
+            let dispatch_code = dispatch_code.or(code).unwrap_or(CLOSE_CODE_NOT_SPECIFIED);
             if self.send_buffer.borrow().readable_length() == 0 {
                 self.shutdown_after_close_frame();
                 self.clear_data();
@@ -1495,6 +1513,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             .and_then(|str| encode_close_reason(str, &mut reason_buf))
             .unwrap_or(0);
 
+        let code = (code != CLOSE_CODE_NOT_SPECIFIED).then_some(code);
         this.send_close_with_body(code, None, &reason_buf[..reason_len]);
     }
 

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -118,6 +118,11 @@ static size_t getFramingOverhead(size_t payloadSize)
 
 const size_t maxReasonSizeInBytes = 123;
 
+// RFC 6455 7.4.1: reserved, never valid on the wire. Handed to the native client
+// to mean "close() was called without a code", which sends a Close frame with no
+// payload; the peer then reports 1005 "no status received" (7.1.5).
+static constexpr uint16_t closeCodeNotSpecified = 1005;
+
 // Close codes an endpoint may put on the wire (RFC 6455 7.4 + the IANA registry).
 // Deliberately the RFC endpoint set, not the browser's "1000 or 3000-4999":
 // non-browser clients legitimately send 1001 or 1011, and `ws` accepts the same set.
@@ -989,7 +994,10 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
         if (utf8Reason.length() > maxReasonSizeInBytes)
             return Exception { SyntaxError, makeString("The close reason must not be greater than "_s, maxReasonSizeInBytes, " UTF-8 bytes. Received "_s, utf8Reason.length(), " bytes."_s) };
     }
-    int code = optionalCode ? optionalCode.value() : static_cast<int>(1000);
+    // https://websockets.spec.whatwg.org/#dom-websocket-close step 3: with neither
+    // a code nor a reason, the Close message must not have a body. A reason still
+    // needs one, since the wire format puts the status code in front of it.
+    int code = optionalCode ? optionalCode.value() : static_cast<int>(reason.isEmpty() ? closeCodeNotSpecified : 1000);
 
     if (m_state == CLOSING || m_state == CLOSED)
         return {};

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -995,9 +995,10 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
             return Exception { SyntaxError, makeString("The close reason must not be greater than "_s, maxReasonSizeInBytes, " UTF-8 bytes. Received "_s, utf8Reason.length(), " bytes."_s) };
     }
     // https://websockets.spec.whatwg.org/#dom-websocket-close step 3: with neither
-    // a code nor a reason, the Close message must not have a body. A reason still
-    // needs one, since the wire format puts the status code in front of it.
-    int code = optionalCode ? optionalCode.value() : static_cast<int>(reason.isEmpty() ? closeCodeNotSpecified : 1000);
+    // a code nor a reason present, the Close message must not have a body. A reason
+    // still needs one, since the wire format puts the status code in front of it.
+    // An empty reason is still present; only an absent one is a null String.
+    int code = optionalCode ? optionalCode.value() : static_cast<int>(reason.isNull() ? closeCodeNotSpecified : 1000);
 
     if (m_state == CLOSING || m_state == CLOSED)
         return {};

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "bun";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import crypto from "crypto";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, nodeExe } from "harness";
 import { createServer } from "http";
 import { AddressInfo, connect } from "net";
 import path from "node:path";
@@ -485,7 +485,9 @@ async function listen(): Promise<URL> {
   const pathname = path.resolve(import.meta.dir, "../../web/websocket/websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();
   const server = spawn({
-    cmd: [bunExe(), pathname],
+    // Node runs the echo server, as in websocket-client.test.ts: these tests
+    // cover the client, and a debug build spends the 1s budget just booting.
+    cmd: [nodeExe() ?? bunExe(), pathname],
     cwd: import.meta.dir,
     env: bunEnv,
     stdout: "inherit",

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -190,12 +190,14 @@ describe("WebSocket", () => {
     }
   });
   describe("close()", () => {
+    // No code means no body on the close frame, which RFC 6455 §7.1.5 reports as
+    // 1005 "no status received" on both ends. Matches npm `ws`.
     test("(no arguments)", (ws, done) => {
       ws.on("open", () => {
         ws.close();
       });
       ws.on("close", (code: number, reason: string, wasClean: boolean) => {
-        expect(code).toBe(1000);
+        expect(code).toBe(1005);
         expect(reason).toBeString();
         expect(wasClean).toBeTrue();
         done();

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -187,12 +187,14 @@ describe("WebSocket", () => {
     }
   });
   describe("close()", () => {
+    // No code means no body on the close frame, which RFC 6455 §7.1.5 reports as
+    // 1005 "no status received" on both ends.
     test("(no arguments)", (ws, done) => {
       ws.addEventListener("open", () => {
         ws.close();
       });
       ws.addEventListener("close", ({ code, reason, wasClean }) => {
-        expect(code).toBe(1000);
+        expect(code).toBe(1005);
         expect(reason).toBeString();
         expect(wasClean).toBeTrue();
         done();

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -128,6 +128,18 @@ describe.concurrent("WebSocket close() argument validation", () => {
     ws.close();
   });
 
+  // RFC 6455 §7.1.5: a Close frame with no status code is reported as 1005 "no
+  // status received", which is how a peer tells close() apart from close(1000).
+  it("close() with no code reports 1005 to the server and to JS", async () => {
+    const serverGotClose = Promise.withResolvers<{ code: number; reason: string }>();
+    using server = upgradeServer(serverGotClose.resolve);
+    const ws = await open(server);
+    const clientClosed = new Promise(resolve => (ws.onclose = e => resolve({ code: e.code, reason: e.reason })));
+    ws.close();
+    expect(await serverGotClose.promise).toEqual({ code: 1005, reason: "" });
+    expect(await clientClosed).toEqual({ code: 1005, reason: "" });
+  });
+
   describe.each(VALID_CODES)("close(%i) is allowed", code => {
     it("and the code and reason reach the server", async () => {
       const serverGotClose = Promise.withResolvers<{ code: number; reason: string }>();
@@ -143,14 +155,17 @@ describe.concurrent("WebSocket close() argument validation", () => {
 
 describe.concurrent("WebSocket client and server-sent close frames", () => {
   // Raw TCP server: complete the WS handshake, then run `afterUpgrade(socket)`.
-  function rawWsServer(afterUpgrade: (socket: Socket) => void) {
+  // Bytes the client sends afterwards go to `onClientData` when it is given;
+  // otherwise the socket is ended (the other tests have the server speak first).
+  function rawWsServer(afterUpgrade: (socket: Socket) => void, onClientData?: (chunk: Buffer) => void) {
     return new Promise<ReturnType<typeof createServer>>(resolveServer => {
       const server = createServer(sock => {
         let buf = "";
         let upgraded = false;
         sock.on("data", chunk => {
           if (upgraded) {
-            sock.end();
+            if (onClientData) onClientData(chunk);
+            else sock.end();
             return;
           }
           buf += chunk.toString("latin1");
@@ -225,6 +240,76 @@ describe.concurrent("WebSocket client and server-sent close frames", () => {
       code: 1007,
       reason: "Server sent invalid UTF8",
       wasClean: false,
+    });
+  });
+
+  // Collects the first frame the client sends. A client always masks, and a
+  // close payload is at most 125 bytes, so the layout is a 2-byte header, the
+  // 4-byte masking key, then the payload.
+  function captureClientFrame() {
+    const { promise, resolve } = Promise.withResolvers<{
+      opcode: number;
+      payloadLength: number;
+      code: number | null;
+      reason: string;
+    }>();
+    let buf = Buffer.alloc(0);
+    const onClientData = (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (buf.length < 2) return;
+      const payloadLength = buf[1] & 0x7f;
+      if (buf.length < 6 + payloadLength) return;
+      const payload = Buffer.from(buf.subarray(6, 6 + payloadLength));
+      for (let i = 0; i < payload.length; i++) payload[i] ^= buf[2 + (i % 4)];
+      resolve({
+        opcode: buf[0] & 0x0f,
+        payloadLength,
+        code: payloadLength >= 2 ? payload.readUInt16BE(0) : null,
+        reason: payload.subarray(2).toString(),
+      });
+    };
+    return { promise, onClientData };
+  }
+
+  // Run `close` on an open socket, then report the close frame it put on the
+  // wire alongside the CloseEvent the client dispatched for itself.
+  async function closeAndReadFrame(close: (ws: WebSocket) => void) {
+    const frame = captureClientFrame();
+    const server = await rawWsServer(() => {}, frame.onClientData);
+    const address = server.address() as import("node:net").AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}`);
+    const closed = Promise.withResolvers<{ code: number; reason: string }>();
+    ws.addEventListener("close", e => closed.resolve({ code: e.code, reason: e.reason }));
+    ws.addEventListener("error", () => closed.reject(new Error("WebSocket errored")));
+    ws.addEventListener("open", () => close(ws));
+    const [sent, closeEvent] = await Promise.all([frame.promise, closed.promise]);
+    await new Promise(r => server.close(r));
+    return { frame: sent, closeEvent };
+  }
+
+  // https://websockets.spec.whatwg.org/#dom-websocket-close step 3: "If neither
+  // code nor reason is present, the WebSocket Close message must not have a
+  // body." A 1000 body would tell the peer it asked for a normal closure.
+  it("close() with no code sends a close frame with no payload", async () => {
+    expect(await closeAndReadFrame(ws => ws.close())).toEqual({
+      frame: { opcode: 0x8, payloadLength: 0, code: null, reason: "" },
+      closeEvent: { code: 1005, reason: "" },
+    });
+  });
+
+  it("close(1000) sends the code on the wire", async () => {
+    expect(await closeAndReadFrame(ws => ws.close(1000))).toEqual({
+      frame: { opcode: 0x8, payloadLength: 2, code: 1000, reason: "" },
+      closeEvent: { code: 1000, reason: "" },
+    });
+  });
+
+  // A reason cannot be framed on its own: RFC 6455 §5.5.1 puts it after the
+  // 2-byte status code, so a code-less close() with a reason still sends 1000.
+  it("close() with only a reason sends 1000 in front of it", async () => {
+    expect(await closeAndReadFrame(ws => ws.close(undefined, "bye"))).toEqual({
+      frame: { opcode: 0x8, payloadLength: 5, code: 1000, reason: "bye" },
+      closeEvent: { code: 1000, reason: "bye" },
     });
   });
 });

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -312,4 +312,13 @@ describe.concurrent("WebSocket client and server-sent close frames", () => {
       closeEvent: { code: 1000, reason: "bye" },
     });
   });
+
+  // An explicitly passed reason counts as present even when it is empty, so the
+  // frame keeps its body. Only an omitted reason leaves the payload out.
+  it('close(undefined, "") sends 1000 with an empty reason', async () => {
+    expect(await closeAndReadFrame(ws => ws.close(undefined, ""))).toEqual({
+      frame: { opcode: 0x8, payloadLength: 2, code: 1000, reason: "" },
+      closeEvent: { code: 1000, reason: "" },
+    });
+  });
 });


### PR DESCRIPTION
`WebSocket#close()` with no arguments put a 1000 status code on the wire, so the peer could not tell `close()` apart from `close(1000)`. RFC 6455 7.1.5 reserves 1005 ("no status received") precisely for that distinction, and server logic keyed on it saw Bun clients requesting a normal closure they never asked for.

## Repro

A raw TCP server that completes the handshake and prints the client's close frame:

```js
const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
ws.onopen = () => ws.close(); // no code, no reason
```

```
bun           : client close frame: payload len=2 code=1000
ws / browsers : payload len=0  -> the peer reports 1005
```

## Cause

`WebSocket::close()` (`src/jsc/bindings/webcore/WebSocket.cpp`) collapsed an absent code to 1000 before handing it to the frame builder:

```cpp
int code = optionalCode ? optionalCode.value() : static_cast<int>(1000);
```

The native client then always framed a 2-byte status code, so a bodyless close frame was unreachable from JS.

## Fix

Pass 1005 down instead. It is reserved and never legal on the wire (`isValidCloseCodeForSending` already rejects it from user input), which is how WebKit marks "no code was specified". `send_close_with_body` now takes an `Option<u16>` and frames a zero-byte payload when there is no code; JS sees 1005 in the `CloseEvent`, matching step 3 of the [WHATWG `close()` algorithm](https://websockets.spec.whatwg.org/#dom-websocket-close) ("If neither code nor reason is present, the WebSocket Close message must not have a body"), `ws`, undici and WebKit.

A reason keeps the body: RFC 6455 5.5.1 puts the reason after the status code, so `close(undefined, "bye")` still sends 1000 in front of it. An explicitly passed `""` is present under WebIDL and keeps the body too; only an omitted reason (a null `String` from the binding) leaves it out.

Bun's own uWS server already skips 1005/1006 in `formatClosePayload`, so only the client fabricated a code.

## Verification

`test/js/web/websocket/websocket-close-code.test.ts` asserts the bytes on the wire and the `CloseEvent` for `close()`, `close(1000)`, `close(undefined, "bye")` and `close(undefined, "")`, plus a `Bun.serve` round trip showing the server's close handler now reports 1005. Two existing assertions on the old behavior are updated (`websocket-client.test.ts`, `ws.test.ts`), where `ws.close()` now reports 1005 exactly as npm `ws` does.

`ws.test.ts` also runs its echo server under node now, the way `websocket-client.test.ts` already does with the same fixture. That block spawns a server process per test against a 1s budget, which a debug build spends on startup alone, so all 30 of its tests timed out under `bun bd test`; under node they pass.

<details>
<summary>fail before / pass after</summary>

```
without the fix:
(fail) close() with no code reports 1005 to the server and to JS
(fail) close() with no code sends a close frame with no payload
(fail) WebSocket > close() > (no arguments)        [websocket-client.test.ts]
(fail) WebSocket > close() > (no arguments)        [ws.test.ts]

$ bun bd test websocket-close-code.test.ts websocket-client.test.ts ws.test.ts
 103 pass, 0 fail
```

</details>