### PR TITLE
fetch: set Response.type and exclude URL fragments per the fetch spec

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5014,7 +5014,7 @@ impl<'a> HTTPClient<'a> {
                         debug_assert!(string_builder.cap == string_builder.len);
 
                         let input = BunString::borrow_utf8(string_builder.allocated_slice());
-                        let normalized_url = bun_url::href_from_string(&input);
+                        let normalized_url = bun_url::href_from_string_without_fragment(&input);
                         if normalized_url.tag() == BunStringTag::Dead {
                             // URL__getHref failed, dont pass dead tagged string to toOwnedSlice.
                             return Err(crate::Error::RedirectURLInvalid);
@@ -5070,7 +5070,7 @@ impl<'a> HTTPClient<'a> {
                         debug_assert!(string_builder.cap == string_builder.len);
 
                         let input = BunString::borrow_utf8(string_builder.allocated_slice());
-                        let normalized_url = bun_url::href_from_string(&input);
+                        let normalized_url = bun_url::href_from_string_without_fragment(&input);
                         if normalized_url.tag() == BunStringTag::Dead {
                             return Err(crate::Error::RedirectURLInvalid);
                         }
@@ -5094,7 +5094,7 @@ impl<'a> HTTPClient<'a> {
 
                         let base = BunString::borrow_utf8(original_url.href);
                         let rel = BunString::borrow_utf8(location);
-                        let new_url_ = bun_url::join(&base, &rel);
+                        let new_url_ = bun_url::join_without_fragment(&base, &rel);
 
                         if new_url_.is_empty() {
                             return Err(crate::Error::InvalidRedirectURL);

--- a/src/jsc/CommonStrings.rs
+++ b/src/jsc/CommonStrings.rs
@@ -37,6 +37,7 @@ enum CommonStringsForRust {
     QuicDatagramLost = 22,
     Base64 = 23,
     Write = 24,
+    FetchBasic = 25,
 }
 
 unsafe extern "C" {
@@ -91,6 +92,11 @@ impl<'a> CommonStrings<'a> {
     #[inline]
     pub fn default(self) -> JSValue {
         CommonStringsForRust::FetchDefault.to_js(self.global_object)
+    }
+    /// `"basic"`
+    #[inline]
+    pub fn basic(self) -> JSValue {
+        CommonStringsForRust::FetchBasic.to_js(self.global_object)
     }
     /// `"error"`
     #[inline]

--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -209,6 +209,7 @@ enum class CommonStringsForRust : uint8_t {
     quicDatagramLost = 22,
     base64 = 23,
     write = 24,
+    fetchBasic = 25,
 };
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForRust commonString)
@@ -265,6 +266,8 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForRust c
         return commonStrings.base64String();
     case CommonStringsForRust::write:
         return commonStrings.writeString();
+    case CommonStringsForRust::fetchBasic:
+        return commonStrings.fetchBasicString();
     default: {
         ASSERT_NOT_REACHED();
         return jsUndefined();

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -76,6 +76,7 @@
     macro(binaryTypeNodeBuffer, "nodebuffer") \
     macro(binaryTypeUint8Array, "uint8array") \
     macro(buffer, "buffer") \
+    macro(fetchBasic, "basic") \
     macro(fetchCors, "cors") \
     macro(fetchFollow, "follow") \
     macro(fetchForceCache, "force-cache") \

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -633,6 +633,16 @@ extern "C" BunString URL__getHref(const BunString* input)
     return Bun::toStringRef(url.string());
 }
 
+extern "C" BunString URL__getHrefWithoutFragment(const BunString* input)
+{
+    auto&& str = input->toWTFString();
+    auto url = WTF::URL(str);
+    if (!url.isValid() || url.isEmpty())
+        return { BunStringTag::Dead };
+
+    return Bun::toStringRef(url.stringWithoutFragmentIdentifier());
+}
+
 extern "C" BunString URL__pathFromFileURL(const BunString* input)
 {
     auto&& str = input->toWTFString();
@@ -652,6 +662,17 @@ extern "C" BunString URL__getHrefJoin(const BunString* baseStr, const BunString*
         return { BunStringTag::Dead };
 
     return Bun::toStringRef(url.string());
+}
+
+extern "C" BunString URL__getHrefJoinWithoutFragment(const BunString* baseStr, const BunString* relativeStr)
+{
+    auto base = baseStr->toWTFString();
+    auto relative = relativeStr->toWTFString();
+    auto url = WTF::URL(WTF::URL(base), relative);
+    if (!url.isValid() || url.isEmpty())
+        return { BunStringTag::Dead };
+
+    return Bun::toStringRef(url.stringWithoutFragmentIdentifier());
 }
 
 extern "C" BunString URL__fragmentIdentifier(WTF::URL* url)

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -462,6 +462,7 @@ impl HTMLRewriter {
                 body_value,
                 BunString::EMPTY,
                 false,
+                webcore::ResponseType::Default,
             ));
 
             // Carries its own article: "an ArrayBuffer", not "a ArrayBuffer".
@@ -1038,6 +1039,7 @@ impl RewriterPipe {
             }),
             BunString::EMPTY,
             false,
+            original.response_type(),
         ));
         let result_ref = BackRef::from(result);
         // SAFETY: `result` is the live Response just allocated above.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5423,6 +5423,7 @@ impl DevServer {
                     )),
                     BunString::EMPTY,
                     false,
+                    crate::webcore::ResponseType::Default,
                 );
                 let vm = self.vm();
                 let _exit = vm.enter_event_loop_scope();

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -214,7 +214,7 @@ pub use body::{Body, Value as BodyValue};
 
 #[path = "webcore/Response.rs"]
 pub mod response;
