### PR TITLE
node:vm: make the contextified sandbox the store for guest-created globals

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1394,31 +1394,8 @@ bool NodeVMGlobalObject::defineOwnProperty(JSObject* cell, JSGlobalObject* globa
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
     }
 
-    // Dispatch through the method table so exotic sandboxes (e.g. Proxy objects)
-    // observe the [[DefineOwnProperty]] exactly once, like V8's contextify
-    // PropertyDefinerCallback.
-    if (descriptor.isAccessorDescriptor()) {
-        RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
-    }
-
-    // The lookup above may have filled `slot` as cacheable (e.g. a lazy global
-    // stored as a CustomGetterSetter on a non-dictionary structure). Reusing it
-    // here would trip PropertySlot's CachingDisallowed asserts if the sandbox
-    // resolves the same name via setGetterSlot/setCustom/setValue(3-arg), which
-    // happens once the sandbox has transitioned to an uncacheable dictionary.
-    PropertySlot sandboxSlot(globalObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
-    bool isDeclaredOnSandbox = contextifiedObject->getPropertySlot(globalObject, propertyName, sandboxSlot);
-    RETURN_IF_EXCEPTION(scope, false);
-
-    if (isDeclaredOnSandbox && !isDeclaredOnGlobalProxy) {
-        RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
-    }
-
-    auto did = contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (!did) return false;
-
-    RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
+    // Define on the sandbox only, via the method table so a Proxy sandbox sees it once.
+    RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
 }
 
 DEFINE_VISIT_CHILDREN(NodeVMGlobalObject);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1148,13 +1148,18 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     auto* sandbox = thisObject->m_sandbox.get();
 
     VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = slot.thisValue();
     bool isContextualStore = thisValue != JSValue(globalObject);
     if (auto* proxy = dynamicDowncast<JSGlobalProxy>(thisValue); proxy && proxy->target() == globalObject) {
         isContextualStore = false;
     }
-    bool isDeclaredOnGlobalObject = slot.type() == JSC::PutPropertySlot::NewProperty;
-    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Qualified call: skip this class' sandbox interception.
+    PropertySlot globalSlot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
+    bool isDeclaredOnGlobalObject = thisObject->JSC::JSGlobalObject::getOwnPropertySlot(thisObject, globalObject, propertyName, globalSlot);
+    RETURN_IF_EXCEPTION(scope, false);
+
     PropertySlot getter(sandbox, PropertySlot::InternalMethodType::Get, nullptr);
     bool isDeclaredOnSandbox = sandbox->getPropertySlot(globalObject, propertyName, getter);
     RETURN_IF_EXCEPTION(scope, false);
@@ -1166,7 +1171,7 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
     }
 
