### PR TITLE
structuredClone: serialize sparse arrays by their own index keys

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -598,9 +598,9 @@ static constexpr unsigned StringDataIs8BitFlag = 0x80000000;
  *
  * Array :-
  *     ArrayTag <length:uint32_t>(<index:uint32_t><value:Value>)* (NonIndexPropertiesTag (<name:StringData><value:Value>)*)? TerminatorTag
- *     <index> is always less than NonIndexPropertiesTag. The array indices at or above it
- *     (0xFFFFFFFD and 0xFFFFFFFE) would read back as control tags, so they are written as
- *     named properties, which the deserializer turns back into indices.
+ *     <index> is always below NonIndexPropertiesTag: 0xFFFFFFFD reads back as that control tag,
+ *     and 0xFFFFFFFE is reserved with it to keep the range contiguous. Both are valid array
+ *     indices, so they are written as named properties, which deserialize back into indices.
  *
  * Object :-
  *     ObjectTag (<name:StringData><value:Value>)* TerminatorTag

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5659,6 +5659,9 @@ DeserializationResult CloneDeserializer::deserialize()
         }
         case ObjectEndVisitMember: {
             putProperty(outputObjectStack.last(), propertyNameStack.last(), outValue);
+            if (scope.exception()) [[unlikely]] {
+                goto error;
+            }
             propertyNameStack.removeLast();
             goto objectStartVisitMember;
         }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2798,10 +2798,10 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 arrayEndStack.removeLast();
 
                 propertyStack.append(PropertyNameArrayBuilder(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude));
-                array->getOwnNonIndexPropertyNames(m_lexicalGlobalObject, propertyStack.last(), DontEnumPropertiesMode::Exclude);
-                RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
                 for (unsigned i = cursor; i < keys.size(); ++i)
                     propertyStack.last().add(keys[i]);
