### PR TITLE
stdio: route process.stdout/stderr writes through Writable's buffer accounting

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -471,7 +471,10 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     this[kWriteStreamFastPath] = fd ? Bun.file(fd).writer() : true;
     this._write = underscoreWriteFast;
     this._writev = undefined;
-    this.write = writeFast as any;
+    // The FileSink encodes strings straight into its own buffer, so skip the
+    // Buffer.from() round-trip. node's process.stdout/stderr (net.Socket) also
+    // run with decodeStrings: false.
+    options.decodeStrings = false;
     if (fd != null) {
       // Already-open fd (stdio): skip the async _construct round-trip so the
       // stream is born constructed, like node's stdio streams (net.Socket /
@@ -586,13 +589,20 @@ function _write(data, encoding, cb) {
 }
 writeStreamPrototype._write = _write;
 
-function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) {
+// `_write` for FileSink-backed streams (process.stdout/stderr, tty.WriteStream,
+// child.stdin). Completes synchronously when the sink took the whole chunk, so
+// that back-to-back writes don't pile up in the Writable buffer, and defers to
+// the sink's promise when it had to buffer, which is what keeps
+// writableLength/writableNeedDrain honest.
+function underscoreWriteFast(this: FSStream, chunk: any, encoding: any, cb: any) {
   let fileSink = this[kWriteStreamFastPath];
   if (!fileSink) {
     // When the fast path is disabled, the write function gets reset.
     this._write = _write;
-    return this._write(data, encoding, cb);
+    return this._write(chunk, encoding, cb);
   }
+
+  let maybePromise;
   try {
     if (fileSink === true) {
       fileSink = this[kWriteStreamFastPath] = Bun.file(this.path).writer();
@@ -600,82 +610,22 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
       this.fd = fileSink._getFd();
     }
 
-    const maybePromise = fileSink.write(data);
-    if ($isPromise(maybePromise)) {
-      maybePromise.then(
-        () => {
-          if (cb) cb(null);
-          this.emit("drain");
-        },
-        err => {
-          if (cb) cb(err);
-          require("internal/streams/destroy").errorOrDestroy(this, err);
-        },
-      );
-      return false;
-    } else {
-      if (cb) process.nextTick(cb, null);
-      return true;
+    // decodeStrings is off for this path: the sink encodes UTF-8 itself, but
+    // every other encoding has to be decoded here.
+    if (typeof chunk === "string" && encoding !== "utf8" && encoding !== "utf-8") {
+      chunk = Buffer.from(chunk, encoding);
     }
+
+    maybePromise = fileSink.write(chunk);
   } catch (e) {
-    if (cb) process.nextTick(cb, e);
-    require("internal/streams/destroy").errorOrDestroy(this, e, true);
-    return false;
-  }
-}
-
-// This function implementation is not correct.
-const writablePrototypeWrite = Writable.prototype.write;
-const kWriteMonkeyPatchDefense = Symbol("!");
-function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
-  if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
-
-  // After end()/destroy() the Writable contract requires write() to fail with
-  // ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED and not reach the sink.
-  const state = this._writableState;
-  if (state !== undefined && (state.ending || state.destroyed)) {
-    return writablePrototypeWrite.$call(this, data, encoding, cb);
+    cb(e);
+    return;
   }
 
-  if (typeof encoding === "function") {
-    cb = encoding;
-    encoding = undefined;
-  }
-  if (typeof cb !== "function") {
-    cb = streamNoop;
-  }
-
-  const fileSink = this[kWriteStreamFastPath];
-  if (fileSink && fileSink !== true) {
-    const maybePromise = fileSink.write(data);
-    if ($isPromise(maybePromise)) {
-      // Two-arg then(): a throw from the fulfillment handler must not be
-      // mistaken for a write failure.
-      maybePromise.then(
-        () => {
-          this.emit("drain"); // Emit drain event
-          cb(null);
-        },
-        err => {
-          cb(err);
-          // Node.js onwriteError: callback AND destroy are both invoked; the
-          // callback is additive, not a replacement for the 'error' event.
-          require("internal/streams/destroy").errorOrDestroy(this, err);
-        },
-      );
-      return false; // Indicate backpressure
-    } else {
-      cb(null);
-      return true; // No backpressure
-    }
+  if ($isPromise(maybePromise)) {
+    maybePromise.then(() => cb(null), cb);
   } else {
-    const result: any = this._write(data, encoding, cb);
-    if (this.write === writeFast) {
-      this.write = writablePrototypeWrite;
-    } else {
-      this[kWriteMonkeyPatchDefense] = true;
-    }
-    return result;
+    cb(null);
   }
 }
 

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -470,7 +470,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   if (fastPath) {
     this[kWriteStreamFastPath] = fd ? Bun.file(fd).writer() : true;
     this._write = underscoreWriteFast;
-    this._writev = undefined;
+    this._writev = underscoreWritevFast;
     // The FileSink encodes strings straight into its own buffer, so skip the
     // Buffer.from() round-trip. node's process.stdout/stderr (net.Socket) also
     // run with decodeStrings: false.
@@ -627,6 +627,22 @@ function underscoreWriteFast(this: FSStream, chunk: any, encoding: any, cb: any)
   } else {
     cb(null);
   }
+}
+
+// `_writev` for the same streams. A corked burst (and a backlog drained after
+// backpressure) reaches the sink as one write, and so one write(2), which is
+// what cork() is for: node's stdio over a pipe coalesces the same burst into a
+// single writev(2).
+function underscoreWritevFast(this: FSStream, data: any, cb: any) {
+  const len = data.length;
+  const chunks = new Array(len);
+
+  for (let i = 0; i < len; i++) {
+    const { chunk, encoding } = data[i];
+    chunks[i] = typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
+  }
+
+  return underscoreWriteFast.$call(this, len === 1 ? chunks[0] : Buffer.concat(chunks), "buffer", cb);
 }
 
 writeStreamPrototype._writev = function (data, cb) {

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -165,4 +165,75 @@ describe("child.stdin", () => {
       cbCode: "ERR_STREAM_DESTROYED",
     });
   });
