### PR TITLE
node:http2: fix connection-specific and pseudo-header validation on outbound header blocks

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2479,6 +2479,7 @@ class Http2Stream extends Duplex {
     // symbol keys, and deleting it here would flip the object into dictionary mode,
     // pessimizing every later property access on it.
     const sensitiveNames = buildSensitiveNames(headers, sensitives);
+    assertNoConnectionHeaders(headers);
     // node keeps the never-index list visible on sentTrailers (symbol keys are not iterated by
     // the wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -3473,6 +3474,7 @@ class ServerHttp2Stream extends Http2Stream {
     // Pre-validate single-value headers in JS so a throwing additionalHeaders() leaves no partial
     // state in the shared HPACK table (same rule request() applies).
     if (this[bunHTTP2Session]?.[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+    assertNoConnectionHeaders(headers);
     let hasStatus = true;
     if (headers[HTTP2_HEADER_STATUS] === undefined) {
       headers[HTTP2_HEADER_STATUS] = 200;
@@ -3584,6 +3586,7 @@ class ServerHttp2Stream extends Http2Stream {
     // Pre-validate single-value headers in JS so a throwing respond() leaves no partial state in
     // the shared HPACK table (same rule request() applies).
     if (session[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+    assertNoConnectionHeaders(headers);
     // node keeps the never-index list visible on sentHeaders (symbol keys are not iterated by the
     // wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -3754,9 +3757,9 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
     if (destroy_self) self.destroy();
   }
 }
-// Outbound guard: header values carrying code points above 0xFF (or raw CR/LF/NUL) cannot be
-// legally serialized as an HTTP field value; node's stack drops such headers at submit time
-// (response-splitting probes rely on them). Returns true when the value must be dropped.
+// RFC 9113 §8.2.2: connection-specific fields must never appear in an HTTP/2 message. node
+// rejects them from every outbound header block (buildNgHeaderString), so each site that encodes
+// one calls this first; `te` survives, but only with the exact value "trailers".
 const kForbiddenConnectionHeaders = new SafeSet([
   "connection",
   "upgrade",
@@ -3766,9 +3769,15 @@ const kForbiddenConnectionHeaders = new SafeSet([
   "transfer-encoding",
 ]);
 function assertNoConnectionHeaders(headers): void {
-  for (const name in headers) {
+  const keys = ObjectKeys(headers);
+  for (let i = 0; i < keys.length; i++) {
+    const name = keys[i];
+    if (name === "") continue;
+    const value = headers[name];
+    // An undefined value or an empty array encodes no header at all, so neither is forbidden.
+    if (value === undefined || ($isArray(value) && value.length === 0)) continue;
     const lower = name.toLowerCase();
-    if (kForbiddenConnectionHeaders.has(lower) || (lower === "te" && headers[name] !== "trailers")) {
+    if (kForbiddenConnectionHeaders.has(lower) || (lower === "te" && String(value) !== "trailers")) {
       const err = new TypeError(`HTTP/1 Connection specific headers are forbidden: "${lower}"`);
       err.code = "ERR_HTTP2_INVALID_CONNECTION_HEADERS";
       throw err;
@@ -3776,6 +3785,9 @@ function assertNoConnectionHeaders(headers): void {
   }
 }
 
+// Outbound guard: header values carrying code points above 0xFF (or raw CR/LF/NUL) cannot be
+// legally serialized as an HTTP field value; node's stack drops such headers at submit time
+// (response-splitting probes rely on them). Returns true when the value must be dropped.
 function headerValueIsUnsendable(value): boolean {
   if ($isArray(value)) {
     // Array-valued headers (e.g. set-cookie): unsendable if any element is.
@@ -5930,6 +5942,7 @@ class ClientHttp2Session extends Http2Session {
       // Validate single-value constraints before anything is encoded (a mid-encode throw would
       // desync the shared HPACK table from the peer).
       if (this[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+      assertNoConnectionHeaders(headers);
       // node keeps the never-index list visible on the request's sentHeaders (symbol keys are
       // not iterated by the wire-encoding path, so re-attaching is safe).
       if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2991,7 +2991,11 @@ function doSendFileFD(options, fd, headers, err, stat) {
 
     if (onError) onError(err);
     else {
-      this.respond(headers, options);
+      // respond() validates headers and can throw (e.g. a connection-specific header); the
+      // stream must still be torn down, so never let that throw skip the destroy below.
+      try {
+        this.respond(headers, options);
+      } catch {}
       this.destroy(streamErrorFromCode(NGHTTP2_INTERNAL_ERROR));
     }
     return;
@@ -3010,7 +3014,11 @@ function doSendFileFD(options, fd, headers, err, stat) {
       if (ownsFd) tryClose(fd);
       if (onError) onError(err);
       else {
-        this.respond(headers, options);
+        // respond() validates headers and can throw (e.g. a connection-specific header); the
+        // stream must still be torn down, so never let that throw skip the destroy below.
+        try {
+          this.respond(headers, options);
+        } catch {}
         this.destroy(err);
       }
       return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2991,8 +2991,6 @@ function doSendFileFD(options, fd, headers, err, stat) {
 
     if (onError) onError(err);
     else {
-      // respond() validates headers and can throw (e.g. a connection-specific header); the
-      // stream must still be torn down, so never let that throw skip the destroy below.
       try {
         this.respond(headers, options);
       } catch {}
@@ -3014,8 +3012,6 @@ function doSendFileFD(options, fd, headers, err, stat) {
       if (ownsFd) tryClose(fd);
       if (onError) onError(err);
       else {
-        // respond() validates headers and can throw (e.g. a connection-specific header); the
-        // stream must still be torn down, so never let that throw skip the destroy below.
         try {
           this.respond(headers, options);
         } catch {}
@@ -3765,9 +3761,7 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
     if (destroy_self) self.destroy();
   }
 }
-// RFC 9113 §8.2.2: connection-specific fields must never appear in an HTTP/2 message. node
-// rejects them from every outbound header block (buildNgHeaderString), so each site that encodes
-// one calls this first; `te` survives, but only with the exact value "trailers".
+// RFC 9113 §8.2.2: connection-specific fields are forbidden on every HTTP/2 header block.
 const kForbiddenConnectionHeaders = new SafeSet([
   "connection",
   "upgrade",
@@ -3793,9 +3787,7 @@ function assertNoConnectionHeaders(headers): void {
   }
 }
 
-// Outbound guard: header values carrying code points above 0xFF (or raw CR/LF/NUL) cannot be
-// legally serialized as an HTTP field value; node's stack drops such headers at submit time
-// (response-splitting probes rely on them). Returns true when the value must be dropped.
+// Header values with code points above 0xFF or CR/LF/NUL cannot be serialized; drop them.
 function headerValueIsUnsendable(value): boolean {
   if ($isArray(value)) {
     // Array-valued headers (e.g. set-cookie): unsendable if any element is.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -649,6 +649,25 @@ fn is_valid_request_pseudo_header(name: &[u8]) -> bool {
     REQUEST_PSEUDO_HEADERS.contains(name)
 }
 
+bun_core::comptime_string_set! {
+    static PSEUDO_HEADERS = {
+        b":status",
+        b":path",
+        b":method",
+        b":scheme",
+        b":protocol",
+        b":authority",
+    };
+}
+
+/// Every pseudo-header the spec defines (node's `kValidPseudoHeaders`). Outbound request and
+/// PUSH_PROMISE blocks validate against this, not the request-only set: a `:status` sent in a
+/// request is a protocol error the *peer* reports, so it reaches the wire instead of throwing.
+#[inline]
+fn is_valid_pseudo_header(name: &[u8]) -> bool {
+    PSEUDO_HEADERS.contains(name)
+}
+
 #[inline]
 fn is_valid_header_value(value: &[u8]) -> bool {
     !value.iter().any(|&c| matches!(c, 0 | b'\n' | b'\r'))
@@ -8139,7 +8158,7 @@ impl H2FrameParser {
                     if ignore_pseudo_headers == 1 {
                         continue;
                     }
-                    if !is_valid_request_pseudo_header(validated_name) {
+                    if !is_valid_pseudo_header(validated_name) {
                         if !global_object.has_exception() {
                             return Err(global_object
                                 .err(
@@ -8538,7 +8557,7 @@ impl H2FrameParser {
                                 }
                                 return Ok(JSValue::ZERO);
                             }
-                        } else if !is_valid_request_pseudo_header(validated_name) {
+                        } else if !is_valid_pseudo_header(validated_name) {
                             if !global_object.has_exception() {
                                 return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
                             }
@@ -8678,7 +8697,7 @@ impl H2FrameParser {
                             return Ok(JSValue::ZERO);
                         }
                     } else {
-                        if !is_valid_request_pseudo_header(validated_name) {
+                        if !is_valid_pseudo_header(validated_name) {
                             if !global_object.has_exception() {
                                 return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
                             }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -660,9 +660,7 @@ bun_core::comptime_string_set! {
     };
 }
 
-/// Every pseudo-header the spec defines (node's `kValidPseudoHeaders`). Outbound request and
-/// PUSH_PROMISE blocks validate against this, not the request-only set: a `:status` sent in a
-/// request is a protocol error the *peer* reports, so it reaches the wire instead of throwing.
+/// Node's `kValidPseudoHeaders`: outbound requests accept every defined pseudo-header.
 #[inline]
 fn is_valid_pseudo_header(name: &[u8]) -> bool {
     PSEUDO_HEADERS.contains(name)

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2811,6 +2811,207 @@ it("http2 server rejects requests carrying connection-specific or repeated pseud
   }
 });
 
+it("http2 client.request() rejects connection-specific headers synchronously", async () => {
+  // RFC 9113 Section 8.2.2 forbids connection-specific fields in an HTTP/2 message, and node
+  // rejects them with a synchronous ERR_HTTP2_INVALID_CONNECTION_HEADERS from every site that
+  // encodes a header block. A request that can never succeed must therefore never reach the
+  // wire, otherwise `try { session.request(h) } catch` never fires and retry logic keeps
+  // replaying a permanently-invalid request.
+  const delivered = [];
+  const server = http2.createServer();
+  server.on("stream", (stream, headers) => {
+    delivered.push(headers);
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+
+  // Returns the synchronous error code, or null when a stream was handed back.
+  const responses = [];
+  const tryRequest = headers => {
+    try {
+      const req = client.request(headers, { endStream: true });
+      const { promise, resolve, reject } = Promise.withResolvers();
+      req.on("response", resolve);
+      req.on("error", reject);
+      req.resume();
+      responses.push(promise);
+      return null;
+    } catch (e) {
+      return e.code;
+    }
+  };
+
+  try {
+    const FORBIDDEN = "ERR_HTTP2_INVALID_CONNECTION_HEADERS";
+    expect({
+      connection: tryRequest({ ":path": "/", connection: "keep-alive" }),
+      upgrade: tryRequest({ ":path": "/", upgrade: "websocket" }),
+      keepAlive: tryRequest({ ":path": "/", "keep-alive": "timeout=5" }),
+      proxyConnection: tryRequest({ ":path": "/", "proxy-connection": "keep-alive" }),
+      transferEncoding: tryRequest({ ":path": "/", "transfer-encoding": "chunked" }),
+      http2Settings: tryRequest({ ":path": "/", "http2-settings": "AAMAAABkAAQAoAAAAAIAAAAA" }),
+      teGzip: tryRequest({ ":path": "/", te: "gzip" }),
+      teArrayWithGzip: tryRequest({ ":path": "/", te: ["trailers", "gzip"] }),
+      mixedCase: tryRequest({ ":path": "/", Connection: "keep-alive" }),
+      rawHeadersArray: tryRequest([":path", "/", "connection", "keep-alive"]),
+    }).toEqual({
+      connection: FORBIDDEN,
+      upgrade: FORBIDDEN,
+      keepAlive: FORBIDDEN,
+      proxyConnection: FORBIDDEN,
+      transferEncoding: FORBIDDEN,
+      http2Settings: FORBIDDEN,
+      teGzip: FORBIDDEN,
+      teArrayWithGzip: FORBIDDEN,
+      mixedCase: FORBIDDEN,
+      rawHeadersArray: FORBIDDEN,
+    });
+
+    // `te: trailers` is the one connection-specific field HTTP/2 keeps. An undefined value or an
+    // empty array encodes no header at all, so neither is forbidden.
+    expect({
+      te: tryRequest({ ":path": "/", te: "trailers" }),
+      teArray: tryRequest({ ":path": "/", te: ["trailers"] }),
+      emptyArray: tryRequest({ ":path": "/", connection: [] }),
+      rawTe: tryRequest([":path", "/", "te", "trailers"]),
+    }).toEqual({ te: null, teArray: null, emptyArray: null, rawTe: null });
+
+    const statuses = await Promise.all(responses);
+    expect(statuses.map(h => h[":status"])).toEqual([200, 200, 200, 200]);
+    // Nothing forbidden reached the wire. `http2-settings` in particular used to be encoded into
+    // the HEADERS frame, which conforming peers may treat as a protocol error for the session.
+    expect(
+      delivered.map(h => ({
+        te: h.te ?? null,
+        settings: h["http2-settings"] ?? null,
+        connection: h.connection ?? null,
+      })),
+    ).toEqual([
+      { te: "trailers", settings: null, connection: null },
+      { te: "trailers", settings: null, connection: null },
+      { te: null, settings: null, connection: null },
+      { te: "trailers", settings: null, connection: null },
+    ]);
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
+it("http2 client.request() sends a :status pseudo-header instead of throwing", async () => {
+  // node's kValidPseudoHeaders accepts every spec-defined pseudo-header on an outbound request
+  // block, so a request carrying `:status` is encoded and the peer answers with a stream error.
+  // Bun threw ERR_HTTP2_INVALID_PSEUDOHEADER synchronously, which no node code path does.
+  const delivered = [];
+  const server = http2.createServer();
+  server.on("stream", (stream, headers) => {
+    delivered.push(headers[":path"]);
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+
+  try {
+    const events = [];
+    const { promise: closed, resolve: onClose } = Promise.withResolvers();
+    const req = client.request({ ":path": "/bad", ":status": "200" }, { endStream: true });
+    req.on("response", h => events.push(`response:${h[":status"]}`));
+    req.on("error", e => events.push(`error:${e.code}`));
+    req.on("close", onClose);
+    req.resume();
+    await closed;
+    expect({ events, rstCode: req.rstCode }).toEqual({
+      events: ["error:ERR_HTTP2_STREAM_ERROR"],
+      rstCode: http2.constants.NGHTTP2_PROTOCOL_ERROR,
+    });
+
+    // A pseudo-header the spec does not define is still a synchronous throw.
+    let unknownPseudoHeader;
+    try {
+      client.request({ ":path": "/", ":bogus": "x" }, { endStream: true });
+    } catch (e) {
+      unknownPseudoHeader = e.code;
+    }
+    expect(unknownPseudoHeader).toBe("ERR_HTTP2_INVALID_PSEUDOHEADER");
+
+    // The peer reset the stream rather than the session: the next request still works, and the
+    // malformed one never reached the application.
+    const { promise: responded, resolve: onResponse, reject: onError } = Promise.withResolvers();
+    const ok = client.request({ ":path": "/ok" }, { endStream: true });
+    ok.on("response", onResponse);
+    ok.on("error", onError);
+    ok.resume();
+    expect((await responded)[":status"]).toBe(200);
+    expect(delivered).toEqual(["/ok"]);
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
+it("http2 respond(), additionalHeaders() and sendTrailers() reject connection-specific headers", async () => {
+  // node validates the same connection-specific set on every outbound header block, not just on
+  // pushStream(). A throwing call leaves the stream untouched, so the next call still succeeds.
+  const codes = {};
+  const capture = (name, fn) => {
+    try {
+      fn();
+      codes[name] = null;
+    } catch (e) {
+      codes[name] = e.code;
+    }
+  };
+
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.on("error", () => {});
+    capture("additionalHeaders", () => stream.additionalHeaders({ ":status": 103, connection: "keep-alive" }));
+    capture("respond", () => stream.respond({ ":status": 200, "http2-settings": "AAMAAABkAAQAoAAAAAIAAAAA" }));
+    capture("respondTeGzip", () => stream.respond({ ":status": 200, te: "gzip" }));
+    stream.respond({ ":status": 200, te: "trailers" }, { waitForTrailers: true });
+    stream.on("wantTrailers", () => {
+      capture("sendTrailers", () => stream.sendTrailers({ "transfer-encoding": "chunked" }));
+      stream.sendTrailers({ "x-ok": "1" });
+    });
+    stream.end("ok");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+
+  try {
+    const { promise: gotTrailers, resolve: onTrailers, reject: onError } = Promise.withResolvers();
+    const req = client.request({ ":path": "/" }, { endStream: true });
+    const informational = [];
+    req.on("headers", h => informational.push(h[":status"]));
+    req.on("trailers", onTrailers);
+    req.on("error", onError);
+    req.resume();
+    const trailers = await gotTrailers;
+
+    const FORBIDDEN = "ERR_HTTP2_INVALID_CONNECTION_HEADERS";
+    expect(codes).toEqual({
+      additionalHeaders: FORBIDDEN,
+      respond: FORBIDDEN,
+      respondTeGzip: FORBIDDEN,
+      sendTrailers: FORBIDDEN,
+    });
+    // The rejected additionalHeaders() never sent its informational response, and the rejected
+    // sendTrailers() left the stream able to send real trailers.
+    expect(informational).toEqual([]);
+    expect(trailers["x-ok"]).toBe("1");
+    expect(trailers["transfer-encoding"]).toBeUndefined();
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
 it("http2 client survives session teardown from a socket write while flushing queued DATA frames", async () => {
   // A flow-control-limited DATA frame sits in the native outbound queue until
   // the peer reopens the window. The flush that follows writes to the JS

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2877,17 +2877,6 @@ it("http2 client.request() rejects connection-specific headers synchronously", a
       rawTe: tryRequest([":path", "/", "te", "trailers"]),
     }).toEqual({ te: null, teArray: null, emptyArray: null, rawTe: null });
 
-    // An undefined value also encodes no header, so it is not a connection-specific violation:
-    // it fails the same way any undefined-valued header does. (Bun rejects those for every header
-    // name while node skips them - a separate divergence this change does not touch.)
-    expect({
-      connectionUndefined: tryRequest({ ":path": "/", connection: undefined }),
-      plainUndefined: tryRequest({ ":path": "/", "x-anything": undefined }),
-    }).toEqual({
-      connectionUndefined: "ERR_HTTP2_INVALID_HEADER_VALUE",
-      plainUndefined: "ERR_HTTP2_INVALID_HEADER_VALUE",
-    });
-
     const statuses = await Promise.all(responses);
     expect(statuses.map(h => h[":status"])).toEqual([200, 200, 200, 200]);
     // Nothing forbidden reached the wire. `http2-settings` in particular used to be encoded into

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3075,6 +3075,41 @@ it("http2 respondWithFile()/respondWithFD() reject connection-specific headers o
   }
 });
 
+it("http2 respondWithFile() on a directory with a connection-specific header tears down the stream", async () => {
+  // doSendFileFD's error branch calls respond() before destroy(). respond() validates headers and
+  // can throw on a connection-specific field, which must not skip the teardown: node destroys the
+  // stream (ERR_HTTP2_SEND_FILE), so the client sees a stream error instead of hanging forever.
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.on("error", () => {});
+    stream.respondWithFile(tmpdir(), { connection: "keep-alive" });
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+
+  try {
+    const { promise, resolve } = Promise.withResolvers();
+    const req = client.request({ ":path": "/" }, { endStream: true });
+    const events = [];
+    req.on("response", () => events.push("response"));
+    req.on("error", e => events.push(`error:${e.code}`));
+    req.on("data", () => {});
+    // Without the teardown guard the server throws inside the fstat callback, never RSTs the
+    // stream, and this close never fires - the await hangs until the test times out.
+    req.on("close", () => resolve());
+    req.resume();
+    await promise;
+    expect({ events, rstCode: req.rstCode }).toEqual({
+      events: ["error:ERR_HTTP2_STREAM_ERROR"],
+      rstCode: http2.constants.NGHTTP2_INTERNAL_ERROR,
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
 it("http2 client survives session teardown from a socket write while flushing queued DATA frames", async () => {
   // A flow-control-limited DATA frame sits in the native outbound queue until
   // the peer reopens the window. The flush that follows writes to the JS

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2812,11 +2812,9 @@ it("http2 server rejects requests carrying connection-specific or repeated pseud
 });
 
 it("http2 client.request() rejects connection-specific headers synchronously", async () => {
-  // RFC 9113 Section 8.2.2 forbids connection-specific fields in an HTTP/2 message, and node
-  // rejects them with a synchronous ERR_HTTP2_INVALID_CONNECTION_HEADERS from every site that
-  // encodes a header block. A request that can never succeed must therefore never reach the
-  // wire, otherwise `try { session.request(h) } catch` never fires and retry logic keeps
-  // replaying a permanently-invalid request.
+  // RFC 9113 Section 8.2.2 forbids connection-specific fields in an HTTP/2 message; node rejects
+  // them with a synchronous ERR_HTTP2_INVALID_CONNECTION_HEADERS from every site that encodes a
+  // header block, so a request that can never succeed never reaches the wire.
   const delivered = [];
   const server = http2.createServer();
   server.on("stream", (stream, headers) => {
@@ -2870,14 +2868,25 @@ it("http2 client.request() rejects connection-specific headers synchronously", a
       rawHeadersArray: FORBIDDEN,
     });
 
-    // `te: trailers` is the one connection-specific field HTTP/2 keeps. An undefined value or an
-    // empty array encodes no header at all, so neither is forbidden.
+    // `te: trailers` is the one connection-specific field HTTP/2 keeps, and an empty array
+    // encodes no header at all.
     expect({
       te: tryRequest({ ":path": "/", te: "trailers" }),
       teArray: tryRequest({ ":path": "/", te: ["trailers"] }),
       emptyArray: tryRequest({ ":path": "/", connection: [] }),
       rawTe: tryRequest([":path", "/", "te", "trailers"]),
     }).toEqual({ te: null, teArray: null, emptyArray: null, rawTe: null });
+
+    // An undefined value also encodes no header, so it is not a connection-specific violation:
+    // it fails the same way any undefined-valued header does. (Bun rejects those for every header
+    // name while node skips them - a separate divergence this change does not touch.)
+    expect({
+      connectionUndefined: tryRequest({ ":path": "/", connection: undefined }),
+      plainUndefined: tryRequest({ ":path": "/", "x-anything": undefined }),
+    }).toEqual({
+      connectionUndefined: "ERR_HTTP2_INVALID_HEADER_VALUE",
+      plainUndefined: "ERR_HTTP2_INVALID_HEADER_VALUE",
+    });
 
     const statuses = await Promise.all(responses);
     expect(statuses.map(h => h[":status"])).toEqual([200, 200, 200, 200]);
@@ -3006,6 +3015,60 @@ it("http2 respond(), additionalHeaders() and sendTrailers() reject connection-sp
     expect(informational).toEqual([]);
     expect(trailers["x-ok"]).toBe("1");
     expect(trailers["transfer-encoding"]).toBeUndefined();
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
+it("http2 respondWithFile()/respondWithFD() reject connection-specific headers on the stream", async () => {
+  // Both build their header block through respond(), so they inherit its validation. node does the
+  // same inside processRespondWithFD: the send-file path destroys the stream with the error rather
+  // than throwing synchronously, because the header block is encoded after the fstat completes.
+  const syncThrew = {};
+  const serverErrors = {};
+  const server = http2.createServer();
+  server.on("stream", (stream, headers) => {
+    const which = headers["x-which"];
+    stream.on("error", e => (serverErrors[which] = e.code));
+    try {
+      if (which === "file") {
+        stream.respondWithFile(import.meta.path, { connection: "keep-alive" });
+      } else {
+        const fd = fs.openSync(import.meta.path, "r");
+        stream.on("close", () => {
+          try {
+            fs.closeSync(fd);
+          } catch {}
+        });
+        stream.respondWithFD(fd, { "http2-settings": "AAMAAABkAAQAoAAAAAIAAAAA" });
+      }
+      syncThrew[which] = false;
+    } catch (e) {
+      syncThrew[which] = e.code;
+    }
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+
+  try {
+    const clientErrors = {};
+    for (const which of ["file", "fd"]) {
+      const { promise: closed, resolve: onClose } = Promise.withResolvers();
+      const req = client.request({ ":path": "/", "x-which": which }, { endStream: true });
+      req.on("error", e => (clientErrors[which] = e.code));
+      req.on("data", () => {});
+      req.on("close", onClose);
+      await closed;
+    }
+
+    const FORBIDDEN = "ERR_HTTP2_INVALID_CONNECTION_HEADERS";
+    expect({ syncThrew, serverErrors, clientErrors }).toEqual({
+      syncThrew: { file: false, fd: false },
+      serverErrors: { file: FORBIDDEN, fd: FORBIDDEN },
+      clientErrors: { file: "ERR_HTTP2_STREAM_ERROR", fd: "ERR_HTTP2_STREAM_ERROR" },
+    });
   } finally {
     client.close();
     server.close();


### PR DESCRIPTION
## Repro

```js
import http2 from "node:http2";
// server: a plain node http2.createServer answering 200 to everything
const ses = http2.connect(`http://127.0.0.1:${port}`);
ses.on("error", () => {});
for (const [tag, h] of [
  ["connection", { connection: "keep-alive" }],
  ["http2-settings", { "http2-settings": "AAMAAABkAAQAoAAAAAIAAAAA" }],
  ["status-in-request", { ":status": "200" }],
]) {
  try {
    const st = ses.request({ ":path": "/x", ...h }, { endStream: true });
    st.on("error", e => console.log(tag, "async", e.code));
    st.resume();
  } catch (e) {
    console.log(tag, "SYNC-THROW", e.code);
  }
}
```

|  | node v26.3.0 | bun 1.4.0 / main |
| --- | --- | --- |
| `connection` / `upgrade` / `keep-alive` / `proxy-connection` / `transfer-encoding` / `te: gzip` | `SYNC-THROW ERR_HTTP2_INVALID_CONNECTION_HEADERS` | stream, async `ERR_HTTP2_STREAM_ERROR`, `rst=1` |
| `http2-settings` | `SYNC-THROW ERR_HTTP2_INVALID_CONNECTION_HEADERS` | stream, `200`, **sent on the wire** |
| `:status` in a request | stream, peer RSTs with `PROTOCOL_ERROR` | `SYNC-THROW ERR_HTTP2_INVALID_PSEUDOHEADER` |

The node-idiomatic `try { session.request(h) } catch` never fires for a request that can never succeed, so the error surfaces later as what looks like a peer failure and retry logic keeps replaying a permanently-invalid request. Accepting `http2-settings` puts a connection-specific field on the wire, which conforming HTTP/2 peers may treat as a protocol error for the whole session (RFC 9113 §8.2.2).

## Cause

Node routes every outbound header block through `buildNgHeaderString`, which calls `isIllegalConnectionSpecificHeader` on each non-pseudo field. Bun has the equivalent helper, `assertNoConnectionHeaders`, but it was only wired into `pushStream()`. The other four sites that encode a header block never called it:

| site | node | bun before |
| --- | --- | --- |
| `session.request()` | throws | no check |
| `stream.respond()` | throws | no check |
| `stream.additionalHeaders()` | throws | no check |
| `stream.sendTrailers()` | throws | no check |
| `stream.pushStream()` | throws | throws |

The `:status` case is the same validation read in the other direction. Node's `kValidPseudoHeaders` holds all six spec-defined pseudo-headers and is what both request and `PUSH_PROMISE` blocks validate against, so `:status` is encoded and the peer reports the protocol error. Bun's native encoder validated an outbound request against the request-only set (`h2_frame_parser.rs`, `is_valid_request_pseudo_header`) and threw `ERR_HTTP2_INVALID_PSEUDOHEADER` synchronously.

## Fix

- `src/js/node/http2.ts`: call `assertNoConnectionHeaders()` from `request()`, `respond()`, `additionalHeaders()` and `sendTrailers()`, and give it node's value semantics: an `undefined` value or an empty array encodes no header at all, a single-element array unwraps, and a multi-element `te` array is illegal. Header names are matched case-insensitively, as before.
- `src/runtime/api/bun/h2_frame_parser.rs`: add `is_valid_pseudo_header` (node's `kValidPseudoHeaders`) and use it for outbound request and `PUSH_PROMISE` blocks. Server responses keep `is_valid_response_pseudo_header`, and the inbound decoder keeps the strict request/response split, so a received request carrying `:status` is still malformed.

`pushStream()` is unchanged; it already had the check. `respondWithFile`/`respondWithFD` inherit it through `respond()` and destroy the stream on the throw, matching node's `processRespondWithFD`. The two `doSendFileFD` error branches (fstat failure, directory/non-seekable target) called `respond()` before `destroy()`, so a throwing `respond()` skipped the teardown; both are now guarded so the stream is always torn down.

## Verification

`bun bd test test/js/node/http2/node-http2.test.js` passes; the five new tests fail on an unpatched build.

The repro above now prints the same table as node v26.3.0 for all ten shapes (the six connection-specific fields, `te: gzip`, `te: trailers`, `http2-settings`, `:status`), including the raw `[name, value, ...]` headers form and the value-shape matrix (`te: ["trailers"]` allowed, `te: ["trailers", "gzip"]` rejected, `connection: []` skipped).

<details>
<summary>Ported node http2 suite: no change</summary>

All 272 `test/js/node/test/parallel/test-http2-*.js` files were run before and after. The same set passes; `test-http2-misused-pseudoheaders`, `test-http2-info-headers`, `test-http2-server-push-stream-errors-args` and `test-http2-invalidheaderfield` (which assert on these error codes) pass both ways. `test-http2-util-headers-list`, `test-http2-util-assert-valid-pseudoheader` and `test-http2-respond-file-fd-leak` fail identically on stock bun 1.4.0 and are unrelated (they require `internalBinding("http2")` / `internal/http2/util`, or cover an fd leak on `respondWithFile`'s error path).

</details>

## Rebase note

Main wrapped `assertSingleValueHeaders(headers)` in a `kStrictSingleValueFields !== false` conditional at the same three call sites this change inserts `assertNoConnectionHeaders(headers)` after. Node's `buildNgHeaderString` gates the single-value check on that flag but calls `isIllegalConnectionSpecificHeader` unconditionally, so the resolution keeps main's conditional for the single-value check and calls `assertNoConnectionHeaders` unconditionally after it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 16 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (0691f8e6f)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [869.61ms]
(pass) node none > Client Basics > should be able to send a POST request [608.10ms]
(pass) node none > Client Basics > constants [19.00ms]
(pass) node none > Client Basics > getDefaultSettings [7.81ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.37ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.16ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.05ms]
(pass) node none > Client Basics > should be able to send data using end [639.17ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [628.07ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 101 failed, 6 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.48ms]
(pass) node none > Client Basics > getDefaultSettings [0.18ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.16ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [2.08ms]
(pass) node none > Client Basics > is possible to abort request [1.10ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.75ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.62ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.02ms]
782 |           client.on("error", reject);
783 |           const req = client.request({ ":path": "/", "test-hea
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (0691f8e6f)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [884.72ms]
(pass) node none > Client Basics > should be able to send a POST request [627.51ms]
(pass) node none > Client Basics > constants [19.06ms]
(pass) node none > Client Basics > getDefaultSettings [7.13ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.19ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.87ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.45ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.95ms]
(pass) node none > Client Basics > should be able to send data using end [656.02ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [647.21ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0691f8e6f8
  features     baseline

22 deps, 108 codegen, 1171 objects in 1099ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [13.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [21.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] gen bindgenv2
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] fetch zlib
[zlib] up to date
[10/1234] gen .bind.ts → Gene
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                   |  27 +++-
 src/runtime/api/bun/h2_frame_parser.rs |  23 ++-
 test/js/node/http2/node-http2.test.js  | 288 +++++++++++++++++++++++++++++++++
 3 files changed, 328 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 16

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/http2.ts                        8     14      0
src/runtime/api/bun/h2_frame_parser.rs      6      8      0
test/js/node/http2/node-http2.test.js       8      7      0
```

</details>

<!-- robobun:evidence:end -->