### PR TITLE
s3: stop trimming separators from object keys

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -825,20 +825,10 @@ pub mod store {
                     .unwrap_or(0)
         }
 
+        /// `bucket/key` for an `s3://bucket/key` URL, otherwise the path as
+        /// given. S3 object keys are opaque byte strings, so nothing is trimmed.
         pub fn path(&self) -> &[u8] {
-            let mut path_name = bun_url::URL::parse(self.pathlike.slice()).s3_path();
-            // normalize start and ending
-            if bun_core::strings::ends_with(path_name, b"/") {
-                path_name = &path_name[0..path_name.len()];
-            } else if bun_core::strings::ends_with(path_name, b"\\") {
-                path_name = &path_name[0..path_name.len() - 1];
-            }
-            if bun_core::strings::starts_with(path_name, b"/")
-                || bun_core::strings::starts_with(path_name, b"\\")
-            {
-                path_name = &path_name[1..];
-            }
-            path_name
+            bun_url::URL::parse(self.pathlike.slice()).s3_path()
         }
 
         pub fn init_with_referenced_credentials(

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -338,32 +338,31 @@ impl S3Credentials {
         } else {
             guess_region(&self.endpoint)
         };
-        let mut full_path = request_path;
-        // handle \\ on bucket name
-        if strings::starts_with(full_path, b"/") || strings::starts_with(full_path, b"\\") {
-            full_path = &full_path[1..];
-        }
-
-        let mut path: &[u8] = full_path;
+        let mut path: &[u8] = request_path;
         let mut bucket: &[u8] = &self.bucket;
 
-        if !self.virtual_hosted_style {
-            if bucket.is_empty() {
-                // guess bucket using path
-                if let Some(end) = strings::index_of(full_path, b"/") {
-                    bucket = &full_path[..end];
-                    path = &full_path[end + 1..];
-                } else if let Some(backslash_index) = strings::index_of(full_path, b"\\") {
-                    bucket = &full_path[..backslash_index];
-                    path = &full_path[backslash_index + 1..];
-                } else {
-                    return Err(SignError::InvalidPath);
-                }
+        if !self.virtual_hosted_style && bucket.is_empty() {
+            // No bucket configured, so the path carries it: `[/]bucket/key`.
+            // Only this form has a leading separator to drop; everywhere else
+            // the path is the object key, which is an opaque byte string.
+            let mut full_path = request_path;
+            if strings::starts_with(full_path, b"/") || strings::starts_with(full_path, b"\\") {
+                full_path = &full_path[1..];
+            }
+            if let Some(end) = strings::index_of(full_path, b"/") {
+                bucket = &full_path[..end];
+                path = &full_path[end + 1..];
+            } else if let Some(backslash_index) = strings::index_of(full_path, b"\\") {
+                bucket = &full_path[..backslash_index];
+                path = &full_path[backslash_index + 1..];
+            } else {
+                return Err(SignError::InvalidPath);
             }
         }
 
-        let path = normalize_name(path);
-        let bucket = normalize_name(bucket);
+        // A bucket name cannot contain a path separator, so trimming one is
+        // always safe; the object key is passed through untouched.
+        let bucket = strings::trim(bucket, b"/\\");
 
         // if we allow path.len == 0 it will list the bucket for now we disallow
         if !ALLOW_EMPTY_PATH && path.is_empty() {
@@ -1210,13 +1209,6 @@ pub fn encode_uri_component<'b, const ENCODE_SLASH: bool>(
 
     // `written <= buffer.len()` by construction; safe sub-slice of the owning buffer.
     Ok(&buffer[..written])
-}
-
-fn normalize_name(name: &[u8]) -> &[u8] {
-    if name.is_empty() {
-        return name;
-    }
-    strings::trim(name, b"/\\")
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -416,9 +416,12 @@ impl<'a> URL<'a> {
         }
     }
 
+    /// Everything after the `://` of an `s3://bucket/key` URL, or the whole
+    /// string when there is no protocol. `parse_protocol` only sets `protocol`
+    /// when `://` follows it, so `protocol.len() + 3` is always in bounds here.
     pub fn s3_path(&self) -> &'a [u8] {
         if !self.protocol.is_empty() && self.href.len() > self.protocol.len() + 2 {
-            &self.href[self.protocol.len() + 2..]
+            &self.href[self.protocol.len() + 3..]
         } else {
             self.href
         }

--- a/test/js/bun/s3/s3-object-key.test.ts
+++ b/test/js/bun/s3/s3-object-key.test.ts
@@ -1,0 +1,129 @@
+import { S3Client } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// S3 object keys are opaque byte strings, so `dir`, `dir/` and `/dir` name
+// three different objects. Bun must sign and send the key it was given.
+const credentials = {
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  region: "us-east-1",
+  endpoint: "http://127.0.0.1:9999",
+};
+
+function signedPath(client: S3Client, key: string): string {
+  return new URL(client.presign(key)).pathname;
+}
+
+test("presign keeps the separators an object key was given", () => {
+  const client = new S3Client({ ...credentials, bucket: "bucket" });
+
+  expect({
+    plain: signedPath(client, "dir"),
+    trailing: signedPath(client, "dir/"),
+    leading: signedPath(client, "/dir"),
+    both: signedPath(client, "/dir/"),
+    repeated: signedPath(client, "//dir//"),
+    nested: signedPath(client, "a/b/"),
+  }).toEqual({
+    plain: "/bucket/dir",
+    trailing: "/bucket/dir/",
+    leading: "/bucket//dir",
+    both: "/bucket//dir/",
+    repeated: "/bucket///dir//",
+    nested: "/bucket/a/b/",
+  });
+});
+
+test("presign keeps the separators of a virtual hosted-style object key", () => {
+  const client = new S3Client({ ...credentials, bucket: "bucket", virtualHostedStyle: true });
+
+  expect({
+    trailing: signedPath(client, "dir/"),
+    leading: signedPath(client, "/dir"),
+  }).toEqual({
+    trailing: "/dir/",
+    leading: "//dir",
+  });
+});
+
+test("an S3 file presigns the same key it reports as its name", () => {
+  const client = new S3Client({ ...credentials, bucket: "bucket" });
+  const folderMarker = client.file("a/b/");
+
+  expect(folderMarker.name).toBe("a/b/");
+  expect(new URL(folderMarker.presign()).pathname).toBe("/bucket/a/b/");
+});
+
+const fixture = /* ts */ `
+const requests: string[] = [];
+await using server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    requests.push(req.method + " " + new URL(req.url).pathname);
+    return new Response("", { headers: { ETag: '"etag"' } });
+  },
+});
+
+const credentials = {
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  region: "us-east-1",
+  endpoint: "http://127.0.0.1:" + server.port,
+};
+
+const client = new Bun.S3Client({ ...credentials, bucket: "bucket" });
+await client.write("dir/", "value");
+await client.write("dir", "value");
+await client.file("/lead").text();
+await client.file("a/").exists();
+await client.delete("x/y/");
+
+// With no bucket configured the first path segment is the bucket; the rest of
+// the path is still the object key verbatim.
+const fromPath = new Bun.S3Client(credentials);
+await fromPath.write("s3://other/dir/", "value");
+await fromPath.write("other/nested/dir/", "value");
+
+console.log(JSON.stringify(requests));
+`;
+
+test("the object key reaches the wire untrimmed", async () => {
+  using dir = tempDir("s3-object-key", { "key-fixture.ts": fixture });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "key-fixture.ts"],
+    // Bun.S3Client ignores NO_PROXY, so an inherited proxy would hijack the
+    // requests aimed at the stub server. The bucket must come from the client.
+    env: {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+      S3_BUCKET: undefined,
+      AWS_BUCKET: undefined,
+      S3_ENDPOINT: undefined,
+      AWS_ENDPOINT: undefined,
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // stderr only joins the assertion when the child failed: a successful debug
+  // or ASAN build still writes benign warnings there.
+  const requests = exitCode === 0 ? JSON.parse(stdout.trim() || "null") : { exitCode, stdout, stderr };
+
+  expect(requests).toEqual([
+    "PUT /bucket/dir/",
+    "PUT /bucket/dir",
+    "GET /bucket//lead",
+    "HEAD /bucket/a/",
+    "DELETE /bucket/x/y/",
+    "PUT /other/dir/",
+    "PUT /other/nested/dir/",
+  ]);
+});


### PR DESCRIPTION
### Repro

```ts
const client = new Bun.S3Client({ bucket: "b", /* ...credentials */ });

client.presign("dir/");  // -> http://.../b/dir    a different object
client.presign("/lead"); // -> http://.../b/lead
client.presign("//a");   // -> http://.../b/a
await client.write("dir/", "v");      // PUT /b/dir
await client.file("a/").exists();     // HEAD /b/a
await client.delete("x/y/");          // DELETE /b/x/y
```

`"dir/"`, `"/lead"`, `"a"` and `"a/"` are all distinct, legal S3 object keys, and `"<prefix>/"` zero-byte keys are the folder marker the S3 console and most tools create for every folder. aws-sdk-js, the AWS CLI and MinIO clients address all of these verbatim. Bun read, wrote, overwrote and deleted a different object than the one it was asked for, and every operation succeeded, so the caller never saw it.

### Cause

Two layers trimmed the key:

- `S3::path()` (`src/jsc/webcore_types.rs`) stripped a leading `/` or `\` and a trailing `\`.
- `sign_request` (`src/s3_signing/credentials.rs`) stripped another leading separator, then ran the key through `normalize_name` = `strings::trim(name, "/\\")`, which removes every `/` and `\` from both ends.

The leading-separator strip is load-bearing for one form only: when no bucket is configured, the path carries it (`[/]bucket/key`, which is also the shape `s3://bucket/key` arrives in). It was applied unconditionally.

### Fix

The object key is passed through untouched. The single leading separator is now dropped only inside the branch that splits the bucket out of the path, and `URL::s3_path()` returns everything after `://` so the `s3://bucket/key` form arrives in that same shape instead of carrying a leading `/`. The bucket name is still trimmed, since a bucket name cannot contain a separator (`test/js/bun/s3/s3.test.ts` covers `/buntest/`-style bucket names against MinIO).

`file("/lead")` now addresses the key `/lead` rather than `lead`, which is what every other S3 client does with that key.

An in-key `\` still reaches the wire as `/` because `encode_uri_component` rewrites it. That is a separate bug, fixed by #33295; this PR deliberately leaves `encode_uri_component` alone.

### Verification

`test/js/bun/s3/s3-object-key.test.ts` asserts the signed path for a matrix of keys (`dir`, `dir/`, `/dir`, `/dir/`, `//dir//`, `a/b/`), both path-style and virtual hosted-style, and spawns a fixture that runs a `Bun.serve` stub and checks the literal request lines for `write`, `text`, `exists` and `delete`, with and without a configured bucket.

<details>
<summary>before the fix (4 fail)</summary>

```
  [
-   "PUT /bucket/dir/",
    "PUT /bucket/dir",
-   "GET /bucket//lead",
-   "HEAD /bucket/a/",
-   "DELETE /bucket/x/y/",
-   "PUT /other/dir/",
-   "PUT /other/nested/dir/",
+   "PUT /bucket/dir",
+   "GET /bucket/lead",
+   "HEAD /bucket/a",
+   "DELETE /bucket/x/y",
+   "PUT /other/dir",
+   "PUT /other/nested/dir",
  ]
```

</details>

`bun bd test test/js/bun/s3/` is green (91 pass, 0 fail). `fetch("s3://bucket/dir/")`, `Bun.write("s3://bucket/dir/", …)`, `Bun.s3.file(…).text()/.unlink()/.exists()` and the multipart upload path were all checked against the same stub server.
