### PR TITLE
perf_hooks: make observed net/http entries real PerformanceEntry objects

### DIFF
--- a/src/js/internal/perf_hooks/performance_entry.ts
+++ b/src/js/internal/perf_hooks/performance_entry.ts
@@ -1,0 +1,86 @@
+// Entries for the Node-only entry types ('net', 'http', 'dns'), which the
+// native (WebCore) Performance implementation does not produce.
+// https://github.com/nodejs/node/blob/v24.10.0/lib/internal/perf/performance_entry.js
+
+const { PerformanceEntry } = globalThis;
+
+const kName = Symbol("kName");
+const kType = Symbol("kType");
+const kStart = Symbol("kStart");
+const kDuration = Symbol("kDuration");
+const kDetail = Symbol("kDetail");
+
+let inspect: typeof import("node:util").inspect;
+
+/**
+ * The native PerformanceEntry has no public constructor, so `extends` would
+ * make super() throw; Node wires up the same prototype chain by hand for its
+ * own internal entries.
+ */
+class PerformanceNodeEntry {
+  constructor(name, type, startTime, duration, detail) {
+    this[kName] = name;
+    this[kType] = type;
+    this[kStart] = startTime;
+    this[kDuration] = duration;
+    this[kDetail] = detail;
+  }
+
+  get name() {
+    return this[kName];
+  }
+
+  get entryType() {
+    return this[kType];
+  }
+
+  get startTime() {
+    return this[kStart];
+  }
+
+  get duration() {
+    return this[kDuration];
+  }
+
+  get detail() {
+    return this[kDetail];
+  }
+
+  toJSON() {
+    return {
+      name: this[kName],
+      entryType: this[kType],
+      startTime: this[kStart],
+      duration: this[kDuration],
+      detail: this[kDetail],
+    };
+  }
+
+  // Print the serialized entry rather than a wall of [Getter]s.
+  [Symbol.for("nodejs.util.inspect.custom")](depth, options) {
+    if (depth < 0) return this;
+    inspect ??= require("node:util").inspect;
+    const depth_ = options?.depth;
+    return `PerformanceNodeEntry ${inspect(this.toJSON(), { ...options, depth: depth_ == null ? null : depth_ - 1 })}`;
+  }
+}
+
+const kEnumerable = { __proto__: null, enumerable: true };
+Object.defineProperties(PerformanceNodeEntry.prototype, {
+  name: kEnumerable,
+  entryType: kEnumerable,
+  startTime: kEnumerable,
+  duration: kEnumerable,
+  detail: kEnumerable,
+  toJSON: kEnumerable,
+});
+Object.setPrototypeOf(PerformanceNodeEntry.prototype, PerformanceEntry.prototype);
+Object.setPrototypeOf(PerformanceNodeEntry, PerformanceEntry);
+
+function createPerformanceNodeEntry(name, type, startTime, duration, detail) {
+  return new PerformanceNodeEntry(name, type, startTime, duration, detail);
+}
+
+export default {
+  createPerformanceNodeEntry,
+};

--- a/src/js/internal/perf_hooks/performance_entry.ts
+++ b/src/js/internal/perf_hooks/performance_entry.ts
@@ -65,14 +65,14 @@ class PerformanceNodeEntry {
   }
 }
 
+// Node leaves `detail` and `toJSON` non-enumerable and marks the four base
+// accessors enumerable, which is what a `for...in` over an entry yields.
 const kEnumerable = { __proto__: null, enumerable: true };
 Object.defineProperties(PerformanceNodeEntry.prototype, {
   name: kEnumerable,
   entryType: kEnumerable,
   startTime: kEnumerable,
   duration: kEnumerable,
-  detail: kEnumerable,
-  toJSON: kEnumerable,
 });
 Object.setPrototypeOf(PerformanceNodeEntry.prototype, PerformanceEntry.prototype);
 Object.setPrototypeOf(PerformanceNodeEntry, PerformanceEntry);

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -169,6 +169,8 @@ function hasObserver(type) {
   return (observerCounts.get(type) ?? 0) > 0;
 }
 