-pub use response::Response;
+pub use response::{Response, ResponseType};
 
 #[path = "webcore/Request.rs"]
 pub mod request;

--- a/src/runtime/webcore/BakeResponse.rs
+++ b/src/runtime/webcore/BakeResponse.rs
@@ -203,6 +203,7 @@ fn construct_render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
         crate::webcore::Body::new(crate::webcore::BodyValue::Empty),
         BunString::EMPTY,
         false,
+        crate::webcore::ResponseType::Default,
     ));
 
     // Ownership of the allocation transfers to the JS wrapper.

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -213,6 +213,7 @@ pub struct Response {
     init: JsCell<Init>,
     url: JsCell<BunString>,
     redirected: Cell<bool>,
+    response_type: Cell<ResponseType>,
     /// The JS wrapper, fetch (so a discarded JS Response can still resolve
     /// its body) and HTMLRewriter each hold a ref.
     ref_count: Cell<u32>,
@@ -237,11 +238,39 @@ impl Default for Response {
             init: JsCell::new(Init::default()),
             url: JsCell::new(BunString::EMPTY),
             redirected: Cell::new(false),
+            response_type: Cell::new(ResponseType::Default),
             ref_count: Cell::new(1),
             weak_ptr_data: WeakPtrData::EMPTY,
             js_ref: JsCell::new(JsRef::empty()),
             reported_estimated_size: Cell::new(0),
             abort_listener: JsCell::new(None),
+        }
+    }
+}
+
+/// <https://fetch.spec.whatwg.org/#concept-response-type>
+///
+/// Bun has no notion of an origin, so response tainting is always "basic" and
+/// the filtered types ("cors", "opaque", "opaqueredirect") are unreachable.
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum ResponseType {
+    /// `new Response()`, `Response.json()`, `Response.redirect()`, and the
+    /// responses Bun's servers construct.
+    Default = 0,
+    /// Anything `fetch()` resolves with.
+    Basic = 1,
+    /// `Response.error()`.
+    Error = 2,
+}
+
+impl ResponseType {
+    fn to_js(self, global_this: &JSGlobalObject) -> JSValue {
+        let common_strings = global_this.common_strings();
+        match self {
+            Self::Default => common_strings.default(),
+            Self::Basic => common_strings.basic(),
+            Self::Error => common_strings.error(),
         }
     }
 }
@@ -314,12 +343,14 @@ impl Response {
         body: Body,
         url: BunString,
         redirected: bool,
+        response_type: ResponseType,
     ) -> Response {
         Response {
             init: JsCell::new(response_init),
             body: JsCell::new(body),
             url: JsCell::new(url),
             redirected: Cell::new(redirected),
+            response_type: Cell::new(response_type),
             ..Default::default()
         }
     }
