### PR TITLE
net: honor allowHalfOpen on unix socket listeners and clients

### DIFF
--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -580,6 +580,11 @@ impl SocketConfig {
         // On any `?` below, `result` drops and `Handlers::Drop` unprotects its
         // JSValues — no manual error-path cleanup needed.
 
+        // allowHalfOpen shapes every accepted/connected socket no matter how the
+        // address was given; exclusive/reusePort/ipv6Only are bind-time options a
+        // unix path or an already-bound descriptor has nothing to apply them to.
+        result.allow_half_open = generated.allow_half_open;
+
         if result.fd.is_some() {
             // If a user passes a file descriptor then prefer it over hostname or unix
         } else if let Some(unix) = generated.unix_.get() {
@@ -620,7 +625,6 @@ impl SocketConfig {
                 },
             });
             result.exclusive = generated.exclusive;
-            result.allow_half_open = generated.allow_half_open;
             result.reuse_port = generated.reuse_port;
             result.ipv6_only = generated.ipv6_only;
         } else {

--- a/test/js/node/net/node-net-allowHalfOpen.test.js
+++ b/test/js/node/net/node-net-allowHalfOpen.test.js
@@ -1,6 +1,8 @@
-import { expect, test } from "bun:test";
-import { nodeExe, tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { nodeExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { once } from "node:events";
 import net from "node:net";
+import { join } from "node:path";
 
 async function nodeRun(callback, clients = 1) {
   const cwd = tempDirWithFiles("server", {
@@ -112,4 +114,42 @@ test("allowHalfOpen: false should work on client-side", async () => {
       .map(s => s.trim())
       .filter(s => s),
   ).toEqual(["Hello, World", "Received FIN"]);
+});
+
+// Replies on the tick after the peer's FIN, which only lands if the accepted
+// socket really stayed half-open: a listener that auto-closes on EOF has already
+// torn the socket down by the time the `end` listener's setImmediate runs.
+function replyAfterFin(reply) {
+  return conn => conn.on("end", () => setImmediate(() => conn.end(reply)));
+}
+
+function halfCloseThenRead(options) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const client = net.connect(options);
+  let received = "";
+  client.on("connect", () => client.end());
+  client.on("data", chunk => (received += chunk));
+  client.on("close", () => resolve(received));
+  client.on("error", reject);
+  return promise;
+}
+
+describe("allowHalfOpen: true on the server side", () => {
+  test.each([
+    ["tcp", () => ({ port: 0, host: "127.0.0.1" })],
+    ["unix", () => ({ path: join(tmpdirSync(), "half-open.sock") })],
+  ])("keeps an accepted %s socket writable after the peer's FIN", async (_name, makeListenOptions) => {
+    const server = net.createServer({ allowHalfOpen: true }, replyAfterFin("REPLY-AFTER-FIN"));
+    server.listen(makeListenOptions());
+    await once(server, "listening");
+
+    try {
+      const address = server.address();
+      const connectOptions =
+        typeof address === "string" ? { path: address } : { port: address.port, host: address.address };
+      expect(await halfCloseThenRead(connectOptions)).toBe("REPLY-AFTER-FIN");
+    } finally {
+      server.close();
+    }
+  });
 });


### PR DESCRIPTION
`SocketConfig::from_generated` only reads `allowHalfOpen` on its hostname branch, so a unix listener or client gets the native default of `false`. The accepted (or connected) socket is then closed on the peer's FIN with the writable side still open, discarding whatever the stream layer had yet to flush.

Both `kConnectPipe` and `kRealListen` in `src/js/node/net.ts` pass `allowHalfOpen: true` for exactly the opposite reason, with a comment saying the native socket is "always half-open" and the stream layer implements `allowHalfOpen: false` itself. That holds for TCP. For unix it did not.

## Repro

```js
import net from "node:net";

// reply on the tick after the peer's FIN
const handler = conn => conn.on("end", () => setImmediate(() => conn.end("ASYNC-REPLY")));
const server = net.createServer({ allowHalfOpen: true }, handler);
server.listen(path); // or (0, "127.0.0.1")

// client connects, writes, then half-closes with client.end()
```

```
node: tcp -> "ASYNC-REPLY"   unix -> "ASYNC-REPLY"
bun:  tcp -> "ASYNC-REPLY"   unix -> ""
```

## Cause

```rust
} else if let Some(unix) = generated.unix_.get() {
    // ... never touches result.allow_half_open
} else if let Some(hostname) = generated.hostname.get() {
    // ...
    result.exclusive = generated.exclusive;
    result.allow_half_open = generated.allow_half_open;   // <- only here
    result.reuse_port = generated.reuse_port;
    result.ipv6_only = generated.ipv6_only;
}
```

`allow_half_open` reaches usockets through `socket_flags()` as `LIBUS_SOCKET_ALLOW_HALF_OPEN`, which `us_internal_init_listen_socket` / `us_internal_init_connect_socket` stamp onto the socket and accepted sockets inherit. Without the bit, usockets closes the socket immediately after dispatching `end`, so a write issued from the `end` handler's next tick is lost.

## Fix

Read `allowHalfOpen` for every address form. It shapes accepted and connected sockets no matter how the address was given, unlike `exclusive` / `reusePort` / `ipv6Only`, which are bind-time options a unix path has nothing to apply them to and which stay on the hostname branch.

## Verification

`test/js/node/net/node-net-allowHalfOpen.test.js` grows a server-side pair; the tests already there cover the client side against a real Node server. An accepted socket must still be writable on the tick after the peer's FIN, over TCP and over a unix path. The unix case fails on an unpatched build; the TCP case passes either way and is the control.

Vendored Node tests `test-net-allow-half-open`, `test-tls-socket-allow-half-open-option`, `test-http-unix-socket`, `test-http-unix-socket-keep-alive`, `test-https-unix-socket-self-signed`, `test-net-server-listen-path`, `test-pipe-address` and `test-net-pipe-connect-errors` all pass.

---

This PR originally also implemented `server.listen({ fd })`. #31715 already does that, with the same `us_socket_group_listen_fd`, and is green with no unresolved review threads, so that half is dropped here rather than competing with it. The deltas worth folding into #31715 are in https://github.com/oven-sh/bun/pull/31715#issuecomment-4893572886.

#31715 also sets `allow_half_open` inside its `fd` branch; whichever of the two lands second can drop the duplicate line, since the hoist here covers it.
