### PR TITLE
node:http2: don't let a header block that fails validation reach the HPACK encoder

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -406,18 +406,6 @@ function emitEventNT(self: any, event: string, ...args: any[]) {
     self.emit(event, ...args);
   }
 }
-function emitErrorNT(self: any, error: any, destroy: boolean) {
-  if (destroy) {
-    if (self.listenerCount("error") > 0) {
-      self.destroy(error);
-    } else {
-      self.destroy();
-    }
-  } else if (self.listenerCount("error") > 0) {
-    self.emit("error", error);
-  }
-}
-
 function emitOutofStreamErrorNT(self: any) {
   self.destroy($ERR_HTTP2_OUT_OF_STREAMS());
 }
@@ -5215,9 +5203,15 @@ class ClientHttp2Session extends Http2Session {
       process.nextTick(emitEventNT, req, "ready");
       return req;
     } catch (e: any) {
+      // node reports a request() that fails its own header validation purely as the synchronous
+      // throw, with no session 'error' event. The stream id reserved above never reached the peer,
+      // so hand back the connection slot its streamStart callback took.
       if (connectionsCounted) {
         this.#connections--;
-        process.nextTick(emitErrorNT, this, e, this.#connections === 0 && this.#closed);
+        // Giving the slot back can be what finishes a close() that was waiting on it.
+        if (this.#connections === 0 && this.#closed) {
+          this.destroy();
+        }
       }
       throw e;
     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -19,6 +19,7 @@ use crate::node::{Encoding, StringOrBuffer};
 use crate::socket::NativeCallbacks;
 use crate::webcore::AutoFlusher;
 use bstr::BStr;
+use bun_collections::smallvec::SmallVec;
 use bun_collections::{ByteVecExt, HashMap as BunHashMap, HiveArrayFallback, VecExt};
 use bun_core::MutableString;
 use bun_core::String as BunString;
@@ -621,6 +622,73 @@ fn is_valid_request_pseudo_header(name: &[u8]) -> bool {
 #[inline]
 fn is_valid_header_value(value: &[u8]) -> bool {
     !value.iter().any(|&c| matches!(c, 0 | b'\n' | b'\r'))
+}
+
+/// A header block held back from the HPACK encoder until every field in it has been validated.
+///
+/// One encoder, and so one dynamic table, serves every block on a session, and the peer's decoder
+/// mirrors it entry for entry: a field encoded into a block that then throws stays in a table the
+/// peer never saw, and every later block decodes against the wrong entries. The inline capacity
+/// keeps an ordinary request or response block off the heap.
+#[derive(Default)]
+struct PendingHeaderBlock {
+    /// Each field's name bytes followed by its value bytes.
+    bytes: SmallVec<[u8; 512]>,
+    fields: SmallVec<[PendingHeaderField; 16]>,
+}
+
+#[derive(Clone, Copy)]
+struct PendingHeaderField {
+    name_start: usize,
+    name_len: usize,
+    value_len: usize,
+    never_index: bool,
+}
+
+impl PendingHeaderBlock {
+    fn push(&mut self, name: &[u8], value: &[u8], never_index: bool) {
+        let name_start = self.bytes.len();
+        self.bytes.extend_from_slice(name);
+        self.bytes.extend_from_slice(value);
+        self.fields.push(PendingHeaderField {
+            name_start,
+            name_len: name.len(),
+            value_len: value.len(),
+            never_index,
+        });
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8], bool)> {
+        self.fields.iter().map(move |field| {
+            let value_start = field.name_start + field.name_len;
+            (
+                &self.bytes[field.name_start..value_start],
+                &self.bytes[value_start..value_start + field.value_len],
+                field.never_index,
+            )
+        })
+    }
+
+    /// Whether any field is too large for lshpack to encode. Its scratch buffer holds one
+    /// name/value pair, so a larger field fails the encode and would strand every field before it
+    /// in the dynamic table.
+    fn has_oversized_field(&self) -> bool {
+        self.fields
+            .iter()
+            .any(|field| field.name_len + field.value_len > lshpack::HPACK::LSHPACK_MAX_HEADER_SIZE)
+    }
+
+    /// Upper bound on this block's HPACK-encoded size, the same one nghttp2 measures
+    /// `maxSendHeaderBlockLength` against (`nghttp2_hd_deflate_bound`): two 6-byte table-size
+    /// updates, then per field a 6-byte length prefix for its name and another for its value,
+    /// plus the literal bytes, taking every field as a new-name literal without indexing.
+    fn encoded_size_bound(&self) -> usize {
+        12 + self
+            .fields
+            .iter()
+            .map(|field| 6 * 2 + field.name_len + field.value_len)
+            .sum::<usize>()
+    }
 }
 
 #[inline]
@@ -7343,8 +7411,8 @@ impl H2FrameParser {
         )?;
 
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
+        let mut pending = PendingHeaderBlock::default();
 
-        // Encode trailer headers using HPACK
         while let Some(header_name) = iter.next()? {
             if header_name.length() == 0 {
                 continue;
@@ -7386,11 +7454,7 @@ impl H2FrameParser {
                 }
             };
 
-            // closure for encode error handling
-            let mut handle_encode = |this: &Self,
-                                     value: &[u8],
-                                     never_index: bool|
-             -> JsResult<Option<JSValue>> {
+            let mut stash_header = |value: &[u8], never_index: bool| -> JsResult<()> {
                 if !is_valid_header_value(value) {
                     let exception = global_object.to_type_error(
                         bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
@@ -7398,47 +7462,8 @@ impl H2FrameParser {
                     );
                     return Err(global_object.throw_value(exception));
                 }
-                bun_output::scoped_log!(
-                    H2FrameParser,
-                    "encode header {} {}",
-                    BStr::new(validated_name),
-                    BStr::new(value)
-                );
-                match this.encode_header_into_list(
-                    &mut encoded_headers,
-                    validated_name,
-                    value,
-                    never_index,
-                ) {
-                    Ok(_) => Ok(None),
-                    Err(crate::Error::Alloc(bun_alloc::AllocError)) => {
-                        Err(global_object.throw(format_args!("Failed to allocate header buffer")))
-                    }
-                    Err(_) => {
-                        let identifier = stream.get_identifier();
-                        identifier.ensure_still_alive();
-                        this.dispatch_with_2_extra(
-                            JSH2FrameParser::Gc::onFrameError,
-                            identifier,
-                            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
-                            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-                        );
-                        // The trailer block cannot be encoded into a legal frame: reset the
-                        // stream so the peer sees RST_STREAM(FRAME_SIZE_ERROR), then shut the
-                        // session down gracefully — the encoder state is no longer trustworthy
-                        // (node/nghttp2 treat this as fatal and close with a NO_ERROR GOAWAY).
-                        let triggering_id = stream.id;
-                        this.end_stream(&mut stream, ErrorCode::FRAME_SIZE_ERROR);
-                        this.send_go_away(
-                            triggering_id,
-                            ErrorCode::NO_ERROR,
-                            b"",
-                            this.last_stream_id.get(),
-                            true,
-                        );
-                        Ok(Some(JSValue::UNDEFINED))
-                    }
-                }
+                pending.push(validated_name, value, never_index);
+                Ok(())
             };
 
             if js_value.js_type().is_array() {
@@ -7499,9 +7524,7 @@ impl H2FrameParser {
                     let value_slice = value_str.to_slice(global_object);
                     let value = value_slice.slice();
 
-                    if let Some(ret) = handle_encode(this, value, never_index)? {
-                        return Ok(ret);
-                    }
+                    stash_header(value, never_index)?;
                 }
             } else {
                 if let Some(idx) = single_value_headers_index_of(validated_name) {
@@ -7545,17 +7568,59 @@ impl H2FrameParser {
 
                 let value_slice = value_str.to_slice(global_object);
                 let value = value_slice.slice();
+
+                stash_header(value, never_index)?;
+            }
+        }
+
+        // A field lshpack cannot encode makes the whole trailer block unsendable. Catch it before
+        // the encoder is advanced for the fields ahead of it; an encode failure past that point is
+        // an lshpack fault rather than bad input, and leaves the dynamic table unusable.
+        let mut unencodable = pending.has_oversized_field();
+        if !unencodable {
+            for (name, value, never_index) in pending.iter() {
                 bun_output::scoped_log!(
                     H2FrameParser,
                     "encode header {} {}",
                     BStr::new(name),
                     BStr::new(value)
                 );
-
-                if let Some(ret) = handle_encode(this, value, never_index)? {
-                    return Ok(ret);
+                match this.encode_header_into_list(&mut encoded_headers, name, value, never_index) {
+                    Ok(_) => {}
+                    Err(crate::Error::Alloc(bun_alloc::AllocError)) => {
+                        return Err(
+                            global_object.throw(format_args!("Failed to allocate header buffer"))
+                        );
+                    }
+                    Err(_) => {
+                        unencodable = true;
+                        break;
+                    }
                 }
             }
+        }
+        if unencodable {
+            let identifier = stream.get_identifier();
+            identifier.ensure_still_alive();
+            this.dispatch_with_2_extra(
+                JSH2FrameParser::Gc::onFrameError,
+                identifier,
+                JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
+                JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
+            );
+            // Reset the stream so the peer sees RST_STREAM(FRAME_SIZE_ERROR), then shut the session
+            // down gracefully: node/nghttp2 measure a block this large against their own 64KB limit
+            // and treat overrunning it as fatal, closing with a NO_ERROR GOAWAY.
+            let triggering_id = stream.id;
+            this.end_stream(&mut stream, ErrorCode::FRAME_SIZE_ERROR);
+            this.send_go_away(
+                triggering_id,
+                ErrorCode::NO_ERROR,
+                b"",
+                this.last_stream_id.get(),
+                true,
+            );
+            return Ok(JSValue::UNDEFINED);
         }
         let encoded_data = encoded_headers.as_slice();
         let encoded_size = encoded_data.len();
@@ -7823,6 +7888,7 @@ impl H2FrameParser {
 
         let mut name_buffer = [0u8; 4096];
         let mut encoded_headers: Vec<u8> = Vec::new();
+        let mut pending = PendingHeaderBlock::default();
 
         // A PUSH_PROMISE carries a REQUEST, so request pseudo-headers are valid even on the server.
         // Pseudo-headers must be encoded first, so iterate twice.
@@ -7904,20 +7970,35 @@ impl H2FrameParser {
                 };
                 let value_slice = value_str.to_slice(global_object);
                 let value = value_slice.slice();
-                if this
-                    .encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    )
-                    .is_err()
-                {
-                    return Err(
-                        global_object.throw(format_args!("Failed to encode push promise headers"))
-                    );
-                }
+
+                pending.push(validated_name, value, never_index);
             }
+        }
+
+        // A field lshpack cannot encode: reject before the encoder is advanced for the fields
+        // ahead of it.
+        if pending.has_oversized_field() {
+            return Err(global_object.throw(format_args!("Failed to encode push promise headers")));
+        }
+        // Nothing below rejects this block, so the encoder is only ever advanced for one that
+        // reaches the wire. An encode failure here is an lshpack fault rather than bad input: the
+        // dynamic table can no longer be trusted, so the session goes down (as send_trailers does).
+        for (name, value, never_index) in pending.iter() {
+            let Err(err) =
+                this.encode_header_into_list(&mut encoded_headers, name, value, never_index)
+            else {
+                continue;
+            };
+            if !matches!(err, crate::Error::Alloc(_)) {
+                this.send_go_away(
+                    parent_id,
+                    ErrorCode::NO_ERROR,
+                    b"",
+                    this.last_stream_id.get(),
+                    true,
+                );
+            }
+            return Err(global_object.throw(format_args!("Failed to encode push promise headers")));
         }
 
         let max_frame =
@@ -8223,6 +8304,7 @@ impl H2FrameParser {
 
         // we iterate twice, because pseudo headers must be sent first, but can appear anywhere in the headers object
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
+        let mut pending = PendingHeaderBlock::default();
 
         // Raw (flat [name, value, ...] array) headers form: encode each pair in
         // its given order, pseudo-headers first (same two-pass split as the
@@ -8334,42 +8416,8 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
 
-                    if let Err(err) = this.encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    ) {
-                        if matches!(err, crate::Error::Alloc(_)) {
-                            return Err(global_object
-                                .throw(format_args!("Failed to allocate header buffer")));
-                        }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream_id as f64));
-                    }
+                    pending.push(validated_name, value, never_index);
                 }
             }
         }
