### PR TITLE
node:cluster: report the bound address in the 'listening' event

### DIFF
--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -108,6 +108,13 @@ cluster._getServer = function (obj, options, cb) {
     const address = obj.address();
     message.act = "listening";
     message.port = (address && address.port) || options.port;
+    // Node resolves the host before listening, so its message.address already holds
+    // the bound IP. Bun binds in the worker, so read it back off the socket instead.
+    // An unspecified host stays null; a unix socket's address() is already its path.
+    if (message.address != null && address !== null && typeof address === "object") {
+      message.address = address.address;
+      message.addressType = address.family === "IPv6" ? 6 : 4;
+    }
     send(message);
   });
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -531,11 +531,16 @@ Server.prototype.listen = function () {
     server.once("listening", () => {
       cluster.worker.state = "listening";
       const address = server.address();
+      // Node's `listening` payload is {address, port, addressType}: the bound
+      // address (null when no host was requested, the path for a unix socket)
+      // and its family as 4/6, or -1 for a unix socket.
+      const isUnix = typeof address === "string";
       const message = {
         act: "listening",
-        port: (address && address.port) || port,
+        port: isUnix ? -1 : (address && address.port) || port,
         data: null,
-        addressType: 4,
+        address: isUnix ? address : host && address ? address.address : null,
+        addressType: isUnix ? -1 : host && address && address.family === "IPv6" ? 6 : 4,
       };
       sendHelper(message, null);
     });

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3247,6 +3247,9 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
   let readableAll = false;
   let writableAll = false;
   let fd;
+  // The host the caller asked for, before it is defaulted to the wildcard
+  // address. Cluster workers report an unspecified host to the primary as null.
+  let listenHost;
   //port is actually path
   if (typeof port === "string") {
     if (Number.isSafeInteger(hostname)) {
@@ -3376,6 +3379,7 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
       error.code = "ERR_INVALID_ARG_VALUE";
       throw error;
     }
+    listenHost = hostname;
     hostname = hostname || "::";
   }
 
@@ -3409,11 +3413,17 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
       options[kSocketClass] = Socket;
     }
 
+    // Node reports an unspecified host to the primary as address: null / addressType: 4,
+    // and a unix socket as its path with addressType: -1.
+    // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L2165
+    const clusterAddress = path ?? listenHost ?? null;
+    const clusterAddressType = path != null ? -1 : clusterAddress && isIPv6(clusterAddress) ? 6 : 4;
+
     listenInCluster(
       this,
-      null,
+      clusterAddress,
       port,
-      4,
+      clusterAddressType,
       backlog,
       fd,
       exclusive,

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, isIPv6, joinP, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -185,3 +185,85 @@ test("disconnect() on a cluster.Worker built around a plain object does not abor
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "returned self: true", exitCode: 0 });
 });
+
+// The worker binds one server per host, in order, and the primary collects the
+// `listening` payloads off the ordered IPC channel in that same order. node:net and
+// node:http are required only in the worker; loading them in the primary too costs
+// another ~2s of debug-build module loading.
+// https://nodejs.org/api/cluster.html#event-listening-1
+const listeningFixture = /* js */ `
+const cluster = require("node:cluster");
+
+const hosts = JSON.parse(process.env.HOSTS);
+
+if (cluster.isPrimary) {
+  const payloads = [];
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const worker = cluster.fork();
+
+  cluster.on("listening", (listeningWorker, address) => {
+    if (listeningWorker !== worker) {
+      reject(new Error("'listening' came from an unexpected worker"));
+      return;
+    }
+    payloads.push({ address: address.address, addressType: address.addressType, port: typeof address.port });
+    if (payloads.length === hosts.length) resolve();
+  });
+  worker.on("error", reject);
+  worker.on("exit", (code, signal) => {
+    reject(new Error("worker exited before it finished listening (" + code + ", " + signal + ")"));
+  });
+
+  promise.then(
+    () => {
+      console.log(JSON.stringify(payloads));
+      worker.kill();
+      process.exit(0);
+    },
+    error => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
+} else {
+  const { createServer } = require("node:" + process.env.MODULE);
+
+  (async () => {
+    for (const host of hosts) {
+      const server = createServer(() => {});
+      await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        // A listen() with no host must be reported to the primary as address: null.
+        if (host === null) server.listen(0, resolve);
+        else server.listen(0, host, resolve);
+      });
+    }
+  })().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+`;
+
+test.each(["net", "http"])(
+  "cluster 'listening' reports the address a %s server bound",
+  moduleName => {
+    const hosts: (string | null)[] = ["127.0.0.1", null];
+    if (isIPv6()) hosts.push("::1");
+
+    const dir = tempDirWithFiles("cluster-listening", { "fixture.js": listeningFixture });
+    // bunRun is synchronous and rethrows the fixture's stderr on a non-zero exit.
+    const { stdout } = bunRun(joinP(dir, "fixture.js"), { MODULE: moduleName, HOSTS: JSON.stringify(hosts) });
+
+    expect(JSON.parse(stdout)).toEqual(
+      hosts.map(host => ({
+        address: host,
+        addressType: host?.includes(":") ? 6 : 4,
+        port: "number",
+      })),
+    );
+  },
+  // A cluster primary plus a forked worker is two Bun process boots, and requiring
+  // node:http costs ~2s on its own in a debug build. It lands at ~4s of the 5s default.
+  30_000,
+);


