### PR TITLE
sql(mysql): don't hang when the server answers a query with a LOCAL INFILE request

### DIFF
--- a/src/sql/shared/ConnectionFlags.rs
+++ b/src/sql/shared/ConnectionFlags.rs
@@ -8,6 +8,10 @@ bitflags! {
         const USE_UNNAMED_PREPARED_STATEMENTS = 1 << 2;
         const WAITING_TO_PREPARE              = 1 << 3;
         const HAS_BACKPRESSURE                = 1 << 4;
+        /// MySQL only: a LOCAL INFILE request was answered with the empty packet
+        /// that ends the file transfer, so the next packet is the server's
+        /// terminal OK/ERR for the query that triggered it.
+        const AWAITING_LOCAL_INFILE_RESULT    = 1 << 5;
     }
 }
 

--- a/src/sql/shared/ConnectionFlags.rs
+++ b/src/sql/shared/ConnectionFlags.rs
@@ -8,9 +8,6 @@ bitflags! {
         const USE_UNNAMED_PREPARED_STATEMENTS = 1 << 2;
         const WAITING_TO_PREPARE              = 1 << 3;
         const HAS_BACKPRESSURE                = 1 << 4;
-        /// MySQL only: a LOCAL INFILE request was answered with the empty packet
-        /// that ends the file transfer, so the next packet is the server's
-        /// terminal OK/ERR for the query that triggered it.
         const AWAITING_LOCAL_INFILE_RESULT    = 1 << 5;
     }
 }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -905,6 +905,27 @@ impl JSMySQLConnection {
         }
     }
 
