### PR TITLE
sql(mysql): scramble caching_sha2_password against the 20-byte nonce

### DIFF
--- a/src/sql/mysql/protocol/Auth.rs
+++ b/src/sql/mysql/protocol/Auth.rs
@@ -13,6 +13,9 @@ use crate::shared::Data;
 
 bun_core::declare_scope!(Auth, hidden);
 
+/// `SCRAMBLE_LENGTH` from `mysql_com.h`; the NUL that terminates it on the wire is not nonce data (#26195).
+pub const SCRAMBLE_LENGTH: usize = 20;
+
 pub(crate) mod mysql_native_password {
     use super::*;
 
@@ -28,7 +31,7 @@ pub(crate) mod mysql_native_password {
         // A malicious or broken server can send an AuthSwitchRequest with a
         // short plugin_data; without this check the slicing below reads past
         // the end of the buffer.
-        if nonce.len() < 20 {
+        if nonce.len() < SCRAMBLE_LENGTH {
             return Err(crate::Error::MissingAuthData);
         }
 
@@ -47,7 +50,7 @@ pub(crate) mod mysql_native_password {
         // Stage 3: SHA1(nonce + SHA1(SHA1(password)))
         let mut sha1 = SHA1::init();
         sha1.update(&nonce[0..8]);
-        sha1.update(&nonce[8..20]);
+        sha1.update(&nonce[8..SCRAMBLE_LENGTH]);
         sha1.update(&stage2);
         sha1.r#final(&mut stage3);
         // `defer sha1.deinit()` → handled by Drop on SHA1
@@ -71,6 +74,12 @@ pub mod caching_sha2_password {
         let mut digest2 = [0u8; 32];
         let mut digest3 = [0u8; 32];
         let mut result: [u8; 32] = [0u8; 32];
+
+        // Same short-plugin_data hazard as mysql_native_password::scramble above.
+        if nonce.len() < SCRAMBLE_LENGTH {
+            return Err(crate::Error::MissingAuthData);
+        }
+        let nonce = &nonce[..SCRAMBLE_LENGTH];
 
         // SHA256(password)
         // Null ENGINE — see note in mysql_native_password::scramble.

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -682,6 +682,8 @@ impl MySQLConnection {
             .extend_from_slice(&handshake.auth_plugin_data_part_1[..]);
         self.auth_data
             .extend_from_slice(&handshake.auth_plugin_data_part_2[..]);
+        // The wire nonce is NUL-terminated; see `Auth::SCRAMBLE_LENGTH` (#26195).
+        self.auth_data.truncate(Auth::SCRAMBLE_LENGTH);
 
         // Get auth plugin
         if !handshake.auth_plugin_name.slice().is_empty() {
@@ -927,6 +929,8 @@ impl MySQLConnection {
                 self.auth_switch_count += 1;
 
                 let auth_data = auth_switch.plugin_data.slice();
+                // Terminated the same way as the handshake's auth-plugin-data.
+                let auth_data = &auth_data[..auth_data.len().min(Auth::SCRAMBLE_LENGTH)];
                 self.auth_plugin = Some(auth_method);
                 self.auth_data.clear();
                 self.auth_data.extend_from_slice(auth_data);

--- a/test/js/sql/sql-mysql-auth-short-nonce.test.ts
+++ b/test/js/sql/sql-mysql-auth-short-nonce.test.ts
@@ -10,69 +10,76 @@
 // straight into scramble() as the nonce — OOB read (panic under safety
 // checks, silent heap over-read in release). With the fix the client rejects
 // with ERR_MYSQL_MISSING_AUTH_DATA before touching the buffer.
+// caching_sha2_password.scramble() takes the same nonce from the same packet,
+// so it rejects a short one the same way.
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import {
   listeningServer,
   mysqlAuthSwitchRequest,
+  mysqlErrorPacket,
   mysqlHandshakeV10,
   mysqlRawPacket,
   mysqlReadPackets,
 } from "./wire-frames";
 
-test("MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read", async () => {
-  let sawAuthSwitchResponse = false;
+// The handshake has to advertise the other plugin so the client follows the
+// AuthSwitchRequest path into `switchTo`.scramble() with server-controlled plugin_data.
+test.each([
+  { switchTo: "mysql_native_password", greeting: "caching_sha2_password" },
+  { switchTo: "caching_sha2_password", greeting: "mysql_native_password" },
+])(
+  "MySQL: AuthSwitchRequest with a short $switchTo nonce is rejected, not OOB-read",
+  async ({ switchTo, greeting }) => {
+    let sawAuthSwitchResponse = false;
 
-  // Advertise caching_sha2_password in the initial handshake so the client has
-  // to follow the AuthSwitchRequest path to reach mysql_native_password.scramble()
-  // with the server-controlled plugin_data.
-  const greeting = mysqlHandshakeV10({ authPlugin: "caching_sha2_password" });
-
-  const { server, port } = await listeningServer(socket => {
-    let buffered = Buffer.alloc(0);
-    let sentAuthSwitch = false;
-    socket.write(greeting);
-    socket.on("data", chunk => {
-      buffered = Buffer.concat([buffered, chunk]);
-      while (buffered.length >= 4) {
-        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
-        if (buffered.length < 4 + len) break;
-        const seq = buffered[3];
-        buffered = buffered.subarray(4 + len);
-        if (!sentAuthSwitch) {
-          // Reply to HandshakeResponse41 with the short-nonce AuthSwitch: only 4
-          // bytes of plugin_data — well under the 20 bytes scramble() slices.
-          sentAuthSwitch = true;
-          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(4, 0x63)));
-        } else {
-          // Pre-fix release builds OOB-read garbage into the scramble and
-          // still send an AuthSwitchResponse; reaching here means the
-          // length check did not fire. Close so the client does not hang.
-          sawAuthSwitchResponse = true;
-          socket.end();
+    const { server, port } = await listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let sentAuthSwitch = false;
+      socket.write(mysqlHandshakeV10({ authPlugin: greeting }));
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 4) {
+          const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+          if (buffered.length < 4 + len) break;
+          const seq = buffered[3];
+          buffered = buffered.subarray(4 + len);
+          if (!sentAuthSwitch) {
+            // Reply to HandshakeResponse41 with the short-nonce AuthSwitch: only 4
+            // bytes of plugin_data — well under the 20 bytes scramble() slices.
+            sentAuthSwitch = true;
+            socket.write(mysqlAuthSwitchRequest(seq + 1, switchTo, Buffer.alloc(4, 0x63)));
+          } else {
+            // Pre-fix release builds OOB-read garbage into the scramble and still
+            // send an AuthSwitchResponse; reaching here means the length check did
+            // not fire. Reject it the way a real server rejects a bad scramble, so
+            // the client fails the query instead of reconnecting forever.
+            sawAuthSwitchResponse = true;
+            socket.end(mysqlErrorPacket(seq + 1, 1045, "28000", "Access denied for user 'root'@'localhost'"));
+          }
         }
-      }
+      });
+      socket.on("error", () => {});
     });
-    socket.on("error", () => {});
-  });
 
-  try {
-    // Non-empty password so scramble() proceeds past the empty-password early return.
-    await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
-    const err = await sql`select 1`.then(
-      () => ({ code: "UNEXPECTED_SUCCESS" }),
-      e => ({ code: e?.code ?? String(e) }),
-    );
+    try {
+      // Non-empty password so scramble() proceeds past the empty-password early return.
+      await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+      const err = await sql`select 1`.then(
+        () => ({ code: "UNEXPECTED_SUCCESS" }),
+        e => ({ code: e?.code ?? String(e) }),
+      );
 
-    expect({ err, sawAuthSwitchResponse }).toEqual({
-      err: { code: "ERR_MYSQL_MISSING_AUTH_DATA" },
-      sawAuthSwitchResponse: false,
-    });
-  } finally {
-    await new Promise<void>(r => server.close(() => r()));
-  }
-});
+      expect({ err, sawAuthSwitchResponse }).toEqual({
+        err: { code: "ERR_MYSQL_MISSING_AUTH_DATA" },
+        sawAuthSwitchResponse: false,
+      });
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  },
+);
 
 test("MySQL: an AuthSwitchRequest frame declaring a zero-length payload is rejected", async () => {
   const greeting = mysqlHandshakeV10();

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -1,13 +1,17 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
-import { createHash } from "node:crypto";
+import { constants, createHash, generateKeyPairSync, privateDecrypt } from "node:crypto";
 import {
   listeningServer,
   MYSQL_FAST_AUTH_SUCCESS,
   MYSQL_MOCK_AUTH_DATA_PART_1,
   MYSQL_MOCK_AUTH_DATA_PART_2,
+  MYSQL_MOCK_NONCE,
+  MYSQL_PERFORM_FULL_AUTHENTICATION,
+  MYSQL_REQUEST_PUBLIC_KEY,
   mysqlAuthMoreData,
+  mysqlAuthSwitchRequest,
   mysqlHandshakeV10,
   mysqlOkPacket,
   mysqlParseHandshakeResponse41,
@@ -46,9 +50,11 @@ describeWithContainer(
         });
 
         await sql`DROP USER IF EXISTS caching@'%';`.simple();
+        // No FLUSH PRIVILEGES: CREATE USER/GRANT take effect immediately on MySQL 8,
+        // and a FLUSH would clear the caching_sha2_password cache out from under the
+        // concurrent fast-auth test below.
         await sql`CREATE USER caching@'%' IDENTIFIED WITH caching_sha2_password BY 'bunbun';
-              GRANT ALL PRIVILEGES ON bun_sql_test.* TO caching@'%';
-            FLUSH PRIVILEGES;`.simple();
+              GRANT ALL PRIVILEGES ON bun_sql_test.* TO caching@'%';`.simple();
       }
       {
         // Negative case: default (allowPublicKeyRetrieval unset) must refuse to fetch the server key.
@@ -92,11 +98,42 @@ describeWithContainer(
         expect(await cold`select 1 as x`).toEqual([{ x: 1 }]);
       }
 
-      // Connection #2: warm cache -> the server should take the fast path. Until the
-      // 21-byte-nonce bug (#26195 / #28161) also lands, it degrades to full auth via
-      // allowPublicKeyRetrieval. The scripted tests below carry the fast-auth proof.
-      await using fast = new SQL({ url: userUrl, max: 1, allowPublicKeyRetrieval: true });
+      // Connection #2: warm cache -> the server takes the fast path. Leaving
+      // allowPublicKeyRetrieval at its default (false) makes this the container-level
+      // fast-auth proof: a wrong token gets perform_full_authentication and fails with
+      // ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED instead of silently falling back.
+      await using fast = new SQL({ url: userUrl, max: 1 });
       expect(await fast`select 'REAL-ROW' as v`).toEqual([{ v: "REAL-ROW" }]);
+    });
+
+    // #26195: full authentication sends the NUL-terminated password XORed cyclically
+    // against the nonce, so a password at least as long as the 20-byte nonce is the first
+    // one whose bytes get masked by a 21st nonce byte that should not be there.
+    test("caching_sha2_password full auth with a password longer than the nonce", async () => {
+      const password = "bunbunbunbunbunbunbunbunbun"; // 27 chars
+      {
+        await using admin = new SQL({ url: getUrl(), max: 1 });
+        await admin`DROP USER IF EXISTS longpw@'%';`.simple();
+        await admin
+          .unsafe(
+            `CREATE USER longpw@'%' IDENTIFIED WITH caching_sha2_password BY '${password}';
+             GRANT ALL PRIVILEGES ON bun_sql_test.* TO longpw@'%';`,
+          )
+          .simple();
+      }
+
+      // Cold cache, plain TCP: the server answers perform_full_authentication and the
+      // password travels RSA-encrypted, which is the path the nonce length corrupts.
+      await using sql = new SQL({
+        url: `mysql://longpw:${password}@${container.host}:${container.port}/bun_sql_test`,
+        max: 1,
+        allowPublicKeyRetrieval: true,
+      });
+      const result = await sql`select 1 as x`.then(
+        rows => ({ rows }),
+        (e: { code?: string; message?: string }) => ({ code: e?.code, message: e?.message }),
+      );
+      expect(result).toEqual({ rows: [{ x: 1 }] });
     });
   },
 );
@@ -164,10 +201,26 @@ test.each(["split", "coalesced"] as const)(
   },
 );
 
