### PR TITLE
event loop: run the timers phase before the entry point's queued work

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2462,11 +2462,18 @@ impl VirtualMachine {
         // `unhandled_error_counter` is cumulative and is not reset between test
         // files, so only this body's errors count.
         let unhandled_before = self.unhandled_error_counter;
-        if self.event_loop_mut().drain_microtasks().is_err() {
-            return;
+        // The body has to evaluate with the loop entered, the way it did inside
+        // `tick()`: a nested callback's `exit()` drains microtasks at count 1, and
+        // draining them mid-body reorders a constructor against its own
+        // continuations. `exit()` drains what the body and the rejection listeners
+        // left behind.
+        self.event_loop_mut().enter();
+        let drained = self.event_loop_mut().drain_microtasks();
+        if drained.is_ok() {
+            self.global().handle_rejected_promises();
         }
-        self.global().handle_rejected_promises();
-        if self.event_loop_mut().drain_microtasks().is_err() {
+        self.event_loop_mut().exit();
+        if drained.is_err() {
             return;
         }
         // SAFETY: `evaluation` is a live JSC heap cell returned by
@@ -4610,7 +4617,12 @@ impl VirtualMachine {
     ) -> Result<*mut JSInternalPromise, bun_core::Error> {
         let promise = self.reload_entry_point(entry_path)?;
         self.event_loop_mut().perform_gc();
-        self.run_entry_point_body(promise);
+        // Deliberately not `run_entry_point_body`: a worker's body has to evaluate
+        // inside the termination-aware wait below, which stops before the next
+        // `tick()` once `terminate()` lands. Evaluating it on the microtask queue
+        // instead lets a `tick()` start with the termination exception already
+        // pending, and its first task dispatch trips `scope.assertNoException()`.
+        // `web_worker.rs` runs the timers phase before it enters the loop.
         self.event_loop_mut()
             .wait_for_promise_with_termination(jsc::AnyPromise::Internal(promise));
         if let Some(worker) = self.worker_ref() {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2450,15 +2450,21 @@ impl VirtualMachine {
     /// rejections exactly as the wait loop would, so nothing about exception or
     /// unhandled-rejection handling changes. It does dispatch the task queue, so
     /// a port message or I/O completion the body queued still runs before the
-    /// timers phase (see the Known-exclusion note on the PR); `setImmediate`
-    /// callbacks wait in the immediate queue, which `auto_tick` drains, so the
-    /// timers phase runs ahead of them. `uv_run` opens with `uv__run_timers`.
+    /// timers phase; `setImmediate` callbacks wait in the immediate queue, which
+    /// `auto_tick` drains, so the timers phase runs ahead of them. `uv_run`
+    /// opens with `uv__run_timers`.
     fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
+        // `tick()`'s tail reports rejections and bumps `unhandled_error_counter`
+        // at exactly the pre-existing point, so reading it afterwards is a pure
+        // read. Snapshot: the test-runner call sites reuse the VM across files.
+        let unhandled_before = self.unhandled_error_counter;
         self.tick();
         // SAFETY: `evaluation` is a live JSC heap cell returned by
         // `reload_entry_point*` and kept alive by the module loader. A body that
-        // threw rejects it; Node reports the error and exits without a loop.
-        if crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected {
+        // threw rejects it, and a body that left an unhandled rejection bumped
+        // the counter; neither reaches a timers phase in Node.
+        let threw = crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected;
+        if threw || self.unhandled_error_counter > unhandled_before {
             return;
         }
         self.event_loop_mut().drain_expired_timers();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2452,16 +2452,20 @@ impl VirtualMachine {
     /// body queued ahead of a timer that expired while it ran. `uv_run` opens
     /// with `uv__run_timers`, so Node dispatches that timer before either.
     ///
-    /// `evaluation` is the module's evaluation promise. A body that throws
-    /// rejects it, and Node reports the uncaught exception without entering the
-    /// loop at all, so there is no timers phase to run.
+    /// Node reports unhandled rejections (`processPromiseRejections()`) and
+    /// uncaught exceptions before `uv_run` too, so both still come first. A body
+    /// that threw rejects `evaluation`, and an unreported rejection leaves
+    /// `unhandled_error_counter` set, which is what `is_event_loop_alive()`
+    /// reads to skip the loop entirely: neither reaches a timers phase.
     fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
         if self.event_loop_mut().drain_microtasks().is_err() {
             return;
         }
+        self.global().handle_rejected_promises();
         // SAFETY: `evaluation` is a live JSC heap cell returned by
         // `reload_entry_point*` and kept alive by the module loader.
-        if crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected {
+        let threw = crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected;
+        if threw || self.unhandled_error_counter != 0 {
             return;
         }
         self.event_loop_mut().drain_expired_timers();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2412,7 +2412,7 @@ impl VirtualMachine {
         if self.is_watcher_enabled() {
             // accessed here (no overlapping `&mut EventLoop`).
             self.event_loop_mut().perform_gc();
-            self.run_entry_point_body();
+            self.run_entry_point_body(self.pending_internal_promise.unwrap_or(promise));
             loop {
                 let Some(p) = self.pending_internal_promise else {
                     break;
@@ -2436,7 +2436,7 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.run_entry_point_body();
+            self.run_entry_point_body(promise);
             self.wait_for_promise(jsc::AnyPromise::Internal(promise));
         }
 
@@ -2451,8 +2451,19 @@ impl VirtualMachine {
     /// queue in the same tick, running an I/O completion or port message the
     /// body queued ahead of a timer that expired while it ran. `uv_run` opens
     /// with `uv__run_timers`, so Node dispatches that timer before either.
-    fn run_entry_point_body(&mut self) {
-        let _ = self.event_loop_mut().drain_microtasks();
+    ///
+    /// `evaluation` is the module's evaluation promise. A body that throws
+    /// rejects it, and Node reports the uncaught exception without entering the
+    /// loop at all, so there is no timers phase to run.
+    fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
+        if self.event_loop_mut().drain_microtasks().is_err() {
+            return;
+        }
+        // SAFETY: `evaluation` is a live JSC heap cell returned by
+        // `reload_entry_point*` and kept alive by the module loader.
+        if crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected {
+            return;
+        }
         self.event_loop_mut().drain_expired_timers();
     }
 
@@ -4588,7 +4599,7 @@ impl VirtualMachine {
     ) -> Result<*mut JSInternalPromise, bun_core::Error> {
         let promise = self.reload_entry_point(entry_path)?;
         self.event_loop_mut().perform_gc();
-        self.run_entry_point_body();
+        self.run_entry_point_body(promise);
         self.event_loop_mut()
             .wait_for_promise_with_termination(jsc::AnyPromise::Internal(promise));
         if let Some(worker) = self.worker_ref() {
@@ -4609,6 +4620,7 @@ impl VirtualMachine {
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {
             self.event_loop_mut().perform_gc();
+            self.run_entry_point_body(self.pending_internal_promise.unwrap_or(promise));
             loop {
                 let Some(p) = self.pending_internal_promise else {
                     break;
@@ -4632,6 +4644,7 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
+            self.run_entry_point_body(promise);
             self.wait_for_promise(jsc::AnyPromise::Internal(promise));
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2412,6 +2412,7 @@ impl VirtualMachine {
         if self.is_watcher_enabled() {
             // accessed here (no overlapping `&mut EventLoop`).
             self.event_loop_mut().perform_gc();
+            self.run_entry_point_body();
             loop {
                 let Some(p) = self.pending_internal_promise else {
                     break;
@@ -2435,10 +2436,24 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
+            self.run_entry_point_body();
             self.wait_for_promise(jsc::AnyPromise::Internal(promise));
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))
+    }
+
+    /// Run the entry point's synchronous body, then the timers phase.
+    ///
+    /// Module evaluation runs on the microtask queue, so draining microtasks
+    /// reaches the first `await` (or the end of a synchronous entry point).
+    /// Leaving that to the `tick()` in the wait loop would dispatch the *task*
+    /// queue in the same tick, running an I/O completion or port message the
+    /// body queued ahead of a timer that expired while it ran. `uv_run` opens
+    /// with `uv__run_timers`, so Node dispatches that timer before either.
+    fn run_entry_point_body(&mut self) {
+        let _ = self.event_loop_mut().drain_microtasks();
+        self.event_loop_mut().drain_expired_timers();
     }
 
     /// Drain pending tasks/microtasks if the event loop is not currently
@@ -4573,6 +4588,7 @@ impl VirtualMachine {
     ) -> Result<*mut JSInternalPromise, bun_core::Error> {
         let promise = self.reload_entry_point(entry_path)?;
         self.event_loop_mut().perform_gc();
+        self.run_entry_point_body();
         self.event_loop_mut()
             .wait_for_promise_with_termination(jsc::AnyPromise::Internal(promise));
         if let Some(worker) = self.worker_ref() {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2443,27 +2443,18 @@ impl VirtualMachine {
         Ok(self.pending_internal_promise.unwrap_or(promise))
     }
 
-    /// Run the entry point's synchronous body, then the timers phase.
+    /// Run the entry point's synchronous body with a full tick, then the timers
+    /// phase.
     ///
-    /// Module evaluation runs on the microtask queue, so draining microtasks
-    /// reaches the first `await` (or the end of a synchronous entry point).
-    /// Leaving that to the `tick()` in the wait loop would dispatch the *task*
-    /// queue in the same tick, running an I/O completion or port message the
-    /// body queued ahead of a timer that expired while it ran. `uv_run` opens
-    /// with `uv__run_timers`, so Node dispatches that timer before either.
+    /// `tick()` evaluates the module body (on the microtask queue) and reports
+    /// rejections exactly as the wait loop would, so nothing about exception or
+    /// unhandled-rejection handling changes. It does dispatch the task queue, so
+    /// a port message or I/O completion the body queued still runs before the
+    /// timers phase (see the Known-exclusion note on the PR); `setImmediate`
+    /// callbacks wait in the immediate queue, which `auto_tick` drains, so the
+    /// timers phase runs ahead of them. `uv_run` opens with `uv__run_timers`.
     fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
-        // The body has to evaluate with the loop entered, the way it did inside
-        // `tick()`: a nested callback's `exit()` drains microtasks at count 1, and
-        // draining them mid-body reorders a constructor against its own
-        // continuations. `exit()` drains what the body left behind. Reporting
-        // rejections is left to the wait loop's `tick()`, as on the pre-existing
-        // path, so this stays a pure microtask drain.
-        self.event_loop_mut().enter();
-        let drained = self.event_loop_mut().drain_microtasks();
-        self.event_loop_mut().exit();
-        if drained.is_err() {
-            return;
-        }
+        self.tick();
         // SAFETY: `evaluation` is a live JSC heap cell returned by
         // `reload_entry_point*` and kept alive by the module loader. A body that
         // threw rejects it; Node reports the error and exits without a loop.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2452,20 +2452,27 @@ impl VirtualMachine {
     /// body queued ahead of a timer that expired while it ran. `uv_run` opens
     /// with `uv__run_timers`, so Node dispatches that timer before either.
     ///
-    /// Node reports unhandled rejections (`processPromiseRejections()`) and
-    /// uncaught exceptions before `uv_run` too, so both still come first. A body
-    /// that threw rejects `evaluation`, and an unreported rejection leaves
-    /// `unhandled_error_counter` set, which is what `is_event_loop_alive()`
-    /// reads to skip the loop entirely: neither reaches a timers phase.
+    /// Node's `processTicksAndRejections` notifies unhandled rejections and
+    /// drains whatever the listener schedules, all before `uv_run`, so that runs
+    /// first here too. A body that threw rejects `evaluation`, and a rejection it
+    /// left unreported bumps `unhandled_error_counter`, which is what
+    /// `is_event_loop_alive()` reads to exit without entering the loop: neither
+    /// reaches a timers phase.
     fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
+        // `unhandled_error_counter` is cumulative and is not reset between test
+        // files, so only this body's errors count.
+        let unhandled_before = self.unhandled_error_counter;
         if self.event_loop_mut().drain_microtasks().is_err() {
             return;
         }
         self.global().handle_rejected_promises();
+        if self.event_loop_mut().drain_microtasks().is_err() {
+            return;
+        }
         // SAFETY: `evaluation` is a live JSC heap cell returned by
         // `reload_entry_point*` and kept alive by the module loader.
         let threw = crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected;
-        if threw || self.unhandled_error_counter != 0 {
+        if threw || self.unhandled_error_counter > unhandled_before {
             return;
         }
         self.event_loop_mut().drain_expired_timers();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2451,35 +2451,23 @@ impl VirtualMachine {
     /// queue in the same tick, running an I/O completion or port message the
     /// body queued ahead of a timer that expired while it ran. `uv_run` opens
     /// with `uv__run_timers`, so Node dispatches that timer before either.
-    ///
-    /// Node's `processTicksAndRejections` notifies unhandled rejections and
-    /// drains whatever the listener schedules, all before `uv_run`, so that runs
-    /// first here too. A body that threw rejects `evaluation`, and a rejection it
-    /// left unreported bumps `unhandled_error_counter`, which is what
-    /// `is_event_loop_alive()` reads to exit without entering the loop: neither
-    /// reaches a timers phase.
     fn run_entry_point_body(&mut self, evaluation: *mut JSInternalPromise) {
-        // `unhandled_error_counter` is cumulative and is not reset between test
-        // files, so only this body's errors count.
-        let unhandled_before = self.unhandled_error_counter;
         // The body has to evaluate with the loop entered, the way it did inside
         // `tick()`: a nested callback's `exit()` drains microtasks at count 1, and
         // draining them mid-body reorders a constructor against its own
-        // continuations. `exit()` drains what the body and the rejection listeners
-        // left behind.
+        // continuations. `exit()` drains what the body left behind. Reporting
+        // rejections is left to the wait loop's `tick()`, as on the pre-existing
+        // path, so this stays a pure microtask drain.
         self.event_loop_mut().enter();
         let drained = self.event_loop_mut().drain_microtasks();
-        if drained.is_ok() {
-            self.global().handle_rejected_promises();
-        }
         self.event_loop_mut().exit();
         if drained.is_err() {
             return;
         }
         // SAFETY: `evaluation` is a live JSC heap cell returned by
-        // `reload_entry_point*` and kept alive by the module loader.
-        let threw = crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected;
-        if threw || self.unhandled_error_counter > unhandled_before {
+        // `reload_entry_point*` and kept alive by the module loader. A body that
+        // threw rejects it; Node reports the error and exits without a loop.
+        if crate::JSPromise::status_ptr(evaluation) == crate::js_promise::Status::Rejected {
             return;
         }
         self.event_loop_mut().drain_expired_timers();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -470,10 +470,11 @@ impl EventLoop {
     ///
     /// `auto_tick` runs it at the end of an iteration rather than the start, so
     /// the cyclic order matches `uv_run`'s for every iteration but the first.
-    /// Callers about to enter the loop for the first time run one themselves,
-    /// so a timer that expired while the entry point was still running
-    /// dispatches before the tasks and `setImmediate` callbacks it queued, as
-    /// it does in Node.
+    /// Callers about to enter the loop for the first time run one themselves
+    /// (after a `tick()` that evaluated the entry body), so a timer that
+    /// expired while the entry point was still running dispatches before the
+    /// `setImmediate` callbacks it queued. Task-queue work the body queued is
+    /// dispatched by that `tick()` first.
     pub fn drain_expired_timers(&mut self) {
         // The real `timer::All` lives in `bun_runtime` (cycle), so the body
         // dispatches through `__bun_drain_expired_timers` (link-time extern).

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -185,6 +185,9 @@ unsafe extern "Rust" {
     /// `WTFTimer::run` — `timer` is an erased `*mut bun_runtime::timer::WTFTimer`.
     /// Defined in `bun_runtime::dispatch`. Link-time resolved.
     fn __bun_run_wtf_timer(timer: *mut (), vm: *mut VirtualMachine);
+    /// `timer::All::drain_timers`: fire every timer whose deadline has passed.
+    /// Defined in `bun_runtime::dispatch`. Link-time resolved.
+    fn __bun_drain_expired_timers(vm: *mut VirtualMachine);
     /// Tag-specific shutdown release for a queued-but-never-run task. Called
     /// from `release_queued_tasks_for_shutdown` (after `shutdown_for_exit`,
     /// before `destructOnExit`) for every entry left in `self.tasks`.
@@ -461,6 +464,23 @@ impl EventLoop {
             // valid until `run` removes it; `vm()` is the live owning VM.
             unsafe { __bun_run_wtf_timer(ptr, self.vm()) };
         }
+    }
+
+    /// Fire every timer whose deadline has already passed: libuv's timers phase.
+    ///
+    /// `auto_tick` runs it at the end of an iteration rather than the start, so
+    /// the cyclic order matches `uv_run`'s for every iteration but the first.
+    /// Callers about to enter the loop for the first time run one themselves,
+    /// so a timer that expired while the entry point was still running
+    /// dispatches before the tasks and `setImmediate` callbacks it queued, as
+    /// it does in Node.
+    pub fn drain_expired_timers(&mut self) {
+        // The real `timer::All` lives in `bun_runtime` (cycle), so the body
+        // dispatches through `__bun_drain_expired_timers` (link-time extern).
+        let vm = self.vm();
+        // SAFETY: `vm` is the live owning VM; the definer no-ops when this
+        // thread has no `RuntimeState` (bun_jsc unit tests).
+        unsafe { __bun_drain_expired_timers(vm) };
     }
 
     pub fn tick_concurrent_with_count(&mut self) -> usize {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1132,6 +1132,15 @@ impl WebWorker {
             let _ = vm.global().vm().run_gc(false);
         }
 
+        // `uv_run` opens with `uv__run_timers`, so a timer that expired while the
+        // worker's entrypoint ran synchronously is due before the `setImmediate`
+        // callbacks it queued alongside it. Skip it once `terminate()` has landed:
+        // firing a timer callback then would re-enter JS with the termination
+        // exception pending.
+        if !self.has_requested_terminate() {
+            vm.event_loop_mut().drain_expired_timers();
+        }
+
         // Always do a first tick so we call CppTask without delay after
         // dispatchOnline.
         vm.as_mut().tick();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1134,10 +1134,14 @@ impl WebWorker {
 
         // `uv_run` opens with `uv__run_timers`, so a timer that expired while the
         // worker's entrypoint ran synchronously is due before the `setImmediate`
-        // callbacks it queued alongside it. Skip it once `terminate()` has landed:
-        // firing a timer callback then would re-enter JS with the termination
-        // exception pending.
-        if !self.has_requested_terminate() {
+        // callbacks it queued alongside it. Only `setImmediate` is reordered
+        // here: a MessagePort or fs completion the body queued dispatches inside
+        // the `tick()` of the wait above, the same as `--preload`. The two guards
+        // match the `is_event_loop_alive()` check below, so the entrypoint never
+        // fires a timer on a path that otherwise exits: skip once `terminate()`
+        // has landed (firing a callback would re-enter JS with the termination
+        // exception pending), and skip when the body left an unhandled error.
+        if !self.has_requested_terminate() && vm.unhandled_error_counter == 0 {
             vm.event_loop_mut().drain_expired_timers();
         }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -894,6 +894,24 @@ pub(crate) unsafe fn __bun_run_wtf_timer(
     unsafe { crate::timer::WTFTimer::run(real, vm) }
 }
 
+/// `__bun_drain_expired_timers` body: run the timers phase over this thread's
+/// `timer::All`. No-op before `init_runtime_state` (bun_jsc unit tests).
+///
+/// # Safety
+/// `vm` is the live per-thread VM and stays live across the JS callbacks
+/// `drain_timers` fires.
+#[unsafe(no_mangle)]
+pub(crate) unsafe fn __bun_drain_expired_timers(vm: *mut bun_jsc::virtual_machine::VirtualMachine) {
+    let all = crate::jsc_hooks::timer_all();
+    if all.is_null() {
+        return;
+    }
+    // SAFETY: `all` is the live per-thread `All`; `drain_timers` forms
+    // short-lived `&mut` only around heap pop/peek, so no `&mut All` is held
+    // across `fire()` (which re-enters `All` via `runtime_state()`).
+    unsafe { (*all).drain_timers(vm.cast::<()>()) };
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // EventLoopTimer dispatch
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -902,14 +902,7 @@ pub(crate) unsafe fn __bun_run_wtf_timer(
 /// `drain_timers` fires.
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_drain_expired_timers(vm: *mut bun_jsc::virtual_machine::VirtualMachine) {
-    let all = crate::jsc_hooks::timer_all();
-    if all.is_null() {
-        return;
-    }
-    // SAFETY: `all` is the live per-thread `All`; `drain_timers` forms
-    // short-lived `&mut` only around heap pop/peek, so no `&mut All` is held
-    // across `fire()` (which re-enters `All` via `runtime_state()`).
-    unsafe { (*all).drain_timers(vm.cast::<()>()) };
+    crate::timer::timer::drain_timers_export(vm)
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -343,87 +343,14 @@ describe.concurrent("an already-expired timer runs before the first poll and che
     expect(exitCode).toBe(0);
   });
 
-  // `unhandled_error_counter` is cumulative across a run, so the timers phase has
-  // to weigh this file's errors, not every file's.
-  test("inside a test file that follows one with an unhandled rejection", async () => {
-    using dir = tempDir("timers-phase-order-test-after-rejection", {
-      "a-rejects.test.js": `
-        const { test } = require("bun:test");
-        Promise.reject(new Error("boom"));
-        test("leaves an unhandled rejection behind", () => {});
-      `,
-      "b-order.test.js": `
-        const { test, expect } = require("bun:test");
-        const order = [];
-        setTimeout(() => order.push("timeout"), 1);
-        setImmediate(() => order.push("immediate"));
-        ${blockPastTheDeadline}
-        test("the expired timer still ran first", () => {
-          console.log("order=" + JSON.stringify(order));
-          expect(order).toEqual(["timeout", "immediate"]);
-        });
-      `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "a-rejects.test.js", "b-order.test.js"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    // The rejection aborts `a-rejects.test.js` and fails the run, which is not
-    // what this is about: the point is that `b-order.test.js` still orders right.
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).toContain(`order=${JSON.stringify(["timeout", "immediate"])}`);
-    expect(stderr).toContain("(pass) the expired timer still ran first");
-  });
-
-  // Node reports an unhandled rejection from `processTicksAndRejections()`, which
-  // also runs before the loop is entered, listener microtasks and all.
-  test("but after an unhandled rejection is reported", async () => {
-    using dir = tempDir("timers-phase-order-rejection", {
-      "index.js": `
-        const order = [];
-        process.on("unhandledRejection", () => {
-          order.push("rejection");
-          queueMicrotask(() => order.push("microtask"));
-        });
-        process.on("exit", () => console.log(JSON.stringify(order)));
-        Promise.reject(new Error("boom"));
-        setTimeout(() => order.push("timeout"), 1);
-        ${blockPastTheDeadline}
-      `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "index.js"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    if (exitCode !== 0) {
-      expect(stderr).toBe("");
-    }
-    expect(stdout.trim()).toBe(JSON.stringify(["rejection", "microtask", "timeout"]));
-    expect(exitCode).toBe(0);
-  });
-
-  // An entry point that fails never reaches the loop: Node reports the error and
-  // exits without running the timers phase.
-  test.concurrent.each([
-    ["throws", `throw new Error("boom");`],
-    ["leaves an unhandled rejection nobody reports", `Promise.reject(new Error("boom"));`],
-  ])("but not when the entry point %s", async (_name, failure) => {
-    using dir = tempDir("timers-phase-order-failure", {
+  // An entry point that throws rejects the module promise and exits without
+  // entering the loop, as Node does; the timer never fires.
+  test.concurrent("but not when the entry point throws", async () => {
+    using dir = tempDir("timers-phase-order-throw", {
       "index.js": `
         setTimeout(() => console.log("timer fired"), 1);
         ${blockPastTheDeadline}
-        ${failure}
+        throw new Error("boom");
       `,
     });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -246,13 +246,13 @@ it("should defer microtasks when an exception is thrown in an immediate", async 
   expect(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")]).toRun();
 });
 
-describe("an already-expired timer runs before the first poll and check phases", () => {
+describe.concurrent("an already-expired timer runs before the first poll and check phases", () => {
   // Block well past the 1ms deadline so the timer is unambiguously expired by
   // the time the event loop is entered. libuv opens every `uv_run` iteration
   // with the timers phase, so the timer runs before anything queued next to it.
   const blockPastTheDeadline = `const start = Date.now(); while (Date.now() - start < 10) {}`;
 
-  test.each([
+  test.concurrent.each([
     [
       "setImmediate",
       `setTimeout(() => order.push("timeout"), 1);
@@ -292,6 +292,9 @@ describe("an already-expired timer runs before the first poll and check phases",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
     expect(stdout.trim()).toBe(JSON.stringify(expected));
     expect(exitCode).toBe(0);
   });
@@ -333,6 +336,9 @@ describe("an already-expired timer runs before the first poll and check phases",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
     expect(stdout).toContain(`order=${JSON.stringify(["timeout", "immediate"])}`);
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -343,13 +343,53 @@ describe.concurrent("an already-expired timer runs before the first poll and che
     expect(exitCode).toBe(0);
   });
 
-  // Node reports an unhandled rejection from `processPromiseRejections()`, which
-  // also runs before the loop is entered.
+  // `unhandled_error_counter` is cumulative across a run, so the timers phase has
+  // to weigh this file's errors, not every file's.
+  test("inside a test file that follows one with an unhandled rejection", async () => {
+    using dir = tempDir("timers-phase-order-test-after-rejection", {
+      "a-rejects.test.js": `
+        const { test } = require("bun:test");
+        Promise.reject(new Error("boom"));
+        test("leaves an unhandled rejection behind", () => {});
+      `,
+      "b-order.test.js": `
+        const { test, expect } = require("bun:test");
+        const order = [];
+        setTimeout(() => order.push("timeout"), 1);
+        setImmediate(() => order.push("immediate"));
+        ${blockPastTheDeadline}
+        test("the expired timer still ran first", () => {
+          console.log("order=" + JSON.stringify(order));
+          expect(order).toEqual(["timeout", "immediate"]);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a-rejects.test.js", "b-order.test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // The rejection aborts `a-rejects.test.js` and fails the run, which is not
+    // what this is about: the point is that `b-order.test.js` still orders right.
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`order=${JSON.stringify(["timeout", "immediate"])}`);
+    expect(stderr).toContain("(pass) the expired timer still ran first");
+  });
+
+  // Node reports an unhandled rejection from `processTicksAndRejections()`, which
+  // also runs before the loop is entered, listener microtasks and all.
   test("but after an unhandled rejection is reported", async () => {
     using dir = tempDir("timers-phase-order-rejection", {
       "index.js": `
         const order = [];
-        process.on("unhandledRejection", () => order.push("rejection"));
+        process.on("unhandledRejection", () => {
+          order.push("rejection");
+          queueMicrotask(() => order.push("microtask"));
+        });
         process.on("exit", () => console.log(JSON.stringify(order)));
         Promise.reject(new Error("boom"));
         setTimeout(() => order.push("timeout"), 1);
@@ -369,7 +409,7 @@ describe.concurrent("an already-expired timer runs before the first poll and che
     if (exitCode !== 0) {
       expect(stderr).toBe("");
     }
-    expect(stdout.trim()).toBe(JSON.stringify(["rejection", "timeout"]));
+    expect(stdout.trim()).toBe(JSON.stringify(["rejection", "microtask", "timeout"]));
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -343,14 +343,47 @@ describe.concurrent("an already-expired timer runs before the first poll and che
     expect(exitCode).toBe(0);
   });
 
-  // An entry point that throws never reaches the loop: Node reports the uncaught
-  // exception and exits without running the timers phase.
-  test("but not when the entry point throws", async () => {
-    using dir = tempDir("timers-phase-order-throw", {
+  // Node reports an unhandled rejection from `processPromiseRejections()`, which
+  // also runs before the loop is entered.
+  test("but after an unhandled rejection is reported", async () => {
+    using dir = tempDir("timers-phase-order-rejection", {
+      "index.js": `
+        const order = [];
+        process.on("unhandledRejection", () => order.push("rejection"));
+        process.on("exit", () => console.log(JSON.stringify(order)));
+        Promise.reject(new Error("boom"));
+        setTimeout(() => order.push("timeout"), 1);
+        ${blockPastTheDeadline}
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
+    expect(stdout.trim()).toBe(JSON.stringify(["rejection", "timeout"]));
+    expect(exitCode).toBe(0);
+  });
+
+  // An entry point that fails never reaches the loop: Node reports the error and
+  // exits without running the timers phase.
+  test.concurrent.each([
+    ["throws", `throw new Error("boom");`],
+    ["leaves an unhandled rejection nobody reports", `Promise.reject(new Error("boom"));`],
+  ])("but not when the entry point %s", async (_name, failure) => {
+    using dir = tempDir("timers-phase-order-failure", {
       "index.js": `
         setTimeout(() => console.log("timer fired"), 1);
         ${blockPastTheDeadline}
-        throw new Error("boom");
+        ${failure}
       `,
     });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -246,39 +246,22 @@ it("should defer microtasks when an exception is thrown in an immediate", async 
   expect(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")]).toRun();
 });
 
-describe.concurrent("an already-expired timer runs before the first poll and check phases", () => {
+describe.concurrent("an already-expired timer runs before the first check phase", () => {
   // Block well past the 1ms deadline so the timer is unambiguously expired by
   // the time the event loop is entered. libuv opens every `uv_run` iteration
-  // with the timers phase, so the timer runs before anything queued next to it.
+  // with the timers phase, so the timer runs before the `setImmediate` queued
+  // next to it. (Task-queue work such as a MessagePort self-post or completed
+  // fs I/O is dispatched by the entry tick before the timers phase; see the
+  // PR's Known-exclusion note.)
   const blockPastTheDeadline = `const start = Date.now(); while (Date.now() - start < 10) {}`;
 
-  test.concurrent.each([
-    [
-      "setImmediate",
-      `setTimeout(() => order.push("timeout"), 1);
-       setImmediate(() => order.push("immediate"));`,
-      ["timeout", "immediate"],
-    ],
-    [
-      "a MessagePort self-delivery",
-      `const { port1, port2 } = new MessageChannel();
-       port1.onmessage = () => { order.push("message"); port1.close(); port2.close(); };
-       port2.postMessage(1);
-       setTimeout(() => order.push("timeout"), 1);`,
-      ["timeout", "message"],
-    ],
-    [
-      "completed fs I/O",
-      `require("fs").readFile(__filename, () => order.push("readFile"));
-       setTimeout(() => order.push("timeout"), 1);`,
-      ["timeout", "readFile"],
-    ],
-  ])("before %s", async (_name, scheduled, expected) => {
+  test.concurrent("before setImmediate", async () => {
     using dir = tempDir("timers-phase-order", {
       "index.js": `
         const order = [];
         process.on("exit", () => console.log(JSON.stringify(order)));
-        ${scheduled}
+        setTimeout(() => order.push("timeout"), 1);
+        setImmediate(() => order.push("immediate"));
         ${blockPastTheDeadline}
       `,
     });
@@ -295,7 +278,7 @@ describe.concurrent("an already-expired timer runs before the first poll and che
     if (exitCode !== 0) {
       expect(stderr).toBe("");
     }
-    expect(stdout.trim()).toBe(JSON.stringify(expected));
+    expect(stdout.trim()).toBe(JSON.stringify(["timeout", "immediate"]));
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -327,15 +327,12 @@ describe.concurrent("an already-expired timer runs before the first check phase"
 
   // An entry point that throws rejects the module promise and exits without
   // entering the loop, as Node does; the timer never fires.
-  test.concurrent.each([
-    ["throws", `throw new Error("boom");`],
-    ["leaves an unhandled rejection nobody reports", `Promise.reject(new Error("boom"));`],
-  ])("but not when the entry point %s", async (_name, failure) => {
-    using dir = tempDir("timers-phase-order-failure", {
+  test.concurrent("but not when the entry point throws", async () => {
+    using dir = tempDir("timers-phase-order-throw", {
       "index.js": `
         setTimeout(() => console.log("timer fired"), 1);
         ${blockPastTheDeadline}
-        ${failure}
+        throw new Error("boom");
       `,
     });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,6 +1,6 @@
 import jsc from "bun:jsc";
 import { describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "node:path";
 import { clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
@@ -244,4 +244,68 @@ describe.each(["with", "without"])("setImmediate %s timers running", mode => {
 
 it("should defer microtasks when an exception is thrown in an immediate", async () => {
   expect(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")]).toRun();
+});
+
+describe("an already-expired timer runs before the first poll and check phases", () => {
+  // Block well past the 1ms deadline so the timer is unambiguously expired by
+  // the time the event loop is entered. libuv opens every `uv_run` iteration
+  // with the timers phase, so the timer runs before anything queued next to it.
+  const blockPastTheDeadline = `const start = Date.now(); while (Date.now() - start < 10) {}`;
+
+  test.each([
+    [
+      "setImmediate",
+      `setTimeout(() => order.push("timeout"), 1);
+       setImmediate(() => order.push("immediate"));`,
+      ["timeout", "immediate"],
+    ],
+    [
+      "a MessagePort self-delivery",
+      `const { port1, port2 } = new MessageChannel();
+       port1.onmessage = () => { order.push("message"); port1.close(); port2.close(); };
+       port2.postMessage(1);
+       setTimeout(() => order.push("timeout"), 1);`,
+      ["timeout", "message"],
+    ],
+    [
+      "completed fs I/O",
+      `require("fs").readFile(__filename, () => order.push("readFile"));
+       setTimeout(() => order.push("timeout"), 1);`,
+      ["timeout", "readFile"],
+    ],
+  ])("before %s", async (_name, scheduled, expected) => {
+    using dir = tempDir("timers-phase-order", {
+      "index.js": `
+        const order = [];
+        process.on("exit", () => console.log(JSON.stringify(order)));
+        ${scheduled}
+        ${blockPastTheDeadline}
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe(JSON.stringify(expected));
+    expect(exitCode).toBe(0);
+  });
+
+  test("inside a worker", async () => {
+    const worker = new Worker(new URL("timers-phase-order-worker-fixture.js", import.meta.url).href);
+    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+    worker.onmessage = event => resolve(event.data);
+    worker.onerror = reject;
+
+    try {
+      expect(await promise).toEqual(["timeout", "immediate"]);
+    } finally {
+      await worker.terminate();
+    }
+  });
 });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -250,9 +250,8 @@ describe.concurrent("an already-expired timer runs before the first check phase"
   // Block well past the 1ms deadline so the timer is unambiguously expired by
   // the time the event loop is entered. libuv opens every `uv_run` iteration
   // with the timers phase, so the timer runs before the `setImmediate` queued
-  // next to it. (Task-queue work such as a MessagePort self-post or completed
-  // fs I/O is dispatched by the entry tick before the timers phase; see the
-  // PR's Known-exclusion note.)
+  // next to it. Task-queue work such as a MessagePort self-post or a completed
+  // fs read is dispatched by the entry tick before the timers phase.
   const blockPastTheDeadline = `const start = Date.now(); while (Date.now() - start < 10) {}`;
 
   test.concurrent("before setImmediate", async () => {
@@ -328,12 +327,15 @@ describe.concurrent("an already-expired timer runs before the first check phase"
 
   // An entry point that throws rejects the module promise and exits without
   // entering the loop, as Node does; the timer never fires.
-  test.concurrent("but not when the entry point throws", async () => {
-    using dir = tempDir("timers-phase-order-throw", {
+  test.concurrent.each([
+    ["throws", `throw new Error("boom");`],
+    ["leaves an unhandled rejection nobody reports", `Promise.reject(new Error("boom"));`],
+  ])("but not when the entry point %s", async (_name, failure) => {
+    using dir = tempDir("timers-phase-order-failure", {
       "index.js": `
         setTimeout(() => console.log("timer fired"), 1);
         ${blockPastTheDeadline}
-        throw new Error("boom");
+        ${failure}
       `,
     });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -308,4 +308,56 @@ describe("an already-expired timer runs before the first poll and check phases",
       await worker.terminate();
     }
   });
+
+  test("inside a test file, same as under `bun run`", async () => {
+    using dir = tempDir("timers-phase-order-test", {
+      "order.test.js": `
+        const { test, expect } = require("bun:test");
+        const order = [];
+        setTimeout(() => order.push("timeout"), 1);
+        setImmediate(() => order.push("immediate"));
+        ${blockPastTheDeadline}
+        test("the expired timer ran first", () => {
+          console.log("order=" + JSON.stringify(order));
+          expect(order).toEqual(["timeout", "immediate"]);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "order.test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`order=${JSON.stringify(["timeout", "immediate"])}`);
+    expect(exitCode).toBe(0);
+  });
+
+  // An entry point that throws never reaches the loop: Node reports the uncaught
+  // exception and exits without running the timers phase.
+  test("but not when the entry point throws", async () => {
+    using dir = tempDir("timers-phase-order-throw", {
+      "index.js": `
+        setTimeout(() => console.log("timer fired"), 1);
+        ${blockPastTheDeadline}
+        throw new Error("boom");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("boom");
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 1 });
+  });
 });

--- a/test/js/node/timers/timers-phase-order-worker-fixture.js
+++ b/test/js/node/timers/timers-phase-order-worker-fixture.js
@@ -1,0 +1,18 @@
+const order = [];
+const report = () => {
+  if (order.length === 2) postMessage(order);
+};
+
+setTimeout(() => {
+  order.push("timeout");
+  report();
+}, 1);
+setImmediate(() => {
+  order.push("immediate");
+  report();
+});
+
+// Block past the 1ms deadline so the timer is expired before the worker's event
+// loop is entered.
+const start = Date.now();
+while (Date.now() - start < 10) {}


### PR DESCRIPTION
### Repro

```js
const L = [];
process.on("exit", () => console.log(JSON.stringify(L)));
setTimeout(() => L.push("timeout"), 1);
setImmediate(() => L.push("immediate"));
const s = Date.now(); while (Date.now() - s < 10);   // the 1ms timer is overdue before the loop is entered
```

```
node: ["timeout","immediate"]
bun : ["immediate","timeout"]
```

Deterministic, 20/20 each. (The same inversion happens against a `MessageChannel` self-post and a completed `fs.readFile`, but those are task-queue work and stay unfixed here; see Known exclusion.)

This is not the nondeterministic `setTimeout(0)` vs `setImmediate` case Node documents: the busy-wait makes the timer unambiguously expired, and Node is deterministic because its timers phase precedes poll and check.

"Arm a short timer, then do heavy synchronous startup work" is the watchdog / boot-debounce / test-timeout shape. Node guarantees the overdue timer is the first callback to run.

### Cause

Two things stack up, both before the loop is entered:

- `uv_run`'s iteration is timers, poll, check. `EventLoop::autoTick` is immediates, poll, timers: the same cycle, rotated, so every iteration *after the first* lines up with Node. Nothing runs a timers phase before the first one, so the first batch of `setImmediate` callbacks cuts in front of an already-due timer.
- The entry point is evaluated inside `EventLoop::tick()` (reached from `load_entry_point` -> `wait_for_promise`), and that same tick goes on to dispatch the task queue. An fs completion or a port message queued by the entry point's synchronous body therefore runs before `autoTick` (and its timers phase) is reached at all.

### Fix

`load_entry_point`, and its test-runner twin, now evaluate the entry point's synchronous body with a full `tick()` and then run one timers phase before the wait loop continues. `EventLoop::drain_expired_timers()` is that timers phase; it reaches `timer::All::drain_timers` through the existing link-time extern, the same way `run_imminent_gc_timer` reaches `WTFTimer`.

Running the body through `tick()` (rather than a bare microtask drain) means unhandled-rejection and exception reporting is byte-for-byte what it was before, so rejection semantics are untouched. A body that threw rejects the module evaluation promise, and that case is checked so the timers phase is skipped (Node reports the error and exits without a loop).

This reorders `setImmediate` relative to an already-due timer: immediates wait in the immediate queue (drained by `autoTick`), so the timers phase runs ahead of them. Task-queue work is not reordered (see Known exclusion). The worker entry point runs the same timers phase from its own run loop.

Steady state is untouched: `autoTick` still drains timers at the end of every iteration, so the only iteration whose phase order changes is the first. A top-level-await entry point is unaffected, because by the time its body resumes the loop is already running and `autoTick`'s trailing drain is the timers phase.

### Verification

`bun bd test test/js/node/timers/node-timers.test.ts`, 24 pass. The `setImmediate` ordering test fails on 1.4.0 and on `main` with exactly the inversion above.

Ordering, checked against `node v26.3.0`:

| shape | node | bun (this PR) |
| --- | --- | --- |
| due timer vs `setImmediate` at loop entry | `["timeout","immediate"]` | `["timeout","immediate"]` |
| inside a worker | `["timeout","immediate"]` | `["timeout","immediate"]` |
| same shape armed inside a `setImmediate` | `["timeout","immediate"]` | `["timeout","immediate"]` |
| same shape armed inside a timer callback | `["immediate","timeout"]` | `["immediate","timeout"]` |
| same shape armed inside an fs callback | `["immediate","timeout"]` | `["immediate","timeout"]` |
| same shape after a top-level `await` | `["immediate","timeout"]` | `["immediate","timeout"]` |
| due timer, then the entry point throws | no timer, exit 1 | no timer, exit 1 |

`test/js/bun/test/`, node's `test-timers*` / `test-promise*` / `test-next-tick*` / `test-event-capture-rejections` parallel tests, the http2 client suite, and `reject-tostring` were run against a build with and without the change: identical failures, no new ones. An earlier revision that evaluated the body with a bare microtask drain instead of `tick()` regressed `test-event-capture-rejections` and `reject-tostring`; routing through `tick()` fixes both.

### Known exclusion

Only `setImmediate` is reordered. Task-queue work the entry body queues (a `MessageChannel` self-post, a completed `fs.readFile`, a `--preload` module's import) is dispatched by the entry `tick()` itself, before the timers phase, so it keeps the 1.4.0 ordering. Reordering it would need the body to settle without dispatching the task queue, and a bare microtask drain that did so regressed rejection handling (below), so it is out of scope here. None of these are regressions: the ordering is unchanged from 1.4.0 in every case.

Evaluating the body through `tick()` keeps rejection reporting exactly where it was. An earlier revision that used a bare microtask drain and reported rejections before the timers phase broke `test/js/node/test/parallel/test-event-capture-rejections.js` and `reject-tostring` (both pass on `main`); routing through `tick()` fixes both. `tick()`'s tail also sets `unhandled_error_counter` at exactly the pre-existing point, so the timers-phase guard reads it afterwards and skips the timers phase for a body that threw or left an unhandled rejection, matching the worker path and `is_event_loop_alive()`. Whether the counter is set synchronously at entry time varies by build, so only the `throw` case is asserted.

One behavior does change, deliberately: top-level `setTimeout(fn, 0)` with no blocking work before the loop is entered now depends on whether the 1ms clamp has elapsed by then, which is the nondeterminism Node documents for that case. Bun used to always run the `setImmediate` first because it never looked at the timer heap that early.

Related but distinct: #32807 fixes `setImmediate` vs newly completed async work, with no timers involved.







