### PR TITLE
node:vm: await and validate the importModuleDynamically hook's return value

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -32,7 +32,9 @@ const ArrayPrototypeForEach = Array.prototype.forEach;
 const ArrayPrototypeIndexOf = Array.prototype.indexOf;
 
 const kPerContextModuleId = Symbol("kPerContextModuleId");
-const kNative = Symbol("kNative");
+// Created in NodeVM.cpp so the dynamic import hook's return value can be
+// recognized as a Module from native code too.
+const kNative = vm.kNativeModule;
 const kContext = Symbol("kContext");
 const kLink = Symbol("kLink");
 const kDependencySpecifiers = Symbol("kDependencySpecifiers");
@@ -46,7 +48,6 @@ const {
   createContext: createContextNative,
   isContext,
   compileFunction,
-  isModuleNamespaceObject,
   kLinked,
   kEvaluated,
   kErrored,
@@ -225,7 +226,7 @@ class Module {
         options.cachedData,
         options.initializeImportMeta,
         this,
-        options.importModuleDynamically ? importModuleDynamicallyWrap(options.importModuleDynamically) : undefined,
+        options.importModuleDynamically,
       );
     } else {
       $assert(syntheticEvaluationSteps);
@@ -615,25 +616,6 @@ const constants = {
 
 function isModule(object) {
   return typeof object === "object" && object !== null && ObjectPrototypeHasOwnProperty.$call(object, kNative);
-}
-
-function importModuleDynamicallyWrap(importModuleDynamically) {
-  const importModuleDynamicallyWrapper = async (specifier, referrer, attributes, phase) => {
-    // JSC has no source-phase imports, so every dynamic import is an
-    // evaluation-phase request (Node passes the phase name as 4th argument).
-    const m: any = await importModuleDynamically.$call(this, specifier, referrer, attributes, phase ?? "evaluation");
-    if (isModuleNamespaceObject(m)) {
-      return m;
-    }
-    if (!isModule(m)) {
-      throw $ERR_VM_MODULE_NOT_MODULE();
-    }
-    if (m.status === "errored") {
-      throw m.error;
-    }
-    return m.namespace;
-  };
-  return importModuleDynamicallyWrapper;
 }
 
 function getConstructorOf(obj) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -326,39 +326,48 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
 
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (result.isUndefinedOrNull()) {
-        throwException(globalObject, scope, createError(globalObject, ErrorCode::ERR_VM_MODULE_NOT_MODULE, "Provided module is not an instance of Module"_s));
-        return nullptr;
-    }
-
-    if (auto* promise = dynamicDowncast<JSPromise>(result)) {
-        return promise;
-    }
-
-    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-
+    // Building a vm.Module means awaiting link()/evaluate(), so the hook is usually
+    // async: await its return value before handing anything to the guest's import().
+    auto* promise = JSPromise::resolvedPromise(globalObject, result);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
+    // import() resolves with the module's namespace, and anything that is not a
+    // module (or a namespace) is rejected with ERR_VM_MODULE_NOT_MODULE.
     auto* transformer = JSNativeStdFunction::create(vm, globalObject, 1, {}, [](JSGlobalObject* globalObject, CallFrame* callFrame) -> JSC::EncodedJSValue {
         VM& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         JSValue argument = callFrame->argument(0);
 
-        if (JSObject* object = argument.getObject()) {
-            JSValue result = object->get(globalObject, JSC::Identifier::fromString(vm, "namespace"_s));
+        if (argument.inherits<JSModuleNamespaceObject>()) {
+            return JSValue::encode(argument);
+        }
+
+        if (!getModuleFromWrapper(globalObject, argument)) {
+            throwException(globalObject, scope, createError(globalObject, ErrorCode::ERR_VM_MODULE_NOT_MODULE, "Provided module is not an instance of Module"_s));
+            return {};
+        }
+
+        JSObject* module = asObject(argument);
+
+        JSValue status = module->get(globalObject, JSC::Identifier::fromString(vm, "status"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+
+        if (status.isString()) {
+            auto statusString = asString(status)->value(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            if (!result.isUndefinedOrNull()) {
-                return JSValue::encode(result);
+
+            if (statusString.data == "errored"_s) {
+                JSValue error = module->get(globalObject, JSC::Identifier::fromString(vm, "error"_s));
+                RETURN_IF_EXCEPTION(scope, {});
+                throwException(globalObject, scope, error);
+                return {};
             }
         }
 
-        return JSValue::encode(argument);
+        RELEASE_AND_RETURN(scope, JSValue::encode(module->get(globalObject, JSC::Identifier::fromString(vm, "namespace"_s))));
     });
 
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    promise->fulfill(vm, result);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSObject* thenResult = promise->then(globalObject, transformer, jsUndefined());
@@ -786,6 +795,23 @@ bool isUseMainContextDefaultLoaderConstant(JSGlobalObject* globalObject, JSValue
     }
 
     return false;
+}
+
+NodeVMModule* getModuleFromWrapper(JSGlobalObject* globalObject, JSValue value)
+{
+    JSObject* wrapper = value.getObject();
+    if (!wrapper) {
+        return nullptr;
+    }
+
+    Zig::GlobalObject* zigGlobalObject = defaultGlobalObject(globalObject);
+    Symbol* key = zigGlobalObject->m_nodeVMModuleNative.get(zigGlobalObject);
+    JSValue native = wrapper->getDirect(globalObject->vm(), Identifier::fromUid(key->privateName()));
+    if (!native) {
+        return nullptr;
+    }
+
+    return dynamicDowncast<NodeVMModule>(native);
 }
 
 } // namespace NodeVM
@@ -1743,11 +1769,6 @@ void NodeVMGlobalObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject* glo
     RELEASE_AND_RETURN(scope, Base::getOwnPropertyNames(cell, globalObject, propertyNames, mode));
 }
 
-JSC_DEFINE_HOST_FUNCTION(vmIsModuleNamespaceObject, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    return JSValue::encode(jsBoolean(callFrame->argument(0).inherits(JSModuleNamespaceObject::info())));
-}
-
 JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -1774,9 +1795,6 @@ JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "compileFunction"_s)),
         JSC::JSFunction::create(vm, globalObject, 0, "compileFunction"_s, vmModuleCompileFunction, ImplementationVisibility::Public), 0);
     obj->putDirect(
-        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "isModuleNamespaceObject"_s)),
-        JSC::JSFunction::create(vm, globalObject, 0, "isModuleNamespaceObject"_s, vmIsModuleNamespaceObject, ImplementationVisibility::Public), 1);
-    obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "kUnlinked"_s)),
         JSC::jsNumber(static_cast<unsigned>(NodeVMSourceTextModule::Status::Unlinked)), 0);
     obj->putDirect(
@@ -1794,6 +1812,9 @@ JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "kErrored"_s)),
         JSC::jsNumber(static_cast<unsigned>(NodeVMSourceTextModule::Status::Errored)), 0);