+                array->getOwnNonIndexPropertyNames(m_lexicalGlobalObject, propertyStack.last(), DontEnumPropertiesMode::Exclude);
+                RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
                 if (propertyStack.last().size()) {
                     write(NonIndexPropertiesTag);
                     indexStack.append(0);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -597,7 +597,10 @@ static constexpr unsigned StringDataIs8BitFlag = 0x80000000;
  * Value :- Array | Object | Map | Set | Terminal
  *
  * Array :-
- *     ArrayTag <length:uint32_t>(<index:uint32_t><value:Value>)* TerminatorTag
+ *     ArrayTag <length:uint32_t>(<index:uint32_t><value:Value>)* (NonIndexPropertiesTag (<name:StringData><value:Value>)*)? TerminatorTag
+ *     <index> is always less than NonIndexPropertiesTag. The array indices at or above it
+ *     (0xFFFFFFFD and 0xFFFFFFFE) would read back as control tags, so they are written as
+ *     named properties, which the deserializer turns back into indices.
  *
  * Object :-
  *     ObjectTag (<name:StringData><value:Value>)* TerminatorTag
@@ -2719,11 +2722,23 @@ SYSV_ABI void SerializedScriptValue::writeBytesForBun(CloneSerializer* ctx, cons
     ctx->write(data, size);
 }
 
+// Only array-storage arrays hold elements past their vector, in a sparse map, which is the
+// only way an array's length can dwarf its element count. Stepping 0..length there is work
+// proportional to nothing, so visit the array's own index keys instead.
+static ALWAYS_INLINE bool shouldVisitOwnIndexKeys(JSArray* array)
+{
+    return array->length() > array->getVectorLength();
+}
+
 SerializationReturnCode CloneSerializer::serialize(JSValue in)
 {
     VM& vm = m_lexicalGlobalObject->vm();
     Vector<uint32_t, 16> indexStack;
-    Vector<uint32_t, 16> lengthStack;
+    // For each array being walked: one past its last cursor value, and the own index keys to
+    // visit (empty when the cursor steps 0..length directly). Keys that the index slot cannot
+    // represent sit past the end, and are written as named properties once the walk finishes.
+    Vector<uint32_t, 16> arrayEndStack;
+    Vector<Vector<uint32_t>, 4> arrayKeyStack;
     Vector<PropertyNameArrayBuilder, 16> propertyStack;
     Vector<JSObject*, 32> inputObjectStack;
     Vector<JSMapIterator*, 4> mapIteratorStack;
@@ -2745,22 +2760,48 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             unsigned length = inArray->length();
             if (!startArray(inArray))
                 break;
+
+            Vector<uint32_t> keys;
+            unsigned walkEnd = length;
+            if (shouldVisitOwnIndexKeys(inArray)) {
+                PropertyNameArrayBuilder indexNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+                inArray->getOwnIndexedPropertyNames(m_lexicalGlobalObject, indexNames, DontEnumPropertiesMode::Exclude);
+                RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
+                Vector<uint32_t> reservedKeys;
+                for (const Identifier& name : indexNames) {
+                    std::optional<uint32_t> key = parseIndex(name);
+                    if (!key)
+                        continue;
+                    if (*key >= NonIndexPropertiesTag)
+                        reservedKeys.append(*key);
+                    else
+                        keys.append(*key);
+                }
+                walkEnd = keys.size();
+                keys.appendVector(reservedKeys);
+            }
+
             inputObjectStack.append(inArray);
             indexStack.append(0);
-            lengthStack.append(length);
+            arrayEndStack.append(walkEnd);
+            arrayKeyStack.append(WTF::move(keys));
         }
         arrayStartVisitMember:
             [[fallthrough]];
         case ArrayStartVisitMember: {
             JSObject* array = inputObjectStack.last();
-            uint32_t index = indexStack.last();
-            if (index == lengthStack.last()) {
+            uint32_t cursor = indexStack.last();
+            if (cursor == arrayEndStack.last()) {
+                Vector<uint32_t> keys = WTF::move(arrayKeyStack.last());
+                arrayKeyStack.removeLast();
                 indexStack.removeLast();
-                lengthStack.removeLast();
+                arrayEndStack.removeLast();
 
                 propertyStack.append(PropertyNameArrayBuilder(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude));
                 array->getOwnNonIndexPropertyNames(m_lexicalGlobalObject, propertyStack.last(), DontEnumPropertiesMode::Exclude);
                 RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
+                for (unsigned i = cursor; i < keys.size(); ++i)
+                    propertyStack.last().add(keys[i]);
                 if (propertyStack.last().size()) {
                     write(NonIndexPropertiesTag);
                     indexStack.append(0);
@@ -2772,6 +2813,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 inputObjectStack.removeLast();
                 break;
             }
+
+            const Vector<uint32_t>& keys = arrayKeyStack.last();
+            uint32_t index = keys.isEmpty() ? cursor : keys[cursor];
             inValue = array->getDirectIndex(m_lexicalGlobalObject, index);
             RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
             if (!inValue) {
@@ -2779,6 +2823,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 goto arrayStartVisitMember;
             }
 
+            ASSERT(index < NonIndexPropertiesTag);
             write(index);
             auto terminalCode = SerializationReturnCode::SuccessfullyCompleted;
             auto dumped = dumpIfTerminal(inValue, terminalCode);

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1012,6 +1012,36 @@ describe("sparse arrays", () => {
     }
   });
 
+  // Deserializing a non-terminal value under a numeric property name puts it with
+  // putDirectMayBeIndex, which reaches a throwing path once the index is past the object's
+  // vector. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.
+  test("a nested value at a numeric property name checks for an exception", async () => {
+    const fixture = /* js */ `
+      // A plain object whose key is above JSC's MIN_SPARSE_ARRAY_INDEX.
+      const sparseKey = structuredClone({ "200000": { nested: "a" } });
+      // And an array index the serializer writes as a name for the same reason.
+      const reserved = [];
+      reserved[4294967293] = { nested: "b" };
+      const clonedReserved = structuredClone(reserved);
+      console.log(sparseKey[200000].nested + clonedReserved[4294967293].nested);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Combined so stderr, where JSC prints the exception check failure, lands in the diff.
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
+      stdout: expect.stringMatching(/ab\n$/),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   // The serializer writes each element as <index:uint32_t>, and 0xFFFFFFFD..0xFFFFFFFF are
   // reserved there for control tags. 4294967293 and 4294967294 are the last two valid array
   // indices, so they have to be written as named properties instead.

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1154,7 +1154,8 @@ describe("sparse arrays", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+    // stderr lands in the failure diff without being pinned to "".
+    expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toMatchObject({
       stdout: {
         hugeLength: { keys: ["0"], at0: "only", length: 1e9 },
         4294967292: {
@@ -1200,7 +1201,6 @@ describe("sparse arrays", () => {
           values: ["first", "reserved", "named"],
         },
       },
-      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1125,6 +1125,24 @@ describe("sparse arrays", () => {
         reservedHigh: nameInPayload(4294967294),
       };
 
+      // StructuredSerializeInternal walks [[OwnPropertyKeys]]: every array index ascending, then
+      // string keys. Indices 4294967293/4294967294 go out as named properties, but their getters
+      // still fire before any string key's. Only observable through accessors on the input.
+      {
+        const input = [];
+        const order = [];
+        const read = (name, value) => ({ get: () => (order.push(name), value), enumerable: true, configurable: true });
+        Object.defineProperty(input, 0, read("i0", "first"));
+        Object.defineProperty(input, 4294967293, read("iReserved", "reserved"));
+        Object.defineProperty(input, "tag", read("tag", "named"));
+        const cloned = structuredClone(input);
+        results.readOrder = {
+          order,
+          keys: Object.keys(cloned),
+          values: [cloned[0], cloned[4294967293], cloned.tag],
+        };
+      }
+
       console.log(JSON.stringify(results));
     `;
 
@@ -1176,6 +1194,11 @@ describe("sparse arrays", () => {
           innerLength: 4294967295,
         },
         wireFormat: { control: false, reservedLow: true, reservedHigh: true },
+        readOrder: {
+          order: ["i0", "iReserved", "tag"],
+          keys: ["0", "4294967293", "tag"],
+          values: ["first", "reserved", "named"],
+        },
       },
       stderr: "",
       exitCode: 0,

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -978,3 +978,116 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
   });
 });
+
+describe("sparse arrays", () => {
+  // Dictionary-mode arrays keep their elements in a sparse map, so the serializer has to
+  // visit their own index keys. Walking 0..length instead is work proportional to nothing.
+  test("a sparse array round-trips its elements, named properties and length", () => {
+    const input: any = [];
+    input[0] = "first";
+    input[200_000] = "far";
+    input.tag = "named";
+
+    for (const cloned of [structuredClone(input), deserialize(serialize(input))]) {
+      expect(Object.getOwnPropertyNames(cloned)).toEqual(["0", "200000", "length", "tag"]);
+      expect(cloned[0]).toBe("first");
+      expect(cloned[200_000]).toBe("far");
+      expect(cloned.tag).toBe("named");
+      expect(cloned.length).toBe(200_001);
+    }
+  });
+
+  // StructuredSerializeInternal walks EnumerableOwnPropertyNames, so a non-enumerable index
+  // is dropped the same way a non-enumerable named property already was. Matches node.
+  test("a non-enumerable index is not cloned", () => {
+    const input: any = [];
+    Object.defineProperty(input, 0, { value: 42, enumerable: false, writable: true, configurable: true });
+    Object.defineProperty(input, "named", { value: 43, enumerable: false, writable: true, configurable: true });
+    input[1] = "kept";
+
+    for (const cloned of [structuredClone(input), deserialize(serialize(input))]) {
+      expect(Object.getOwnPropertyNames(cloned)).toEqual(["1", "length"]);
+      expect(cloned[1]).toBe("kept");
+      expect(cloned.length).toBe(2);
+    }
+  });
+
+  // The serializer writes each element as <index:uint32_t>, and 0xFFFFFFFD..0xFFFFFFFF are
+  // reserved there for control tags. 4294967293 and 4294967294 are the last two valid array
+  // indices, so they have to be written as named properties instead.
+  //
+  // An O(length) walk cannot finish any of these arrays. The child is where that shows up:
+  // without the own-index-keys path it never prints a result and the test times out.
+  test("the last valid array indices round-trip, and length never drives the walk", async () => {
+    const fixture = /* js */ `
+      import { deserialize, serialize } from "bun:jsc";
+
+      const results = {};
+
+      const hugeLength = [];
+      hugeLength[0] = "only";
+      hugeLength.length = 1e9;
+      const clonedHugeLength = structuredClone(hugeLength);
+      results.hugeLength = {
+        keys: Object.keys(clonedHugeLength),
+        at0: clonedHugeLength[0],
+        length: clonedHugeLength.length,
+      };
+
+      // 4294967292 sits one below the reserved range and is the control.
+      for (const index of [4294967292, 4294967293, 4294967294]) {
+        const input = [];
+        input[0] = "first";
+        input[index] = { nested: index };
+        input.tag = "named";
+        const cloned = deserialize(serialize(structuredClone(input)));
+        results[index] = {
+          keys: Object.keys(cloned),
+          at0: cloned[0],
+          atIndex: cloned[index],
+          tag: cloned.tag,
+          length: cloned.length,
+        };
+      }
+
+      console.log(JSON.stringify(results));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      stdout: {
+        hugeLength: { keys: ["0"], at0: "only", length: 1e9 },
+        4294967292: {
+          keys: ["0", "4294967292", "tag"],
+          at0: "first",
+          atIndex: { nested: 4294967292 },
+          tag: "named",
+          length: 4294967293,
+        },
+        4294967293: {
+          keys: ["0", "4294967293", "tag"],
+          at0: "first",
+          atIndex: { nested: 4294967293 },
+          tag: "named",
+          length: 4294967294,
+        },
+        4294967294: {
+          keys: ["0", "4294967294", "tag"],
+          at0: "first",
+          atIndex: { nested: 4294967294 },
+          tag: "named",
+          length: 4294967295,
+        },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1063,6 +1063,38 @@ describe("sparse arrays", () => {
         length: clonedOnlyReserved.length,
       };
 
+      // A sparse array at a reserved index of another sparse array: the outer walk holds a
+      // pending escaped key while the inner one pushes and pops a whole frame of its own.
+      const inner = [];
+      inner[0] = "inner-first";
+      inner[4294967294] = "inner-high";
+      const outer = [];
+      outer[0] = "outer-first";
+      outer[4294967293] = inner;
+      const clonedNested = deserialize(serialize(structuredClone(outer)));
+      results.nested = {
+        keys: Object.keys(clonedNested),
+        at0: clonedNested[0],
+        length: clonedNested.length,
+        innerKeys: Object.keys(clonedNested[4294967293]),
+        innerAt0: clonedNested[4294967293][0],
+        innerHigh: clonedNested[4294967293][4294967294],
+        innerLength: clonedNested[4294967293].length,
+      };
+
+      // The escaped index goes out as its decimal name, not as a raw <index:uint32_t>. The
+      // control index stays in-band, so its digits never appear in the payload.
+      const nameInPayload = index => {
+        const a = [];
+        a[index] = 1;
+        return Buffer.from(serialize(a)).includes(String(index));
+      };
+      results.wireFormat = {
+        control: nameInPayload(4294967292),
+        reservedLow: nameInPayload(4294967293),
+        reservedHigh: nameInPayload(4294967294),
+      };
+
       console.log(JSON.stringify(results));
     `;
 
@@ -1104,6 +1136,16 @@ describe("sparse arrays", () => {
           high: "high",
           length: 4294967295,
         },
+        nested: {
+          keys: ["0", "4294967293"],
+          at0: "outer-first",
+          length: 4294967294,
+          innerKeys: ["0", "4294967294"],
+          innerAt0: "inner-first",
+          innerHigh: "inner-high",
+          innerLength: 4294967295,
+        },
+        wireFormat: { control: false, reservedLow: true, reservedHigh: true },
       },
       stderr: "",
       exitCode: 0,

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -625,7 +625,7 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
       expect(["OK", "SKIP"]).toContain(stdout.trim());
       expect(proc.signalCode).toBe(null);
       expect(exitCode).toBe(0);
-    });
+    }, 30_000); // Allocating 1.6GB and copying it twice takes 3.8-5.0s under ASAN.
   }
 });
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1050,6 +1050,19 @@ describe("sparse arrays", () => {
         };
       }
 
