### PR TITLE
stdio: run write completion callbacks in write order

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -42,10 +42,9 @@ const kIoDone = Symbol("kIoDone");
 // Bun supports a fast path for `createWriteStream("path.txt")` where instead of
 // using `node:fs`, `Bun.file(...).writer()` is used instead.
 const kWriteStreamFastPath = Symbol("kWriteStreamFastPath");
-// The promise the sink handed back for the writes it is still buffering, if any,
-// and how many completion reports are still queued on it. The sink hands back the
-// same promise for every write it parks, so counting is the only way to know when
-// the last of them has reported.
+// The promise the sink handed back for writes it is still buffering, and how many
+// completion reports are still queued on it. The sink hands back the same promise
+// for every write it parks, so counting is the only way to know the last has reported.
 const kBackpressurePromise = Symbol("kBackpressurePromise");
 const kPendingReports = Symbol("kPendingReports");
 const kFs = Symbol("kFs");

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -30,6 +30,8 @@ type FSStream = import("node:fs").ReadStream &
      * sink = FileSink
      */
     [kWriteStreamFastPath]?: undefined | true | FileSink;
+    [kBackpressurePromise]?: undefined | Promise<number>;
+    [kPendingReports]?: number;
   };
 type FD = number;
 
@@ -40,6 +42,12 @@ const kIoDone = Symbol("kIoDone");
 // Bun supports a fast path for `createWriteStream("path.txt")` where instead of
 // using `node:fs`, `Bun.file(...).writer()` is used instead.
 const kWriteStreamFastPath = Symbol("kWriteStreamFastPath");
+// The promise the sink handed back for the writes it is still buffering, if any,
+// and how many completion reports are still queued on it. The sink hands back the
+// same promise for every write it parks, so counting is the only way to know when
+// the last of them has reported.
+const kBackpressurePromise = Symbol("kBackpressurePromise");
+const kPendingReports = Symbol("kPendingReports");
 const kFs = Symbol("kFs");
 
 const {
@@ -469,6 +477,8 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   // Enable fast path
   if (fastPath) {
     this[kWriteStreamFastPath] = fd ? Bun.file(fd).writer() : true;
+    this[kBackpressurePromise] = undefined;
+    this[kPendingReports] = 0;
     this._write = underscoreWriteFast;
     this._writev = undefined;
     this.write = writeFast as any;
@@ -624,6 +634,13 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
   }
 }
 
+// Every report queued on the parked promise decrements on its way out. Only the last
+// one unparks, so a write accepted while any of them is still queued chains behind it
+// rather than reporting from a tick of its own.
+function unparkWhenDrained(stream: FSStream) {
+  if (--stream[kPendingReports]! === 0) stream[kBackpressurePromise] = undefined;
+}
+
 // This function implementation is not correct.
 const writablePrototypeWrite = Writable.prototype.write;
 const kWriteMonkeyPatchDefense = Symbol("!");
@@ -641,7 +658,8 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
     cb = encoding;
     encoding = undefined;
   }
