### PR TITLE
Stop treating a locked body stream as a consumed one

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -918,7 +918,7 @@ JSValue tryUseReadableStreamBufferedFastPath(JSGlobalObject* globalObject, WebCo
     JSObject* handle = nativePtr.getObject();
     if (!handle)
         return {};
-    if (stream->m_disturbed)
+    if (stream->nativeSourceConsumed())
         return {};
     JSValue methodValue = handle->get(globalObject, method);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -525,7 +525,7 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     auto* domGlobalObject = defaultGlobalObject(globalObject);
     auto* runtime = WebCore::JSStreamsRuntime::from(globalObject);
 
-    stream->m_disturbed = true;
+    stream->m_nativeSourceMaterialized = true;
     size_t autoAllocateChunkSize = stream->m_autoAllocateChunkSize ? static_cast<size_t>(stream->m_autoAllocateChunkSize) : nativeSourceDefaultChunkSize;
 
     MarkedArgumentBuffer startArgs;

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -64,9 +64,7 @@ public:
     // Body.textStream(): the native source adapter decodes each chunk as UTF-8
     // text before enqueue.
     bool m_nativeTextMode : 1 { false };
-    // materializeNativeSource() ran m_nativePtr's start()/drain(), so some of the handle's
-    // bytes now live in the controller's queue. NOT [[disturbed]]: installing a controller
-    // is not a read.
+    // Set by materializeNativeSource(). Distinct from [[disturbed]]: see nativeSourceConsumed().
     bool m_nativeSourceMaterialized : 1 { false };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).
@@ -121,9 +119,8 @@ public:
     {
         return m_transferred || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);
     }
-    // The native handle no longer holds the whole body: it was read, or materializing moved
-    // bytes into the controller. Gates every path that bypasses the stream to take the
-    // handle's bytes directly (the buffered consumers here, ReadableStream::to_any_blob in Rust).
+    // Materializing drains the native handle into the controller's queue, so after a read OR
+    // a materialize the handle alone no longer holds the whole body. Check before reading it.
     bool nativeSourceConsumed() const { return m_disturbed || m_nativeSourceMaterialized; }
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -64,6 +64,10 @@ public:
     // Body.textStream(): the native source adapter decodes each chunk as UTF-8
     // text before enqueue.
     bool m_nativeTextMode : 1 { false };
+    // materializeNativeSource() ran m_nativePtr's start()/drain(), so some of the handle's
+    // bytes now live in the controller's queue. NOT [[disturbed]]: installing a controller
+    // is not a read.
+    bool m_nativeSourceMaterialized : 1 { false };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).
     JSC::WriteBarrier<JSReadableStreamReaderBase> m_reader;
@@ -117,6 +121,10 @@ public:
     {
         return m_transferred || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);
     }