+      // Both reserved indices, and nothing the index slot can carry: every key the walk
+      // produces is escaped, so it writes no element at all before the named properties.
+      const onlyReserved = [];
+      onlyReserved[4294967293] = "low";
+      onlyReserved[4294967294] = "high";
+      const clonedOnlyReserved = deserialize(serialize(structuredClone(onlyReserved)));
+      results.onlyReserved = {
+        keys: Object.keys(clonedOnlyReserved),
+        low: clonedOnlyReserved[4294967293],
+        high: clonedOnlyReserved[4294967294],
+        length: clonedOnlyReserved.length,
+      };
+
       console.log(JSON.stringify(results));
     `;
 
@@ -1083,6 +1096,12 @@ describe("sparse arrays", () => {
           at0: "first",
           atIndex: { nested: 4294967294 },
           tag: "named",
+          length: 4294967295,
+        },
+        onlyReserved: {
+          keys: ["4294967293", "4294967294"],
+          low: "low",
+          high: "high",
           length: 4294967295,
         },
       },


### PR DESCRIPTION
## Repro

```js
// 1. a sparse array's clone cost tracks `length`, not its 2 elements
const a = [];
a[0] = 1;
a.length = 1e9;
console.time("clone");
structuredClone(a); // 14694ms on 1.4.0 (c76d6b216). node v26: 0ms
console.timeEnd("clone");

