### PR TITLE
sql(mysql): surface 64-bit last_insert_id / affected_rows without rounding

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1323,6 +1323,14 @@ const now = await mysql`SELECT NOW() as current_time`;
 const uuid = await mysql`SELECT UUID() as id`;
 ```
 
+`lastInsertRowid` and `affectedRows` are 64-bit on the wire. They are `number`s while they stay inside `Number.MAX_SAFE_INTEGER`, and `BigInt`s past it, so a large `BIGINT UNSIGNED` auto-increment key is never rounded:
+
+```ts
+// AUTO_INCREMENT keys seeded from a snowflake-style generator
+const { lastInsertRowid } = await mysql`INSERT INTO events (kind) VALUES (${"click"})`;
+console.log(lastInsertRowid); // 4611686018427387911n
+```
+
 ### MySQL Error Handling
 
 ```ts

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -81,6 +81,8 @@ initMySQL(
 
 export interface MySQLDotZig {
   init: (
+    // The OK packet's last_insert_id / affected_rows are u64: they arrive as a
+    // number while they fit Number.MAX_SAFE_INTEGER, and as a BigInt past it.
     onResolveQuery: (
       query: Query<any, any>,
       result: SQLResultArray,
@@ -88,6 +90,8 @@ export interface MySQLDotZig {
       count: number,
       queries: any,
       is_last: boolean,
+      last_insert_rowid: number | bigint,
+      affected_rows: number | bigint,
     ) => void,
     onRejectQuery: (query: Query<any, any>, err: Error, queries) => void,
   ) => void;

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -26,6 +26,20 @@ use super::my_sql_statement::MySQLStatement;
 
 bun_core::define_scoped_log!(debug, MySQLQuery);
 
+/// The OK packet's `affected_rows` and `last_insert_id` are u64 on the wire, so
+/// a `BIGINT UNSIGNED` AUTO_INCREMENT key past 2^53 has no exact double. Values
+/// outside the safe-integer range cross into JS as BigInt instead of rounding.
+/// The BigInt branch allocates on the JS heap and so can throw, like the sibling
+/// `JSValue::from_timeval_no_truncate`.
+fn ok_packet_int_to_js(global_object: &JSGlobalObject, value: u64) -> JsResult<JSValue> {
+    if value <= bun_jsc::MAX_SAFE_INTEGER as u64 {
+        return Ok(JSValue::js_number_from_uint64(value));
+    }
+    jsc::host_fn::from_js_host_call(global_object, || {
+        JSValue::from_uint64_no_truncate(global_object, value)
+    })
+}
+
 // The `#[bun_jsc::JsClass]` derive is intentionally not applied: this type's
 // JS wiring (`to_js`/`from_js`, the exported `MySQLQueryPrototype__*` /
 // `MySQLQueryClass__*` wrappers) is owned by the `.classes.ts` codegen
@@ -234,11 +248,35 @@ impl JSMySQLQuery {
         Ok(JSValue::UNDEFINED)
     }
 
+    /// `(last_insert_id, affected_rows)` for the resolve callback.
+    fn ok_packet_ints(&self, result: &MySQLQueryResult) -> JsResult<(JSValue, JSValue)> {
+        if self.vm().is_shutting_down() {
+            // The caller returns before reading these; allocating is not safe here.
+            return Ok((JSValue::UNDEFINED, JSValue::UNDEFINED));
+        }
+        let global_object = self.global_object();
+        let last_insert_id = ok_packet_int_to_js(global_object, result.last_insert_id)?;
+        last_insert_id.ensure_still_alive();
+        let affected_rows = ok_packet_int_to_js(global_object, result.affected_rows)?;
+        affected_rows.ensure_still_alive();
+        Ok((last_insert_id, affected_rows))
+    }
+
     pub fn resolve(&self, queries_array: JSValue, result: &MySQLQueryResult) {
         // `ref_guard` brackets re-entry; drops *after* `_downgrade` so the
         // allocation outlives the closure body.
         let _guard = self.ref_guard();
         let is_last_result = result.is_last_result;
+
+        // Converted before `q.result()` below marks the query terminal, because a
+        // throw from the BigInt allocation has to be able to reject it, and
+        // `reject` is a no-op on a query already marked Success.
+        let ok_ints = self.ok_packet_ints(result);
+        let Ok((last_insert_id, affected_rows)) = ok_ints else {
+            self.reject(queries_array, AnyMySQLError::Error::JSError);
+            return;
+        };
+
         // R-2: `&Self` is `Copy`; the guard captures it by value and runs on
         // every exit path (defer). All mutation is `JsCell`-backed.
         let _downgrade = scopeguard::guard(self, move |s| {
@@ -300,8 +338,8 @@ impl JSMySQLQuery {
                     queries_array
                 },
                 JSValue::js_boolean(is_last_result),
-                JSValue::js_number(result.last_insert_id as f64),
-                JSValue::js_number(result.affected_rows as f64),
+                last_insert_id,
+                affected_rows,
             ],
         );
     }

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1,8 +1,9 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { bunEnv, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
+import type net from "node:net";
 import path from "path";
-import { listeningServer } from "./wire-frames";
+import { listeningServer, mysqlHandshakeV10, mysqlOkPacket, mysqlReadPackets } from "./wire-frames";
 const dir = tempDirWithFiles("sql-test", {
   "select-param.sql": `select ? as x`,
   "select.sql": `select CAST(1 AS SIGNED) as x`,
@@ -141,6 +142,28 @@ if (isDockerEnabled()) {
           const { affectedRows } =
             await sql`UPDATE ${sql(random_name)} SET name = "test2" WHERE id = ${lastInsertRowid}`;
           expect(affectedRows).toBe(1);
+        });
+        test("lastInsertRowid above 2^53 is the key the server assigned", async () => {
+          await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
+          using sql = await db.reserve();
+          const t = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+
+          // (1 << 62) + 7 — a legal BIGINT UNSIGNED auto-increment key, and the
+          // magnitude Snowflake-style id generators land on. It has no exact
+          // double: as a JS number it reads back as 4611686018427388000.
+          const firstId = 4611686018427387911n;
+          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, name text)`;
+          await sql.unsafe(`ALTER TABLE \`${t}\` AUTO_INCREMENT = ${firstId}`);
+
+          const { lastInsertRowid } = await sql`INSERT INTO ${sql(t)} (name) VALUES (${"test"})`;
+          expect(lastInsertRowid).toBe(firstId);
+
+          // Narrowing by the reported id must reach the row that was just
+          // inserted, which only holds if every one of the 64 bits survived.
+          // The id goes in as a literal because binding a BigInt parameter is a
+          // separate bug, fixed in #32265.
+          const rows = await sql.unsafe(`SELECT name FROM \`${t}\` WHERE id = ${lastInsertRowid}`);
+          expect(rows).toEqual([{ name: "test" }]);
         });
         test("MEDIUMINT not in the last column reads following columns correctly", async () => {
           // MySQL's binary protocol sends MYSQL_TYPE_INT24 as a fixed 4-byte
@@ -1194,3 +1217,118 @@ if (isDockerEnabled()) {
     );
   }
 }
+
+// The OK packet's affected_rows and last_insert_id are u64, so they carry
+// values a double cannot hold. A mock server is used because seeding
+// AUTO_INCREMENT past 2^53 is the only way a real server reaches there, and
+// these must also run without Docker.
+describe("MySQL OK packet 64-bit integers", () => {
+  const COM_QUERY = 0x03;
+
+  // (1 << 62) + 7 — a legal BIGINT UNSIGNED auto-increment key, and the
+  // magnitude Snowflake-style id generators land on. The nearest double is
+  // 4611686018427388000, so a lossy hand-off is visible in the low digits.
+  const hugeId = 4611686018427387911n;
+
+  function handshakeThen(onCommand: (socket: net.Socket, seq: number, payload: Buffer) => void) {
+    return listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let authed = false;
+      socket.write(mysqlHandshakeV10());
+      socket.on("data", chunk => {
+        buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+          if (!authed) {
+            authed = true;
+            socket.write(mysqlOkPacket(seq + 1));
+            return;
+          }
+          onCommand(socket, seq, payload);
+        });
+      });
+      socket.on("error", () => {});
+    });
+  }
+
+  // `sql.unsafe` with no bind values takes the COM_QUERY path, so the OK packet
+  // is the only frame the server has to produce.
+  async function unsafeInsert(
+    rows: { affectedRows?: number | bigint; lastInsertId?: number | bigint },
+    options: { bigint?: boolean } = {},
+  ) {
+    const { server, port } = await handshakeThen((socket, seq, payload) => {
+      if (payload[0] === COM_QUERY) socket.write(mysqlOkPacket(seq + 1, 0x00, rows));
+    });
+    try {
+      await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1, ...options });
+      const result = await sql.unsafe("INSERT INTO t (v) VALUES (1)");
+      return { lastInsertRowid: result.lastInsertRowid, affectedRows: result.affectedRows };
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  test.each([false, true])("last_insert_id above 2^53 reaches JS exactly (bigint: %p)", async bigint => {
+    expect(await unsafeInsert({ affectedRows: 1, lastInsertId: hugeId }, { bigint })).toEqual({
+      lastInsertRowid: hugeId,
+      affectedRows: 1,
+    });
+  });
+
+  test("affected_rows above 2^53 reaches JS exactly", async () => {
+    expect(await unsafeInsert({ affectedRows: hugeId, lastInsertId: 0 })).toEqual({
+      lastInsertRowid: 0,
+      affectedRows: hugeId,
+    });
+  });
+
+  test("values inside the safe-integer range stay plain numbers", async () => {
+    expect(await unsafeInsert({ affectedRows: 2, lastInsertId: Number.MAX_SAFE_INTEGER })).toEqual({
+      lastInsertRowid: Number.MAX_SAFE_INTEGER,
+      affectedRows: 2,
+    });
+  });
+
+  test("the first value that is not a safe integer crosses over to BigInt", async () => {
+    // 2**53 is exactly representable as a double, but Number.isSafeInteger(2**53)
+    // is false: it shares its double with 2**53 + 1. The cutoff sits here.
+    expect(await unsafeInsert({ affectedRows: 1, lastInsertId: 2n ** 53n })).toEqual({
+      lastInsertRowid: 9007199254740992n,
+      affectedRows: 1,
+    });
+  });
+
+  test("allocating the BigInt leaves no unchecked JS exception", async () => {
+    // JSBigInt::createFrom declares a JSC ThrowScope. Delivering the result
+    // re-enters JS, which aborts if that scope was never checked, so the client
+    // runs in a child with the validator on (a no-op outside debug/ASAN builds,
+    // where the printed id still has to be exact).
+    const { server, port } = await handshakeThen((socket, seq, payload) => {
+      if (payload[0] === COM_QUERY) {
+        socket.write(mysqlOkPacket(seq + 1, 0x00, { affectedRows: 1, lastInsertId: hugeId }));
+      }
+    });
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `await using sql = new Bun.SQL({ url: "mysql://root@127.0.0.1:${port}/db", max: 1 });
+           const result = await sql.unsafe("INSERT INTO t (v) VALUES (1)");
+           console.log(String(result.lastInsertRowid));`,
+        ],
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1", BUN_JSC_dumpSimulatedThrows: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // An unchecked scope aborts the child, so stdout is empty and exitCode is a signal.
+      expect({ stdout: stdout.trim(), exitCode, abort: stderr.includes("exception check validation failed") }).toEqual({
+        stdout: String(hugeId),
+        exitCode: 0,
+        abort: false,
+      });
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -271,8 +271,22 @@ export function mysqlHandshakeV10(
 
 // MySQL Protocol::OK_Packet — page_protocol_basic_ok_packet.html: Int<1>(header) lenenc(affected_rows) lenenc(last_insert_id) Int<2>(status) Int<2>(warnings)
 // The header is 0x00, except for the CLIENT_DEPRECATE_EOF result-set terminator, which is an OK packet with a 0xFE header.
-export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
-  return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+// affected_rows / last_insert_id are u64, so they accept bigint as well as number.
+export function mysqlOkPacket(
+  seq: number,
+  header: 0x00 | 0xfe = 0x00,
+  rows: { affectedRows?: number | bigint; lastInsertId?: number | bigint } = {},
+): Buffer {
+  return mysqlRawPacket(
+    seq,
+    Buffer.concat([
+      Buffer.from([header]),
+      mysqlLenencInt(rows.affectedRows ?? 0),
+      mysqlLenencInt(rows.lastInsertId ?? 0),
+      Buffer.from([0x02, 0x00]), // status_flags (SERVER_STATUS_AUTOCOMMIT)
+      Buffer.from([0x00, 0x00]), // warnings
+    ]),
+  );
 }
 
 // MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:


### PR DESCRIPTION
## Repro

MySQL's OK packet carries `affected_rows` and `last_insert_id` as u64. Bun handed both to JS as doubles, so a `BIGINT UNSIGNED` AUTO_INCREMENT key above 2^53 came back rounded, with no error:

```ts
// the server's LAST_INSERT_ID() is 4611686018427387911
const { lastInsertRowid } = await sql`INSERT INTO events (kind) VALUES (${"click"})`;
console.log(lastInsertRowid); // 4611686018427388000  <- not the row's id
```

An application that uses `lastInsertRowid` as the row's key gets a different id than the database assigned. `bigint: true` did not help: it governs column decoding, and never reached the OK packet. AUTO_INCREMENT keys land up here routinely under Snowflake-style id schemes, which is exactly why those deployments picked `BIGINT UNSIGNED`.

## Cause

`JSMySQLQuery::resolve` converted both u64s with `JSValue::js_number(x as f64)`. Past `Number.MAX_SAFE_INTEGER` that silently drops the low digits. The value is intact everywhere else: `OKPacket::decode_internal` reads a lenenc u64, and it stays a u64 through `handle_result_set_ok` and `MySQLQueryResult`. Only the hand-off to JS was lossy.

## Fix

`last_insert_id` and `affected_rows` cross into JS as a number while they fit inside `Number.MAX_SAFE_INTEGER`, and as a BigInt past it.

Values at or below the limit keep their current type, so nothing that works today changes. Above it the value was already wrong, and there is no third option: silently rounding a primary key is worse than handing back a BigInt. `SQLResultArray` already declares both fields as `number | bigint | null`. The conversion happens before the pending result array leaves its cached slot, since allocating a heap BigInt can trigger GC.

## Verification

5 tests in `test/js/sql/sql-mysql.test.ts` drive a mock MySQL server, so they run without Docker: both u64 fields above 2^53, and the safe-integer boundary in both directions (`Number.MAX_SAFE_INTEGER` stays a `number`; `2**53`, the first value `Number.isSafeInteger` rejects, crosses to `BigInt`). 4 of the 5 fail on an unfixed build; the one that passes is the guard that in-range values keep their current type.

One Docker-backed test seeds a real `BIGINT UNSIGNED AUTO_INCREMENT` table past 2^53 and checks that the reported id selects the row that was just inserted.

<details>
<summary>Before / after on the reporter's scripted wire server</summary>

```
# before
bigint:false  server last_insert_id=4611686018427387911  lastInsertRowid=4611686018427388000 (number)  exact=false
bigint:true   server last_insert_id=4611686018427387911  lastInsertRowid=4611686018427388000 (number)  exact=false

# after
bigint:false  server last_insert_id=4611686018427387911  lastInsertRowid=4611686018427387911 (bigint)  exact=true
bigint:true   server last_insert_id=4611686018427387911  lastInsertRowid=4611686018427387911 (bigint)  exact=true
```

Also confirmed end to end against a real MySQL-protocol server with `AUTO_INCREMENT = 4611686018427387911`.

</details>

## Related

Passing that key back to the server is a separate bug: `JSC__isBigIntIn{Int64,UInt64}Range` declares its bounds as `(value, max, min)` while every caller passes `(min, max)`, and returns `true` as soon as `value >= min` instead of requiring both bounds, so binding any in-range `BigInt` parameter throws `ERR_OUT_OF_RANGE`. #32265 fixes that and is green; this PR deliberately does not touch it. The two are independent (each is a strict improvement alone) but they complete each other: #32265 lets you bind the key, this one makes the key correct.