@@ -359,6 +390,11 @@ impl Response {
     #[inline]
     pub(crate) fn url(&self) -> &BunString {
         self.url.get()
+    }
+
+    #[inline]
+    pub(crate) fn response_type(&self) -> ResponseType {
+        self.response_type.get()
     }
 
     #[inline]
@@ -549,7 +585,8 @@ impl Response {
 
     // JS getter; codegen calls this exact name.
     pub(crate) fn get_url(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        // https://developer.mozilla.org/en-US/docs/Web/API/Response/url
+        // https://fetch.spec.whatwg.org/#dom-response-url
+        // fetch() stores the url with the fragment already excluded.
         this.url.get().to_js(global_this)
     }
 
@@ -557,11 +594,8 @@ impl Response {
         this: &Self,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        if this.init.get().status_code < 200 {
-            return Ok(global_this.common_strings().error());
-        }
-
-        Ok(global_this.common_strings().default())
+        // https://fetch.spec.whatwg.org/#dom-response-type
+        Ok(this.response_type.get().to_js(global_this))
     }
 
     pub(crate) fn get_status_text(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
@@ -805,6 +839,7 @@ impl Response {
             init: JsCell::new(init),
             url: JsCell::new(self.url.get().clone()),
             redirected: Cell::new(self.redirected.get()),
+            response_type: Cell::new(self.response_type.get()),
             ..Default::default()
         })
     }
@@ -1040,6 +1075,7 @@ impl Response {
                 ..Default::default()
             }),
             body: JsCell::new(Body::new(BodyValue::Empty)),
+            response_type: Cell::new(ResponseType::Error),
             ..Default::default()
         }));
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -248,15 +248,11 @@ impl Default for Response {
     }
 }
 