+
+  it("fails a write issued after end() with ERR_STREAM_WRITE_AFTER_END", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    const echoed = Promise.withResolvers();
+    let data = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", chunk => (data += chunk));
+    child.stdout.on("end", () => echoed.resolve(data));
+    child.stdout.on("error", echoed.reject);
+    child.on("error", echoed.reject);
+
+    // Registered so an unexpected emission fails the assertion below instead of
+    // crashing the test. None is expected: autoDestroy has already run by the
+    // time we write, so errorOrDestroy short-circuits and only the callback
+    // receives the error.
+    const errorEvents = [];
+    child.stdin.on("error", err => errorEvents.push(err.code));
+
+    const finished = Promise.withResolvers();
+    child.stdin.on("finish", finished.resolve);
+    child.stdin.end("kept\n");
+    await finished.promise;
+
+    const writeCb = Promise.withResolvers();
+    const ret = child.stdin.write("dropped\n", err => writeCb.resolve(err));
+
+    expect((await writeCb.promise)?.code).toBe("ERR_STREAM_WRITE_AFTER_END");
+    expect(ret).toBe(false);
+    // The bytes must not reach the child.
+    expect(await echoed.promise).toBe("data: kept\n");
+    expect(errorEvents).toEqual([]);
+  });
+
+  it("emits 'error' for a callback-less write issued after end()", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    const errored = Promise.withResolvers();
+    child.stdin.on("error", errored.resolve);
+    child.on("error", errored.reject);
+    child.on("exit", () => errored.reject(new Error("child exited before stdin errored")));
+
+    child.stdin.end("kept\n");
+    const ret = child.stdin.write("dropped\n");
+
+    expect((await errored.promise).code).toBe("ERR_STREAM_WRITE_AFTER_END");
+    expect(ret).toBe(false);
+    child.kill();
+  });
+
+  it("fails a write issued after destroy() with ERR_STREAM_DESTROYED", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    child.stdin.destroy();
+
+    const writeCb = Promise.withResolvers();
+    const ret = child.stdin.write("dropped\n", err => writeCb.resolve(err));
+
+    expect((await writeCb.promise)?.code).toBe("ERR_STREAM_DESTROYED");
+    expect(ret).toBe(false);
+    child.kill();
+  });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import fs from "fs";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -291,6 +292,65 @@ describe.concurrent("process-stdio", () => {
       });
       expect(stdout.length).toBe(N);
       expect(await proc.exited).toBe(0);