-// The scramble is XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce)) with the double
-// hash hashed FIRST: MySQL's Generate_scramble, mysql2, go-sql-driver, and Connector/J all
-// agree. mysql_native_password concatenates the other way around, which is NOT correct here.
-test("caching_sha2_password scramble hashes the double-SHA256 before the nonce", async () => {
+const sha256 = (b: Buffer) => createHash("sha256").update(b).digest();
+
+// The fast-auth token is XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce)) with the
+// double hash hashed FIRST: MySQL's Generate_scramble, mysql2, go-sql-driver, and
+// Connector/J all agree. mysql_native_password concatenates the other way around, which
+// is NOT correct here. `nonce` is the 20-byte scramble, never the NUL that terminates it.
+function cachingSha2Token(password: string, nonce: Buffer): Buffer {
+  const digest1 = sha256(Buffer.from(password));
+  const digest3 = sha256(Buffer.concat([sha256(digest1), nonce]));
+  return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i]));
+}
+
+// perform_full_authentication sends the NUL-terminated password XORed cyclically against
+// the same 20-byte nonce, RSA-encrypted with the server's public key.
+function obfuscatePassword(password: string, nonce: Buffer): Buffer {
+  const plain = Buffer.from(`${password}\0`, "utf-8");
+  return Buffer.from(plain.map((byte, i) => byte ^ nonce[i % nonce.length]));
+}
+
+test("caching_sha2_password scramble hashes the double-SHA256 before the 20-byte nonce", async () => {
   const password = "pw";
   const scrambleSent = Promise.withResolvers<Buffer>();
   const { server, port } = await listeningServer(socket => {
@@ -200,21 +253,147 @@ test("caching_sha2_password scramble hashes the double-SHA256 before the nonce",
     await using sql = new SQL({ url: `mysql://root:${password}@127.0.0.1:${port}/db`, max: 1 });
     const [sent, rows] = await Promise.all([scrambleSent.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
 
-    const sha256 = (b: Buffer) => createHash("sha256").update(b).digest();
-    const digest1 = sha256(Buffer.from(password));
-    const digest2 = sha256(digest1);
-    const expected = (nonce: Buffer) => {
-      const digest3 = sha256(Buffer.concat([digest2, nonce]));
-      return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i])).toString("hex");
-    };
-    // The spec nonce is 20 bytes (part1 + the first 12 bytes of part2). Bun currently
-    // also keeps part2's trailing filler byte (#26195, fixed separately in #28161), so
-    // accept either nonce length: this test pins only the concatenation order.
-    const nonce20 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2.subarray(0, 12)]);
+    // The nonce is part1 + the first 12 bytes of part2. Hashing part2's 13th byte (the
+    // NUL terminator) too produces a token no MySQL 8 server can ever verify (#26195).
     const nonce21 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2]);
