### PR TITLE
stdio: run write completion callbacks in write order

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -611,6 +611,9 @@ function _write(data, encoding, cb) {
 }
 writeStreamPrototype._write = _write;
 
+// Unlike writeFast() this needs no ordering against the sink's backpressure promise:
+// Writable only calls _write() once the previous one has called back, so at most one
+// completion is ever outstanding here.
 function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) {
   let fileSink = this[kWriteStreamFastPath];
   if (!fileSink) {

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -30,6 +30,7 @@ type FSStream = import("node:fs").ReadStream &
      * sink = FileSink
      */
     [kWriteStreamFastPath]?: undefined | true | FileSink;
+    [kBackpressurePromise]?: undefined | Promise<number>;
   };
 type FD = number;
 
@@ -45,6 +46,8 @@ const kIoDone = Symbol("kIoDone");
 // Bun supports a fast path for `createWriteStream("path.txt")` where instead of
 // using `node:fs`, `Bun.file(...).writer()` is used instead.
 const kWriteStreamFastPath = Symbol("kWriteStreamFastPath");
+// The promise the sink handed back for the writes it is still buffering, if any.
+const kBackpressurePromise = Symbol("kBackpressurePromise");
 const kFs = Symbol("kFs");
 
 const {
@@ -490,6 +493,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   // Enable fast path
   if (fastPath) {
     this[kWriteStreamFastPath] = fd ? Bun.file(fd).writer() : true;
+    this[kBackpressurePromise] = undefined;
     this._write = underscoreWriteFast;
     this._writev = undefined;
     this.write = writeFast as any;
@@ -673,12 +677,18 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (fileSink && fileSink !== true) {
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
+      // The sink hands every write it buffers the same promise, so these reactions
+      // run in write order. Park it: a later write the sink accepts outright has to
+      // report completion behind the ones still waiting here.
+      this[kBackpressurePromise] = maybePromise;
       maybePromise
         .then(() => {
+          if (this[kBackpressurePromise] === maybePromise) this[kBackpressurePromise] = undefined;
           this.emit("drain"); // Emit drain event
           cb(null);
         })
         .catch(err => {
+          if (this[kBackpressurePromise] === maybePromise) this[kBackpressurePromise] = undefined;
           // Always call the callback with the error
           cb(err);
           // If no callback was provided, emit the error on the stream
@@ -690,7 +700,20 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
         });
       return false; // Indicate backpressure
     } else {
-      cb(null);
+      if (hasCallback) {
+        const backpressurePromise = this[kBackpressurePromise];
+        if (backpressurePromise === undefined) {
+          // node never invokes a write callback during write(). Deferring also keeps
+          // it ordered with readline's no-op cursorTo()/moveCursor(), which call back
+          // from process.nextTick().
+          process.nextTick(cb, null);
+        } else {
+          // Accepting this write is what drained the sink, so the callbacks parked on
+          // that promise are queued but have not run. Land behind them.
+          const report = () => cb(null);
+          backpressurePromise.then(report, report);
+        }
+      }
       return true; // No backpressure
     }
   } else {

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -677,9 +677,9 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (fileSink && fileSink !== true) {
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
-      // The sink hands every write it buffers the same promise, so these reactions
-      // run in write order. Park it: a later write the sink accepts outright has to
-      // report completion behind the ones still waiting here.
+      // The sink drains in FIFO order, so what it is still buffering completes before
+      // anything written after it. Park that promise: a write the sink later accepts
+      // outright must report completion behind the callbacks waiting on it.
       this[kBackpressurePromise] = maybePromise;
       maybePromise
         .then(() => {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import fs from "node:fs";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -123,6 +124,80 @@ describe.concurrent("process-stdio", () => {
     });
 
     expect(stdout?.toString()).toBe(`hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`);
+  });
+
+  test.skipIf(isWindows)("process.stdout - write callbacks run in write order under backpressure", async () => {
+    using dir = tempDir("stdout-write-order", {});
+    const fifo = path.join(String(dir), "stdout.fifo");
+    expect(spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+
+    // Hold the read end open so opening the write end succeeds. Nothing here ever
+    // reads it: the fixture drains the pipe itself, synchronously.
+    const readFd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    let writeFd = fs.openSync(fifo, fs.constants.O_WRONLY);
+    try {
+      await using proc = spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-order-fixture.js")],
+        stdin: "ignore",
+        stdout: writeFd,
+        stderr: "pipe",
+        env: { ...bunEnv, BUN_TEST_FIFO: fifo },
+      });
+      fs.closeSync(writeFd);
+      writeFd = -1;
+
+      const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const lines = stderrText.trim().split("\n");
+      const { backpressured, lastWriteAccepted, order } = JSON.parse(lines[lines.length - 1]);
+
+      // Guards the setup: without these the fixture never reached the racy path.
+      expect({ backpressured, lastWriteAccepted, wroteEnough: order.length > 2, exitCode }).toEqual({
+        backpressured: true,
+        lastWriteAccepted: true,
+        wroteEnough: true,
+        exitCode: 0,
+      });
+      expect(order).toEqual(Array.from({ length: order.length }, (_, i) => i));
+    } finally {
+      if (writeFd !== -1) fs.closeSync(writeFd);
+      fs.closeSync(readFd);
+    }
+  });
+
+  // readline reports a no-op cursor move with process.nextTick(), so a write
+  // callback that runs during write() itself jumps ahead of it.
+  test("process.stdout - write callbacks run in call order with readline cursor callbacks", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const readline = require("node:readline");
+          const order = [];
+          let pending = 5;
+          const done = name => {
+            order.push(name);
+            if (--pending === 0) process.stderr.write(order.join(","));
+          };
+          process.stdout.write("A", () => done("w1"));
+          readline.moveCursor(process.stdout, 0, 0, () => done("m0")); // no-op move
+          process.stdout.write("B", () => done("w2"));
+          readline.cursorTo(process.stdout, 3, undefined, () => done("c"));
+          readline.moveCursor(process.stdout, 1, 0, () => done("m1"));
+        `,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // cursorTo(3) writes CSI 4G and moveCursor(1, 0) writes CSI 1C.
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "AB\x1b[4G\x1b[1C",
+      stderr: "w1,m0,w2,c,m1",
+      exitCode: 0,
+    });
   });
 
   test("process.stdout - write a lot (string)", () => {

--- a/test/js/node/process/process-stdout-write-order-fixture.js
+++ b/test/js/node/process/process-stdout-write-order-fixture.js
@@ -1,0 +1,50 @@
+// stdout is a FIFO nobody else reads. Fill it until the sink reports
+// backpressure, drain the pipe synchronously, then write once more: that last
+// write is accepted outright while the previous one is still parked on the
+// sink's backpressure promise.
+const fs = require("node:fs");
+
+const readFd = fs.openSync(process.env.BUN_TEST_FIFO, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+
+const order = [];
+let total = -1;
+let resolveDone;
+const done = new Promise(resolve => (resolveDone = resolve));
+
+function record(index) {
+  order.push(index);
+  if (total >= 0 && order.length >= total) resolveDone();
+}
+
+const chunk = Buffer.alloc(4096, 0x61);
+let next = 0;
+let backpressured = false;
+while (next < 1024) {
+  const index = next++;
+  if (!process.stdout.write(chunk, () => record(index))) {
+    backpressured = true;
+    break;
+  }
+}
+
+// Empty the pipe so the next write can flush the sink's whole buffer in one go.
+const scratch = Buffer.alloc(65536);
+for (;;) {
+  try {
+    if (fs.readSync(readFd, scratch, 0, scratch.length, null) === 0) break;
+  } catch (err) {
+    if (err.code === "EAGAIN") break;
+    throw err;
+  }
+}
+
+const last = next++;
+const lastWriteAccepted = process.stdout.write(Buffer.from("."), () => record(last));
+
+total = next;
+if (order.length >= total) resolveDone();
+
+done.then(() => {
+  process.stderr.write(JSON.stringify({ backpressured, lastWriteAccepted, order }) + "\n");
+  process.exit(0);
+});


### PR DESCRIPTION
### What's wrong

`process.stdout.write()` completion callbacks do not run in the order the writes were queued. Under backpressure a later write reports completion before an earlier one:

```
node: sorted: true — 10/10 attempts
bun : FAIL on attempt 5: [1,2,3,4,5,6,7,8,9,10,14,15,0,11,12,13,16,…]   (and callback 0 arrives 12th)
```

`Writable` promises the opposite: completion callbacks fire in the order the writes were queued, which is how streaming producers implement windowed flow control and ordered acknowledgement. Code that pairs callback N with buffer N (retry queues, per-chunk offset accounting) silently corrupts its bookkeeping, and only under backpressure.

It reproduces on `process.stderr` and on a child's `stdin` too: they share the `fs.WriteStream` fast path.

### Cause

`writeFast()` — the `write()` installed on the stdio fast path — called the user's callback synchronously when the `FileSink` accepted a write outright:

```js
const maybePromise = fileSink.write(data);
if ($isPromise(maybePromise)) { /* backpressure: callback rides the promise */ }
else {
  cb(null);          // <- synchronous
  return true;
}
```

The two paths are not independent. While the sink is backed up it hands every write the *same* promise, and it resolves that promise the moment its buffer drains. So the write that is accepted outright is usually the very write that drained the sink: by the time `cb(null)` runs, the earlier writes' callbacks have been queued as promise reactions but have not run yet, and the newest callback jumps the whole queue.

### Fix

A synchronous completion now reports through `process.nextTick(cb, null)`, matching node, which never invokes a write callback during the `write()` call. When the sink still holds a pending promise, the callback is chained onto that promise instead, so it lands behind the callbacks already waiting on it. The pending promise is parked on the stream and cleared when it settles, so the common unbackpressured path stays on `nextTick`.

### Verification

The ordering fixture (`test/js/node/process/process-stdout-write-order-fixture.js`) makes the race deterministic rather than probabilistic: stdout is a FIFO nobody else reads, the fixture fills it until the sink reports backpressure, drains the pipe synchronously itself, then writes once more. That last write is accepted outright while the previous one is still parked on the sink's promise. 8/8 runs reorder before the fix, 8/8 are in order after it.

`process.nextTick` on its own is not sufficient here — the nextTick queue drains before the microtask queue, so a `nextTick`ed callback still overtakes a promise reaction. That is why the pending-promise chaining is needed as well. Conversely, deferring with `queueMicrotask` alone would fix the backpressure ordering but break interleaving with readline's `cursorTo()`/`moveCursor()`, which report completion from `process.nextTick()`. Both orderings are covered by tests:

```
$ bun bd test test/js/node/process/process-stdio.test.ts -t order
(pass) process.stdout - write callbacks run in write order under backpressure
(pass) process.stdout - write callbacks run in call order with readline cursor callbacks
```

<details>
<summary>readline interleave, before and after</summary>

```js
const readline = require("node:readline");
const order = [];
let pending = 5;
const done = n => { order.push(n); if (--pending === 0) console.error("ORDER=" + order.join(",")); };
process.stdout.write("A", () => done("w1"));
readline.moveCursor(process.stdout, 0, 0, () => done("m0")); // no-op move
process.stdout.write("B", () => done("w2"));
readline.cursorTo(process.stdout, 3, undefined, () => done("c"));
readline.moveCursor(process.stdout, 1, 0, () => done("m1"));
```

```
before: ORDER=w1,w2,c,m1,m0
after:  ORDER=w1,m0,w2,c,m1
node:   ORDER=w1,m0,w2,c,m1
```

</details>

This supersedes #33484, which deferred to `process.nextTick` for the same reason but left the backpressure reordering in place.
