### PR TITLE
stdio: emit 'error' on a failed write even when a write callback is passed

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -672,17 +672,20 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (fileSink && fileSink !== true) {
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
-      maybePromise
-        .then(() => {
+      // Two-arg then(): a throw from the fulfillment handler must not be mistaken
+      // for a write failure.
+      maybePromise.then(
+        () => {
           this.emit("drain"); // Emit drain event
           cb(null);
-        })
-        .catch(err => {
+        },
+        err => {
           // This path bypasses Writable's machinery, so it has to do what
           // onwriteError does: report to the callback and error the stream.
           cb(err);
           this.destroy(err);
-        });
+        },
+      );
       return false; // Indicate backpressure
     } else {
       cb(null);

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -664,8 +664,7 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
     cb = encoding;
     encoding = undefined;
   }
-  const hasCallback = typeof cb === "function";
-  if (!hasCallback) {
+  if (typeof cb !== "function") {
     cb = streamNoop;
   }
 
@@ -679,14 +678,10 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
           cb(null);
         })
         .catch(err => {
-          // Always call the callback with the error
+          // This path bypasses Writable's machinery, so it has to do what
+          // onwriteError does: report to the callback and error the stream.
           cb(err);
-          // If no callback was provided, emit the error on the stream
-          // This matches Node.js behavior where unhandled write errors
-          // are emitted as 'error' events on the stream
-          if (!hasCallback) {
-            this.destroy(err);
-          }
+          this.destroy(err);
         });
       return false; // Indicate backpressure
     } else {

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -240,7 +240,12 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
       terminal,
     });
 