// 2. an element at either of the last two valid array indices cannot be cloned at all
const b = [];
b[0] = 1;
b[4294967293] = 2; // 0xFFFFFFFD, a perfectly valid array index
structuredClone(b); // after ~69s: TypeError: Unable to deserialize data.
```

Same serializer backs every `postMessage` (Worker, MessagePort, BroadcastChannel) and `bun:jsc`'s `serialize`/`deserialize`, so one `new Array(n)` typo, or one "array indexed by a u32 id", stalls the sending thread synchronously with no error.

## Cause

`CloneSerializer::serialize` stepped an array's element walk from `0` to `length`, one `getDirectIndex` per slot, with no own-keys path at any length. An array's `length` says nothing about how many elements it has.

The grammar is `ArrayTag <length:uint32_t> (<index:uint32_t><value>)* TerminatorTag`, and `0xFFFFFFFD` (`NonIndexPropertiesTag`) and `0xFFFFFFFF` (`TerminatorTag`) are reserved *in the same uint32 index space*. The maximum array index is `2^32 - 2`, so an element at `4294967293` is written as its own index and read back as a control tag. The deserializer then misparses the rest of the stream and fails.

## Fix

Only array-storage arrays hold elements past their vector, in a sparse map, and that is the only way `length` can outrun the element count. When `length > vectorLength`, ask JSC for the array's own index keys (`JSObject::getOwnIndexedPropertyNames`, bounded by `min(length, vectorLength) + sparse map size`) instead of guessing every index. Dense arrays keep the existing walk, which is already bounded by the butterfly they allocated.

Array indices in the reserved range are written as named properties, which the deserializer's existing `putDirectMayBeIndex` turns back into indices. No wire format change and no version bump: old payloads still read, and new payloads stay readable by older deserializers.

One behavior change falls out of enumerating own keys: sparse element enumeration honors `DontEnum`, so a non-enumerable index is no longer cloned. That matches `StructuredSerializeInternal`'s `EnumerableOwnPropertyNames` and Node (non-enumerable *named* properties were already dropped). A non-enumerable index can only exist in dictionary indexing mode, so the dense walk never saw one.

One unchecked exception came out of this. `putProperty(object, Identifier, value)` routes a numeric name through `putDirectMayBeIndex`, and once the index is past the object's vector that reaches `putDirectIndexBeyondVectorLengthWithArrayStorage`, which can throw. Of the four `putProperty` calls in the deserializer, `ObjectEndVisitMember` was the only one not checking the scope afterwards. That is reachable on main today with `structuredClone({"4294967293": {nested: 1}})`, but writing reserved array indices as named properties makes it a normal path for any sparse array carrying an object at `4294967293` or `4294967294`, so it is fixed here.

## Verification

`bun bd test test/js/web/workers/structured-clone.test.ts`: 233 pass, 0 fail. With `src/` reverted to main, 230 pass / 3 fail, and the three failures are the new tests. Four new tests in `describe("sparse arrays")` cover the round-trip, the `DontEnum` index, and the three indices at the top of the index space (`4294967292` as the control, `4294967293`, `4294967294`) plus a `1e9`-length array, in a child process that an `O(length)` walk can never finish. The fourth runs a child under `BUN_JSC_validateExceptionChecks=1`, which aborts it if the deserializer stops checking the scope. The whole set also passes under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` alongside the other clone suites (379 pass).

