### PR TITLE
fs: decode write(chunk, encoding) on the WriteStream fast path

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -25,6 +25,7 @@ type FSStream = import("node:fs").ReadStream &
     flush: boolean;
     open: () => void;
     autoClose: boolean;
+    _writableState: { defaultEncoding: string };
     /**
      * true = path must be opened
      * sink = FileSink
@@ -654,6 +655,15 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
   }
 }
 
+// The FileSink encodes strings as UTF-8, so every other encoding has to be
+// decoded to bytes here, the way `decodeStrings` does on the Writable path this
+// fast path bypasses. Buffer.from throws ERR_UNKNOWN_ENCODING for bad encodings.
+function decodeStringChunk(stream: FSStream, chunk: string, encoding: any) {
+  if (!encoding) encoding = stream._writableState.defaultEncoding;
+  if (encoding === "utf8" || encoding === "utf-8") return chunk;
+  return Buffer.from(chunk, encoding);
+}
+
 // This function implementation is not correct.
 const writablePrototypeWrite = Writable.prototype.write;
 const kWriteMonkeyPatchDefense = Symbol("!");
@@ -667,6 +677,10 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   const hasCallback = typeof cb === "function";
   if (!hasCallback) {
     cb = streamNoop;
+  }
+
+  if (typeof data === "string") {
+    data = decodeStringChunk(this, data, encoding);
   }
 
   const fileSink = this[kWriteStreamFastPath];

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -126,7 +126,9 @@ describe("process.stdin", () => {
     child.stdout.on("data", chunk => chunks.push(chunk));
     child.stdout.on("error", done);
     child.on("error", done);
-    child.on("exit", code => {
+    // 'close' rather than 'exit': the stdio streams may still be draining when
+    // the child terminates.
+    child.on("close", code => {
       try {
         expect(Buffer.concat(chunks).toString("hex")).toBe("48490a414243");
         expect(code).toBe(0);

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -116,4 +116,28 @@ describe("process.stdin", () => {
     });
     expect(result).toEqual("data: File read successfully");
   });
+
+  it("decodes the chunk passed to child.stdin.write(chunk, encoding)", done => {
+    const child = spawn(bunExe(), ["-e", "process.stdin.pipe(process.stdout)"], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    const chunks = [];
+    child.stdout.on("data", chunk => chunks.push(chunk));
+    child.stdout.on("error", done);
+    child.on("error", done);
+    child.on("exit", code => {
+      try {
+        expect(Buffer.concat(chunks).toString("hex")).toBe("48490a414243");
+        expect(code).toBe(0);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+    child.stdin.write("48490a", "hex");
+    child.stdin.setDefaultEncoding("base64");
+    child.stdin.write("QUJD");
+    child.stdin.end();
+  });
 });

--- a/test/js/node/process/process-stdio-encoding.test.ts
+++ b/test/js/node/process/process-stdio-encoding.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// process.stdout/process.stderr take the fs.WriteStream fast path, which used to
+// hand every string to the FileSink as UTF-8 and drop the encoding argument.
+describe.concurrent("process stdio write(chunk, encoding)", () => {
+  test("decodes the chunk with the requested encoding", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write("48490a", "hex");
+         process.stdout.write("QUJD", "base64");
+         process.stdout.write("é", "latin1");
+         process.stdout.setDefaultEncoding("hex");
+         process.stdout.write("21");
+         process.stderr.write("6f6b", "hex");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.bytes(), proc.exited]);
+
+    expect({
+      stdout: Buffer.from(stdout).toString("hex"),
+      stderr: Buffer.from(stderr).toString("hex"),
+      exitCode,
+    }).toEqual({ stdout: "48490a414243e921", stderr: "6f6b", exitCode: 0 });
+  });
+
+  test("throws on an unknown encoding", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const codes = [];
+         for (const encoding of ["nope", "buffer"]) {
+           try {
+             process.stdout.write("x", encoding);
+             codes.push("did not throw");
+           } catch (e) {
+             codes.push(e.code);
+           }
+         }
+         process.stdout.write(codes.join(","));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "ERR_UNKNOWN_ENCODING,ERR_UNKNOWN_ENCODING",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("leaves write(chunk, callback) and Buffer chunks alone", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { promise, resolve } = Promise.withResolvers();
+         process.stdout.write("utf8:é", resolve);
+         await promise;
+         process.stdout.write(Buffer.from("2162756621", "hex"), "hex");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "utf8:é!buf!", stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

`stream.write(chunk, encoding)` is a core `Writable` contract, but on `process.stdout`, `process.stderr` and `child.stdin` the encoding argument (and `setDefaultEncoding()`) was silently ignored. The string was always written as UTF-8 text, so piping binary out of a CLI with `process.stdout.write(b64, "base64")` delivered the base64 *text* to the receiver instead of the payload.

## Repro

```js
import { spawn } from "node:child_process";
if (process.argv[2] === "child") {
  process.stdout.write("48490a", "hex");   // -> "HI\n"
  process.stdout.write("QUJD", "base64");  // -> "ABC"
  process.stdout.write("é", "latin1");     // -> 0xe9
  process.stdout.setDefaultEncoding("hex"); process.stdout.write("21");   // -> "!"
  process.stderr.write("6f6b", "hex");     // -> "ok"
} else {
  const p = spawn(process.execPath, [process.argv[1], "child"], { stdio: ["ignore", "pipe", "pipe"] });
  const o = [], e = [];
  p.stdout.on("data", d => o.push(d));
  p.stderr.on("data", d => e.push(d));
  p.on("exit", () => console.log("stdout:", Buffer.concat(o).toString("hex"), "stderr:", Buffer.concat(e).toString("hex")));
}
```

```
node: stdout: 48490a414243e921            stderr: 6f6b            (the decoded bytes)
bun : stdout: 34383439306151554a44c3a93231 stderr: 36663662        (the source strings, re-encoded as UTF-8)
```

`child.stdin.write(chunk, encoding)` has the same problem:

```js
p.stdin.write("48490a", "hex");   // node sends 48 49 0a, bun sends "48490a"
```

## Cause

`process.stdout`/`process.stderr` (both the TTY and the pipe/file variants) and `child.stdin` are all `fs.WriteStream`s constructed with the `$fastPath` flag, which replaces `write()` with `writeFast()` in `src/js/internal/fs/streams.ts`. That function bypasses the `Writable` state machine entirely and passes the chunk straight to `Bun.file(fd).writer()`, whose `write()` encodes strings as UTF-8. The `encoding` parameter and `_writableState.defaultEncoding` never reached anything.

The generic `node:stream` `Writable` path already handles this: `WriteStream` is constructed with `decodeStrings: true`, so `Buffer.from(chunk, encoding)` runs in `writeOrBuffer`. Only the fast path missed it, which is why `fs.createWriteStream(...).write(s, "hex")`, `net.Socket` and `http.ServerResponse` were already correct.

## Fix

Decode string chunks in `writeFast()` with the requested encoding (falling back to `defaultEncoding`) before handing them to the sink. `utf8`/`utf-8` keeps passing the string through untouched so the common path stays allocation-free, and `Buffer.from()` raises `ERR_UNKNOWN_ENCODING` for a bad encoding, which `write("x", "nope")` and `write("x", "buffer")` previously accepted silently.

## Verification

New `test/js/node/process/process-stdio-encoding.test.ts` covers the repro above (hex, base64, latin1, `setDefaultEncoding`, on both stdout and stderr), the `ERR_UNKNOWN_ENCODING` rejection, and that `write(chunk, callback)` plus `Buffer` chunks are unaffected. `test/js/node/child_process/child-process-stdio.test.js` gains a case for `child.stdin.write(chunk, encoding)`, which reaches the same fast path through `writableFromFileSink`.

All three fail on `main` and pass with this change.
