### PR TITLE
redis: close the socket when the connection fails

### DIFF
--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -627,10 +627,15 @@ impl ValkeyClient {
             jsvalue,
         );
 
-        if !self.connection_ready() {
-            self.flags.is_manually_closed = true;
-            self.close();
-        }
+        // A failed client rejects every later command, so the socket has to go with it.
+        // Leaving it open strands the client in `failed && connected`: `onclose` never
+        // fires and `.connected` keeps reporting true. The failure is ours, not the
+        // socket's (bad handshake, a frame we cannot parse, an idle timeout), so
+        // reconnecting would just hit it again: mark it deliberate and let `connect()`
+        // revive the client. A socket the peer drops never reaches here, so
+        // `autoReconnect` still covers it. `close()` is idempotent.
+        self.flags.is_manually_closed = true;
+        self.close();
         val
     }
 

--- a/test/js/valkey/reliability/connection-teardown.test.ts
+++ b/test/js/valkey/reliability/connection-teardown.test.ts
@@ -1,0 +1,171 @@
+import type { RedisOptions } from "bun";
+import { describe, expect, test } from "bun:test";
+import net from "net";
+
+/**
+ * A connection-level failure must close the socket, so `on_close` gets to run the
+ * client's reconnect / `onclose` policy. Without that the client is stranded in
+ * `failed && connected`: every command rejects, but nothing ever tells the app.
+ */
+
+const CRLF = "\r\n";
+const bulk = (value: string) => `$${Buffer.byteLength(value)}${CRLF}${value}${CRLF}`;
+const HELLO_REPLY = `%3${CRLF}${bulk("server")}${bulk("redis")}${bulk("proto")}:3${CRLF}${bulk("version")}${bulk("7.4.0")}`;
+/** `\x01` is not a RESP type byte, so the client must treat the reply as a protocol failure. */
+const UNPARSEABLE_REPLY = `\x01not-a-resp-type${CRLF}`;
+
+/** Pull every complete `*N\r\n$len\r\n…` command frame out of `buffer`. */
+function takeCommands(buffer: Buffer): { commands: string[][]; rest: Buffer } {
+  const commands: string[][] = [];
+  let rest = buffer;
+  while (rest.length > 0 && rest[0] === 0x2a /* '*' */) {
+    const headerEnd = rest.indexOf(CRLF);
+    if (headerEnd < 0) break;
+    const argCount = Number(rest.subarray(1, headerEnd).toString());
+    if (!Number.isInteger(argCount) || argCount < 0) break;
+
+    let pos = headerEnd + 2;
+    const argv: string[] = [];
+    let complete = true;
+    for (let i = 0; i < argCount; i++) {
+      if (pos >= rest.length || rest[pos] !== 0x24 /* '$' */) {
+        complete = false;
+        break;
+      }
+      const lengthEnd = rest.indexOf(CRLF, pos);
+      if (lengthEnd < 0) {
+        complete = false;
+        break;
+      }
+      const length = Number(rest.subarray(pos + 1, lengthEnd).toString());
+      if (!Number.isInteger(length) || length < 0 || rest.length < lengthEnd + 2 + length + 2) {
+        complete = false;
+        break;
+      }
+      argv.push(rest.subarray(lengthEnd + 2, lengthEnd + 2 + length).toString());
+      pos = lengthEnd + 2 + length + 2;
+    }
+    if (!complete) break;
+
+    commands.push(argv);
+    rest = rest.subarray(pos);
+  }
+  return { commands, rest };
+}
+
+type MockServer = Disposable & {
+  port: number;
+  /** Resolves once a client connection has been torn down. */
+  disconnected: Promise<void>;
+};
+
+async function startMockValkey(respond: (socket: net.Socket, argv: string[]) => void) {
+  const { promise: disconnected, resolve: onDisconnected } = Promise.withResolvers<void>();
+  const sockets: net.Socket[] = [];
+
+  const server = net.createServer(socket => {
+    sockets.push(socket);
+    let buffered = Buffer.alloc(0);
+    socket.on("data", chunk => {
+      buffered = buffered.length > 0 ? Buffer.concat([buffered, chunk]) : chunk;
+      const { commands, rest } = takeCommands(buffered);
+      buffered = rest;
+      for (const argv of commands) respond(socket, argv);
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => onDisconnected());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    disconnected,
+    [Symbol.dispose]() {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    },
+  } satisfies MockServer;
+}
+
+function createClient(port: number, options: RedisOptions) {
+  return new Bun.RedisClient(`redis://127.0.0.1:${port}`, { connectionTimeout: 5_000, ...options });
+}
+
+describe("Valkey: a failed connection is torn down", () => {
+  test("a protocol error closes the socket and fires onclose", async () => {
+    using server = await startMockValkey((socket, argv) => {
+      if (argv[0].toUpperCase() === "HELLO") socket.write(HELLO_REPLY);
+      else socket.write(UNPARSEABLE_REPLY);
+    });
+    const client = createClient(server.port, { autoReconnect: false });
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+    client.onclose = () => onClosed();
+
+    try {
+      await client.connect();
+      const rejection = await client.ping().then(
+        () => null,
+        (thrown: any) => thrown,
+      );
+      expect(rejection?.code).toBe("ERR_REDIS_INVALID_RESPONSE_TYPE");
+
+      await closed;
+      await server.disconnected;
+      expect(client.connected).toBe(false);
+    } finally {
+      client.close();
+    }
+  });
+
+  // `onclose` only fires on the terminal branch of `on_close` — the reconnecting branch
+  // never calls it — so seeing it here is proof the client did not re-dial. That matters:
+  // a repeatable post-handshake failure would otherwise loop forever, because a successful
+  // HELLO resets `retry_attempts` and `maxRetries` is never reached.
+  test("a protocol error is terminal even with autoReconnect enabled, and connect() revives", async () => {
+    let handshakes = 0;
+    let pings = 0;
+
+    using server = await startMockValkey((socket, argv) => {
+      switch (argv[0].toUpperCase()) {
+        case "HELLO":
+          handshakes++;
+          socket.write(HELLO_REPLY);
+          break;
+        case "PING":
+          // Break the first connection mid-stream, then answer normally.
+          socket.write(++pings === 1 ? UNPARSEABLE_REPLY : `+PONG${CRLF}`);
+          break;
+        default:
+          socket.write(`+OK${CRLF}`);
+          break;
+      }
+    });
+    const client = createClient(server.port, { autoReconnect: true });
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+    client.onclose = () => onClosed();
+
+    try {
+      await client.connect();
+      const rejection = await client.ping().then(
+        () => null,
+        (thrown: any) => thrown,
+      );
+      expect(rejection?.code).toBe("ERR_REDIS_INVALID_RESPONSE_TYPE");
+
+      await closed;
+      await server.disconnected;
+      expect(client.connected).toBe(false);
+
+      // The app is handed the failure and can re-dial on its own terms.
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect({ connected: client.connected, handshakes }).toEqual({ connected: true, handshakes: 2 });
+    } finally {
+      client.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

`Bun.RedisClient` can end up permanently half-alive: `flags.failed` is set, every command rejects with `ERR_REDIS_CONNECTION_CLOSED`, but the socket is still open, `.connected` still reports `true`, and `onclose` never fires. The application is never told the connection is dead.

`ValkeyClient::fail()` is the single entry point for every connection-level failure: a RESP frame the parser can't read, a non-`OK` `SELECT`, the idle timeout, an unrecognised RESP3 push. On an established connection none of them closed the socket.

## Repro

A scripted RESP3 server that answers `HELLO` and then sends a byte that is not a RESP type:

```js
const client = new Bun.RedisClient(url, { autoReconnect: false });
client.onclose = () => console.log("onclose fired");

await client.connect();
try { await client.ping(); } catch (e) { console.log("ping ->", e.code); }

console.log({ connected: client.connected });
```

```
ping -> ERR_REDIS_INVALID_RESPONSE_TYPE
{ connected: true }          <- socket still open, onclose never fired
```

Every later command rejects, forever, and nothing ever tells the app.

## Cause

```rust
// src/runtime/valkey_jsc/valkey.rs
self.flags.failed = true;
let val = Self::reject_all_pending_commands(..);

if !self.connection_ready() {           // is_authenticated && !is_selecting_db_internal
    self.flags.is_manually_closed = true;
    self.close();
}
```

The socket was only closed while the handshake was still in flight. Once `is_authenticated` flipped, `fail()` rejected the queues and returned, leaving a live socket attached to a client that refuses to use it. `status` stays `Connected` because only the socket's `on_close` callback moves it to `Disconnected`, and that callback is the one thing that runs the `onclose` / reconnect policy.

## Fix

Close the socket, and mark the close as deliberate:

```rust
self.flags.is_manually_closed = true;
self.close();
```

Deliberate, rather than letting it fall into auto-reconnect, because every failure that reaches `fail()` is the client's own and recurs on reconnect. `handle_hello_response()` resets `retry_attempts = 0` on each successful `HELLO`, so a post-handshake failure can never reach `maxRetries` — it would re-dial forever. Measured, with the reconnecting variant of this patch and `redis://host/99` (bad DB index): **22 handshakes in 1.5s, `onclose` never fired**. With the patch as it stands: one handshake, one `onclose`, `connected === false`.

What does *not* change:

- A socket the peer drops never goes through `fail()` — `on_close()`'s reconnect branch handles it — so `autoReconnect` still covers the case it exists for. Verified against a scripted server that destroys the connection: 2 handshakes, client reconnects, identical to `main`.
- `connect()` revives a failed client (it clears `failed` and `is_manually_closed`), which is what `test/regression/issue/29925.test.ts` already pins.
- `close()` is idempotent (it early-returns on a detached or already-closed socket), so the callers that had closed the socket before reaching `fail()` (`on_close` itself, `on_connect_error`, `fail_handshake`, the TLS-context failure) are unaffected.

## fail() callers, and what each does now

| caller | before | after |
| --- | --- | --- |
| `handle_hello_response` (bad auth, RESP2 server) | close, terminal | unchanged |
| `authenticate` (OOM writing HELLO/SELECT) | close, terminal | unchanged |
| `on_close` (3 branches), `on_connect_error` | socket already gone, no-op | unchanged |
| `fail_handshake`, TLS-context failure | close, terminal | unchanged |
| connection timeout (`on_timer`, pre-auth) | close, terminal | unchanged |
| `on_data` parse error (post-auth) | **stranded** | close, `onclose`, terminal |
| `SELECT` failure (error / non-`OK` / wrong type) | **stranded** | close, `onclose`, terminal |
| idle timeout (`on_timer`, post-auth) | **stranded** | close, `onclose`, terminal |
| unrecognised RESP3 push on a subscriber | **stranded** | close, `onclose`, terminal |

## Verification

`test/js/valkey/reliability/connection-teardown.test.ts` drives both branches of the policy against an in-process RESP3 server (no Redis needed). Both tests hang on `main` (the close never arrives) and pass with the fix. The `autoReconnect: true` test asserts `onclose` fires — which only happens on the terminal branch of `on_close`, never on the reconnecting one — and that exactly 2 handshakes are seen, pinning the absence of a re-dial storm.

`test/js/valkey/` is green, and `test/regression/issue/29925.test.ts` (which spawns a real `redis-server` and exercises `flags.failed` through `close()`/`connect()`) still passes.

## Relationship to #32858

This is the other half of the same report. #32858 fixes the *trigger* in the subscriber path — a `pmessage`/`smessage`/`invalidate` push made the client call `fail()` on itself — and rewrites the push-kind dispatch so those frames stop failing anything. It deliberately leaves `fail()` alone.

This PR fixes what `fail()` does once it is reached, from any of its callers, so no code path can strand a client in `failed && connected`. The two touch different functions and do not conflict.