### PR TITLE
net: don't emit 'drop' when blockList rejects a connection

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1155,23 +1155,7 @@ function onconnection(err, clientHandle) {
 
   _socket[kAttach](clientHandle.localPort, clientHandle);
 
-  const blockList = self.blockList;
-  if (blockList) {
-    const addressType = isIP(clientHandle.remoteAddress);
-    if (addressType && blockList.check(clientHandle.remoteAddress, `ipv${addressType}`)) {
-      const data = {
-        localAddress: _socket.localAddress,
-        localPort: _socket.localPort || clientHandle.localPort,
-        localFamily: _socket.localFamily,
-        remoteAddress: _socket.remoteAddress,
-        remotePort: _socket.remotePort,
-        remoteFamily: _socket.remoteFamily || "IPv4",
-      };
-      clientHandle.end();
-      self.emit("drop", data);
-      return;
-    }
-  }
+  // maxConnections before blockList: https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L2314
   if (self.maxConnections != null && self._connections >= self.maxConnections) {
     const data = {
       localAddress: _socket.localAddress,
@@ -1185,6 +1169,15 @@ function onconnection(err, clientHandle) {
     clientHandle.end();
     self.emit("drop", data);
     return;
+  }
+
+  const blockList = self.blockList;
+  if (blockList) {
+    const addressType = isIP(clientHandle.remoteAddress);
+    if (addressType && blockList.check(clientHandle.remoteAddress, `ipv${addressType}`)) {
+      clientHandle.end();
+      return;
+    }
   }
 
   const bunTLS = _socket[bunTlsSymbol];

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from "fs";
 import { bunEnv, bunExe } from "harness";
-import { AddressInfo, createServer, Server, Socket } from "net";
+import { AddressInfo, BlockList, connect, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
 import { tmpdir } from "os";
@@ -460,6 +460,79 @@ describe("net.createServer events", () => {
         }
         await Promise.all(promises).catch(closeAndFail);
       });
+  });
+
+  // The server ends the accepted socket in every case below, so waiting for the
+  // client's "close" proves the server already ran its onconnection handler.
+  async function connectToRejectingServer({
+    blockedAddress,
+    maxConnections,
+  }: {
+    blockedAddress: string;
+    maxConnections?: number;
+  }) {
+    const blockList = new BlockList();
+    blockList.addAddress(blockedAddress);
+
+    let connections = 0;
+    const drops: any[] = [];
+    const server = createServer({ blockList }, () => {
+      connections++;
+    });
+    if (maxConnections !== undefined) {
+      server.maxConnections = maxConnections;
+    }
+    server.on("drop", data => drops.push(data));
+
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const { port } = server.address() as AddressInfo;
+      const client = connect({ port, host: "127.0.0.1" });
+      client.on("error", () => {});
+      await once(client, "close");
+
+      return { connections, drops };
+    } finally {
+      server.close();
+    }
+  }
+
+  it("should not emit drop when blockList rejects the connection", async () => {
+    const { connections, drops } = await connectToRejectingServer({ blockedAddress: "127.0.0.1" });
+
+    expect({ connections, drops }).toEqual({ connections: 0, drops: [] });
+  });
+
+  it("should emit drop when maxConnections is reached and a blockList allows the address", async () => {
+    const { connections, drops } = await connectToRejectingServer({
+      blockedAddress: "1.1.1.1",
+      maxConnections: 0,
+    });
+
+    expect(connections).toBe(0);
+    expect(drops.length).toBe(1);
+    expect(Object.keys(drops[0]).sort()).toEqual([
+      "localAddress",
+      "localFamily",
+      "localPort",
+      "remoteAddress",
+      "remoteFamily",
+      "remotePort",
+    ]);
+  });
+
+  // maxConnections is checked before the blockList, so a blocked address still
+  // reports the saturation, matching Node.
+  it("should emit drop when maxConnections is reached and a blockList blocks the address", async () => {
+    const { connections, drops } = await connectToRejectingServer({
+      blockedAddress: "127.0.0.1",
+      maxConnections: 0,
+    });
+
+    expect(connections).toBe(0);
+    expect(drops.length).toBe(1);
   });
 
   it("should error on an invalid port", () => {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -22,14 +22,11 @@ describe("net.createServer listen", () => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       0,
@@ -50,14 +47,11 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       0,
@@ -79,9 +73,7 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
@@ -89,13 +81,10 @@ describe("net.createServer listen", () => {
     server.on("error", closeAndFail).on(
       "listening",
       mustCall(() => {
-        clearTimeout(timeout);
         server.close();
         done();
       }),
     );
-
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(0, "0.0.0.0");
   });
@@ -106,9 +95,7 @@ describe("net.createServer listen", () => {
     const server: Server = createServer();
     expect(server.listening).toBeFalse();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
@@ -117,14 +104,11 @@ describe("net.createServer listen", () => {
       "listening",
       mustCall(() => {
         expect(server.listening).toBeTrue();
-        clearTimeout(timeout);
         server.close();
         expect(server.listening).toBeFalse();
         done();
       }),
     );
-
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(0, "0.0.0.0");
   });
@@ -134,14 +118,11 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       0,
@@ -163,14 +144,11 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       0,
@@ -190,14 +168,11 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       mustCall(() => {
@@ -217,14 +192,11 @@ describe("net.createServer listen", () => {
 
     const server: Server = createServer();
 
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       socket_domain,
@@ -241,14 +213,11 @@ describe("net.createServer listen", () => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 
     const server: Server = createServer();
-    let timeout: Timer;
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall()();
     };
     server.on("error", closeAndFail);
-    timeout = setTimeout(closeAndFail, 100);
 
     server.listen(
       0,
@@ -299,12 +268,10 @@ describe("net.createServer listen", () => {
 describe("net.createServer events", () => {
   it("should receive data", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
-    let timeout: Timer;
     let client: any = null;
     let is_done = false;
     const onData = mustCall(data => {
       is_done = true;
-      clearTimeout(timeout);
       server.close();
       expect(data.byteLength).toBe(5);
       expect(data.toString("utf8")).toBe("Hello");
@@ -317,16 +284,12 @@ describe("net.createServer events", () => {
 
     const closeAndFail = () => {
       if (is_done) return;
-      clearTimeout(timeout);
       server.close();
       client?.end();
       mustNotCall("no data received")();
     };
 
     server.on("error", closeAndFail);
-
-    //should be faster than 500ms (this was previously 100 but the test was flaky on local machine -@alii)
-    timeout = setTimeout(closeAndFail, 500);
 
     server.listen(
       mustCall(async () => {
@@ -350,11 +313,9 @@ describe("net.createServer events", () => {
 
   it("should call end", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
-    let timeout: Timer;
     let is_done = false;
     const onEnd = mustCall(() => {
       is_done = true;
-      clearTimeout(timeout);
       server.close();
       done();
     });
@@ -366,13 +327,10 @@ describe("net.createServer events", () => {
 
     const closeAndFail = () => {
       if (is_done) return;
-      clearTimeout(timeout);
       server.close();
       mustNotCall("end not called")();
     };
     server.on("error", closeAndFail);
-
-    timeout = setTimeout(closeAndFail, 500);
 
     server.listen(
       mustCall(async () => {
@@ -401,7 +359,6 @@ describe("net.createServer events", () => {
   it("should call connection and drop", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 
-    let timeout: Timer;
     let is_done = false;
     const server = createServer();
     let maxClients = 2;
@@ -409,12 +366,10 @@ describe("net.createServer events", () => {
 
     const closeAndFail = () => {
       if (is_done) return;
-      clearTimeout(timeout);
       server.close();
       mustNotCall("drop not called")();
     };
 
-    timeout = setTimeout(closeAndFail, 500);
     let connection_called = false;
     server
       .on(
@@ -428,7 +383,6 @@ describe("net.createServer events", () => {
         mustCall(data => {
           is_done = true;
           server.close();
-          clearTimeout(timeout);
           expect(data.localPort).toBeDefined();
           expect(data.remotePort).toBeDefined();
           expect(data.remoteFamily).toBeDefined();
@@ -549,22 +503,18 @@ describe("net.createServer events", () => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 
     const controller = new AbortController();
-    let timeout: Timer;
     const server = createServer();
 
     const closeAndFail = () => {
-      clearTimeout(timeout);
       server.close();
       mustNotCall("close not called")();
     };
 
-    timeout = setTimeout(closeAndFail, 500);
-
     server
+      .on("error", closeAndFail)
       .on(
         "close",
         mustCall(() => {
-          clearTimeout(timeout);
           done();
         }),
       )
@@ -575,7 +525,6 @@ describe("net.createServer events", () => {
 
   it("should echo data", done => {
     const { mustNotCall } = createCallCheckCtx(done);
-    let timeout: Timer;
     let client: any = null;
     const server: Server = createServer((socket: Socket) => {
       socket.pipe(socket);
@@ -583,15 +532,12 @@ describe("net.createServer events", () => {
     let is_done = false;
     const closeAndFail = () => {
       if (is_done) return;
-      clearTimeout(timeout);
       server.close();
       client?.end();
       mustNotCall("no data received")();
     };
 
     server.on("error", closeAndFail);
-
-    timeout = setTimeout(closeAndFail, 500);
 
     server.listen(async () => {
       const address = server.address() as AddressInfo;
@@ -604,7 +550,6 @@ describe("net.createServer events", () => {
           },
           data(socket, data) {
             is_done = true;
-            clearTimeout(timeout);
             server.close();
             socket.end();
             expect(data.byteLength).toBe(5);


### PR DESCRIPTION
`net.createServer({ blockList })` emits a spurious `'drop'` event when a connection is rejected by the blockList. In Node, `'drop'` is emitted exclusively when the connection count reaches `server.maxConnections`; a blockList rejection closes the handle silently.

## Repro

```js
import net from "node:net";

const bl = new net.BlockList();
bl.addAddress("127.0.0.1");

let connections = 0,
  drops = 0;
const srv = net.createServer({ blockList: bl }, () => connections++);
srv.on("drop", () => drops++);
srv.listen(0, "127.0.0.1", () => {
  const c = net.connect(srv.address().port, "127.0.0.1");
  c.on("error", () => {});
  c.on("close", () => {
    console.log(JSON.stringify({ connections, drops }));
    process.exit(0);
  });
});
```

```
node v24: {"connections":0,"drops":0}
bun 1.4.0: {"connections":0,"drops":1}   // payload: localAddress, localFamily, localPort, remoteAddress, remoteFamily, remotePort
```

## Cause

In `onconnection` (`src/js/node/net.ts`) the blockList branch shared its tail with the `maxConnections` branch: build the drop payload, `clientHandle.end()`, `self.emit("drop", data)`. It also ran before the `maxConnections` check, the reverse of Node's order.

## Fix

Check `maxConnections` first (it keeps emitting `'drop'`), then the blockList, which now just ends the handle and returns. This mirrors [Node's `onconnection`](https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L2314): the `maxConnections` block emits `'drop'` and closes, the blockList block below it closes with no event. Covers `tls.createServer({ blockList })` too, since it shares this handler.

Why the ordering matters: with Node's order, a blocked peer arriving while the server is already at `maxConnections` still reports saturation via `'drop'`. With the old order it never did.

## Verification

Three tests in `test/js/node/net/node-net-server.test.ts`:

- blockList rejection emits neither `'connection'` nor `'drop'` (fails before this change: `drops` contains one event with the full payload)
- `maxConnections` reached with a blockList that allows the peer still emits `'drop'` with the full payload
- `maxConnections` reached with a blockList that blocks the peer still emits `'drop'`

`test-net-server-blocklist.js`, `test-net-blocklist.js` and `test-blocklist.js` from the Node suite still exit 0.

## Second commit: removing the watchdog timers in that test file

`bun bd test test/js/node/net/node-net-server.test.ts` could not pass before this PR, so the new tests had nowhere green to land. Every test in the file raced a hardcoded `setTimeout(closeAndFail, 100)` (or `500`) against the server finishing its work:

```
(fail) net.createServer listen > should listen on IPv6 by default [251.28ms]
```

It is not IPv6-specific. The first `listen()` in a debug+ASAN process costs ~250ms, so whichever test listens first loses: run `-t "should listen on IPv4"` alone and that one fails at 267ms instead. The 500ms group sat within 2x of its budget, which is how those flaked on loaded machines, already recorded in the file:

```js
//should be faster than 500ms (this was previously 100 but the test was flaky on local machine -@alii)
```

The commit deletes the timers (-56/+1). No failure mode is lost: `closeAndFail` stays wired to `'error'` and `connectError`, the `mustCall` slots still have to fire for `done()` to run, and bun's test runner already fails a test that hangs. The file now runs 21/21 under `bun bd test`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/node-net-server.test.ts
bun test v1.4.0 (4602b31fc)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [38.97ms]
(pass) net.createServer listen > should listen on IPv6 by default [136.50ms]
(pass) net.createServer listen > should listen on IPv4 [27.90ms]
(pass) net.createServer listen > should call listening [14.83ms]
(pass) net.createServer listen > should provide listening property [17.69ms]
(pass) net.createServer listen > should listen on localhost [18.30ms]
(pass) net.createServer listen > should listen on localhost [16.98ms]
(pass) net.createServer listen > should listen without port or host [17.45ms]
(pass) net.createServer listen > should listen on unix domain socket [17.80ms]
(pass) net.createServer listen > should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355 [26.77ms]
(pass) net.createServer events > should receive data [144.09ms]
(pass) net.createServer events > should call end [130.09ms]
(pass) net.createServer events > sh
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [0.54ms]
(pass) net.createServer listen > should listen on IPv6 by default [3.21ms]
(pass) net.createServer listen > should listen on IPv4 [1.28ms]
(pass) net.createServer listen > should call listening [1.21ms]
(pass) net.createServer listen > should provide listening property [1.25ms]
(pass) net.createServer listen > should listen on localhost [1.23ms]
(pass) net.createServer listen > should listen on localhost [1.21ms]
(pass) net.createServer listen > should listen without port or host [1.24ms]
(pass) net.createServer listen > should listen on unix domain socket [1.35ms]
(pass) net.createServer listen > should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355 [1.57ms]
(pass) net.createServer events > should receive data [4.02ms]
(pass) net.createServer events > should call end [1.76ms]
(pass) net.createServer events > should call close [0.16ms]
(pass) net.createServer events > should call connection and drop [1.91ms]
454 |   }
455 | 
456 |   it("should not emit drop when blockList rejects the conn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/node-net-server.test.ts
bun test v1.4.0 (4602b31fc)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [38.85ms]
(pass) net.createServer listen > should listen on IPv6 by default [131.98ms]
(pass) net.createServer listen > should listen on IPv4 [26.57ms]
(pass) net.createServer listen > should call listening [15.78ms]
(pass) net.createServer listen > should provide listening property [18.68ms]
(pass) net.createServer listen > should listen on localhost [18.92ms]
(pass) net.createServer listen > should listen on localhost [17.14ms]
(pass) net.createServer listen > should listen without port or host [17.31ms]
(pass) net.createServer listen > should listen on unix domain socket [17.75ms]
(pass) net.createServer listen > should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355 [27.23ms]
(pass) net.createServer events > should receive data [138.27ms]
(pass) net.createServer events > should call end [131.66ms]
(pass) net.createServer events > sh
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4602b31fc6
  features     baseline

22 deps, 108 codegen, 1171 objects in 951ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[4/1234] gen bindgenv2
[5/1234] gen ErrorCode+*.h
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] fetch libjpeg-turbo
[libjpeg-turbo] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                       |  27 +++----
 test/js/node/net/node-net-server.test.ts | 132 ++++++++++++++++++-------------
 2 files changed, 85 insertions(+), 74 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/node/net.ts                            3      4      0
test/js/node/net/node-net-server.test.ts      9     13      0
```

</details>

**root cause** · written by the author bot

The `onconnection` handler in `src/js/node/net.ts` routed both the `maxConnections` and `blockList` rejection paths through the same tail that emitted the `'drop'` event, whereas Node reserves `'drop'` exclusively for the `maxConnections` threshold and closes blockList-rejected connections silently. The fix separates the two branches so the `blockList` case closes the client handle and returns without emitting `'drop'`, while the `maxConnections` path retains the existing emit. This brings the observable event semantics in line with Node, preventing blocked peers from triggering false satur…

<!-- robobun:evidence:end -->