-    expect([expected(nonce20), expected(nonce21)]).toContain(sent.toString("hex"));
+    expect(sent.toString("hex")).toBe(cachingSha2Token(password, MYSQL_MOCK_NONCE).toString("hex"));
+    expect(sent.toString("hex")).not.toBe(cachingSha2Token(password, nonce21).toString("hex"));
     expect(rows).toEqual([{ v: "REAL-ROW" }]);
   } finally {
     server.close();
   }
 });
+
+// A warm server-side auth cache is the only time fast auth can succeed, and it is what
+// every other client gets by default over plain TCP: the server verifies the token and
+// concludes with OK. A token the server cannot verify demotes the exchange to
+// perform_full_authentication, which bun's default `allowPublicKeyRetrieval: false`
+// refuses — so a wrong token is a failed connection, not just a slower one.
+test("caching_sha2_password fast auth succeeds over plain TCP against a warm cache", async () => {
+  const password = "pw";
+  let tokenVerified = false;
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          const { authResponse } = mysqlParseHandshakeResponse41(payload);
+          tokenVerified = authResponse.equals(cachingSha2Token(password, MYSQL_MOCK_NONCE));
+          if (tokenVerified) {
+            socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([MYSQL_FAST_AUTH_SUCCESS])));
+            socket.write(mysqlOkPacket(seq + 2));
+          } else {
+            socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([MYSQL_PERFORM_FULL_AUTHENTICATION])));
+          }
+        } else if (payload[0] === COM_QUERY) {
+          socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+        } else {
+          socket.end();
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root:${password}@127.0.0.1:${port}/db`, max: 1 });
+    const result = await sql`SELECT 'REAL-ROW' AS v`.simple().then(
+      rows => ({ rows }),
+      (e: { code?: string }) => ({ code: e?.code ?? String(e) }),
+    );
+    expect({ result, tokenVerified }).toEqual({ result: { rows: [{ v: "REAL-ROW" }] }, tokenVerified: true });
+  } finally {
+    server.close();
+  }
+});
+
+// The nonce reaches the RSA path too. A password at least as long as the nonce wraps the
+// cyclic XOR, so a 21-byte nonce corrupts every byte from the 20th on and the server
+// decrypts garbage: #26195. The nonce that has to be used is the one from whichever packet
+// last carried auth-plugin-data, so drive both of them.
+const rsaKeyPair = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const AUTH_SWITCH_NONCE = Buffer.from(Array.from({ length: 20 }, (_, i) => 0x41 + i));
+
+test.each(["handshake", "auth-switch"] as const)(
+  "caching_sha2_password full auth XORs the password against the 20-byte nonce (%s)",
+  async entry => {
+    // Longer than the nonce so the cyclic XOR wraps; `x`-filled so the plaintext is
+    // unambiguous about which nonce byte masked each position.
+    const password = `pw-${Buffer.alloc(24, "x").toString()}`;
+    const nonce = entry === "handshake" ? MYSQL_MOCK_NONCE : AUTH_SWITCH_NONCE;
+    const decrypted = Promise.withResolvers<Buffer>();
+    const requests: number[] = [];
+
+    const { server, port } = await listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let step = entry === "handshake" ? 1 : 0;
+      socket.write(mysqlHandshakeV10({ authPlugin: entry === "handshake" ? "caching_sha2_password" : undefined }));
+      socket.on("data", chunk => {
+        buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+          switch (step++) {
+            case 0:
+              // HandshakeResponse41 for the server's advertised mysql_native_password;
+              // switch the account over to caching_sha2_password with a fresh nonce.
+              socket.write(
+                mysqlAuthSwitchRequest(
+                  seq + 1,
+                  "caching_sha2_password",
+                  Buffer.concat([AUTH_SWITCH_NONCE, Buffer.from([0])]),
+                ),
+              );
+              return;
+            case 1:
+              // The scramble: cold cache, so the server demands the full exchange.
+              socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([MYSQL_PERFORM_FULL_AUTHENTICATION])));
+              return;
+            case 2:
+              requests.push(payload[0]);
+              socket.write(mysqlAuthMoreData(seq + 1, Buffer.from(rsaKeyPair.publicKey)));
+              return;
+            case 3:
+              try {
+                decrypted.resolve(
+                  privateDecrypt({ key: rsaKeyPair.privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING }, payload),
+                );
+              } catch (e) {
+                decrypted.reject(e);
+              }
+              socket.write(mysqlOkPacket(seq + 1));
+              return;
+            default:
+              if (payload[0] === COM_QUERY) {
+                socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+              } else {
+                socket.end();
+              }
+          }
+        });
+      });
+      socket.on("error", () => {});
+    });
+
+    try {
+      await using sql = new SQL({
+        url: `mysql://root:${password}@127.0.0.1:${port}/db`,
+        max: 1,
+        allowPublicKeyRetrieval: true,
+      });
+      const [plain, rows] = await Promise.all([decrypted.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
+
+      expect({ plain: plain.toString("hex"), requests, rows }).toEqual({
+        plain: obfuscatePassword(password, nonce).toString("hex"),
+        requests: [MYSQL_REQUEST_PUBLIC_KEY],
+        rows: [{ v: "REAL-ROW" }],
+      });
+    } finally {
+      server.close();
+    }
+  },
+);

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -312,6 +312,10 @@ export function mysqlRawPacket(seq: number, payload: Buffer, declaredLength: num
 // PART_2; PART_2's 13th byte is the protocol's trailing NUL filler, not nonce data.
 export const MYSQL_MOCK_AUTH_DATA_PART_1: Buffer = Buffer.alloc(8, 0x61);
 export const MYSQL_MOCK_AUTH_DATA_PART_2: Buffer = Buffer.concat([Buffer.alloc(12, 0x62), Buffer.from([0])]);
+export const MYSQL_MOCK_NONCE: Buffer = Buffer.concat([
+  MYSQL_MOCK_AUTH_DATA_PART_1,
+  MYSQL_MOCK_AUTH_DATA_PART_2.subarray(0, 12),
+]);
 
 // MySQL Protocol::HandshakeV10 — page_protocol_connection_phase_packets_protocol_handshake_v10.html
 // Int<1>(10) NulString(server_version) Int<4>(thread_id) String<8>(auth1) Int<1>(0) Int<2>(cap_lo)
@@ -356,15 +360,32 @@ export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
   return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
 }
 
