### PR TITLE
Reject Bun.serve response header values that cannot be written as an HTTP field-value

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -2,8 +2,8 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 use crate::virtual_machine::VirtualMachine;
-use crate::{JSGlobalObject, JSValue, JsResult, VM, host_fn};
-use bun_core::{String as BunString, StringPointer, ZigString};
+use crate::{ErrorCode, JSGlobalObject, JSValue, JsResult, VM, host_fn};
+use bun_core::{OwnedString, String as BunString, StringPointer, ZigString};
 use bun_uws::ResponseKind;
 
 bun_opaque::opaque_ffi! {
@@ -67,6 +67,10 @@ unsafe extern "C" {
     safe fn WebCore__FetchHeaders__fastGet_(arg0: &FetchHeaders, arg1: u8, arg2: &mut ZigString);
     safe fn WebCore__FetchHeaders__fastHas_(arg0: &FetchHeaders, arg1: u8) -> bool;
     safe fn WebCore__FetchHeaders__fastRemove_(arg0: &FetchHeaders, arg1: u8);
+    safe fn WebCore__FetchHeaders__findInvalidValueHeaderName(
+        arg0: &FetchHeaders,
+        arg1: &mut BunString,
+    );
     safe fn WebCore__FetchHeaders__get_(
         arg0: &FetchHeaders,
         arg1: &ZigString,
@@ -206,6 +210,22 @@ impl FetchHeaders {
         WebCore__FetchHeaders__toUWSResponse(self, kind, uws_response)
     }
 
+    /// Name of the first header whose value holds a character that cannot be
+    /// written as an HTTP field-value (RFC 9110 §5.5: VCHAR / obs-text / SP /
+    /// HTAB), or `None` when every value can go on the wire as-is.
+    ///
+    /// `Headers` only rejects NUL/CR/LF (the Fetch spec's rule) and code units
+    /// above 0xFF, so anything serializing these headers into an HTTP message
+    /// must reject the remaining control characters, as `node:http` does.
+    pub fn find_invalid_value_header_name(&self) -> Option<OwnedString> {
+        let mut name = BunString::DEAD;
+        WebCore__FetchHeaders__findInvalidValueHeaderName(self, &mut name);
+        if name.is_empty() {
+            return None;
+        }
+        Some(OwnedString::new(name))
+    }
+
     pub fn create_empty() -> NonNull<FetchHeaders> {
         NonNull::new(WebCore__FetchHeaders__createEmpty())
             .expect("WebCore__FetchHeaders__createEmpty returned null")
@@ -340,6 +360,29 @@ impl FetchHeaders {
         // SAFETY: caller guarantees names/values/buf are sized per a prior `count()` call
         unsafe { WebCore__FetchHeaders__copyTo(self, names, values, buf) }
     }
+}
+
+/// RFC 9110 §5.5 `field-value`: `field-vchar` (VCHAR / obs-text), SP and HTAB.
+/// The byte-slice form of the scan
+/// [`FetchHeaders::find_invalid_value_header_name`] runs over a `FetchHeaders`,
+/// for values the HTTP serializers write without going through the header map.
+pub fn is_valid_header_value(value: &[u8]) -> bool {
+    !value
+        .iter()
+        .any(|&byte| byte != b'\t' && (byte < 0x20 || byte == 0x7f))
+}
+
+/// Node's `ERR_INVALID_CHAR` for a header whose value failed
+/// [`is_valid_header_value`]. Matches the message `validateHeaderValue` throws
+/// from `node:http`'s `setHeader`.
+pub fn invalid_header_value_error(
+    global: &JSGlobalObject,
+    name: impl core::fmt::Display,
+) -> JSValue {
+    ErrorCode::ERR_INVALID_CHAR.fmt(
+        global,
+        format_args!("Invalid character in header content [\"{name}\"]"),
+    )
 }
 
 // Canonical enum lives in `bun_http_types::Method::HeaderName` (same 92

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1868,6 +1868,50 @@ bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char 
     return arg0->fastHas(static_cast<HTTPHeaderName>(HTTPHeaderName1));
 }
 
+// RFC 9110 §5.5 `field-value`: `field-vchar` (VCHAR / obs-text) plus SP and
+// HTAB. Everything below SP except HTAB, and DEL, is unwritable. Node's
+// `checkInvalidHeaderChar` (`/[^\t\x20-\x7e\x80-\xff]/`) rejects the same
+// characters; `Headers` already rejects the code units above 0xFF it also bans.
+static bool isInvalidHTTPHeaderValue(const WTF::String& value)
+{
+    return value.contains([](char16_t character) {
+        return character != '\t' && (character < 0x20 || character == 0x7f);
+    });
+}
+
+// Writes the name of the first header whose value cannot be serialized into an
+// HTTP field-value, or the empty string when every value can go on the wire.
+// `Headers` itself only rejects NUL/CR/LF (per the Fetch spec), so the HTTP
+// serializers have to reject the remaining control characters themselves.
+// Names are reported lowercased, the form `Headers` exposes through its keys.
+void WebCore__FetchHeaders__findInvalidValueHeaderName(WebCore::FetchHeaders* headers, BunString* outName)
+{
+    const auto& internalHeaders = headers->internalHeaders();
+
+    for (const auto& value : internalHeaders.getSetCookieHeaders()) {
+        if (isInvalidHTTPHeaderValue(value)) {
+            *outName = Bun::toStringRef(WTF::httpHeaderNameStringImpl(WebCore::HTTPHeaderName::SetCookie));
+            return;
+        }
+    }
+
+    for (const auto& header : internalHeaders.commonHeaders()) {
+        if (isInvalidHTTPHeaderValue(header.value)) {
+            *outName = Bun::toStringRef(WTF::httpHeaderNameStringImpl(header.key));
+            return;
+        }
+    }
+
+    for (const auto& header : internalHeaders.uncommonHeaders()) {
+        if (isInvalidHTTPHeaderValue(header.value)) {
+            *outName = Bun::toStringRef(header.key.convertToASCIILowercase());
+            return;
+        }
+    }
+
+    *outName = BunStringEmpty;
+}
+
 void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, unsigned char* buf)
 {
     auto iter = headers->createIterator(false);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -92,6 +92,7 @@ CPP_DECL void WebCore__FetchHeaders__deref(WebCore::FetchHeaders* arg0);
 CPP_DECL void WebCore__FetchHeaders__fastGet_(WebCore::FetchHeaders* arg0, unsigned char arg1, ZigString* arg2);
 CPP_DECL bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char arg1);
 CPP_DECL void WebCore__FetchHeaders__fastRemove_(WebCore::FetchHeaders* arg0, unsigned char arg1);
+CPP_DECL void WebCore__FetchHeaders__findInvalidValueHeaderName(WebCore::FetchHeaders* arg0, BunString* arg1);
 CPP_DECL void WebCore__FetchHeaders__get_(WebCore::FetchHeaders* arg0, const ZigString* arg1, ZigString* arg2, JSC::JSGlobalObject* arg3);
 CPP_DECL bool WebCore__FetchHeaders__has(WebCore::FetchHeaders* arg0, const ZigString* arg1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool WebCore__FetchHeaders__isEmpty(WebCore::FetchHeaders* arg0);

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1110,7 +1110,9 @@ pub use self::resolved_source_tag::ResolvedSourceTag;
 // ──────────────────────────────────────────────────────────────────────────
 #[path = "FetchHeaders.rs"]
 pub mod fetch_headers;
-pub use self::fetch_headers::{FetchHeaders, HTTPHeaderName};
+pub use self::fetch_headers::{
+    FetchHeaders, HTTPHeaderName, invalid_header_value_error, is_valid_header_value,
+};
 
 /// `BuiltinName` — fast-path property keys preallocated as `JSC::Identifier`s
 /// in C++ (`BunBuiltinNames.h`). Passed to `JSValue::fast_get` as a `u8` index

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -146,6 +146,15 @@ impl FileRoute {
             body_value.to_blob_if_possible();
             let needs_read = matches!(body_value, BodyValue::Blob(b) if b.needs_to_read_file());
             if needs_read {
+                if let Some(name) = response
+                    .get_init_headers()
+                    .and_then(FetchHeaders::find_invalid_value_header_name)
+                {
+                    return Err(
+                        global.throw_value(bun_jsc::invalid_header_value_error(global, &name))
+                    );
+                }
+
                 // `needs_to_read_file()` ⇒ `store` is Some and `data` is `File`.
                 let is_fd = matches!(
                     body_value,

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -791,6 +791,18 @@ impl NodeHTTPResponse {
             }
         }
 
+        // `node:http` validates every header value in JS before it builds the
+        // flat name/value array, but a `Headers` object reaches the serializer
+        // unvalidated, and it writes field-values the same way.
+        if let Some(headers) = jsc::FetchHeaders::cast(headers_object_value) {
+            // SAFETY: `cast` returns a live `*mut FetchHeaders` owned by the JS cell.
+            let headers = bun_opaque::opaque_deref(headers.as_ptr().cast_const());
+            if let Some(name) = headers.find_invalid_value_header_name() {
+                return Err(global_object
+                    .throw_value(jsc::invalid_header_value_error(global_object, &name)));
+            }
+        }
+
         'do_it: {
             if status_message_bytes.is_empty() {
                 if let Some(status_message) =

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -754,7 +754,7 @@ where
         };
         // SAFETY: `response` is the live cell pointer; `value` is rooted by the
         // caller's frame and protect()'d below.
-        if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
+        if unsafe { ctx.reject_unsendable_response(response) } {
             return;
         }
         ctx.response_jsvalue = value;
@@ -2656,7 +2656,7 @@ where
         // for as long as `response` is used.
         if let Some(response) = as_response(response_value) {
             // SAFETY: `response` is the live, rooted cell pointer.
-            if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
+            if unsafe { ctx.reject_unsendable_response(response) } {
                 return;
             }
             ctx.response_jsvalue = response_value;
@@ -2733,7 +2733,7 @@ where
                     };
 
                     // SAFETY: `response` is the live, rooted cell pointer.
-                    if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
+                    if unsafe { ctx.reject_unsendable_response(response) } {
                         return;
                     }
 
@@ -3363,13 +3363,29 @@ where
     }
 
     /// `false` when the Response can be written. A status outside `100..=999`
-    /// has no HTTP status line, so the Response can never reach the client:
-    /// report it like a thrown error rather than writing an unparseable one.
+    /// has no HTTP status line, and a header value holding a C0 control or DEL
+    /// has no HTTP field-value encoding, so neither can reach the client
+    /// intact: report them like a thrown error rather than writing an
+    /// unparseable response.
     ///
-    /// Takes the status, not the Response: `run_error_handler` below runs user
-    /// JS, which may write through the cell pointer the caller holds.
-    fn reject_unsendable_response(&mut self, status: u16) -> bool {
-        if HTTPStatusText::is_sendable(status) {
+    /// Takes the cell pointer, not `&Response`: the header scan yields an owned
+    /// name, and `run_error_handler` below runs user JS that may write through
+    /// the pointer, so no borrow may be held across it.
+    ///
+    /// # Safety
+    /// `response` must be a live, rooted `Response` cell pointer.
+    unsafe fn reject_unsendable_response(&mut self, response: *mut Response) -> bool {
+        // SAFETY: caller contract; both reads produce owned values and hold no
+        // borrow across `run_error_handler`.
+        let status = unsafe { (*response).status_code() };
+        let status_is_sendable = HTTPStatusText::is_sendable(status);
+        let invalid_header = if status_is_sendable {
+            // SAFETY: caller contract; the returned name owns its bytes.
+            unsafe { invalid_response_header_name(response) }
+        } else {
+            None
+        };
+        if status_is_sendable && invalid_header.is_none() {
             return false;
         }
         let Some(server) = self.server else {
@@ -3378,9 +3394,12 @@ where
         };
         // SAFETY: BACKREF
         let global_this = (*server).global_this();
-        let err = global_this.create_error_instance(format_args!(
-            "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
-        ));
+        let err = match &invalid_header {
+            Some(name) => jsc::invalid_header_value_error(global_this, name),
+            None => global_this.create_error_instance(format_args!(
+                "Cannot send a Response with status {status}. HTTP status codes must be between 100 and 999 (Response.error() returns status 0).",
+            )),
+        };
         self.run_error_handler(err);
         true
     }
@@ -3476,7 +3495,7 @@ where
                         // An unsendable Response from the error handler itself
                         // falls through to the default error page below.
                         // SAFETY: `response` is the live, rooted cell pointer.
-                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                        if unsafe { response_is_sendable(response) } {
                             // SAFETY: as above.
                             unsafe { self.render(response) };
                             return;
@@ -3530,7 +3549,7 @@ where
                 };
 
                 // SAFETY: `response` is the live, rooted cell pointer.
-                if !HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                if !unsafe { response_is_sendable(response) } {
                     ctx.finish_running_error_handler(value, status);
                     return;
                 }
@@ -3678,9 +3697,12 @@ where
                 if !basename.is_empty() {
                     let mut filename_buf = [0u8; 1024];
                     let truncated = &basename[..basename.len().min(1024 - 32)];
-                    if !truncated
-                        .iter()
-                        .any(|&b| matches!(b, b'\r' | b'\n' | 0 | b'"'))
+                    // On top of the field-value rule, `"` closes the
+                    // quoted-string early and `\` escapes whatever follows it,
+                    // including the closing quote. A filename that cannot be
+                    // encoded drops the header.
+                    if jsc::is_valid_header_value(truncated)
+                        && !truncated.iter().any(|&b| b == b'"' || b == b'\\')
                     {
                         let header_value = {
                             let mut w = &mut filename_buf[..];
@@ -4477,6 +4499,31 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
         #[cfg(not(debug_assertions))]
         let _ = v;
     }
+}
+
+/// Name of the first header on `response` whose value cannot be written as an
+/// HTTP field-value. Paired with [`jsc::invalid_header_value_error`] to report
+/// it the way `node:http`'s `setHeader` does.
+///
+/// # Safety
+/// `response` must be a live, rooted `Response` cell pointer. The returned
+/// `OwnedString` owns its bytes, so the transient borrow ends with this call.
+unsafe fn invalid_response_header_name(response: *mut Response) -> Option<bun_core::OwnedString> {
+    // SAFETY: caller contract — transient shared read, no borrow escapes.
+    unsafe { &*response }
+        .get_init_headers()
+        .and_then(FetchHeaders::find_invalid_value_header_name)
+}
+
+/// Both halves of a Response that the HTTP serializer must be able to encode:
+/// a status line and header values. See [`invalid_response_header_name`].
+///
+/// # Safety
+/// `response` must be a live, rooted `Response` cell pointer.
+unsafe fn response_is_sendable(response: *mut Response) -> bool {
+    // SAFETY: caller contract.
+    HTTPStatusText::is_sendable(unsafe { (*response).status_code() })
+        && unsafe { invalid_response_header_name(response) }.is_none()
 }
 
 fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (MimeType, bool, bool) {

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -163,6 +163,14 @@ impl StaticRoute {
                 )));
             }
 
+            if let Some(name) = response
+                .get_init_headers()
+                .and_then(FetchHeaders::find_invalid_value_header_name)
+            {
+                return Err(global_this
+                    .throw_value(bun_jsc::invalid_header_value_error(global_this, &name)));
+            }
+
             // The user may want to pass in the same Response object multiple endpoints
             // Let's let them do that.
             let body_value = response.get_body_value();

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -628,6 +628,10 @@ impl AnyRoute {
         headers: Option<&FetchHeaders>,
         path: &mut Node::PathOrFileDescriptor,
     ) -> JsResult<AnyRoute> {
+        if let Some(name) = headers.and_then(FetchHeaders::find_invalid_value_header_name) {
+            return Err(global.throw_value(jsc::invalid_header_value_error(global, &name)));
+        }
+
         // The file/static route doesn't ref it.
         let blob = <Blob as BlobExt>::find_or_create_file_from_path(path, global, false);
 
@@ -1836,6 +1840,12 @@ where
                             return Err(JsError::Thrown);
                         }
 
+                        if let Some(name) = fetch_headers_to_use.find_invalid_value_header_name() {
+                            return Err(
+                                global.throw_value(jsc::invalid_header_value_error(global, &name))
+                            );
+                        }
+
                         if let Some(protocol) =
                             fetch_headers_to_use.fast_get(HTTPHeaderName::SecWebSocketProtocol)
                         {
@@ -2053,6 +2063,11 @@ where
 
                     // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                     let fh = bun_opaque::opaque_deref_mut(fh);
+                    if let Some(name) = fh.find_invalid_value_header_name() {
+                        return Err(
+                            global.throw_value(jsc::invalid_header_value_error(global, &name))
+                        );
+                    }
                     if let Some(p) = fh.fast_get(HTTPHeaderName::SecWebSocketProtocol) {
                         _sec_websocket_protocol_owned = p.to_slice_clone();
                         sec_websocket_protocol =
@@ -2069,6 +2084,23 @@ where
                 if global.has_exception() {
                     return Err(JsError::Thrown);
                 }
+            }
+        }
+
+        // uWS echoes these two into the 101 response through its upgrade
+        // arguments rather than the header map, so `to_uws_response` never sees
+        // them. They can come from `options.headers`, from a `request.headers`
+        // the handler mutated, or from the client's own request, and every one
+        // of those reaches the wire verbatim.
+        for (name, value) in [
+            ("sec-websocket-protocol", sec_websocket_protocol.to_slice()),
+            (
+                "sec-websocket-extensions",
+                sec_websocket_extensions.to_slice(),
+            ),
+        ] {
+            if !jsc::is_valid_header_value(value.slice()) {
+                return Err(global.throw_value(jsc::invalid_header_value_error(global, name)));
             }
         }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1354,6 +1354,327 @@ describe("Response.error()", () => {
   });
 });
 
+// A `Headers` value may hold C0 controls and DEL -- the Fetch spec only bans
+// NUL/CR/LF there -- but RFC 9110 5.5 `field-value` cannot encode them, so the
+// HTTP/1 serializer must refuse them the way node's `setHeader` does, instead
+// of writing bytes no strict parser (bun's own `fetch()` included) accepts.
+describe("header values that cannot be written to the wire", () => {
+  const invalidChar = (name: string) => `Invalid character in header content ["${name}"]`;
+
+  async function rawResponse(port: number): Promise<string> {
+    const received: Buffer[] = [];
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data(socket, data) {
+          received.push(data);
+        },
+        end() {
+          resolve();
+        },
+        error(socket, error) {
+          reject(error);
+        },
+        close() {
+          resolve();
+        },
+      },
+    });
+    connection.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    connection.flush();
+    await promise;
+    return Buffer.concat(received).toString("latin1");
+  }
+
+  // A WebSocket handshake a real client cannot send: `WebSocket` rejects a
+  // subprotocol holding DEL long before it reaches the wire.
+  async function rawHandshake(port: number, extraHeader: string): Promise<string> {
+    const received: Buffer[] = [];
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        // The server answers in one write either way: a 400 and close, or the
+        // 101 block. Resolving on the first chunk avoids waiting on a close
+        // that a successful upgrade would never send.
+        data(socket, data) {
+          received.push(data);
+          resolve();
+        },
+        error(socket, error) {
+          reject(error);
+        },
+        close() {
+          resolve();
+        },
+      },
+    });
+    connection.write(
+      "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n${extraHeader}\r\n`,
+    );
+    connection.flush();
+    await promise;
+    return Buffer.concat(received).toString("latin1");
+  }
+
+  // The `Headers` constructor has to accept every one of these (see the
+  // Fetch spec's header value definition), which is what makes them reachable.
+  const unwritable: [label: string, header: string, value: string][] = [
+    ["SOH in set-cookie", "Set-Cookie", "k=a\x01b"],
+    ["DEL in set-cookie", "Set-Cookie", "k=a\x7fb"],
+    ["form feed in a common header", "Location", "/a\x0cb"],
+    ["unit separator in an uncommon header", "X-Request-Id", "a\x1fb"],
+  ];
+
+  it.each(unwritable)("Headers accepts %s, the wire does not", (_label, header, value) => {
+    expect(new Headers({ [header]: value }).get(header)).toBe(value);
+  });
+
+  describe.each(unwritable)("%s", (_label, header, value) => {
+    // `Headers` keys are lowercase, so that is how the offender is named.
+    const reported = header.toLowerCase();
+
+    it.each([
+      ["sync", () => new Response("hello", { headers: { [header]: value } })],
+      ["async", async () => new Response("hello", { headers: { [header]: value } })],
+    ])("a %s fetch handler returning it reaches error()", async (_kind, fetchImpl) => {
+      const errors: Error[] = [];
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch: fetchImpl,
+        error(error) {
+          errors.push(error);
+          return new Response("handled", { status: 502 });
+        },
+      });
+
+      const raw = await rawResponse(server.port);
+      expect(raw.split("\r\n")[0]).toBe("HTTP/1.1 502 Bad Gateway");
+      expect(raw).not.toContain(value);
+      expect(errors.map(error => [error.name, (error as NodeJS.ErrnoException).code, error.message])).toEqual([
+        ["TypeError", "ERR_INVALID_CHAR", invalidChar(reported)],
+      ]);
+    });
+
+    it.each([
+      ["an in-memory body", () => "hello"],
+      ["a file body", () => file(import.meta.path)],
+    ])("is rejected when registered as a static route with %s", (_kind, body) => {
+      expect(() =>
+        Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          routes: { "/": new Response(body(), { headers: { [header]: value } }) },
+        }),
+      ).toThrow(invalidChar(reported));
+    });
+
+    // An HTML import's manifest carries per-file headers straight to the same
+    // static/file route writers, bypassing the Response constructor entirely.
+    it("is rejected in an HTML import manifest", () => {
+      using dir = tempDir("serve-html-manifest-header", { "index.html": "<!DOCTYPE html><html></html>" });
+      const manifest = {
+        index: "./index.html",
+        files: [
+          {
+            input: "index.html",
+            path: join(String(dir), "index.html"),
+            loader: "html",
+            isEntry: true,
+            headers: { [header]: value },
+          },
+        ],
+      };
+
+      expect(() => Bun.serve({ port: 0, hostname: "127.0.0.1", routes: { "/": manifest } })).toThrow(
+        invalidChar(reported),
+      );
+    });
+
+    // The 101 response carries `options.headers` verbatim, so upgrade() has to
+    // refuse the same values. It throws inside the fetch handler, like
+    // `setHeader` would, rather than writing them after the status line.
+    it("is rejected by server.upgrade()", async () => {
+      const errors: Error[] = [];
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch(request, server) {
+          try {
+            server.upgrade(request, { headers: { [header]: value } });
+            return new Response("upgraded");
+          } catch (error) {
+            errors.push(error as Error);
+            return new Response("rejected", { status: 400 });
+          }
+        },
+        websocket: { message() {} },
+      });
+
+      const { resolve, reject, promise } = Promise.withResolvers<void>();
+      const socket = new WebSocket(server.url);
+      socket.onopen = () => reject(new Error("handshake should not have succeeded"));
+      socket.onerror = () => resolve();
+      socket.onclose = () => resolve();
+      await promise;
+
+      expect(errors.map(error => [error.name, (error as NodeJS.ErrnoException).code, error.message])).toEqual([
+        ["TypeError", "ERR_INVALID_CHAR", invalidChar(reported)],
+      ]);
+    });
+  });
+
+  // uWS echoes these two into the 101 response through its upgrade arguments
+  // rather than the header map, so they never pass through `options.headers`.
+  // Their value can also come from a mutated `request.headers` or straight off
+  // the client's request, and all three reach the wire.
+  describe.each(["sec-websocket-protocol", "sec-websocket-extensions"])("%s", header => {
+    it("is rejected by server.upgrade() when it comes from request.headers", async () => {
+      const errors: Error[] = [];
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch(request, server) {
+          request.headers.set(header, "a\x01b");
+          try {
+            server.upgrade(request);
+            return new Response("upgraded");
+          } catch (error) {
+            errors.push(error as Error);
+            return new Response("rejected", { status: 400 });
+          }
+        },
+        websocket: { message() {} },
+      });
+
+      const { resolve, reject, promise } = Promise.withResolvers<void>();
+      const socket = new WebSocket(server.url);
+      socket.onopen = () => reject(new Error("handshake should not have succeeded"));
+      socket.onerror = () => resolve();
+      socket.onclose = () => resolve();
+      await promise;
+
+      expect(errors.map(error => [error.name, (error as NodeJS.ErrnoException).code, error.message])).toEqual([
+        ["TypeError", "ERR_INVALID_CHAR", invalidChar(header)],
+      ]);
+    });
+
+    // uWS's request parser rejects bytes below SP in a field-value but lets DEL
+    // through, so a client can hand the server one it must not echo back.
+    it("is rejected by server.upgrade() when the client sends DEL in it", async () => {
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch(request, server) {
+          try {
+            server.upgrade(request);
+            return new Response("upgraded");
+          } catch {
+            return new Response("rejected", { status: 400 });
+          }
+        },
+        websocket: { message() {} },
+      });
+
+      const raw = await rawHandshake(server.port, `${header}: a\x7fb\r\n`);
+      expect(raw.split("\r\n")[0]).toBe("HTTP/1.1 400 Bad Request");
+      expect(raw).not.toContain("\x7f");
+    });
+  });
+
+  // Bun reports the synthesized error the same way it reports a thrown one, which
+  // would fail this test process, so the default 500 page is checked in a child.
+  // An error() handler that returns an equally unwritable Response -- directly or
+  // through a promise -- falls back to that page instead of writing the bytes.
+  it("responds 500 with no error() handler, and when error() returns one too", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const bad = () => new Response("hello", { headers: { "Set-Cookie": "k=a\\x01b" } });
+        const servers = [
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: bad }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: bad, error: bad }),
+          Bun.serve({ port: 0, hostname: "127.0.0.1", development: false, fetch: bad, error: async () => bad() }),
+        ];
+        for (const server of servers) {
+          const response = await fetch(server.url);
+          console.log(response.status, await response.text());
+          server.stop(true);
+        }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("500 Something went wrong!\n".repeat(3));
+    expect(stderr).toContain(invalidChar("set-cookie"));
+  });
+
+  // `new Response(Bun.file(path))` derives `Content-Disposition: filename="..."`
+  // from the file name, which an app serving user uploads does not control.
+  // Windows cannot name a file this way, so only POSIX can reach it.
+  describe.skipIf(!isPosix)("the auto Content-Disposition filename", () => {
+    it.each([
+      ["is dropped when the file name holds a control character", "a\x01b.bin", null],
+      ["is dropped when the file name holds DEL", "a\x7fb.bin", null],
+      // `filename="a\"` escapes the closing quote, leaving the value unterminated.
+      ["is dropped when the file name holds a backslash", "a\\b.bin", null],
+      ["is kept for a writable file name", "a~b.bin", 'filename="a~b.bin"'],
+    ])("%s", async (_label, name, expected) => {
+      using dir = tempDir("serve-content-disposition", { [name]: "x" });
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        fetch: () => new Response(file(join(String(dir), name))),
+      });
+
+      // Nothing the field-value grammar excludes reaches the socket. CR and LF
+      // are the message's own framing, and the body here is a single `x`.
+      expect(await rawResponse(server.port)).not.toMatch(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/);
+      const response = await fetch(server.url);
+      expect(await response.text()).toBe("x");
+      expect(response.headers.get("content-disposition")).toBe(expected);
+    });
+  });
+
+  // The rule is RFC 9110's `field-vchar / SP / HTAB`, not "ASCII printable":
+  // rejecting more than that would break header values that are legal today.
+  // `~` (0x7e) and SP (0x20) sit right next to the two rejected boundaries.
+  it.each([
+    ["interior HTAB", "a\tb"],
+    ["interior space", "a b"],
+    ["obs-text", "caf\u00e9"],
+    ["VCHAR below DEL", "a~b"],
+  ])("still writes %s", async (_label, value) => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      fetch: () => new Response("hello", { headers: { "X-Request-Id": value } }),
+      error: error => new Response(error.message, { status: 502 }),
+    });
+
+    // The value has to reach the client intact, not merely escape rejection: a
+    // silent drop would satisfy a status-only assertion.
+    const response = await fetch(server.url);
+    expect(response.headers.get("x-request-id")).toBe(value);
+    expect(await response.text()).toBe("hello");
+    expect(response.status).toBe(200);
+  });
+});
+
 describe("response framing", () => {
   type RawResponse = { statusLine: string; headerNames: string[]; headers: Record<string, string>; body: string };
   // Read the raw response so that `Content-Length: 0` and an absent

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1989,6 +1989,29 @@ describe("HTTP Server Security Tests - Advanced", () => {
       expect(response).toInclude("200 Everything Is Fine");
       expect(response).toInclude("ok");
     });
+
+    // `setHeader`/`writeHead` validate header values in JS, but the native handle
+    // underneath also writes field-values straight out of a `Headers` object, which
+    // the Fetch spec lets hold C0 controls and DEL. It has to refuse them too.
+    test("rejects a control character in a Headers value passed to the native writeHead()", async () => {
+      const { promise: errorPromise, resolve: resolveError } = Promise.withResolvers<Error>();
+      server.on("request", (req, res) => {
+        const handle = res[Object.getOwnPropertySymbols(res).find(symbol => symbol.description === "handle")!];
+        try {
+          handle.writeHead(200, "OK", new Headers({ "set-cookie": "k=a\x01b" }));
+        } catch (e: any) {
+          resolveError(e);
+        }
+        res.end("safe");
+      });
+
+      const response = (await sendRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")) as string;
+      const err = await errorPromise;
+      expect((err as any).code).toBe("ERR_INVALID_CHAR");
+      expect(err.message).toBe('Invalid character in header content ["set-cookie"]');
+      expect(response).not.toInclude("set-cookie");
+      expect(response).toInclude("safe");
+    });
   });
 
   test("Server should not crash in clientError is emitted when calling destroy", async () => {


### PR DESCRIPTION
## What

`Bun.serve` writes response header **values** containing C0 control octets and DEL (`0x01`-`0x08`, `0x0B`, `0x0C`, `0x0E`-`0x1F`, `0x7F`) onto the wire verbatim. The result is an RFC 9110-invalid response that bun's own `fetch()` then refuses to parse. Node's server APIs refuse to *write* such a value (`ERR_INVALID_CHAR`), so the same handler code cannot emit the malformed response on node.

```js
const BAD = "k=a\x01b";
using srv = Bun.serve({ port: 0, fetch: () => new Response("hello", { headers: { "Set-Cookie": BAD } }) });

console.log("Headers accepts it:", !!new Headers({ "set-cookie": BAD }));
try { await fetch(`http://127.0.0.1:${srv.port}/`); } catch (e) { console.log("fetch:", e.message); }
```

```
Headers accepts it: true
wire header bytes: "set-cookie: k=a\u0001b"     <- the CTL octet goes on the wire
bun fetch() of bun's own response: FETCH FAILED: Malformed_HTTP_Response
```

Any handler reflecting an unvetted string into a header (cookie values, `Location`, `Content-Disposition` filenames, request-id echoes) emits a response that bun's own client and strict proxies reject while lenient intermediaries pass through.

## Cause

The `Headers` object accepting the value is correct: the Fetch spec's [header value](https://fetch.spec.whatwg.org/#header-value) definition only excludes NUL and HTTP newline bytes, and node/undici agree. The missing piece is validation at the HTTP/1 serializer. `writeFetchHeadersToUWSResponse` (`src/jsc/bindings/NodeHTTP.cpp`) memcpys each value into the response with no `field-content` check, so everything `Headers` allows reaches the socket.

Node draws the line in `_http_outgoing`'s `validateHeaderValue` / `checkInvalidHeaderChar` (`/[^\t\x20-\x7e\x80-\xff]/`), which throws `TypeError [ERR_INVALID_CHAR]`. Bun's `node:http` already does the same in JS; only `Bun.serve`'s `Response` path was unguarded.

## Fix

A new `WebCore__FetchHeaders__findInvalidValueHeaderName` scans a `FetchHeaders` for the first value that is not a valid RFC 9110 §5.5 `field-value` (`field-vchar` = VCHAR / obs-text, plus SP and HTAB) and names it. It walks exactly the three collections the serializer writes (`getSetCookieHeaders`, `commonHeaders`, `uncommonHeaders`), so scan and writer cannot disagree.

Every place a user-controlled `Response`'s headers reach the wire now runs it before a single byte is written:

| Path | Behavior |
| --- | --- |
| `fetch` handler's `Response` (sync, promise, inline-fulfilled) | `ERR_INVALID_CHAR` to the `error()` handler, so 500 instead of a broken response. Extends the existing `reject_unsendable_response`, which already does this for a status outside `100..=999`. |
| `error()` handler's own `Response` | Falls through to the default error page, matching what it already does for an unsendable status. |
| `routes: { "/": new Response(...) }` (static and `Bun.file` routes) | Throws from `Bun.serve()`. |
| HTML import manifest per-file `headers` | Throws from `Bun.serve()`. |
| `server.upgrade(req, { headers })` (both paths) | Throws inside the handler, before `101 Switching Protocols` is written. |
| native `NodeHTTPResponse.writeHead(..., Headers)` | Throws, alongside the `statusMessage` check already there. |

The error message and `.code` match what `node:http`'s `setHeader` already throws in bun: `TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["set-cookie"]`.

Two adjacent holes in the same class, closed here too:

- The auto `Content-Disposition: filename="..."` header derived from `Bun.file()` already skipped CR/LF/NUL/`"`; it now skips the whole unwritable set, plus `\` (which escapes the closing quote and leaves the value unterminated).
- `server.upgrade`'s `Sec-WebSocket-Protocol` / `Sec-WebSocket-Extensions`, which uWS writes through its own upgrade arguments rather than the header map.

Nothing legal is newly rejected: obs-text (`café`), interior SP and HTAB, and VCHAR up to `~` all still go on the wire. Values with code units above `0xFF` were already rejected by `Headers` itself (WebIDL `ByteString`), same as node/undici.

## Verification

```
bun bd test test/js/bun/http/serve.test.ts -t "cannot be written to the wire"   # 37 pass, 0 fail
USE_SYSTEM_BUN=1 bun test <same>                                                 # 28 fail
```

The 9 that pass on stock bun are the ones that assert the negative contract (`Headers` still accepts the values; valid values are still written), which is the point.

<details>
<summary>Full test coverage added</summary>

`test/js/bun/http/serve.test.ts`, next to the existing `Response.error()` unsendable-response block:

- Four offenders across the three header storage classes: SOH and DEL in `set-cookie`, form feed in a common header (`Location`), unit separator in an uncommon header (`X-Request-Id`).
- For each: sync and async `fetch` handler, static route with an in-memory body, static route with a `Bun.file` body, HTML import manifest, and `server.upgrade()`. Each asserts the raw socket bytes never carry the value, the error's `name`/`code`/`message`, and that the reported name is the lowercase form `Headers.keys()` exposes.
- No `error()` handler, and an `error()` handler that returns an equally unwritable `Response` (directly and through a promise): default 500 page, checked in a child process.
- The auto `Content-Disposition` filename: dropped for a control character, DEL, and a backslash; kept for `a~b.bin`.
- Negative contract: interior HTAB, interior space, obs-text, and `~` (0x7E, the VCHAR adjacent to DEL) still reach the client.

`test/js/node/http/node-http.test.ts`, in the existing `Response Splitting Protection` block: the native `writeHead(status, message, Headers)` entry point.

</details>

Also run: `bun-serve-headers`, `bun-serve-static`, `bun-serve-routes`, `bun-serve-file`, `bun-serve-cookies`, `bun-serve-html`, `bun-serve-html-manifest`, `websocket-server-upgrade-reentrant`, and the full `serve.test.ts` / `node-http.test.ts`. No new failures.
