### PR TITLE
util: %s should inspect built-ins that inherit Symbol.toPrimitive

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -125,6 +125,7 @@ const StringPrototypeValueOf = uncurryThis(String.prototype.valueOf);
 const SymbolPrototypeToString = uncurryThis(Symbol.prototype.toString);
 const SymbolPrototypeValueOf = uncurryThis(Symbol.prototype.valueOf);
 const SymbolIterator = Symbol.iterator;
+const SymbolToPrimitive = Symbol.toPrimitive;
 const SymbolToStringTag = Symbol.toStringTag;
 
 const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
@@ -2467,36 +2468,44 @@ function hasBuiltInToString(value) {
     if (proxyTarget === null) {
       return true;
     }
-    value = proxyTarget;
+    return hasBuiltInToString(proxyTarget);
   }
 
-  // Check if value has a custom Symbol.toPrimitive transformation.
-  if (typeof value[Symbol.toPrimitive] === "function") {
-    return false;
-  }
+  let hasOwnToString = ObjectPrototypeHasOwnProperty;
+  let hasOwnToPrimitive = ObjectPrototypeHasOwnProperty;
 
-  // Count objects that have no `toString` function as built-in.
+  // Count objects without `toString` and `Symbol.toPrimitive` function as built-in.
   if (typeof value.toString !== "function") {
-    return true;
-  }
-
-  // The object has a own `toString` property. Thus it's not not a built-in one.
-  if (ObjectPrototypeHasOwnProperty(value, "toString")) {
+    if (typeof value[SymbolToPrimitive] !== "function") {
+      return true;
+    } else if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
+      return false;
+    }
+    hasOwnToString = returnFalse;
+  } else if (ObjectPrototypeHasOwnProperty(value, "toString")) {
+    return false;
+  } else if (typeof value[SymbolToPrimitive] !== "function") {
+    hasOwnToPrimitive = returnFalse;
+  } else if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
     return false;
   }
 
-  // Find the object that has the `toString` property as own property in the
-  // prototype chain.
+  // Find the object that has the `toString` property or the `Symbol.toPrimitive`
+  // property as own property in the prototype chain.
   let pointer = value;
   do {
     pointer = ObjectGetPrototypeOf(pointer);
-  } while (!ObjectPrototypeHasOwnProperty(pointer, "toString"));
+  } while (!hasOwnToString(pointer, "toString") && !hasOwnToPrimitive(pointer, SymbolToPrimitive));
 
   // Check closer if the object is a built-in.
   const descriptor = ObjectGetOwnPropertyDescriptor(pointer, "constructor");
   return (
     descriptor !== undefined && typeof descriptor.value === "function" && builtInObjects.has(descriptor.value.name)
   );
+}
+
+function returnFalse() {
+  return false;
 }
 
 const firstErrorLine = error => StringPrototypeSplit(error.message, "\n", 1)[0];

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -495,3 +495,51 @@ test("no assertion failures", () => {
     );
   });
 });
+
+test("%s inspects values whose Symbol.toPrimitive is inherited from a built-in", () => {
+  // Date and boxed Symbol both inherit Symbol.toPrimitive from a built-in
+  // prototype, so they are inspected rather than passed to String().
+  assert.strictEqual(util.format("%s", new Date(0)), "1970-01-01T00:00:00.000Z");
+  assert.strictEqual(util.format("%s", Object(symbol)), "[Symbol: Symbol(foo)]");
+  assert.strictEqual(util.formatWithOptions({ colors: true }, "%s", new Date(0)), "1970-01-01T00:00:00.000Z");
+  assert.strictEqual(util.format("%s", Object.create(Date.prototype)), "Date {}");
+
+  class MyDate extends Date {}
+  assert.strictEqual(util.format("%s", new MyDate(0)), "MyDate 1970-01-01T00:00:00.000Z");
+
+  // The proxy is unwrapped before the check, so the built-in target counts.
+  const proxiedDate = new Proxy(new Date(0), {});
+  assert.strictEqual(
+    util.format("%s", proxiedDate),
+    util.inspect(proxiedDate, { depth: 0, colors: false, compact: 3 }),
+  );
+
+  // An own or user-defined conversion is still preferred over inspecting.
+  assert.strictEqual(util.format("%s", { [Symbol.toPrimitive]: () => "own toPrimitive" }), "own toPrimitive");
+  assert.strictEqual(
+    util.format("%s", { __proto__: null, [Symbol.toPrimitive]: () => "own toPrimitive, no toString" }),
+    "own toPrimitive, no toString",
+  );
+  class UserToPrimitive {
+    [Symbol.toPrimitive]() {
+      return "user prototype toPrimitive";
+    }
+  }
+  assert.strictEqual(util.format("%s", new UserToPrimitive()), "user prototype toPrimitive");
+  class SubDate extends Date {
+    [Symbol.toPrimitive]() {
+      return "subclass toPrimitive";
+    }
+  }
+  assert.strictEqual(util.format("%s", new SubDate(0)), "subclass toPrimitive");
+  const dateWithOwnToString = new Date(0);
+  dateWithOwnToString.toString = () => "own toString";
+  assert.strictEqual(util.format("%s", dateWithOwnToString), "own toString");
+
+  // Inherited from a prototype with no constructor: not a built-in.
+  const nullProtoToPrimitive = { __proto__: { __proto__: null, [Symbol.toPrimitive]: () => "null prototype" } };
+  assert.strictEqual(util.format("%s", nullProtoToPrimitive), "null prototype");
+
+  // A non-callable Symbol.toPrimitive is ignored.
+  assert.strictEqual(util.format("%s", { [Symbol.toPrimitive]: 5 }), "{ Symbol(Symbol.toPrimitive): 5 }");
+});


