### PR TITLE
process: exit 7 and skip 'exit' listeners when the uncaught-exception handler throws

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -483,6 +483,9 @@ pub fn is_smol_mode() -> bool {
 #[derive(Default)]
 pub struct ExitHandler {
     pub exit_code: u8,
+    /// Set when an exception escapes the uncaught-exception handler. Node does
+    /// not run `'exit'` listeners in that state, so neither do we.
+    pub skip_exit_event: bool,
 }
 
 impl ExitHandler {
@@ -503,7 +506,9 @@ impl ExitHandler {
     /// reference instead; the body re-enters JS so no `&mut` is held.
     pub fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
-        Process__dispatchOnExit(vm.global(), exit_code);
+        if !vm.exit_handler.skip_exit_event {
+            Process__dispatchOnExit(vm.global(), exit_code);
+        }
         if vm.worker.is_none() {
             Bun__closeAllSQLiteDatabasesForTermination();
             Bun__WebView__closeAllForTermination();
@@ -1375,6 +1380,27 @@ impl VirtualMachine {
         bun_core::env_var::feature_flag::BUN_DESTRUCT_VM_ON_EXIT::get().unwrap_or(false)
     }
 
+    /// An exception escaped the handler that was itself handling an uncaught
+    /// exception. Node calls this "Internal Exception Handler Run-Time Failure":
+    /// it reports `err`, skips `'exit'` listeners and exits 7 (1 in a worker).
+    ///
+    /// Does not return on the main thread; forwards to the parent and returns
+    /// on a worker.
+    #[cold]
+    pub fn fatal_exception_in_handler(&mut self, global_object: &JSGlobalObject, err: JSValue) {
+        self.exit_handler.skip_exit_event = true;
+        if !self.is_main_thread() {
+            self.exit_handler.exit_code = 1;
+            (self.on_unhandled_rejection)(self, global_object, err);
+            return;
+        }
+        let hooks = runtime_hooks().expect("RuntimeHooks not installed");
+        self.run_error_handler(err, None);
+        // SAFETY: `global_object` is the live VM global; `process_exit` is
+        // `bun_runtime::node::process::exit` (main-thread `noreturn`).
+        unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
+    }
+
     pub fn uncaught_exception(
         &mut self,
         global_object: &JSGlobalObject,
@@ -1393,20 +1419,12 @@ impl VirtualMachine {
 
         let hooks = runtime_hooks().expect("RuntimeHooks not installed");
         if self.is_handling_uncaught_exception {
+            self.fatal_exception_in_handler(global_object, err);
             if !self.is_main_thread() {
-                // node parity: a throw inside the uncaughtException handler in a
-                // worker exits the worker with code 1 (not the main-thread fatal
-                // code 7). Report it to the parent + arm termination via the
-                // normal path; process_exit() RETURNS on a worker, so the
-                // main-thread process_exit(7)+panic below would crash.
-                self.exit_handler.exit_code = 1;
-                (self.on_unhandled_rejection)(self, global_object, err);
+                // Worker: the funnel forwarded to the parent and returned.
                 return false;
             }
-            self.run_error_handler(err, None);
-            // SAFETY: `global_object` is the live VM global; `process_exit` is
-            // `bun_runtime::node::process::exit` (main-thread `noreturn`).
-            unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
+            // Unreachable: the funnel called process_exit(7) on the main thread.
             panic!("Uncaught exception while handling uncaught exception");
         }
         self.is_handling_uncaught_exception = true;
@@ -1427,7 +1445,8 @@ impl VirtualMachine {
                 // throws. No handler is running, so drop the recursion guard or
                 // that re-entry exits 7 ("handler threw") instead of 1.
                 self.is_handling_uncaught_exception = false;
-                // SAFETY: see above.
+                // SAFETY: `global_object` is the live VM global; `process_exit` is
+                // `bun_runtime::node::process::exit` (main-thread `noreturn`).
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
                 panic!("made it past process.exit()");
             }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1203,7 +1203,7 @@ void signalHandler(uv_signal_t* signal, int signalNumber)
 #endif
 };
 
-extern "C" void Bun__logUnhandledException(JSC::EncodedJSValue exception);
+extern "C" void Bun__reportFatalExceptionInHandler(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 
 extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue exception, int isRejection)
 {
@@ -1250,10 +1250,12 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         (void)call(lexicalGlobalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
         if (auto ex = scope.exception()) {
-            (void)scope.tryClearException();
-            // if an exception is thrown in the uncaughtException handler, we abort
-            Bun__logUnhandledException(JSValue::encode(JSValue(ex)));
-            Bun__Process__exit(lexicalGlobalObject, 1);
+            // A throw from the capture callback is fatal, same as one from an
+            // 'uncaughtException' listener: report it and exit without running
+            // 'exit' listeners.
+            if (scope.tryClearException()) {
+                Bun__reportFatalExceptionInHandler(lexicalGlobalObject, JSValue::encode(JSValue(ex)));
+            }
         }
     } else if (wrapped.listenerCount(uncaughtExceptionIdent) > 0) {
         wrapped.emit(uncaughtExceptionIdent, args);

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -126,6 +126,18 @@ pub fn report_unhandled_error(global: &JSGlobalObject, value: JSValue) -> JSValu
     JSValue::UNDEFINED
 }
 
+/// See [`VirtualMachine::fatal_exception_in_handler`]. Does not return on the
+/// main thread.
+// HOST_EXPORT(Bun__reportFatalExceptionInHandler, c)
+pub fn report_fatal_exception_in_handler(global: &JSGlobalObject, value: JSValue) {
+    crate::mark_binding!();
+
+    global
+        .bun_vm()
+        .as_mut()
+        .fatal_exception_in_handler(global, value);
+}
+
 /// This function is called on another thread
 /// The main difference: we need to allocate the task & wakeup the thread
 /// We can avoid that if we run it from the main thread.

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -60,14 +60,6 @@ pub fn drain_microtasks_from_js(global: &JSGlobalObject, _cf: &CallFrame) -> JSV
     JSValue::UNDEFINED
 }
 
-/// `export fn Bun__logUnhandledException(exception: JSValue) void { get().runErrorHandler(exception, null); }`
-// HOST_EXPORT(Bun__logUnhandledException, c)
-pub fn log_unhandled_exception(exception: JSValue) {
-    VirtualMachine::get()
-        .as_mut()
-        .run_error_handler(exception, None);
-}
-
 /// `export fn Bun__remapStackFramePositions(vm, frames, frames_count)` —
 /// **may run on the heap-collector thread** (see oven-sh/bun#17087); the
 /// underlying method serializes on `remap_stack_frames_mutex`.

--- a/test/js/node/process/process-onUncaughtExceptionAbort.js
+++ b/test/js/node/process/process-onUncaughtExceptionAbort.js
@@ -1,4 +1,7 @@
+process.on("exit", () => console.log("exit-listener"));
+
 process.on("uncaughtException", err => {
+  console.log("handler");
   throw new Error("bar");
 });
 

--- a/test/js/node/process/process-uncaughtExceptionCaptureCallbackAbort.js
+++ b/test/js/node/process/process-uncaughtExceptionCaptureCallbackAbort.js
@@ -1,4 +1,7 @@
+process.on("exit", () => console.log("exit-listener"));
+
 process.setUncaughtExceptionCaptureCallback(err => {
+  console.log("handler");
   throw new Error("bar");
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1135,20 +1135,93 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  // A throw from the handler that is itself handling an uncaught exception is node's
+  // "Internal Exception Handler Run-Time Failure": exit code 7, and 'exit' listeners are
+  // not run because the process is already mid-failure inside its own failure handler.
   it("aborts when the uncaughtException handler throws", async () => {
-    const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")],
+      env: bunEnv,
+      stdout: "pipe",
       stderr: "pipe",
     });
-    expect(await proc.exited).toBe(7);
-    expect(await proc.stderr.text()).toContain("bar");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("handler\n");
+    expect(stderr).toContain("bar");
+    expect(exitCode).toBe(7);
   });
 
   it("aborts when the uncaughtExceptionCaptureCallback throws", async () => {
-    const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-uncaughtExceptionCaptureCallbackAbort.js")], {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "process-uncaughtExceptionCaptureCallbackAbort.js")],
+      env: bunEnv,
+      stdout: "pipe",
       stderr: "pipe",
     });
-    expect(await proc.exited).toBe(1);
-    expect(await proc.stderr.text()).toContain("bar");
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("handler\n");
+    expect(stderr).toContain("bar");
+    expect(exitCode).toBe(7);
+  });
+
+  it("aborts when the uncaughtExceptionMonitor listener throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.on("exit", () => console.log("exit-listener"));
+          process.on("uncaughtExceptionMonitor", () => { throw new Error("bar"); });
+          process.on("uncaughtException", () => { console.log("handler"); });
+          setTimeout(() => { throw new Error("foo"); }, 1);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("bar");
+    expect(exitCode).toBe(7);
+  });
+
+  // In a worker node forwards the exception to the parent's 'error' handler, reports exit code 1
+  // (not 7), and still skips the worker's 'exit' listeners.
+  it.each([
+    [
+      "uncaughtExceptionCaptureCallback",
+      `process.setUncaughtExceptionCaptureCallback(() => { throw new Error("bar"); });`,
+    ],
+    ["uncaughtException listener", `process.on("uncaughtException", () => { throw new Error("bar"); });`],
+  ])("terminates the worker when its %s throws", async (_, handlerSetup) => {
+    using dir = tempDir("uncaught-exception-worker", {
+      "index.js": `
+        const { Worker } = require("node:worker_threads");
+        const worker = new Worker(require("node:path").join(__dirname, "worker.js"));
+        worker.on("error", e => console.log("parent-error:", e.message));
+        worker.on("exit", code => console.log("worker exit", code));
+      `,
+      "worker.js": `
+        process.on("exit", () => console.log("worker-exit-listener"));
+        ${handlerSetup}
+        setTimeout(() => { throw new Error("foo"); }, 1);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "parent-error: bar\nworker exit 1\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
Node documents exit code 7 as "Internal Exception Handler Run-Time Failure": if an exception is thrown from inside the handler that is itself handling an uncaught exception, node reports the *new* exception, exits 7, and **does not run `'exit'` listeners** — the process is by definition mid-failure inside its own failure handler. Supervisors and restart policies key on that exit code.

Bun diverges in both directions.

## Repro

```js
process.setUncaughtExceptionCaptureCallback(e => {
  console.log("cap", e.message);
  throw new Error("inner");
});
process.on("exit", c => console.log("exit listener, code", c));
setTimeout(() => {
  throw new Error("outer");
}, 1);
```

| shape (handler that throws)         | node v26.3.0          | bun 1.4.0                     |
| ----------------------------------- | --------------------- | ----------------------------- |
| `setUncaughtExceptionCaptureCallback` | exit 7, no `'exit'` | **exit 1**, **runs `'exit'`** |
| `'uncaughtException'` listener      | exit 7, no `'exit'`   | exit 7, **runs `'exit'`**     |
| `'uncaughtExceptionMonitor'` listener | exit 7, no `'exit'` | exit 7, **runs `'exit'`**     |

So a supervisor watching a bun process sees an ordinary exit 1 for the capture-callback shape, and user cleanup code runs in a state node deems unsafe to continue in.

## Cause

Two halves of the same funnel disagreed.

`Bun__handleUncaughtException` (`src/jsc/bindings/BunProcess.cpp`) special-cased a throw from the capture callback: it logged the exception and called `Bun__Process__exit(global, 1)`. A throw from an `'uncaughtException'` / `'uncaughtExceptionMonitor'` listener instead re-entered `VirtualMachine::uncaught_exception`, whose recursion guard already picked the correct code 7.

Neither path suppressed the `'exit'` event: both reach `ExitHandler::dispatch_on_exit`, which unconditionally called `Process__dispatchOnExit`.

## Fix

Add `VirtualMachine::fatal_exception_in_handler`, one funnel for node's `kExceptionInFatalExceptionHandler` path: report the exception, set `ExitHandler::skip_exit_event`, exit 7. `dispatch_on_exit` honours the flag, so the `'exit'` emission is skipped while the rest of the shutdown (sqlite/webview termination, cleanup hooks) still runs.

The capture-callback branch in C++ now calls that funnel (via a new `Bun__reportFatalExceptionInHandler` host export) instead of hand-rolling its own exit, and the recursion guard calls it too.

In a worker the funnel exits 1 rather than 7, which is what node does: its `workerOnGlobalUncaughtException` uses `kGenericUserError` and gates the `'exit'` emission on `!handlerThrew`, rather than going through the C++ fatal try/catch that produces 7.

`Bun__logUnhandledException` had no remaining callers and is deleted.

## Verification

`test/js/node/process/process.test.js`, verified against node v26.3.0 for every shape:

- `aborts when the uncaughtException handler throws` — exit 7, stdout is exactly the handler's line
- `aborts when the uncaughtExceptionCaptureCallback throws` — exit 7 (was 1)
- `aborts when the uncaughtExceptionMonitor listener throws` — exit 7
- `terminates the worker when its uncaughtExceptionCaptureCallback throws` — worker exit code stays 1

The first three fail on `main`. Unchanged shapes stay unchanged: a plain uncaught exception still exits 1 *with* `'exit'` listeners, and a handler that does not throw still exits 0.

## Not in this PR

`uncaught_exception`'s recursion guard still ends in `panic!("Uncaught exception while handling uncaught exception")`, which is unreachable on the main thread but does fire in a worker whose `'uncaughtException'` listener throws. #32387 fixes that properly (it forwards the error to the parent via `on_unhandled_rejection`), so this PR leaves that hunk alone. The capture-callback path does not reach the panic, before or after this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->