-    await ready;
+    await Promise.race([
+      ready,
+      proc.exited.then(code => {
+        throw new Error(`child exited (${code}) before writing READY`);
+      }),
+    ]);
     terminal.close();
 
     const exitCode = await proc.exited;

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 import { WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
@@ -190,5 +191,77 @@ describe("WriteStream.prototype.getColorDepth", () => {
 
   it("empty", () => {
     expect(WriteStream.prototype.getColorDepth.call(undefined, {})).toBe(isWindows ? 24 : 1);
+  });
+});
+
+// When the pty master goes away (ssh drop, terminal emulator killed) writes to
+// the slave fail with EIO. Node reports that to the write callback *and* errors
+// the stream, which is the only signal a CLI gets that its terminal is gone.
+describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
+  const fixture = `
+    const { writeFileSync } = require("node:fs");
+    const events = [];
+    process.on("exit", () => writeFileSync(process.env.RESULT_FILE, JSON.stringify(events)));
+
+    // Outlive the SIGHUP the kernel sends when the master closes, like a
+    // nohup'd daemon, so the failing write is actually reached.
+    process.on("SIGHUP", () => {});
+
+    if (!process.env.NO_ERROR_LISTENER) {
+      process.stdout.on("error", err => events.push("error:" + err.code));
+    }
+
+    // Once stdin hits EOF the pty is hung up, so the next write to it is
+    // guaranteed to fail. No polling, no timers.
+    process.stdin.on("end", () => {
+      process.stdout.write("after hangup\\n", err => {
+        if (err) events.push("cb:" + err.code);
+      });
+    });
+    process.stdin.resume();
+
+    process.stdout.write("READY\\n");
+  `;
+
+  async function runUntilHangup(env: Record<string, string | undefined>) {
+    using dir = tempDir("stdout-hangup", { "fixture.js": fixture });
+    const resultFile = join(String(dir), "result.json");
+
+    const { promise: ready, resolve } = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      data(_terminal, chunk) {
+        if (Buffer.from(chunk).toString().includes("READY")) resolve();
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "fixture.js")],
+      env: { ...bunEnv, ...env, RESULT_FILE: resultFile },
+      terminal,
+    });
+
+    await ready;
+    terminal.close();
+
+    const exitCode = await proc.exited;
+    const events = await Bun.file(resultFile)
+      .json()
+      .catch(() => null);
+    return { events, exitCode, signalCode: proc.signalCode };
+  }
+
+  test("emits 'error' on the stream, not only to the write callback", async () => {
+    expect(await runUntilHangup({})).toEqual({
+      events: ["cb:EIO", "error:EIO"],
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("an unhandled write error terminates the process", async () => {
+    const { events, exitCode, signalCode } = await runUntilHangup({ NO_ERROR_LISTENER: "1" });
+    expect(events).toEqual(["cb:EIO"]);
+    expect(signalCode).toBe(null);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -227,10 +227,13 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
     using dir = tempDir("stdout-hangup", { "fixture.js": fixture });
     const resultFile = join(String(dir), "result.json");
 
+    let output = "";
+    const decoder = new TextDecoder();
     const { promise: ready, resolve } = Promise.withResolvers<void>();
     await using terminal = new Bun.Terminal({
-      data(_terminal, chunk) {
-        if (Buffer.from(chunk).toString().includes("READY")) resolve();
+      data(_terminal, chunk: Uint8Array) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("READY")) resolve();
       },
     });
 


### PR DESCRIPTION
## Repro

When a terminal goes away (ssh drop, terminal emulator killed, `script` ending) the pty master closes and writes to the slave fail with `EIO`. The `'error'` event on `process.stdout` is the signal a CLI gets that this happened.

```js
// x.mjs
import { writeFileSync } from "node:fs";
const seen = [];
process.stdout.on("error", e => { seen.push("error:" + e.code); process.exit(0); });
setInterval(() => process.stdout.write("tick\n", e => { if (e) seen.push("cb:" + e.code); }), 200);
process.on("exit", () => writeFileSync("/tmp/out.json", JSON.stringify(seen)));
setTimeout(() => process.exit(0), 4000);
```

Run it with stdout on a pty whose master is closed after 1.2s:

```sh
python3 -c 'import os,sys,time
m,s=os.openpty()
if os.fork()==0:
    os.close(m); os.dup2(s,0); os.dup2(s,1); os.dup2(s,2); os.execvp(sys.argv[1],sys.argv[1:])
os.close(s); time.sleep(1.2); os.close(m); os.wait()' bun x.mjs
```

```
node: ["cb:EIO","error:EIO","exit:0"]                 <- 'error' fires, fatal if unhandled
bun : ["cb:EIO","cb:EIO","cb:EIO",...,"exit:0"]       <- callback only, process keeps writing into the void
```

Daemons and CLIs that node would terminate (or that handle `'error'` to shut down cleanly) keep running after an ssh disconnect.

## Cause

`process.stdout`, `process.stderr` and `child.stdin` are `WriteStream`s on the `FileSink` fast path, whose `.write()` is `writeFast` in `src/js/internal/fs/streams.ts`. That function bypasses `Writable`'s state machine entirely, so `onwriteError` — which calls the write callback **and** `errorOrDestroy(stream, er)` — never runs. `writeFast` only errored the stream when no callback had been passed:

```js
.catch(err => {
  cb(err);
  if (!hasCallback) {
    this.destroy(err);
  }
});
```

So passing a per-write callback suppressed the `'error'` event. With no callback bun already matched node, which is why `console.log`-style writes looked fine and `process.stdout.write(data, cb)` did not.

## Fix

Always do both, the way `onwriteError` does. For stdio, `_destroy` is the `cb(err); this._undestroy()` override, so the stream stays writable afterwards, same as node's `dummyDestroy`.

The rejection handler also moved into `then()`'s second argument (as `underscoreWriteFast` next to it already does) rather than a chained `.catch`. A chained `.catch` also catches a throw from the *fulfillment* handler, so a write callback that throws on success was being reported to that same callback a second time, and would have errored the stream as if the write had failed.

## Verification

The fixed build is byte-for-byte identical to node v26.3.0 on the repro above, including when the error handler keeps the process alive and when no listener is attached:

| | node | bun before | bun after |
|---|---|---|---|
| with `'error'` listener | `["cb:EIO","error:EIO"]` | `["cb:EIO"]×14` | `["cb:EIO","error:EIO"]` |
| no listener | `uncaught:EIO`, exit 1 | exit 0 | `uncaught:EIO`, exit 1 |
| listener keeps running | `cb`/`error` per write, `writable:true` | `cb` only | `cb`/`error` per write, `writable:true` |

The `then()` change fixes a second, pre-existing bug on the same path. A write callback that throws on success (reachable on `child.stdin`, whose sink returns a promise once the pipe backpressures) was invoked twice and its exception swallowed:

| | cb invocations | exception |
|---|---|---|
| node | `["cb-null"]` | `uncaught:oops` |
| bun before | `["cb-null","cb-err:oops"]` | silently swallowed |
| bun after | `["cb-null"]` | `unhandledRejection:oops` |

Tests in `test/js/node/tty.test.ts` reproduce the hangup deterministically with `Bun.Terminal`: closing the master makes the child's stdin hit EOF, which is the trigger for the write that must fail, so there is no polling or timer. Both fail on the unfixed build (no `error:EIO`; exit 0 instead of 1).

<details>
<summary>existing coverage</summary>

`test/regression/issue/1632.test.ts` (the EPIPE test that introduced the `!hasCallback` guard) still passes, as do `test-console-log-stdio-broken-dest`, `test-process-external-stdio-close{,-spawn}`, `test-stdio-closed`, `test-stdin-hang`, `test-child-process-stdout-flush{,-exit}`, `test-child-process-can-write-to-stdout`, and `test/js/node/child_process/child_process.test.ts`.

</details>

Note this is the stream half of the problem, and it deliberately does not close #7251. That issue's repro writes through `console.log`, which uses a separate native writer and never reaches `process.stdout`, so it still hangs on this branch; #30635 covers that half.