### PR DESCRIPTION
## Reproduction

```js
import cluster from "node:cluster";
import net from "node:net";
import http from "node:http";

if (cluster.isPrimary) {
  cluster.on("listening", (w, a) => console.log(JSON.stringify(a)));
  for (const kind of ["net", "http"]) {
    const w = cluster.fork({ KIND: kind });
    await new Promise(r => w.on("message", m => m?.a === "up" && r()));
    w.process.kill("SIGKILL");
    await new Promise(r => w.on("exit", r));
  }
} else {
  const done = () => process.send({ a: "up" });
  if (process.env.KIND === "net") net.createServer(() => {}).listen(0, "127.0.0.1", done);
  else http.createServer(() => {}).listen(0, "127.0.0.1", done);
}
```

```
node: {"addressType":4,"address":"127.0.0.1","port":41827}   (both workers)
bun:  {"addressType":4,"address":null,       "port":43319}   (net worker)
      {"addressType":4,"port":36013}                          (http worker; no address key)
```

`'listening'` is how a primary learns where a worker bound, and its payload is documented as `{ address, port, addressType }`. Patterns keyed on `` `${a.address}:${a.port}` `` render `null:3000` / `undefined:3000`. `addressType` was also wrong: always `4`, even for an IPv6 host or a unix socket.

## Cause

`net.Server.prototype.listen` passed literals into the cluster query:

```js
listenInCluster(this, null, port, 4, /* ... */);
//                    ^^^^        ^ addressType
```

so `serverQuery.address` was always `null` and `serverQuery.addressType` always `4`. Node passes the host it resolved (or `null` when unspecified, or the pipe name with `-1` for a unix socket) — [`lib/net.js`](https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L2165).

`http.Server` doesn't go through `cluster._getServer` at all; it hand-builds the `listening` IPC message in `_http_server.ts`, and that object simply had no `address` key and a hardcoded `addressType: 4`.

## Fix

- `net.ts`: thread the requested host through to `listenInCluster` (`null` for an unspecified host, the path for a unix socket) along with the matching `addressType` (`4` / `6` / `-1`), instead of the hardcoded `null` / `4`.
- `internal/cluster/child.ts`: in the `listening` hook, read the resolved address back off the socket. Node resolves the host with `dns.lookup` before it binds, so its `message.address` is already the bound IP; Bun binds in the worker, so the socket is where the resolved address lives. This is what makes `listen(0, "localhost")` report `"::1"` rather than `"localhost"`.
- `_http_server.ts`: add `address`/`addressType` to the `listening` message, from the same bound address the `port` already comes from.

## Verification

Every net/http x explicit-host/wildcard/ipv6/localhost/unix combination now matches Node v26.3.0 exactly:

| listen | node v26.3.0 | bun (before) | bun (after) |
| --- | --- | --- | --- |
| `listen(0, "127.0.0.1")` | `"127.0.0.1"`, 4 | `null` / absent, 4 | `"127.0.0.1"`, 4 |
| `listen(0)` | `null`, 4 | `null` / absent, 4 | `null`, 4 |
| `listen(0, "::1")` | `"::1"`, 6 | `null` / absent, 4 | `"::1"`, 6 |
| `listen(0, "localhost")` | `"::1"`, 6 | `null` / absent, 4 | `"::1"`, 6 |
| `listen(unixPath)` (http) | path, -1 | absent, 4 | path, -1 |

`test/js/node/cluster.test.ts` covers net and http against an explicit host, an unspecified host, and (where IPv6 is available) `::1`. It fails on a build without the fix and passes with it. All 58 `test-cluster-*` / `test-*-cluster-*` tests under `test/js/node/test/parallel/` still pass.

## Not covered

`net.createServer().listen(path)` in a cluster worker still does not work: Bun's cluster IPC cannot hand a listening handle to a worker, so the worker binds its own socket while the primary's `RoundRobinHandle` binds the same path. This change does not fix that (it does turn the primary-side `TypeError` into an `EADDRINUSE` on the worker, which is at least diagnosable). #33025 and #30603 are the open PRs for that half of the problem; this one is limited to the event payload and only overlaps them textually. #33025 happens to add `address` to the http message as a side effect, but leaves `addressType` hardcoded and the net path untouched.