+let createPerformanceNodeEntry;
+
 function startPerf(target, key, context) {
   context.startTime = performance.now();
   target[key] = context;
@@ -181,16 +183,16 @@ function stopPerf(target, key, context) {
   }
   target[key] = undefined;
   const startTime = ctx.startTime;
-  const entry = {
-    name: ctx.name,
-    entryType: ctx.type,
+  createPerformanceNodeEntry ??= require("internal/perf_hooks/performance_entry").createPerformanceNodeEntry;
+  const entry = createPerformanceNodeEntry(
+    ctx.name,
+    ctx.type,
     startTime,
-    duration: performance.now() - startTime,
+    performance.now() - startTime,
     // Node.js merges the detail recorded at startPerf() with the detail
     // passed to stopPerf() (e.g. http entries carry both req and res).
-    detail:
-      ctx.detail !== undefined || context?.detail !== undefined ? { ...ctx.detail, ...context?.detail } : undefined,
-  };
+    ctx.detail !== undefined || context?.detail !== undefined ? { ...ctx.detail, ...context?.detail } : undefined,
+  );
   for (const observer of kObservers) {
     observer.bufferEntry(entry);
   }

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -65,6 +65,7 @@ test("observed net and http entries are PerformanceEntry objects with toJSON()",
   for (const entry of entries) {
     expect(entry).toBeInstanceOf(PerformanceEntry);
     expect(entry.constructor.name).toBe("PerformanceNodeEntry");
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(entry))).toBe(PerformanceEntry.prototype);
     expect(entry.startTime).toBeNumber();
     expect(entry.duration).toBeNumber();
     // Serializing what you observe is the whole point of observing it.
@@ -76,6 +77,13 @@ test("observed net and http entries are PerformanceEntry objects with toJSON()",
       detail: entry.detail,
     });
     expect(JSON.parse(JSON.stringify(entry))).toEqual(JSON.parse(JSON.stringify(entry.toJSON())));
