### PR TITLE
process: route throws from beforeExit/exit listeners through uncaughtException

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1399,12 +1399,6 @@ impl VirtualMachine {
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
             panic!("Uncaught exception while handling uncaught exception");
         }
-        if self.exit_on_uncaught_exception {
-            self.run_error_handler(err, None);
-            // SAFETY: see above.
-            unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
-            panic!("made it past process.exit()");
-        }
         self.is_handling_uncaught_exception = true;
         let handled = Bun__handleUncaughtException(
             global_object,
@@ -1412,6 +1406,15 @@ impl VirtualMachine {
             if is_rejection { 1 } else { 0 },
         ) > 0;
         if !handled {
+            // `beforeExit` has already been dispatched, so the run is winding
+            // down and there is no loop turn left to defer to: print the error
+            // and exit, like node's fatal-exception path.
+            if self.exit_on_uncaught_exception {
+                self.run_error_handler(err, None);
+                // SAFETY: see above.
+                unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
+                panic!("made it past process.exit()");
+            }
             // TODO maybe we want a separate code path for uncaught exceptions
             self.unhandled_error_counter += 1;
             self.exit_handler.exit_code = 1;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1411,6 +1411,10 @@ impl VirtualMachine {
             // and exit, like node's fatal-exception path.
             if self.exit_on_uncaught_exception {
                 self.run_error_handler(err, None);
+                // `process_exit` emits `exit`, re-entering here if a listener
+                // throws. No handler is running, so drop the recursion guard or
+                // that re-entry exits 7 ("handler threw") instead of 1.
+                self.is_handling_uncaught_exception = false;
                 // SAFETY: see above.
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
                 panic!("made it past process.exit()");

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -624,8 +624,25 @@ describe.concurrent(() => {
       });
       const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
       expect(stdout).toBe("worker uncaughtException boom\nworker exit 0\n");
-      expect(stderr).not.toInclude("panic");
       expect(exitCode).toBe(0);
+    });
+
+    it("exits 1, not 7, when an exit listener also throws and nothing handles it", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("beforeExit", () => { throw new Error("a"); });
+           process.on("exit", () => { throw new Error("b"); });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stderr).toInclude("error: a");
+      expect(stdout).toBeEmpty();
+      // 7 is node's "the uncaughtException handler itself threw"; there is no handler here.
+      expect(exitCode).toBe(1);
     });
   });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -627,7 +627,6 @@ describe.concurrent(() => {
       expect(stderr).not.toInclude("panic");
       expect(exitCode).toBe(0);
     });