@@ -8521,42 +8569,8 @@ impl H2FrameParser {
                                 )
                                 .throw());
                         }
-                        bun_output::scoped_log!(
-                            H2FrameParser,
-                            "encode header {} {}",
-                            BStr::new(validated_name),
-                            BStr::new(value)
-                        );
 
-                        if let Err(err) = this.encode_header_into_list(
-                            &mut encoded_headers,
-                            validated_name,
-                            value,
-                            never_index,
-                        ) {
-                            if matches!(err, crate::Error::Alloc(_)) {
-                                return Err(global_object
-                                    .throw(format_args!("Failed to allocate header buffer")));
-                            }
-                            let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                                return Ok(JSValue::js_number(-1.0));
-                            };
-                            // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                            let stream = unsafe { &mut *stream };
-                            if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                                && stream_ctx_arg.is_object()
-                            {
-                                stream.set_context(stream_ctx_arg, global_object);
-                            }
-                            stream.state = StreamState::CLOSED;
-                            stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                            this.dispatch_with_extra(
-                                JSH2FrameParser::Gc::onStreamError,
-                                stream.get_identifier(),
-                                JSValue::js_number(stream.rst_code as f64),
-                            );
-                            return Ok(JSValue::UNDEFINED);
-                        }
+                        pending.push(validated_name, value, never_index);
                     }
                 } else if !js_value.is_empty_or_undefined_or_null() {
                     bun_output::scoped_log!(H2FrameParser, "single header {}", BStr::new(name));
@@ -8611,46 +8625,11 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
 
-                    if let Err(err) = this.encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    ) {
-                        if matches!(err, crate::Error::Alloc(_)) {
-                            return Err(global_object
-                                .throw(format_args!("Failed to allocate header buffer")));
-                        }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
-                        return Ok(JSValue::js_number(stream_id as f64));
-                    }
+                    pending.push(validated_name, value, never_index);
                 }
             }
         }
