### PR TITLE
redis: arm idleTimeout on an idle timer, not the connect timer

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -407,6 +407,24 @@ const client = new RedisClient("redis://localhost:6379", {
 });
 ```
 
+### Idle Timeout
+
+`connectionTimeout` bounds how long the client waits to establish a connection. Once connected, it no longer applies.
+
+`idleTimeout` bounds how long an established connection may sit without traffic. Every command sent and every reply received resets it. When it elapses, the client closes the connection and calls `onclose`; the next command opens a new one:
+
+```ts idle-timeout.ts icon="/icons/typescript.svg"
+const client = new RedisClient("redis://localhost:6379", {
+  idleTimeout: 30000, // close the connection after 30s of inactivity
+});
+
+await client.set("key", "value");
+// ... 30 seconds pass with no commands, the connection is closed ...
+await client.get("key"); // reconnects transparently
+```
+
+The default is `0`, which keeps the connection open indefinitely.
+
 ### Reconnection Behavior
 
 When a connection is lost, the client automatically attempts to reconnect with exponential backoff:

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -7,7 +7,10 @@ declare module "bun" {
     connectionTimeout?: number;
 
     /**
-     * Idle timeout in milliseconds
+     * How long an established connection may sit without traffic, in
+     * milliseconds. Reset by every command sent and every reply received. When
+     * it elapses the connection is closed, `onclose` is called, and the next
+     * command opens a new connection.
      * @default 0 (no timeout)
      */
     idleTimeout?: number;

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1402,6 +1402,11 @@ impl JSValkeyClient {
 
     // Callback for when Valkey client needs to reconnect
     pub fn on_valkey_reconnect(&self) {
+        // The closed connection's deadline must not outlive it: left armed, it
+        // fires during the reconnect delay and is read as a connection timeout.
+        // `connect()` arms a fresh one for the new attempt.
+        self.disable_connection_timeout();
+
         // Schedule reconnection using our safe timer methods
         if self.reconnect_timer.get().state == Timer::State::ACTIVE {
             self.remove_timer(&self.reconnect_timer);
@@ -1426,6 +1431,9 @@ impl JSValkeyClient {
     // Callback for when Valkey client closes
     pub fn on_valkey_close(&self) -> JsTerminatedResult<()> {
         let global_object = self.global_object;
+
+        // The connection is gone; so is its deadline. See `on_valkey_reconnect`.
+        self.disable_connection_timeout();
 
         let self_ptr = self.as_ctx_ptr();
         let _defer = scopeguard::guard(self_ptr, |p| {
@@ -1583,6 +1591,7 @@ impl JSValkeyClient {
 
     fn connect(&self) -> Result<(), bun_core::Error> {
         self.client_mut().flags.needs_to_open_socket = false;
+        self.client_mut().reset_for_new_connection();
 
         self.ref_();
         let _d = deref_guard(self);
@@ -1697,11 +1706,6 @@ impl JSValkeyClient {
     ) -> Result<*mut JSPromise, bun_core::Error> {
         if self.client.get().flags.needs_to_open_socket {
             bun_core::hint::cold();
-            // A new socket drops the previous connection's sticky state, the
-            // same way `do_connect` does. Without this the first command after
-            // an idle-timeout close rejects against the old connection.
-            self.client_mut().flags.is_manually_closed = false;
-            self.client_mut().flags.failed = false;
 
             if let Err(err) = self.connect() {
                 self.client_mut().flags.needs_to_open_socket = true;

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1127,6 +1127,18 @@ impl JSValkeyClient {
         }
     }
 
+    /// Re-arm the timeout after socket activity.
+    ///
+    /// Only does something once the handshake completed: while connecting, the
+    /// connect deadline must not be pushed out by traffic. Cancels the
+    /// connect-phase timer when `idleTimeout` is 0.
+    fn reset_idle_timeout(&self) {
+        if self.client.get().status != valkey::Status::Connected {
+            return;
+        }
+        self.reset_connection_timeout();
+    }
+
     pub fn disable_connection_timeout(&self) {
         if self.timer.get().state == Timer::State::ACTIVE {
             self.remove_timer(&self.timer);
@@ -1170,8 +1182,14 @@ impl JSValkeyClient {
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
+                // Dropping an idle connection is deliberate, so auto-reconnect
+                // must not immediately re-establish it. The socket reopens on
+                // the next command, like a freshly constructed client.
+                self.client_mut().flags.is_manually_closed = true;
+                self.client_mut().flags.needs_to_open_socket = true;
                 let _ = self.client_fail(msg, protocol::RedisError::IdleTimeout);
                 // TODO: properly propagate exception upwards
+                self.client_mut().close();
             }
             valkey::Status::Disconnected | valkey::Status::Connecting => {
                 use std::io::Write;
@@ -1679,6 +1697,11 @@ impl JSValkeyClient {
     ) -> Result<*mut JSPromise, bun_core::Error> {
         if self.client.get().flags.needs_to_open_socket {
             bun_core::hint::cold();
+            // A new socket drops the previous connection's sticky state, the
+            // same way `do_connect` does. Without this the first command after
+            // an idle-timeout close rejects against the old connection.
+            self.client_mut().flags.is_manually_closed = false;
+            self.client_mut().flags.failed = false;
 
             if let Err(err) = self.connect() {
                 self.client_mut().flags.needs_to_open_socket = true;
@@ -1698,7 +1721,9 @@ impl JSValkeyClient {
 
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
-        self.client_mut().send(global_this, command)
+        let promise = self.client_mut().send(global_this, command);
+        self.reset_idle_timeout();
+        promise
     }
 
     // Getter for memory cost - useful for diagnostics
@@ -2020,12 +2045,14 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.ref_();
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
+        // Status goes first: `on_close` runs JS (`onclose`, rejected promises),
+        // and those must not observe `.connected === true` on a dead socket.
+        this.client_mut().status = valkey::Status::Disconnected;
         let this_ptr = this.as_ctx_ptr();
         let _defer = scopeguard::guard(this_ptr, |p| {
             // SAFETY: `p` was `this.as_ctx_ptr()`; the `ref_()` taken above
             // keeps `*p` live until this guard's `deref` releases it.
             unsafe {
-                (*p).client_mut().status = valkey::Status::Disconnected;
                 (*p).update_poll_ref();
                 JSValkeyClient::deref(p);
             }
@@ -2050,13 +2077,14 @@ impl<const SSL: bool> SocketHandler<SSL> {
     ) -> JsTerminatedResult<()> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
+        // See `on_close`: JS runs before this returns and must see the status.
+        this.client_mut().status = valkey::Status::Disconnected;
         this.ref_();
         let this_ptr = this.as_ctx_ptr();
         let _defer = scopeguard::guard(this_ptr, |p| {
             // SAFETY: `p` was `this.as_ctx_ptr()`; the `ref_()` taken above
             // keeps `*p` live until this guard's `deref` releases it.
             unsafe {
-                (*p).client_mut().status = valkey::Status::Disconnected;
                 (*p).update_poll_ref();
                 JSValkeyClient::deref(p);
             }
@@ -2079,6 +2107,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.ref_();
         let _d = deref_guard(this);
         let _ = this.client_mut().on_data(data); // TODO: properly propagate exception upwards
+        // A completed handshake lands here too: this is what swaps the
+        // connect-phase timer for the idle timer.
+        this.reset_idle_timeout();
         this.update_poll_ref();
     }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1297,6 +1297,17 @@ impl ValkeyClient {
         Ok(())
     }
 
+    /// Drop the state belonging to the previous connection, before a new socket
+    /// is opened. `on_open` resets the same flags once that socket is up, but
+    /// commands sent in the window before it opens consult `connection_ready()`
+    /// and must not be routed as if the closed connection were still live.
+    pub fn reset_for_new_connection(&mut self) {
+        self.flags.is_manually_closed = false;
+        self.flags.failed = false;
+        self.flags.is_authenticated = false;
+        self.flags.is_selecting_db_internal = false;
+    }
+
     /// Test whether we are ready to run "normal" RESP commands, such as
     /// get/set, pub/sub, etc.
     fn connection_ready(&self) -> bool {

--- a/test/js/valkey/valkey-timeout.test.ts
+++ b/test/js/valkey/valkey-timeout.test.ts
@@ -43,11 +43,17 @@ function takeCommands(state: { buf: Buffer }): string[][] {
 }
 
 /**
- * A RESP3 server just real enough to handshake and answer GET, so these tests
- * run without a redis/valkey server. `answerHello: false` accepts the socket
- * but never completes the handshake.
+ * A RESP3 server just real enough to handshake, answer GET, and reply `+OK` to
+ * anything else, so these tests run without a redis/valkey server.
+ *
+ * - `answerHello: false` accepts the socket but never completes the handshake.
+ * - `endFirstConnectionAfterMs` makes the server hang up on its first client,
+ *   the way a server enforcing its own idle timeout would.
  */
-function startMockRedis({ answerHello = true }: { answerHello?: boolean } = {}) {
+function startMockRedis({
+  answerHello = true,
+  endFirstConnectionAfterMs = 0,
+}: { answerHello?: boolean; endFirstConnectionAfterMs?: number } = {}) {
   const state = { hellos: 0 };
   const listener = Bun.listen<{ buf: Buffer }>({
     hostname: "127.0.0.1",
@@ -65,6 +71,11 @@ function startMockRedis({ answerHello = true }: { answerHello?: boolean } = {}) 
             case "HELLO":
               state.hellos++;
               if (answerHello) socket.write(HELLO_REPLY);
+              // Scripted server behaviour, not a wait: the hangup has to land
+              // at a known point relative to the client's idle deadline.
+              if (endFirstConnectionAfterMs > 0 && state.hellos === 1) {
+                setTimeout(() => socket.end(), endFirstConnectionAfterMs);
+              }
               break;
             case "GET":
               socket.write(bulk("v"));
@@ -154,6 +165,58 @@ describe("RedisClient timeouts", () => {
     }
   });
 
+  // A command that cannot be auto-pipelined takes the write-immediately path in
+  // enqueue() unless connection_ready() is false, so reopening must not leave
+  // the closed connection's `is_authenticated` behind: the bytes would be
+  // written to a socket that has not opened yet, dropped by on_open, and the
+  // promise orphaned in the in-flight queue.
+  for (const [name, options, run] of [
+    ["a non-pipelineable command", {}, (c: RedisClient) => c.send("INFO", [])],
+    ["enableAutoPipelining: false", { enableAutoPipelining: false }, (c: RedisClient) => c.send("INFO", [])],
+  ] as const) {
+    test(`${name} reopens the connection after an idle-timeout close`, async () => {
+      const server = startMockRedis();
+      const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { idleTimeout: 300, ...options });
+      const { promise: closed, resolve } = Promise.withResolvers<Error>();
+      client.onclose = resolve;
+
+      try {
+        await client.connect();
+        await closed;
+
+        expect(await run(client)).toBe("OK");
+        // And the in-flight queue is still aligned: this reply is the GET's.
+        expect(await client.get("key")).toBe("v");
+        expect(server.hellos).toBe(2);
+      } finally {
+        client.close();
+        server.stop();
+      }
+    });
+  }
+
+  test("a server-initiated close does not leave the idle timer armed", async () => {
+    // Deadlines, all in the same timer heap so their order is fixed: the server
+    // hangs up at 270ms, the idle timer would fire at 300ms, auto-reconnect runs
+    // at 270+50ms. A timer left armed by the close fires inside that window,
+    // against a disconnected client, and rejects the offline queue.
+    const server = startMockRedis({ endFirstConnectionAfterMs: 270 });
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { idleTimeout: 300 });
+
+    try {
+      await client.connect();
+      while (client.connected) await Bun.sleep(1);
+
+      // Queued while disconnected: it must ride out the reconnect, not be
+      // rejected by the dead connection's timer.
+      expect(await client.get("key")).toBe("v");
+      expect({ connected: client.connected, hellos: server.hellos }).toEqual({ connected: true, hellos: 2 });
+    } finally {
+      client.close();
+      server.stop();
+    }
+  });
+
   test("connectionTimeout still fires when the handshake never completes", async () => {
     const server = startMockRedis({ answerHello: false });
     const client = new RedisClient(`redis://127.0.0.1:${server.port}`, {