+    // The native handle no longer holds the whole body: it was read, or materializing moved
+    // bytes into the controller. Gates every path that bypasses the stream to take the
+    // handle's bytes directly (the buffered consumers here, ReadableStream::to_any_blob in Rust).
+    bool nativeSourceConsumed() const { return m_disturbed || m_nativeSourceMaterialized; }
 
 private:
     JSReadableStream(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -133,6 +133,12 @@ extern "C" bool ReadableStream__isDisturbed(JSC::EncodedJSValue possibleReadable
     return stream && stream->m_disturbed;
 }
 
+extern "C" bool ReadableStream__isNativeSourceConsumed(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
+{
+    auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
+    return stream && stream->nativeSourceConsumed();
+}
+
 extern "C" bool ReadableStream__isLocked(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -646,6 +646,7 @@ int32_t ReadableStreamTag__tagged(Zig::GlobalObject*, JSC::EncodedJSValue* possi
 // The ReadableStream__* set.
 bool ReadableStream__tee(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*, JSC::EncodedJSValue* possibleReadableStream1, JSC::EncodedJSValue* possibleReadableStream2); // userJS: yes
 bool ReadableStream__isDisturbed(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
+bool ReadableStream__isNativeSourceConsumed(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
 bool ReadableStream__isLocked(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
 // no-op unless the reader slot holds a REAL reader (the direct/native lock is a no-op here).
 void ReadableStream__cancel(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: yes

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3091,6 +3091,19 @@ where
                             return;
                         }
 
+                        // A materialized ByteStream has already moved its buffered bytes into
+                        // the controller's queue, so the handle below would serve a truncated
+                        // body. Read through the stream instead.
+                        readable_stream::Source::Bytes(_)
+                            if stream.is_native_source_consumed(global_this) =>
+                        {
+                            if let Some(resp) = this.resp.get() {
+                                let mut pair = StreamPair { stream, this };
+                                resp.run_corked_with_type(Self::do_render_stream, &raw mut pair);
+                            }
+                            return;
+                        }
+
                         readable_stream::Source::Bytes(byte_stream_ptr) => {
                             // BACKREF: `Source::Bytes` stores a live non-null
                             // `*mut ByteStream` (the JS wrapper's `m_ctx` heap

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3091,9 +3091,7 @@ where
                             return;
                         }
 
-                        // A materialized ByteStream has already moved its buffered bytes into
-                        // the controller's queue, so the handle below would serve a truncated
-                        // body. Read through the stream instead.
+                        // The arm below reads the handle, which no longer holds the whole body.
                         readable_stream::Source::Bytes(_)
                             if stream.is_native_source_consumed(global_this) =>
                         {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1010,7 +1010,9 @@ impl Value {
             }
 
             match readable.ptr {
-                webcore::readable_stream::Source::Blob(blob) => {
+                webcore::readable_stream::Source::Blob(blob)
+                    if !readable.is_native_source_consumed(global_this) =>
+                {
                     // SAFETY: `Source::Blob` holds a live *mut ByteBlobLoader for the
                     // lifetime of the ReadableStream JS wrapper.
                     let result = unsafe { (*blob).to_any_blob(global_this) }
@@ -1741,6 +1743,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if readable.is_disturbed(global_object) {
                     return Ok(handle_body_already_used(global_object));
                 }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
+                }
                 let value = self.get_body_value();
                 if let Value::Locked(locked) = value {
                     return locked.set_promise(global_object, Action::GetText, Some(readable));
@@ -1875,6 +1880,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if readable.is_disturbed(global_object) {
                     return Ok(handle_body_already_used(global_object));
                 }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
+                }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
                 if let Value::Locked(locked) = value {
@@ -1924,6 +1932,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             if let Some(readable) = self.get_body_readable_stream() {
                 if readable.is_disturbed(global_object) {
                     return Ok(handle_body_already_used(global_object));
+                }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -1980,6 +1991,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if readable.is_disturbed(global_object) {
                     return Ok(handle_body_already_used(global_object));
                 }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
+                }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
                 if let Value::Locked(locked) = value {
@@ -2030,6 +2044,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             if let Some(readable) = self.get_body_readable_stream() {
                 if readable.is_disturbed(global_object) {
                     return Ok(handle_body_already_used(global_object));
+                }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -2134,6 +2151,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 {
                     return Ok(handle_body_already_used(global_object));
                 }
+                if readable.is_locked(global_object) {
+                    return Ok(handle_body_locked(global_object));
+                }
                 value.to_blob_if_possible();
                 if let Value::Locked(locked) = value {
                     return locked.set_promise(global_object, Action::GetBlob, Some(readable));
@@ -2193,6 +2213,18 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
         .err(
             jsc::ErrorCode::BODY_ALREADY_USED,
             format_args!("Body already used"),
+        )
+        .reject()
+}
+
+/// Fetch spec "body unusable": a body whose stream is locked rejects the read without
+/// recording an action, so releasing the lock leaves the body readable again. Mirrors the
+/// message `Bun.readableStreamTo*` would have rejected with further down.
+fn handle_body_locked(global_object: &JSGlobalObject) -> JSValue {
+    global_object
+        .err(
+            jsc::ErrorCode::INVALID_STATE_TypeError,
+            format_args!("Invalid state: ReadableStream is locked"),
         )
         .reject()
 }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2217,9 +2217,6 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
         .reject()
 }
 
-/// Fetch spec "body unusable": a body whose stream is locked rejects the read without
-/// recording an action, so releasing the lock leaves the body readable again. Mirrors the
-/// message `Bun.readableStreamTo*` would have rejected with further down.
 fn handle_body_locked(global_object: &JSGlobalObject) -> JSValue {
     global_object
         .err(

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -317,6 +317,13 @@ impl ReadableStream {
         use streams::{SourceHandle, Start, StreamError, StreamResult, Writable};
         use webcore::SinkHandle;
 
+        // Once the stream has been materialized, part of the body already sits in the
+        // controller's queue, which only the JS pump can reach. Wiring the native source
+        // here would deliver just the bytes that arrive after this point.
+        if self.is_native_source_consumed(global) {
+            return NativeWireResult::NotNative;
+        }
+
         if let Some(byte_stream) = self.ptr.bytes() {
             if byte_stream.sink.get().is_none() {
                 set_source(SourceHandle::ByteStream(byte_stream));

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -317,9 +317,7 @@ impl ReadableStream {
         use streams::{SourceHandle, Start, StreamError, StreamResult, Writable};
         use webcore::SinkHandle;
 
-        // Once the stream has been materialized, part of the body already sits in the
-        // controller's queue, which only the JS pump can reach. Wiring the native source
-        // here would deliver just the bytes that arrive after this point.
+        // Only the JS pump can reach bytes already queued on the controller.
         if self.is_native_source_consumed(global) {
             return NativeWireResult::NotNative;
         }
@@ -407,9 +405,7 @@ impl ReadableStream {
         is_disturbed_value(self.value, global_object)
     }
 
-    /// The native source handle no longer holds the whole body: the stream was read, or
-    /// materializing it moved bytes into the controller's queue. Bypassing the stream to
-    /// read the handle directly is only sound while this is false.
+    /// See `JSReadableStream::nativeSourceConsumed()`.
     pub fn is_native_source_consumed(&self, global_object: &JSGlobalObject) -> bool {
         // SAFETY: FFI call; value is a valid ReadableStream JSValue.
         ReadableStream__isNativeSourceConsumed(self.value, global_object)

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -136,6 +136,10 @@ unsafe extern "C" {
         possible_readable_stream: JSValue,
         global_object: &JSGlobalObject,
     ) -> bool;
+    safe fn ReadableStream__isNativeSourceConsumed(
+        possible_readable_stream: JSValue,
+        global_object: &JSGlobalObject,
+    ) -> bool;
     safe fn ReadableStream__isLocked(
         possible_readable_stream: JSValue,
         global_object: &JSGlobalObject,
@@ -189,7 +193,7 @@ impl ReadableStream {
     }
 
     pub fn to_any_blob(&mut self, global_this: &JSGlobalObject) -> Option<webcore::blob::Any> {
-        if self.is_disturbed(global_this) {
+        if self.is_native_source_consumed(global_this) {
             return None;
         }
 
@@ -394,6 +398,14 @@ impl ReadableStream {
 
     pub fn is_disturbed(&self, global_object: &JSGlobalObject) -> bool {
         is_disturbed_value(self.value, global_object)
+    }
+
+    /// The native source handle no longer holds the whole body: the stream was read, or
+    /// materializing it moved bytes into the controller's queue. Bypassing the stream to
+    /// read the handle directly is only sound while this is false.
+    pub fn is_native_source_consumed(&self, global_object: &JSGlobalObject) -> bool {
+        // SAFETY: FFI call; value is a valid ReadableStream JSValue.
+        ReadableStream__isNativeSourceConsumed(self.value, global_object)
     }
 
     pub fn is_locked(&self, global_object: &JSGlobalObject) -> bool {

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1032,9 +1032,12 @@ pub(crate) fn upload_stream(
 
     // Native ByteStream fast-path: wire the source/sink handles directly so
     // bytes flow via `ByteStream::on_data` → `SinkHandle::write` without the JS
-    // `readStreamIntoSink` pump.
+    // `readStreamIntoSink` pump. Not once the stream is materialized: the bytes
+    // already moved into the controller's queue are only reachable by the pump.
     if let Some(byte_stream) = readable_stream.ptr.bytes() {
-        if byte_stream.sink.get().is_none() {
+        if byte_stream.sink.get().is_none()
+            && !readable_stream.is_native_source_consumed(global_this)
+        {
             sink.source = crate::webcore::streams::SourceHandle::ByteStream(byte_stream);
             byte_stream.sink.set(sink_handle);
             byte_stream.sink_paused.set(false);

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1032,8 +1032,7 @@ pub(crate) fn upload_stream(
 
     // Native ByteStream fast-path: wire the source/sink handles directly so
     // bytes flow via `ByteStream::on_data` → `SinkHandle::write` without the JS
-    // `readStreamIntoSink` pump. Not once the stream is materialized: the bytes
-    // already moved into the controller's queue are only reachable by the pump.
+    // `readStreamIntoSink` pump.
     if let Some(byte_stream) = readable_stream.ptr.bytes() {
         if byte_stream.sink.get().is_none()
             && !readable_stream.is_native_source_consumed(global_this)

--- a/test/js/bun/s3/s3-materialized-stream-upload.test.ts
+++ b/test/js/bun/s3/s3-materialized-stream-upload.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The S3 uploader has its own copy of the native ByteStream fast path: it takes the stream's
+// buffered bytes straight off the ByteStream handle. Once the stream has been materialized
+// (anything that installs its controller, such as getReader()), those bytes already live in
+// the controller's queue, so the fast path must stand down or the upload is truncated.
+//
+// 1 MB: a short body is uploaded before anything buffers, which hides the truncation.
+const fixture = /* ts */ `
+import { S3Client } from "bun";
+
+const PAYLOAD_LENGTH = 1_000_000;
+const payload = Buffer.alloc(PAYLOAD_LENGTH, "z").toString();
+let received = 0;
+
+const xml = (body: string) => new Response(body, { headers: { "content-type": "application/xml" } });
+
+using s3 = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    if (req.method === "PUT") {
+      received += (await req.arrayBuffer()).byteLength;
+      return new Response("", { headers: { ETag: '"etag"' } });
+    }
+    if (new URL(req.url).searchParams.has("uploads")) {
+      return xml("<InitiateMultipartUploadResult><UploadId>upload</UploadId></InitiateMultipartUploadResult>");
+    }
+    await req.text();
+    return xml("<CompleteMultipartUploadResult></CompleteMultipartUploadResult>");
+  },
+});
+
+using upstream = Bun.serve({ port: 0, fetch: () => new Response(payload) });
+
+const client = new S3Client({
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:" + s3.port,
+});
+
+const res = await fetch("http://127.0.0.1:" + upstream.port + "/");
+res.body!.getReader().releaseLock(); // materialize, do not read
+await client.write("object", new Response(res.body));
+
+console.log(JSON.stringify({ received, expected: PAYLOAD_LENGTH }));
+`;
+
+// The S3 client does not honor NO_PROXY, so an inherited proxy would hijack the
+// request to the stub server.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+describe("S3Client.write()", () => {
+  test("uploads a materialized stream body in full", async () => {
+    using dir = tempDir("s3-materialized-stream", { "fixture.ts": fixture });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: envWithoutProxy,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("S3Error");
+    expect(JSON.parse(stdout)).toEqual({ received: 1_000_000, expected: 1_000_000 });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,7 +1,8 @@
 import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite } from "harness";
+import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
+import { join } from "node:path";
 
 const exampleServer = exampleSite("http");
 
@@ -1158,6 +1159,95 @@ for (const { body, fn } of bodyTypes) {
       }
     });
 
+    // `bodyUsed` is the stream's [[disturbed]] bit, which only a read or a cancel sets.
+    // Merely locking the stream (getReader, tee) leaves the body intact.
+    describe("locking the body stream does not consume it", () => {
+      const bodies = [
+        { label: "string", make: () => "bun" },
+        { label: "Blob", make: () => new Blob(["bun"]) },
+        { label: "Uint8Array", make: () => new Uint8Array([0x62, 0x75, 0x6e]) },
+        {
+          label: "ReadableStream",
+          make: () =>
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("bun"));
+                controller.close();
+              },
+            }),
+        },
+      ];
+
+      for (const { label, make } of bodies) {
+        describe(label, () => {
+          test("getReader() alone does not set bodyUsed", () => {
+            const result = fn(make());
+            result.body!.getReader();
+            expect(result.bodyUsed).toBe(false);
+            expect(result.body!.locked).toBe(true);
+          });
+
+          test("getReader() + releaseLock() leaves the body readable", async () => {
+            const result = fn(make());
+            result.body!.getReader().releaseLock();
+            expect(result.bodyUsed).toBe(false);
+            expect(result.body!.locked).toBe(false);
+            expect(await result.text()).toBe("bun");
+            expect(result.bodyUsed).toBe(true);
+          });
+
+          test("tee() does not set bodyUsed", async () => {
+            const result = fn(make());
+            const [branch] = result.body!.tee();
+            expect(result.bodyUsed).toBe(false);
+            expect(result.body!.locked).toBe(true);
+            expect(await new Response(branch).text()).toBe("bun");
+          });
+
+          test("clone() after getReader() + releaseLock()", async () => {
+            const result = fn(make());
+            result.body!.getReader().releaseLock();
+            const cloned = result.clone();
+            expect(await cloned.text()).toBe("bun");
+            expect(await result.text()).toBe("bun");
+          });
+
+          test("the released stream is accepted as a new body", async () => {
+            const result = fn(make());
+            result.body!.getReader().releaseLock();
+            expect(await new Response(result.body).text()).toBe("bun");
+          });
+
+          test("reading one chunk does consume it", async () => {
+            const result = fn(make());
+            const reader = result.body!.getReader();
+            await reader.read();
+            reader.releaseLock();
+            expect(result.bodyUsed).toBe(true);
+            await expect(result.text()).rejects.toThrow(TypeError);
+          });
+
+          test("cancelling consumes it", async () => {
+            const result = fn(make());
+            await result.body!.cancel();
+            expect(result.bodyUsed).toBe(true);
+            await expect(result.text()).rejects.toThrow(TypeError);
+          });
+
+          // A consume that rejects because the stream is locked must not record the read:
+          // once the lock is released the body is still there.
+          test("a rejected read while locked does not consume it", async () => {
+            const result = fn(make());
+            const reader = result.body!.getReader();
+            await expect(result.text()).rejects.toThrow(TypeError);
+            expect(result.bodyUsed).toBe(false);
+            reader.releaseLock();
+            expect(await result.text()).toBe("bun");
+          });
+        });
+      }
+    });
+
     describe("new Response()", () => {
       ["text", "arrayBuffer", "bytes", "blob"].map(method => {
         test(method, async () => {
@@ -1273,6 +1363,39 @@ describe.concurrent("string body consumption does not leak", () => {
       expect(exitCode).toBe(0);
     });
   }
+});
+
+// Network-backed bodies are the case where materializing the stream really does move bytes
+// out of the native source and into the controller's queue, so the "peek then read" shape
+// has to survive that too.
+describe("locking a network-backed body stream does not consume it", () => {
+  test("fetch() response body", async () => {
+    using server = Bun.serve({ port: 0, fetch: () => new Response("from server") });
+    const res = await fetch(server.url);
+    res.body!.getReader().releaseLock();
+    expect(res.bodyUsed).toBe(false);
+    expect(await res.text()).toBe("from server");
+  });
+
+  test("incoming Bun.serve() request body", async () => {
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        req.body!.getReader().releaseLock();
+        return Response.json({ bodyUsed: req.bodyUsed, text: await req.text() });
+      },
+    });
+    const res = await fetch(server.url, { method: "POST", body: "payload" });
+    expect(await res.json()).toEqual({ bodyUsed: false, text: "payload" });
+  });
+
+  test("Bun.file() body", async () => {
+    using dir = tempDir("body-peek", { "body.txt": "filebody" });
+    const res = new Response(file(join(String(dir), "body.txt")));
+    res.body!.getReader().releaseLock();
+    expect(res.bodyUsed).toBe(false);
+    expect(await res.text()).toBe("filebody");
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/6860

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1398,6 +1398,70 @@ describe("locking a network-backed body stream does not consume it", () => {
   });
 });
 
+// Materializing a ByteStream moves its buffered bytes into the stream controller's queue, so
+// anything that reaches past the stream for the native handle's bytes has to stop doing that
+// once the stream has been materialized.
+describe("a materialized body stream is not read through its native handle", () => {
+  // 1 MB: a short payload is served off the socket before anything buffers, which hides the
+  // truncation. At this size the ByteStream always holds a prefix by the time it materializes.
+  const payload = Buffer.alloc(1_000_000, "z").toString();
+
+  test("Bun.serve() streams a re-wrapped fetch() body in full", async () => {
+    using upstream = Bun.serve({ port: 0, fetch: () => new Response(payload) });
+    using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        const res = await fetch(upstream.url);
+        res.body!.getReader().releaseLock(); // materialize, do not read
+        return new Response(res.body);
+      },
+    });
+    const res = await fetch(server.url);
+    const text = await res.text();
+    expect(text.length).toBe(payload.length);
+    expect(text).toBe(payload);
+  });
+
+  test("Bun.serve() streams a re-wrapped Blob body in full", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        const src = new Response(new Blob([payload]));
+        src.body!.getReader().releaseLock();
+        return new Response(src.body);
+      },
+    });
+    expect(await (await fetch(server.url)).text()).toBe(payload);
+  });
+
+  // The consumers below attach to the body through `ReadableStream::wire_native_sink`, which
+  // takes the ByteStream's buffer directly. Once the stream is materialized that buffer is
+  // already in the controller's queue, so they have to fall back to reading the stream.
+  test("fetch() uploads a re-wrapped body in full", async () => {
+    using upstream = Bun.serve({ port: 0, fetch: () => new Response(payload) });
+    using target = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        return new Response(String((await req.arrayBuffer()).byteLength));
+      },
+    });
+    const res = await fetch(upstream.url);
+    res.body!.getReader().releaseLock(); // materialize, do not read
+    const uploaded = await fetch(target.url, { method: "POST", body: res.body, duplex: "half" });
+    expect(await uploaded.text()).toBe(String(payload.length));
+  });
+
+  test("HTMLRewriter transforms a re-wrapped body in full", async () => {
+    using upstream = Bun.serve({ port: 0, fetch: () => new Response(payload) });
+    const res = await fetch(upstream.url);
+    res.body!.getReader().releaseLock(); // materialize, do not read
+    const rewritten = new HTMLRewriter().on("p", {}).transform(new Response(res.body));
+    const text = await rewritten.text();
+    expect(text.length).toBe(payload.length);
+    expect(text).toBe(payload);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/6860
 describe("constructing a body from an unusable ReadableStream", () => {
   const bytes = () =>

--- a/test/regression/issue/07001.test.ts
+++ b/test/regression/issue/07001.test.ts
@@ -55,7 +55,7 @@ test("await fetch(req) throws if req.body is already consumed (stream that has b
   expect(req.bodyUsed).toBe(true);
 });
 
-test("await fetch(req) throws if req.body is already consumed (stream)", async () => {
+test("await fetch(req) throws if req.body is locked (stream)", async () => {
   const req = new Request("https://example.com/", {
     body: "test",
     method: "POST",
@@ -63,5 +63,20 @@ test("await fetch(req) throws if req.body is already consumed (stream)", async (
 
   req.body.getReader();
   expect(() => fetch(req)).toThrow();
-  expect(req.bodyUsed).toBe(true);
+  // Holding a reader makes the body unusable, but it does not disturb the stream,
+  // so the body is locked without being used.
+  expect(req.body.locked).toBe(true);
+  expect(req.bodyUsed).toBe(false);
+});
+
+test("await fetch(req) throws if req.body is locked (tee)", async () => {
+  const req = new Request("https://example.com/", {
+    body: "test",
+    method: "POST",
+  });
+
+  req.body.tee();
+  expect(() => fetch(req)).toThrow();
+  expect(req.body.locked).toBe(true);
+  expect(req.bodyUsed).toBe(false);
 });


### PR DESCRIPTION
### Problem

- `body.getReader()` followed by `releaseLock()`, with nothing read, sets `bodyUsed` and makes the body permanently unreadable: `text()` rejects with `TypeError: Body already used`. Node returns the content. `tee()` does the same. Affects every body with a native source (string, `Blob`, `Bun.file()`, network), not user `ReadableStream` bodies.
- `materializeNativeSource()` (`BunStreamSource.cpp`) sets `m_disturbed` when it installs the controller, and `getReader()`/`tee()` both run it. The flag also told several fast paths that the native handle no longer holds the whole body.

### Fix

- `materializeNativeSource()` sets a new bit, `m_nativeSourceMaterialized`. `[[disturbed]]` is now set only by reads and cancels.
- Fast paths that read the handle check `nativeSourceConsumed()`, the OR of both bits, so each stays as conservative as before: the C++ buffered consumers, `to_any_blob`, body extraction, `RequestContext`'s renderer, `wire_native_sink` (`fetch()` uploads, `FileSink`, `HTMLRewriter`), and the S3 uploader. Without a gate, a re-wrapped materialized body is served or uploaded truncated (about 870 KB of 1 MB).
- The body getters recorded a read before the stream rejected it as locked, which burned the body too. They now reject a locked stream first.
- Verified: `test/js/web/fetch/body.test.ts` (41 new cases fail on `main`), `test/js/bun/s3/s3-materialized-stream-upload.test.ts`, `test/regression/issue/07001.test.ts` (one assertion encoded the bug). The other suites run are listed in Notes.

### Background

- A native-source body's `ReadableStream` gets its controller lazily, from `materializeNativeSource()`. That step calls the handle's `start()`/`drain()`, which moves the handle's buffered bytes into the controller's queue.
- From then on the handle alone is incomplete. The fast paths read it directly to skip the JS stream machinery, so they would deliver only the bytes that arrive later.
- Spec `[[disturbed]]` means a read or cancel happened, and `bodyUsed` reports it. Locking (`getReader()`, `tee()`) is a separate state.

<details><summary>Notes</summary>

Differential against node v26.3.0, 12 cases covering `getReader`+`releaseLock`, `tee`, `clone`, re-wrapping the released stream, and the cases that must still consume the body (a real `read()`, `cancel()`, a reader held across the consume). Bun diverged on 6 before and matches on all 12 after.

Truncation without the gates, 1 MB body, three runs each:

```
Bun.serve() re-wrapped fetch() body      873024 / 672585 / 607102
fetch() upload of a re-wrapped body      872000 / 738068 / 541619
S3 upload of a re-wrapped body           934464
HTMLRewriter on a re-wrapped body        872000
```

A short body hides this: it is served off the socket before anything buffers, so the tests use 1 MB.

Other suites run: `body-stream.test.ts` (9086 cases), `body-clone`, `body-mixin-errors` (#36499's tests), `09555`, the four `html-rewriter` suites, `bun-write`, `serve`, and `fetch.test.ts` as a differential against `main` (the container fails about 40 network tests either way; the failure sets with and without this diff are identical).

History. The PR originally also fixed `fetch()` not rejecting a locked Request body, a `ValueBufferer` arm that hit `unreachable!()`, and `ResumableSink`. After rebasing onto current `main`: #36499 had fixed the `fetch()` case independently (its tests pass unchanged here), #38656 removed `ValueBufferer`, and #36087 replaced `ResumableSink` with `wire_native_sink`, which carried the same bug, so the gate moved there. The S3 uploader has an inlined copy of that fast path and gets its own gate and test.

Issues suggested by the find-issues bot (#19939, #24766, #28952) were each reproduced and are not fixed by this change; see the comment below.

The S3 test spawns its fixture with the proxy variables cleared, following `s3-connection-close.test.ts`, because the S3 client does not honor `NO_PROXY`.

While verifying, found that `Bun.write(path, new Response(stream))` hangs and `Bun.write(path, stream)` stringifies the stream, on `main` and on the release build alike. Unrelated; reported separately.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->