### PR TITLE
net: give every listen failure Node's error shape

### DIFF
--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -54,9 +54,8 @@ let util: typeof import("node:util");
 class ExceptionWithHostPort extends Error {
   errno: number;
   syscall: string;
+  port?: number;
   address: string;
-  // `declare` keeps `port` off the instances that have none, the way Node's errors do.
-  declare port?: number;
 
   constructor(err: number, syscall: string, address: string, port?: number) {
     // TODO(joyeecheung): We have to use the type-checked

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -54,8 +54,9 @@ let util: typeof import("node:util");
 class ExceptionWithHostPort extends Error {
   errno: number;
   syscall: string;
-  port?: number;
   address: string;
+  // `declare` keeps `port` off the instances that have none, the way Node's errors do.
+  declare port?: number;
 
   constructor(err: number, syscall: string, address: string, port?: number) {
     // TODO(joyeecheung): We have to use the type-checked
@@ -72,6 +73,60 @@ class ExceptionWithHostPort extends Error {
     }
 
     super(`${syscall} ${code}${details}`);
+
+    this.errno = err;
+    this.code = code;
+    this.syscall = syscall;
+    this.address = address;
+    if (port) {
+      this.port = port;
+    }
+  }
+  get ["constructor"]() {
+    return Error;
+  }
+}
+
+let uvBinding: any;
+let uvErrorMap: Map<number, [string, string]>;
+const uvUnmappedError = ["UNKNOWN", "unknown error"];
+
+function lazyUV() {
+  return (uvBinding ??= process.binding("uv"));
+}
+
+/** The libuv errno for a system error code, e.g. `"EACCES"` -> `-13`. `undefined` if libuv has no such code. */
+function uvErrnoFromCode(code: string): number | undefined {
+  return lazyUV()["UV_" + code];
+}
+
+/** `[code, description]` for a libuv errno, e.g. `-13` -> `["EACCES", "permission denied"]`. */
+function uvErrmapGet(errno: number) {
+  uvErrorMap ??= lazyUV().getErrorMap();
+  return uvErrorMap.$get(errno);
+}
+
+/**
+ * Node's `uvExceptionWithHostPort`: `"<syscall> <CODE>: <description> <address>"`.
+ * https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/errors.js#L692
+ */
+class UVExceptionWithHostPort extends Error {
+  errno: number;
+  syscall: string;
+  address: string;
+  // `declare` keeps `port` off the instances that have none, the way Node's errors do.
+  declare port?: number;
+
+  constructor(err: number, syscall: string, address: string, port?: number) {
+    const { 0: code, 1: uvmsg } = uvErrmapGet(err) || uvUnmappedError;
+    let details = "";
+    if (port && port > 0) {
+      details = ` ${address}:${port}`;
+    } else if (address) {
+      details = ` ${address}`;
+    }
+
+    super(`${syscall} ${code}: ${uvmsg}${details}`);
 
     this.errno = err;
     this.code = code;
@@ -277,6 +332,8 @@ export default {
   hideFromStack,
   warnNotImplementedOnce,
   ExceptionWithHostPort,
+  UVExceptionWithHostPort,
+  uvErrnoFromCode,
   NodeAggregateError,
   ConnResetException,
   ErrnoException,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -28,6 +28,8 @@ let dns: typeof import("node:dns");
 const normalizedArgsSymbol = Symbol("normalizedArgs");
 const {
   ExceptionWithHostPort,
+  UVExceptionWithHostPort,
+  uvErrnoFromCode,
   ConnResetException,
   NodeAggregateError,
   ErrnoException,
@@ -3431,7 +3433,7 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
     );
   } catch (err) {
     const isUnix = path != null;
-    setTimeout(emitErrorNextTick, 1, this, formatListenError(err, isUnix ? path : hostname, isUnix ? undefined : port));
+    setTimeout(emitErrorNextTick, 1, this, formatListenError(err, isUnix ? path : hostname, isUnix ? -1 : port));
   }
   return this;
 };
@@ -3726,36 +3728,20 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
   }
 }
 
-// Reformat a native listen error to Node's "listen <CODE>: <description> <addr>"
-// (Node uses exceptionWithHostPort). Only rewrites known uv codes; the code is
-// already set natively.
+// Reshape a native listen failure into the error Node builds with
+// uvExceptionWithHostPort(): "listen <CODE>: <description> <address>", the
+// negative libuv errno, and the address/port as own properties.
+// A pipe listen is signalled by port === -1, the way Node encodes it.
 // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L1899
-function uvListenErrorDescription(code) {
-  switch (code) {
-    case "EADDRINUSE":
-      return "address already in use";
-    case "EACCES":
-      return "permission denied";
-    case "EADDRNOTAVAIL":
-      return "address not available";
-    case "EINVAL":
-      return "invalid argument";
-    default:
-      return undefined;
-  }
-}
 function formatListenError(err, address, port) {
-  const desc = err && typeof err.code === "string" ? uvListenErrorDescription(err.code) : undefined;
-  if (desc) {
-    err.syscall = "listen";
-    // Node's exceptionWithHostPort also exposes the failing address/port as
-    // own properties; user code commonly reads them off listen errors.
-    err.address = address;
-    if (port) err.port = port;
-    const where = port ? `${address}:${port}` : address;
-    err.message = `listen ${err.code}: ${desc}${where ? ` ${where}` : ""}`;
-  }
-  return err;
+  // Argument validation and the readableAll/writableAll chmod reach this path
+  // too; only the native bind/listen failure carries syscall === "listen".
+  if (!err || err.syscall !== "listen" || typeof err.code !== "string") return err;
+  // libuv's uv_pipe_bind reports a pipe path it cannot reach as EACCES.
+  const code = port === -1 && err.code === "ENOENT" ? "EACCES" : err.code;
+  const errno = uvErrnoFromCode(code);
+  if (errno === undefined) return err;
+  return new UVExceptionWithHostPort(errno, "listen", address, port);
 }
 
 function checkBindError(err, port, handle) {

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -27,6 +27,14 @@ test/js/node/test/parallel/test-inspector-enabled.js [ FAIL ]
 # alpine 3.23 x64 + x64-baseline only).
 [ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # JSC FinalizationRegistry callback delivery vs setImmediate timing on musl x64
 
+# The net twin of the test above: same body, net.createConnection() instead of
+# tls.connect(), so the same FinalizationRegistry-vs-setImmediate race. It also
+# tipped over on alpine 3.23 x64 + x64-baseline only (build 68957), once this
+# PR's additions to internal/shared.ts shifted startup heap layout again. The
+# connect listener IS removed (verified: listenerCount("connect") === 0 after
+# the callback fires) and the test passes 10/10 on glibc Linux.
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-net-connect-memleak.js [ FLAKY ] # JSC FinalizationRegistry callback delivery vs setImmediate timing on musl x64
+
 # Vendored node v26.3.0 stream tests blocked on missing native subsystems (see PR #31826)
 test/js/node/test/parallel/test-stream-pipeline.js [ SKIP ] # block at L271 hangs: pipeline(rs, req) writes 11x'hello' raw after a never-ended GET's \r\n\r\n; node's llhttp rejects lowercase 'h' as a method char (HPE_INVALID_METHOD -> clientError -> 400+close -> req 'close' -> pipeline callback fires), but bun's uWS HttpParser buffers any incomplete run of valid tchars waiting for the request-line, so the connection stays open and the callback never fires. Pre-existing server-parser leniency; needs uWS HttpParser to reject non-uppercase method bytes like llhttp.
 test/js/node/test/parallel/test-stream-wrap.js [ FAIL ] # needs internal/test/binding + js_stream (net.Socket({handle}) libuv compat layer)

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -1,8 +1,9 @@
 import { realpathSync } from "fs";
+import { isWindows, tempDir } from "harness";
 import { AddressInfo, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
-import { tmpdir } from "os";
+import { constants, tmpdir } from "os";
 import { join } from "path";
 
 const { describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
@@ -566,6 +567,89 @@ describe("net.createServer events", () => {
       client.end();
     } finally {
       server.close();
+    }
+  });
+});
+
+describe("net.Server listen errors", () => {
+  // Node shapes every listen failure with uvExceptionWithHostPort():
+  // "listen <CODE>: <description> <address>", errno is the negative libuv code,
+  // and the failing address/port are own properties. A pipe listen reports port -1.
+  async function listenError(options: object) {
+    const server = createServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    server.on("error", resolve);
+    server.once("listening", () => {
+      server.close();
+      reject(new Error("expected listen() to fail, but the server started listening"));
+    });
+    server.listen(options as any);
+    return await promise;
+  }
+
+  function shapeOf(err: any) {
+    return {
+      code: err.code,
+      errno: err.errno,
+      syscall: err.syscall,
+      address: err.address,
+      port: err.port,
+      hasOwnPort: Object.hasOwn(err, "port"),
+      message: err.message,
+    };
+  }
+
+  // libuv's uv_pipe_bind converts a bind() ENOENT into EACCES, so Node never
+  // reports ENOENT for a unix socket whose directory does not exist.
+  it.skipIf(isWindows)("a unix socket in a missing directory reports EACCES", async () => {
+    using dir = tempDir("netlisten", {});
+    const path = join(String(dir), "does-not-exist", "x.sock");
+
+    expect(shapeOf(await listenError({ path }))).toEqual({
+      code: "EACCES",
+      errno: -13,
+      syscall: "listen",
+      address: path,
+      port: -1,
+      hasOwnPort: true,
+      message: `listen EACCES: permission denied ${path}`,
+    });
+  });
+
+  // ENOTDIR is not one of the handful of codes Bun used to know how to format.
+  it.skipIf(isWindows)("a unix socket under a non-directory reports ENOTDIR in Node's shape", async () => {
+    using dir = tempDir("netlisten", { "file.txt": "" });
+    const path = join(String(dir), "file.txt", "x.sock");
+
+    expect(shapeOf(await listenError({ path }))).toEqual({
+      code: "ENOTDIR",
+      errno: -20,
+      syscall: "listen",
+      address: path,
+      port: -1,
+      hasOwnPort: true,
+      message: `listen ENOTDIR: not a directory ${path}`,
+    });
+  });
+
+  it("a TCP listen failure carries the negative libuv errno", async () => {
+    const taken = createServer();
+    try {
+      taken.listen(0, "127.0.0.1");
+      await once(taken, "listening");
+      const { port } = taken.address() as AddressInfo;
+
+      expect(shapeOf(await listenError({ host: "127.0.0.1", port }))).toEqual({
+        code: "EADDRINUSE",
+        errno: -constants.errno.EADDRINUSE,
+        syscall: "listen",
+        address: "127.0.0.1",
+        port,
+        hasOwnPort: true,
+        message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}`,
+      });
+    } finally {
+      taken.close();
     }
   });
 });

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -652,4 +652,19 @@ describe("net.Server listen errors", () => {
       taken.close();
     }
   });
+
+  // Node exposes `port` only when there is one (`if (port) ex.port = port`), so an
+  // ephemeral-port listen that never got a port must not carry it at all.
+  // 192.0.2.0/24 is TEST-NET-1 (RFC 5737): never assigned to an interface.
+  it("a listen failure with no port does not expose a port property", async () => {
+    expect(shapeOf(await listenError({ host: "192.0.2.1", port: 0 }))).toEqual({
+      code: "EADDRNOTAVAIL",
+      errno: -constants.errno.EADDRNOTAVAIL,
+      syscall: "listen",
+      address: "192.0.2.1",
+      port: undefined,
+      hasOwnPort: false,
+      message: "listen EADDRNOTAVAIL: address not available 192.0.2.1",
+    });
+  });
 });


### PR DESCRIPTION
## Repro

```js
import net from "node:net";
import fs from "node:fs";
import os from "node:os";

const dir = fs.mkdtempSync(`${os.tmpdir()}/nsrv-`);
const path = `${dir}/does-not-exist/x.sock`; // parent directory is missing

const s = net.createServer();
s.on("error", e => {
  console.log({ code: e.code, errno: e.errno, port: e.port, message: e.message });
  process.exit(0);
});
s.listen(path);
```

```
node: { code: 'EACCES',  errno: -13, port: -1,        message: 'listen EACCES: permission denied <path>' }
bun:  { code: 'ENOENT',  errno: 2,   port: undefined, message: 'Failed to listen at <path>' }
```

## Cause

Two separate divergences in `node:net`.

1. libuv's `uv_pipe_bind` deliberately converts a pipe `bind()` `ENOENT` into
   `UV_EACCES`, so Node never reports `ENOENT` for a unix socket whose
   directory is missing. Bun surfaced the raw `ENOENT`, which breaks every
   `if (err.code === 'EACCES')` recovery path around unix-socket servers.

2. Node formats *every* listen failure with `uvExceptionWithHostPort()`:
   `"listen <CODE>: <description> <address>"`, `errno` is the negative libuv
   code, and the failing `address`/`port` are own properties (a pipe listen
   reports `port: -1`). Bun's `formatListenError` only rewrote a hardcoded
   table of four codes (`EADDRINUSE|EACCES|EADDRNOTAVAIL|EINVAL`), left `errno`
   positive, and never set `port` for a pipe. Anything outside that table kept
   the internal `"Failed to listen at ..."` text, e.g. a socket path under a
   regular file:

   ```
   node: listen ENOTDIR: not a directory /tmp/x/file.txt/y.sock
   bun:  Failed to listen at /tmp/x/file.txt/y.sock
   ```

   The errno sign is not cosmetic: `util.getSystemErrorName()` takes the
   negative libuv code, so on `main` the most ordinary thing you can do with a
   listen error throws.

   ```js
   server.on("error", e => util.getSystemErrorName(e.errno));
   // main:     throws ERR_OUT_OF_RANGE  (errno is +98)
   // node:     "EADDRINUSE"
   // this PR:  "EADDRINUSE"
   ```

## Fix

- `internal/shared.ts` gains `UVExceptionWithHostPort`, a port of Node's
  `uvExceptionWithHostPort`, next to the existing `ExceptionWithHostPort`. It
  reads the code/description pair out of `process.binding("uv").getErrorMap()`,
  which Bun already exposes, so every libuv code is covered rather than four.
- `formatListenError` now rebuilds the error through it: the negative libuv
  errno, Node's message, and `address`/`port` own properties. A pipe bind's
  `ENOENT` becomes `EACCES`, mirroring `uv_pipe_bind`. Errors that are not
  native listen failures (argument validation, the `readableAll`/`writableAll`
  chmod) are passed through untouched.
- `port` on `UVExceptionWithHostPort` is `declare`d, so a listen error without a
  port no longer carries `port: undefined` as an own property, matching Node.
  `ExceptionWithHostPort` (net `connect`/`bind`, dgram `send`) is untouched.

## Verification

`bun bd test test/js/node/net/node-net-server.test.ts` — 22 pass, 0 fail. The
four new tests in `net.Server listen errors` fail on the released binary
(`ENOENT` vs `EACCES`, `errno` sign, `"Failed to listen at"`, a `port: 0` own
property Node omits) and pass with the fix.

<details>
<summary>Every listen failure now matches Node byte for byte</summary>

|   | node v26.3.0 | bun (this branch) |
|---|---|---|
| missing parent dir | `EACCES` / `-13` / `port -1` / `listen EACCES: permission denied <path>` | same |
| path under a file | `ENOTDIR` / `-20` / `port -1` / `listen ENOTDIR: not a directory <path>` | same |
| path too long | `EINVAL` / `-22` / `port -1` / `listen EINVAL: invalid argument <path>` | same |
| existing socket file | `EADDRINUSE` / `-98` / `port -1` / `listen EADDRINUSE: address already in use <path>` | same |
| tcp address not available | `EADDRNOTAVAIL` / `-99` / no `port` / `listen EADDRNOTAVAIL: address not available 1.2.3.4` | same |
| tcp port in use | `EADDRINUSE` / `-98` / `port 43533` / `listen EADDRINUSE: address already in use 127.0.0.1:43533` | same |

The own-property set (`address,code,errno,message,port,syscall`) matches in
every row.
</details>

All upstream `test-net-*` and `test-dgram-*` parallel tests pass, as do
`test-net-eaddrinuse`, `test-net-server-listen-path`, `test-net-bind-twice`,
`test-http-bind-twice`, `test-cluster-eaddrinuse`, and
`test/js/node/http/node-http.test.ts`.

The two unix-socket tests are POSIX-only: on Windows a filesystem path is not a
pipe name, so neither runtime takes this code path.