+// MySQL Protocol::ERR_Packet — page_protocol_basic_err_packet.html:
+//   Int<1>(0xff) Int<2>(error_code) String<1>('#') String<5>(sql_state) String<EOF>(error_message)
+export function mysqlErrorPacket(seq: number, errorCode: number, sqlState: string, message: string): Buffer {
+  return mysqlRawPacket(
+    seq,
+    Buffer.concat([
+      Buffer.from([0xff, errorCode & 0xff, (errorCode >> 8) & 0xff]),
+      Buffer.from(`#${sqlState}`),
+      Buffer.from(message, "utf-8"),
+    ]),
+  );
+}
+
 // MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:
 //   Int<1>(0x01) String<EOF>(plugin-specific payload)
 export function mysqlAuthMoreData(seq: number, data: Buffer): Buffer {
   return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0x01]), data]));
 }
 
-// caching_sha2_password fast_auth_success marker carried in an AuthMoreData payload —
-// page_caching_sha2_authentication_exchanges.html (its sibling, 0x04, is perform_full_authentication).
+// caching_sha2_password markers carried in an AuthMoreData payload —
+// page_caching_sha2_authentication_exchanges.html. The server answers the client's
+// scramble with fast_auth_success or perform_full_authentication; over a plaintext
+// connection the client answers the latter with request_public_key.
 export const MYSQL_FAST_AUTH_SUCCESS = 0x03;