+    /// Rejects a single request with `message` and `err`, leaving the connection open.
+    pub fn on_error_with_message(
+        &self,
+        request: &JSMySQLQuery,
+        message: &[u8],
+        err: AnyMySQLErrorT,
+    ) {
+        if self.vm().is_shutting_down() {
+            request.mark_as_failed();
+            return;
+        }
+        if let Some(err_) = self.global_object.try_take_exception() {
+            request.reject_with_js_value(self.get_queries_array(), err_);
+            return;
+        }
+        let queries_array = self.get_queries_array();
+        let instance = mysql_error_to_js(&self.global_object, message, err);
+        instance.ensure_still_alive();
+        request.reject_with_js_value(queries_array, instance);
+    }
+
     pub fn on_error_packet(&self, request: Option<&JSMySQLQuery>, err: &ErrorPacket) {
         if let Some(request) = request {
             if self.vm().is_shutting_down() {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1351,16 +1351,35 @@ impl MySQLConnection {
         // `ThisPtr::get` borrows the local `request` (Copy), not `*self`.
         let request: &JSMySQLQuery = request.get();
 
+        let mut ok = OKPacket {
+            header: 0,
+            affected_rows: 0,
+            last_insert_id: 0,
+            status_flags: StatusFlags::default(),
+            warnings: 0,
+            info: Data::Empty,
+            session_state_changes: Data::Empty,
+            packet_size: header_length,
+        };
+
         if self
             .flags
             .contains(ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT)
         {
-            // The server's answer to the empty file sent in place of the one it asked for.
-            // It is an OK packet whenever the server accepts that empty file, so the query
-            // is failed here rather than reported as a successful load of zero rows.
-            // `process_packets` skips the payload.
             self.flags
                 .remove(ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT);
+            match PacketType(first_byte) {
+                PacketType::ERROR => {}
+                PacketType::OK => {
+                    // An OK means the server accepted the empty file; it must not become a zero-row success.
+                    ok.decode_internal(reader)?;
+                    if ok.status_flags.has(StatusFlag::SERVER_MORE_RESULTS_EXISTS) {
+                        // Trailing result sets belong to a query that just failed; drop the connection.
+                        return Err(AnyMySQLError::LocalInfileNotSupported);
+                    }
+                }
+                _ => return Err(AnyMySQLError::UnexpectedPacket),
+            }
             if let Some(statement) = request.get_statement() {
                 statement.reset();
             }
@@ -1376,16 +1395,6 @@ impl MySQLConnection {
             return Ok(());
         }
 
-        let mut ok = OKPacket {
-            header: 0,
-            affected_rows: 0,
-            last_insert_id: 0,
-            status_flags: StatusFlags::default(),
-            warnings: 0,
-            info: Data::Empty,
-            session_state_changes: Data::Empty,
-            packet_size: header_length,
-        };
         match PacketType(first_byte) {
             PacketType::ERROR => {
                 let mut err = ErrorPacket::default();
@@ -1437,18 +1446,17 @@ impl MySQLConnection {
                     }
 
                     if packet_type == PacketType::LOCAL_INFILE {
-                        // The server wants us to upload a local file (LOAD DATA LOCAL INFILE).
-                        // We never negotiate CLIENT_LOCAL_FILES, so only a server that ignores
-                        // the capability flags gets here. 0xFB is not a valid column count
-                        // either (251 columns encode as `0xfc 0xfb 0x00`), so reading it as a
-                        // result-set header leaves the query waiting for columns that never
-                        // arrive. End the file transfer with the empty packet the protocol
-                        // requires and fail the query once the server's reply comes back.
+                        // 0xFB is never a lenenc column count (251 encodes as `0xfc 0xfb 0x00`).
                         let mut infile = LocalInfileRequest {
                             packet_size: header_length,
                             ..Default::default()
                         };
                         infile.decode_internal(reader)?;
+                        bun_core::scoped_log!(
+                            MySQLConnection,
+                            "Refusing LOCAL INFILE request for {}",
+                            bstr::BStr::new(infile.filename.slice())
+                        );
 
                         let mut packet = self.writer().start(self.sequence_id)?;
                         packet.end()?;

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -874,16 +874,6 @@ impl MySQLConnection {
                             return Err(AnyMySQLError::UnexpectedPacket);
                         }
                     }
-                } else if first_byte == PacketType::LOCAL_INFILE.0 {
-                    // Handle LOCAL INFILE request
-                    let mut infile = LocalInfileRequest {
-                        packet_size: header_length,
-                        ..Default::default()
-                    };
-                    infile.decode_internal(reader)?;
-
-                    // We don't support LOCAL INFILE for security reasons
-                    return Err(AnyMySQLError::LocalInfileNotSupported);
                 } else {
                     bun_core::scoped_log!(
                         MySQLConnection,
@@ -1360,6 +1350,32 @@ impl MySQLConnection {
         let _request_guard = request.ref_guard();
         // `ThisPtr::get` borrows the local `request` (Copy), not `*self`.
         let request: &JSMySQLQuery = request.get();
+
+        if self
+            .flags
+            .contains(ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT)
+        {
+            // The server's answer to the empty file sent in place of the one it asked for.
+            // It is an OK packet whenever the server accepts that empty file, so the query
+            // is failed here rather than reported as a successful load of zero rows.
+            // `process_packets` skips the payload.
+            self.flags
+                .remove(ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT);
+            if let Some(statement) = request.get_statement() {
+                statement.reset();
+            }
+            self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
+            self.queue.mark_as_ready_for_query();
+            self.queue.mark_current_request_as_finished(request);
+            self.js_connection_ref().on_error_with_message(
+                request,
+                b"LOAD DATA LOCAL INFILE is not supported",
+                AnyMySQLError::LocalInfileNotSupported,
+            );
+            let _ = self.flush_queue();
+            return Ok(());
+        }
+
         let mut ok = OKPacket {
             header: 0,
             affected_rows: 0,
@@ -1417,6 +1433,28 @@ impl MySQLConnection {
                             ok.last_insert_id,
                             ok.affected_rows,
                         );
+                        return Ok(());
+                    }
+
+                    if packet_type == PacketType::LOCAL_INFILE {
+                        // The server wants us to upload a local file (LOAD DATA LOCAL INFILE).
+                        // We never negotiate CLIENT_LOCAL_FILES, so only a server that ignores
+                        // the capability flags gets here. 0xFB is not a valid column count
+                        // either (251 columns encode as `0xfc 0xfb 0x00`), so reading it as a
+                        // result-set header leaves the query waiting for columns that never
+                        // arrive. End the file transfer with the empty packet the protocol
+                        // requires and fail the query once the server's reply comes back.
+                        let mut infile = LocalInfileRequest {
+                            packet_size: header_length,
+                            ..Default::default()
+                        };
+                        infile.decode_internal(reader)?;
+
+                        let mut packet = self.writer().start(self.sequence_id)?;
+                        packet.end()?;
+                        self.flush_data();
+                        self.flags
+                            .insert(ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT);
                         return Ok(());
                     }
 

--- a/test/js/sql/sql-mysql-local-infile.test.ts
+++ b/test/js/sql/sql-mysql-local-infile.test.ts
@@ -4,16 +4,15 @@
 // All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
 // Buffer.alloc frame construction here.
 
-// Bun never negotiates CLIENT_LOCAL_FILES, so a compliant server answers LOAD DATA LOCAL
-// INFILE with an ERR packet. A server that ignores the capability flags answers with a LOCAL
-// INFILE request (0xFB) instead, and MySQLConnection.handle_result_set used to read that 0xFB
-// as a length-encoded column count of 251: the query then waited for 251 column definitions
-// that never arrive, wedging it and every query queued behind it on that pooled connection
-// forever, with no error and no timeout.
+// Bun never negotiates CLIENT_LOCAL_FILES, so only a server that ignores the capability flags
+// answers a query with a LOCAL INFILE request (0xFB). It has to fail that query and leave the
+// pooled connection usable.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import {
   listeningServer,
+  MYSQL_SERVER_MORE_RESULTS_EXISTS,
+  MYSQL_SERVER_STATUS_AUTOCOMMIT,
   mysqlHandshakeV10,
   mysqlLocalInfileRequest,
   mysqlOkPacket,
@@ -30,21 +29,22 @@ const MYSQL_TYPE_VAR_STRING = 0xfd;
 type Mock = {
   port: number;
   close: () => Promise<void>;
-  /** true once the mock answered a LOAD DATA query with a 0xFB LOCAL INFILE request */
-  sentLocalInfileRequest: () => boolean;
-  /** true once the client ended the refused file transfer with the protocol-mandated empty packet */
-  sawEmptyFilePacket: () => boolean;
+  /** sequence ids of the mock's 0xFB request and of the empty packet the client answered it with */
+  exchange: () => { localInfileRequest: number | null; emptyFilePacket: number | null };
 };
 
 // Answers every LOAD DATA query (COM_QUERY or COM_STMT_EXECUTE) with a LOCAL INFILE request,
 // every other query with a one-row result set, and the client's empty file packet with an OK.
-async function localInfileServer(): Promise<Mock> {
-  let sentLocalInfileRequest = false;
-  let sawEmptyFilePacket = false;
+// `moreResults` makes that OK the first half of a multi-statement batch: it sets
+// SERVER_MORE_RESULTS_EXISTS and the next statement's result set follows immediately.
+async function localInfileServer({ moreResults = false } = {}): Promise<Mock> {
+  let localInfileRequest: number | null = null;
+  let emptyFilePacket: number | null = null;
 
   const { server, port } = await listeningServer(socket => {
     let buffered = Buffer.alloc(0);
     let authed = false;
+    let trailingResultSetSeq: number | null = null;
     socket.write(mysqlHandshakeV10());
     socket.on("data", chunk => {
       buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
@@ -56,8 +56,29 @@ async function localInfileServer(): Promise<Mock> {
         // A command packet always carries at least its command byte, so an empty payload is
         // the end-of-file marker that terminates a LOCAL INFILE transfer.
         if (payload.length === 0) {
-          sawEmptyFilePacket = true;
+          emptyFilePacket = seq;
+          if (moreResults) {
+            socket.write(
+              mysqlOkPacket(seq + 1, 0x00, MYSQL_SERVER_STATUS_AUTOCOMMIT | MYSQL_SERVER_MORE_RESULTS_EXISTS),
+            );
+            trailingResultSetSeq = seq + 2;
+            return;
+          }
           socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        // Running the batch's second statement takes the server a moment, so its result set only
+        // goes out once the client has sent something else: a client that moved on sees the result
+        // set land on that next query instead.
+        if (trailingResultSetSeq !== null) {
+          socket.write(
+            mysqlTextResultSet(
+              trailingResultSetSeq,
+              [{ name: "v", type: MYSQL_TYPE_VAR_STRING }],
+              [["trailing-result-set"]],
+            ),
+          );
+          trailingResultSetSeq = null;
           return;
         }
         const command = payload[0];
@@ -71,7 +92,7 @@ async function localInfileServer(): Promise<Mock> {
           const isLoadData =
             command === COM_STMT_EXECUTE || payload.subarray(1).toString("utf-8").startsWith("LOAD DATA");
           if (isLoadData) {
-            sentLocalInfileRequest = true;
+            localInfileRequest = seq + 1;
             socket.write(mysqlLocalInfileRequest(seq + 1, "/tmp/bun-local-infile-does-not-exist.csv"));
             return;
           }
@@ -87,10 +108,14 @@ async function localInfileServer(): Promise<Mock> {
   return {
     port,
     close: () => new Promise<void>(resolve => server.close(() => resolve())),
-    sentLocalInfileRequest: () => sentLocalInfileRequest,
-    sawEmptyFilePacket: () => sawEmptyFilePacket,
+    exchange: () => ({ localInfileRequest, emptyFilePacket }),
   };
 }
+
+// A LOCAL INFILE request is the server's 1st packet in answer to the command (sequence id 1), and
+// the empty packet that ends the file transfer continues that sequence. A real server rejects any
+// other sequence id.
+const refusedTransfer = { localInfileRequest: 1, emptyFilePacket: 2 };
 
 // A wedged query never settles, so the fixtures bound every await on one shared deadline and
 // report "pending" for whatever the wedge swallowed. Nothing waits for it on a fixed build.
@@ -124,7 +149,13 @@ const localInfileRejection = {
   message: "LOAD DATA LOCAL INFILE is not supported",
 };
 
-test("MySQL: a LOCAL INFILE request fails the query instead of wedging the connection", async () => {
+const connectionDropped = {
+  status: "rejected",
+  code: "ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
+  message: "Connection closed",
+};
+
+test.concurrent("MySQL: a LOCAL INFILE request fails the query instead of wedging the connection", async () => {
   const mock = await localInfileServer();
   try {
     const { stdout, stderr, exitCode, signalCode } = await runFixture(
@@ -157,20 +188,14 @@ test("MySQL: a LOCAL INFILE request fails the query instead of wedging the conne
       queued: { status: "fulfilled", value: [{ v: "still-usable" }] },
       closed: { status: "fulfilled" },
     });
-    expect({
-      sentLocalInfileRequest: mock.sentLocalInfileRequest(),
-      sawEmptyFilePacket: mock.sawEmptyFilePacket(),
-    }).toEqual({
-      sentLocalInfileRequest: true,
-      sawEmptyFilePacket: true,
-    });
+    expect(mock.exchange()).toEqual(refusedTransfer);
     expect(exitCode).toBe(0);
   } finally {
     await mock.close();
   }
 });
 
-test("MySQL: a LOCAL INFILE request to a prepared statement fails the query", async () => {
+test.concurrent("MySQL: a LOCAL INFILE request to a prepared statement fails the query", async () => {
   const mock = await localInfileServer();
   try {
     const { stdout, stderr, exitCode, signalCode } = await runFixture(
@@ -202,13 +227,48 @@ test("MySQL: a LOCAL INFILE request to a prepared statement fails the query", as
       reused: { status: "fulfilled", value: [{ v: "still-usable" }] },
       closed: { status: "fulfilled" },
     });
-    expect({
-      sentLocalInfileRequest: mock.sentLocalInfileRequest(),
-      sawEmptyFilePacket: mock.sawEmptyFilePacket(),
-    }).toEqual({
-      sentLocalInfileRequest: true,
-      sawEmptyFilePacket: true,
+    expect(mock.exchange()).toEqual(refusedTransfer);
+    expect(exitCode).toBe(0);
+  } finally {
+    await mock.close();
+  }
+});
+
+test.concurrent("MySQL: a LOCAL INFILE request inside a statement batch fails the connection", async () => {
+  const mock = await localInfileServer({ moreResults: true });
+  try {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture(
+      mock.port,
+      /* js */ `
+        const { SQL } = require("bun");
+        ${outcomeHelper}
+        const sql = new SQL({ url: "mysql://root@127.0.0.1:__PORT__/db", max: 1 });
+
+        // The OK for the refused file carries SERVER_MORE_RESULTS_EXISTS, so the result set of the
+        // batch's second statement still arrives. It belongs to no query now that this one failed.
+        const loadData = sql.unsafe("LOAD DATA LOCAL INFILE 'x.csv' INTO TABLE t; SELECT 2");
+        const queued = sql.unsafe("SELECT 'still-usable' AS v");
+
+        console.log(JSON.stringify({
+          loadData: await outcome(loadData),
+          queued: await outcome(queued),
+        }));
+        process.exit(0);
+      `,
+    );
+
+    expect({ stderr, stdout, signalCode }).toEqual({
+      stderr: expect.any(String),
+      stdout: expect.stringMatching(/^\{.*\}$/),
+      signalCode: null,
     });
+    // The connection is dropped, so the queued query runs on a fresh one and gets its own rows:
+    // it never sees the trailing result set that the batch's second statement produced.
+    expect(JSON.parse(stdout)).toEqual({
+      loadData: connectionDropped,
+      queued: { status: "fulfilled", value: [{ v: "still-usable" }] },
+    });
+    expect(mock.exchange()).toEqual(refusedTransfer);
     expect(exitCode).toBe(0);
   } finally {
     await mock.close();

--- a/test/js/sql/sql-mysql-local-infile.test.ts
+++ b/test/js/sql/sql-mysql-local-infile.test.ts
@@ -1,0 +1,216 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+
+// Bun never negotiates CLIENT_LOCAL_FILES, so a compliant server answers LOAD DATA LOCAL
+// INFILE with an ERR packet. A server that ignores the capability flags answers with a LOCAL
+// INFILE request (0xFB) instead, and MySQLConnection.handle_result_set used to read that 0xFB
+// as a length-encoded column count of 251: the query then waited for 251 column definitions
+// that never arrive, wedging it and every query queued behind it on that pooled connection
+// forever, with no error and no timeout.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import {
+  listeningServer,
+  mysqlHandshakeV10,
+  mysqlLocalInfileRequest,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+  mysqlTextResultSet,
+} from "./wire-frames";
+
+const COM_QUERY = 0x03;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+type Mock = {
+  port: number;
+  close: () => Promise<void>;
+  /** true once the mock answered a LOAD DATA query with a 0xFB LOCAL INFILE request */
+  sentLocalInfileRequest: () => boolean;
+  /** true once the client ended the refused file transfer with the protocol-mandated empty packet */
+  sawEmptyFilePacket: () => boolean;
+};
+
+// Answers every LOAD DATA query (COM_QUERY or COM_STMT_EXECUTE) with a LOCAL INFILE request,
+// every other query with a one-row result set, and the client's empty file packet with an OK.
+async function localInfileServer(): Promise<Mock> {
+  let sentLocalInfileRequest = false;
+  let sawEmptyFilePacket = false;
+
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        // A command packet always carries at least its command byte, so an empty payload is
+        // the end-of-file marker that terminates a LOCAL INFILE transfer.
+        if (payload.length === 0) {
+          sawEmptyFilePacket = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        const command = payload[0];
+        if (command === COM_STMT_PREPARE) {
+          socket.write(mysqlStmtPrepareOk(seq + 1, 1, 0, 0));
+          return;
+        }
+        if (command === COM_QUERY || command === COM_STMT_EXECUTE) {
+          // COM_STMT_EXECUTE carries no SQL, so the prepared LOAD DATA is recognized by being
+          // the only statement this mock ever prepares.
+          const isLoadData =
+            command === COM_STMT_EXECUTE || payload.subarray(1).toString("utf-8").startsWith("LOAD DATA");
+          if (isLoadData) {
+            sentLocalInfileRequest = true;
+            socket.write(mysqlLocalInfileRequest(seq + 1, "/tmp/bun-local-infile-does-not-exist.csv"));
+            return;
+          }
+          socket.write(mysqlTextResultSet(seq + 1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["still-usable"]]));
+          return;
+        }
+        socket.end();
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  return {
+    port,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+    sentLocalInfileRequest: () => sentLocalInfileRequest,
+    sawEmptyFilePacket: () => sawEmptyFilePacket,
+  };
+}
+
+// A wedged query never settles, so the fixtures bound every await on one shared deadline and
+// report "pending" for whatever the wedge swallowed. Nothing waits for it on a fixed build.
+const outcomeHelper = /* js */ `
+  const deadline = Bun.sleep(3000).then(() => "pending");
+  const outcome = promise =>
+    Promise.race([
+      promise.then(
+        value => ({ status: "fulfilled", value }),
+        reason => ({ status: "rejected", code: reason?.code, message: reason?.message }),
+      ),
+      deadline,
+    ]);
+`;
+
+async function runFixture(port: number, fixture: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture.replaceAll("__PORT__", String(port))],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+}
+
+const localInfileRejection = {
+  status: "rejected",
+  code: "ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
+  message: "LOAD DATA LOCAL INFILE is not supported",
+};
+
+test("MySQL: a LOCAL INFILE request fails the query instead of wedging the connection", async () => {
+  const mock = await localInfileServer();
+  try {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture(
+      mock.port,
+      /* js */ `
+        const { SQL } = require("bun");
+        ${outcomeHelper}
+        const sql = new SQL({ url: "mysql://root@127.0.0.1:__PORT__/db", max: 1 });
+
+        const loadData = sql.unsafe("LOAD DATA LOCAL INFILE 'x.csv' INTO TABLE t");
+        // Queued behind the LOAD DATA on the single pooled connection.
+        const queued = sql.unsafe("SELECT 'still-usable' AS v");
+
+        console.log(JSON.stringify({
+          loadData: await outcome(loadData),
+          queued: await outcome(queued),
+          closed: await outcome(sql.close()),
+        }));
+        process.exit(0);
+      `,
+    );
+
+    expect({ stderr, stdout, signalCode }).toEqual({
+      stderr: expect.any(String),
+      stdout: expect.stringMatching(/^\{.*\}$/),
+      signalCode: null,
+    });
+    expect(JSON.parse(stdout)).toEqual({
+      loadData: localInfileRejection,
+      queued: { status: "fulfilled", value: [{ v: "still-usable" }] },
+      closed: { status: "fulfilled" },
+    });
+    expect({
+      sentLocalInfileRequest: mock.sentLocalInfileRequest(),
+      sawEmptyFilePacket: mock.sawEmptyFilePacket(),
+    }).toEqual({
+      sentLocalInfileRequest: true,
+      sawEmptyFilePacket: true,
+    });
+    expect(exitCode).toBe(0);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("MySQL: a LOCAL INFILE request to a prepared statement fails the query", async () => {
+  const mock = await localInfileServer();
+  try {
+    const { stdout, stderr, exitCode, signalCode } = await runFixture(
+      mock.port,
+      /* js */ `
+        const { SQL } = require("bun");
+        ${outcomeHelper}
+        const sql = new SQL({ url: "mysql://root@127.0.0.1:__PORT__/db", max: 1 });
+
+        // A tagged template with no parameters still goes through COM_STMT_PREPARE / COM_STMT_EXECUTE.
+        const loadData = sql\`LOAD DATA LOCAL INFILE 'x.csv' INTO TABLE t\`;
+
+        console.log(JSON.stringify({
+          loadData: await outcome(loadData),
+          reused: await outcome(sql.unsafe("SELECT 'still-usable' AS v")),
+          closed: await outcome(sql.close()),
+        }));
+        process.exit(0);
+      `,
+    );
+
+    expect({ stderr, stdout, signalCode }).toEqual({
+      stderr: expect.any(String),
+      stdout: expect.stringMatching(/^\{.*\}$/),
+      signalCode: null,
+    });
+    expect(JSON.parse(stdout)).toEqual({
+      loadData: localInfileRejection,
+      reused: { status: "fulfilled", value: [{ v: "still-usable" }] },
+      closed: { status: "fulfilled" },
+    });
+    expect({
+      sentLocalInfileRequest: mock.sentLocalInfileRequest(),
+      sawEmptyFilePacket: mock.sawEmptyFilePacket(),
+    }).toEqual({
+      sentLocalInfileRequest: true,
+      sawEmptyFilePacket: true,
+    });
+    expect(exitCode).toBe(0);
+  } finally {
+    await mock.close();
+  }
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -317,10 +317,21 @@ export function mysqlHandshakeV10(
   return mysqlRawPacket(0, payload);
 }
 
+// Status flags — page_protocol_basic_ok_packet.html (subset used by the mocks).
+export const MYSQL_SERVER_STATUS_AUTOCOMMIT = 0x0002;
+export const MYSQL_SERVER_MORE_RESULTS_EXISTS = 0x0008;
+
 // MySQL Protocol::OK_Packet — page_protocol_basic_ok_packet.html: Int<1>(header) lenenc(affected_rows) lenenc(last_insert_id) Int<2>(status) Int<2>(warnings)
 // The header is 0x00, except for the CLIENT_DEPRECATE_EOF result-set terminator, which is an OK packet with a 0xFE header.
-export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
-  return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+export function mysqlOkPacket(
+  seq: number,
+  header: 0x00 | 0xfe = 0x00,
+  statusFlags: number = MYSQL_SERVER_STATUS_AUTOCOMMIT,
+): Buffer {
+  return mysqlRawPacket(
+    seq,
+    Buffer.from([header, 0x00, 0x00, statusFlags & 0xff, (statusFlags >> 8) & 0xff, 0x00, 0x00]),
+  );
 }
 
 // MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -329,6 +329,13 @@ export function mysqlAuthMoreData(seq: number, data: Buffer): Buffer {
   return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0x01]), data]));
 }
 
+// MySQL Protocol::LOCAL INFILE Request — page_protocol_com_query_response_local_infile_request.html:
+//   Int<1>(0xfb) String<EOF>(filename). Sent in place of a result set when the server wants the
+//   client to upload a file; the client answers with the file's contents, then an empty packet.
+export function mysqlLocalInfileRequest(seq: number, filename: string): Buffer {
+  return mysqlRawPacket(seq, Buffer.concat([Buffer.from([0xfb]), Buffer.from(filename, "utf-8")]));
+}
+
 // caching_sha2_password fast_auth_success marker carried in an AuthMoreData payload —
 // page_caching_sha2_authentication_exchanges.html (its sibling, 0x04, is perform_full_authentication).
 export const MYSQL_FAST_AUTH_SUCCESS = 0x03;


### PR DESCRIPTION
### What

A MySQL server that answers a query with a LOCAL INFILE request packet (first byte `0xFB`) permanently wedges that query, every query queued behind it on the pooled connection, and `sql.close()`. No error, no timeout.

```ts
// scripted wire server that answers LOAD DATA with 0xFB + filename
sql.unsafe("LOAD DATA LOCAL INFILE 'x.csv' INTO TABLE t").then(...); // never settles
sql.unsafe("SELECT 1").then(...);                                    // never settles either
// after 3s: LOAD DATA query = PENDING; next query on the pool = PENDING
```

Full reproduction in `test/js/sql/sql-mysql-local-infile.test.ts`.

### Why

`handle_result_set` treats anything that is not an OK or ERR packet as the start of a result set, so `0xFB` went to `ResultSetHeader::decode`, which reads it as a 1-byte length-encoded integer: column count 251. The connection then waited for 251 column definitions that never arrive.

`0xFB` is never a valid column count. A length-encoded integer only uses the 1-byte form below 251, so a 251-column result set is encoded as `0xfc 0xfb 0x00`. In the column-count position, `0xFB` can only be the LOCAL INFILE marker. (As a row's NULL marker it is already handled in `ResultSet.rs`, and rows are only parsed once the header has been received.)

Bun already had the handler, `LocalInfileRequest` + `AnyMySQLError::LocalInfileNotSupported`, but it was wired into the authentication-state dispatch inside the `MORE_DATA` match arm, where `first_byte` is always `0x01`: unreachable.

Reachability: Bun never advertises `CLIENT_LOCAL_FILES`, so a compliant server answers `LOAD DATA LOCAL INFILE` with an ERR packet (verified against MariaDB 11.8: `ERR_MYSQL_SERVER_ERROR`, "the local infile capability is disabled"). The `0xFB` byte is peer-controlled, so a buggy or hostile server or proxy can still send it.

### Fix

Handle `PacketType::LOCAL_INFILE` in `handle_result_set`, in the position where the result-set header is expected:

- answer with the empty packet the protocol requires to end a file transfer, and record `ConnectionFlags::AWAITING_LOCAL_INFILE_RESULT`;
- when the server's terminal OK/ERR for that transfer arrives, fail the query with `ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED` ("LOAD DATA LOCAL INFILE is not supported"), mark the connection ready, and flush the queue.

The query always fails, including when the server reports OK because it accepted the empty file: reporting a successful load of zero rows would be worse than an error. The pooled connection stays usable, which is what mysql2 and go-sql-driver do in the same position. While the flag is set the queue cannot write the next query (`is_ready_for_query` stays false), so the terminal packet cannot be attributed to the wrong request.

One case cannot keep the connection: bun negotiates `CLIENT_MULTI_STATEMENTS`, so `LOAD DATA LOCAL INFILE 'x' INTO TABLE t; SELECT 2` is a single command with two result sets, and the terminal OK then carries `SERVER_MORE_RESULTS_EXISTS`. Those trailing result sets belong to a query that just failed, so the connection is dropped rather than handing them to whatever runs next. Anything other than an OK or ERR in that position is an `UnexpectedPacket`.

The unreachable branch in `handle_auth` is deleted.

### Verification

- `bun bd test test/js/sql/sql-mysql-local-infile.test.ts`: 3 pass. All three fail on an unpatched build (every outcome reports `"pending"`).
- Covers the simple-query (`COM_QUERY`) and prepared-statement (`COM_STMT_PREPARE` / `COM_STMT_EXECUTE`) paths, a query queued behind the wedged one, connection reuse after the failure, and the multi-statement batch. The mock asserts the empty packet continues the server's sequence id, and holds the batch's trailing result set back until the client sends its next command: with the `SERVER_MORE_RESULTS_EXISTS` check removed, the queued query resolves with `[{ v: "trailing-result-set" }]`, another statement's rows.
- Existing MySQL wire-protocol tests pass, and a real MariaDB still returns `NULL` first columns (a row starting with `0xFB`), prepared statements, and multi-column result sets correctly.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-local-infile.test.ts
bun test v1.4.0 (c14563e00)

test/js/sql/sql-mysql-local-infile.test.ts:
181 |     expect({ stderr, stdout, signalCode }).toEqual({
182 |       stderr: expect.any(String),
183 |       stdout: expect.stringMatching(/^\{.*\}$/),
184 |       signalCode: null,
185 |     });
186 |     expect(JSON.parse(stdout)).toEqual({
                                     ^
error: expect(received).toEqual(expected)

  {
-   "closed": {
-     "status": "fulfilled",
-   },
-   "loadData": {
-     "code": "ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
-     "message": "LOAD DATA LOCAL INFILE is not supported",
-     "status": "rejected",
-   },
-   "queued": {
-     "status": "fulfilled",
-     "value": [
-       {
-         "v": "still-usable",
-       },
-     ],
-   },
+   "closed": "pending",
+   "loadData": "pending",
+   "queued": "pending",
  }

- Expected  - 16
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-local-infile.test.ts:186:32)
220 |     expect({ stderr, stdout, signalCode }).to
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/sql/sql-mysql-local-infile.test.ts:
181 |     expect({ stderr, stdout, signalCode }).toEqual({
182 |       stderr: expect.any(String),
183 |       stdout: expect.stringMatching(/^\{.*\}$/),
184 |       signalCode: null,
185 |     });
186 |     expect(JSON.parse(stdout)).toEqual({
                                     ^
error: expect(received).toEqual(expected)

  {
-   "closed": {
-     "status": "fulfilled",
-   },
-   "loadData": {
-     "code": "ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
-     "message": "LOAD DATA LOCAL INFILE is not supported",
-     "status": "rejected",
-   },
-   "queued": {
-     "status": "fulfilled",
-     "value": [
-       {
-         "v": "still-usable",
-       },
-     ],
-   },
+   "closed": "pending",
+   "loadData": "pending",
+   "queued": "pending",
  }

- Expected  - 16
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-local-infile.test.ts:186:32)
(fail) MySQL: a LOCAL INFILE request fails the query instead of wedging the connection [3024.21ms]
220 |     expect({ stderr, stdout, signalCode }).toEqual({
221 |       stderr: expect.any(String),
222 |       stdout: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-local-infile.test.ts
bun test v1.4.0 (c14563e00)

test/js/sql/sql-mysql-local-infile.test.ts:
(pass) MySQL: a LOCAL INFILE request inside a statement batch fails the connection [1557.76ms]
(pass) MySQL: a LOCAL INFILE request to a prepared statement fails the query [1569.55ms]
(pass) MySQL: a LOCAL INFILE request fails the query instead of wedging the connection [1696.37ms]

 3 pass
 0 fail
 12 expect() calls
Ran 3 tests across 1 file. [3.92s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c14563e009
  features     baseline

22 deps, 108 codegen, 1171 objects in 915ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [4.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[5/1234] gen bindgenv2
[6/1234] fetch picohttpparser
[picohttpparser] up to date
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] fetch zlib
[zlib] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/shared/ConnectionFlags.rs          |   1 +
 src/sql_jsc/mysql/JSMySQLConnection.rs     |  21 +++
 src/sql_jsc/mysql/MySQLConnection.rs       |  66 +++++--
 test/js/sql/sql-mysql-local-infile.test.ts | 276 +++++++++++++++++++++++++++++
 test/js/sql/wire-frames.ts                 |  22 ++-
 5 files changed, 374 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/sql/shared/ConnectionFlags.rs               2      2      0
src/sql_jsc/mysql/JSMySQLConnection.rs          3      3      0
src/sql_jsc/mysql/MySQLConnection.rs           11     11      0
test/js/sql/sql-mysql-local-infile.test.ts      5     12      0
test/js/sql/wire-frames.ts                      1      2      0
```

</details>

<!-- robobun:evidence:end -->