-/// <https://fetch.spec.whatwg.org/#concept-response-type>
-///
-/// Bun has no notion of an origin, so response tainting is always "basic" and
-/// the filtered types ("cors", "opaque", "opaqueredirect") are unreachable.
+/// <https://fetch.spec.whatwg.org/#concept-response-type>. Bun has no origin, so the filtered types never apply.
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ResponseType {
-    /// `new Response()`, `Response.json()`, `Response.redirect()`, and the
-    /// responses Bun's servers construct.
+    /// Constructed responses: `new Response()`, `Response.json()`, `Response.redirect()`, server-built ones.
     Default = 0,
     /// Anything `fetch()` resolves with.
     Basic = 1,
@@ -585,8 +581,7 @@ impl Response {
 
     // JS getter; codegen calls this exact name.
     pub(crate) fn get_url(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        // https://fetch.spec.whatwg.org/#dom-response-url
-        // fetch() stores the url with the fragment already excluded.
+        // https://fetch.spec.whatwg.org/#dom-response-url (fetch() stores it without the fragment)
         this.url.get().to_js(global_this)
     }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -511,8 +511,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
-    // Nothing in a fetch reads the fragment, and `Response.url` is serialized
-    // without it. https://fetch.spec.whatwg.org/#dom-response-url
+    // A fetch never uses the fragment, and `Response.url` excludes it: https://fetch.spec.whatwg.org/#dom-response-url
     let href = bun_url::href_from_string_without_fragment(&url_str);
     drop(url_str);
     if href.tag() == BunStringTag::Dead {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -60,6 +60,7 @@ use crate::webcore::response::HeadersRef;
 use crate::webcore::s3::client as s3;
 use crate::webcore::{
     AbortSignal, Blob, Body, FetchHeaders, ObjectURLRegistry, ReadableStream, Request, Response,
+    ResponseType,
 };
 use crate::webcore::{blob, readable_stream, response};
 use bun_http_jsc as _;
@@ -177,6 +178,7 @@ fn data_url_response(url: BunString, global_this: &JSGlobalObject) -> JSValue {
         Body::new(BodyValue::Blob(blob)),
         url,
         false,
+        ResponseType::Basic,
     )));
 
     // Ownership of the boxed Response is transferred to the JS GC via
@@ -509,24 +511,25 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
-    if url_str.starts_with_ascii(b"data:") {
-        return Ok(data_url_response(url_str, global_this));
+    // Nothing in a fetch reads the fragment, and `Response.url` is serialized
+    // without it. https://fetch.spec.whatwg.org/#dom-response-url
+    let href = bun_url::href_from_string_without_fragment(&url_str);
+    drop(url_str);
+    if href.tag() == BunStringTag::Dead {
+        let err = ctx.to_type_error(
+            jsc::ErrorCode::INVALID_URL,
+            format_args!("fetch() URL is invalid"),
+        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
-    // `ZigURL::from_string` returns `OwnedURL` (owns href buffer); we
-    // immediately move that buffer into `url_proxy_buffer` and re-parse `url` to
-    // borrow it.
-    let owned_url = match ZigURL::from_string(&url_str) {
-        Ok(u) => u,
-        Err(_) => {
-            let err = ctx.to_type_error(
-                jsc::ErrorCode::INVALID_URL,
-                format_args!("fetch() URL is invalid"),
-            );
-            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
-        }
-    };
-    let mut url_proxy_buffer = owned_url.into_href().into_vec();
+    if href.starts_with_ascii(b"data:") {
+        return Ok(data_url_response(href, global_this));
+    }
+
+    // Move the href into `url_proxy_buffer` and re-parse `url` to borrow it.
+    let mut url_proxy_buffer = href.to_owned_slice();
+    drop(href);
     let mut url = parse_url_detached!(&url_proxy_buffer[..]);
     if url.is_file() {
         url_type = URLType::File;
@@ -1320,6 +1323,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             Body::new(BodyValue::Blob(blob_to_use)),
             url_string,
             false,
+            ResponseType::Basic,
         )));
 
         // Ownership of the boxed Response transfers to the JS GC; see
@@ -1862,6 +1866,7 @@ impl<'a> S3StreamWrapper<'a> {
                     Body::new(BodyValue::Empty),
                     BunString::create_atom_if_possible(self_.url.href),
                     false,
+                    ResponseType::Basic,
                 ));
                 // SAFETY: `into_raw` yields a freshly allocated heap `Response`;
                 // ownership transfers to JSC.
@@ -1884,6 +1889,7 @@ impl<'a> S3StreamWrapper<'a> {
                     })),
                     BunString::create_atom_if_possible(self_.url.href),
                     false,
+                    ResponseType::Basic,
                 ));
 
                 // SAFETY: `into_raw` yields a freshly allocated heap `Response`;

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -29,7 +29,7 @@ use crate::webcore::blob::{Any as AnyBlob, Blob, SizeType as BlobSizeType, Store
 use crate::webcore::body::{self, Body, Value as BodyValue, ValueError as BodyValueError};
 use crate::webcore::fetch::fetch_request_body_sink::{FetchRequestBodySink, RequestBodyChunk};
 use crate::webcore::readable_stream::{ReadableStream, Strong as ReadableStreamStrong};
-use crate::webcore::response::HeadersRef;
+use crate::webcore::response::{HeadersRef, ResponseType};
 use crate::webcore::sink::JSSink;
 use crate::webcore::streams::{SourceHandle, StreamError, StreamResult, Writable};
 use crate::webcore::{AbortSignal, DrainResult, FetchHeaders, InternalBlob, Response, SinkHandle};
@@ -1789,6 +1789,7 @@ impl FetchTasklet {
             Body::new(body),
             url,
             redirected,
+            ResponseType::Basic,
         )
     }
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -72,9 +72,11 @@ pub mod whatwg {
         safe fn URL__fragmentIdentifier(url: &URL) -> String;
         fn URL__deinit(url: *mut URL);
         safe fn URL__getHref(input: &String) -> String;
+        safe fn URL__getHrefWithoutFragment(input: &String) -> String;
         safe fn URL__getFileURLString(input: &String) -> String;
         safe fn URL__pathFromFileURL(input: &String) -> String;
         safe fn URL__getHrefJoin(base: &String, relative: &String) -> String;
+        safe fn URL__getHrefJoinWithoutFragment(base: &String, relative: &String) -> String;
         fn URL__originLength(latin1_slice: *const u8, len: usize) -> usize;
     }
 
