### PR TITLE
Reject zero-length input in deserialize() instead of returning null

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6642,6 +6642,23 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
 
         return JSC::jsUndefined();
     }
+
+    auto size = std::min(arrayBuffer->byteLength(), maxByteLength);
+
+    // CloneDeserializer reads empty data as WebCore's null-value sentinel
+    // (SerializedScriptValue::nullValue()). Bytes handed to us by a caller carry no such
+    // meaning: zero bytes have no version header, so reject them like any other bad input.
+    if (!size) {
+        if (didFail)
+            *didFail = true;
+
+        if (throwExceptions == SerializationErrorMode::Throwing)
+            maybeThrowExceptionIfSerializationFailed(*globalObject, SerializationReturnCode::ValidationError);
+        RETURN_IF_EXCEPTION(throwScope, {});
+
+        return JSC::jsUndefined();
+    }
+
     auto blobURLs = Vector<String> {};
     auto blobFiles = Vector<String> {};
 
@@ -6651,7 +6668,6 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
     }
 
     auto* data = static_cast<uint8_t*>(arrayBuffer->data()) + byteOffset;
-    auto size = std::min(arrayBuffer->byteLength(), maxByteLength);
     auto span = std::span<uint8_t> { data, size };
 
     auto result = CloneDeserializer::deserialize(&domGlobal, globalObject, {}, nullptr, span, blobURLs, blobFiles, nullptr

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -25,6 +25,7 @@ import {
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import v8 from "node:v8";
 
 describe("bun:jsc", () => {
   function count() {
@@ -220,6 +221,37 @@ describe("bun:jsc", () => {
     expect(result3.functions).toBeDefined();
     expect(result3.stackTraces).toBeDefined();
     expect(result3.stackTraces.traces.length).toBeGreaterThan(0);
+  });
+});
+
+describe("deserialize rejects input with no bytes", () => {
+  // Zero bytes cannot encode a value, so they must fail the same way any other
+  // payload without a version header does, instead of producing a plausible null.
+  function expectRejected(fn: () => unknown) {
+    expect(fn).toThrow(TypeError);
+    expect(fn).toThrow("Unable to deserialize data.");
+  }
+
+  it.each([
+    ["Buffer.alloc(0)", () => Buffer.alloc(0)],
+    ["new Uint8Array(0)", () => new Uint8Array(0)],
+    ["new DataView(new ArrayBuffer(0))", () => new DataView(new ArrayBuffer(0))],
+    ["new ArrayBuffer(0)", () => new ArrayBuffer(0)],
+    ["new SharedArrayBuffer(0)", () => new SharedArrayBuffer(0)],
+    ["a zero-length view of a non-empty buffer", () => new Uint8Array(new ArrayBuffer(8), 4, 0)],
+  ])("%s", (_label, make) => {
+    expectRejected(() => deserialize(make()));
+    expectRejected(() => v8.deserialize(make() as any));
+  });
+
+  it("still deserializes a value that really is null", () => {
+    expect(deserialize(serialize(null))).toBeNull();
+    expect(v8.deserialize(v8.serialize(null))).toBeNull();
+  });
+
+  it("still deserializes a serialized empty buffer", () => {
+    expect(deserialize(serialize(Buffer.alloc(0)))).toStrictEqual(Buffer.alloc(0));
+    expect(v8.deserialize(v8.serialize(Buffer.alloc(0)))).toStrictEqual(Buffer.alloc(0));
   });
 });
 


### PR DESCRIPTION
### Problem

`v8.deserialize()` (and `bun:jsc`'s `deserialize()`) manufactures a `null` out of zero bytes instead of throwing:

```js
const v8 = require("node:v8");
for (const buf of [Buffer.alloc(0), new Uint8Array(0), new DataView(new ArrayBuffer(0))]) {
  try { console.log("->", v8.deserialize(buf)); } catch (e) { console.log("threw", e.name); }
}
// node: all three -> threw Error
// bun:  all three -> null
```

An empty buffer is what a truncated file, an empty IPC frame, or a zero-length redis/S3 value looks like, which is exactly what the wire-format header check exists to catch. Code that stores `serialize()` output and later `deserialize()`s it gets back an ordinary-looking application value instead of an error.

Every other malformed payload already throws, so zero-length was the only hole:

| input | before |
| --- | --- |
| `Buffer.alloc(0)` | `null` |
| `Buffer.from([0])` | `TypeError: Unable to deserialize data.` |
| `Buffer.from("abc")` | `TypeError: Unable to deserialize data.` |
| `v8.serialize({a:1}).subarray(0, 2)` | `TypeError: Unable to deserialize data.` |

### Cause

`CloneDeserializer::deserialize` maps an empty buffer to `(jsNull(), SerializationReturnCode::UnspecifiedError)`. That is WebCore's null-value sentinel: an empty `m_data` is how `SerializedScriptValue::nullValue()` is represented, so `maybeThrowExceptionIfSerializationFailed` deliberately leaves `UnspecifiedError` unthrown.

`SerializedScriptValue::fromArrayBuffer` is the entry point for bytes supplied by a caller (its only caller is `functionDeserialize` in `BunJSCModule.h`, behind `bun:jsc`'s `deserialize()`, which `node:v8`'s `deserialize()` wraps). It passed the sentinel straight through and returned the `jsNull()`.

### Fix

`fromArrayBuffer` now rejects an empty span before handing it to the deserializer. Bytes from a caller carry no sentinel meaning: zero bytes have no version header, so they fail with the same `ValidationError` every other unparsable payload already produces (`TypeError: Unable to deserialize data.`).

This covers `Buffer`, `Uint8Array`, `DataView`, `ArrayBuffer`, `SharedArrayBuffer`, and a zero-length view over a non-empty backing buffer. `structuredClone()`, `postMessage()`, and `child_process` IPC go through `SerializedScriptValue::deserialize`, a different function, and are untouched.

The thrown error's class and message still differ from Node's (`TypeError: Unable to deserialize data.` vs `Error: Unable to deserialize cloned data due to invalid or unsupported version.`). That divergence already applies to every malformed payload, because Bun's wire format is JSC's structured clone rather than V8's; matching Node only for the empty case would have made `v8.deserialize` inconsistent with itself.

### Verification

New tests in `test/js/bun/jsc/bun-jsc.test.ts` cover both APIs, all six empty shapes, and the two things that must keep working: a value that really is `null`, and a serialized empty `Buffer`.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/bun-jsc.test.ts -t "deserialize rejects input with no bytes"
 2 pass
 6 fail

$ bun bd test test/js/bun/jsc/bun-jsc.test.ts -t "deserialize rejects input with no bytes"
 8 pass
 0 fail
```

Also green: the whole `bun-jsc.test.ts` file, `test/js/web/structured-clone-blob-file.test.ts`, `test/js/web/workers/structured-clone.test.ts`, `structuredClone-classes.test.ts`, `worker-postmessage-transfer.test.ts`, and Node's `test/parallel/test-v8-deserialize-buffer.js`. `BUN_JSC_validateExceptionChecks=1` reports no unchecked exception on the new throw path.