-        let encoded_size = encoded_headers.len();
 
         let Some(stream_ptr) = this.handle_received_stream_id(stream_id) else {
             return Ok(JSValue::js_number(-1.0));
@@ -8852,17 +8831,25 @@ impl H2FrameParser {
             }
             return Ok(JSValue::js_number(stream_id as f64));
         }
-        let mut length: usize = encoded_size;
-        if has_priority {
-            length += 5;
-            flags |= HeadersFrameFlags::PRIORITY as u8;
+
+        // A field lshpack cannot encode: reject the stream before the encoder is advanced for the
+        // fields ahead of it.
+        if pending.has_oversized_field() {
+            stream.state = StreamState::CLOSED;
+            stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
+            this.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamError,
+                stream.get_identifier(),
+                JSValue::js_number(stream.rst_code as f64),
+            );
+            return Ok(JSValue::js_number(stream_id as f64));
         }
 
-        bun_output::scoped_log!(H2FrameParser, "request encoded_size {}", encoded_size);
-
-        // Check if headers block exceeds maxSendHeaderBlockLength
+        // maxSendHeaderBlockLength is measured against an upper bound on the encoded size rather
+        // than the encoded block itself, as nghttp2 does, because an encoder advanced for a block
+        // that is then refused can never be wound back.
         if this.max_send_header_block_length.get() != 0
