### PR TITLE
node:http2: defer the callback in Http2Stream#end() on an already-ended stream

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2853,9 +2853,8 @@ class Http2Stream extends Duplex {
     }
 
     if ((status & StreamState.EndedCalled) !== 0) {
-      typeof callback == "function" && callback();
-      // Writable#end always returns the stream (request(...).end() chains rely on it).
-      return this;
+      // Writable#end with kEnding already set only routes the callback; it cannot reach _final.
+      return super.end(undefined, undefined, callback);
     }
     this[bunHTTP2StreamStatus] = status | StreamState.EndedCalled;
     // Don't create an empty buffer for end() without data - let the Duplex stream

--- a/test/js/node/http2/node-http2-end-stream.test.ts
+++ b/test/js/node/http2/node-http2-end-stream.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "bun:test";
+import http2 from "node:http2";
+import net from "node:net";
+import http2utils from "./helpers";
+
+// A HEADERS frame carrying END_STREAM closes the writable side of the stream, so a body-less
+// request (an explicit `endStream`, or the GET/HEAD/DELETE default) must not look aborted when it
+// completes normally. The writable side is closed at request() time, like node does.
+
+async function withEchoServer(fn: (client: http2.ClientHttp2Session) => Promise<void>) {
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    let body = "";
+    stream.setEncoding("utf8");
+    stream.on("data", chunk => (body += chunk));
+    stream.on("end", () => {
+      stream.respond({ ":status": 200 });
+      stream.end(body);
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+  const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+  try {
+    await fn(client);
+  } finally {
+    client.close();
+    server.close();
+  }
+}
+
+// Returns what the request stream observed over its whole lifetime, plus the state of its writable
+// side the instant request() returned.
+function roundtrip(client: http2.ClientHttp2Session, headers: object, options?: object, body?: string) {
+  const { promise, resolve, reject } = Promise.withResolvers<object>();
+  const events: string[] = [];
+  const req = client.request(headers, options);
+  const writableEndedAtRequest = req.writableEnded;
+  for (const name of ["response", "aborted", "end"]) req.on(name, () => events.push(name));
+  req.on("error", reject);
+  let received = "";
+  req.setEncoding("utf8");
+  req.on("data", chunk => (received += chunk));
+  req.on("close", () => resolve({ events, received, aborted: req.aborted, writableEndedAtRequest }));
+  if (body !== undefined) req.end(body);
+  return promise;
+}
+
+describe("http2 client request() endStream", () => {
+  it.each([
+    ["explicit endStream", { ":path": "/a" }, { endStream: true }],
+    ["implicit GET", { ":path": "/b" }, undefined],
+    ["implicit DELETE", { ":path": "/c", ":method": "DELETE" }, undefined],
+    ["POST with endStream", { ":path": "/d", ":method": "POST" }, { endStream: true }],
+  ])("%s does not emit 'aborted'", async (_name, headers, options) => {
+    await withEchoServer(async client => {
+      expect(await roundtrip(client, headers, options)).toEqual({
+        events: ["response", "end"],
+        received: "",
+        aborted: false,
+        writableEndedAtRequest: true,
+      });
+    });
+  });
+
+  // endStream only defaults from the method when the caller leaves it unset.
+  it.each([
+    ["GET", "GET"],
+    ["DELETE", "DELETE"],
+  ])("%s with an explicit endStream: false keeps the writable side open", async (_name, method) => {
+    await withEchoServer(async client => {
+      expect(await roundtrip(client, { ":path": "/e", ":method": method }, { endStream: false }, "hello")).toEqual({
+        events: ["response", "end"],
+        received: "hello",
+        aborted: false,
+        writableEndedAtRequest: false,
+      });
+    });
+  });
+
+  it("close() on a body-less request does not emit 'aborted'", async () => {
+    await withEchoServer(async client => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      const req = client.request({ ":path": "/f" });
+      let aborted = false;
+      req.on("aborted", () => (aborted = true));
+      req.on("error", () => {});
+      req.on("close", () => resolve());
+      req.close();
+      await promise;
+      expect({ aborted, streamAborted: req.aborted }).toEqual({ aborted: false, streamAborted: false });
+    });
+  });
+
+  // The negative contract. 'aborted' must still fire for a stream that really was cut short, so
+  // the writable-side-ended check stays the thing that tells the two apart, as it does in node:
+  // a request whose writable half is open is abortable, a body-less one is already done writing.
+  describe("a request whose writable side is still open", () => {
+    // Responds but never ends, so the client can cut the stream short mid-body.
+    async function withStalledServer(fn: (client: http2.ClientHttp2Session) => Promise<void>) {
+      const server = http2.createServer();
+      server.on("stream", (stream, headers) => {
+        stream.on("error", () => {});
+        stream.resume();
+        stream.respond({ ":status": 200 });
+        // For the peer-reset case, send RST_STREAM only once the DATA frame is on the wire, so the
+        // client always observes it after 'response'. No timers.
+        if (headers[":path"] === "/rst") {
+          stream.write("partial", () => stream.close(http2.constants.NGHTTP2_CANCEL));
+        } else {
+          stream.write("partial");
+        }
+      });
+      await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+      const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+      try {
+        client.on("error", () => {});
+        await fn(client);
+      } finally {
+        client.close();
+        server.close();
+      }
+    }
+
+    function abortProbe(client: http2.ClientHttp2Session, method: string, path: string, useController: boolean) {
+      const { promise, resolve } = Promise.withResolvers<object>();
+      const controller = useController ? new AbortController() : undefined;
+      const req = client.request({ ":path": path, ":method": method }, controller && { signal: controller.signal });
+      let abortedEmitted = false;
+      req.on("aborted", () => (abortedEmitted = true));
+      req.on("error", () => {});
+      // A POST that never calls end() keeps its writable half open; a GET is already ended.
+      if (method === "POST") req.write("x");
+      req.on("data", () => controller?.abort());
+      req.on("close", () => resolve({ abortedEmitted, streamAborted: req.aborted }));
+      return promise;
+    }
+
+    it.each([
+      ["an AbortController firing mid-body", "/hang", true],
+      ["the peer sending RST_STREAM(CANCEL)", "/rst", false],
+    ])("still emits 'aborted' on %s", async (_name, path, useController) => {
+      await withStalledServer(async client => {
+        expect(await abortProbe(client, "POST", path, useController)).toEqual({
+          abortedEmitted: true,
+          streamAborted: true,
+        });
+      });
+    });
+
+    // ...while the same two cases on a body-less request stay quiet, exactly as in node.
+    it.each([
+      ["an AbortController firing mid-body", "/hang", true],
+      ["the peer sending RST_STREAM(CANCEL)", "/rst", false],
+    ])("a body-less request stays quiet on %s", async (_name, path, useController) => {
+      await withStalledServer(async client => {
+        expect(await abortProbe(client, "GET", path, useController)).toEqual({
+          abortedEmitted: false,
+          streamAborted: false,
+        });
+      });
+    });
+  });
+
+  // request() already closed the writable side, so a user's end() lands on Http2Stream#end's
+  // already-ended path. It still has to honour Writable#end: return the stream, and never invoke
+  // the callback synchronously.
+  it("end() on an already-ended request stays chainable and defers the callback", async () => {
+    await withEchoServer(async client => {
+      const req = client.request({ ":path": "/g" });
+      req.resume();
+
+      let finishFired = false;
+      req.on("finish", () => (finishFired = true));
+      const { promise, resolve } = Promise.withResolvers<object>();
+      let stillInsideEndCall = true;
+      const endReturned = req.end(() =>
+        resolve({ calledSynchronously: stillInsideEndCall, finishFiredFirst: finishFired }),
+      );
+      stillInsideEndCall = false;
+      const callbackObserved = await promise;
+      // The stream runs to completion before anything can throw, so a failing assertion can't
+      // leave an in-flight request to error on the session close.
+      await new Promise<void>(resolve => req.on("close", () => resolve()));
+
+      expect(req.writableEnded).toBe(true);
+      expect(endReturned).toBe(req);
+      // node runs the callback from Writable's kOnFinished queue, just before it emits 'finish'.
+      expect(callbackObserved).toEqual({ calledSynchronously: false, finishFiredFirst: false });
+    });
+  });
+
+  it("end(callback) once the writable side finished reports ERR_STREAM_ALREADY_FINISHED", async () => {
+    await withEchoServer(async client => {
+      const req = client.request({ ":path": "/h" });
+      req.resume();
+      await new Promise<void>(resolve => req.on("finish", () => resolve()));
+      const { promise, resolve } = Promise.withResolvers<string>();
+      req.end((err?: Error & { code?: string }) => resolve(err?.code ?? "no error"));
+      const code = await promise;
+      await new Promise<void>(resolve => req.on("close", () => resolve()));
+      expect(code).toBe("ERR_STREAM_ALREADY_FINISHED");
+    });
+  });
+
+  // A request queued behind the peer's SETTINGS_MAX_CONCURRENT_STREAMS has no stream id yet, so
+  // _final parks on 'ready' and only runs once the HEADERS frame is actually submitted.
+  it("requests queued behind maxConcurrentStreams end their writable side once submitted", async () => {
+    const server = http2.createServer({ settings: { maxConcurrentStreams: 1 } });
+    server.on("stream", stream => {
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+      });
+      stream.resume();
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    try {
+      await new Promise<void>(resolve => client.on("remoteSettings", () => resolve()));
+      const requests: Promise<object>[] = [];
+      for (let i = 0; i < 3; i++) {
+        const { promise, resolve, reject } = Promise.withResolvers<object>();
+        const req = client.request({ ":path": `/${i}` });
+        const writableEndedAtRequest = req.writableEnded;
+        let aborted = false;
+        req.on("aborted", () => (aborted = true));
+        req.on("error", reject);
+        req.resume();
+        req.on("close", () =>
+          resolve({ writableEndedAtRequest, aborted, writableFinished: req.writableFinished, rstCode: req.rstCode }),
+        );
+        requests.push(promise);
+      }
+      // The first request goes out immediately; the other two sit in the pending queue.
+      expect(await Promise.all(requests)).toEqual(
+        Array.from({ length: 3 }, () => ({
+          writableEndedAtRequest: true,
+          aborted: false,
+          writableFinished: true,
+          rstCode: 0,
+        })),
+      );
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  // Ending the writable side must not put an extra empty DATA frame on a stream the HEADERS frame
+  // already half-closed: the native write is suppressed because the stream is HALF_CLOSED_LOCAL.
+  // Conversely, endStream: false has to leave room for the body on the wire.
+  it("puts a DATA frame on the wire only when the request can carry a body", async () => {
+    // Decodes the frames the client sends, and answers each HEADERS with an END_STREAM response
+    // carrying an HPACK-indexed ":status: 200" so the request completes.
+    type Frame = { type: string | number; endStream: boolean; payload: Buffer };
+    const frames: Frame[] = [];
+    const server = net.createServer(socket => {
+      socket.write(new http2utils.SettingsFrame().data);
+      let buffer = Buffer.alloc(0);
+      let sawMagic = false;
+      socket.on("error", () => {});
+      socket.on("data", chunk => {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (!sawMagic) {
+          if (buffer.length < http2utils.kClientMagic.length) return;
+          buffer = buffer.subarray(http2utils.kClientMagic.length);
+          sawMagic = true;
+        }
+        while (buffer.length >= 9) {
+          const length = buffer.readUIntBE(0, 3);
+          if (buffer.length < 9 + length) return;
+          const [type, flags] = [buffer[3], buffer[4]];
+          const streamId = buffer.readUInt32BE(5) & 0x7fffffff;
+          const payload = buffer.subarray(9, 9 + length);
+          buffer = buffer.subarray(9 + length);
+          if (type === 4 && !(flags & 0x1)) socket.write(new http2utils.SettingsFrame(true).data);
+          if (streamId === 0) continue;
+          frames.push({
+            type: type === 0 ? "DATA" : type === 1 ? "HEADERS" : type,
+            endStream: !!(flags & 0x1),
+            payload,
+          });
+          if (type === 1) socket.write(new http2utils.HeadersFrame(streamId, Buffer.from([0x88]), 0, true, true).data);
+        }
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    try {
+      client.on("error", () => {});
+      async function wire(options: object, body?: string) {
+        frames.length = 0;
+        const req = client.request({ ":path": "/" }, options);
+        req.on("error", () => {});
+        req.resume();
+        if (body !== undefined) req.end(body);
+        await new Promise<void>(resolve => req.on("close", () => resolve()));
+        return frames.slice();
+      }
+
+      const endStream = await wire({ endStream: true });
+      expect(endStream.map(({ type, endStream }) => ({ type, endStream }))).toEqual([
+        { type: "HEADERS", endStream: true },
+      ]);
+
+      const withBody = await wire({ endStream: false }, "hello");
+      expect(withBody[0]).toMatchObject({ type: "HEADERS", endStream: false });
+      const data = withBody.slice(1);
+      expect(Buffer.concat(data.map(frame => frame.payload)).toString()).toBe("hello");
+      expect(data.at(-1)!.endStream).toBe(true);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Repro

Since #32488, `request()` closes the writable side of every body-less request itself. A user's first `.end(cb)` on that stream now lands on `Http2Stream#end()`'s already-ended short-circuit, which invokes the callback **synchronously**. Node's `Writable#end` never does.

```js
const req = client.request({ ":path": "/" });   // GET, endStream defaults true
let stillSync = true;
req.end(() => console.log({ calledSynchronously: stillSync }));
stillSync = false;
```

```
node v26.3.0            { calledSynchronously: false }
bun main (59242d6)      { calledSynchronously: true }
bun release (pre-#32488)  { calledSynchronously: false }
```

The same short-circuit also swallows the `ERR_STREAM_ALREADY_FINISHED` / `ERR_STREAM_DESTROYED` that `Writable#end` reports to the callback once the stream is past those states.

### Cause

The already-ended path hand-rolled half the `Writable#end` contract (the return value) and dropped the other half:

```js
if ((status & StreamState.EndedCalled) !== 0) {
  typeof callback == "function" && callback();   // synchronous, no error
  return this;
}
```

Before #32488 nothing inside `request()` set `EndedCalled`, so a user's first `.end(cb)` fell through to `super.end(cb)` and stayed async. Now every GET/HEAD/DELETE, and every explicit `{ endStream: true }`, routes the first user `.end(cb)` into this branch.

### Fix

Forward to `Writable#end`:

```js
if ((status & StreamState.EndedCalled) !== 0) {
  return super.end(undefined, undefined, callback);
}
```

`kEnding` is already set, so `super.end()` skips the `finishMaybe` branch and cannot re-enter `_final`; all it does is route the callback, through the `kOnFinished` queue, with `ERR_STREAM_ALREADY_FINISHED` / `ERR_STREAM_DESTROYED` where node reports them, and it returns the stream. Passing `undefined` for the chunk keeps the existing silent-drop of a repeat `end(chunk)` (a separate pre-existing divergence).

### History

This PR originally fixed the spurious `'aborted'` on `endStream` requests (see the thread). #32488 landed the same fix independently and now covers that whole area. Running this PR's 15-test file against current `main` showed the headline bug is gone, but the `end(cb)` timing is not, for the same reason review caught it in the earlier version of this PR. So the PR now carries only that remaining piece.

### Verification

New tests in `test/js/node/http2/node-http2-end-stream.test.ts` (15 tests). Two fail on `main`:

- `end()` on an already-ended request stays chainable and defers the callback
- `end(callback)` once the writable side finished reports `ERR_STREAM_ALREADY_FINISHED`

The other 13 pass on `main` (#32488 fixed them) and pin the contract `main` now claims: no `'aborted'` on the four endStream shapes, explicit `endStream: false` delivering a body on GET/DELETE, `close()` on a body-less request, the queued-behind-`maxConcurrentStreams` path, the wire shape (no DATA frame on a stream the HEADERS frame already half-closed), and the negative contract (an `AbortController` firing mid-body and a peer `RST_STREAM(CANCEL)` still emit `'aborted'` on a request whose writable half is open, and stay quiet on a body-less one).

<details>
<summary>Before / after, and no regressions</summary>

```
$ git stash push -- src/
$ bun bd test test/js/node/http2/node-http2-end-stream.test.ts
(fail) end() on an already-ended request stays chainable and defers the callback
(fail) end(callback) once the writable side finished reports ERR_STREAM_ALREADY_FINISHED
 13 pass, 2 fail

$ git stash pop
$ bun bd test test/js/node/http2/node-http2-end-stream.test.ts
 15 pass, 0 fail
```

Three consecutive runs of the new file: 15 pass each time.

`bun bd test test/js/node/http2/`: 423 pass / 1 fail, versus 421 pass / 3 fail on `main` with this test file in place. The one remaining failure is the pre-existing `does not hold *Stream across user-controlled options getters` debug+ASAN timeout.

All `test-http2-*` files under `test/js/node/test/parallel/` against the debug build: 1 failure before and after, identical.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2-end-stream.test.ts"
bun test v1.4.0 (860820a15)

test/js/node/http2/node-http2-end-stream.test.ts:
(pass) http2 client request() endStream > explicit endStream does not emit 'aborted' [1150.77ms]
(pass) http2 client request() endStream > implicit GET does not emit 'aborted' [254.13ms]
(pass) http2 client request() endStream > implicit DELETE does not emit 'aborted' [148.89ms]
(pass) http2 client request() endStream > POST with endStream does not emit 'aborted' [108.34ms]
(pass) http2 client request() endStream > GET with an explicit endStream: false keeps the writable side open [145.65ms]
(pass) http2 client request() endStream > DELETE with an explicit endStream: false keeps the writable side open [156.98ms]
(pass) http2 client request() endStream > close() on a body-less request does not emit 'aborted' [185.37ms]
(pass) http2 client request() endStream > a request whose writable side is still open > still emits 'aborted' on an AbortController firing mid-body [209.34ms]
(pass) http2 client request() endS
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2-end-stream.test.ts:
51 |     ["implicit GET", { ":path": "/b" }, undefined],
52 |     ["implicit DELETE", { ":path": "/c", ":method": "DELETE" }, undefined],
53 |     ["POST with endStream", { ":path": "/d", ":method": "POST" }, { endStream: true }],
54 |   ])("%s does not emit 'aborted'", async (_name, headers, options) => {
55 |     await withEchoServer(async client => {
56 |       expect(await roundtrip(client, headers, options)).toEqual({
                                                             ^
error: expect(received).toEqual(expected)

  {
-   "aborted": false,
+   "aborted": true,
    "events": [
      "response",
      "end",
+     "aborted",
    ],
    "received": "",
-   "writableEndedAtRequest": true,
+   "writableEndedAtRequest": false,
  }

- Expected  - 2
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/node/http2/node-http2-end-stream.test.ts:56:57)
      at async withEchoServer (/workspace/bun/test/js/node/http2/node-http2-end-stream.test.ts:24:11)
      at async <anonymous> (/workspace/bun/test/js/node/http2/node-http2-end-stream.test.ts:55:11)
(fail) http2 client 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2-end-stream.test.ts"
bun test v1.4.0 (860820a15)

test/js/node/http2/node-http2-end-stream.test.ts:
(pass) http2 client request() endStream > explicit endStream does not emit 'aborted' [772.45ms]
(pass) http2 client request() endStream > implicit GET does not emit 'aborted' [233.07ms]
(pass) http2 client request() endStream > implicit DELETE does not emit 'aborted' [112.78ms]
(pass) http2 client request() endStream > POST with endStream does not emit 'aborted' [108.36ms]
(pass) http2 client request() endStream > GET with an explicit endStream: false keeps the writable side open [137.47ms]
(pass) http2 client request() endStream > DELETE with an explicit endStream: false keeps the writable side open [129.30ms]
(pass) http2 client request() endStream > close() on a body-less request does not emit 'aborted' [118.13ms]
(pass) http2 client request() endStream > a request whose writable side is still open > still emits 'aborted' on an AbortController firing mid-body [186.67ms]
(pass) http2 client request() endSt
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     860820a15a
  features     baseline

22 deps, 108 codegen, 1171 objects in 993ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [16.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] gen bindgenv2
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1234] fetch zlib
[zlib] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                             |   5 +-
 test/js/node/http2/node-http2-end-stream.test.ts | 316 +++++++++++++++++++++++
 2 files changed, 318 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js/node/http2.ts                                  9     12      0
test/js/node/http2/node-http2-end-stream.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->