+export const MYSQL_PERFORM_FULL_AUTHENTICATION = 0x04;
+export const MYSQL_REQUEST_PUBLIC_KEY = 0x02;
 
 // MySQL Protocol::AuthSwitchRequest — page_protocol_connection_phase_packets_protocol_auth_switch_request.html:
 //   Int<1>(0xfe) NulString(plugin_name) String<EOF>(plugin_provided_data)


### PR DESCRIPTION
`caching_sha2_password` is MySQL 8's default auth plugin, and bun computes its scramble over the **21-byte** auth-plugin-data instead of the 20-byte nonce, so the token it sends can never verify against a real server.

## Repro

Any MySQL 8 account whose credentials the server has already cached (i.e. every connection after the first), over plain TCP:

```ts
const sql = new Bun.SQL({ adapter: "mysql", hostname, port, username, password, database });
await sql`SELECT 1`;
// ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED: Connection closed
```

mysql2, go-sql-driver and Connector/J all connect here, via fast auth.

## Cause

`handle_handshake` stores `auth_plugin_data_part_1` (8 bytes) + `auth_plugin_data_part_2` (13 bytes) as the nonce. Part 2's 13th byte is the NUL that terminates auth-plugin-data, not nonce data: every other client cuts it (go-sql-driver `authData[:20]`, mysql2 `data.slice(0, 20)`, and the server's own `Generate_scramble` in `sha2_password_common.cc` hashes the 20-byte `m_rnd`).

