### PR TITLE
Report a CommonJS entry point's top-level throw as uncaughtException

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -158,6 +158,9 @@ pub struct VirtualMachine {
     /// `main()`.
     main: bun_ptr::RawSlice<u8>,
     pub main_is_html_entrypoint: bool,
+    /// Whether the entry module was instantiated as CommonJS. Set by the module
+    /// loader, reset by `set_main`.
+    pub main_is_commonjs: bool,
     pub main_resolved_path: bun_core::String,
     pub main_hash: u32,
     /// Set if code overrides Bun.main to a custom value.
@@ -366,6 +369,7 @@ unsafe extern "C" {
         promise: JSValue,
     ) -> c_int;
     safe fn Bun__emitHandledPromiseEvent(global: &JSGlobalObject, promise: JSValue) -> bool;
+    safe fn Bun__hasUncaughtExceptionCaptureCallback(global: &JSGlobalObject) -> bool;
 
     safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: u8);
     safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8);
@@ -1375,6 +1379,13 @@ impl VirtualMachine {
         bun_core::env_var::feature_flag::BUN_DESTRUCT_VM_ON_EXIT::get().unwrap_or(false)
     }
 
+    /// The `is_rejection` to report a failed entry-point evaluation with. Node
+    /// throws a CommonJS entry's error straight out of `Module._load`, and
+    /// skips its `fromPromise` funnel when a capture callback is installed.
+    pub fn entry_point_error_is_rejection(&self) -> bool {
+        !self.main_is_commonjs && !Bun__hasUncaughtExceptionCaptureCallback(self.global())
+    }
+
     pub fn uncaught_exception(
         &mut self,
         global_object: &JSGlobalObject,
@@ -2222,6 +2233,7 @@ impl VirtualMachine {
     #[inline]
     pub fn set_main(&mut self, path: &[u8]) {
         self.main = bun_ptr::RawSlice::new(path);
+        self.main_is_commonjs = false;
     }
 
     /// `eventLoop().waitForPromise(promise)` — spin tick/auto_tick until

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -908,15 +908,15 @@ JSC_DEFINE_HOST_FUNCTION(Process_setUncaughtExceptionCaptureCallback, (JSC::JSGl
     return JSC::JSValue::encode(jsUndefined());
 }
 
+extern "C" bool Bun__hasUncaughtExceptionCaptureCallback(Zig::GlobalObject* globalObject)
+{
+    JSValue cb = globalObject->processObject()->getUncaughtExceptionCaptureCallback();
+    return !cb.isEmpty() && cb.isCell();
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_hasUncaughtExceptionCaptureCallback, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    auto* zigGlobal = defaultGlobalObject(globalObject);
-    JSValue cb = zigGlobal->processObject()->getUncaughtExceptionCaptureCallback();
-    if (cb.isEmpty() || !cb.isCell()) {
-        return JSValue::encode(jsBoolean(false));
-    }
-
-    return JSValue::encode(jsBoolean(true));
+    return JSValue::encode(jsBoolean(Bun__hasUncaughtExceptionCaptureCallback(defaultGlobalObject(globalObject))));
 }
 
 extern "C" uint64_t Bun__readOriginTimer(void*);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -84,6 +84,7 @@
 #include "WebCoreJSBuiltins.h"
 
 extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const BunString*);
+extern "C" void Bun__VM__noteCommonJSModuleLoaded(JSC::JSGlobalObject* global, const BunString*);
 
 namespace Bun {
 using namespace JSC;
@@ -1543,6 +1544,12 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
                 auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
                 auto& vm = JSC::getVM(globalObject);
                 auto scope = DECLARE_THROW_SCOPE(vm);
+
+                // Record the format before the body runs: a CommonJS module that
+                // throws here is evicted from the require cache and never gets a
+                // module record, so afterwards nothing tells it apart from ESM.
+                auto keyString = Bun::toString(moduleKey.string());
+                Bun__VM__noteCommonJSModuleLoaded(globalObject, &keyString);
 
                 JSValue keyValue = identifierToJSValue(vm, moduleKey);
                 JSValue entry = globalObject->requireMap()->get(globalObject, keyValue);

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -87,6 +87,17 @@ pub fn is_bun_main(global: &JSGlobalObject, str: &BunString) -> bool {
     str.eql_utf8(global.bun_vm().as_mut().main())
 }
 
+/// Called for every CommonJS module the ES module loader instantiates, just
+/// before its body runs.
+// HOST_EXPORT(Bun__VM__noteCommonJSModuleLoaded, c)
+pub fn note_common_js_module_loaded(global: &JSGlobalObject, specifier: &BunString) {
+    // JSGlobalObject::bun_vm contract.
+    let vm = global.bun_vm().as_mut();
+    if specifier.eql_utf8(vm.main()) {
+        vm.main_is_commonjs = true;
+    }
+}
+
 /// When IPC environment variables are passed, the socket is not immediately opened,
 /// but rather we wait for process.on('message') or process.send() to be called, THEN
 /// we open the socket. This is to avoid missing messages at the start of the program.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1097,10 +1097,11 @@ impl WebWorker {
         // SAFETY: `promise` is a live JSC heap cell.
         unsafe {
             if (*promise).status() == jsc::js_promise::Status::Rejected {
+                let is_rejection = vm.entry_point_error_is_rejection();
                 let handled = vm.as_mut().uncaught_exception(
                     vm.global(),
                     (*promise).result(vm.jsc_vm()),
-                    true,
+                    is_rejection,
                 );
                 if !handled {
                     vm.as_mut().exit_handler.exit_code = 1;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1510,8 +1510,9 @@ impl Run {
                     // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
                     let result = promise.result(unsafe { &mut *vm.jsc_vm });
                     let global = vm.global;
+                    let is_rejection = vm.entry_point_error_is_rejection();
                     // SAFETY: `global` valid for VM lifetime.
-                    let handled = vm.uncaught_exception(unsafe { &*global }, result, true);
+                    let handled = vm.uncaught_exception(unsafe { &*global }, result, is_rejection);
                     promise.set_handled();
                     vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -896,6 +896,99 @@ describe.concurrent(() => {
     expect(await proc.exited).toBe(42);
   });
 
+  describe("origin reported for an entry point that throws at the top level", () => {
+    const listeners = [
+      `process.on("uncaughtExceptionMonitor", (err, origin) => console.log("monitor " + origin));`,
+      `process.on("uncaughtException", (err, origin) => console.log("handler " + origin));`,
+    ].join("\n");
+
+    async function run(files, ...args) {
+      using dir = tempDir("uncaught-exception-origin", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim().split("\n"), stderr, exitCode };
+    }
+
+    // A CommonJS entry point throws synchronously out of the require, so node
+    // reports 'uncaughtException'. Bun evaluates it through a module promise,
+    // which used to surface as 'unhandledRejection'.
+    it("is 'uncaughtException' for a CommonJS entry point", async () => {
+      const { stdout, exitCode } = await run({ "entry.cjs": `${listeners}\nthrow new Error("boom");` }, "entry.cjs");
+      expect(stdout).toEqual(["monitor uncaughtException", "handler uncaughtException"]);
+      expect(exitCode).toBe(0);
+    });
+
+    it("is 'uncaughtException' for a .js entry point in a CommonJS package", async () => {
+      const { stdout, exitCode } = await run(
+        {
+          "package.json": JSON.stringify({ name: "cjs-pkg", type: "commonjs" }),
+          "entry.js": `${listeners}\nthrow new Error("boom");`,
+        },
+        "entry.js",
+      );
+      expect(stdout).toEqual(["monitor uncaughtException", "handler uncaughtException"]);
+      expect(exitCode).toBe(0);
+    });
+
+    // `require` makes this eval a CommonJS module; without a CommonJS marker
+    // Bun evaluates ambiguous source as ESM, and reports it that way.
+    it("is 'uncaughtException' for a CommonJS -e script", async () => {
+      const { stdout, exitCode } = await run({}, "-e", `require("node:path");\n${listeners}\nthrow new Error("boom");`);
+      expect(stdout).toEqual(["monitor uncaughtException", "handler uncaughtException"]);
+      expect(exitCode).toBe(0);
+    });
+
+    // An ES module's failure genuinely is a module-evaluation promise
+    // rejection, and node attributes it that way.
+    it("is 'unhandledRejection' for an ES module entry point", async () => {
+      const { stdout, exitCode } = await run({ "entry.mjs": `${listeners}\nthrow new Error("boom");` }, "entry.mjs");
+      expect(stdout).toEqual(["monitor unhandledRejection", "handler unhandledRejection"]);
+      expect(exitCode).toBe(0);
+    });
+
+    // node's ESM entry funnel skips its `fromPromise` flag entirely when a
+    // capture callback is installed.
+    it("is 'uncaughtException' for an ES module entry point with a capture callback", async () => {
+      const { stdout, exitCode } = await run(
+        {
+          "entry.mjs": [
+            `process.on("uncaughtExceptionMonitor", (err, origin) => console.log("monitor " + origin));`,
+            `process.setUncaughtExceptionCaptureCallback(() => process.exit(0));`,
+            `throw new Error("boom");`,
+          ].join("\n"),
+        },
+        "entry.mjs",
+      );
+      expect(stdout).toEqual(["monitor uncaughtException"]);
+      expect(exitCode).toBe(0);
+    });
+
+    it("is 'uncaughtException' for a CommonJS worker entry point", async () => {
+      const { stdout, exitCode } = await run(
+        {
+          "entry.cjs": [
+            `const { Worker } = require("node:worker_threads");`,
+            `new Worker(require("node:path").join(__dirname, "worker.cjs"));`,
+          ].join("\n"),
+          "worker.cjs": [
+            listeners,
+            `process.on("uncaughtException", () => process.exit(0));`,
+            `throw new Error("boom");`,
+          ].join("\n"),
+        },
+        "entry.cjs",
+      );
+      expect(stdout).toEqual(["monitor uncaughtException", "handler uncaughtException"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("catches exceptions with process.on('unhandledRejection', fn)", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUnhandledRejection.js")]);
     expect(await proc.exited).toBe(42);


### PR DESCRIPTION
## Repro

```js
// entry.cjs
process.on("uncaughtExceptionMonitor", (e, origin) => console.log("monitor origin =", origin));
process.on("uncaughtException",        (e, origin) => console.log("handler origin =", origin));
throw new Error("boom");
```

```
node: monitor origin = uncaughtException   / handler origin = uncaughtException
bun : monitor origin = unhandledRejection  / handler origin = unhandledRejection
```

`origin` is the only way a last-resort handler can tell a synchronous exception from a rejection, so every handler that branches on it (log-and-exit vs log-and-continue, `--unhandled-rejections`-style shims, APM error taxonomies) misclassifies a top-level CommonJS failure.

## Cause

Bun evaluates every entry point, including `.cjs`, through the synthetic `bun:main` wrapper's module-evaluation promise. The two sites that surface a rejected entry-point promise therefore passed `is_rejection = true` unconditionally:

- `src/runtime/cli/run_command.rs`
- `src/jsc/web_worker.rs`

Node draws the line at the entry's module format (`lib/internal/modules/run_main.js`): a CommonJS entry throws straight out of `Module._load`, while an ES module entry goes through `triggerUncaughtException(err, true /* fromPromise */)`. The one wrinkle is that node's ESM funnel calls `process._fatalException(err)` with no `fromPromise` argument when a capture callback is installed, so that case reports `'uncaughtException'` too.

| entry | node | bun before | bun after |
| --- | --- | --- | --- |
| CommonJS | `uncaughtException` | `unhandledRejection` | `uncaughtException` |
| ES module | `unhandledRejection` | `unhandledRejection` | `unhandledRejection` |
| ES module + capture callback | `uncaughtException` | `unhandledRejection` | `uncaughtException` |

## Fix

Record on the VM whether the entry module was instantiated as CommonJS, and use it (plus the capture-callback check) to pick the origin.

The flag is set from the CommonJS synthetic-source callback, which runs for every CommonJS module the ES module loader instantiates, just before the body runs. That timing is load-bearing: nothing survives a throwing CommonJS evaluation to identify it afterwards. The module is evicted from the require cache (`JSCommonJSModule.cpp`, "On error, remove the module from the require map"), so `require.main` / `process.mainModule` are already `undefined` by then, and because a CommonJS body runs during *instantiation* rather than evaluation, a throwing CommonJS module never gets an `AbstractModuleRecord` attached to its `ModuleRegistryEntry` either.

`set_main` resets the flag, so hot reloads and worker VMs re-derive it.

### Scope

Bun evaluates ambiguous source (a plain `.js` with no CommonJS or ESM markers, and a bare `bun -e '<script>'`) as ESM, where node treats it as CommonJS. That is a pre-existing, deliberate difference, visible today as `typeof module === "undefined"` and `process.mainModule === undefined` in those files. The origin now follows Bun's own classification rather than node's extension rule, so those entries keep reporting `unhandledRejection`. Adding a CommonJS marker (`require(...)`, `module.exports`, `"type": "commonjs"`) makes them report `uncaughtException`, as covered by the tests.

## Verification

`test/js/node/process/process.test.js` gains a block covering the CommonJS entry, a `.js` entry in a `"type": "commonjs"` package, a CommonJS `-e` script, a CommonJS worker entry, the ES module entry (unchanged, as a regression guard), and the ES module + capture-callback case. Five of the six fail on `main` and pass with this change; the ES module case passes both ways.

`--unhandled-rejections=strict` / `=throw` go through a different path and keep reporting `unhandledRejection`.

<details>
<summary>Suites run against the debug build</summary>

`test/js/node/process/`, `test/js/bun/resolve/`, `test/js/node/module/`, `test/js/web/workers/`, and the CommonJS cases in `test/cli/run/` pass. Two failures reproduce on `main` without this change: `process` (the container has no `$USER`) and `load the same file 2000 times` (a timing test, too slow under debug + ASAN).

</details>