### PR TITLE
node:perf_hooks: make performance the global object, like node

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -276,60 +276,49 @@ function processTimerifyComplete(name, start, args, histogram) {
   }
 }
 
+// Node-only members the web `performance` (a WebCore object) lacks. Put them on
+// the Performance prototype (non-enumerable, like node) so node:perf_hooks can
+// export the global object itself instead of a wrapper that re-forwards methods.
+// Target Performance.prototype (not getPrototypeOf(performance)) so a replaced
+// global can't redirect the define onto Object.prototype, and guard with hasOwn
+// so a future native move that adds these as own prototype props suppresses the
+// stub rather than inheriting through the chain.
+const PerformancePrototype = Performance.prototype;
+if (!Object.hasOwn(PerformancePrototype, "nodeTiming")) {
+  Object.defineProperty(PerformancePrototype, "nodeTiming", {
+    __proto__: null,
+    value: createPerformanceNodeTiming(),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+if (!Object.hasOwn(PerformancePrototype, "eventLoopUtilization")) {
+  Object.defineProperty(PerformancePrototype, "eventLoopUtilization", {
+    __proto__: null,
+    value: eventLoopUtilization,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+if (!Object.hasOwn(PerformancePrototype, "timerify")) {
+  Object.defineProperty(PerformancePrototype, "timerify", {
+    __proto__: null,
+    value: timerify,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
 export default {
-  timerify,
-  performance: {
-    mark(_) {
-      return performance.mark(...arguments);
-    },
-    measure(_) {
-      return performance.measure(...arguments);
-    },
-    clearMarks(_) {
-      return performance.clearMarks(...arguments);
-    },
-    clearMeasures(_) {
-      return performance.clearMeasures(...arguments);
-    },
-    getEntries(_) {
-      return performance.getEntries(...arguments);
-    },
-    getEntriesByName(_) {
-      return performance.getEntriesByName(...arguments);
-    },
-    getEntriesByType(_) {
-      return performance.getEntriesByType(...arguments);
-    },
-    setResourceTimingBufferSize(_) {
-      return performance.setResourceTimingBufferSize(...arguments);
-    },
-    timeOrigin: performance.timeOrigin,
-    toJSON(_) {
-      return performance.toJSON(...arguments);
-    },
-    onresourcetimingbufferfull: performance.onresourcetimingbufferfull,
-    nodeTiming: createPerformanceNodeTiming(),
-    now: () => performance.now(),
-    timerify,
-    eventLoopUtilization: eventLoopUtilization,
-    clearResourceTimings: function () {},
-  },
-  // performance: {
-  //   clearMarks: [Function: clearMarks],
-  //   clearMeasures: [Function: clearMeasures],
-  //   clearResourceTimings: [Function: clearResourceTimings],
-  //   getEntries: [Function: getEntries],
-  //   getEntriesByName: [Function: getEntriesByName],
-  //   getEntriesByType: [Function: getEntriesByType],
-  //   mark: [Function: mark],
-  //   measure: [Function: measure],
-  //   now: performance.now,
-  //   setResourceTimingBufferSize: [Function: setResourceTimingBufferSize],
-  //   timeOrigin: performance.timeOrigin,
-  //   toJSON: [Function: toJSON],
-  //   onresourcetimingbufferfull: [Getter/Setter]
-  // },
+  performance,
   constants,
+  // Read off performance so these exports stay identical to
+  // performance.<name> regardless of which layer installed them.
+  eventLoopUtilization: performance.eventLoopUtilization,
+  timerify: performance.timerify,
   Performance,
   PerformanceEntry,
   PerformanceMark,
@@ -337,7 +326,6 @@ export default {
   PerformanceObserver: PerformanceObserverForNodeTypes,
   PerformanceObserverEntryList,
   PerformanceNodeTiming,
-  eventLoopUtilization,
   monitorEventLoopDelay: function monitorEventLoopDelay(options?: { resolution?: number }) {
     const impl = require("internal/perf_hooks/monitorEventLoopDelay");
     return impl(options);

--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -276,49 +276,48 @@ function processTimerifyComplete(name, start, args, histogram) {
   }
 }
 
-// Node-only members the web `performance` (a WebCore object) lacks. Put them on
-// the Performance prototype (non-enumerable, like node) so node:perf_hooks can
-// export the global object itself instead of a wrapper that re-forwards methods.
-// Target Performance.prototype (not getPrototypeOf(performance)) so a replaced
-// global can't redirect the define onto Object.prototype, and guard with hasOwn
-// so a future native move that adds these as own prototype props suppresses the
-// stub rather than inheriting through the chain.
-const PerformancePrototype = Performance.prototype;
-if (!Object.hasOwn(PerformancePrototype, "nodeTiming")) {
-  Object.defineProperty(PerformancePrototype, "nodeTiming", {
-    __proto__: null,
-    value: createPerformanceNodeTiming(),
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-}
-if (!Object.hasOwn(PerformancePrototype, "eventLoopUtilization")) {
-  Object.defineProperty(PerformancePrototype, "eventLoopUtilization", {
-    __proto__: null,
-    value: eventLoopUtilization,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-}
-if (!Object.hasOwn(PerformancePrototype, "timerify")) {
-  Object.defineProperty(PerformancePrototype, "timerify", {
-    __proto__: null,
-    value: timerify,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
+// Node-only members go on Performance.prototype (non-enumerable, like node).
+// Not getPrototypeOf(performance): a replaced global would land these on
+// Object.prototype. hasOwn so a future native own-prop suppresses the stub.
+const PerformancePrototype = Performance?.prototype;
+if (PerformancePrototype) {
+  if (!Object.hasOwn(PerformancePrototype, "nodeTiming")) {
+    Object.defineProperty(PerformancePrototype, "nodeTiming", {
+      __proto__: null,
+      value: createPerformanceNodeTiming(),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  if (!Object.hasOwn(PerformancePrototype, "eventLoopUtilization")) {
+    Object.defineProperty(PerformancePrototype, "eventLoopUtilization", {
+      __proto__: null,
+      value: eventLoopUtilization,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  if (!Object.hasOwn(PerformancePrototype, "timerify")) {
+    Object.defineProperty(PerformancePrototype, "timerify", {
+      __proto__: null,
+      value: timerify,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
 }
 
 export default {
   performance,
   constants,
-  // Read off performance so these exports stay identical to
-  // performance.<name> regardless of which layer installed them.
-  eventLoopUtilization: performance.eventLoopUtilization,
-  timerify: performance.timerify,
+  // Read off the same prototype the defines target, so a replaced global
+  // `performance` cannot make these undefined, and a future native own-prop
+  // is what the export picks up.
+  eventLoopUtilization: PerformancePrototype?.eventLoopUtilization ?? eventLoopUtilization,
+  timerify: PerformancePrototype?.timerify ?? timerify,
   Performance,
   PerformanceEntry,
   PerformanceMark,

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -3,12 +3,10 @@ import { bunEnv, bunExe } from "harness";
 import net from "net";
 import perf, { PerformanceObserver } from "perf_hooks";
 
-test("stubs", () => {
-  expect(perf.performance.nodeTiming).toBeObject();
-
-  expect(perf.performance.now()).toBeNumber();
-  expect(perf.performance.timeOrigin).toBeNumber();
-  expect(perf.performance.eventLoopUtilization()).toBeObject();
+// Like node, require("node:perf_hooks").performance is the global performance
+// object itself, not a separate wrapper.
+test("perf_hooks.performance is the global performance object", () => {
+  expect(perf.performance).toBe(globalThis.performance);
 });
 
 test("doesn't throw", () => {
@@ -58,6 +56,8 @@ test("timerify entry shape", async () => {
 test("timerify is exposed on both performance and as a top-level export (Node v25.2+)", () => {
   expect(perf.performance.timerify).toBeFunction();
   expect(perf.timerify).toBeFunction();
+  // Same function object, matching node's lib/perf_hooks.js module.exports.
+  expect(perf.timerify).toBe(perf.performance.timerify);
 });
 
 // Captured from the real node v26.3.0 binary:
@@ -158,4 +158,65 @@ test("net entries are instanceof PerformanceEntry", async () => {
   expect(entry).toBeInstanceOf(PerformanceEntry);
   expect(entry.constructor.name).toBe("PerformanceNodeEntry");
   expect(entry.entryType).toBe("net");
+});
+
+test("node-only members are present on performance", () => {
+  expect(perf.performance.nodeTiming).toBeObject();
+  expect(perf.performance.now()).toBeNumber();
+  expect(perf.performance.timeOrigin).toBeNumber();
+  expect(perf.performance.eventLoopUtilization).toBeFunction();
+  expect(perf.performance.eventLoopUtilization()).toEqual({
+    idle: expect.any(Number),
+    active: expect.any(Number),
+    utilization: expect.any(Number),
+  });
+});
+
+// markResourceTiming / clearResourceTimings were missing / a JS no-op before the
+// module exported the global; now they are the global's own methods.
+test("resource-timing methods are present and callable", () => {
+  expect(perf.performance.markResourceTiming).toBeFunction();
+  expect(() => perf.performance.markResourceTiming()).not.toThrow();
+  expect(perf.performance.clearResourceTimings).toBeFunction();
+  expect(() => perf.performance.clearResourceTimings()).not.toThrow();
+});
+
+// node puts the node-only members on Performance.prototype, non-enumerable, so
+// Object.keys(performance) is unchanged.
+test("node-only members live on the prototype, non-enumerable", () => {
+  const proto = Object.getPrototypeOf(globalThis.performance);
+  for (const key of ["nodeTiming", "eventLoopUtilization", "timerify"]) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+    expect(descriptor).toBeDefined();
+    expect(descriptor!.enumerable).toBe(false);
+  }
+  expect(Object.keys(globalThis.performance)).not.toContain("nodeTiming");
+  expect(Object.keys(globalThis.performance)).not.toContain("eventLoopUtilization");
+  expect(Object.keys(globalThis.performance)).not.toContain("timerify");
+});
+
+// onresourcetimingbufferfull is the global's own accessor; since the module
+// object is the global, assigning through either reaches the same object.
+test("onresourcetimingbufferfull is the global's accessor", () => {
+  const previous = globalThis.performance.onresourcetimingbufferfull;
+  try {
+    const listener = () => {};
+    perf.performance.onresourcetimingbufferfull = listener;
+    expect(globalThis.performance.onresourcetimingbufferfull).toBe(listener);
+  } finally {
+    globalThis.performance.onresourcetimingbufferfull = previous;
+  }
+});
+
+// node's lib/perf_hooks.js lists eventLoopUtilization in module.exports as well
+// as on `performance`, and the two are the same function object. (It is absent
+// from the module exports on v22 and earlier; this matches current node.)
+test("perf_hooks exports eventLoopUtilization at the module level", () => {
+  expect(perf.eventLoopUtilization).toBeFunction();
+  expect(perf.eventLoopUtilization).toBe(perf.performance.eventLoopUtilization);
+  expect(perf.eventLoopUtilization()).toEqual({
+    idle: expect.any(Number),
+    active: expect.any(Number),
+    utilization: expect.any(Number),
+  });
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -195,6 +195,38 @@ test("node-only members live on the prototype, non-enumerable", () => {
   expect(Object.keys(globalThis.performance)).not.toContain("timerify");
 });
 
+// The members are installed on the prototype by node:perf_hooks; the bare web
+// global has none of them until the module is loaded. A future native move (onto
+// JSPerformance.cpp) would make the first half eager and require this to change.
+test("node-only members are installed onto the prototype when node:perf_hooks is loaded", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const proto = Performance.prototype;
+       const keys = ["nodeTiming", "eventLoopUtilization", "timerify"];
+       const describe = () => keys.map(k => {
+         const d = Object.getOwnPropertyDescriptor(proto, k);
+         return k + "=" + typeof globalThis.performance[k] + (d ? "|proto|enum=" + d.enumerable : "|absent");
+       }).join(" ");
+       console.log("before: " + describe());
+       require("node:perf_hooks");
+       console.log("after:  " + describe());`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect({ stdout, exitCode }).toEqual({
+    stdout:
+      "before: nodeTiming=undefined|absent eventLoopUtilization=undefined|absent timerify=undefined|absent\n" +
+      "after:  nodeTiming=object|proto|enum=false eventLoopUtilization=function|proto|enum=false timerify=function|proto|enum=false\n",
+    exitCode: 0,
+  });
+});
+
 // onresourcetimingbufferfull is the global's own accessor; since the module
 // object is the global, assigning through either reaches the same object.
 test("onresourcetimingbufferfull is the global's accessor", () => {


### PR DESCRIPTION
## What

`require("node:perf_hooks").performance` is now the global `performance` object itself, as in Node, instead of a separate wrapper.

## Background

The module exported a hand-written facade that forwarded a hardcoded subset of the global `performance` to it. That subset had drifted from what the global actually carries:

- `markResourceTiming` was never forwarded.
- `clearResourceTimings` was a local `function () {}` no-op, shadowing the real method.
- `onresourcetimingbufferfull` was a value snapshotted at module load, so assigning to it never reached the global.

And because it was a distinct object, `require("node:perf_hooks").performance !== globalThis.performance`, unlike Node where the two are the same object.

## Fix

Export the global `performance` directly. The only members Node's `performance` carries that the web `Performance` lacks are `nodeTiming`, `eventLoopUtilization`, and `timerify` (the last from #31825, which has since merged); define those on the `Performance` prototype, non-enumerable, exactly as Node does (verified against `node -e` on v26.3.0: all three are `PROTO`, `enumerable=false`, and `Object.keys(performance)` is unchanged). With the node-only members on the prototype, the module object can be the global itself, and every per-method forwarder is gone.

`eventLoopUtilization` and `timerify` are also exported at the module level, read off `performance` after the prototype install so they share function identity with `performance.<name>`, matching Node's `lib/perf_hooks.js` `module.exports`.

## One implementation note

The three node-only members are attached to the prototype from the `node:` layer (`src/js/node/perf_hooks.ts`) rather than ported into `JSPerformance.cpp`:

- `nodeTiming` is a faked `PerformanceEntry` (it has to be `instanceof PerformanceEntry` with live getters), `eventLoopUtilization` is the zeroed stub, and `timerify` is the full JS implementation from #31825; porting them to C++ now would mean reimplementing that work. #32618 is turning `eventLoopUtilization` into a real implementation in this same JS layer.
- The `if (!Object.hasOwn(prototype, name))` guards target `Performance.prototype` (never `Object.getPrototypeOf(performance)`, so a replaced global can't redirect the define onto `Object.prototype`) and make the install forward-compatible: if any of these later move into `JSPerformance` in C++, the JS definitions are skipped rather than clobbering them.

The one behavioral nuance versus Node: the members attach when `node:perf_hooks` is first required, rather than being present on a bare `globalThis.performance` before any `require`. They are node-only and weren't on the global at all before this change, so this is strictly closer to Node; making them eager is a follow-up that belongs with the C++ move.

## Merge-conflict resolution against #31825

#31825 added `timerify` (and its `processTimerifyComplete` helper, plus the `PerformanceNodeEntry` class and `enqueueNodeEntry`) on the facade and as a module-level export. All of that is kept unchanged here; the only change relative to #31825 is where `timerify` lives on `performance`: on `Performance.prototype` alongside `nodeTiming`/`eventLoopUtilization`, instead of on a separate facade object. The `timerify` tests, `PerformanceNodeEntry` shape checks, and prototype-pollution tests from #31825 all still pass.

## Verification

`bun bd test test/js/node/perf_hooks/perf_hooks.test.ts` → 13 pass. With `src/js/node/perf_hooks.ts` reverted to main, 4 of the 13 fail (the single-object assertions; #31825's `timerify` tests still pass against main as expected).

Node parity confirmed side by side on v26.3.0: `perf_hooks.performance === globalThis.performance`, `nodeTiming`/`eventLoopUtilization`/`timerify` present and on the prototype non-enumerable, module-level `eventLoopUtilization`/`timerify` with matching identity.

`test-perf-hooks-timerify-histogram-async.mjs`, `test-performance-function-async.js`, `test-net-perf_hooks.js`, `test-performance-measure.js` and `test/js/web/timers/performance.test.js` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (491bf6b6d)

test/js/node/perf_hooks/perf_hooks.test.ts:
4 | import perf, { PerformanceObserver } from "perf_hooks";
5 | 
6 | // Like node, require("node:perf_hooks").performance is the global performance
7 | // object itself, not a separate wrapper.
8 | test("perf_hooks.performance is the global performance object", () => {
9 |   expect(perf.performance).toBe(globalThis.performance);
                               ^
error: expect(received).toBe(expected)

Expected: Performance {
  now: [Function: now],
  timeOrigin: 1784376391811.121,
  timing: PerformanceTiming {
    navigationStart: 0,
    unloadEventStart: 0,
    unloadEventEnd: 0,
    redirectStart: 0,
    redirectEnd: 0,
    fetchStart: 0,
    domainLookupStart: 0,
   
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (491bf6b6d)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) perf_hooks.performance is the global performance object [0.95ms]
(pass) doesn't throw [0.29ms]
(pass) timerify entry shape [1.72ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.03ms]
(pass) export surface matches Node v26.3.0 [0.16ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [19.99ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [14.17ms]
(pass) net entries are instanceof PerformanceEntry [10.71ms]
(pass) node-only members are present on performance [0.11ms]
(pass) resource-timing methods are present and callable [0.07ms]
(pass) node-only members live on the prototype, non-enumerable [0.12ms]
(pass) node-only members are installed onto the prototype when node:perf_hooks is loaded [23.47ms]
(pass) onresourcetimingbufferfull is the global's accessor [0.18ms]
(pass) perf_hooks exports eventLoopUtilization at the module level [0.12ms]

 14 pass
 0 fail
 71 expect() calls
Ran 14 tests across 1 file. [440.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (491bf6b6d)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) perf_hooks.performance is the global performance object [8.35ms]
(pass) doesn't throw [25.13ms]
(pass) timerify entry shape [63.56ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [2.23ms]
(pass) export surface matches Node v26.3.0 [8.91ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [755.74ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [819.99ms]
(pass) net entries are instanceof PerformanceEntry [498.69ms]
(pass) node-only members are present on performance [5.06ms]
(pass) resource-timing methods are present and callable [5.18ms]
(pass) node-only membe
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 742ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7934ms)
Bundle modules (37ms)
Postprocesss modules (152ms)
Bundle Functions (765ms)
Generate Code (81ms)

[8.99s] Bundled "src/js" for production
  2038 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (491bf6b6d)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) perf_hooks.performance is the global performance object [0.58ms]
(pass) doesn't throw [0.18ms]
(pass) timerify entry shape [0.97ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.02ms]
(pass) export surface matches Node v26.3.0 [0.12ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [15.2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/perf_hooks.ts                  |  93 +++++++++++--------------
 test/js/node/perf_hooks/perf_hooks.test.ts | 105 +++++++++++++++++++++++++++--
 2 files changed, 139 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 6 passed · 1 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/node/perf_hooks.ts                      11     17      0
test/js/node/perf_hooks/perf_hooks.test.ts     12     15      0
```

</details>

<!-- robobun:evidence:end -->