### PR TITLE
net: fail the write when the kernel rejects the bytes outright

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -205,6 +205,14 @@ function writeAfterFIN(chunk, encoding, cb) {
 
   return false;
 }
+// The native write returns -1 once the kernel rejected the bytes outright
+// (EPIPE/ECONNRESET - the peer is gone). Nothing will ever drain, so the write
+// fails the way Node's afterWrite reports uv_write's error, which destroys the
+// socket. Node uses errnoException(UV_EPIPE, 'write').
+// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L1026
+function writeFailedException() {
+  return new ErrnoException(process.platform === "win32" ? -4047 /* UV_EPIPE */ : -32 /* UV_EPIPE */, "write");
+}
 function onConnectEnd() {
   if (!this._hadError && this.secureConnecting) {
     const options = this[kConnectOptions];
@@ -281,14 +289,17 @@ const SocketHandlers: SocketHandler = {
     self.connecting = false;
     if (callback) {
       const writeChunk = self._pendingData;
-      if (socket.$write(writeChunk || "", self._pendingEncoding || "utf8")) {
+      const wrote = socket.$write(writeChunk || "", self._pendingEncoding || "utf8");
+      self[kBytesWritten] = socket.bytesWritten;
+      if (wrote === -1) {
+        self._pendingData = self[kwriteCallback] = null;
+        callback(writeFailedException());
+      } else if (wrote) {
         self._pendingData = self[kwriteCallback] = null;
         callback(null);
       } else {
         self._pendingData = null;
       }
-
-      self[kBytesWritten] = socket.bytesWritten;
     }
   },
   end(socket) {
@@ -906,7 +917,10 @@ function onconnection(err, clientHandle) {
         remotePort: _socket.remotePort,
         remoteFamily: _socket.remoteFamily || "IPv4",
       };
-      clientHandle.end();
+      // Node closes the handle outright rather than half-closing it, so the
+      // refused connection is released whatever the peer does with the FIN:
+      // https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/net.js#L2338
+      clientHandle.close();
       self.emit("drop", data);
       return;
     }
@@ -921,7 +935,7 @@ function onconnection(err, clientHandle) {
       remoteFamily: _socket.remoteFamily || "IPv4",
     };
 
-    clientHandle.end();
+    clientHandle.close();
     self.emit("drop", data);
     return;
   }
@@ -1030,12 +1044,15 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.connecting = false;
     if (callback) {
       const writeChunk = self._pendingData;
-      if (socket.$write(writeChunk || "", self._pendingEncoding || "utf8")) {
-        self[kBytesWritten] = socket.bytesWritten;
+      const wrote = socket.$write(writeChunk || "", self._pendingEncoding || "utf8");
+      self[kBytesWritten] = socket.bytesWritten;
+      if (wrote === -1) {
+        self._pendingData = self[kwriteCallback] = null;
+        callback(writeFailedException());
+      } else if (wrote) {
         self._pendingData = self[kwriteCallback] = null;
         callback(null);
       } else {
-        self[kBytesWritten] = socket.bytesWritten;
         self._pendingData = null;
       }
     }
@@ -2415,6 +2432,12 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
   }
   const success = socket.$write(chunk, encoding);
   this[kBytesWritten] = socket.bytesWritten;
+  if (success === -1) {
+    // The peer is gone, so there is no drain to wait for: fail the write and
+    // let the Writable tear the socket down, the way Node's afterWrite does.
+    process.nextTick(callback, writeFailedException());
+    return false;
+  }
   if (success) {
     if (this.encrypted) {
       // TLS batches writes through the SSL engine, so the bytes stay buffered

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -825,9 +825,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         // f0325bddf2) made Windows servers reset FIN-terminated responses:
         // write_check_error's fatal detection interacts with Windows
         // would-block semantics, and a skipped drain stalls the response
-        // teardown into an RST. Until that detection is verified on Windows,
-        // keep the legacy contract (the close path still fails the pending
-        // write callback when the socket is torn down).
+        // teardown into an RST. The drain is how the failure reaches JS anyway:
+        // a flush that hit a fatal error leaves FATAL_WRITE_ERROR set, so the
+        // write the drain callback retries reports -1 and node:net fails it.
         let _ = this.internal_flush();
         log!(
             "onWritable buffered_data_for_node_net {}",
@@ -1262,6 +1262,9 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// not live in the ext slot so those are left for the caller's existing
     /// `debug_assert!` to catch.
     pub fn detach_for_reconnect(&self) {
+        // A fresh connection starts with a clean write state: the previous
+        // connection's send failure must not fail this one's writes.
+        self.update_flags(|f| f.remove(Flags::FATAL_WRITE_ERROR));
         let old = self.socket.get();
         let Some(ext) = old.ext::<*mut c_void>() else {
             return;
@@ -2418,14 +2421,15 @@ impl<const SSL: bool> NewSocket<SSL> {
             // inside the write call - a synchronous close dispatches the whole
             // JS teardown ('close' -> http2 session destroy -> ...) underneath
             // the caller that issued this write, which is how the x64-asan
-            // lane caught a stale read. Returning -1 makes the JS write fail,
-            // and node:net destroys the handle on a clean stack; the read side
-            // surfaces the reset for anyone who is only waiting.
+            // lane caught a stale read. Recording the failure makes every JS
+            // write report -1 from here on, and node:net destroys the handle on
+            // a clean stack.
             //
             // The undeliverable buffered data (if the input aliases it) is
             // dropped by the caller: clearing it here would create a `&mut` of
             // `buffered_data_for_node_net` while `buffer` may still borrow its
             // heap allocation.
+            self.update_flags(|f| f.insert(Flags::FATAL_WRITE_ERROR));
             return -1;
         }
         let uwrote: usize = usize::try_from(res.max(0)).expect("int cast");
@@ -2453,7 +2457,12 @@ impl<const SSL: bool> NewSocket<SSL> {
             match this.write_or_end_buffered::<false>(global, args.ptr[0], args.ptr[1]) {
                 WriteResult::Fail => JSValue::ZERO,
                 WriteResult::Success { wrote, total } => {
-                    if usize::try_from(wrote.max(0)).expect("int cast") == total {
+                    if this.flags.get().contains(Flags::FATAL_WRITE_ERROR) {
+                        // The peer is gone. `false` would park the write on a
+                        // drain that can never complete, so report the failure
+                        // and let node:net fail the write callback.
+                        JSValue::js_number_from_int32(-1)
+                    } else if usize::try_from(wrote.max(0)).expect("int cast") == total {
                         JSValue::TRUE
                     } else {
                         JSValue::FALSE
@@ -2888,11 +2897,10 @@ impl<const SSL: bool> NewSocket<SSL> {
     }
 
     /// Returns `false` when a fatal send error dropped the buffered data.
-    /// NOTE: callers currently ignore this (the drain callback is dispatched
-    /// regardless) - skipping the drain on fatal made Windows servers reset
-    /// FIN-terminated responses (see a5e7ba5905). The return value stays so
-    /// the contract can be re-landed once the Windows fatal-write detection
-    /// is verified.
+    /// Callers ignore this: the drain callback is still dispatched (skipping it
+    /// on fatal made Windows servers reset FIN-terminated responses), and the
+    /// `FATAL_WRITE_ERROR` flag it sets is what makes the drained JS write
+    /// report the failure instead of completing successfully.
     fn internal_flush(&self) -> bool {
         // R-2: every mutated field is `Cell`/`JsCell`, so `&self` carries no
         // `noalias` for them and the previous `black_box` launder (which
@@ -2919,12 +2927,12 @@ impl<const SSL: bool> NewSocket<SSL> {
                 if fatal {
                     // Same rule as write_maybe_corked: drop the undeliverable
                     // buffer and stop re-arming the writable retry, but do not
-                    // close from inside the drain dispatch - the peer reset is
-                    // delivered on the read side and tears the socket down on
-                    // a clean stack. Report the failure so callers do not
-                    // dispatch the JS drain callback (the write did NOT
-                    // complete; Node fails the callback instead of succeeding
-                    // it).
+                    // close from inside the drain dispatch. Recording the
+                    // failure makes the drained JS write report -1 instead of
+                    // completing, so node:net fails it (Node's afterWrite) and
+                    // destroys the socket on a clean stack. A half-open socket
+                    // has no read side left to surface the reset on.
+                    self.update_flags(|f| f.insert(Flags::FATAL_WRITE_ERROR));
                     self.buffered_data_for_node_net
                         .with_mut(|b| b.clear_and_free());
                     return false;
@@ -4057,6 +4065,11 @@ bitflags::bitflags! {
         const BYPASS_TLS           = 1 << 9;
         const OWNS_HANDLERS        = 1 << 10;
         const HOSTNAME_MISMATCH    = 1 << 11;
+        /// The kernel rejected a `send()` with a non-retryable error
+        /// (EPIPE/ECONNRESET): no later byte can be delivered either. Sticky so
+        /// the drain dispatch can fail the pending JS write instead of
+        /// completing it; cleared when the wrapper is reused for a new connect.
+        const FATAL_WRITE_ERROR    = 1 << 12;
     }
 }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4065,10 +4065,12 @@ bitflags::bitflags! {
         const BYPASS_TLS           = 1 << 9;
         const OWNS_HANDLERS        = 1 << 10;
         const HOSTNAME_MISMATCH    = 1 << 11;
-        /// The kernel rejected a `send()` with a non-retryable error
-        /// (EPIPE/ECONNRESET): no later byte can be delivered either. Sticky so
-        /// the drain dispatch can fail the pending JS write instead of
-        /// completing it; cleared when the wrapper is reused for a new connect.
+        /// A `send()` failed with a non-retryable error (EPIPE/ECONNRESET): no
+        /// later byte can be delivered either. Sticky, so the drain dispatch
+        /// fails the pending JS write rather than completing it; cleared when
+        /// the wrapper is reused for a new connect. Only the plain-TCP arm sets
+        /// it (`write_check_error` signals no fatal for SSL/duplex/pipe), so
+        /// `writeBuffered`'s `-1` only ever reaches a node:net handle.
         const FATAL_WRITE_ERROR    = 1 << 12;
     }
 }

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "fs";
-import { AddressInfo, createServer, Server, Socket } from "net";
+import { AddressInfo, connect, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
 import { tmpdir } from "os";
@@ -459,6 +459,45 @@ describe("net.createServer events", () => {
         }
         await Promise.all(promises).catch(closeAndFail);
       });
+  });
+
+  // A connection refused by maxConnections has to learn it was refused. The
+  // server closes the accepted handle, so the peer's next write is rejected by
+  // the kernel and surfaces as `write EPIPE` the way Node's afterWrite reports
+  // it - not as a write that silently disappears into a half-open socket.
+  it("should fail the writes of a connection it dropped", async () => {
+    const server = createServer((socket: Socket) => {
+      socket.write("hi"); // holds the one allowed connection open
+    });
+    server.maxConnections = 1;
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const accepted = connect(port, "127.0.0.1");
+    accepted.on("error", () => {});
+    await once(accepted, "data"); // the single slot is taken
+
+    const dropped = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+    const droppedError = once(dropped, "error");
+    const droppedEnd = once(dropped, "end");
+    const [dropData] = await once(server, "drop");
+    expect(dropData.remotePort).toBeGreaterThan(0);
+    await droppedEnd; // the server let go of its side
+
+    // The first chunk lands in the send buffer; the peer's reset comes back
+    // before the next one, and every byte after that is undeliverable.
+    const chunk = Buffer.alloc(64 * 1024, 0x41);
+    for (let i = 0; i < 8 && dropped.writable; i++) dropped.write(chunk);
+
+    const [err] = (await droppedError) as [NodeJS.ErrnoException];
+    expect({ code: err.code, syscall: err.syscall }).toEqual({ code: "EPIPE", syscall: "write" });
+    await once(dropped, "close");
+    expect(dropped.destroyed).toBe(true);
+
+    accepted.destroy();
+    server.close();
+    await once(server, "close");
   });
 
   it("should error on an invalid port", () => {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -466,7 +466,11 @@ describe("net.createServer events", () => {
   // the kernel and surfaces as `write EPIPE` the way Node's afterWrite reports
   // it - not as a write that silently disappears into a half-open socket.
   it("should fail the writes of a connection it dropped", async () => {
+    let held: Socket | undefined;
+    let accepted: Socket | undefined;
+    let dropped: Socket | undefined;
     const server = createServer((socket: Socket) => {
+      held = socket;
       socket.write("hi"); // holds the one allowed connection open
     });
     server.maxConnections = 1;
@@ -474,29 +478,33 @@ describe("net.createServer events", () => {
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
 
-    const accepted = connect(port, "127.0.0.1");
-    accepted.on("error", () => {});
-    await once(accepted, "data"); // the single slot is taken
+    try {
+      accepted = connect(port, "127.0.0.1");
+      accepted.on("error", () => {});
+      await once(accepted, "data"); // the single slot is taken
 
-    const dropped = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
-    const droppedError = once(dropped, "error");
-    const droppedEnd = once(dropped, "end");
-    const [dropData] = await once(server, "drop");
-    expect(dropData.remotePort).toBeGreaterThan(0);
-    await droppedEnd; // the server let go of its side
+      dropped = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+      const droppedError = once(dropped, "error");
+      const droppedEnd = once(dropped, "end");
+      const [dropData] = await once(server, "drop");
+      expect(dropData.remotePort).toBeGreaterThan(0);
+      await droppedEnd; // the server let go of its side
 
-    // The first chunk lands in the send buffer; the peer's reset comes back
-    // before the next one, and every byte after that is undeliverable.
-    const chunk = Buffer.alloc(64 * 1024, 0x41);
-    for (let i = 0; i < 8 && dropped.writable; i++) dropped.write(chunk);
+      // The first chunk lands in the send buffer; the peer's reset comes back
+      // before the next one, and every byte after that is undeliverable.
+      const chunk = Buffer.alloc(64 * 1024, 0x41);
+      for (let i = 0; i < 8 && dropped.writable; i++) dropped.write(chunk);
 
-    const [err] = (await droppedError) as [NodeJS.ErrnoException];
-    expect({ code: err.code, syscall: err.syscall }).toEqual({ code: "EPIPE", syscall: "write" });
-    await once(dropped, "close");
-    expect(dropped.destroyed).toBe(true);
-
-    accepted.destroy();
-    server.close();
+      const [err] = (await droppedError) as [NodeJS.ErrnoException];
+      expect({ code: err.code, syscall: err.syscall }).toEqual({ code: "EPIPE", syscall: "write" });
+      await once(dropped, "close");
+      expect(dropped.destroyed).toBe(true);
+    } finally {
+      held?.destroy();
+      accepted?.destroy();
+      dropped?.destroy();
+      server.close();
+    }
     await once(server, "close");
   });
 


### PR DESCRIPTION
`net.Server#maxConnections` looked like it wasn't capping: a refused connection kept its socket, its fd, and went on writing into the server forever. The cap is actually fine (the server closes the accepted fd), but the peer never found out it was dropped.

## Repro

```js
import net from "node:net";
const srv = net.createServer(c => c.write("hi")); // holds the one allowed socket open
srv.maxConnections = 1;
srv.listen(0, "127.0.0.1", async () => {
  const port = srv.address().port;
  const c1 = net.connect(port, "127.0.0.1");
  c1.on("error", () => {});
  await new Promise(r => c1.once("data", r)); // the quota is full

  const dropped = net.connect({ port, host: "127.0.0.1", allowHalfOpen: true });
  let errors = 0;
  dropped.on("error", () => errors++);
  await new Promise(r => dropped.once("end", r)); // the server closed its side

  const buf = Buffer.alloc(65536, 0x41);
  for (let k = 0; k < 8; k++) dropped.write(buf);
  await new Promise(r => setTimeout(r, 900));
  console.log({ errors, writable: dropped.writable, bytesWritten: dropped.bytesWritten });
  process.exit(0);
});
```

```
node v26.3.0: { errors: 1, writable: false, bytesWritten: 131072 }
bun 1.4.0:    { errors: 0, writable: true,  bytesWritten: 65536  }
```

Half a megabyte was handed to `write()` and silently discarded, the socket stayed writable forever, and its fd was never released. A dropped peer, a `blockList` rejection, or any peer that closes while we still have a half-open socket to write to hits this.

## Cause

`us_socket_write_check_error` already separates a fatal `send()` error (EPIPE/ECONNRESET, the peer is gone) from would-block, and `write_maybe_corked` / `internal_flush` act on it by dropping the undeliverable bytes. But nothing reported the failure:

- `writeBuffered` (`$write`) returned `false`, which `node:net` reads as "would block" and parks the stream callback for a drain.
- `on_writable` dispatches the drain callback regardless of the flush result, so the parked callback completed with success, and the next chunk repeated the cycle.
- Nothing closed the socket. The comment in `write_maybe_corked` assumed "the read side surfaces the reset for anyone who is only waiting", but a half-open socket has no read side left: uws switches the poll to writable-only after the peer's FIN, and the `send()` that failed already consumed `sk_err`, so `EPOLLERR` never arrives either.

## Fix

Record the fatal send error on the socket (`Flags::FATAL_WRITE_ERROR`) where it is detected, and report it from `writeBuffered` as `-1`. `node:net`'s `_write` and its two drain handlers turn that into `errnoException(UV_EPIPE, 'write')` on the write callback, which is what makes the Writable destroy the socket -- the same shape Node's `afterWrite` produces for a failed `uv_write`. The drain dispatch itself is unchanged (skipping it on fatal is what broke FIN-terminated responses on Windows before); the drain is simply how the failure now reaches JS.

The flag is cleared when the wrapper is reused for a fresh `connect()`.

The other two `$write` callers are deliberately left alone: `internal/debugger.ts` discards the return value, and `_http2_upgrade.ts`'s handle is an `InternalSocket::UpgradedDuplex`, whose `write_check_error` arm cannot report fatal (there is no fd to `send()` on -- the ciphertext goes back to a JS Duplex), so `-1` is unreachable there. That invariant is now stated on the flag itself.

Separately, both `onconnection` drop branches now `close()` the refused handle instead of `end()`-ing it, matching Node. `end()` only tears the socket down if the flush path's flags happen to line up; `close()` releases it whatever the peer does with the FIN.

## Verification

The repro now prints byte-identical output to node, as does the reporter's longer 20-connection version (`{"drops":20,"clientErrors":20,"stillWritableAfterDrop":0,"serverFdDelta":0}`).

New test in `test/js/node/net/node-net-server.test.ts` asserts a dropped peer's writes fail with `write EPIPE` and the socket is destroyed. It times out on `main` (no error is ever emitted) and passes with the fix.

<details>
<summary>Suites run against the debug build</summary>

- `test/js/node/test/parallel/test-net-*.js`: 141/141 pass
- `test/js/node/test/parallel/test-tls-*.js`, `test-http2-*.js`: no new failures
- `test/js/node/net/`, `test/js/node/tls/`, `test/js/node/http/`, `test/js/bun/net/`: no new failures (the remaining ones fail identically on a stock bun in this container: `localhost` resolution and DNS)

</details>