@@ -170,6 +233,32 @@ describe("RedisClient timeouts", () => {
         code: "ERR_REDIS_CONNECTION_CLOSED",
         connected: false,
       });
+    } finally {
+      client.close();
+      server.stop();
+    }
+  });
+});
+
+describe("RedisClient reconnect state", () => {
+  // Closing leaves the client marked authenticated, so a command issued before
+  // the reopened socket came up took enqueue()'s write-immediately path: on_open
+  // dropped the bytes, the promise stayed in the in-flight queue, and every
+  // later reply was paired with the wrong command.
+  test("a command racing an un-awaited connect() gets its own reply", async () => {
+    const server = startMockRedis();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`);
+
+    try {
+      await client.connect();
+      expect(await client.get("key")).toBe("v");
+
+      client.close();
+      client.connect(); // deliberately not awaited: the socket is still opening
+
+      expect(await client.send("INFO", [])).toBe("OK");
+      expect(await client.get("key")).toBe("v");
+      expect(server.hellos).toBe(2);
     } finally {
       client.close();
       server.stop();

--- a/test/js/valkey/valkey-timeout.test.ts
+++ b/test/js/valkey/valkey-timeout.test.ts
@@ -1,0 +1,178 @@
+import { RedisClient } from "bun";
+import { describe, expect, test } from "bun:test";
+
+const CRLF = "\r\n";
+const bulk = (value: string) => `$${Buffer.byteLength(value)}${CRLF}${value}${CRLF}`;
+const HELLO_REPLY = `%3${CRLF}${bulk("server")}${bulk("redis")}${bulk("proto")}:3${CRLF}${bulk("version")}${bulk("7.4.0")}`;
+
+/** Pull every complete `*N $len arg ...` command out of the socket's buffer. */
+function takeCommands(state: { buf: Buffer }): string[][] {
+  const commands: string[][] = [];
+  for (;;) {
+    const buf = state.buf;
+    if (buf.length === 0 || buf[0] !== 0x2a /* * */) break;
+    const argcEnd = buf.indexOf(CRLF);
+    if (argcEnd < 0) break;
+    const argc = Number(buf.subarray(1, argcEnd).toString());
+    const args: string[] = [];
+    let offset = argcEnd + 2;
+    let complete = true;
+    for (let i = 0; i < argc; i++) {
+      if (offset >= buf.length || buf[offset] !== 0x24 /* $ */) {
+        complete = false;
+        break;
+      }
+      const lengthEnd = buf.indexOf(CRLF, offset);
+      if (lengthEnd < 0) {
+        complete = false;
+        break;
+      }
+      const length = Number(buf.subarray(offset + 1, lengthEnd).toString());
+      if (buf.length < lengthEnd + 2 + length + 2) {
+        complete = false;
+        break;
+      }
+      args.push(buf.subarray(lengthEnd + 2, lengthEnd + 2 + length).toString());
+      offset = lengthEnd + 2 + length + 2;
+    }
+    if (!complete) break;
+    state.buf = buf.subarray(offset);
+    commands.push(args);
+  }
+  return commands;
+}
+
+/**
+ * A RESP3 server just real enough to handshake and answer GET, so these tests
+ * run without a redis/valkey server. `answerHello: false` accepts the socket
+ * but never completes the handshake.
+ */
+function startMockRedis({ answerHello = true }: { answerHello?: boolean } = {}) {
+  const state = { hellos: 0 };
+  const listener = Bun.listen<{ buf: Buffer }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = { buf: Buffer.alloc(0) };
+      },
+      error() {},
+      close() {},
+      data(socket, chunk) {
+        socket.data.buf = socket.data.buf.length ? Buffer.concat([socket.data.buf, chunk]) : chunk;
+        for (const command of takeCommands(socket.data)) {
+          switch (command[0].toUpperCase()) {
+            case "HELLO":
+              state.hellos++;
+              if (answerHello) socket.write(HELLO_REPLY);
+              break;
+            case "GET":
+              socket.write(bulk("v"));
+              break;
+            default:
+              socket.write(`+OK${CRLF}`);
+          }
+        }
+      },
+    },
+  });
+  return {
+    port: listener.port,
+    /** how many handshakes the server has seen, so reconnects are visible */
+    get hellos() {
+      return state.hellos;
+    },
+    stop() {
+      listener.stop(true);
+    },
+  };
+}
+
+describe("RedisClient timeouts", () => {
+  test("a busy connection outlives connectionTimeout when idleTimeout is set", async () => {
+    const server = startMockRedis();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, {
+      idleTimeout: 60_000,
+      connectionTimeout: 400,
+    });
+    const closes: Error[] = [];
+    client.onclose = error => {
+      closes.push(error);
+    };
+
+    try {
+      await client.connect();
+
+      // Keep the connection busy well past connectionTimeout. Neither timeout
+      // may fire while commands are flowing.
+      let answered = 0;
+      const deadline = Date.now() + 3 * 400;
+      while (Date.now() < deadline) {
+        expect(await client.get(`key-${answered}`)).toBe("v");
+        answered++;
+        await Bun.sleep(25);
+      }
+
+      expect({
+        busy: answered > 1,
+        closes,
+        connected: client.connected,
+        hellos: server.hellos,
+      }).toEqual({ busy: true, closes: [], connected: true, hellos: 1 });
+    } finally {
+      client.close();
+      server.stop();
+    }
+  });
+
+  test("an idle connection is closed after idleTimeout and reopens on the next command", async () => {
+    const server = startMockRedis();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, {
+      idleTimeout: 300,
+      connectionTimeout: 10_000,
+    });
+    const { promise: closed, resolve } = Promise.withResolvers<Error>();
+    client.onclose = resolve;
+
+    try {
+      await client.connect();
+      expect(client.connected).toBe(true);
+
+      const error: any = await closed;
+      expect({ code: error?.code, connected: client.connected }).toEqual({
+        code: "ERR_REDIS_CONNECTION_CLOSED",
+        connected: false,
+      });
+
+      // The connection was dropped because it was idle, not because it broke:
+      // the next command opens a fresh one.
+      expect(await client.get("key")).toBe("v");
+      expect(server.hellos).toBe(2);
+    } finally {
+      client.close();
+      server.stop();
+    }
+  });
+
+  test("connectionTimeout still fires when the handshake never completes", async () => {
+    const server = startMockRedis({ answerHello: false });
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, {
+      idleTimeout: 60_000,
+      connectionTimeout: 300,
+    });
+
+    try {
+      const error: any = await client.connect().then(
+        () => null,
+        e => e,
+      );
+      expect({ code: error?.code, connected: client.connected }).toEqual({
+        code: "ERR_REDIS_CONNECTION_CLOSED",
+        connected: false,
+      });
+    } finally {
+      client.close();
+      server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Repro

`idleTimeout: 60_000` with `connectionTimeout: 250`, against a scripted RESP3 server, issuing a command every 25ms:

```ts
const c = new Bun.RedisClient(url, { idleTimeout: 60_000, connectionTimeout: 250 });
c.onclose = () => console.log("onclose fired");
await c.connect();
for (let i = 0; Date.now() - t0 < 1200; i++) {
  try { await c.get("k" + i); } catch (e) { console.log(Date.now() - t0, e.code, e.message); break; }
  await Bun.sleep(25);
}
console.log({ connected: c.connected });
```

```
254 ERR_REDIS_CONNECTION_CLOSED Connection has failed
{ connected: true }
```

The client dies exactly `connectionTimeout` ms after it connected, while it is busy, and `onclose` never fires. With the default `idleTimeout: 0` the same mis-armed timer fires too, but its handler is a no-op, which is why only opt-in users see it. Previously reported as #18897 and #19044, both closed by changing the default to `0`.

## Cause

There is one timer. `connect()` arms it with `connection_timeout_ms`, and nothing cancels or re-arms it afterwards. `on_connection_timeout` then decides what the firing *means* from the status at that moment:

```rust
match self.status {
    Status::Connected => // "Idle timeout reached after {idle_timeout_interval_ms}ms"
    _ => // "Connection timeout reached after {connection_timeout_ms}ms"
}
```

So the connect-phase timer detonates on a now-connected client and is reported as an idle timeout. Conversely, a connection that really is idle is never closed, because the idle interval is never armed.

The failure path then left the client unusable but undetectable: `fail_with_js_value` only closes the socket when `!connection_ready()`, so a connected client kept `status == Connected` (`.connected === true`), never fired `onclose`, never auto-reconnected, and rejected every later command with `Connection has failed`.

## Fix

The two-phase timer mirrors what `PostgresSQLConnection` already does.

- `reset_idle_timeout()` re-arms the timer only once the handshake completed, so traffic cannot push out the connect deadline. Called after every reply (`on_data`) and every command (`send`). The handshake reply lands in `on_data` too, so that is also where the connect-phase timer gets swapped for the idle timer (or cancelled, when `idleTimeout` is 0).
- When the idle timer fires, the socket is closed: `onclose` runs, `.connected` goes false, pending commands reject with `ERR_REDIS_IDLE_TIMEOUT`. Auto-reconnect is suppressed (dropping an idle connection is deliberate, reconnecting it immediately would defeat the option), and the client reopens lazily on the next command, like a freshly constructed one.
- The timer is cancelled when the connection closes, in `on_valkey_close()` and `on_valkey_reconnect()`, the two hooks every branch of `ValkeyClient::on_close()` funnels through. Left armed, it fired during the reconnect backoff and rejected the offline queue with a `connectionTimeout` that never applied, while setting `is_manually_closed`, which `on_open` does not clear: auto-reconnect was then off for good.
- `connect()` calls the new `ValkeyClient::reset_for_new_connection()` before opening a socket, so a reopened connection does not inherit the closed one's `is_authenticated`. Without it, `enqueue()` saw `connection_ready()` and wrote the command straight to a socket that had not opened yet; `on_open` dropped those bytes and the promise stayed in the in-flight queue, pairing every later reply with the wrong command. That one was already reachable on `main` without `idleTimeout`, via `close()` plus an un-awaited `connect()`.
- `status` is set to `Disconnected` before `on_close` runs JS, so `onclose` handlers and rejected promises no longer observe `.connected === true` on a dead socket. `ValkeyClient::close()` already ordered it this way on its semi-socket path.

`connectionTimeout` now bounds exactly the connect phase, which is what it is documented to do.

## Verification

`test/js/valkey/valkey-timeout.test.ts` (new, talks to an in-process RESP3 server so it needs no redis):

| | before | after |
|---|---|---|
| busy connection outlives `connectionTimeout` | fails at 415ms | pass |
| idle connection closed at `idleTimeout`, reopens on next command | `onclose` never fires | pass |
| non-pipelineable command reopens after an idle close | resolves with the HELLO map | pass |
| `enableAutoPipelining: false` reopens after an idle close | resolves with the HELLO map | pass |
| server-initiated close leaves no timer armed | rejects with a bogus `ERR_REDIS_CONNECTION_TIMEOUT` | pass |
| command racing an un-awaited `connect()` gets its own reply | resolves with the HELLO map | pass |
| `connectionTimeout` still fires on a stalled handshake | pass | pass |

The server-close test is deterministic rather than racy: the hangup (270ms), the idle deadline (300ms) and the reconnect (~320ms) are all deadlines in one timer heap, so their order holds even under a stall. 10/10 clean runs.

Also ran the docker-gated suites against a local redis (`reliability/recovery.test.ts` (#29925), `reliability/connection-failures.test.ts`, `unit/*`, `integration/complex-operations.test.ts`): 84 pass, 1 fail, and that one needs a route to `192.0.2.1` and fails identically on `main` in the same container.

<details>
<summary>Manual check against a real redis (pub/sub, manual close, server-side <code>CLIENT KILL</code> + autoReconnect, idle close + reopen)</summary>

```
1 get: 1 connected: true
1 onclose: { code: "ERR_REDIS_CONNECTION_CLOSED", connected: false }   # was connected: true
2 after 700ms idle, default idleTimeout: 1 connected: true             # connectionTimeout was 200
3 pubsub: hello
4 after server kill, autoReconnect get: 1 connected: true
5 idle close: { code: "ERR_REDIS_CONNECTION_CLOSED", connected: false } after 255 ms
5 reopen on next command: 1 connected: true
6 INFO after close()+connect(): own reply (correct)
```

</details>