The same file's five `under 2GiB clones without crashing` cases (from #32590) copy 1.6GB twice and measure 3.8-5.0s under ASAN against the 5000ms default, so they fail on a busy machine. Their workload is pinned by the 2GiB serialization cap they exercise, so they get a timeout that fits the work instead.

| | 1.4.0 | this PR | node v26.3.0 |
|---|---|---|---|
| `a[0]=1; a.length=1e9` | 14694ms | 0ms | 0ms |
| `new Array(2e8)`, 2 elements | 2828ms | 0ms | 0ms |
| `a[0]=1; a[4294967293]=2` | `TypeError: Unable to deserialize data.` after 69239ms | 0ms | 0ms |
| `new Array(1e7).fill(0); a[1e9]=1` | ~15s | 7343ms | 8273ms |

<details>
<summary>Cases left unchanged, and why</summary>

`structuredClone(new Array(1e8))` with 2 elements still costs ~770ms, unchanged by this PR. JSC materializes the full 800MB backing vector for `new Array(1e8)` (it is under `MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH`), so the array really does have 1e8 slots and the serializer walks storage it already paid for. V8 keeps that array in dictionary mode, which is why node reports 0ms. Skipping the holes via `tryGetIndexQuickly` instead of `getDirectIndex` measured as a wash (766ms vs 769ms), so the walk is left alone.