`mysql_native_password::scramble` slices `nonce[0..20]`, which is why native auth works. `caching_sha2_password::scramble` hashed the whole slice, so the token is `XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce || 0x00))`. Two consequences:

1. The token never verifies, so even a warm server-side cache answers `perform_full_authentication` (0x04). With the default `allowPublicKeyRetrieval: false` (copied from mysql2 / Connector/J) the connection then fails outright, and the fast-auth-success path is dead code in production. With TLS or the opt-in it "works", at the cost of a full RSA/TLS password round-trip on every connection.
2. The same nonce masks the password on the RSA path, where the XOR is cyclic (`plain[i] ^= nonce[i % nonce.len]`). A 21-byte nonce shifts every byte from the 20th on, so passwords of 20 bytes and over are corrupted and full authentication fails as well. That is #26195.

## Fix

`auth_data` holds the 20-byte scramble: truncated where the handshake stores it, and where an AuthSwitchRequest replaces it (the switch packet terminates its plugin_data the same way). `caching_sha2_password::scramble` now rejects a short nonce and slices to 20, exactly like its `mysql_native_password` sibling.

Builds on #28161 by @kernoeb, which fixed the handshake nonce for the RSA path; this additionally covers the AuthSwitchRequest nonce and the fast-auth token, and proves all of it without a new container.