+    });
+
+    // The point of cork(): the burst reaches the fd as one write(2), the way
+    // node's stdio coalesces it into a single writev(2). /proc/self/io's syscw
+    // counter is the only way to observe it, so this one is Linux-only.
+    //
+    // stdout is a regular file rather than a pipe on purpose. A pipe that fills
+    // up makes the sink buffer and coalesce writes on its own, which would sink
+    // both numbers below and leave the test asserting nothing; a file never
+    // applies backpressure, so every sink write is exactly one write(2).
+    test.skipIf(!isLinux)("uncork() flushes a corked burst in a single write syscall", async () => {
+      const chunks = 1000;
+      using dir = tempDir("stdout-cork-syscalls", {});
+      const outPath = path.join(String(dir), "stdout.bin");
+      const outFd = fs.openSync(outPath, "w");
+
+      try {
+        await using proc = spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+              const fs = require("fs");
+              const syscw = () => Number(/syscw:\\s*(\\d+)/.exec(fs.readFileSync("/proc/self/io", "utf8"))[1]);
+              const chunk = Buffer.alloc(64, 0x41);
+              process.stdout.write(chunk); // settle any startup writes
+
+              const before = syscw();
+              process.stdout.cork();
+              for (let i = 0; i < ${chunks}; i++) process.stdout.write(chunk);
+              const corkedLength = process.stdout.writableLength;
+              process.stdout.uncork();
+              const corked = syscw() - before;
+
+              const uncorkedBefore = syscw();
+              for (let i = 0; i < ${chunks}; i++) process.stdout.write(chunk);
+              const uncorked = syscw() - uncorkedBefore;
+
+              process.stderr.write("@@" + JSON.stringify({ corkedLength, corked, uncorked }) + "@@");
+            `,
+          ],
+          stdout: outFd,
+          stderr: "pipe",
+          env: bunEnv,
+        });
+
+        const [, json] = await markerReader(proc.stderr)(/@@(.*)@@/);
+        const { corkedLength, corked, uncorked } = JSON.parse(json);
+
+        expect(corkedLength).toBe(chunks * 64);
+        // One write(2) for the whole burst; a per-chunk flush would be `chunks`.
+        expect(corked).toBeLessThan(10);
+        // The control: uncorked writes have to hit the fd one at a time.
+        expect(uncorked).toBe(chunks);
+        expect(await proc.exited).toBe(0);
+        expect(fs.statSync(outPath).size).toBe(64 * (1 + chunks * 2));
+      } finally {
+        fs.closeSync(outFd);
+      }
     });
   });
 

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,4 +158,178 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
+
+  // `process.stdout` used to write straight to its native sink, leaving
+  // `_writableState` untouched: writableLength/writableNeedDrain always read
+  // as "nothing buffered" and cork() never held anything back.
+  describe("backpressure accounting", () => {
+    const N = 4 * 1024 * 1024;
+
+    /** Reads `stream` incrementally, resolving each time `marker` matches. */
+    function markerReader(stream: ReadableStream<Uint8Array>) {
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let buffered = "";
+      return async function until(marker: RegExp): Promise<RegExpMatchArray> {
+        while (true) {
+          const matched = buffered.match(marker);
+          if (matched) return matched;
+          const { done, value } = await reader.read();
+          if (value) buffered += decoder.decode(value, { stream: true });
+          else if (done) throw new Error(`stream ended before ${marker} matched: ${JSON.stringify(buffered)}`);
+        }
+      };
+    }
+
+    test("writableLength, writableNeedDrain and cork() track the buffered bytes", async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const so = process.stdout;
+            const facts = { hwm: so.writableHighWaterMark };
+            facts.writeRet = so.write(Buffer.alloc(${N}, 0x41), () => {});
+            facts.length = so.writableLength;
+            facts.needDrain = so.writableNeedDrain;
+            so.cork();
+            so.write(Buffer.alloc(1000, 0x42), () => {});
+            facts.corkedLength = so.writableLength;
+            facts.corked = so.writableCorked;
+            so.uncork();
+            process.stderr.write("@@" + JSON.stringify(facts) + "@@");
+          `,
+        ],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+
+      // stdout is deliberately left unread until the facts land on stderr, so the
+      // 4 MB write has nowhere to drain to and the sink has to buffer all of it.
+      const [, json] = await markerReader(proc.stderr)(/@@(.*)@@/);
+
+      expect(JSON.parse(json)).toEqual({
+        hwm: 65536,
+        writeRet: false,
+        length: N,
+        needDrain: true,
+        corkedLength: N + 1000,
+        corked: 1,
+      });
+
+      // Unblock the child so it can flush and exit.
+      expect((await proc.stdout.text()).length).toBe(N + 1000);
+      expect(await proc.exited).toBe(0);
+    });
+
+    test("'drain' resets writableLength and writableNeedDrain", async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const so = process.stdout;
+            const writeRet = so.write(Buffer.alloc(${N}, 0x41));
+            const before = { length: so.writableLength, needDrain: so.writableNeedDrain };
+            so.once("drain", () => {
+              const after = { length: so.writableLength, needDrain: so.writableNeedDrain };
+              process.stderr.write("@@" + JSON.stringify({ writeRet, before, after }) + "@@");
+            });
+            process.stderr.write("##buffered##");
+          `,
+        ],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+
+      const until = markerReader(proc.stderr);
+      // Only start draining stdout once the child reports the write is buffered,
+      // otherwise it might never backpressure and 'drain' would never fire.
+      await until(/##buffered##/);
+      const [stdout, [, json]] = await Promise.all([proc.stdout.text(), until(/@@(.*)@@/)]);
+
+      expect(JSON.parse(json)).toEqual({
+        writeRet: false,
+        before: { length: N, needDrain: true },
+        after: { length: 0, needDrain: false },
+      });
+      expect(stdout.length).toBe(N);
+      expect(await proc.exited).toBe(0);
+    });
+  });
+
+  test("process.stdout - write() decodes the encoding argument", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write("414243", "hex");
+         process.stdout.write("ZGVm", "base64");
+         process.stdout.write("\\u00e9", "latin1");
+         process.stdout.setDefaultEncoding("hex");
+         process.stdout.write("21");`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: Buffer.from(stdout).toString("latin1"), exitCode }).toEqual({
+      stdout: "ABCdef\xe9!",
+      exitCode: 0,
+    });
+  });
+
+  // sonic-boom (pino) treats an own `write` as a tampered stream and drops off
+  // its batched fast path, so stdio must inherit write() from the prototype.
+  test("process.stdout - write() is inherited, not an own property", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(JSON.stringify({
+           untampered: process.stdout.write === process.stdout.constructor.prototype.write,
+           ownWrite: Object.hasOwn(process.stdout, "write"),
+         }));`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ ...JSON.parse(stdout), exitCode }).toEqual({ untampered: true, ownWrite: false, exitCode: 0 });
+  });
+
+  // Write callbacks are deferred, so they interleave with readline's cursor
+  // callbacks (which report from process.nextTick) in call order.
+  test("process.stdout - write callbacks run in call order with readline cursor callbacks", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const readline = require("node:readline");
+         const order = [];
+         let pending = 5;
+         const done = n => {
+           order.push(n);
+           if (--pending === 0) require("fs").writeSync(2, order.join(","));
+         };
+         process.stdout.write("A", () => done("w1"));
+         readline.moveCursor(process.stdout, 0, 0, () => done("m0"));
+         process.stdout.write("B", () => done("w2"));
+         readline.cursorTo(process.stdout, 3, undefined, () => done("c"));
+         readline.moveCursor(process.stdout, 1, 0, () => done("m1"));`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "w1,m0,w2,c,m1", exitCode: 0 });
+  });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -216,7 +216,12 @@ describe.concurrent("process-stdio", () => {
       };
     }
 
