### PR TITLE
webcrypto: reject RSA modulusLength values that cannot be generated exactly

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -172,6 +172,11 @@ size_t CryptoKeyRSA::keySizeInBits() const
     return getRSAModulusLength(rsa);
 }
 
+// BoringSSL's RSA_generate_key_ex rounds the requested size down to a multiple of
+// 128 bits (crypto/fipsmodule/rsa/rsa_impl.cc), so sizes outside this granularity
+// cannot be generated.
+static constexpr unsigned rsaKeyGenerationGranularityInBits = 128;
+
 // Convert the exponent vector to a 32-bit value, if possible.
 static std::optional<uint32_t> exponentVectorToUInt32(const Vector<uint8_t>& exponent)
 {
@@ -198,12 +203,20 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
         return;
     }
 
+    // The generated modulus has to be exactly modulusLength bits, otherwise the caller
+    // would silently get a weaker key than it asked for.
+    if (modulusLength % rsaKeyGenerationGranularityInBits) {
+        failureCallback();
+        return;
+    }
+
     auto exponent = convertToBigNumber(publicExponent);
     auto privateRSA = RSAPtr(RSA_new());
     if (!exponent || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0) {
         failureCallback();
         return;
     }
+    ASSERT(RSA_bits(privateRSA.get()) == modulusLength);
 
     auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
     if (!publicRSA) {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -318,6 +318,46 @@ describe("oversized inputs", () => {
   });
 });
 
+describe("RSA generateKey", () => {
+  const rsaAlgorithms: [string, KeyUsage[]][] = [
+    ["RSASSA-PKCS1-v1_5", ["sign", "verify"]],
+    ["RSA-PSS", ["sign", "verify"]],
+    ["RSA-OAEP", ["encrypt", "decrypt"]],
+  ];
+
+  // Resolves to the reported and actual modulus size of the generated key, or to the
+  // name of the error generateKey rejected with.
+  const outcome = async (name: string, modulusLength: number, keyUsages: KeyUsage[]) => {
+    try {
+      const { publicKey } = (await crypto.subtle.generateKey(
+        { name, modulusLength, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+        true,
+        keyUsages,
+      )) as CryptoKeyPair;
+      const jwk = (await crypto.subtle.exportKey("jwk", publicKey)) as JsonWebKey;
+      return {
+        reported: (publicKey.algorithm as KeyAlgorithm & { modulusLength: number }).modulusLength,
+        actual: Buffer.from(jwk.n!, "base64url").length * 8,
+      };
+    } catch (e) {
+      return (e as Error).name;
+    }
+  };
+
+  // BoringSSL rounds the requested modulus down to a multiple of 128 bits, so asking
+  // for 520 or 1032 bits used to resolve with a 512- or 1024-bit key instead.
+  it.each(rsaAlgorithms)("%s rejects a modulusLength it cannot generate exactly", async (name, keyUsages) => {
+    expect({
+      "520": await outcome(name, 520, keyUsages),
+      "1032": await outcome(name, 1032, keyUsages),
+    }).toEqual({ "520": "OperationError", "1032": "OperationError" });
+  });
+
+  it("generates a modulus of exactly modulusLength bits", async () => {
+    expect(await outcome("RSASSA-PKCS1-v1_5", 1024, ["sign", "verify"])).toEqual({ reported: 1024, actual: 1024 });
+  });
+});
+
 describe("Ed25519", () => {
   describe("generateKey", () => {
     it("should return CryptoKeys without namedCurve in algorithm field", async () => {


### PR DESCRIPTION
## Repro

```js
const s = crypto.subtle;
for (const ml of [1024, 1032, 1064, 2000, 2048]) {
  const k = await s.generateKey(
    { name: "RSASSA-PKCS1-v1_5", modulusLength: ml, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
    true, ["sign", "verify"]);
  const jwk = await s.exportKey("jwk", k.publicKey);
  const nBits = Buffer.from(jwk.n, "base64url").length * 8;
  console.log(`requested=${ml} algorithm.modulusLength=${k.publicKey.algorithm.modulusLength} n bits=${nBits}`);
}
```

On `main`, asking for a modulus that is not a multiple of 128 bits silently hands back a smaller one:

```
requested=1032 algorithm.modulusLength=1024 n bits=1024
requested=2000 algorithm.modulusLength=1920 n bits=1920
```

Node v26.3.0 returns exactly 1032 and 2000 bits for the same input. Web Crypto's "generate key" for `RsaHashedKeyGenParams` requires a modulus of exactly `modulusLength` bits, or an `OperationError`; a caller with a policy-mandated size such as 2000 bits was getting weaker RSA than it asked for, with no error.

## Cause

`CryptoKeyRSA::generatePair` passes `modulusLength` straight to `RSA_generate_key_ex`. Unlike OpenSSL, BoringSSL rounds it down (`vendor/boringssl/crypto/fipsmodule/rsa/rsa_impl.cc.inc`):

```c
// Always generate RSA keys which are a multiple of 128 bits. Round `bits`
// down as needed.
bits &= ~127;
```

Nothing on the way in validated the request against that rounding, and nothing on the way out checked the size of the key that came back.

## Fix

Reject a `modulusLength` that is not a multiple of 128 bits before generating, so `generateKey` rejects with `OperationError` instead of resolving with a weaker key. Sizes BoringSSL generates exactly (512, 1024, 2048, 3072, 4096, ...) are unaffected. A debug assertion keeps the invariant honest if BoringSSL's granularity ever changes.

This covers all four RSA key-generation entry points, which share `CryptoKeyRSA::generatePair`: `RSASSA-PKCS1-v1_5`, `RSA-PSS`, `RSA-OAEP`, `RSAES-PKCS1-v1_5`.

After:

```
requested=1024 algorithm.modulusLength=1024 n bits=1024
requested=1032 OperationError: The operation failed for an operation-specific reason
requested=1064 OperationError: The operation failed for an operation-specific reason
requested=2000 OperationError: The operation failed for an operation-specific reason
requested=2048 algorithm.modulusLength=2048 n bits=2048
```

Deliberately not changed: `node:crypto`'s `generateKeyPair('rsa', { modulusLength })` rounds the same way, but Bun already reports `process.versions.boringssl` and pins that behavior in `test/js/node/test/parallel/test-crypto-keygen-bit-length.js` (`common.openSSLIsBoringSSL ? 512 : 513`). Making it throw is a separate call; happy to do it here if that's preferred.

## Verification

New tests in `test/js/web/crypto/web-crypto.test.ts` cover the three RSA algorithms reachable from `crypto.subtle.generateKey`, plus a positive control that 1024 bits still produces a 1024-bit modulus.

<details>
<summary>test output</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t "RSA generateKey"
  {
-   "1032": "OperationError",
-   "520": "OperationError",
+   "1032": { "actual": 1024, "reported": 1024 },
+   "520": { "actual": 512, "reported": 512 },
  }
 1 pass
 3 fail

$ bun bd test test/js/web/crypto/web-crypto.test.ts
 27 pass
 0 fail
```

`test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts` (10226 tests), `test-webcrypto-encrypt-decrypt.js`, `test-webcrypto-sign-verify.js`, `test-webcrypto-wrap-unwrap.js` and `test-crypto-keygen-bit-length.js` all still pass.

</details>
