### PR TITLE
node:stream: restore the destroyed-stream guard in Readable.prototype.pause

### DIFF
--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -1135,13 +1135,9 @@ function nReadingNextTick(self) {
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function () {
   const state = this._readableState;
-  // Deliberate divergence from Node 26: upstream early-returns here (and in
-  // pause()) when the stream is destroyed. Legacy Readable subclasses like
-  // fd-slicer assign `this.destroyed = true` (the prototype setter) right
-  // before push(null), so with the guard a piped destination's drain can no
-  // longer resume the source and the final buffered chunk is never delivered —
-  // silently truncating yauzl/extract-zip/puppeteer downloads. Keep the
-  // Node 24 behavior of letting destroyed streams flush their buffer.
+  // Deliberate divergence from Node 26 (nodejs/node#62557): no destroyed
+  // early-return here. fd-slicer-style readables set `destroyed` right before
+  // push(null), and the guard strands their buffer when a piped dest drains.
   if ((state[kState] & kFlowing) === 0) {
     $debug("resume");
     // We flow only if there is no one listening
@@ -1181,7 +1177,9 @@ function resume_(stream, state) {
 
 Readable.prototype.pause = function () {
   const state = this._readableState;
-  // No destroyed early-return: see the comment in resume() above.
+  if ((state[kState] & kDestroyed) !== 0) {
+    return this;
+  }
   $debug("call pause");
   if ((state[kState] & (kHasFlowing | kFlowing)) !== kHasFlowing) {
     $debug("pause");

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1203,8 +1203,59 @@ describe("node v26 stream semantics", () => {
     expect(r.read()).toBeNull();
   });
 
-  // Deliberate divergence from Node 26 (nodejs/node#62557 made pause/resume
-  // no-ops on destroyed streams): legacy Readable subclasses like fd-slicer
+  // Upstream: nodejs/node#62557 (test-stream-destroy.js).
+  it("pause() is a no-op on a destroyed stream", async () => {
+    const r = new Readable({ read() {} });
+    r.resume();
+    r.destroy();
+    const emitted = [];
+    r.on("pause", () => emitted.push("pause"));
+    expect(r.pause()).toBe(r);
+    expect(r.readableFlowing).toBe(true);
+    expect(r.isPaused()).toBe(false);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(emitted).toEqual([]);
+  });
+
+  // A completed pipe unpipes the source, and unpipe() calls source.pause().
+  // On a source that autoDestroy'd itself at 'end', that pause() must no-op so
+  // the post-pipe readable state matches a plain resume()'d stream.
+  it("a source autoDestroyed by a completed pipe stays flowing", async () => {
+    const sink = () =>
+      new Writable({
+        write(chunk, encoding, callback) {
+          callback();
+        },
+      });
+    // 'unpipe' on the destination is emitted by Readable.prototype.unpipe right
+    // after it calls source.pause(), so it is the exact point to assert on.
+    const unpiped = dest => new Promise(resolve => dest.on("unpipe", resolve));
+
+    const resumed = new PassThrough();
+    resumed.resume();
+    resumed.end("x");
+
+    const pipedDest = sink();
+    const piped = new PassThrough();
+    piped.pipe(pipedDest);
+    piped.end("x");
+
+    // autoDestroy: false keeps the source alive, so unpipe() does pause it.
+    const aliveDest = sink();
+    const pipedAlive = new PassThrough({ autoDestroy: false });
+    pipedAlive.pipe(aliveDest);
+    pipedAlive.end("x");
+
+    await Promise.all([new Promise(resolve => resumed.on("close", resolve)), unpiped(pipedDest), unpiped(aliveDest)]);
+
+    const state = s => ({ readableFlowing: s.readableFlowing, isPaused: s.isPaused(), destroyed: s.destroyed });
+    expect(state(resumed)).toEqual({ readableFlowing: true, isPaused: false, destroyed: true });
+    expect(state(piped)).toEqual({ readableFlowing: true, isPaused: false, destroyed: true });
+    expect(state(pipedAlive)).toEqual({ readableFlowing: false, isPaused: true, destroyed: false });
+  });
+
+  // Deliberate divergence from Node 26 (nodejs/node#62557 also made resume() a
+  // no-op on destroyed streams): legacy Readable subclasses like fd-slicer
   // (yauzl → extract-zip → puppeteer/electron tooling) assign
   // `this.destroyed = true` via the prototype setter right before push(null).
   // With the upstream guard, a piped destination's drain can no longer resume


### PR DESCRIPTION
## Repro

```js
import { PassThrough, Writable } from "node:stream";

const sink = () => new Writable({ write(c, e, cb) { cb(); } });
const a = new PassThrough(); a.resume(); a.end("x");      // control: no pipe
const b = new PassThrough(); b.pipe(sink()); b.end("x");  // piped to completion
setTimeout(() => {
  console.log(`resume-only: readableFlowing=${a.readableFlowing} isPaused=${a.isPaused()}`);
  console.log(`piped:       readableFlowing=${b.readableFlowing} isPaused=${b.isPaused()}`);
}, 150);
```

```
node v26.3.0: resume-only readableFlowing=true  isPaused=false · piped readableFlowing=true  isPaused=false
bun 1.4.0:    resume-only readableFlowing=true  isPaused=false · piped readableFlowing=false isPaused=true
```

The post-pipe readable-state flags diverge on every completed pipe. Code that inspects `isPaused()` / `readableFlowing` to decide whether to re-`resume()` a reusable source concludes the wrong thing on Bun.

## Cause

A completed pipe unpipes its source, and `Readable.prototype.unpipe` calls `source.pause()`. Node's `pause()` early-returns when the stream is destroyed, so a source that autoDestroy'd itself at `'end'` keeps `readableFlowing === true`. Bun's `pause()` has no such guard, so it pauses the already-destroyed source.

The guard was removed from **both** `pause()` and `resume()` in 6abf57e204, so that legacy fd-slicer-style readables (yauzl → extract-zip → puppeteer) keep working. Those assign `this.destroyed = true` right before `push(null)`, which on modern streams hits the prototype setter; with the upstream guard, a piped destination's `'drain'` can no longer resume the source and the last buffered chunk is dropped.

Only the **`resume()`** guard causes that truncation. With `pause()` guarded, `pause()` leaves `kFlowing` set, so `resume()`'s `if (flowing === 0)` check is skipped and `flow()` is never rescheduled. Emulating each variant on Node v26.3.0 with the fd-slicer pattern:

| variant | result |
| --- | --- |
| both guards (stock Node 26) | truncated, 131072 / 171072 bytes |
| `pause()` guard only | truncated, 131072 / 171072 bytes |
| `resume()` guard only removed | complete, 171072 / 171072 bytes |
| both guards removed (Bun today) | complete, 171072 / 171072 bytes |

So `pause()` was over-reverted: its guard is not load-bearing for fd-slicer.

## Fix

Restore `if ((state[kState] & kDestroyed) !== 0) return this;` in `Readable.prototype.pause` only. `resume()` keeps the documented divergence.

## Verification

Every flag now matches Node v26.3.0:

| case | node | bun before | bun after |
| --- | --- | --- | --- |
| pipe to completion (autoDestroy default) | `flowing=true paused=false` | `flowing=false paused=true` | `flowing=true paused=false` |
| pipe to completion, `autoDestroy: false` | `flowing=false paused=true` | `flowing=false paused=true` | `flowing=false paused=true` |
| manual `unpipe()` of a live source | `flowing=false paused=true` | `flowing=false paused=true` | `flowing=false paused=true` |
| `pause()` after `destroy()` | `flowing=true paused=false` | `flowing=false paused=true` | `flowing=true paused=false` |

Both new test bodies in `test/js/node/stream/node-stream.test.js` were run verbatim against real Node v26.3.0 and pass there unchanged, so the expectations are not hand-derived.

- `test/js/node/stream/node-stream.test.js`: two new tests (`pause()` no-op on destroyed; post-pipe state for autoDestroy on/off). Both fail on `main`, pass with this change. The existing fd-slicer regression test still passes.
- `test/js/node/test/parallel/test-stream-destroy.js`: the vendored upstream `pause()` assertion no longer needs the Bun gate, so it now runs.
- 249 vendored `test-stream-*.js`, 493 vendored `test-http-*` / `test-net-*` / `test-readline*` / `test-pipe*`: no new failures (the handful that fail do so identically on a baseline debug build of `main`).