-    test("writableLength, writableNeedDrain and cork() track the buffered bytes", async () => {
+    // Windows hands the chunk to uv_write and reports it complete the moment
+    // libuv accepts it, so the sink never tells the stream it had to buffer and
+    // writableLength can't see libuv's queue. That's native-side and predates
+    // this change (`write()` returns true on main there too); cork() accounting
+    // does work on Windows, it's only the backpressure signal that doesn't.
+    test.skipIf(isWindows)("writableLength, writableNeedDrain and cork() track the buffered bytes", async () => {
       await using proc = spawn({
         cmd: [
           bunExe(),
@@ -258,7 +263,9 @@ describe.concurrent("process-stdio", () => {
       expect(await proc.exited).toBe(0);
     });
 
-    test("'drain' resets writableLength and writableNeedDrain", async () => {
+    // Skipped on Windows for the same reason: nothing backpressures, so the
+    // write never sets needDrain and 'drain' never fires.
+    test.skipIf(isWindows)("'drain' resets writableLength and writableNeedDrain", async () => {
       await using proc = spawn({
         cmd: [
           bunExe(),
@@ -351,6 +358,40 @@ describe.concurrent("process-stdio", () => {
       } finally {
         fs.closeSync(outFd);
       }
+    });
+  });
+
+  // Behavior change: the old fast path fed anything the native sink accepted
+  // straight through, so an ArrayBuffer written to stdio "worked" while the very
+  // same write on an fs.WriteStream already threw. Both now reject it, as node does.
+  test("process.stdout - write() rejects an ArrayBuffer like node", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const codes = [];
+         for (const chunk of [new ArrayBuffer(4), new SharedArrayBuffer(4)]) {
+           try {
+             process.stdout.write(chunk);
+             codes.push("accepted");
+           } catch (e) {
+             codes.push(e.code);
+           }
+         }
+         // A view over the same buffer is the supported spelling, and still works.
+         process.stdout.write(new Uint8Array([0x41, 0x42]));
+         process.stderr.write(codes.join(","));`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout, exitCode }).toEqual({
+      stderr: "ERR_INVALID_ARG_TYPE,ERR_INVALID_ARG_TYPE",
+      stdout: "AB",
+      exitCode: 0,
     });
   });
 

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import fs from "fs";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -125,6 +125,40 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(`hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`);
   });
 
+  test("process.stdout - write after end()", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.stdout.on("error", e => process.stderr.write("error-event:" + e.code + "\\n"));
+          process.stdout.write("kept\\n");
+          process.stdout.end();
+          const ret = process.stdout.write("dropped\\n", err => {
+            process.stderr.write("cb:" + (err && err.code) + "\\n");
+          });
+          process.stderr.write("ret:" + ret + "\\n");
+        `,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: null,
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The chunk written after end() is dropped, and the failure is reported
+    // through the write callback and an 'error' event, like node.
+    expect(stdout).toBe("kept\n");
+    expect(stderr.split("\n").filter(Boolean)).toEqual([
+      "ret:false",
+      "cb:ERR_STREAM_WRITE_AFTER_END",
+      "error-event:ERR_STREAM_WRITE_AFTER_END",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test("process.stdout - write a lot (string)", () => {
     const { stdout } = spawnSync({
       cmd: [bunExe(), path.join(import.meta.dir, "stdio-test-instance-a-lot.js")],

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -46,7 +46,8 @@ function jscSerializeRoundtripCrossProcessCold(original: any) {
     import {deserialize, serialize} from "bun:jsc";
     const serialized = deserialize(await Bun.stdin.bytes());
     const cloned = serialize(serialized);
-    process.stdout.write(cloned);
+    // serialize() hands back a SharedArrayBuffer, which Writable rejects (as node does).
+    process.stdout.write(new Uint8Array(cloned));
     `,
     ],
     env: bunEnv,

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -75,7 +75,8 @@ const crossProcessChildScript = `
         chunks = [buf];
         break;
       }
-      const cloned = serialize(deserialize(buf.subarray(4, 4 + len)));
+      // serialize() hands back a SharedArrayBuffer, which Writable rejects (as node does).
+      const cloned = new Uint8Array(serialize(deserialize(buf.subarray(4, 4 + len))));
       const header = Buffer.alloc(4);
       header.writeUInt32LE(cloned.byteLength, 0);
       process.stdout.write(header);

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -81,7 +81,8 @@ describe("serialize & deserialize", () => {
         import {deserialize, serialize} from "bun:jsc";
         const serialized = deserialize(await Bun.stdin.bytes());
         const cloned = serialize(serialized);
-        process.stdout.write(cloned);
+        // serialize() hands back a SharedArrayBuffer, which Writable rejects (as node does).
+        process.stdout.write(new Uint8Array(cloned));
         `,
         ],
         env: bunEnv,


### PR DESCRIPTION
## Repro

Every documented backpressure signal on `process.stdout` except the `write()` return value reports "nothing buffered".

```js
import { spawn } from "node:child_process";
const N = 4 * 1024 * 1024;
if (process.argv[2] === "child") {
  const so = process.stdout, facts = { hwm: so.writableHighWaterMark };
  facts.writeRet = so.write(Buffer.alloc(N, 0x41), () => {});
  facts.writableLength = so.writableLength;
  facts.writableNeedDrain = so.writableNeedDrain;
  so.cork(); so.write(Buffer.alloc(1000, 0x42), () => {});
  facts.corkedLength = so.writableLength;
  facts.writableCorked = so.writableCorked; so.uncork();
  process.stderr.write("@@" + JSON.stringify(facts) + "@@\n");
} else {
  const p = spawn(process.execPath, [process.argv[1], "child"], { stdio: ["ignore", "pipe", "pipe"] });
  let err = ""; p.stderr.on("data", d => (err += d));
  p.stdout.pause();                                  // let the pipe fill
  setTimeout(() => p.stdout.resume(), 400);
  p.on("exit", () => console.log(err.match(/@@(.*)@@/)?.[1]));
}
```

```
node: {"hwm":65536,"writeRet":false,"writableLength":4194304,"writableNeedDrain":true,"corkedLength":4195304,"writableCorked":1}
bun : {"hwm":65536,"writeRet":false,"writableLength":0,      "writableNeedDrain":false,"corkedLength":0,      "writableCorked":1}
```

Producers that throttle on `writableLength` or `writableNeedDrain` (loggers, NDJSON/CSV writers, hand-rolled pump loops) see an empty buffer forever and keep writing at full speed into an unread pipe.

## Cause

`process.stdout`, `process.stderr`, `tty.WriteStream` and a child's `stdin` all take the `fs.WriteStream` `$fastPath`, which installs an **own** `write()` (`writeFast`) that hands the chunk straight to the native `FileSink` and never calls `Writable.prototype.write`. `_writableState` is therefore never touched, so `writeOrBuffer()` / `onwrite()` / `afterWrite()` never run. Five separate contracts break off that one bypass:

| symptom | cause |
| --- | --- |
| `writableLength` / `writableNeedDrain` stuck at `0` / `false` | `state.length` and the `needDrain` flag are only maintained by `writeOrBuffer()`/`onwrite()` |
| `cork()` buffers nothing | corked chunks are supposed to land in `state.buffered` |
| `write(chunk, encoding)` ignores `encoding` | `writeFast` passed the raw string to the sink |
| write callbacks can complete out of order under backpressure | `writeFast` ran the callback synchronously when the sink accepted outright, jumping the queue of callbacks already parked on the sink's promise |
| no `'error'` event when a write callback is supplied | `writeFast` only called the callback; `onwriteError()` does both |
| a write after `end()`/`destroy()` silently succeeded | `Writable.prototype.write`'s `ERR_STREAM_WRITE_AFTER_END` / `ERR_STREAM_DESTROYED` checks were never reached |

## Fix

Delete the `write()` override and let the standard `Writable` machinery do the accounting. `_write()` stays as the bridge into the `FileSink`: it completes the write synchronously when the sink took the whole chunk (so back-to-back writes don't pile up in the Writable buffer), and defers to the sink's promise when the sink had to buffer, which is exactly what makes `writableLength` and `writableNeedDrain` honest. The hand-rolled `emit("drain")` and the `kWriteMonkeyPatchDefense` hack go away with it; `afterWrite()` emits `'drain'` and `write()` is now inherited from the prototype, like node's.

`decodeStrings` is set to `false` on this path so UTF-8 strings still reach the sink without a `Buffer.from()` round-trip; other encodings are decoded first. node's `process.stdout` over a pipe is a `net.Socket`, which also runs with `decodeStrings: false`.

`decodeStrings` aside, the one thing the Writable machinery needs that it didn't have is a `_writev`, so a corked burst reaches the sink as a single write instead of one per chunk (see below).

## Supersedes #33474, #31538, #33484, #33485, #33500, #33557, #34267, #34268 (and #33511, already closed into this branch)

Each of those PRs patches one of the symptoms above from inside `writeFast`. Removing the bypass fixes them at the root; every one is verified against `main` and node below, not assumed.

| PR | check | main | this PR | node |
| --- | --- | --- | --- | --- |
| #33474 | `write("48490a","hex") + write("QUJD","base64") + setDefaultEncoding("hex") + write("21")` | `48490aQUJD21` | `HI\nABC!` | `HI\nABC!` |
| #31538 | `process.stdout.write === process.stdout.constructor.prototype.write` (sonic-boom/pino tamper check) | `false` | `true` | `true` |
| #33485 | events seen when a pty master closes mid-write | `["cb:EIO", ...]` | `["cb:EIO","error:EIO"]` | `["cb:EIO","error:EIO"]` |
| #33500 | write callbacks in queue order under backpressure | reordered 6/6 runs | in order 6/6 | in order 6/6 |
| #33484 | `write("A",cb)` / `moveCursor(0,0,cb)` / `write("B",cb)` / `cursorTo(3,cb)` on a pty | `w1,w2,c,m0` | `w1,m0,w2,c` | `w1,m0,w2,c` |
| #33511 | `write()` after `end()` on `process.stdout` | callback fired with no error, bytes still reached the fd | `ERR_STREAM_WRITE_AFTER_END` | `ERR_STREAM_WRITE_AFTER_END` |
| #33557 | `write()` after `end()` on piped stdout/stderr: `write("A"); end("B"); write("C")` | pipe reader received `"ABC"` | pipe reader receives `"AB"`, `ERR_STREAM_WRITE_AFTER_END` | pipe reader receives `"AB"`, `ERR_STREAM_WRITE_AFTER_END` |
| #34267 | `child.stdin.write()` after child `'close'` | `{ret: true, cb: undefined}` | `{ret: false, cb: 'ERR_STREAM_DESTROYED'}` | `{ret: false, cb: 'ERR_STREAM_DESTROYED'}` |
| #34268 | `child.stdin` write failure (EPIPE) with a callback: is `'error'` emitted and the stream destroyed? | `'error'` never fired when a callback was supplied | `'error'` fires, stream destroyed | `'error'` fires, stream destroyed |

**Conflict resolution for #33557, #34267 and #34268 (all merged):** each of those PRs added a guard or error-path tweak *inside* `writeFast`/the old `underscoreWriteFast`, the functions this PR deletes. The resolution is to keep the deletion: `Writable.prototype.write` implements the `ERR_STREAM_WRITE_AFTER_END` / `ERR_STREAM_DESTROYED` checks; #34268's `errorOrDestroy` call is reached structurally because `_write`'s `cb(err)` is `state.onwrite`, and `onwrite(err)` calls `onwriteError` → `errorOrDestroy(stream, err)`. Verified by running each PR's own test (`process-stdout-write-after-end.test.ts`, `child-process-stdio.test.js`, `child_process.test.ts -t "stdin write failure"`) against the resolved tree: all pass. The `child-process-stdio.test.js` conflict was a both-sides-add-tests; both sets were kept.

One caveat for whoever closes #33500: its fixture (`process-stdout-write-order-fixture.js`) only terminates against the old semantics. It sizes the in-flight data against `write()` returning `false` at the *first* buffered byte; once `write()` returns `false` at the high-water mark instead (node's rule), more bytes are in flight than the FIFO can hold and the fixture stalls. **node stalls on it too.** A drain loop in the fixture makes it terminate, and then it shows the reordering on `main` and in-order completion here and on node. This PR ports the deterministic half of that coverage (the readline-cursor interleave) instead.

### What this PR does *not* fix

Two bot suggestions to add `Fixes #...` lines, both checked and both wrong:

- **#23061 (`bytesWritten` always 0)** is untouched. Nothing on this path increments `bytesWritten`, before or after, and `Writable` doesn't track it. Still `0` here. (For whoever picks it up: node only exposes it when stdout is a pipe/TTY, where it's a `net.Socket`; over a file it's `SyncWriteStream` and `bytesWritten` is `undefined`, not `0`. #31627 is the open PR for this, and it patches the function this PR deletes, so it needs a small rebase onto `underscoreWriteFast`.)
- **#24158 (`EINVAL: invalid argument, kqueue` from `new tty.WriteStream(fs.openSync("/dev/tty","w"))` on macOS)** is untouched. The failure is inside `Bun.file(fd).writer()`, and this PR leaves that line exactly where it was; only the `write()` override is removed. The bot read `this.write = writeFast` out of the minified stack-trace line and assumed the whole fast path was gone.

Also related and not superseded: #29232 fixes the same encoding bug as #33474, but by routing *every* string through `Buffer.from()`. That costs ~3x on string writes, which is why this PR keeps `decodeStrings: false` and only decodes the non-UTF-8 encodings.

## One behavior change, on purpose

The old fast path handed the chunk straight to the native sink without type validation, so an `ArrayBuffer` written to stdio "worked". `Writable.prototype.write` validates it, so it now throws `ERR_INVALID_ARG_TYPE`. This is not a new restriction so much as the end of an inconsistency — bun's own `fs.WriteStream` already rejected it, only stdio didn't:

| | `fs.createWriteStream(...).write(ab)` | `process.stdout.write(ab)` |
| --- | --- | --- |
| node | throws | **throws** |
| bun, today | throws | **accepted** |
| this PR | throws | throws |

A view over the same buffer (`new Uint8Array(ab)`) is the supported spelling and is unaffected. Two in-tree test helpers were leaning on the old leniency (they wrote `bun:jsc` `serialize()`'s `SharedArrayBuffer` to stdout) and are updated; the new behavior is pinned by `process.stdout - write() rejects an ArrayBuffer like node`. Flagging it here rather than burying it: if Bun would rather keep accepting `ArrayBuffer` on stdio, that has to be a deliberate extension, and it cannot live on this path without reintroducing the `write()` override.

## Known gap: Windows does not report backpressure

`writableLength` / `writableNeedDrain` still read as "nothing buffered" on Windows, and that is **not** fixed here. Its writer hands the chunk to `uv_write` and reports completion the moment libuv accepts it, so the sink never tells the stream it had to buffer and `writableLength` cannot see libuv's queue. This predates the PR — `process.stdout.write()` returns `true` for a 4 MB write into a blocked pipe on `main` too — and closing it means teaching `WindowsBufferedWriter` to report `Pending` while a `uv_write` is in flight, which is a native change I can't test here. `cork()` accounting *does* work on Windows. The two backpressure tests carry `skipIf(isWindows)` with that reason recorded inline.

## Verification

`writableLength` / `writableNeedDrain` / `writableCorked` now match node byte-for-byte on both destinations stdio can have:

```
                 stdout -> pipe (Socket / WriteStream)                      stdout -> file (SyncWriteStream / WriteStream)
node   writeRet=false len=4194304 needDrain=true corked=4195304   |   writeRet=true len=0 needDrain=false corked=1000
bun    writeRet=false len=4194304 needDrain=true corked=4195304   |   writeRet=true len=0 needDrain=false corked=1000
```

New tests, every one verified failing on `main` and passing here:

`test/js/node/process/process-stdio.test.ts`
- `writableLength, writableNeedDrain and cork() track the buffered bytes`
- `'drain' resets writableLength and writableNeedDrain`
- `uncork() flushes a corked burst in a single write syscall` (Linux-only)
- `process.stdout - write() decodes the encoding argument`
- `process.stdout - write() is inherited, not an own property`
- `process.stdout - write callbacks run in call order with readline cursor callbacks`
- `process.stdout - write() rejects an ArrayBuffer like node`
- `process.stdout - write after end()`

`test/js/node/child_process/child-process-stdio.test.js`
- `child.stdin` write after `end()` / `destroy()`, with and without a callback

913 of node's `test/parallel` stream / fs / child_process / process / net / tty / console tests run identically before and after (894 pass, 19 pre-existing failures, zero drift), as do `test/js/node/stream`, `test/js/node/child_process`, `test/js/node/fs`, `test/js/node/tty` and `test/regression/issue/1632.test.ts` (stdout EPIPE).

### `_writev`: cork() has to batch, not just buffer

Review raised this and it was a real gap. With `cork()` finally buffering, `clearBuffer()` was flushing the backlog one chunk at a time, so a corked burst of 1000 writes cost 1000 `write(2)` calls where node coalesces the same burst into a single `writev(2)`. Giving the FileSink-backed streams a `_writev` closes it. Counted with `/proc/self/io`'s `syscw`, 1000 × 64-byte writes:

| | `writableLength` while corked | syscalls, corked burst | syscalls, uncorked control |
| --- | --- | --- | --- |
| main | 0 (cork was a no-op) | 1000 | 1000 |
| this PR, before `_writev` | 64000 | 1000 | 1000 |
| **this PR** | **64000** | **1** | **1000** |
| node (stdout → pipe) | 64000 | 1 | 1000 |

To be precise about the "regression" framing: cork never batched *before* this PR either, because `writeFast` ignored `state.corked` and pushed every chunk straight at the sink. Nothing regressed; the batching simply never existed, and now it does.

`_writev` also flushes the post-backpressure backlog in one sink write, which is where it earns back some of the cost in the table above.

The regression test for it is Linux-only (`syscw` is the only way to observe a syscall count) and points stdout at a **regular file** rather than a pipe: a pipe that fills up makes the sink coalesce on its own, which would sink both numbers and leave the test asserting nothing. Verified it fails in both directions it needs to:

```
src at main                  -> both cork tests fail
fix present, _writev removed -> accounting passes, syscall test fails  (so it pins _writev, not the accounting)
full fix                     -> both pass
```

### Performance

`process.stdout.write()` now pays the `Writable` bookkeeping node pays, so it gets slower. Release builds, same commit, 300k × 64-byte writes:

| destination | payload | main | this PR | node |
| --- | --- | --- | --- | --- |
| `/dev/null` | Buffer | 4.69M ops/s | 3.55M ops/s (-24%) | 2.11M ops/s |
| `/dev/null` | string | 4.05M ops/s | 3.15M ops/s (-22%) | 1.65M ops/s |
| pipe (drained) | Buffer | 1.35M ops/s | 1.19M ops/s (-12%) | 1.13M ops/s |
| pipe (drained) | string | 1.27M ops/s | 1.21M ops/s (-4%) | 1.04M ops/s |

Against a real pipe, where the syscall dominates, the cost is 4-12% and Bun stays ahead of node. Keeping `decodeStrings: false` is what holds the string column up; routing strings through `Buffer.from()` like a plain `fs.WriteStream` would have cost ~3x instead. I did not find a way to keep a fast path here and stay correct: whether the sink buffers is only knowable *after* the write, and by then the bytes are already in the sink and the accounting has to be reconstructed by hand.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 15 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts

<!-- robobun:evidence:end -->