-    if (!isDeclared && value.isSymbol()) {
+    if (!isDeclared && propertyName.isSymbol()) {
         RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
     }
 
@@ -1183,6 +1188,11 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     if (!result) return false;
 
     if (isDeclaredOnSandbox && getter.isAccessor() and (getter.attributes() & PropertyAttribute::DontEnum) == 0) {
+        return true;
+    }
+
+    // Only mirror onto the global object when it already declares the property.
+    if (!isDeclaredOnGlobalObject) {
         return true;
     }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1433,6 +1433,60 @@ describe("contextified sandbox is the store for guest-created globals", () => {
     expect(runInContext("typeof Object", sandbox)).toBe("number");
   });
 
+  test("Object.defineProperty on the context's global writes only to the sandbox", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext(
+      "Object.defineProperty(globalThis, 'a', { value: 1, writable: true, enumerable: true, configurable: true });",
+      sandbox,
+    );
+
+    expect(sandbox.a).toBe(1);
+    expect(delete sandbox.a).toBe(true);
+    expect(runInContext("typeof a", sandbox)).toBe("undefined");
+    expect(runInContext("Object.getOwnPropertyDescriptor(globalThis, 'a')", sandbox)).toBeUndefined();
+  });
+
+  // A `var` leaves a non-configurable binding on the context's global object, so
+  // redefining it has to land on the sandbox or the global rejects the descriptor.
+  test("Object.defineProperty does not collide with a var binding on the global", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext(
+      "var v = 1; Object.defineProperty(globalThis, 'v', { value: 2, writable: true, enumerable: true, configurable: true });",
+      sandbox,
+    );
+
+    expect(sandbox.v).toBe(2);
+    expect(runInContext("globalThis.v", sandbox)).toBe(2);
+    expect(delete sandbox.v).toBe(true);
+    expect(runInContext("globalThis.v", sandbox)).toBe(1);
+  });
+
+  test("Object.defineProperty over a builtin leaves the global's copy intact", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext(
+      "Object.defineProperty(globalThis, 'Object', { value: 5, writable: true, enumerable: true, configurable: true });",
+      sandbox,
+    );
+
+    expect(sandbox.Object).toBe(5);
+    expect(delete sandbox.Object).toBe(true);
+    expect(runInContext("typeof Object", sandbox)).toBe("function");
+  });
+
+  test("an accessor the guest defines is not flattened onto the global", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("Object.defineProperty(globalThis, 'g', { get() { return 7; }, configurable: true });", sandbox);
+
+    expect(typeof Object.getOwnPropertyDescriptor(sandbox, "g")?.get).toBe("function");
+    expect(runInContext("g", sandbox)).toBe(7);
+    expect(delete sandbox.g).toBe(true);
+    expect(runInContext("typeof g", sandbox)).toBe("undefined");
+  });
+
   test("a sandbox accessor still receives the guest's assignment", () => {
     let written;
     const sandbox: any = {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1307,6 +1307,115 @@ describe("DONT_CONTEXTIFY", () => {
   });
 });
 
+describe("contextified sandbox is the store for guest-created globals", () => {
+  test("deleting a guest-assigned global from the sandbox removes it from the context", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("globalThis.a = 1;", sandbox);
+
+    expect(delete sandbox.a).toBe(true);
+    expect("a" in sandbox).toBe(false);
+
+    expect(runInContext("typeof a", sandbox)).toBe("undefined");
+    expect(runInContext("'a' in globalThis", sandbox)).toBe(false);
+    expect(runInContext("Object.getOwnPropertyNames(globalThis).includes('a')", sandbox)).toBe(false);
+    expect(runInContext("Object.getOwnPropertyDescriptor(globalThis, 'a')", sandbox)).toBeUndefined();
+  });
+
+  test("deleting an implicitly-created global from the sandbox removes it from the context", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("c = 3;", sandbox);
+
+    expect(delete sandbox.c).toBe(true);
+    expect(runInContext("typeof c", sandbox)).toBe("undefined");
+  });
+
+  test("deleting a host-provided global the guest overwrote removes it from the context", () => {
+    const sandbox: any = { x: 1 };
+    createContext(sandbox);
+    runInContext("x = 2;", sandbox);
+
+    expect(sandbox.x).toBe(2);
+    expect(delete sandbox.x).toBe(true);
+    expect(runInContext("typeof x", sandbox)).toBe("undefined");
+  });
+
+  test("resetting the sandbox between runs does not leak globals into the next run", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+
+    runInContext("globalThis.leaked = 'first run';", sandbox);
+    for (const key of Object.keys(sandbox)) delete sandbox[key];
+
+    expect(runInContext("typeof leaked", sandbox)).toBe("undefined");
+    expect(runInContext("Object.getOwnPropertyNames(globalThis).includes('leaked')", sandbox)).toBe(false);
+  });
+
+  test("a symbol-keyed assignment stays on the context's global object", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("globalThis[Symbol.for('vm.symbol.key')] = 1;", sandbox);
+
+    expect(sandbox[Symbol.for("vm.symbol.key")]).toBeUndefined();
+    expect(Object.getOwnPropertySymbols(sandbox)).toEqual([]);
+    expect(runInContext("globalThis[Symbol.for('vm.symbol.key')]", sandbox)).toBe(1);
+  });
+
+  test("a symbol value assigned to a string key still reaches the sandbox", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("globalThis.sym = Symbol('q');", sandbox);
+
+    expect(typeof sandbox.sym).toBe("symbol");
+  });
+
+  // Bindings the context's global object declares itself keep their global copy:
+  // the sandbox entry is a mirror, and deleting it must not unbind them.
+  test("var and function declarations survive deletion of their sandbox copy", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("var b = 2; function f() {}", sandbox);
+
+    expect(sandbox.b).toBe(2);
+    expect(typeof sandbox.f).toBe("function");
+    expect(delete sandbox.b).toBe(true);
+    expect(delete sandbox.f).toBe(true);
+
+    expect(runInContext("typeof b", sandbox)).toBe("number");
+    expect(runInContext("typeof f", sandbox)).toBe("function");
+    expect(
+      runInContext("Object.getOwnPropertyNames(globalThis).filter(n => n === 'b' || n === 'f').sort()", sandbox),
+    ).toEqual(["b", "f"]);
+  });
+
+  test("overwriting a builtin global keeps the global object and the sandbox in sync", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("globalThis.Object = 5;", sandbox);
+
+    expect(sandbox.Object).toBe(5);
+    expect(delete sandbox.Object).toBe(true);
+    expect(runInContext("typeof Object", sandbox)).toBe("number");
+  });
+
+  test("a sandbox accessor still receives the guest's assignment", () => {
+    let written;
+    const sandbox: any = {};
+    Object.defineProperty(sandbox, "g", {
+      get: () => 7,
+      set: value => (written = value),
+      configurable: true,
+      enumerable: true,
+    });
+    createContext(sandbox);
+    runInContext("g = 5;", sandbox);
+
+    expect(written).toBe(5);
+    expect(runInContext("g", sandbox)).toBe(7);
+  });
+});
+
 test("Loader is not defined in vm context", () => {
   // Test with empty context - internal Loader should not leak through
   const emptyContext = createContext({});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1352,6 +1352,40 @@ describe("contextified sandbox is the store for guest-created globals", () => {
     expect(runInContext("Object.getOwnPropertyNames(globalThis).includes('leaked')", sandbox)).toBe(false);
   });
 
+  // A store site hot enough to reach the JIT tiers must not start writing a
+  // second copy onto the context's global object behind the sandbox's back.
+  test("the sandbox stays the store when the assignment site gets hot", () => {
+    const sandbox: any = {};
+    createContext(sandbox);
+    runInContext("for (let i = 0; i < 2000; i++) globalThis.hot = i;", sandbox);
+
+    expect(sandbox.hot).toBe(1999);
+    expect(delete sandbox.hot).toBe(true);
+    expect(runInContext("typeof hot", sandbox)).toBe("undefined");
+
+    sandbox.hot = "rehomed";
+    expect(runInContext("hot", sandbox)).toBe("rehomed");
+  });
+
+  // These reach the `slot.isStrictMode() && !isDeclared` branch, whose isDeclared
+  // input now accounts for bindings on the context's global object.
+  test("strict-mode contextual stores still reach the sandbox", () => {
+    const builtin: any = {};
+    createContext(builtin);
+    runInContext("'use strict'; Object = 5;", builtin);
+    expect(builtin.Object).toBe(5);
+
+    const declared: any = {};
+    createContext(declared);
+    runInContext("'use strict'; var v; v = 7;", declared);
+    expect(declared.v).toBe(7);
+
+    const preset: any = { p: 0 };
+    createContext(preset);
+    runInContext("'use strict'; p = 9;", preset);
+    expect(preset.p).toBe(9);
+  });
+
   test("a symbol-keyed assignment stays on the context's global object", () => {
     const sandbox: any = {};
     createContext(sandbox);


### PR DESCRIPTION
> **Superseded by #39588**, which fixes this with the same approach as part of a full contextify port and closes #33075. Kept open only as a possible stopgap until #39588's WebKit dependency lands. See the status comment.

### Repro

A global the guest creates, and the host then deletes from the sandbox object, stays visible inside the context:

```js
import * as vm from "node:vm";

const box = {};
vm.createContext(box);
vm.runInContext("globalThis.a = 1; var b = 2;", box);

console.log("host delete a:", delete box.a, "| host still sees a:", "a" in box);
console.log(
  "inside:", vm.runInContext("[typeof a, 'a' in globalThis].join(',')", box),
  "| ownNames:", vm.runInContext("Object.getOwnPropertyNames(globalThis).filter(n => n == 'a' || n == 'b').join(',')", box),
);
```

```
node v26.3.0:  inside: undefined,false | ownNames: b
bun 1.4.0:     inside: number,true     | ownNames: b,a     <- the host-deleted global is still there
```

That breaks the common pattern of reusing one context and resetting it between runs by deleting the keys the guest added (`for (const k of Object.keys(box)) delete box[k]`): under bun the guest keeps seeing every stale global from the previous run.

### Cause

Both of the method-table hooks that write a property onto a contextified global store it on the sandbox **and** mirror it onto the JSC global object. The host's `delete box.a` removes only the sandbox copy, so the global copy keeps answering lookups.

V8's contextify callbacks report the operation handled, so the sandbox is the only store. The one exception is a property the global object already declares (a `var`/function binding, a builtin), whose global copy does stay in sync.

**`put`** — the gate that was supposed to decide this never fired:

```cpp
bool isDeclaredOnGlobalObject = slot.type() == JSC::PutPropertySlot::NewProperty;
```

`slot.type()` is `Uncachable` on entry to `put`, before anything has written through the slot, so this was always `false` and the mirroring was unconditional.

**`defineOwnProperty`** — mirrors too, and only *looked* harmless. `JSObject::defineOwnNonIndexProperty` re-reads the current descriptor through `methodTable()->getOwnPropertySlot`, which consults the sandbox first and finds the value written one line earlier, so `validateAndApplyPropertyDescriptor` sees `current.equalTo(descriptor)` and returns early. The mirror was suppressed by accident, and the suppression breaks down as soon as the global has a binding of its own:

```js
vm.runInContext("var v = 1; Object.defineProperty(globalThis, 'v', { value: 2, configurable: true });", box);
// node v26.3.0: succeeds
// bun on main:  TypeError: Attempting to change configurable attribute of unconfigurable property
```

The `var` leaves a non-configurable symbol-table entry on the global; the guest asks for `configurable: true`.

### Fix

`put` computes `isDeclaredOnGlobalObject` with a real own-property lookup on the global object, bypassing this class' sandbox interception (the same qualified-static-call idiom `defineOwnProperty` already used, and it sees symbol-table `var`/function bindings as well as regular properties). When the property isn't declared there, the sandbox is the only store, so a host-side `delete` removes it from the context too.

`defineOwnProperty` defines on the sandbox and stops. The accessor branch and the already-on-the-sandbox branch were doing exactly that already, so the tail collapses into the one remaining call. The `ReadOnly && DontDelete` bail stays; node returns "not intercepted" there too.

`put` also checked `value.isSymbol()` where node checks the *key*: `if (!is_declared && property->IsSymbol())`. Fixed to `propertyName.isSymbol()`, which corrects two more divergences (a symbol-keyed assignment was landing on the sandbox, and a symbol *value* assigned to a string key was not).

### Verification

A behaviour matrix run against node v26.3.0 and bun, covering every direction the store can take. `bun bd` output is now byte-identical to node on all twelve rows; before the fix, rows 1, 2, 3, 9 and 12 diverged.

| # | case | node v26.3.0 | bun before | bun after |
|---|------|--------------|-----------|-----------|
| 1 | guest-assign then host delete | `undefined` | `number` | `undefined` |
| 2 | implicit global, host delete | `undefined` | `number` | `undefined` |
| 3 | host-preset then guest-assign, host delete | `undefined` | `number` | `undefined` |
| 4 | `var`, host delete | `number` | `number` | `number` |
| 5 | function decl, host delete | `function` | `function` | `function` |
| 6 | overwrite builtin `Object` | `number` | `number` | `number` |
| 7 | assign inherited `toString` | `function` | `function` | `function` |
| 8 | sandbox accessor set | `5\|7` | `5\|7` | `5\|7` |
| 9 | reset loop, then read | `undefined,number` | `number,number` | `undefined,number` |
| 10 | guest-assign, host re-set, read | `9` | `9` | `9` |
| 11 | strict undeclared assign | `ReferenceError` | `ReferenceError` | `ReferenceError` |
| 12 | symbol-keyed assign, read on sandbox | `undefined` | `1` | `undefined` |

Fifteen tests added to `test/js/node/vm/vm.test.ts`. Eight fail with `src/jsc/bindings/NodeVM.cpp` reverted to `main`; the other seven are negative-contract tests that must pass both ways (`var`/function bindings survive, builtin overwrites stay mirrored, sandbox accessors still fire, strict-mode stores still reach the sandbox, and the three `defineProperty` cases that previously only worked by accident).

<details>
<summary>Test runs</summary>

```
bun bd test test/js/node/vm/vm.test.ts
 291 pass, 0 fail

for f in test/js/node/test/parallel/test-vm-*; do bun-debug "$f"; done
 97 pass, 0 fail
```

</details>

### Rebase onto current main

Main gained twelve `node:vm` commits since this branch was cut. One conflicted: #36709 (`322f3abf9d`) fixed a debug assertion in `defineOwnProperty` by giving the sandbox probe its own `PropertySlot` instead of reusing the one already filled by the global-object lookup. This PR deletes that probe entirely (the function now defines on the sandbox and stops), so the second lookup #36709 was guarding no longer exists and the fix is subsumed. Resolution: take this branch's collapsed version. #36709's regression test (`Object.defineProperty` on the context global when the sandbox is an uncacheable dictionary holding an accessor) still passes on the merged result, and the fail-before count is unchanged on the new base (8 of the 15 new tests fail with `src/jsc/bindings/NodeVM.cpp` reverted to `main`), so none of the intervening commits fixed this independently.

### Notes for review

**Inline caches.** `put`'s early return leaves `slot.base()` pointing at the sandbox rather than the global object, which is already the case on the pre-existing accessor early-return a few lines above. No inline cache can pick it up: `NodeVMGlobalObject`'s `StructureFlags` carry `ProhibitsPropertyCaching`, so `tryCachePutBy` bails after `CommonSlowPaths::originalStructureBeforePut` unwraps the `JSGlobalProxy` to the target, and `tryCachePutToScopeGlobal` bails independently on `slot.base() != scope`. A test hammers one assignment site 2000 times and then checks the sandbox is still the store.

**Still divergent from node, pre-existing and untouched:**

- No indexed-property interceptor for vm globals (`globalThis[0] = 1` lands on the global, not the sandbox).
- Node's `read_only` early-return in the setter is unimplemented.
- A `var` cannot be shadowed by the sandbox for a free-variable read. JSC's `createGlobalVarBinding<Global>` calls `addSymbolTableEntry`, so a `var` is a scope slot rather than a property, and `op_get_from_scope` resolves it to `GlobalVar` and reads the slot directly without consulting `getOwnPropertySlot`. V8 uses a property cell, which its interceptor does see. So after `var v = 1; box.v = 2`, `v` reads `1` in bun and `2` in node, while `globalThis.v` reads `2` in both. Reachable on `main` with no `defineProperty` involved, and not fixable without changing how JSC creates global var bindings for contextified globals.
- Above a V8 IC-warmup threshold (~100 iterations on one store site, also under `--jitless`), node itself leaves a stale copy on the global and exhibits the original bug. Bun is consistent at every iteration count.