@@ -83,8 +85,16 @@ pub mod whatwg {
     pub fn href_from_string(str: &String) -> String {
         URL__getHref(str)
     }
+    /// [`href_from_string`], serialized with *exclude fragment* set.
+    pub fn href_from_string_without_fragment(str: &String) -> String {
+        URL__getHrefWithoutFragment(str)
+    }
     pub fn join(base: &String, relative: &String) -> String {
         URL__getHrefJoin(base, relative)
+    }
+    /// [`join`], serialized with *exclude fragment* set.
+    pub fn join_without_fragment(base: &String, relative: &String) -> String {
+        URL__getHrefJoinWithoutFragment(base, relative)
     }
     pub fn file_url_from_string(str: &String) -> String {
         URL__getFileURLString(str)
@@ -186,7 +196,8 @@ pub mod whatwg {
 // Re-export the free helpers at crate root so lower-tier callers can write
 // `bun_url::join(...)` / `bun_url::href_from_string(...)` (install, http, bake, js_parser).
 pub use whatwg::{
-    file_url_from_string, href_from_string, join, origin_from_slice, path_from_file_url,
+    file_url_from_string, href_from_string, href_from_string_without_fragment, join,
+    join_without_fragment, origin_from_slice, path_from_file_url,
 };
 
 // URL is a pure view struct — every field is a slice into `href` (or a

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -28,6 +28,7 @@ import type { AddressInfo } from "net";
 import net from "net";
 import { join } from "path";
 import { Readable } from "stream";
+import { pathToFileURL } from "url";
 import { gzipSync } from "zlib";
 
 const tmp_dir = tmpdirSync();
@@ -1386,6 +1387,142 @@ describe("Response", () => {
       expect(Response.error().type).toBe("error");
       expect(Response.error().ok).toBe(false);
       expect(Response.error().status).toBe(0);
+    });
+  });
+  describe("Response.type", () => {
+    it("is 'default' for constructed responses", () => {
+      expect(new Response("hi").type).toBe("default");
+      expect(new Response(null, { status: 404 }).type).toBe("default");
+      // 101 is an accepted status and is not a network error.
+      expect(new Response(null, { status: 101 }).type).toBe("default");
+    });
+
+    it("is 'basic' for fetch responses", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          if (new URL(req.url).pathname === "/redirect") return Response.redirect("/", 302);
+          return new Response("hi");
+        },
+      });
+
+      const response = await fetch(server.url);
+      const cloned = response.clone();
+      expect(response.type).toBe("basic");
+      expect(cloned.type).toBe("basic");
+      expect(await Promise.all([response.text(), cloned.text()])).toEqual(["hi", "hi"]);
+
+      const followed = await fetch(new URL("/redirect", server.url));
+      expect(followed.type).toBe("basic");
+      expect(followed.redirected).toBe(true);
+      await followed.text();
+
+      const manual = await fetch(new URL("/redirect", server.url), { redirect: "manual" });
+      expect(manual.type).toBe("basic");
+      expect(manual.status).toBe(302);
+      await manual.text();
+    });
+
+    it("is 'basic' for data:, blob: and file: fetch responses", async () => {
+      const dataResponse = await fetch("data:text/plain,hello");
+      expect(dataResponse.type).toBe("basic");
+      expect(await dataResponse.text()).toBe("hello");
+
+      const objectURL = URL.createObjectURL(new Blob(["hello"]));
+      try {
+        const blobResponse = await fetch(objectURL);
+        expect(blobResponse.type).toBe("basic");
+        expect(await blobResponse.text()).toBe("hello");
+      } finally {
+        URL.revokeObjectURL(objectURL);
+      }
+
+      const fileResponse = await fetch(pathToFileURL(import.meta.path));
+      expect(fileResponse.type).toBe("basic");
+      expect((await fileResponse.text()).length).toBeGreaterThan(0);
+    });
+  });
+  describe("Response.url excludes the fragment", () => {
+    it("for http: urls, including redirects", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          if (new URL(req.url).pathname === "/redirect") {
+            return new Response(null, { status: 302, headers: { Location: "/target#section" } });
+          }
+          return new Response("hi");
+        },
+      });
+      const origin = server.url.origin;
+
+      const withFragment = await fetch(`${origin}/p?q=1#frag`);
+      expect(withFragment.url).toBe(`${origin}/p?q=1`);
+      expect(withFragment.clone().url).toBe(`${origin}/p?q=1`);
+      await withFragment.text();
+
+      // Only the first "#" delimits the fragment, and a percent-encoded one is
+      // part of the path.
+      const manyHashes = await fetch(`${origin}/p%23a#b#c`);
+      expect(manyHashes.url).toBe(`${origin}/p%23a`);
+      await manyHashes.text();
+
+      const emptyFragment = await fetch(`${origin}/p#`);
+      expect(emptyFragment.url).toBe(`${origin}/p`);
+      await emptyFragment.text();
+
+      // A fragment on the redirect's Location is excluded too.
+      const redirected = await fetch(`${origin}/redirect#frag`);
+      expect(redirected.url).toBe(`${origin}/target`);
+      expect(redirected.redirected).toBe(true);
+      await redirected.text();
+
+      const fromRequest = await fetch(new Request(`${origin}/p#frag`));
+      expect(fromRequest.url).toBe(`${origin}/p`);
+      await fromRequest.text();
+    });
+
+    it("for data: urls, and from the data itself", async () => {
+      const response = await fetch("data:text/plain,hello#frag");
+      expect(response.url).toBe("data:text/plain,hello");
+      expect(await response.text()).toBe("hello");
+
+      expect(await fetch("data:text/plain,hello#").then(r => r.text())).toBe("hello");
+      // A percent-encoded "#" is part of the data, not a fragment delimiter.
+      expect(await fetch("data:text/plain,a%23b#frag").then(r => r.text())).toBe("a#b");
+      expect(await fetch("data:text/plain;base64,aGVsbG8=#frag").then(r => r.text())).toBe("hello");
+
+      // Non-ASCII data is percent-encoded in the url and decoded in the body, as in Node.
+      const nonAscii = await fetch("data:text/plain,\u{1F600}#frag");
+      expect(nonAscii.url).toBe("data:text/plain,%F0%9F%98%80");
+      expect(await nonAscii.text()).toBe("\u{1F600}");
+    });
+
+    it("for blob: urls, which still resolve", async () => {
+      const objectURL = URL.createObjectURL(new Blob(["hello"]));
+      try {
+        const response = await fetch(`${objectURL}#frag`);
+        expect(response.status).toBe(200);
+        expect(response.url).toBe(objectURL);
+        expect(await response.text()).toBe("hello");
+      } finally {
+        URL.revokeObjectURL(objectURL);
+      }
+
+      await expect(fetch("blob:00000000-0000-0000-0000-000000000000#frag")).rejects.toThrow(
+        "Failed to resolve blob:00000000-0000-0000-0000-000000000000",
+      );
+    });
+
+    it("for file: urls", async () => {
+      const response = await fetch(`${pathToFileURL(import.meta.path)}#frag`);
+      expect(response.url).toBe(String(pathToFileURL(import.meta.path)));
+      expect((await response.text()).length).toBeGreaterThan(0);
+    });
+
+    it("but constructed responses have no url", () => {
+      expect(new Response("hi").url).toBe("");
+      expect(Response.error().url).toBe("");
+      expect(Response.redirect("https://example.com/a#b").url).toBe("");
     });
   });
   it("clone", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1338,6 +1338,28 @@ describe("HTMLRewriter", () => {
     }
   });
 