### PR DESCRIPTION
### What's wrong

`util.format("%s", value)` (and anything built on it: `util.formatWithOptions`, `new console.Console(...)`, winston/pino pretty transports) refuses to inspect any value with a callable `Symbol.toPrimitive` and falls back to `String(value)`. That catches `Date` and boxed `Symbol`, whose `@@toPrimitive` lives on a built-in prototype.

```js
import { format } from "node:util";

console.log(format("%s", new Date(0)));
// node: 1970-01-01T00:00:00.000Z
// bun:  Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)  <- locale/TZ dependent

console.log(format("%s", Object(Symbol("q"))));
// node: [Symbol: Symbol(q)]
// bun:  TypeError: Cannot convert a symbol to a string
```

So `console.log("%s", new Date())` through any `Console` instance logs different bytes per machine, and a boxed `Symbol` that merely flows through a `%s` throws out of the logging call.

### Cause

`hasBuiltInToString()` in `src/js/internal/util/inspect.js` started with:

```js
// Check if value has a custom Symbol.toPrimitive transformation.
if (typeof value[Symbol.toPrimitive] === "function") {
  return false;
}
```

An *inherited* `@@toPrimitive` disqualifies the value from the built-in path, so the `%s` branch of `formatWithOptionsInternal` takes `String(tempArg)`. `String(new Date(0))` is the locale string; `String(Object(Symbol("q")))` goes through `Symbol.prototype[@@toPrimitive]`, returns a symbol, and `ToString` on a symbol throws.

### Fix

Port Node's current `hasBuiltInToString`: walk the prototype chain for whichever of `toString` or `@@toPrimitive` appears as an own property first, then check whether *that* object's constructor is a built-in. An own conversion, or one on a user prototype, still returns `false` and takes `String()`; `Date` and boxed `Symbol` now get inspected, as they do in Node. Proxies are unwrapped recursively so the function never reads properties off a proxy (the `value = proxyTarget` unwrap only peeled one layer).

Two more divergences this clears up, both of which previously threw `TypeError: Type error` out of `format()`:

```js
format("%s", Object.create(Date.prototype));   // now "Date {}"
format("%s", new Proxy(new Date(0), {}));      // now inspects the target
```

Out of scope: the global `console.log`'s `%s` is a separate native implementation that follows the WHATWG console spec (`String(value)`), unchanged here.

### Verification

`bun bd test test/js/node/util/node-inspect-tests/parallel/util-format.test.js` covers `Date`, `Date` subclass, `Object.create(Date.prototype)`, boxed `Symbol`, a proxied `Date`, plus the controls that must keep stringifying (own `@@toPrimitive`, `@@toPrimitive` on a user prototype, a subclass of `Date` that overrides `@@toPrimitive`, own `toString`, a non-callable `@@toPrimitive`). The new test fails on the current build with:

```
AssertionError: Expected values to be strictly equal:
+ 'Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)'
- '1970-01-01T00:00:00.000Z'
```

Output for 40 `%s` shapes was diffed against node v26.3.0; everything matches after the fix except two pre-existing `util.inspect` differences unrelated to `%s` (bun does not print the `Proxy(...)` wrapper, and `ArrayBuffer` shows `byteLength` without brackets).