-
   });
 
   describe("process.onExit", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -548,6 +548,86 @@ describe.concurrent(() => {
       expect(stderr).toInclude("error: boom");
       expect(stdout).toBeEmpty();
     });
+
+    it("throwing inside runs uncaughtExceptionMonitor and uncaughtException", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtExceptionMonitor", (e, origin) => console.log("monitor", e.message, origin));
+           process.on("uncaughtException", e => console.log("uncaughtException", e.message));
+           let thrown = false;
+           process.on("beforeExit", () => { if (!thrown) { thrown = true; throw new Error("boom"); } });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("monitor boom uncaughtException\nuncaughtException boom\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
+    });
+
+    it("throwing inside runs the uncaughtException capture callback", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.setUncaughtExceptionCaptureCallback(e => console.log("captured", e.message));
+           let thrown = false;
+           process.on("beforeExit", () => { if (!thrown) { thrown = true; throw new Error("boom"); } });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("captured boom\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
+    });
+
+    it("a throw from work scheduled inside beforeExit still reaches uncaughtException", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtException", e => console.log("uncaughtException", e.message));
+           let scheduled = false;
+           process.on("beforeExit", () => {
+             if (scheduled) return;
+             scheduled = true;
+             setImmediate(() => { throw new Error("late"); });
+           });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("uncaughtException late\n");
+      expect(stderr).not.toInclude("error: late");
+      expect(exitCode).toBe(0);
+    });
+
+    it("throwing inside a worker runs that worker's uncaughtException handler", async () => {
+      using dir = tempDir("process-beforeexit-worker", {
+        "worker.js": `process.on("uncaughtException", e => console.log("worker uncaughtException", e.message));
+                      let thrown = false;
+                      process.on("beforeExit", () => { if (!thrown) { thrown = true; throw new Error("boom"); } });`,
+        "index.js": `const { Worker } = require("node:worker_threads");
+                     const worker = new Worker(require("path").join(__dirname, "worker.js"));
+                     worker.on("exit", code => console.log("worker exit", code));`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "index.js")],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("worker uncaughtException boom\nworker exit 0\n");
+      expect(stderr).not.toInclude("panic");
+      expect(exitCode).toBe(0);
+    });
+
   });
 
   describe("process.onExit", () => {
@@ -561,6 +641,24 @@ describe.concurrent(() => {
       expect(exitCode).toBe(1);
       expect(stderr).toInclude("error: boom");
       expect(stdout).toBeEmpty();
+    });
+
+    it("throwing inside runs uncaughtExceptionMonitor and uncaughtException", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtExceptionMonitor", (e, origin) => console.log("monitor", e.message, origin));
+           process.on("uncaughtException", e => console.log("uncaughtException", e.message));
+           process.on("exit", () => { throw new Error("boom"); });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("monitor boom uncaughtException\nuncaughtException boom\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Repro

```js
process.on("uncaughtExceptionMonitor", (e, origin) => console.log("monitor", e.message, origin));
process.on("uncaughtException", e => console.log("uncaughtException", e.message));
let thrown = false;
process.on("beforeExit", () => { if (!thrown) { thrown = true; throw new Error("boom"); } });
```

```console
$ node repro.js
monitor boom uncaughtException
uncaughtException boom
$ echo $?
0

$ bun repro.js      # before this change
error: boom
$ echo $?
1
```

The installed handler never runs: Bun prints the error and hard-exits 1. Same for a throw from a `process.on("exit")` listener, and for anything that throws after `beforeExit` has been dispatched once (for example, a timer the `beforeExit` listener scheduled). `uncaughtExceptionMonitor` and `process.setUncaughtExceptionCaptureCallback` are bypassed too.

This matters because `beforeExit` is where flush and cleanup hooks live, and a last-resort `uncaughtException` handler is supposed to see every otherwise-fatal throw.

## Cause

`Process__dispatchOnBeforeExit` (`src/jsc/bindings/BunProcess.cpp`) calls `Bun__VirtualMachine__exitDuringUncaughtException` before emitting, which latches `vm.exit_on_uncaught_exception = true`. `VirtualMachine::uncaught_exception` then checked that flag *before* calling `Bun__handleUncaughtException`:

```rust
if self.exit_on_uncaught_exception {
    self.run_error_handler(err, None);
    unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
    panic!("made it past process.exit()");
}
self.is_handling_uncaught_exception = true;
let handled = Bun__handleUncaughtException(...) > 0;
```

so the whole funnel (monitor, capture callback, `uncaughtException` listeners) was skipped. The flag is only ever set, never cleared, so every later uncaught exception in that run took the same path.

Node wraps the `beforeExit` / `exit` emit in a `TryCatchScope(CatchMode::kFatal)`, which routes the throw into `TriggerUncaughtException`: monitor and handler run, and only an *unhandled* exception prints and exits.

## Fix

Consult `Bun__handleUncaughtException` first, and only honor `exit_on_uncaught_exception` when the exception comes back unhandled. That preserves what the flag was added for (an unhandled throw this late in the run can't be deferred to another loop turn, so it exits immediately with `process.exitCode` honored, per `test-process-beforeexit-throw-exit.js`) while letting a registered handler see the error.

## Verification

`test/js/node/process/process.test.js`, alongside the existing "throwing inside preserves exit code" tests:

- `beforeExit` throw reaches `uncaughtExceptionMonitor` + `uncaughtException`, exit 0
- `beforeExit` throw reaches `setUncaughtExceptionCaptureCallback`, exit 0
- a throw from work scheduled inside `beforeExit` still reaches `uncaughtException`, exit 0
- a `beforeExit` throw inside a worker reaches that worker's `uncaughtException` handler (the worker previously aborted with `panic: made it past process.exit()`)
- `exit` throw reaches `uncaughtExceptionMonitor` + `uncaughtException`, exit 0
- both `beforeExit` and `exit` throw with no handler: exit 1, not 7 (regression guard, see below)

5 of those fail on the unfixed build and pass with the fix. The pre-existing unhandled cases are unchanged: `process.on("beforeExit"/"exit")` throwing with no handler still prints both errors and exits 1, byte-identical to `main`.

Moving the branch also means `is_handling_uncaught_exception` is raised when the fatal `process_exit(1)` runs, and `process_exit` emits `exit`, which re-enters `uncaught_exception` if a listener throws. That re-entry hit the recursion guard and exited 7 ("the uncaughtException handler itself threw") when there is no handler at all. The guard is now dropped immediately before the noreturn call, since `Bun__handleUncaughtException` has already returned unhandled there.

`test/js/node/test/parallel/test-process-beforeexit-throw-exit.js`, `test-beforeexit-event-exit.js`, `test-process-beforeexit.js`, `test-process-exit-from-before-exit.js`, `test-timers-unrefed-in-beforeexit.js` and the `*uncaught*` parallel tests all still pass.

## Note on #32387

#32387 fixes the worker abort (`panic: made it past process.exit()` / `panic: Uncaught exception while handling uncaught exception`) from the other direction, in the same function. It leaves the handler bypass in place; this PR leaves the unhandled-in-a-worker abort in place. They are orthogonal and should compose, but the two diffs touch adjacent lines, so whichever lands second will need a trivial rebase.