+
+    // Node keeps the fields on the prototype, with `detail` and `toJSON`
+    // non-enumerable, so an entry has no own keys and enumerates four.
+    expect(Object.keys(entry)).toEqual([]);
+    const enumerated: string[] = [];
+    for (const key in entry) enumerated.push(key);
+    expect(enumerated.sort()).toEqual(["duration", "entryType", "name", "startTime"]);
   }
 
   expect(byName.connect.entryType).toBe("net");

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import perf from "perf_hooks";
+import http from "node:http";
+import perf, { PerformanceEntry, PerformanceObserver } from "perf_hooks";
 
 test("stubs", () => {
   expect(perf.performance.nodeTiming).toBeObject();
@@ -20,4 +21,69 @@ test("doesn't throw", () => {
   expect(() => performance.now()).not.toThrow();
   expect(() => performance.timeOrigin).not.toThrow();
   expect(() => performance.markResourceTiming()).not.toThrow();
+});
+
+test("observed net and http entries are PerformanceEntry objects with toJSON()", async () => {
+  const entries: any[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const observer = new PerformanceObserver(list => {
+    entries.push(...list.getEntries());
+    // 'connect' from the client socket, 'HttpRequest' from the server and
+    // 'HttpClient' from the client request.
+    if (entries.length >= 3) resolve();
+  });
+  observer.observe({ entryTypes: ["net", "http"] });
+
+  const server = http.createServer((req, res) => res.end("ok"));
+  server.on("error", reject);
+
+  let port: number;
+  try {
+    await new Promise<void>(done => server.listen(0, "127.0.0.1", done));
+    port = (server.address() as any).port;
+
+    await new Promise<void>((done, fail) => {
+      http
+        .get({ host: "127.0.0.1", port }, res => {
+          res.on("error", fail);
+          res.on("end", done);
+          res.resume();
+        })
+        .on("error", fail);
+    });
+
+    await promise;
+  } finally {
+    observer.disconnect();
+    server.close();
+  }
+
+  const byName = Object.fromEntries(entries.map(entry => [entry.name, entry]));
+  expect(Object.keys(byName).sort()).toEqual(["HttpClient", "HttpRequest", "connect"]);
+
+  for (const entry of entries) {
+    expect(entry).toBeInstanceOf(PerformanceEntry);
+    expect(entry.constructor.name).toBe("PerformanceNodeEntry");
+    expect(entry.startTime).toBeNumber();
+    expect(entry.duration).toBeNumber();
+    // Serializing what you observe is the whole point of observing it.
+    expect(entry.toJSON()).toEqual({
+      name: entry.name,
+      entryType: entry.entryType,
+      startTime: entry.startTime,
+      duration: entry.duration,
+      detail: entry.detail,
+    });
+    expect(JSON.parse(JSON.stringify(entry))).toEqual(JSON.parse(JSON.stringify(entry.toJSON())));
+  }
+
+  expect(byName.connect.entryType).toBe("net");
+  expect(byName.connect.detail).toEqual({ host: "127.0.0.1", port: port! });
+
+  expect(byName.HttpRequest.entryType).toBe("http");
+  expect(byName.HttpRequest.detail.res.statusCode).toBe(200);
+
+  expect(byName.HttpClient.entryType).toBe("http");
+  expect(byName.HttpClient.detail.req.method).toBe("GET");
 });


### PR DESCRIPTION
### What

The `net` and `http` entries Bun hands to a `PerformanceObserver` are plain object literals. They have no `toJSON()`, and `entry instanceof PerformanceEntry` is false. In Node every observed entry is a real `PerformanceEntry`. Serializing what you observe is the whole point of observing it, so an observer that calls `entry.toJSON()` throws, and because observer callbacks swallow exceptions the metrics just disappear.

```js
import http from "node:http";
import { PerformanceObserver, PerformanceEntry } from "node:perf_hooks";

const seen = [];
new PerformanceObserver(l => seen.push(...l.getEntries())).observe({ entryTypes: ["net", "http"] });

const srv = http.createServer((q, s) => s.end("ok")).listen(0, "127.0.0.1", () => {
  http.get({ port: srv.address().port, host: "127.0.0.1" }, r =>
    r.resume().on("end", () => setImmediate(() => setImmediate(() => {
      console.log(seen.map(e => [e.entryType, typeof e.toJSON, e instanceof PerformanceEntry]));
      seen.forEach(e => e.toJSON());
      srv.close();
    }))));
});
```

```
node: [ [ 'net', 'function', true ], [ 'http', 'function', true ], [ 'http', 'function', true ] ]
bun:  [ [ 'net', 'undefined', false ], [ 'http', 'undefined', false ], [ 'http', 'undefined', false ] ]
      TypeError: e.toJSON is not a function. (In 'e.toJSON()', 'e.toJSON' is undefined)
```

### Cause

The native (WebCore) `PerformanceObserver` only knows `mark`/`measure`/`resource`, so Bun routes the Node-only entry types through a small JS registry in `internal/shared.ts`. `stopPerf()` built each entry as an object literal:

```js
const entry = { name: ctx.name, entryType: ctx.type, startTime, duration, detail };
```

### Fix

Add `internal/perf_hooks/performance_entry`, which mirrors `lib/internal/perf/performance_entry.js`: a `PerformanceNodeEntry` holding its fields on symbols behind `name`/`entryType`/`startTime`/`duration`/`detail` accessors, with `toJSON()` and a `util.inspect.custom` that prints the serialized entry. The native `PerformanceEntry` has no public constructor, so `extends` would make `super()` throw; the prototype chain is wired up with `setPrototypeOf`, the same way Node does it for its own internal entries. `stopPerf()` now constructs one of these.

Result matches Node's observable shape: `instanceof PerformanceEntry`, `constructor.name === "PerformanceNodeEntry"`, own properties `[]`, prototype parent `=== PerformanceEntry.prototype`, working `toJSON()` and `JSON.stringify()`.

```
PerformanceNodeEntry {
  name: 'connect',
  entryType: 'net',
  startTime: 3301.649018,
  duration: 156.97961799999985,
  detail: { host: '127.0.0.1', port: 35195 }
}
```

`performance.nodeTiming` has the same symptom (`nodeTiming.name` throws the same `PerformanceEntry.name getter can only be used on instances of PerformanceEntry`) but a different cause: `$toClass` replaces a class declaration's prototype object with an empty one, dropping the class body's accessors. That is already fixed at the `$toClass` level by #32163, so it is left alone here.

### Verification

`test/js/node/perf_hooks/perf_hooks.test.ts` grows a test that observes `net` + `http`, asserts every entry is a `PerformanceEntry` with a `toJSON()` whose output round-trips through `JSON.stringify`, and checks the `detail` payloads. It fails on `main` and passes with this change. The vendored `test-net-perf_hooks.js` and `test-http-perf_hooks.js` still pass.
