### PR TITLE
fs: report write-after-end on the WriteStream fast path

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -660,6 +660,13 @@ const kWriteMonkeyPatchDefense = Symbol("!");
 function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
 
+  // This fast path skips Writable.prototype.write, which is also where the
+  // ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED checks live. Hand those
+  // writes back to it so the chunk is dropped and the error is reported.
+  if (this.writableEnded || this.destroyed) {
+    return writablePrototypeWrite.$call(this, data, encoding, cb);
+  }
+
   if (typeof encoding === "function") {
     cb = encoding;
     encoding = undefined;

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -117,3 +117,73 @@ describe("process.stdin", () => {
     expect(result).toEqual("data: File read successfully");
   });
 });
+
+describe("child.stdin", () => {
+  it("fails a write issued after end() with ERR_STREAM_WRITE_AFTER_END", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    const echoed = Promise.withResolvers();
+    let data = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", chunk => (data += chunk));
+    child.stdout.on("end", () => echoed.resolve(data));
+    child.stdout.on("error", echoed.reject);
+    child.on("error", echoed.reject);
+
+    // Surfacing the error also destroys the stream, which emits 'error'.
+    const errorEvents = [];
+    child.stdin.on("error", err => errorEvents.push(err.code));
+
+    const finished = Promise.withResolvers();
+    child.stdin.on("finish", finished.resolve);
+    child.stdin.end("kept\n");
+    await finished.promise;
+
+    const writeCb = Promise.withResolvers();
+    const ret = child.stdin.write("dropped\n", err => writeCb.resolve(err));
+
+    expect((await writeCb.promise)?.code).toBe("ERR_STREAM_WRITE_AFTER_END");
+    expect(ret).toBe(false);
+    // The bytes must not reach the child.
+    expect(await echoed.promise).toBe("data: kept\n");
+    expect(errorEvents).toEqual([]);
+  });
+
+  it("emits 'error' for a callback-less write issued after end()", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    const errored = Promise.withResolvers();
+    child.stdin.on("error", errored.resolve);
+    child.on("error", errored.reject);
+    child.on("exit", () => errored.reject(new Error("child exited before stdin errored")));
+
+    child.stdin.end("kept\n");
+    const ret = child.stdin.write("dropped\n");
+
+    expect((await errored.promise).code).toBe("ERR_STREAM_WRITE_AFTER_END");
+    expect(ret).toBe(false);
+    child.kill();
+  });
+
+  it("fails a write issued after destroy() with ERR_STREAM_DESTROYED", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    child.stdin.destroy();
+
+    const writeCb = Promise.withResolvers();
+    const ret = child.stdin.write("dropped\n", err => writeCb.resolve(err));
+
+    expect((await writeCb.promise)?.code).toBe("ERR_STREAM_DESTROYED");
+    expect(ret).toBe(false);
+    child.kill();
+  });
+});

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -125,6 +125,40 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(`hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`);
   });
 
+  test("process.stdout - write after end()", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.stdout.on("error", e => process.stderr.write("error-event:" + e.code + "\\n"));
+          process.stdout.write("kept\\n");
+          process.stdout.end();
+          const ret = process.stdout.write("dropped\\n", err => {
+            process.stderr.write("cb:" + (err && err.code) + "\\n");
+          });
+          process.stderr.write("ret:" + ret + "\\n");
+        `,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: null,
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The chunk written after end() is dropped, and the failure is reported
+    // through the write callback and an 'error' event, like node.
+    expect(stdout).toBe("kept\n");
+    expect(stderr.split("\n").filter(Boolean)).toEqual([
+      "ret:false",
+      "cb:ERR_STREAM_WRITE_AFTER_END",
+      "error-event:ERR_STREAM_WRITE_AFTER_END",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test("process.stdout - write a lot (string)", () => {
     const { stdout } = spawnSync({
       cmd: [bunExe(), path.join(import.meta.dir, "stdio-test-instance-a-lot.js")],


### PR DESCRIPTION
## Repro

```js
process.stdout.on("error", e => process.stderr.write("error-event:" + e.code + "\n"));
process.stdout.write("kept\n");
process.stdout.end();
const ret = process.stdout.write("dropped\n", err => {
  process.stderr.write("cb:" + (err && err.code) + "\n");
});
process.stderr.write("ret:" + ret + "\n");
```

| | stdout | stderr |
|---|---|---|
| node v26 | `kept` | `ret:false`, `cb:ERR_STREAM_WRITE_AFTER_END`, `error-event:ERR_STREAM_WRITE_AFTER_END` |
| bun | `kept`, `dropped` | `ret:true`, `cb:null` |

Bun writes the chunk that was submitted after `end()`, returns `true`, and calls the write callback with no error. Same shape on a child process's stdin:

```js
const cp = spawn("cat", [], { stdio: ["pipe", "ignore", "ignore"] });
cp.stdin.end();
cp.stdin.write("after-end", err => console.log("cb:", err?.code)); // node: ERR_STREAM_WRITE_AFTER_END, bun: undefined
```

## Cause

`writeFast()` in `src/js/internal/fs/streams.ts` is installed as `WriteStream.prototype.write` whenever the `FileSink` fast path is enabled. That covers `process.stdout`, `process.stderr` (via `ProcessObjectInternals` and `node:tty`) and a child process's `stdin` (via `writableFromFileSink`).

`Writable.prototype.write` is where the `ERR_STREAM_WRITE_AFTER_END` / `ERR_STREAM_DESTROYED` checks live. `writeFast()` replaces it and goes straight to the sink without looking at the stream state, so neither check ran. For `process.stdout` the sink also still had an open fd, so the bytes really were written.

## Fix

When the stream is already ending or destroyed, hand the write back to `Writable.prototype.write`, which drops the chunk and reports the error through the write callback and an `'error'` event. Everything else keeps the fast path.

## Verification

`test/js/node/child_process/child-process-stdio.test.js`:
- write after `end()` returns `false` and the callback gets `ERR_STREAM_WRITE_AFTER_END`; the bytes never reach the child
- a callback-less write after `end()` emits `'error'` on `child.stdin`
- write after `destroy()` reports `ERR_STREAM_DESTROYED`

`test/js/node/process/process-stdio.test.ts`:
- `process.stdout` write after `end()` is dropped, returns `false`, and reports through both the callback and `'error'`

All four fail on 1.4.0 and pass with this change. `test/js/node/{fs,child_process,process,tty,stream,console}` and the `test-file-write-stream*` / `test-child-process-stdio` node harness tests show no new failures.

Out of scope: a write to the stdin of a child that has already *exited* is still accepted silently (node reports `ERR_STREAM_DESTROYED`). Nothing tells the JS stream that the subprocess closed the pipe, so that needs separate plumbing. The `Bun.spawn` / `FileSink` side of the same behavior is #32857.
