### PR TITLE
FileSystemRouter: fix reload() livelock when the root dir is cached without a trailing separator

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -699,6 +699,16 @@ impl<'a> RouteLoader<'a> {
         root_dir_info: &DirInfo,
         base_dir: &[u8],
     ) -> Routes {
+        // `load` slices `entry.dir()` at `base_dir.len() - 1` expecting a separator there, and
+        // `route_dirname_len` below counts on the trailing one.
+        debug_assert!(
+            base_dir
+                .last()
+                .copied()
+                .is_some_and(bun_paths::resolve_path::is_sep_any),
+            "base_dir must end with a separator"
+        );
+
         let mut route_dirname_len: u16 = 0;
 
         // Call bun_paths directly to avoid the higher-tier bun_resolver dep.

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -309,11 +309,16 @@ impl FileSystemRouter {
             return Err(global_this.throw_value(err_value?));
         }
 
-        let base_dir_str = if !root_dir_info.abs_real_path.is_empty() {
-            root_dir_info.abs_real_path
-        } else {
-            root_dir_info.abs_path
-        };
+        // `config.dir` is what `reload` loads routes against, and `RouteLoader` requires a
+        // trailing separator. `DirInfo.abs_path` only has one when the resolver happened to
+        // cache that spelling of the directory first.
+        let base_dir_str = strings::paths::clone_normalizing_separators(
+            if !root_dir_info.abs_real_path.is_empty() {
+                root_dir_info.abs_real_path
+            } else {
+                root_dir_info.abs_path
+            },
+        );
 
         // Note: `vm.refCountedString` is an interning cache — on a cache HIT it
         // returns the existing `*mut RefString` WITHOUT bumping the refcount.
@@ -336,7 +341,7 @@ impl FileSystemRouter {
             } else {
                 None
             },
-            base_dir: Some(claim(vm.ref_counted_string::<true>(base_dir_str, None))),
+            base_dir: Some(claim(vm.ref_counted_string::<true>(&base_dir_str, None))),
             asset_prefix: if !asset_prefix_slice.slice().is_empty() {
                 Some(claim(vm.ref_counted_string::<true>(
                     asset_prefix_slice.slice(),

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -835,3 +835,66 @@ it("loads routes from a directory already cached by Bun.build()", async () => {
   expect(normalizeBunSnapshot(stdout, String(dir))).toBe("/a /b /sub/c /b");
   expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
 });
+
+// A failed relative resolve busts the router dir out of the resolver's caches; reaching it
+// again as the *parent* of the subdirectory router then caches it without a trailing slash,
+// which is the spelling `reload()` loads routes against.
+const poisonRootDirCache = (dirExpr: string) => /* ts */ `
+  try { Bun.resolveSync("./does-not-exist.ts", ${dirExpr}); } catch {}
+  new Bun.FileSystemRouter({ dir: path.join(${dirExpr}, "sub"), style: "nextjs", fileExtensions: [".tsx"] });
+`;
+
+it("reload() keeps route names when the root dir is cached without a trailing slash", async () => {
+  using dir = tempDir("fsr-reload-untrailed-root", {
+    "fixture.ts": /* ts */ `
+      import path from "path";
+      const pagesDir = path.join(import.meta.dir, "pages");
+      ${poisonRootDirCache("pagesDir")}
+      const router = new Bun.FileSystemRouter({ dir: pagesDir, style: "nextjs", fileExtensions: [".tsx"] });
+      const before = Object.keys(router.routes).sort().join(" ");
+      router.reload();
+      console.log(before, "|", Object.keys(router.routes).sort().join(" "));
+    `,
+    "pages/b.tsx": "export default 1;\n",
+    "pages/sub/c.tsx": "export default 2;\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stdout, String(dir))).toBe("/b /sub/c | /b /sub/c");
+  expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+});
+
+it("reload() terminates when the root dir is cached without a trailing slash", async () => {
+  // The off-by-one above leaves the index route with a one-character name, and route-pattern
+  // validation spins forever on the empty string that is left after its leading slash.
+  using dir = tempDir("fsr-reload-untrailed-root-index", {
+    "fixture.ts": /* ts */ `
+      import path from "path";
+      const pagesDir = path.join(import.meta.dir, "pages");
+      ${poisonRootDirCache("pagesDir")}
+      const router = new Bun.FileSystemRouter({ dir: pagesDir, style: "nextjs", fileExtensions: [".tsx"] });
+      router.reload();
+      console.log(Object.keys(router.routes).sort().join(" "), router.match("/")?.name);
+    `,
+    "pages/index.tsx": "export default 1;\n",
+    "pages/sub/c.tsx": "export default 2;\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stdout, String(dir))).toBe("/ /sub/c /");
+  expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+});


### PR DESCRIPTION
## Repro

Three ordinary public API calls wedge the process. `reload()` never returns and burns 100% CPU; on a debug build the same sequence aborts instead.

```js
const d = `${tmpdir()}/fsr-reload-${process.pid}`;
mkdirSync(`${d}/z`, { recursive: true });
writeFileSync(`${d}/index.tsx`, "export default 1;\n");
writeFileSync(`${d}/z/a.tsx`, "export default 1;\n");

try { Bun.resolveSync("./nope.ts", d); } catch {}               // 1: failed relative resolve
new Bun.FileSystemRouter({ style: "nextjs", dir: `${d}/z` });   // 2: router over a subdirectory
const q = new Bun.FileSystemRouter({ style: "nextjs", dir: d });
q.reload();                                                     // 3: never returns
console.log("DONE");
```

```
panic: assertion failed: bun_paths::resolve_path::is_sep_any(entry_dir[base_dir.len() - 1])
<bun_router::RouteLoader>::load::<bun_runtime::api::filesystem_router::RouterResolver>
  src/router/lib.rs:863:33
<bun_router::RouteLoader>::load_all::<bun_runtime::api::filesystem_router::RouterResolver>
  src/router/lib.rs:721:14
```

`reload()` is what dev servers call on every file change, so a long-lived server livelocks.

## Cause

`FileSystemRouter::constructor` stores `DirInfo.abs_path` in `RouteConfig.dir`, and that is the dir `reload()` loads routes against. `abs_path` normally ends with a separator, but not always: when a directory is reached as an *ancestor* during a `dir_info_cached` walk, the walk adopts the spelling already interned in the entry cache, and `load_as_file` interns it without a trailing slash.

That is what the three steps arrange. The failed relative resolve makes `load_as_file` intern the router's dir without a trailing slash, then busts it out of both caches and retries, re-interning the same spelling. The subdirectory router's dir walk then reaches it as an ancestor and copies that spelling into `DirInfo.abs_path`.

`RouteLoader` assumes the trailing separator in two places:

* `load` slices `public_dir = &entry_dir[base_dir.len() - 1..]`, so one extra character of the directory name leaks into every route's public path.
* `load_all` derives `route_dirname_len` from whether `config.dir` ends with a separator, so every route name is then stripped of one character too many.

With a non-index route the damage is visible rather than fatal (`"pages"` is the router dir here):

```
before reload: /b /sub/c
after reload:  s/b s/sub/c
```

With an `index` route at the root the name collapses to a single character, `Route::parse` hands `Pattern::validate` the empty string left after its leading slash, and `let end = (input.len() - 1) as u32` wraps to `0xFFFFFFFF` while `Pattern::init_unhashed` keeps returning `len == offset`. That loop never advances.

## Fix

Normalize the dir before storing it, so `config.dir` always keeps its trailing separator. `RouteLoader::load_all` now asserts the contract it depends on.

## Verification

Two tests in `test/js/bun/util/filesystem_router.test.ts`, both running the sequence in a subprocess. On `main` the first fails with corrupted route names and the second times out; the debug build aborts on the assertion above. Both pass with this change, along with the other 27 tests in the file.