-  if (typeof cb !== "function") {
+  const hasCallback = typeof cb === "function";
+  if (!hasCallback) {
     cb = streamNoop;
   }
 
@@ -649,23 +667,57 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (fileSink && fileSink !== true) {
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
+      // The sink drains in FIFO order, so what it is still buffering completes before
+      // anything written after it. Park that promise: a write the sink later accepts
+      // outright must report completion behind the reports already queued on it.
+      this[kBackpressurePromise] = maybePromise;
+      this[kPendingReports]!++;
       // Two-arg then(): a throw from the fulfillment handler must not be
       // mistaken for a write failure.
       maybePromise.then(
         () => {
-          this.emit("drain"); // Emit drain event
-          cb(null);
+          // Unpark after the user code below, never before: a write re-entered from
+          // the drain listener or from cb has to chain onto this promise too. The
+          // finally guarantees the decrement pairs even when that user code throws.
+          try {
+            this.emit("drain"); // Emit drain event
+            cb(null);
+          } finally {
+            unparkWhenDrained(this);
+          }
         },
         err => {
-          cb(err);
-          // Node.js onwriteError: callback AND destroy are both invoked; the
-          // callback is additive, not a replacement for the 'error' event.
-          require("internal/streams/destroy").errorOrDestroy(this, err);
+          try {
+            cb(err);
+            // Node.js onwriteError: callback AND destroy are both invoked; the
+            // callback is additive, not a replacement for the 'error' event.
+            require("internal/streams/destroy").errorOrDestroy(this, err);
+          } finally {
+            unparkWhenDrained(this);
+          }
         },
       );
       return false; // Indicate backpressure
     } else {
-      cb(null);
+      if (hasCallback) {
+        const backpressurePromise = this[kBackpressurePromise];
+        if (backpressurePromise === undefined) {
+          // node never invokes a write callback during write(). Deferring also keeps
+          // it ordered with readline's no-op cursorTo()/moveCursor(), which call back
+          // from process.nextTick().
+          process.nextTick(cb, null);
+        } else {
+          // The reports already queued on that promise can settle a microtask deeper
+          // than it. A tick lands behind them either way, and keeps a throwing callback
+          // an uncaught exception, not an unhandled rejection.
+          this[kPendingReports]!++;
+          const report = () => {
+            process.nextTick(cb, null);
+            unparkWhenDrained(this);
+          };
+          backpressurePromise.then(report, report);
+        }
+      }
       return true; // No backpressure
     }
   } else {

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -701,14 +701,12 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
       if (hasCallback) {
         const backpressurePromise = this[kBackpressurePromise];
         if (backpressurePromise === undefined) {
-          // node never invokes a write callback during write(). Deferring also keeps
-          // it ordered with readline's no-op cursorTo()/moveCursor(), which call back
-          // from process.nextTick().
+          // node never invokes a write callback during write().
           process.nextTick(cb, null);
         } else {
-          // The reports already queued on that promise can settle a microtask deeper
-          // than it. A tick lands behind them either way, and keeps a throwing callback
-          // an uncaught exception, not an unhandled rejection.
+          // The reports already queued on that promise have not run. A tick lands
+          // behind them either way, and keeps a throwing callback an uncaught
+          // exception, not an unhandled rejection.
           this[kPendingReports]!++;
           const report = () => {
             process.nextTick(cb, null);

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -695,6 +695,10 @@ function cursorTo(stream, x, y, callback) {
   if (NumberIsNaN(y)) throw $ERR_INVALID_ARG_VALUE("y", y);
 
   if (stream == null || (typeof x !== "number" && typeof y !== "number")) {
+    // Route through the stream when there is one so the callback queues with the
+    // stream's other write callbacks, not ahead of them; a no-op move must not
+    // overtake a write issued just before it.
+    if (stream != null && typeof callback === "function") return stream.write("", callback);
     if (typeof callback === "function") process.nextTick(callback, null);
     return true;
   }
@@ -715,6 +719,10 @@ function moveCursor(stream, dx, dy, callback?) {
   }
 
   if (stream == null || !(dx || dy)) {
+    // Route through the stream when there is one so the callback queues with the
+    // stream's other write callbacks, not ahead of them; a no-op move must not
+    // overtake a write issued just before it.
+    if (stream != null && typeof callback === "function") return stream.write("", callback);
     if (typeof callback === "function") process.nextTick(callback, null);
     return true;
   }

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -251,10 +251,10 @@ describe.concurrent("process-stdio", () => {
     );
   }
 
-  // A parked write whose callback throws must still settle its report accounting, or
-  // the sink stays parked forever and later writes are reordered for the stream's life.
-  test.skipIf(isWindows)("process.stdout - a throwing parked write callback does not wedge ordering", async () => {
-    using dir = tempDir("stdout-write-order-leak", {});
+  // Each fixture reports {"order": ["write","moveCursor"]} on stderr; the write is
+  // issued first, so its callback must land first.
+  async function expectWriteThenMoveCursor(fixture: string) {
+    using dir = tempDir("stdout-write-order-cursor", {});
     const fifo = path.join(String(dir), "stdout.fifo");
     expect(spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
 
@@ -262,7 +262,7 @@ describe.concurrent("process-stdio", () => {
     let writeFd = fs.openSync(fifo, fs.constants.O_WRONLY);
     try {
       await using proc = spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-order-leak-fixture.js")],
+        cmd: [bunExe(), path.join(import.meta.dir, fixture)],
         stdin: "ignore",
         stdout: writeFd,
         stderr: "pipe",
@@ -276,13 +276,24 @@ describe.concurrent("process-stdio", () => {
       if (report === undefined) {
         throw new Error(`fixture did not report (exit code ${exitCode}):\n${stderrText}`);
       }
-      // The later write was issued before the no-op moveCursor, so it must report first.
       expect({ order: JSON.parse(report).order, exitCode }).toEqual({ order: ["write", "moveCursor"], exitCode: 0 });
     } finally {
       if (writeFd !== -1) fs.closeSync(writeFd);
       fs.closeSync(readFd);
     }
-  });
+  }
+
+  // A parked write whose callback throws must still settle its report accounting, or
+  // the sink stays parked forever and later writes are reordered for the stream's life.
+  test.skipIf(isWindows)("process.stdout - a throwing parked write callback does not wedge ordering", () =>
+    expectWriteThenMoveCursor("process-stdout-write-order-leak-fixture.js"),
+  );
+
+  // A no-op moveCursor co-issued with a write from inside a parked callback must
+  // queue through the stream so it cannot overtake that write.
+  test.skipIf(isWindows)("process.stdout - no-op moveCursor co-issued with a re-entrant write stays ordered", () =>
+    expectWriteThenMoveCursor("process-stdout-write-order-cursor-fixture.js"),
+  );
 
   // `prelude` defines moveCursor(dx, dy, cb) and cursorTo(x, y, cb) bound to
   // process.stdout, either through node:readline or through tty.WriteStream.

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import fs from "node:fs";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -28,16 +29,13 @@ describe.concurrent("process-stdio", () => {
     expect(stdin).toBeDefined();
     expect(stdout).toBeDefined();
     var lines = ["Get Emoji", "— All Emojis to ✂️ Copy and 📋 Paste", "👌", ""];
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      setTimeout(() => {
-        if (line) {
-          stdin?.write(line + "\n");
-          stdin?.flush();
-        } else {
-          stdin?.end();
-        }
-      }, i * 200);
+    for (const line of lines) {
+      if (line) {
+        stdin?.write(line + "\n");
+        stdin?.flush();
+      } else {
+        stdin?.end();
+      }
     }
     var text = await stdout.text();
     expect(text).toBe(lines.join("\n") + "ENDED");
@@ -54,16 +52,13 @@ describe.concurrent("process-stdio", () => {
     expect(stdin).toBeDefined();
     expect(stdout).toBeDefined();
     var lines = ["Get Emoji", "— All Emojis to ✂️ Copy and 📋 Paste", "👌", ""];
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      setTimeout(() => {
-        if (line) {
-          stdin?.write(line + "\n");
-          stdin?.flush();
-        } else {
-          stdin?.end();
-        }
-      }, i * 200);
+    for (const line of lines) {
+      if (line) {
+        stdin?.write(line + "\n");
+        stdin?.flush();
+      } else {
+        stdin?.end();
+      }
     }
     var text = await stdout.text();
     expect(text).toBe("RESUMED" + lines.join("\n") + "ENDED");
@@ -83,16 +78,13 @@ describe.concurrent("process-stdio", () => {
     expect(stdin).toBeDefined();
     expect(stdout).toBeDefined();
     var lines = ["Get Emoji", "— All Emojis to ✂️ Copy and 📋 Paste", "👌", ""];
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      setTimeout(() => {
-        if (line) {
-          stdin?.write(line + "\n");
-          stdin?.flush();
-        } else {
-          stdin?.end();
-        }
-      }, i * 200);
+    for (const line of lines) {
+      if (line) {
+        stdin?.write(line + "\n");
+        stdin?.flush();
+      } else {
+        stdin?.end();
+      }
     }
     var text = await stdout.text();
     expect(text).toBe(lines.join("\n") + "ENDED-CLOSE");
@@ -110,8 +102,10 @@ describe.concurrent("process-stdio", () => {
     expect(process.stderr.isTTY).toBe((isatty(2) || undefined) as any);
   });
 
-  test("process.stdout - write", () => {
-    const { stdout } = spawnSync({
+  // spawnSync blocks the event loop while a debug build boots, which starves
+  // the other concurrent tests in this file.
+  test("process.stdout - write", async () => {
+    await using proc = spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "stdio-test-instance.js")],
       stdout: "pipe",
       stdin: null,
@@ -122,11 +116,13 @@ describe.concurrent("process-stdio", () => {
       },
     });
 
-    expect(stdout?.toString()).toBe(`hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`);
+    expect(await proc.stdout.text()).toBe(
+      `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`,
+    );
   });
 
-  test("process.stdout - write a lot (string)", () => {
-    const { stdout } = spawnSync({
+  test("process.stdout - write a lot (string)", async () => {
+    await using proc = spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "stdio-test-instance-a-lot.js")],
       stdout: "pipe",
       stdin: null,
@@ -138,13 +134,13 @@ describe.concurrent("process-stdio", () => {
       },
     });
 
-    expect(stdout?.toString()).toBe(
+    expect(await proc.stdout.text()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
 
-  test("process.stdout - write a lot (bytes)", () => {
-    const { stdout } = spawnSync({
+  test("process.stdout - write a lot (bytes)", async () => {
+    await using proc = spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "stdio-test-instance-a-lot.js")],
       stdout: "pipe",
       stdin: null,
@@ -154,8 +150,217 @@ describe.concurrent("process-stdio", () => {
         BUN_DEBUG_QUIET_LOGS: "1",
       },
     });
-    expect(stdout?.toString()).toBe(
+    expect(await proc.stdout.text()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
+  });
+
+  // A write callback must never run during the write() call itself. readline's
+  // no-op cursorTo()/moveCursor() fast paths report completion with
+  // process.nextTick(), so a synchronous write callback jumps ahead of them.
+  for (const name of ["stdout", "stderr"] as const) {
+    test(`process.${name}.write - callback is not called synchronously`, async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const order = [];
+            process.${name}.write("A", () => {
+              order.push("callback");
+              process.stdout.write(order.join(","));
+            });
+            order.push("write-returned");
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const written = name === "stdout" ? "A" : "";
+      expect({ stdout, exitCode }).toEqual({ stdout: `${written}write-returned,callback`, exitCode: 0 });
+    });
+  }
+
+  // A write the sink accepts outright must still report completion behind the writes
+  // it is already buffering, whose callbacks are parked on a promise. Each mode
+  // perturbs what runs while that promise's reactions are still queued.
+  const backpressureModes = [
+    ["", "", 1],
+    [" (drain listener writes)", "write-on-drain", 1],
+    [" (write callback writes)", "write-in-callback", 1],
+    [" (two writes parked, second callback writes)", "two-parked-in-cb", 2],
+  ] as const;
+
+  for (const [suffix, mode, parkTarget] of backpressureModes) {
+    test.skipIf(isWindows)(
+      `process.stdout - write callbacks run in write order under backpressure${suffix}`,
+      async () => {
+        using dir = tempDir("stdout-write-order", {});
+        const fifo = path.join(String(dir), "stdout.fifo");
+        expect(spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+
+        // Hold the read end open so opening the write end succeeds. Nothing here ever
+        // reads it: the fixture drains the pipe itself, synchronously.
+        const readFd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+        let writeFd = fs.openSync(fifo, fs.constants.O_WRONLY);
+        try {
+          await using proc = spawn({
+            cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-order-fixture.js")],
+            stdin: "ignore",
+            stdout: writeFd,
+            stderr: "pipe",
+            env: { ...bunEnv, BUN_TEST_FIFO: fifo, BUN_TEST_MODE: mode },
+          });
+          fs.closeSync(writeFd);
+          writeFd = -1;
+
+          const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+          // Scan back for the report: a sanitizer build can print after the fixture has
+          // already written it. A fixture that died before reporting leaves its crash here
+          // instead, which is worth saying rather than burying it in a parse error.
+          const report = stderrText.split("\n").findLast(line => /^\{.*\}$/.test(line));
+          if (report === undefined) {
+            throw new Error(`fixture did not report (exit code ${exitCode}):\n${stderrText}`);
+          }
+          const { parkedCount, reentrant, order } = JSON.parse(report);
+          const reenters = mode !== "";
+
+          // Guards the setup: without these the fixture never reached the racy path.
+          // Whether the trailing write is accepted outright or itself parks depends on
+          // the platform's pipe capacity, so it is not asserted; the order is what holds.
+          expect({
+            parkedCount,
+            wroteEnough: order.length > 2,
+            reentered: reentrant !== -1,
+            exitCode,
+          }).toEqual({
+            parkedCount: parkTarget,
+            wroteEnough: true,
+            reentered: reenters,
+            exitCode: 0,
+          });
+          expect(order).toEqual(Array.from({ length: order.length }, (_, i) => i));
+        } finally {
+          if (writeFd !== -1) fs.closeSync(writeFd);
+          fs.closeSync(readFd);
+        }
+      },
+    );
+  }
+
+  // A parked write whose callback throws must still settle its report accounting, or
+  // the sink stays parked forever and later writes are reordered for the stream's life.
+  test.skipIf(isWindows)("process.stdout - a throwing parked write callback does not wedge ordering", async () => {
+    using dir = tempDir("stdout-write-order-leak", {});
+    const fifo = path.join(String(dir), "stdout.fifo");
+    expect(spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+
+    const readFd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    let writeFd = fs.openSync(fifo, fs.constants.O_WRONLY);
+    try {
+      await using proc = spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-order-leak-fixture.js")],
+        stdin: "ignore",
+        stdout: writeFd,
+        stderr: "pipe",
+        env: { ...bunEnv, BUN_TEST_FIFO: fifo },
+      });
+      fs.closeSync(writeFd);
+      writeFd = -1;
+
+      const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const report = stderrText.split("\n").findLast(line => /^\{.*\}$/.test(line));
+      if (report === undefined) {
+        throw new Error(`fixture did not report (exit code ${exitCode}):\n${stderrText}`);
+      }
+      // The later write was issued before the no-op moveCursor, so it must report first.
+      expect({ order: JSON.parse(report).order, exitCode }).toEqual({ order: ["write", "moveCursor"], exitCode: 0 });
+    } finally {
+      if (writeFd !== -1) fs.closeSync(writeFd);
+      fs.closeSync(readFd);
+    }
+  });
+
+  // `prelude` defines moveCursor(dx, dy, cb) and cursorTo(x, y, cb) bound to
+  // process.stdout, either through node:readline or through tty.WriteStream.
+  const cursorOrderFixture = (prelude: string) =>
+    prelude +
+    `
+    const order = [];
+    let pending = 5;
+    const done = name => {
+      order.push(name);
+      if (--pending === 0) process.stdout.write("|" + order.join(","));
+    };
+    process.stdout.write("A", () => done("w1"));
+    moveCursor(0, 0, () => done("m0")); // no-op move
+    process.stdout.write("B", () => done("w2"));
+    cursorTo(3, undefined, () => done("c"));
+    moveCursor(1, 0, () => done("m1"));
+  `;
+
+  // cursorTo(3) writes CSI 4G and moveCursor(1, 0) writes CSI 1C; the no-op
+  // moveCursor(0, 0) writes nothing but still has to call back in order.
+  const expectedCursorOrder = "AB\x1b[4G\x1b[1C|w1,m0,w2,c,m1";
+
+  test("process.stdout - write and readline cursor callbacks run in call order", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        cursorOrderFixture(`
+          const readline = require("node:readline");
+          const moveCursor = (dx, dy, cb) => readline.moveCursor(process.stdout, dx, dy, cb);
+          const cursorTo = (x, y, cb) => readline.cursorTo(process.stdout, x, y, cb);
+        `),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: expectedCursorOrder, exitCode: 0 });
+  });
+
+  // Windows ConPTY repaints the screen instead of forwarding the child's bytes,
+  // so the raw output can't be compared byte for byte.
+  test.skipIf(isWindows)("process.stdout - write and tty cursor callbacks run in call order", async () => {
+    let output = "";
+    const decoder = new TextDecoder();
+    const eof = Promise.withResolvers<void>();
+
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        cursorOrderFixture(`
+          const moveCursor = (dx, dy, cb) => process.stdout.moveCursor(dx, dy, cb);
+          const cursorTo = (x, y, cb) => process.stdout.cursorTo(x, y, cb);
+        `),
+      ],
+      env: bunEnv,
+      terminal: {
+        cols: 80,
+        rows: 24,
+        data(_terminal: Bun.Terminal, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+        },
+        exit() {
+          eof.resolve();
+        },
+      },
+    });
+
+    // EOF fires once every buffered byte has been delivered.
+    await eof.promise;
+    const exitCode = await proc.exited;
+    proc.terminal?.close();
+    output += decoder.decode();
+
+    expect({ output, exitCode }).toEqual({ output: expectedCursorOrder, exitCode: 0 });
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -155,9 +155,7 @@ describe.concurrent("process-stdio", () => {
     );
   });
 
-  // A write callback must never run during the write() call itself. readline's
-  // no-op cursorTo()/moveCursor() fast paths report completion with
-  // process.nextTick(), so a synchronous write callback jumps ahead of them.
+  // A write callback must never run during the write() call itself.
   for (const name of ["stdout", "stderr"] as const) {
     test(`process.${name}.write - callback is not called synchronously`, async () => {
       await using proc = spawn({
@@ -251,9 +249,9 @@ describe.concurrent("process-stdio", () => {
     );
   }
 
-  // Each fixture reports {"order": ["write","moveCursor"]} on stderr; the write is
-  // issued first, so its callback must land first.
-  async function expectWriteThenMoveCursor(fixture: string) {
+  // Each fixture reports {"order": [...]} on stderr; the write is issued first, so
+  // its callback must land first.
+  async function expectFixtureOrder(fixture: string, expected: readonly string[]) {
     using dir = tempDir("stdout-write-order-cursor", {});
     const fifo = path.join(String(dir), "stdout.fifo");
     expect(spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
@@ -276,7 +274,7 @@ describe.concurrent("process-stdio", () => {
       if (report === undefined) {
         throw new Error(`fixture did not report (exit code ${exitCode}):\n${stderrText}`);
       }
-      expect({ order: JSON.parse(report).order, exitCode }).toEqual({ order: ["write", "moveCursor"], exitCode: 0 });
+      expect({ order: JSON.parse(report).order, exitCode }).toEqual({ order: [...expected], exitCode: 0 });
     } finally {
       if (writeFd !== -1) fs.closeSync(writeFd);
       fs.closeSync(readFd);
@@ -286,13 +284,13 @@ describe.concurrent("process-stdio", () => {
   // A parked write whose callback throws must still settle its report accounting, or
   // the sink stays parked forever and later writes are reordered for the stream's life.
   test.skipIf(isWindows)("process.stdout - a throwing parked write callback does not wedge ordering", () =>
-    expectWriteThenMoveCursor("process-stdout-write-order-leak-fixture.js"),
+    expectFixtureOrder("process-stdout-write-order-leak-fixture.js", ["write", "tick"]),
   );
 
   // A no-op moveCursor co-issued with a write from inside a parked callback must
   // queue through the stream so it cannot overtake that write.
   test.skipIf(isWindows)("process.stdout - no-op moveCursor co-issued with a re-entrant write stays ordered", () =>
-    expectWriteThenMoveCursor("process-stdout-write-order-cursor-fixture.js"),
+    expectFixtureOrder("process-stdout-write-order-cursor-fixture.js", ["write", "moveCursor"]),
   );
 
   // `prelude` defines moveCursor(dx, dy, cb) and cursorTo(x, y, cb) bound to

--- a/test/js/node/process/process-stdout-write-order-cursor-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-cursor-fixture.js
@@ -1,0 +1,53 @@
+// From inside a parked write's completion callback, co-issue a write and a no-op
+// moveCursor. The no-op must report through the same queue as the write so it
+// cannot overtake it; a direct process.nextTick would drain between microtasks
+// and jump ahead.
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+const readFd = fs.openSync(process.env.BUN_TEST_FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+
+function drain() {
+  const scratch = Buffer.alloc(65536);
+  for (;;) {
+    try {
+      if (fs.readSync(readFd, scratch, 0, scratch.length, null) === 0) break;
+    } catch (err) {
+      if (err.code === "EAGAIN") break;
+      throw err;
+    }
+  }
+}
+
+const order = [];
+let pending = 2;
+function done(name) {
+  order.push(name);
+  if (--pending === 0) {
+    finished = true;
+    fs.writeSync(2, JSON.stringify({ order }) + "\n");
+    process.exit(0);
+  }
+}
+
+const chunk = Buffer.alloc(4096, 0x61);
+let parkedIndex = -1;
+let index = 0;
+while (parkedIndex === -1) {
+  const i = index++;
+  const accepted = process.stdout.write(chunk, () => {
+    if (i === parkedIndex) {
+      process.stdout.write("B", () => done("write"));
+      readline.moveCursor(process.stdout, 0, 0, () => done("moveCursor"));
+    }
+  });
+  if (!accepted) parkedIndex = i;
+}
+
+drain();
+
+let finished = false;
+(function pump() {
+  drain();
+  if (!finished) setImmediate(pump);
+})();

--- a/test/js/node/process/process-stdout-write-order-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-fixture.js
@@ -1,0 +1,102 @@
+// stdout is a FIFO nobody else reads. Fill it until the sink reports backpressure,
+// drain the pipe, then write once more: that last write is accepted outright while
+// the earlier ones are still parked on the sink's backpressure promise.
+//
+// BUN_TEST_MODE perturbs what runs while that promise's reactions are still queued,
+// which is where the reporting order is easy to get wrong:
+//   write-on-drain       a 'drain' listener writes
+//   write-in-callback    the parked write's own callback writes
+//   two-parked-in-cb     two writes park on the same promise (the sink hands back the
+//                        same one for both), and the second one's callback writes
+const fs = require("node:fs");
+
+const mode = process.env.BUN_TEST_MODE ?? "";
+// The sink hands the same promise to every write it parks, so reaching the second
+// one means writing past the first `false` rather than stopping at it.
+const parkTarget = mode === "two-parked-in-cb" ? 2 : 1;
+const readFd = fs.openSync(process.env.BUN_TEST_FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+
+const order = [];
+let next = 0;
+let total = -1;
+let resolveDone;
+const done = new Promise(resolve => (resolveDone = resolve));
+
+function seal() {
+  total = next;
+  if (order.length >= total) resolveDone();
+}
+
+function record(index) {
+  order.push(index);
+  if (total >= 0 && order.length >= total) resolveDone();
+}
+
+// Empty whatever is currently in the pipe. Non-blocking: returns when it would block.
+function drainPipe() {
+  const scratch = Buffer.alloc(65536);
+  for (;;) {
+    try {
+      if (fs.readSync(readFd, scratch, 0, scratch.length, null) === 0) break;
+    } catch (err) {
+      if (err.code === "EAGAIN") break;
+      throw err;
+    }
+  }
+}
+
+// The re-entrant write, issued from user code that runs while the sink's promise
+// reactions are still queued. It has to report after every write issued before it.
+let reentrant = -1;
+function writeReentrant() {
+  if (reentrant !== -1) return;
+  reentrant = next++;
+  process.stdout.write(Buffer.from("!"), () => record(reentrant));
+  seal();
+}
+
+if (mode === "write-on-drain") {
+  process.stdout.once("drain", writeReentrant);
+}
+
+const chunk = Buffer.alloc(4096, 0x61);
+const parked = [];
+while (next < 1024 && parked.length < parkTarget) {
+  const index = next++;
+  const accepted = process.stdout.write(chunk, () => {
+    record(index);
+    const reenterAt = parked[parkTarget - 1];
+    if ((mode === "write-in-callback" || mode === "two-parked-in-cb") && index === reenterAt) {
+      writeReentrant();
+    }
+  });
+  if (!accepted) parked.push(index);
+}
+
+// Empty the pipe so the next write is accepted outright while the earlier ones stay
+// parked. The last write's ordering versus those parked callbacks is the point.
+drainPipe();
+
+const last = next++;
+const lastWriteAccepted = process.stdout.write(Buffer.from("."), () => record(last));
+
+// The re-entrant modes seal once their extra write is issued.
+if (reentrant === -1 && mode !== "write-on-drain" && mode !== "write-in-callback" && mode !== "two-parked-in-cb") {
+  seal();
+}
+
+// Keep reading on every event-loop turn so the sink can flush its whole buffer and
+// the parked promises settle, whatever the platform's pipe capacity. The pipe is the
+// only thing blocking progress; draining it lets every queued write complete.
+let finished = false;
+done.then(() => {
+  finished = true;
+  const payload = { parkedCount: parked.length, lastWriteAccepted, reentrant, order };
+  process.stderr.write(JSON.stringify(payload) + "\n");
+  process.exit(0);
+});
+
+(function pump() {
+  drainPipe();
+  if (!finished) setImmediate(pump);
+})();

--- a/test/js/node/process/process-stdout-write-order-leak-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-leak-fixture.js
@@ -1,12 +1,11 @@
 // A parked write whose callback throws must not leak the pending-report count. If it
 // does, the sink's promise stays parked for the life of the stream, and every later
-// accepted write reports from a microtask while readline's no-op moveCursor reports
-// from process.nextTick, permanently reordering them.
+// accepted write reports from a chained microtask while a direct process.nextTick
+// reaches the tick queue first and jumps ahead.
 //
 // Park one write with a throwing callback, drain, then after its promise has settled
-// write once more alongside a no-op moveCursor and report which callback ran first.
+// write once more alongside a direct process.nextTick and report which ran first.
 const fs = require("node:fs");
-const readline = require("node:readline");
 
 // The parked write's callback throws inside the fulfillment handler's try/finally.
 // The finally runs the decrement, then the throw rejects the derived promise that
@@ -65,5 +64,5 @@ settled.promise
       }
     };
     process.stdout.write("A", () => done("write"));
-    readline.moveCursor(process.stdout, 0, 0, () => done("moveCursor"));
+    process.nextTick(() => done("tick"));
   });

--- a/test/js/node/process/process-stdout-write-order-leak-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-leak-fixture.js
@@ -1,0 +1,71 @@
+// A parked write whose callback throws must not leak the pending-report count. If it
+// does, the sink's promise stays parked for the life of the stream, and every later
+// accepted write reports from a microtask while readline's no-op moveCursor reports
+// from process.nextTick, permanently reordering them.
+//
+// Park one write with a throwing callback, drain, then after its promise has settled
+// write once more alongside a no-op moveCursor and report which callback ran first.
+const fs = require("node:fs");
+const readline = require("node:readline");
+
+// The parked write's callback throws on success (.then, cb(null)) and again on the
+// error re-run (.catch, cb(err)). That second throw becomes an unhandled rejection,
+// which fires after the .catch body's finally has run or been skipped: the exact
+// point phase two needs to observe, with no wall-clock wait.
+const settled = Promise.withResolvers();
+process.on("uncaughtException", () => {});
+process.on("unhandledRejection", () => settled.resolve());
+
+const readFd = fs.openSync(process.env.BUN_TEST_FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+
+function drain() {
+  const scratch = Buffer.alloc(65536);
+  for (;;) {
+    try {
+      if (fs.readSync(readFd, scratch, 0, scratch.length, null) === 0) break;
+    } catch (err) {
+      if (err.code === "EAGAIN") break;
+      throw err;
+    }
+  }
+}
+
+const chunk = Buffer.alloc(4096, 0x61);
+let parkedIndex = -1;
+let index = 0;
+while (parkedIndex === -1) {
+  const i = index++;
+  // Only the parked write throws; the accepted ones must report cleanly.
+  const accepted = process.stdout.write(chunk, () => {
+    if (i === parkedIndex) throw new Error("boom");
+  });
+  if (!accepted) parkedIndex = i;
+}
+
+drain();
+
+// Keep reading on every event-loop turn so the sink flushes its whole buffer and the
+// parked write's promise settles, whatever the platform's pipe capacity.
+let finished = false;
+(function pump() {
+  drain();
+  if (!finished) setImmediate(pump);
+})();
+
+// Phase two runs once the parked write's promise has settled and its .catch has run.
+settled.promise
+  .then(() => new Promise(resolve => setImmediate(resolve)))
+  .then(() => {
+    const order = [];
+    let pending = 2;
+    const done = name => {
+      order.push(name);
+      if (--pending === 0) {
+        finished = true;
+        fs.writeSync(2, JSON.stringify({ order }) + "\n");
+        process.exit(0);
+      }
+    };
+    process.stdout.write("A", () => done("write"));
+    readline.moveCursor(process.stdout, 0, 0, () => done("moveCursor"));
+  });

--- a/test/js/node/process/process-stdout-write-order-leak-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-leak-fixture.js
@@ -8,12 +8,10 @@
 const fs = require("node:fs");
 const readline = require("node:readline");
 
-// The parked write's callback throws on success (.then, cb(null)) and again on the
-// error re-run (.catch, cb(err)). That second throw becomes an unhandled rejection,
-// which fires after the .catch body's finally has run or been skipped: the exact
-// point phase two needs to observe, with no wall-clock wait.
+// The parked write's callback throws inside the fulfillment handler's try/finally.
+// The finally runs the decrement, then the throw rejects the derived promise that
+// nothing consumes: that unhandled rejection is phase two's barrier, no wall clock.
 const settled = Promise.withResolvers();
-process.on("uncaughtException", () => {});
 process.on("unhandledRejection", () => settled.resolve());
 
 const readFd = fs.openSync(process.env.BUN_TEST_FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
@@ -52,7 +50,7 @@ let finished = false;
   if (!finished) setImmediate(pump);
 })();
 
-// Phase two runs once the parked write's promise has settled and its .catch has run.
+// Phase two runs once the parked write's promise reaction has run (and decremented).
 settled.promise
   .then(() => new Promise(resolve => setImmediate(resolve)))
   .then(() => {


### PR DESCRIPTION
### What's wrong

Callbacks passed to `process.stdout.write()`, `cursorTo()` and `moveCursor()` do not run in call order. A zero-delta `moveCursor(0, 0, cb)` (the documented no-op move) reports completion last, after every later write.

```js
const order = [];
process.stdout.write("A", () => order.push("w1"));
process.stdout.moveCursor(0, 0, () => order.push("m0")); // no-op move
process.stdout.write("B", () => order.push("w2"));
process.stdout.cursorTo(3, undefined, () => order.push("c"));
process.stdout.moveCursor(1, 0, () => order.push("m1"));
setTimeout(() => console.log("\nORDER=" + order.join(",")), 300);
```

```
node: ORDER=w1,m0,w2,c,m1
bun : ORDER=w1,w2,c,m1,m0
```

This matters for `readline`/ink/prompt libraries, which interleave writes and cursor moves and chain on the callback to know a frame has flushed.

### Cause

Not the no-op short circuit: `readline.moveCursor()` reports a zero-delta move with `process.nextTick(callback, null)` in both runtimes, and node does the same thing. The difference is on the other side, in `writeFast()`, the `write()` installed on the stdio `fs.WriteStream` fast path. It reported completion out of order in two ways.

**1. A write the sink accepts outright called back synchronously.**

```js
const maybePromise = fileSink.write(data);
if ($isPromise(maybePromise)) { /* ... */ }
else {
  cb(null);          // <- during write(), before write() even returns
  return true;
}
```

Node never invokes a write callback during the `write()` call; for a synchronously completed write it queues the callback with `process.nextTick`. So in node all five callbacks above land in the same nextTick queue in call order, while in bun the four real writes called back immediately and only the no-op move waited for the tick.

**2. A write parked on the sink's backpressure promise lost to a later one.**

When the sink is still buffering, that write's callback is parked on the promise the sink handed back, which is a microtask reaction. The `nextTick` queue drains before the microtask queue, so a later write that the sink accepts outright reports completion first:

```js
// sink still buffering, then one write it accepts outright
process.stdout.write(big, () => order.push(0));   // parked on the sink promise
process.stdout.write(".",  () => order.push(1));  // accepted outright
// node: 0,1   bun: 1,0
```

Neither reorder is TTY-specific; both reproduce with stdout piped or redirected to a file, on `process.stdout` and `process.stderr` alike.

### Fix

Park the promise the sink hands back while it is still buffering, and count how many completion reports are still queued on it. The sink hands back the *same* promise for every write it parks while pending, so N parked writes and any accepted writes chained behind them all register reports on one promise. A write the sink accepts outright:

- nothing parked: defer with `process.nextTick(cb, null)`.
- something parked: chain onto that promise and report from a tick, so it lands behind every report already queued there. A tick also keeps a throwing callback an uncaught exception, not an unhandled rejection.

Each arm of the parked-write promise reaction decrements the count from a `finally`, below the user code it calls (`emit("drain")`, then the write callback), so a write re-entered from either one still chains rather than overtaking, and a throwing listener or callback cannot skip the decrement. Only the decrement that reaches zero unparks. Writes with no callback keep their existing fast path, so `console.log` never schedules a tick.

In `src/js/node/readline.ts`, the no-op paths of `cursorTo()` and `moveCursor()` now report through `stream.write("", callback)` when both a stream and a callback are present. Otherwise a no-op co-issued with a write from inside a parked write's completion callback overtakes that write: the write chains onto the parked promise while the no-op's `process.nextTick` reaches the tick queue directly, and Bun drains ticks between microtasks. `stream == null` keeps its tick, and a no-op with no callback still does nothing.

### Verification

`moveCursor`/`cursorTo` output now matches node byte for byte on a tty, a pipe and a file.

New tests in `test/js/node/process/process-stdio.test.ts`:

- `process.stdout.write` / `process.stderr.write` callback is not called synchronously
- write callbacks run in write order under backpressure, across four modes: baseline, a `'drain'` listener that writes, a write callback that writes, and two writes parked on the same promise where the second one's callback writes. The fixture is a FIFO nobody reads, filled until the sink reports backpressure, then drained across event-loop turns so every queued write completes whatever the platform's pipe capacity. Skipped on Windows.
- a throwing parked write callback does not wedge ordering: the count must still decrement, or later writes are permanently reordered
- write + `readline.cursorTo`/`moveCursor` callbacks run in call order (piped stdout)
- write + `tty.WriteStream` `cursorTo`/`moveCursor` callbacks run in call order (real pty via `Bun.spawn({ terminal })`; skipped on Windows, where ConPTY repaints instead of forwarding the child's bytes)

Eight fail against `main`'s `src/` and pass with this change. Every clause of the fix is load-bearing:

| without | failing test |
| --- | --- |
| the `nextTick` deferral | backpressure ordering |
| the chaining onto the parked promise | backpressure ordering |
| unparking below `emit("drain")` | `'drain'` listener writes |
| unparking below the write callback | write callback writes |
| counting reports rather than checking promise identity | two writes parked, second callback writes |
| the `finally` in the fulfillment arm | throwing parked write callback does not wedge ordering |
| routing readline's no-op through `stream.write` | no-op `moveCursor` co-issued with a re-entrant write stays ordered |

The backpressure reorder and its fixture come from #33500, which I have closed into this one.

### Conflict resolution (rebase onto `adbaf41`)

`main` restructured the same `writeFast` handler (#33557, #34267, #34268, #30920): it now delegates to `Writable.prototype.write` on `end()`/`destroy()`, switches to two-arg `.then(onFulfill, onReject)` so a throw from the fulfillment handler is not re-run as a write failure, and routes write errors through `errorOrDestroy`. All of that is preserved.

The parked-write reactions were adapted accordingly: each arm now runs its decrement from a `finally`, so exactly one decrement happens per parked write (the two-arg form guarantees exactly one arm runs for the original promise). The `throw-on-drain` ordering test was dropped, since the scenario it guarded (a throwing `'drain'` listener routing the parked callback one microtask deeper via `.then().catch()`) is structurally impossible under the two-arg form `main` chose.

<details>
<summary>Also in this PR: two fixes to make that test file pass under <code>bun bd test</code></summary>

The three `process.stdin` tests in the file time out on a debug build today, before this change. Two unrelated-to-each-other causes, both banned by the repo's own testing rules:

- the three `process.stdout - write*` tests used `spawnSync`, which blocks the event loop for ~2s per debug-build boot and starves the concurrent tests around it. Converted to async `spawn`.
- the `process.stdin` tests staggered their stdin writes with `setTimeout(..., i * 200)`, which buys nothing (the child echoes the same bytes regardless of chunking) and burns 600ms of a 5s budget. Writes go out immediately now; assertions are unchanged.

With those two, the file goes from 3 failures to 18/18 passing under `bun bd test`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts

<!-- robobun:evidence:end -->