+    obj->putDirect(
+        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "kNativeModule"_s)),
+        globalObject->m_nodeVMModuleNative.get(globalObject), 0);
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "kSourceText"_s)),
         JSC::jsNumber(static_cast<unsigned>(NodeVMModule::Type::SourceText)), 0);
@@ -1816,6 +1837,9 @@ void configureNodeVM(JSC::VM& vm, Zig::GlobalObject* globalObject)
     });
     globalObject->m_nodeVMUseMainContextDefaultLoader.initLater([](const LazyProperty<JSC::JSGlobalObject, Symbol>::Initializer& init) {
         init.set(JSC::Symbol::createWithDescription(init.vm, "vm_use_main_context_default_loader"_s));
+    });
+    globalObject->m_nodeVMModuleNative.initLater([](const LazyProperty<JSC::JSGlobalObject, Symbol>::Initializer& init) {
+        init.set(JSC::Symbol::createWithDescription(init.vm, "kNative"_s));
     });
 
     globalObject->m_NodeVMScriptClassStructure.initLater(

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -17,6 +17,7 @@ namespace Bun {
 class NodeVMGlobalObject;
 class NodeVMContextOptions;
 class CompileFunctionOptions;
+class NodeVMModule;
 
 namespace NodeVM {
 
@@ -35,6 +36,9 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue,
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);
+// node:vm's JS `Module` wrapper keeps its NodeVMModule under a symbol created in
+// configureNodeVM, so native code can recognize a real module like vm.ts's isModule().
+NodeVMModule* getModuleFromWrapper(JSC::JSGlobalObject* globalObject, JSValue value);
 
 } // namespace NodeVM
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -659,6 +659,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSNodeHTTPServerSocketStructure)                      \
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMDontContextify)                                    \
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)                       \
+    V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMModuleNative)                                      \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1160,6 +1160,41 @@ describe("importModuleDynamically", () => {
     const script = new Script("import('x')", { importModuleDynamically: () => Subclass.resolve(mod) as any });
     expect((await script.runInThisContext()).v).toBe(22);
   });