Behavior was diffed against node for a dense array with a trailing length hole, `delete` on a dense array, nested sparse arrays, a sparse index whose getter mutates the array mid-walk, a self-referencing sparse array, a frozen sparse array, an empty array with `length = 2**32 - 1`, and a sparse array with a symbol key. All produce identical own-property names and lengths.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ec6f70012)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [6.77ms]
(pass) structuredClone > primitive null [0.73ms]
(pass) structuredClone > primitive true [1.03ms]
(pass) structuredClone > primitive false [0.48ms]
(pass) structuredClone > primitive string, empty string [0.37ms]
(pass) structuredClone > primitive string, lone high surrogate [0.42ms]
(pass) structuredClone > primitive string, lone low surrogate [0.37ms]
(pass) structuredClone > primitive string, NUL [0.40ms]
(pass) structuredClone > primitive string, astral character [0.59ms]
(pass) structuredClone > primitive number, 0.2 [0.43ms]
(pass) structuredClone > primitive number, 0 [0.39ms]
(pass) structuredClone > pri
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (4673d3d95)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [1.98ms]
(pass) structuredClone > primitive null [0.01ms]
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.02ms]
(pass) structuredClone > primitive number, 9007199254740994
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primitive BigInt
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ec6f70012)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [5.07ms]
(pass) structuredClone > primitive null [0.94ms]
(pass) structuredClone > primitive true [0.50ms]
(pass) structuredClone > primitive false [0.42ms]
(pass) structuredClone > primitive string, empty string [0.38ms]
(pass) structuredClone > primitive string, lone high surrogate [0.37ms]
(pass) structuredClone > primitive string, lone low surrogate [0.36ms]
(pass) structuredClone > primitive string, NUL [0.40ms]
(pass) structuredClone > primitive string, astral character [0.55ms]
(pass) structuredClone > primitive number, 0.2 [0.39ms]
(pass) structuredClone > primitive number, 0 [0.38ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ec6f700122
  features     (none)

22 deps, 106 codegen, 1168 objects in 761ms

ninja: Entering directory `/workspace/bun/build/release'
[1/75] gen ErrorCode+*.h
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/24] gen cpp.rs (cppbind)
[4/24] gen JS modules (bundle-modules)
Preprocess modules (8158ms)
Bundle modules (33ms)
Postprocesss modules (123ms)
Bundle Functions (638ms)
Generate Code (101ms)

[9.07s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nigh
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp |  60 +++++-
 test/js/web/workers/structured-clone.test.ts       | 229 ++++++++++++++++++++-
 2 files changed, 282 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp     11     11      0
test/js/web/workers/structured-clone.test.ts           16     22      0
```

</details>

<!-- robobun:evidence:end -->