## Verification

`bun bd test test/js/sql/sql-mysql.auth.test.ts test/js/sql/sql-mysql-auth-short-nonce.test.ts`, against scripted servers that derive the expected bytes from the password and the nonce they handed out:

- the fast-auth token is the spec token, not the 21-byte one
- fast auth succeeds over plain TCP against a warm cache (before: `ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED`)
- the RSA-encrypted password, decrypted with the mock server's private key, is the NUL-terminated password XORed against the 20-byte nonce, for both the handshake nonce and an AuthSwitchRequest nonce
- a short AuthSwitchRequest nonce is rejected with `ERR_MYSQL_MISSING_AUTH_DATA` on the caching_sha2 path too, not just the native one

One container test covers #26195 end to end: a `caching_sha2_password` account with a 27-character password, full auth against a real MySQL 8.

<details>
<summary>Fail-before, with <code>src/</code> stashed</summary>

```
(fail) caching_sha2_password scramble hashes the double-SHA256 before the 20-byte nonce
(fail) caching_sha2_password fast auth succeeds over plain TCP against a warm cache
(fail) caching_sha2_password full auth XORs the password against the 20-byte nonce (handshake)
(fail) caching_sha2_password full auth XORs the password against the 20-byte nonce (auth-switch)

  {
-   "plain": "31356e3c3d3e3f303132333435363728292a2b2c393a3b3c3d3e3f48",
+   "plain": "31356e3c3d3e3f303132333435363728292a2b2c78393a3b3c3d3e47",
  }
```

The `78` the unfixed build leaves in the RSA plaintext is the password's 21st byte, XORed against the NUL instead of against `nonce[0]`.

</details>

Closes #26195

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-auth-short-nonce.test.ts test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (6a21fe827)