+
+  // The module is recognized through a symbol hanging off the main global, so a
+  // script whose import() runs inside a vm context still has to find it.
+  describe("across realms", () => {
+    test("a script in a vm context resolves import() with a main-realm module's namespace", async () => {
+      const context = createContext({}) as any;
+      const mod = await evaluatedModule(1);
+      const script = new Script("globalThis.imported = import('x')", {
+        importModuleDynamically: async () => mod,
+      });
+      script.runInContext(context);
+      const namespace = await context.imported;
+      expect(namespace).toBe(mod.namespace);
+      expect(namespace.v).toBe(1);
+    });
+
+    test("a script in a vm context rejects with a main-realm module's own error", async () => {
+      const context = createContext({}) as any;
+      const mod = await erroredModule("cross-realm boom");
+      const script = new Script("globalThis.imported = import('x')", {
+        importModuleDynamically: () => mod,
+      });
+      script.runInContext(context);
+      await expect(context.imported).rejects.toThrow("cross-realm boom");
+    });
+
+    test("a script in a vm context rejects ERR_VM_MODULE_NOT_MODULE for a non-module", async () => {
+      const context = createContext({}) as any;
+      const script = new Script("globalThis.imported = import('x')", {
+        importModuleDynamically: async () => 123,
+      });
+      script.runInContext(context);
+      await expect(context.imported).rejects.toMatchObject({ code: "ERR_VM_MODULE_NOT_MODULE" });
+    });
+  });
 });
 
 test("node:vm SourceTextModule.link() rejects non-module entries in the moduleNatives array", async () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1096,6 +1096,70 @@ describe("importModuleDynamically", () => {
       await expect(script.runInThisContext()).rejects.toThrow("boom");
     });
   });