-            && encoded_size > this.max_send_header_block_length.get() as usize
+            && pending.encoded_size_bound() > this.max_send_header_block_length.get() as usize
         {
             stream.state = StreamState::CLOSED;
             stream.rst_code = ErrorCode::REFUSED_STREAM.0;
@@ -8881,6 +8868,50 @@ impl H2FrameParser {
             );
             return Ok(JSValue::js_number(stream_id as f64));
         }
+
+        // Nothing below rejects this request, so the encoder is only ever advanced for a block that
+        // reaches the wire. An encode failure here is an lshpack fault rather than bad input: the
+        // dynamic table can no longer be trusted, so the session goes down (as send_trailers does).
+        for (name, value, never_index) in pending.iter() {
+            bun_output::scoped_log!(
+                H2FrameParser,
+                "encode header {} {}",
+                BStr::new(name),
+                BStr::new(value)
+            );
+            let Err(err) =
+                this.encode_header_into_list(&mut encoded_headers, name, value, never_index)
+            else {
+                continue;
+            };
+            if matches!(err, crate::Error::Alloc(_)) {
+                return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
+            }
+            stream.state = StreamState::CLOSED;
+            stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
+            this.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamError,
+                stream.get_identifier(),
+                JSValue::js_number(stream.rst_code as f64),
+            );
+            this.send_go_away(
+                stream_id,
+                ErrorCode::NO_ERROR,
+                b"",
+                this.last_stream_id.get(),
+                true,
+            );
+            return Ok(JSValue::js_number(stream_id as f64));
+        }
+        let encoded_size = encoded_headers.len();
+
+        let mut length: usize = encoded_size;
+        if has_priority {
+            length += 5;
+            flags |= HeadersFrameFlags::PRIORITY as u8;
+        }
+
+        bun_output::scoped_log!(H2FrameParser, "request encoded_size {}", encoded_size);
 
         let actual_max_frame_size = this
             .remote_settings

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -13,8 +13,10 @@ import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
 const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx } = createTest(import.meta.path);
 // bun-debug ships with ASAN but isn't named bun-asan, so isASAN is false
 // there; the 10k-request maxSessionMemory stress test takes ~90s under