test/js/sql/sql-mysql-auth-short-nonce.test.ts:
(pass) MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read [523.09ms]
69 |       const err = await sql`select 1`.then(
70 |         () => ({ code: "UNEXPECTED_SUCCESS" }),
71 |         e => ({ code: e?.code ?? String(e) }),
72 |       );
73 | 
74 |       expect({ err, sawAuthSwitchResponse }).toEqual({
                                                  ^
error: expect(received).toEqual(expected)

  {
    "err": {
-     "code": "ERR_MYSQL_MISSING_AUTH_DATA",
+     "code": "ERR_MYSQL_SERVER_ERROR",
    },
-   "sawAuthSwitchResponse": false,
+   "sawAuthSwitchResponse": true,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-auth-short-nonce.test.ts:74:46)
(fail) MySQL: AuthSwitchRequest with a short caching_sha2_password nonce is rejected, not OOB-read [56.06ms]
(pass) MySQL: an AuthSwitchRequest 
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/sql/sql-mysql-auth-short-nonce.test.ts:
(pass) MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read [10.22ms]
69 |       const err = await sql`select 1`.then(
70 |         () => ({ code: "UNEXPECTED_SUCCESS" }),
71 |         e => ({ code: e?.code ?? String(e) }),
72 |       );
73 | 
74 |       expect({ err, sawAuthSwitchResponse }).toEqual({
                                                  ^
error: expect(received).toEqual(expected)

  {
    "err": {
-     "code": "ERR_MYSQL_MISSING_AUTH_DATA",
+     "code": "ERR_MYSQL_SERVER_ERROR",
    },
-   "sawAuthSwitchResponse": false,
+   "sawAuthSwitchResponse": true,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-auth-short-nonce.test.ts:74:46)
(fail) MySQL: AuthSwitchRequest with a short caching_sha2_password nonce is rejected, not OOB-read [2.51ms]
(pass) MySQL: an AuthSwitchRequest frame declaring a zero-length payload is rejected [2.21ms]

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daem
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-auth-short-nonce.test.ts test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (6a21fe827)

test/js/sql/sql-mysql-auth-short-nonce.test.ts:
(pass) MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read [545.90ms]
(pass) MySQL: AuthSwitchRequest with a short caching_sha2_password nonce is rejected, not OOB-read [70.78ms]
(pass) MySQL: an AuthSwitchRequest frame declaring a zero-length payload is rejected [57.47ms]

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [106.07ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [41.65ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the 20-byte nonce 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 973ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sql v0.0.0 (/workspace/bun/src/sql)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 38s
[2/6] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+6a21fe827
[build] done
bun test v1.4.0-canary.1 (6a21fe827)

test/js/sql/sql-mysql-auth-short-nonce.test.ts:
(pass) MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read [14.90ms]
(pass) MySQL: AuthSwitchRequest with a short caching_sha2_password nonce is rejected, not OOB-read [2.48ms]
(pass) MySQL: 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/mysql/protocol/Auth.rs                 |  13 +-
 src/sql_jsc/mysql/MySQLConnection.rs           |   4 +
 test/js/sql/sql-mysql-auth-short-nonce.test.ts | 101 +++++------
 test/js/sql/sql-mysql.auth.test.ts             | 225 ++++++++++++++++++++++---
 test/js/sql/wire-frames.ts                     |  25 ++-
 5 files changed, 294 insertions(+), 74 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/sql/mysql/protocol/Auth.rs                      4      7      0
src/sql_jsc/mysql/MySQLConnection.rs                4      3      0
test/js/sql/sql-mysql-auth-short-nonce.test.ts      1      3      0
test/js/sql/sql-mysql.auth.test.ts                  1      3      0
test/js/sql/wire-frames.ts                          1      2      0
```

</details>

**root cause** · written by the author bot

The caching_sha2_password scramble in Bun's MySQL client XORed the fast-auth token over the full 21-byte auth-plugin-data the server sends, including the trailing NUL terminator, rather than over the 20-byte scramble the server actually hashes, so the token never matched and fast auth always failed against MySQL 8. The fix introduces a shared 20-byte scramble length, truncates the nonce to that length when it is read from both the initial handshake and an AuthSwitchRequest, and has the caching_sha2_password scramble function slice to and validate against that length as the native-password p…

<!-- robobun:evidence:end -->