### PR TITLE
node:net: align Socket property and error shapes with node

### DIFF
--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -54,8 +54,9 @@ let util: typeof import("node:util");
 class ExceptionWithHostPort extends Error {
   errno: number;
   syscall: string;
-  port?: number;
   address: string;
+  // `declare` keeps `port` off the instances that have none, the way Node's errors do.
+  declare port?: number;
 
   constructor(err: number, syscall: string, address: string, port?: number) {
     // TODO(joyeecheung): We have to use the type-checked

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1385,7 +1385,6 @@ function Socket(options?) {
   this._host = undefined;
   this._port = undefined;
   this[bunTLSConnectOptions] = null;
-  this.timeout = 0;
   this[kwriteCallback] = undefined;
   this._pendingData = undefined;
   this._pendingEncoding = undefined; // for compatibility
@@ -1488,11 +1487,7 @@ function Socket(options?) {
 $toClass(Socket, "Socket", Duplex);
 
 Socket.prototype.address = function address() {
-  return {
-    address: this.localAddress,
-    family: this.localFamily,
-    port: this.localPort,
-  };
+  return this._getsockname();
 };
 
 Socket.prototype._onTimeout = function () {
@@ -1513,7 +1508,9 @@ Socket.prototype._onTimeout = function () {
 
 Object.defineProperty(Socket.prototype, "bufferSize", {
   get: function () {
-    return this.writableLength;
+    if (this._handle) {
+      return this.writableLength;
+    }
   },
 });
 
@@ -2104,8 +2101,8 @@ Socket.prototype._getpeername = function () {
     const family = this._handle.remoteFamily;
     if (!family) return {};
     this._peername = {
-      family,
       address: this._handle.remoteAddress,
+      family,
       port: this._handle.remotePort,
     };
   }
@@ -2119,8 +2116,8 @@ Socket.prototype._getsockname = function () {
     const family = this._handle.localFamily;
     if (!family) return {};
     this._sockname = {
-      family,
       address: this._handle.localAddress,
+      family,
       port: this._handle.localPort,
     };
   }
@@ -2760,6 +2757,13 @@ function internalConnect(self, options, address, port, addressType, localAddress
 
     traceConnectStart(req, address);
     err = kConnectPipe(self, req, address);
+    if (err) {
+      // libuv defers the pipe connect callback even when connect(2) fails
+      // immediately, so Node reports the failure through afterConnect, which
+      // emits 'connectionAttemptFailed'. doConnect returns the errno instead.
+      process.nextTick(afterConnect, err, self._handle, req, true, true);
+      return;
+    }
   }
 
   if (err) {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -802,6 +802,40 @@ describe("net.Socket node compatibility shapes", () => {
     expect(Object.hasOwn(error!, "port")).toBe(true);
     expect(error?.port).toBe(port);
   });
+
+  // The pipe connect error is delivered on a later tick, so a teardown can land
+  // in between. Mirrors the re-entrancy #32660 fixed on the TCP side.
+  it.each([
+    ["destroyed before the deferred connect error lands", (s: Socket) => s.destroy()],
+    [
+      "destroyed from the connectionAttemptFailed listener",
+      (s: Socket) => s.on("connectionAttemptFailed", () => s.destroy()),
+    ],
+  ])("an IPC socket %s still closes exactly once", async (_label, teardown) => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const path = join(socket_domain, `teardown-${randomUUID()}.sock`);
+    let closes = 0;
+    const uncaught: Error[] = [];
+    const onUncaught = (err: Error) => uncaught.push(err);
+    process.on("uncaughtException", onUncaught);
+    try {
+      const socket = connect({ path });
+      socket.on("error", () => {});
+      socket.on("close", () => {
+        closes++;
+        resolve();
+      });
+      teardown(socket);
+      await promise;
+      // Let the deferred afterConnect tick land on an already-dead socket.
+      await new Promise<void>(r => setImmediate(r));
+      expect(uncaught).toEqual([]);
+      expect(closes).toBe(1);
+      expect(socket.destroyed).toBe(true);
+    } finally {
+      process.removeListener("uncaughtException", onUncaught);
+    }
+  });
 });
 
 it("Socket has a prototype", () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -683,6 +683,127 @@ it("should handle connection error (unix)", done => {
   });
 });
 
+describe("net.Socket node compatibility shapes", () => {
+  type ConnectError = NodeJS.ErrnoException & { address?: string; port?: number };
+
+  it("timeout and bufferSize are undefined until the socket has a handle", () => {
+    const socket = new Socket();
+    socket.on("error", () => {});
+    try {
+      expect(socket.timeout).toBeUndefined();
+      expect(socket.bufferSize).toBeUndefined();
+
+      socket.setTimeout(60_000);
+      expect(socket.timeout).toBe(60_000);
+    } finally {
+      socket.destroy();
+    }
+  });
+
+  it("bufferSize reports writableLength once a handle exists", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<number | undefined>();
+    const server = createServer(socket => socket.resume());
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const socket = connect(port, "127.0.0.1", () => {
+        resolve(socket.bufferSize);
+        socket.destroy();
+      });
+      socket.on("error", reject);
+      expect(await promise).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("address() on an IPC socket is an empty object", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+    const path = join(socket_domain, `address-${randomUUID()}.sock`);
+    const server = createServer(connection => {
+      connection.on("error", () => {});
+      connection.destroy();
+    });
+    try {
+      await new Promise<void>(r => server.listen(path, r));
+      const socket = connect({ path });
+      socket.on("error", reject);
+      socket.on("connect", () => {
+        resolve(Object.keys(socket.address()));
+        socket.destroy();
+      });
+      // Node's Pipe handle has no getsockname(), so address() is `{}`.
+      expect(await promise).toEqual([]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("address() on a TCP socket keeps node's key order", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+    const server = createServer(socket => socket.destroy());
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const socket = connect(port, "127.0.0.1", () => {
+        resolve(Object.keys(socket.address()));
+        socket.destroy();
+      });
+      socket.on("error", reject);
+      expect(await promise).toEqual(["address", "family", "port"]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a failed IPC connect emits 'connectionAttemptFailed' and an error without a port", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const path = join(socket_domain, `missing-${randomUUID()}.sock`);
+    const events: string[] = [];
+    let attemptArgs: unknown[] | undefined;
+    let error: ConnectError | undefined;
+
+    const socket = connect({ path });
+    socket.on("connectionAttemptFailed", (...args: unknown[]) => {
+      events.push("connectionAttemptFailed");
+      attemptArgs = args.slice(0, 3);
+    });
+    socket.on("error", err => {
+      events.push("error");
+      error = err;
+    });
+    socket.on("connect", () => resolve());
+    socket.on("close", () => resolve());
+    await promise;
+
+    expect(events).toEqual(["connectionAttemptFailed", "error"]);
+    // Node reports the pipe path as the address, with no port/addressType.
+    expect(attemptArgs).toEqual([path, undefined, undefined]);
+    expect(error?.code).toBe("ENOENT");
+    expect(error?.message).toBe(`connect ENOENT ${path}`);
+    expect(Object.hasOwn(error!, "port")).toBe(false);
+  });
+
+  it("a failed TCP connect still carries a port on the error", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const server = createServer();
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    const { port } = server.address() as import("node:net").AddressInfo;
+    await new Promise<void>(r => server.close(() => r()));
+
+    let error: ConnectError | undefined;
+    const socket = connect(port, "127.0.0.1");
+    socket.on("error", err => (error = err));
+    socket.on("connect", () => resolve());
+    socket.on("close", () => resolve());
+    await promise;
+
+    expect(error?.code).toBe("ECONNREFUSED");
+    expect(Object.hasOwn(error!, "port")).toBe(true);
+    expect(error?.port).toBe(port);
+  });
+});
+
 it("Socket has a prototype", () => {
   function Connection() {}
   function Connection2() {}


### PR DESCRIPTION
Four small `node:net` shapes diverged from Node. All four are documented surfaces that user code reads.

## Repro

```js
import net from "node:net";
import os from "node:os";

const path = `${os.tmpdir()}/nits-${process.pid}.sock`;
const srv = net.createServer(c => c.on("error", () => {}));
await new Promise(r => srv.listen(path, r));

const s0 = new net.Socket();
console.log("fresh socket:", { timeout: String(s0.timeout), bufferSize: String(s0.bufferSize) });
s0.destroy();

await new Promise(res => {
  const s = net.connect({ path });
  s.on("connect", () => {
    console.log("ipc address() keys:", Object.keys(s.address()).sort().join(","));
    s.destroy();
    res();
  });
});

await new Promise(res => {
  const ev = [];
  const s = net.connect({ path: path + ".missing" });
  s.on("connectionAttemptFailed", () => ev.push("connectionAttemptFailed"));
  s.on("error", e => {
    ev.push("error(" + e.code + ")");
    console.log("'port' in ENOENT err:", "port" in e);
  });
  s.on("close", () => {
    console.log("events:", ev.join(" "));
    res();
  });
});
srv.close();
```

|                        | node v26.3.0                                | bun 1.4.0 / main                   |
| ---------------------- | ------------------------------------------- | ---------------------------------- |
| fresh socket           | `timeout` undefined, `bufferSize` undefined | `timeout` 0, `bufferSize` 0        |
| IPC `address()` keys   | (empty object)                              | `address,family,port`              |
| `'port' in` ENOENT err | `false`                                     | `true`                             |
| IPC failure events     | `connectionAttemptFailed error(ENOENT)`     | `error(ENOENT)` (no attempt event) |

## Cause

- **`timeout`**: the `Socket` constructor pre-initialized `this.timeout = 0`. Node leaves it undefined until `setTimeout()` runs, which is what makes `socket.timeout === undefined` the documented "has a timeout been configured?" probe. Both readers in `net.ts` gate on truthiness, so `undefined` behaves the same; `_http_agent.js` compares `socket.timeout !== agentTimeout`, which is exactly what Node does with an undefined `timeout`.
- **`bufferSize`**: the getter returned `this.writableLength` unconditionally. Node's getter is guarded on `this._handle` and returns undefined without one.
- **`address()`**: it hand-built `{ address, family, port }` from the `localAddress`/`localFamily`/`localPort` getters. Those getters all route through `_getsockname()`, which already returns a bare `{}` for a pipe handle, so the keys were present with undefined values. Node's `address()` simply returns `_getsockname()`. `_getsockname()`/`_getpeername()` now build `{ address, family, port }` in that order so TCP sockets keep Node's key order.
- **`port` on the error**: `ExceptionWithHostPort` declared `port?: number` as a TypeScript class field. With `useDefineForClassFields`, that emits a field initializer, so every instance got an own `port` property set to undefined even though the constructor only assigns it `if (port)`. `declare` makes the declaration type-only.
- **`connectionAttemptFailed`**: `uv_pipe_connect2` returns 0 and queues the callback through `uv__io_feed` even when `connect(2)` fails immediately, so Node always reports a failed pipe connect through `afterConnect`, which emits `connectionAttemptFailed` before destroying the socket. Bun's `doConnect` reports the ENOENT synchronously from inside the dispatch, so `internalConnect` took its synchronous `if (err)` branch and skipped `afterConnect` entirely. The pipe branch now hands the errno to `afterConnect` on the next tick. The TCP branch is unchanged: its `if (err)` mirrors Node's, which also does not emit there.

That last one also fixes a second divergence in the same path. `net.connect({ path: missing })` used to hand back an already-dead socket:

```
                          node v26.3.0                      bun main                      this PR
right after connect()     destroyed false, connecting true  destroyed true, connecting false  destroyed false, connecting true
```

## Verification

Every line of the repro now matches node v26.3.0, including the `connectionAttemptFailed` arguments (`path, undefined, undefined`) and the error's own-property set.

Six tests in `test/js/node/net/node-net.test.ts`: three cover the divergences and fail without the fix, three pin the behavior that must not change (`bufferSize` is still `writableLength` once a handle exists, TCP `address()` keeps its three keys in order, and a TCP connect error still carries `port`).

<details>
<summary>suites run against the debug build, patched vs main</summary>

- `test/js/node/net/` — no new failures (the TCP `.connect(port)` failures reproduce on `main` in this container)
- the 20 `test-net-*` parallel tests that exercise the connect/pipe paths this PR touches (`test-net-pipe-connect-errors`, `test-net-connect-immediate-destroy`, `test-net-connect-after-destroy`, `test-net-connect-abort-controller`, `test-net-socket-connecting`, …) — all pass
- `test/js/node/test/parallel/test-net-*.js` (143 files) plus the `dgram`/`tls`/`http-agent`/`http-client` parallel tests — no new failures; `test-http-client-timeout-option.js` is a pre-existing 1 ms-timeout flake (main 18/30 pass, patched 15/30 interleaved), `test-http-agent-keepalive.js` fails 12/12 on both
- `test/js/node/dgram/`, `test/js/node/tls/`, `test/js/node/http/`, `test/js/node/http2/` — no new failures once the suites are re-run without the box under load

</details>

## Overlap with #33493

#33493 makes the same one-line `declare port?: number` change to `ExceptionWithHostPort`. The hunk here is byte-identical to that one, so the two merge in either order without a conflict; everything else in this PR is disjoint.