-// debug+ASAN vs ~2s release, so scale for either.
-const ASAN_MULTIPLIER = isDebug ? 10 : isASAN ? 3 : 1;
+// debug+ASAN vs ~2s release, so scale for either. 10x left it inside its own
+// budget only on an idle machine: it measures 130s+ on a busy one, and the node
+// test covering the same workload (test-http2-forget-closed-streams) takes 195s.
+const ASAN_MULTIPLIER = isDebug ? 20 : isASAN ? 3 : 1;
 
 function invalidArgTypeHelper(input) {
   if (input === null) return " Received null";
@@ -2353,6 +2355,161 @@ it("http2 client.request() rejects header names longer than 4096 bytes with a ca
   expect(stdout).toContain("STATUS:200");
   expect(exitCode).toBe(0);
 });
+
+it(
+  "http2 a request the session rejects never reaches its HPACK encoder",
+  async () => {
+    // A single HPACK encoder, and so a single dynamic table, serves every header block on a
+    // session; the peer's decoder mirrors it entry for entry. When request()/sendTrailers() rejects
+    // a block, the fields it already walked must not stay in that table - the peer never receives
+    // them, so every later block decodes against the wrong entries. Node reports these failures as
+    // a plain synchronous throw with no session side effects at all.
+    const serverTrailerErrors = [];
+    const server = http2.createServer();
+    server.on("stream", (stream, headers) => {
+      if (headers[":path"] === "/trailers") {
+        stream.respond({ ":status": 200 }, { waitForTrailers: true });
+        stream.on("wantTrailers", () => {
+          try {
+            // "x-trailer" is encoded (and inserted into the dynamic table) before ":bogus" throws.
+            stream.sendTrailers({ "x-trailer": "abc", ":bogus": "x" });
+            serverTrailerErrors.push("did not throw");
+          } catch (err) {
+            serverTrailerErrors.push(err.code);
+          }
+          stream.close();
+        });
+        stream.end("ok");
+        return;
+      }
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    const { promise: listening, resolve: onListening } = Promise.withResolvers();
+    server.listen(0, "127.0.0.1", onListening);
+    await listening;
+
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    const clientSessionErrors = [];
+    client.on("error", err => clientSessionErrors.push(err.code));
+
+    // Resolves to the stream's outcome: the :status on success, "error:<code>" otherwise.
+    const get = (path, extraHeaders) =>
+      new Promise(resolve => {
+        let outcome = "no response";
+        const req = client.request({ ":path": path, ...extraHeaders }, { endStream: true });
+        req.on("response", headers => (outcome = headers[":status"]));
+        req.on("data", () => {});
+        req.on("error", err => (outcome = "error:" + err.code));
+        req.on("close", () => resolve(outcome));
+      });
+
+    try {
+      expect(await get("/warmup")).toBe(200);
+
+      // Every :path below is absent from the HPACK static table, so encoding it inserts into the
+      // dynamic table - the encoder state a later rejection must not be able to leave behind.
+      const rejected = [
+        ["invalid pseudo-header name", { ":path": "/dyn-1", ":bogus": "x" }, {}, "ERR_HTTP2_INVALID_PSEUDOHEADER"],
+        ["invalid header name token", { ":path": "/dyn-2", "bad header": "x" }, {}, "ERR_INVALID_HTTP_TOKEN"],
+        ["invalid header value", { ":path": "/dyn-3", "x-y": "a\nb" }, {}, "ERR_HTTP2_INVALID_HEADER_VALUE"],
+        ["raw header array", [":path", "/dyn-4", ":bogus", "x"], {}, "ERR_HTTP2_INVALID_PSEUDOHEADER"],
+        // Request options are read after the header walk, so their rejections discard a block whose
+        // every field already passed validation.
+        ["invalid request option", { ":path": "/dyn-5" }, { silent: "x" }, "ERR_INVALID_ARG_TYPE"],
+      ];
+
+      for (const [label, headers, options, code] of rejected) {
+        let thrown;
+        try {
+          client.request(headers, { endStream: true, ...options });
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown?.code, label).toBe(code);
+        // The next request on the same session still encodes to something the peer can decode.
+        expect(await get("/after-" + label.replaceAll(" ", "-")), label).toBe(200);
+      }
+
+      // Not every rejection is a throw. lshpack's scratch buffer holds one name/value pair, so a
+      // field larger than it cannot be encoded; refusing the stream must not strand the fields the
+      // block already walked past.
+      expect(await get("/dyn-6", { "x-huge": Buffer.alloc(70000, "a").toString() })).toBe(
+        "error:ERR_HTTP2_STREAM_ERROR",
+      );
+      expect(await get("/after-oversized-field")).toBe(200);
+
+      // Same rule for a trailer block the server throws away: its response encoder stays in sync.
+      expect(await get("/trailers")).toBe(200);
+      expect(serverTrailerErrors).toEqual(["ERR_HTTP2_INVALID_PSEUDOHEADER"]);
+      expect(await get("/after-trailers")).toBe(200);
+
+      // None of the above is a session-level failure: the caller already got the throw.
+      expect(clientSessionErrors).toEqual([]);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+    // ~15 sequential round-trips; give debug+ASAN room on a loaded machine rather than the 5s default.
+  },
+  30_000 * ASAN_MULTIPLIER,
+);
+
+it(
+  "http2 maxSendHeaderBlockLength refuses a request without desyncing the session",
+  async () => {
+    // The limit is measured against an upper bound on the encoded size, the same one nghttp2 uses
+    // (nghttp2_hd_deflate_bound), because an encoder advanced for a block that is then refused can
+    // never be wound back. Node reports the refusal as a frameError plus a stream error.
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    const { promise: listening, resolve: onListening } = Promise.withResolvers();
+    server.listen(0, "127.0.0.1", onListening);
+    await listening;
+
+    // Large enough that a bare request fits, small enough that one padded header does not.
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`, {
+      maxSendHeaderBlockLength: 300,
+    });
+    const clientSessionErrors = [];
+    client.on("error", err => clientSessionErrors.push(err.code));
+
+    const get = (path, extraHeaders) =>
+      new Promise(resolve => {
+        let outcome = "no response";
+        const frameErrors = [];
+        const req = client.request({ ":path": path, ...extraHeaders }, { endStream: true });
+        req.on("response", headers => (outcome = headers[":status"]));
+        req.on("data", () => {});
+        req.on("frameError", (type, code) => frameErrors.push(code));
+        req.on("error", err => (outcome = "error:" + err.code));
+        req.on("close", () => resolve({ outcome, frameErrors }));
+      });
+
+    try {
+      expect(await get("/warmup")).toEqual({ outcome: 200, frameErrors: [] });
+
+      // Over the limit even after Huffman coding, so a build that measures the encoded block refuses
+      // it too - and is left with the encoder advanced for a block it never sent.
+      expect(await get("/oversized", { "x-pad": Buffer.alloc(1000, "a").toString() })).toEqual({
+        outcome: "error:ERR_HTTP2_STREAM_ERROR",
+        frameErrors: [http2.constants.NGHTTP2_FRAME_SIZE_ERROR],
+      });
+
+      // The refused block never reached the encoder, so the peer can still decode what comes next.
+      expect(await get("/after-oversized")).toEqual({ outcome: 200, frameErrors: [] });
+      expect(clientSessionErrors).toEqual([]);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+    // Sequential round-trips; give debug+ASAN room on a loaded machine rather than the 5s default.
+  },
+  30_000 * ASAN_MULTIPLIER,
+);
 
 it("http2 server resets streams whose request headers contain CR, LF, or NUL octets", async () => {
   // RFC 9113 Section 8.2.1: a request carrying a field value with NUL, CR, or


### PR DESCRIPTION
Rebased past #33909 (the per-crate `thiserror` migration) and squashed: the three consolidated `encode_header_into_list` error handlers now match `crate::Error::Alloc(_)` instead of the old `bun_core::err!("OutOfMemory")`. No other textual overlap.

Overlaps #32995, which hoists `request()`'s *options* validation above the encode to fix the same desync from the other side. This PR splits the *header* walk into a validate pass and an encode pass, which is the follow-up #32995 names under "Intentionally excluded, same bug class, different fix", and then moves that encode pass below the options too, so the whole class is closed in one place. #32995 keeps its own value (`parent: 0` is accepted, `weight` is clamped, `PADDED`+`PRIORITY` frame layout) and the two conflict textually in `request()` and in `node-http2.test.js`; whichever lands first, the other gets rebased.

## Repro

```js
import http2 from "node:http2";
// server: a plain node http2.createServer answering 200 to everything
const ses = http2.connect(`http://127.0.0.1:${port}`);
let sessionErrors = 0;
ses.on("error", e => { sessionErrors++; console.log("SESSION 'error':", e.code); });
const plain = tag => new Promise(r => {
  const ev = [], st = ses.request({ ":path": "/" + tag }, { endStream: true });
  st.on("response", h => ev.push("response:" + h[":status"])); st.on("data", () => {});
  st.on("error", e => ev.push("error:" + e.code));
  st.on("close", () => { ev.push("rst=" + st.rstCode); r(ev); });
});
console.log("#1", await plain("one"));
try { ses.request({ ":path": "/bad", ":bogus": "x" }, { endStream: true }); }
catch (e) { console.log("threw synchronously:", e.code, "(caught)"); }
console.log("#2", await plain("two"));
console.log("#3", await plain("three"));
console.log("session 'error' events:", sessionErrors);
```

| | node v26.3.0 | bun 1.4.0 / main |
| --- | --- | --- |
| the throw | `ERR_HTTP2_INVALID_PSEUDOHEADER` (caught) | `ERR_HTTP2_INVALID_PSEUDOHEADER` (caught) |
| session `'error'` events | 0 | 1, `ERR_HTTP2_INVALID_PSEUDOHEADER` |
| `#2` / `#3` | `response:200`, `rst=0` | `error:ERR_HTTP2_STREAM_ERROR`, `rst=1` |

A caught argument-validation error from `request()` permanently breaks the session: every later request on it is reset by the peer, and re-reporting the caught error as a session `'error'` takes down a process that has no session error handler. The same trigger applies to `stream.sendTrailers()` and `stream.pushStream()`.

## Cause

Two independent defects, both on the path a throwing `request()` takes.

**The HPACK encoder is advanced before the request is known to be sendable.** One encoder, and so one dynamic table, serves every header block on a session, and the peer's decoder mirrors it entry for entry (RFC 7541 §4). `request()` in `h2_frame_parser.rs` validated and encoded each field in the same step, so when `:bogus` throws, `:path: /bad` has already been inserted into the encoder's dynamic table. The peer never receives that block, so its decoder's table is one entry behind from then on: every later block resolves its indexed references to the wrong entries, and the peer answers with `RST_STREAM(PROTOCOL_ERROR)` or `GOAWAY(COMPRESSION_ERROR)`.

The desync only happens when a field encoded before the rejection inserts into the dynamic table, which is why the existing `rejects header names longer than 4096 bytes` test passes today: its `:path: /` is a static-table hit. Swapping the value to `/bad` breaks the session, and moving `:bogus` ahead of `:path` (nothing encoded before the throw) leaves it healthy.

`request()` rejects a request in four more places, and every one of them ran after the block was encoded:

| rejection | trigger |
| --- | --- |
| a bad request option | `silent`, `endStream`, `exclusive`, `parent`, `weight`, `signal`, or a throwing getter |
| `maxSessionMemory` exceeded | `ENHANCE_YOUR_CALM` |
| a field lshpack cannot encode | name + value over its 65536-byte scratch buffer |
| `maxSendHeaderBlockLength` exceeded | measured on the encoded block |

`sendTrailers()` and `pushStream()` encode field-by-field and have the header half of the defect.

**The throw is also emitted on the session.** `ClientHttp2Session.request()`'s `catch` re-dispatched the error through `emitErrorNT`. Node treats a `request()` that fails its own validation as purely the caller's problem.

## Fix

- `src/runtime/api/bun/h2_frame_parser.rs`: `PendingHeaderBlock` collects each validated name/value/never-index triple, and the encoder runs in a single pass afterwards, once the whole block is known good. Used by `request()` (which also backs `respond()` and `additionalHeaders()`), `send_trailers()` and `push_promise()`. In `request()` that pass now sits below every rejection listed above, so nothing can abandon an encoded block. The walk order, validation order and error codes are unchanged, so the same input still fails the same way; it just fails before anything is encoded. The three duplicated `encode_header_into_list` error handlers collapse into one, and inline capacity (`SmallVec`) keeps an ordinary block off the heap.
- `maxSendHeaderBlockLength` is now measured against an upper bound on the encoded size rather than the encoded block, which is both what nghttp2 measures it against (`nghttp2_hd_deflate_bound`) and the only way to check it without advancing the encoder. Bun's behavior now matches node v26.3.0 on the repro below.
- `src/js/node/http2.ts`: drop the session `'error'` emit from `request()`'s `catch`, keeping the `#connections--` that balances the slot `streamStart` took, and the graceful-close completion (`destroy()` once the last slot is handed back on a closing session) that every sibling decrement site makes. `emitErrorNT` had no other caller and is deleted.

`send_trailers()` and `push_promise()` get the same oversized-field pre-check, so no site advances the encoder for a field it cannot encode. What each one then does is unchanged: `request()` resets the stream, `push_promise()` throws, and `send_trailers()` resets the stream and takes the session down with a graceful GOAWAY, because nghttp2 measures a trailer block that large against its own 64KB limit and treats overrunning it as fatal (`test-http2-exceeds-server-trailer-size` asserts the client sees the session close). Keeping the encoder clean there still buys something: the GOAWAY is graceful, so streams still draining under it do not encode against a dirty table.

An `encode_header_into_list` failure that survives those pre-checks is an lshpack fault rather than bad input, and leaves the encoder in an unknown state, so all three sites take the session down with the graceful GOAWAY `send_trailers()` already used.

## Verification

Two tests in `test/js/node/http2/node-http2.test.js`, alongside the existing header-validation coverage. Every `:path` is chosen to be absent from the HPACK static table so that encoding it inserts into the dynamic table, and after each rejection the next request on the session must still get a `200`.

1. six rejected client requests (bad pseudo-header name, bad name token, bad value, raw `[name, value, ...]` array form, a bad request option, an oversized field) plus a rejected server trailer block, and no session `'error'` at the end.
2. `maxSendHeaderBlockLength`: an oversized request is refused with a `frameError(FRAME_SIZE_ERROR)` and the session stays usable, matching node v26.3.0 exactly.

The oversized-trailer path is already covered by the ported `test-http2-exceeds-server-trailer-size.js`, which sends a 64KiB trailer field and asserts the `frameError` plus the session close. One commit here got that case wrong (resetting only the stream) and that test caught it.

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/http2/node-http2.test.js -t "HPACK encoder"
Expected: 200
Received: "error:ERR_HTTP2_STREAM_ERROR"
(fail) http2 a request the session rejects never reaches its HPACK encoder

$ USE_SYSTEM_BUN=1 bun test test/js/node/http2/node-http2.test.js -t "maxSendHeaderBlockLength refuses"
error: Stream closed with error code NGHTTP2_COMPRESSION_ERROR
(fail) http2 maxSendHeaderBlockLength refuses a request without desyncing the session

$ bun bd test test/js/node/http2/node-http2.test.js -t "HPACK encoder"
(pass) http2 a request the session rejects never reaches its HPACK encoder
(pass) http2 maxSendHeaderBlockLength refuses a request without desyncing the session
```

`bun bd test test/js/node/http2/` passes (372 pass, 1 timeout on `user-controlled options getters`, which also times out on an unmodified debug+ASAN build on this host; it sits at ~90% of its budget at rest).

<details>
<summary>Ported node http2 suite: no change</summary>

All 59 `test/js/node/test/parallel/test-http2-*.js` files covering header, trailer, push, pseudo-header, option, priority, abort and continuation behavior were run against the patched build: 50 pass, 9 fail. The 9 (`test-http2-client-set-priority`, `test-http2-info-headers-errors`, `test-http2-options-max-headers-exceeds-nghttp2`, `test-http2-server-push-stream-errors`, `test-http2-server-push-stream-head`, `test-http2-single-headers-validation-disabled`, `test-http2-util-assert-valid-pseudoheader`, `test-http2-util-headers-list`, `test-http2-util-update-options-buffer`) fail identically on stock bun 1.4.0 and are unrelated: they need `internalBinding("http2")`, `internal/http2/util`, the `strictSingleValueFields` option, or `stream.state.weight` reporting. `test-http2-options-max-headers-block-length` (the one that exercises the changed limit), `test-http2-misused-pseudoheaders`, `test-http2-invalidheaderfield`, `test-http2-multiheaders-raw`, `test-http2-raw-headers`, `test-http2-trailers` and the sensitive-header tests all pass both ways.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0475cb022)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [865.53ms]
(pass) node none > Client Basics > should be able to send a POST request [612.75ms]
(pass) node none > Client Basics > constants [18.48ms]
(pass) node none > Client Basics > getDefaultSettings [7.80ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.40ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.66ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.17ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.01ms
... (truncated)

release without fix: 8 failed, 6 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.76ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.08ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [1.73ms]
(pass) node none > Client Basics > is possible to abort request [1.00ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.70ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.60ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.92ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [15.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0475cb022)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [734.59ms]
(pass) node none > Client Basics > should be able to send a POST request [499.40ms]
(pass) node none > Client Basics > constants [18.10ms]
(pass) node none > Client Basics > getDefaultSettings [7.10ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.08ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.17ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.92ms
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0475cb0220
  features     (none)

22 deps, 106 codegen, 1168 objects in 1016ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] gen bindgenv2
[6/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1231] fetch picohttpparser
[picohttpparser] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                   |  20 +-
 src/runtime/api/bun/h2_frame_parser.rs | 391 ++++++++++++++++++---------------
 test/js/node/http2/node-http2.test.js  | 161 +++++++++++++-
 3 files changed, 377 insertions(+), 195 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/http2.ts                        3      4      0
src/runtime/api/bun/h2_frame_parser.rs     22     34      0
test/js/node/http2/node-http2.test.js       9     13      0
```

</details>

<!-- robobun:evidence:end -->