+
+  // The validation reads status/error/namespace off the wrapper, so each of those
+  // getters can run user code and throw. Every one must surface as a rejection.
+  describe("adversarial getters on the returned module", () => {
+    function poison(mod: object, property: string, get: () => unknown) {
+      Object.defineProperty(mod, property, { get, configurable: true });
+      return mod;
+    }
+
+    test("a throwing status getter rejects with that error", async () => {
+      const mod = poison(await evaluatedModule(1), "status", () => {
+        throw new Error("status boom");
+      });
+      const script = new Script("import('x')", { importModuleDynamically: () => mod });
+      await expect(script.runInThisContext()).rejects.toThrow("status boom");
+    });
+
+    test("a throwing error getter on an errored module rejects with that error", async () => {
+      const mod = poison(await evaluatedModule(1), "status", () => "errored");
+      poison(mod, "error", () => {
+        throw new Error("error boom");
+      });
+      const script = new Script("import('x')", { importModuleDynamically: () => mod });
+      await expect(script.runInThisContext()).rejects.toThrow("error boom");
+    });
+
+    test("a throwing namespace getter rejects with that error", async () => {
+      const mod = poison(await evaluatedModule(1), "namespace", () => {
+        throw new Error("namespace boom");
+      });
+      const script = new Script("import('x')", { importModuleDynamically: () => mod });
+      await expect(script.runInThisContext()).rejects.toThrow("namespace boom");
+    });
+
+    test("a non-string status is compared, never coerced", async () => {
+      const mod = await evaluatedModule(5);
+      poison(mod, "status", () => ({
+        toString() {
+          throw new Error("status was coerced");
+        },
+      }));
+      const script = new Script("import('x')", { importModuleDynamically: () => mod });
+      expect((await script.runInThisContext()).v).toBe(5);
+    });
+  });
+
+  test("vm.Script awaits a thenable returned by the hook", async () => {
+    const mod = await evaluatedModule(11);
+    const script = new Script("import('x')", {
+      importModuleDynamically: () => ({ then: (resolve: (m: unknown) => void) => resolve(mod) }) as any,
+    });
+    expect((await script.runInThisContext()).v).toBe(11);
+  });
+
+  test("vm.Script handles a promise subclass with a tampered Symbol.species", async () => {
+    const mod = await evaluatedModule(22);
+    class Subclass extends Promise<unknown> {
+      static get [Symbol.species]() {
+        return Promise;
+      }
+    }
+    const script = new Script("import('x')", { importModuleDynamically: () => Subclass.resolve(mod) as any });
+    expect((await script.runInThisContext()).v).toBe(22);
+  });
 });
 
 test("node:vm SourceTextModule.link() rejects non-module entries in the moduleNatives array", async () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -8,6 +8,8 @@ import {
   runInNewContext,
   runInThisContext,
   Script,
+  SourceTextModule,
+  SyntheticModule,
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
@@ -1006,6 +1008,94 @@ test("node:vm native Module prototype methods reject non-module receivers", asyn
     requests: [\"./dep.js\"]"
   `);
   expect(exitCode).toBe(0);
+});
+
+describe("importModuleDynamically", () => {
+  type Hook = (value: any) => any;
+  const hookShapes: [string, Hook][] = [
+    ["sync", value => () => value],
+    ["async", value => async () => value],
+  ];
+  const nonModules: [string, any][] = [
+    ["a number", 123],
+    ["undefined", undefined],
+    ["null", null],
+    ["a plain object", {}],
+    ["an object with a namespace property", { namespace: { v: 1 } }],
+  ];
+
+  async function evaluatedModule(value: unknown) {
+    const mod = new SyntheticModule(["v"], function (this: SyntheticModule) {
+      this.setExport("v", value);
+    });
+    await mod.link(() => {});
+    await mod.evaluate();
+    return mod;
+  }
+
+  async function erroredModule(message: string) {
+    const mod = new SourceTextModule(`throw new Error(${JSON.stringify(message)});`);
+    await mod.link(() => {});
+    await mod.evaluate().catch(() => {});
+    expect(mod.status).toBe("errored");
+    return mod;
+  }
+
+  // An async hook is the normal shape, since building a vm.Module means awaiting
+  // link()/evaluate(). Its return value must be awaited before it is used.
+  test("vm.Script resolves import() with the namespace of a module returned by an async hook", async () => {
+    const script = new Script("import('x')", { importModuleDynamically: async () => evaluatedModule(42) });
+    const namespace = await script.runInThisContext();
+    expect(namespace.v).toBe(42);
+    expect(Object.prototype.toString.call(namespace)).toBe("[object Module]");
+  });
+
+  test("vm.Script resolves import() with the namespace of a module returned by a sync hook", async () => {
+    const mod = await evaluatedModule(7);
+    const script = new Script("import('x')", { importModuleDynamically: () => mod });
+    expect((await script.runInThisContext()).v).toBe(7);
+  });
+
+  test("vm.compileFunction resolves import() with the namespace of a module returned by an async hook", async () => {
+    const fn = compileFunction("return import('x')", [], {
+      importModuleDynamically: async () => evaluatedModule(3),
+    });
+    expect((await fn()).v).toBe(3);
+  });
+
+  test("vm.SourceTextModule resolves import() with the namespace of a module returned by an async hook", async () => {
+    const mod = new SourceTextModule("export const result = import('x');", {
+      importModuleDynamically: async () => evaluatedModule(9),
+    });
+    await mod.link(() => {});
+    await mod.evaluate();
+    expect((await (mod.namespace as any).result).v).toBe(9);
+  });
+
+  test("vm.Script passes a module namespace object returned by the hook straight through", async () => {
+    const mod = await evaluatedModule(1);
+    const script = new Script("import('x')", { importModuleDynamically: async () => mod.namespace });
+    expect(await script.runInThisContext()).toBe(mod.namespace);
+  });
+
+  describe.each(hookShapes)("with a %s hook", (_label, makeHook) => {
+    test.each(nonModules)(
+      "vm.Script rejects ERR_VM_MODULE_NOT_MODULE when the hook returns %s",
+      async (_name, value) => {
+        const script = new Script("import('x')", { importModuleDynamically: makeHook(value) });
+        await expect(script.runInThisContext()).rejects.toMatchObject({
+          code: "ERR_VM_MODULE_NOT_MODULE",
+          message: "Provided module is not an instance of Module",
+        });
+      },
+    );
+
+    test("vm.Script rejects with the module's own error when the hook returns an errored module", async () => {
+      const mod = await erroredModule("boom");
+      const script = new Script("import('x')", { importModuleDynamically: makeHook(mod) });
+      await expect(script.runInThisContext()).rejects.toThrow("boom");
+    });
+  });
 });
 
 test("node:vm SourceTextModule.link() rejects non-module entries in the moduleNatives array", async () => {


### PR DESCRIPTION
## Repro

```js
import * as vm from "node:vm";

async function makeModule() {
  const m = new vm.SyntheticModule(["v"], function () { this.setExport("v", 42); });
  await m.link(() => {});
  await m.evaluate();
  return m;
}

// The natural shape: building a vm.Module requires awaiting link()/evaluate().
const s1 = new vm.Script("import('x')", { importModuleDynamically: async () => makeModule() });
console.log("async hook ->", JSON.stringify(await s1.runInThisContext()));

const s2 = new vm.Script("import('x')", { importModuleDynamically: () => 123 });
await s2.runInThisContext().then(
  ns => console.log("non-module -> resolved", JSON.stringify(ns)),
  e => console.log("non-module -> rejected", e.code),
);
```

```
node v26.3.0:  async hook -> {"v":42}   non-module -> rejected ERR_VM_MODULE_NOT_MODULE
bun 1.4.0:     async hook -> {}         non-module -> resolved 123
```

Every loader mock built on `new vm.Script(src, { importModuleDynamically: async spec => ... })` sees `undefined` for each export of every dynamic import inside the script.

## Cause

`importModuleInner()` in `src/jsc/bindings/NodeVM.cpp` only unwrapped the hook's return value to a module namespace on the synchronous path: a promise was returned to `JSModuleLoader` as-is, so the guest's `import()` resolved with the `vm.Module` wrapper object itself (`{}` when stringified, every export `undefined`). Any other value fell through the `.namespace` lookup and resolved as-is instead of rejecting `ERR_VM_MODULE_NOT_MODULE`.

`vm.SourceTextModule` was unaffected because `src/js/node/vm.ts` wrapped its hook in `importModuleDynamicallyWrap()`, which did the await and the validation in JS. `vm.Script`, `vm.compileFunction` and `vm.createContext` take the native path, which did not.

## Fix

Resolve the hook's return value into a promise, then chain the unwrap+validate step onto it, so it runs for a promise exactly as for a direct value. The transform now mirrors Node's: a module namespace object passes through, anything that is not a `vm.Module` rejects `ERR_VM_MODULE_NOT_MODULE`, an errored module rejects with `module.error`, and otherwise `import()` resolves with `module.namespace`.

Since the native path now covers every entry point, `importModuleDynamicallyWrap()` and the `isModuleNamespaceObject` binding it used are deleted: the validation lives in one place. So native code can recognize a real module, `kNative` (the symbol under which the JS `Module` wrapper stores its `NodeVMModule`) is now created in `NodeVM.cpp` and read from both sides.

## Verification

All five behaviors now match node v26.3.0 byte for byte:

| case | before | after / node v26.3.0 |
| --- | --- | --- |
| `vm.Script`, async hook | `{}` | `{"v":42}` |
| `vm.compileFunction`, async hook | `{}` | `{"v":3}` |
| `vm.SourceTextModule`, async hook | `{"v":9}` | `{"v":9}` |
| hook returns errored module | resolved `{}` | rejected `boom` |
| hook returns `{ namespace: {...} }` | resolved `{"v":1}` | rejected `ERR_VM_MODULE_NOT_MODULE` |

17 new tests in `test/js/node/vm/vm.test.ts`: 12 of them fail on the released binary, all pass with this change. The 95 `test/js/node/test/parallel/test-vm-*.js` tests still pass.