### PR TITLE
s3: keep response metadata across progress callbacks

### DIFF
--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -454,9 +454,16 @@ impl S3HttpSimpleTask {
         // HTTP thread until enqueued back to the JS thread below.
         let this = unsafe { &mut *this };
         let is_done = !result.has_more;
+        // `metadata` is handed over exactly once, on the first callback carrying response headers.
+        // A close-delimited body (no Content-Length, no Transfer-Encoding) reports progress again
+        // at EOF with `metadata: None`, so carry the earlier one across the assignment below.
+        let previous_metadata = this.result.metadata.take();
         // SAFETY: `result.body` (the only borrowed field) points at `this.response_buffer`, which
         // lives for the task's lifetime — extending to `'static` here is sound for self-reference.
         this.result = unsafe { result.detach_lifetime() };
+        if this.result.metadata.is_none() {
+            this.result.metadata = previous_metadata;
+        }
         // `AsyncHTTP` transitively owns Drop types (`HTTPClient`, header
         // `EntryList`s), so a plain `=` here would (a) drop the old `this.http`, freeing heap
         // buffers that `*async_http` (a bitwise clone created by the HTTP thread) still aliases,

--- a/test/js/bun/s3/s3-connection-close.test.ts
+++ b/test/js/bun/s3/s3-connection-close.test.ts
@@ -36,6 +36,86 @@ process.exit(0);
 `;
 }
 
+// A success response carrying a body but neither Content-Length nor Transfer-Encoding
+// is delimited by the connection close (RFC 9112 section 6.3, rule 8) — what HTTP/1.0
+// upstreams and framing-stripping reverse proxies in front of S3 produce. Its headers
+// arrive on one progress update and the completion on a later one carrying no metadata.
+const SMALL_BODY = "hello-close-delimited";
+// Several times one TCP segment, so the body spans several progress updates and the
+// headers end up many callbacks behind the completion.
+const LARGE_BODY_BYTES = 256 * 1024;
+
+// Distinct first and last bytes so a body truncated, duplicated, or reassembled out of
+// order across progress updates fails the assertion. Mirrored by `MAKE_LARGE_BODY` in
+// the fixture; the head/tail/length assertion catches any drift between the two.
+function largeBody() {
+  const body = Buffer.alloc(LARGE_BODY_BYTES, "x");
+  body.write("START");
+  body.write("END", LARGE_BODY_BYTES - 3);
+  return body.toString();
+}
+
+const MAKE_LARGE_BODY = `(() => {
+  const b = Buffer.alloc(${LARGE_BODY_BYTES}, "x");
+  b.write("START");
+  b.write("END", ${LARGE_BODY_BYTES - 3});
+  return b.toString();
+})()`;
+
+const CLOSE_DELIMITED_READ = {
+  text: 'await s3.file("object.txt").text()',
+  bytes: 'new TextDecoder().decode(await s3.file("object.txt").bytes())',
+  "large text": 'await s3.file("object.txt").text()',
+} as const;
+
+function closeDelimitedFixture(op: keyof typeof CLOSE_DELIMITED_READ) {
+  return `
+import net from "node:net";
+
+const body = ${op === "large text" ? MAKE_LARGE_BODY : JSON.stringify(SMALL_BODY)};
+const server = net.createServer(socket => {
+  let buffer = Buffer.alloc(0);
+  socket.on("error", () => {});
+  socket.on("data", chunk => {
+    buffer = Buffer.concat([buffer, chunk]);
+    if (buffer.indexOf("\\r\\n\\r\\n") === -1) return;
+    buffer = Buffer.alloc(0);
+    socket.write('HTTP/1.1 200 OK\\r\\nContent-Type: application/octet-stream\\r\\nETag: "etag"\\r\\nConnection: close\\r\\n\\r\\n');
+    socket.write(body);
+    socket.end();
+  });
+});
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+const s3 = new Bun.S3Client({
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:" + server.address().port,
+});
+
+// Summarised rather than echoed: the large body would outrun the stdout pipe.
+const received = ${CLOSE_DELIMITED_READ[op]};
+console.log(JSON.stringify({ length: received.length, head: received.slice(0, 5), tail: received.slice(-3) }));
+server.close();
+`;
+}
+
+function closeDelimitedExpectation(op: keyof typeof CLOSE_DELIMITED_READ) {
+  const body = op === "large text" ? largeBody() : SMALL_BODY;
+  return JSON.stringify({ length: body.length, head: body.slice(0, 5), tail: body.slice(-3) });
+}
+
+// The S3 client does not honor NO_PROXY, so an inherited proxy would hijack the
+// request to the stub server.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
 describe.each([true, false])("peer sends FIN: %p", sendFin => {
   test.concurrent.each(["write", "delete"] as const)(
     "S3Client.%s() resolves on a Content-Length: 0 + Connection: close response",
@@ -44,15 +124,7 @@ describe.each([true, false])("peer sends FIN: %p", sendFin => {
 
       await using proc = Bun.spawn({
         cmd: [bunExe(), "fixture.ts"],
-        // The S3 client does not honor NO_PROXY, so an inherited proxy would
-        // hijack the request to the stub server.
-        env: {
-          ...bunEnv,
-          HTTP_PROXY: undefined,
-          HTTPS_PROXY: undefined,
-          http_proxy: undefined,
-          https_proxy: undefined,
-        },
+        env: envWithoutProxy,
         cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
@@ -62,6 +134,31 @@ describe.each([true, false])("peer sends FIN: %p", sendFin => {
 
       expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "completed", exitCode: 0 });
       expect(stderr).not.toContain("S3Error");
+      expect(proc.signalCode).toBeNull();
+    },
+  );
+});
+
+describe("close-delimited response body", () => {
+  test.concurrent.each(["text", "bytes", "large text"] as const)(
+    "S3Client %s reads a 200 with no Content-Length and no Transfer-Encoding",
+    async op => {
+      using dir = tempDir("s3-close-delimited", { "fixture.ts": closeDelimitedFixture(op) });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts"],
+        env: envWithoutProxy,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: closeDelimitedExpectation(op), exitCode: 0 });
+      expect(stderr).not.toContain("S3Error");
+      // Before the fix the completion callback carried no response metadata, so
+      // the task aborted the whole process and JS never saw an error at all.
       expect(proc.signalCode).toBeNull();
     },
   );


### PR DESCRIPTION
### What

`Bun.S3Client` aborts the whole process (Rust panic → `SIGABRT`, uncatchable from JS) on any successful response whose body is close-delimited: a plain HTTP/1.1 `200` with no `Content-Length`, no `Transfer-Encoding`, and `Connection: close` + FIN. That is a legal response (RFC 9112 §6.3, rule 8) and exactly what HTTP/1.0 upstreams and framing-stripping reverse proxies in front of S3-compatible services emit, so a server Bun connects to can take the process down with a well-formed `200`.

```js
// bun repro.ts -> exit 134 (SIGABRT); the try/catch never sees it
import * as net from "node:net";

const srv = net.createServer(s => {
  let buf = "";
  s.on("data", d => {
    buf += d.toString("latin1");
    if (buf.includes("\r\n\r\n")) {
      buf = "";
      // legal 200 + body: no Content-Length, no Transfer-Encoding, body ends at FIN
      s.write(`HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nETag: "x"\r\nConnection: close\r\n\r\nhello-close-delimited`);
      s.end();
    }
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const port = srv.address().port;

// control: plain fetch() of the identical bytes is fine
console.log(await (await fetch(`http://127.0.0.1:${port}/b/k`)).text()); // "hello-close-delimited"

const c = new Bun.S3Client({ endpoint: `http://127.0.0.1:${port}`, bucket: "b",
  accessKeyId: "AK", secretAccessKey: "SK", region: "us-east-1" });
try { console.log(await c.file("k").text()); } catch (e) { console.log("caught", e); }
console.log("SURVIVED"); // never printed
```

```
panic: called `Option::unwrap()` on a `None` value
```

…and under a debug build, the assertion that encodes the violated assumption:

```
panic: assertion failed: this.result.metadata.is_some()
S3HttpSimpleTask::on_response  src/runtime/webcore/s3/simple_request.rs:347
```

### Cause

`HTTPClient::to_result()` hands `HTTPResponseMetadata` to a task **exactly once**, via `state.cloned_metadata.take()` — on the first progress callback that carries response headers.

When the body is close-delimited, `content_length` is `None`, so `handle_response_body_from_multiple_packets` reports progress on every read. The headers therefore ship on an early callback (`has_more = true`, `metadata = Some`), and the completing callback arrives separately at EOF carrying `metadata: None`.

`S3HttpSimpleTask::http_callback` overwrote `this.result` wholesale on every callback, so that assignment dropped the stored metadata. `on_response` then did `this.result.metadata.as_ref().unwrap()` and aborted.

Responses with a `Content-Length` or `Transfer-Encoding: chunked` deliver metadata and completion on the same callback, which is why this only ever showed up on close-delimited bodies.

### Fix

Carry the earlier metadata across the assignment. This is the idiom the sibling consumers of `HTTPClientResultCallback` already use — `install::NetworkTask::notify` and `FetchTasklet::callback` both preserve metadata across callbacks, and `s3::download_stream` latches the status code instead; only `s3::simple_request` dropped it.

With metadata preserved, the `debug_assert!` + `unwrap()` in `on_response` become a provable invariant for this path: for S3 the `CertErrors` signal is never enabled, so `certificate_info` is always `None` and cannot pre-empt metadata in `to_result()`; and a terminal success dispatch requires `state.is_done()`, which is only ever reachable downstream of `clone_metadata()`.

### Verification

Covers `.text()`, `.bytes()`, and a 256KB body that spans several progress updates so the headers land many callbacks behind the completion. All three abort with exit 134 on the unfixed build and pass on the fixed one; the large body comes back byte-intact, which is what proves the metadata survives repeated callbacks rather than just the two-callback case.

```
test/js/bun/s3/s3-connection-close.test.ts   7 pass  0 fail
```

### Not fixed here

`AsyncHTTP::send_sync` has a related problem with the same trigger: `SingleHTTPChannel::write_item` replaces the stored result on each callback, and `send_sync` does a real (non-debug) `result.metadata.unwrap()`. A close-delimited response can therefore panic it in release, or unblock the reader on the partial first result. It needs completion-gating rather than a carry-forward, has its own copy-back ordering hazard around `real.response_headers`, and its callers (`bun create`, `bun publish`, `bun pm view`, `bun audit`) only ever talk to registries that frame their responses, so it is left for a separate change.

The `list()` path is affected by this crash too, but its parsed result is separately truncated by a scan-window bug already fixed in #33497, so `list()` is not asserted on here.