+  it("transform() keeps the original response's type and url", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("<div>hello</div>", { headers: { "Content-Type": "text/html" } }),
+    });
+
+    const original = await fetch(`${server.url.origin}/page#frag`);
+    const transformed = new HTMLRewriter()
+      .on("div", {
+        element(element) {
+          element.setInnerContent("it worked!");
+        },
+      })
+      .transform(original);
+
+    expect(transformed.type).toBe("basic");
+    expect(transformed.url).toBe(`${server.url.origin}/page`);
+    expect(await transformed.text()).toBe("<div>it worked!</div>");
+
+    expect(new HTMLRewriter().transform(new Response("<div>hello</div>")).type).toBe("default");
+  });
+
   for (let input of [new Response("<div>hello</div>"), "<div>hello</div>"]) {
     it("supports element handlers with input " + input.constructor.name, async () => {
       var rewriter = new HTMLRewriter();


### PR DESCRIPTION
### Problem
- `fetch()` responses report `response.type === "default"` instead of `"basic"`, and `response.url` keeps the request's `#fragment`. Node and the Fetch spec give `"basic"` and a fragment-free URL.
- `Response.prototype.type` was derived from the status code in `get_response_type` (`src/runtime/webcore/Response.rs`): `"error"` below 200, `"default"` otherwise. There was no response-type state, so `new Response(null, { status: 101 }).type` was `"error"` too.
- The fragment also leaked into scheme processing: `fetch("data:text/plain,hello#frag")` returned the body `"hello#frag"`, and `fetch(objectURL + "#frag")` failed `URL::is_blob()`'s exact-length check and fell through to a real HTTP request.

### Fix
- `Response` carries a `ResponseType` (`default` / `basic` / `error`), set at each construction site: `basic` for anything `fetch()` resolves with, `default` for constructed and server-built responses, `error` for `Response.error()`. `clone()` and `HTMLRewriter.transform()` carry it over.
- `bun_url` gets `href_from_string_without_fragment` and `join_without_fragment`, backed by `WTF::URL::stringWithoutFragmentIdentifier()`. `fetch()` parses its URL once through it, before the `data:` branch, so the data URL processor, the `blob:` lookup, the HTTP client and the stored response URL all see one fragment-free href. The HTTP client's redirect branches use the same helpers for `Location`.
- Correct because a fetch never uses the fragment (it is not sent on the wire), and [`Response.url`](https://fetch.spec.whatwg.org/#dom-response-url) is serialized with *exclude fragment* set. `Request.url` still keeps its fragment.
- Verified: `test/js/web/fetch/fetch.test.ts` (`Response.type`, `Response.url excludes the fragment`) and `test/js/workerd/html-rewriter.test.js`, all failing on stock bun. Also ran the rest of `fetch.test.ts`, `blob.test.ts`, `response.test.ts`, `buffer-resolveObjectURL.test.ts` and `serve.test.ts`.

### Background
- A response's [type](https://fetch.spec.whatwg.org/#concept-response-type) is `"basic"` for a same-origin network response. Bun has no origin, so the filtered types (`cors`, `opaque`, `opaqueredirect`) never apply, and Node reports `"basic"` for every `fetch()` too, including `data:` and `blob:`.
- bun has two URL parsers. `bun_url::whatwg` wraps WebKit's `WTF::URL` and does the WHATWG normalization. `bun_url::URL::parse` is a view struct that slices an already-normalized href for the HTTP client.
- Routing `data:` URLs through the WHATWG parser has two further visible effects, both matching Node: a non-ASCII data URL's `response.url` is percent-encoded, and an uppercase `DATA:` scheme is accepted.

<details><summary>Notes</summary>

Before / after, same script against Node:

```
                                     bun before               bun after == node
fetch(origin + "/p?q=1#frag").type   "default"                "basic"
fetch(origin + "/p?q=1#frag").url    ".../p?q=1#frag"         ".../p?q=1"
302 Location: /target#section  .url  ".../target#section"     ".../target"
fetch("data:…,hello#frag").text()    "hello#frag"             "hello"
fetch("data:…,😀#frag").url          "data:text/plain,😀"     "data:text/plain,%F0%9F%98%80"
fetch(objectURL + "#frag")           real HTTP request        "hello"
fetch("DATA:text/plain,x")           protocol error           "x"
new Response(null,{status:101}).type "error"                  "default"
Response.error().type                "error"                  "error"
Response.json({}).type               "default"                "default"
```

An earlier revision stripped the fragment at each consumer with `index_of(b'#')` (the `Response.url` getter, the `data:` branch, `URL::is_blob()`, `ObjectURLRegistry`). Review asked for the URL parser to own it instead, which is this version. The `URL.revokeObjectURL(url + "#frag")` no-op that the earlier revision also fixed is left out here to keep the change to `fetch()`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js, test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->