### PR TITLE
tls: apply sessionTimeout to the server's SSL context

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4065,6 +4065,12 @@ declare module "bun" {
     clientRenegotiationLimit?: number;
 
     clientRenegotiationWindow?: number;
+
+    /**
+     * Number of seconds a TLS session minted by this server stays resumable.
+     * When unset or 0, the TLS library's own default lifetime applies.
+     */
+    sessionTimeout?: number;
   }
 
   interface SocketAddress {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1074,6 +1074,15 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     SSL_CTX_set_options(ssl_context, options.secure_options);
   }
 
+  /* node:tls `sessionTimeout` stamps the lifetime into every session this
+   * context mints. BoringSSL splits TLS 1.3 off into a second knob, while
+   * OpenSSL (so Node) derives both versions from SSL_CTX_set_timeout(). */
+  if (options.session_timeout > 0) {
+    SSL_CTX_set_timeout(ssl_context, (uint32_t)options.session_timeout);
+    SSL_CTX_set_session_psk_dhe_timeout(ssl_context,
+                                        (uint32_t)options.session_timeout);
+  }
+
   /* Surface resumable sessions through the new-session callback the way Node
    * does: for TLS 1.3 the resumable session only exists once the peer's
    * NewSessionTicket arrives, and BoringSSL only exposes it here. NO_INTERNAL

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -433,6 +433,9 @@ struct us_bun_socket_context_options_t {
     int request_cert;
     unsigned int client_renegotiation_limit;
     unsigned int client_renegotiation_window;
+    // Lifetime in seconds of sessions this context mints (node:tls
+    // `sessionTimeout`); <= 0 leaves BoringSSL's defaults in place.
+    int session_timeout;
 };
 
 enum create_bun_socket_error_t {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -80,6 +80,7 @@ namespace uWS {
         int request_cert = 0;
         unsigned int client_renegotiation_limit = 3;
         unsigned int client_renegotiation_window = 600;
+        int session_timeout = 0;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -43,6 +43,9 @@ pub struct SSLConfig {
     pub protos: CStrPtr,
     pub client_renegotiation_limit: u32,
     pub client_renegotiation_window: u32,
+    /// Lifetime in seconds of sessions the SSL_CTX mints (node:tls
+    /// `sessionTimeout`); 0 = unset/default.
+    pub session_timeout: i32,
     pub requires_custom_request_ctx: bool,
     pub is_using_default_ciphers: bool,
     pub low_memory_mode: bool,
@@ -118,6 +121,7 @@ impl SSLConfig {
         protos: core::ptr::null(),
         client_renegotiation_limit: 0,
         client_renegotiation_window: 0,
+        session_timeout: 0,
         requires_custom_request_ctx: false,
         is_using_default_ciphers: true,
         low_memory_mode: false,
@@ -214,6 +218,7 @@ impl SSLConfig {
         ctx_opts.secure_options = self.secure_options;
         ctx_opts.client_renegotiation_limit = self.client_renegotiation_limit;
         ctx_opts.client_renegotiation_window = self.client_renegotiation_window;
+        ctx_opts.session_timeout = self.session_timeout;
 
         ctx_opts
     }
@@ -298,6 +303,9 @@ impl SSLConfig {
         if self.client_renegotiation_window != other.client_renegotiation_window {
             return false;
         }
+        if self.session_timeout != other.session_timeout {
+            return false;
+        }
         if self.requires_custom_request_ctx != other.requires_custom_request_ctx {
             return false;
         }
@@ -356,6 +364,7 @@ impl SSLConfig {
         hash_cstr!(protos);
         hasher.update(&self.client_renegotiation_limit.to_ne_bytes());
         hasher.update(&self.client_renegotiation_window.to_ne_bytes());
+        hasher.update(&self.session_timeout.to_ne_bytes());
         hasher.update(&[u8::from(self.requires_custom_request_ctx)]);
         hasher.update(&[u8::from(self.is_using_default_ciphers)]);
         hasher.update(&[u8::from(self.low_memory_mode)]);
@@ -447,6 +456,7 @@ impl Clone for SSLConfig {
             protos: clone_string(self.protos),
             client_renegotiation_limit: self.client_renegotiation_limit,
             client_renegotiation_window: self.client_renegotiation_window,
+            session_timeout: self.session_timeout,
             requires_custom_request_ctx: self.requires_custom_request_ctx,
             is_using_default_ciphers: self.is_using_default_ciphers,
             low_memory_mode: self.low_memory_mode,

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -50,4 +50,30 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+// Negative session timeouts are rejected (min 0), and null means "not provided",
+// matching Node — newer OpenSSL/BoringSSL do not handle negative values the way
+// users expect. Shared so tls.Server and https.Server reject the same inputs.
+// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L319
+function validateSessionTimeout(sessionTimeout: unknown) {
+  if (sessionTimeout === undefined || sessionTimeout === null) return;
+  // Node validates this with validateInt32(..., 0), whose range message reads
+  // ">= 0 && <= 2147483647"; the shared validator words it differently, so the
+  // check is spelled out to match.
+  if (typeof sessionTimeout !== "number") {
+    throw $ERR_INVALID_ARG_TYPE("options.sessionTimeout", "number", sessionTimeout);
+  }
+  if (!Number.isInteger(sessionTimeout)) {
+    throw $ERR_OUT_OF_RANGE("options.sessionTimeout", "an integer", sessionTimeout);
+  }
+  if (sessionTimeout < 0 || sessionTimeout > 2147483647) {
+    throw $ERR_OUT_OF_RANGE("options.sessionTimeout", ">= 0 && <= 2147483647", sessionTimeout);
+  }
+}
+
+export {
+  VALID_TLS_ERROR_MESSAGE_TYPES,
+  isValidTLSArray,
+  isValidTLSItem,
+  throwOnInvalidTLSArray,
+  validateSessionTimeout,
+};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -310,7 +310,8 @@ function Server(options, callback): void {
         ca,
         passphrase,
         secureOptions,
-        sessionTimeout: options.sessionTimeout,
+        // null means "not provided"; the native parser only reads undefined as absent.
+        sessionTimeout: options.sessionTimeout ?? undefined,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -310,6 +310,7 @@ function Server(options, callback): void {
         ca,
         passphrase,
         secureOptions,
+        sessionTimeout: options.sessionTimeout,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -470,7 +470,11 @@ Server.prototype.listen = function () {
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
-        tls = normalizeServerTls({ ...otherTLS });
+        // Bun-only: listen({ tls }) replaces the constructor's bag, so apply the
+        // same sessionTimeout handling here (validate synchronously; null means
+        // "not provided", which the native parser only reads as undefined).
+        validateSessionTimeout(otherTLS.sessionTimeout);
+        tls = normalizeServerTls({ ...otherTLS, sessionTimeout: otherTLS.sessionTimeout ?? undefined });
       }
     } else if (typeof arg0 === "string" && !(Number(arg0) >= 0)) {
       // (path[...][, cb])

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { throwOnInvalidTLSArray, validateSessionTimeout } = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -303,6 +303,10 @@ function Server(options, callback): void {
     }
 
     if (this[isTlsSymbol]) {
+      // Node's https.Server extends tls.Server, so it rejects the same values the
+      // tls.createServer path does, synchronously. Guarded by isTlsSymbol: a plain
+      // http.createServer has no TLS context and must keep ignoring the option.
+      validateSessionTimeout(options.sessionTimeout);
       this[tlsSymbol] = normalizeServerTls({
         serverName,
         key,

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -754,7 +754,9 @@ function newNativeSecureContext(options, cached = true) {
         minVersion = tlsStringToProtocolVersion(optMinVersion ?? DEFAULT_MIN_VERSION);
         maxVersion = tlsStringToProtocolVersion(optMaxVersion ?? DEFAULT_MAX_VERSION);
       }
-      options = { ...options, minVersion, maxVersion };
+      // A null sessionTimeout means "not provided" (Node's check is the same),
+      // but the native option parser only reads `undefined` as absent.
+      options = { ...options, minVersion, maxVersion, sessionTimeout: options.sessionTimeout ?? undefined };
     }
   }
   const ctx = (cached ? NativeSecureContext.intern : NativeSecureContext.createPrivate)(options);
@@ -1380,10 +1382,10 @@ function Server(options, secureConnectionListener): void {
       }
       this.secureOptions = secureOptions;
 
-      // validateSecureContextOptions already range-checked this. Assign
-      // unconditionally so an omitted sessionTimeout clears a previous call's
-      // value instead of keeping the old lifetime on the next listen.
-      this.sessionTimeout = options.sessionTimeout;
+      // validateSecureContextOptions already range-checked this, and exempts
+      // null the way Node does. Assign unconditionally so an omitted (or null)
+      // sessionTimeout clears a previous call's value on the next listen.
+      this.sessionTimeout = options.sessionTimeout ?? undefined;
 
       const requestCert = options.requestCert || false;
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,7 +5,7 @@ const Duplex = require("internal/streams/duplex");
 const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { throwOnInvalidTLSArray, validateSessionTimeout } = require("internal/tls");
 const {
   validateString,
   validateNumber,
@@ -396,23 +396,7 @@ function validateSecureContextOptions(options) {
       throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeysByteLength, "must be exactly 48 bytes");
     }
   }
-  // Negative session timeouts are rejected (min 0), matching Node — newer
-  // OpenSSL/BoringSSL do not handle negative values as users expect.
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L319
-  if (sessionTimeout !== undefined && sessionTimeout !== null) {
-    // Node validates this with validateInt32(..., 0), whose range message
-    // reads ">= 0 && <= 2147483647"; the shared validator here words it
-    // differently, so spell the check out to match.
-    if (typeof sessionTimeout !== "number") {
-      throw $ERR_INVALID_ARG_TYPE("options.sessionTimeout", "number", sessionTimeout);
-    }
-    if (!Number.isInteger(sessionTimeout)) {
-      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", "an integer", sessionTimeout);
-    }
-    if (sessionTimeout < 0 || sessionTimeout > 2147483647) {
-      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", ">= 0 && <= 2147483647", sessionTimeout);
-    }
-  }
+  validateSessionTimeout(sessionTimeout);
 }
 
 const SymbolReplace = Symbol.replace;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1247,6 +1247,7 @@ function Server(options, secureConnectionListener): void {
   this.ca = undefined;
   this.passphrase = undefined;
   this.secureOptions = undefined;
+  this.sessionTimeout = undefined;
   this._rejectUnauthorized = rejectUnauthorizedDefault();
   this._requestCert = undefined;
   this.servername = undefined;
@@ -1379,6 +1380,11 @@ function Server(options, secureConnectionListener): void {
       }
       this.secureOptions = secureOptions;
 
+      // validateSecureContextOptions already range-checked this. Assign
+      // unconditionally so an omitted sessionTimeout clears a previous call's
+      // value instead of keeping the old lifetime on the next listen.
+      this.sessionTimeout = options.sessionTimeout;
+
       const requestCert = options.requestCert || false;
 
       if (requestCert) this._requestCert = requestCert;
@@ -1440,6 +1446,7 @@ function Server(options, secureConnectionListener): void {
         ca: this.ca,
         passphrase: this.passphrase,
         secureOptions: this.secureOptions,
+        sessionTimeout: this.sessionTimeout,
         rejectUnauthorized: this._rejectUnauthorized,
         requestCert: isClient ? true : this._requestCert,
         ALPNProtocols: this.ALPNProtocols,

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -315,6 +315,7 @@ pub struct SSLConfig {
     pub ciphers: GenOpt<GenString>,
     pub client_renegotiation_limit: u32,
     pub client_renegotiation_window: u32,
+    pub session_timeout: i32,
 }
 
 // ── refcount release on drop ──────────────────────────────────────────────
@@ -560,6 +561,7 @@ struct ExternSSLConfig {
     ciphers: RawWTFStringImpl,
     client_renegotiation_limit: u32,
     client_renegotiation_window: u32,
+    session_timeout: i32,
 }
 
 // safe: same handle/out-param contract as
@@ -594,6 +596,7 @@ impl SSLConfig {
             ciphers: adopt_opt_string(ext.ciphers),
             client_renegotiation_limit: ext.client_renegotiation_limit,
             client_renegotiation_window: ext.client_renegotiation_window,
+            session_timeout: ext.session_timeout,
         }
     }
 

--- a/src/runtime/socket/SSLConfig.bindv2.ts
+++ b/src/runtime/socket/SSLConfig.bindv2.ts
@@ -96,5 +96,10 @@ export const SSLConfig = b.dictionary(
       default: 0,
       internalName: "client_renegotiation_window",
     },
+    sessionTimeout: {
+      type: b.i32,
+      default: 0,
+      internalName: "session_timeout",
+    },
   },
 );

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -231,10 +231,12 @@ impl SSLConfigFromJs for SSLConfig {
 
         result.client_renegotiation_limit = generated.client_renegotiation_limit;
         result.client_renegotiation_window = generated.client_renegotiation_window;
+        result.session_timeout = generated.session_timeout;
         any = any
             || result.requires_custom_request_ctx
             || result.client_renegotiation_limit != 0
-            || generated.client_renegotiation_window != 0;
+            || generated.client_renegotiation_window != 0
+            || result.session_timeout != 0;
 
         // We don't need to deinit `result` if `any` is false.
         if any { Ok(Some(result)) } else { Ok(None) }

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -118,6 +118,9 @@ pub struct BunSocketContextOptions {
     pub request_cert: i32,
     pub client_renegotiation_limit: u32,
     pub client_renegotiation_window: u32,
+    /// Lifetime in seconds of sessions this context mints (node:tls
+    /// `sessionTimeout`); <= 0 leaves BoringSSL's defaults in place.
+    pub session_timeout: i32,
 }
 
 impl Default for BunSocketContextOptions {
@@ -143,6 +146,7 @@ impl Default for BunSocketContextOptions {
             request_cert: 0,
             client_renegotiation_limit: 3,
             client_renegotiation_window: 600,
+            session_timeout: 0,
         }
     }
 }
@@ -243,6 +247,7 @@ impl BunSocketContextOptions {
         h.update(bun_core::bytes_of(&self.request_cert));
         h.update(bun_core::bytes_of(&self.client_renegotiation_limit));
         h.update(bun_core::bytes_of(&self.client_renegotiation_window));
+        h.update(bun_core::bytes_of(&self.session_timeout));
         let mut out = [0u8; 32];
         h.final_(&mut out);
         out

--- a/test/js/node/tls/node-tls-session-timeout.test.ts
+++ b/test/js/node/tls/node-tls-session-timeout.test.ts
@@ -4,6 +4,7 @@
 import { expect, test } from "bun:test";
 import { tls as COMMON_CERT } from "harness";
 import { once } from "node:events";
+import http from "node:http";
 import https from "node:https";
 import type { AddressInfo } from "node:net";
 import tls, { connect, createServer } from "node:tls";
@@ -136,4 +137,35 @@ test.each([
   const options = { ...COMMON_CERT, sessionTimeout } as unknown as Options;
   expect(() => createServer(options)).toThrow(expect.objectContaining({ code }));
   expect(() => https.createServer(options)).toThrow(expect.objectContaining({ code }));
+});
+
+// Bun-only: http.createServer().listen({ tls }) builds a fresh TLS bag that
+// replaces the constructor's, so it has to run the same validation. The value
+// is rejected synchronously by listen() before the native layer is reached.
+test.each([
+  [-1, "ERR_OUT_OF_RANGE"],
+  [1.5, "ERR_OUT_OF_RANGE"],
+  ["300", "ERR_INVALID_ARG_TYPE"],
+] as const)("http.createServer().listen({ tls }) rejects sessionTimeout %p", (sessionTimeout, code) => {
+  const server = http.createServer(() => {});
+  try {
+    expect(() => server.listen({ port: 0, tls: { ...COMMON_CERT, sessionTimeout } } as never)).toThrow(
+      expect.objectContaining({ code }),
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("http.createServer().listen({ tls: { sessionTimeout: null } }) is accepted", async () => {
+  const server = http.createServer((_, res) => res.end());
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  server.on("error", reject);
+  server.listen({ port: 0, tls: { ...COMMON_CERT, sessionTimeout: null } } as never, resolve);
+  try {
+    await promise;
+  } finally {
+    server.close();
+  }
+  await once(server, "close");
 });

--- a/test/js/node/tls/node-tls-session-timeout.test.ts
+++ b/test/js/node/tls/node-tls-session-timeout.test.ts
@@ -12,8 +12,12 @@ import tls, { connect, createServer } from "node:tls";
 // only guaranteed expired once two full seconds of wall clock have elapsed.
 const SESSION_TIMEOUT_SECONDS = 1;
 const PAST_THE_TIMEOUT_MS = SESSION_TIMEOUT_SECONDS * 2000 + 250;
+const GET = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
 
-async function startServer(label: string, options: tls.TlsOptions, resumesAfterTheWait: boolean) {
+// `sessionTimeout` is exempt from validation when null, so tests pass it.
+type Options = tls.TlsOptions & { sessionTimeout?: number | null };
+
+async function startServer(label: string, options: Options, resumesAfterTheWait: boolean) {
   const reusedServerSide: boolean[] = [];
   const server = createServer({ ...COMMON_CERT, ...options }, socket => {
     reusedServerSide.push(socket.isSessionReused());
@@ -46,10 +50,11 @@ test("tls.createServer refuses a ticket handed back after sessionTimeout has pas
   const servers = await Promise.all(
     (["TLSv1.2", "TLSv1.3"] as const).flatMap(maxVersion => [
       startServer(`${maxVersion} sessionTimeout=1`, { maxVersion, sessionTimeout: SESSION_TIMEOUT_SECONDS }, false),
-      // 0 and "omitted" both mean the TLS library's own (hours-long) default.
-      // Same cert, key and version as the one-second server above, so these
-      // also pin that the SSL_CTX cache keys on sessionTimeout.
+      // 0, null and "omitted" all mean the TLS library's own (hours-long)
+      // default. Same cert, key and version as the one-second server above, so
+      // these also pin that the SSL_CTX cache keys on sessionTimeout.
       startServer(`${maxVersion} sessionTimeout=0`, { maxVersion, sessionTimeout: 0 }, true),
+      startServer(`${maxVersion} sessionTimeout=null`, { maxVersion, sessionTimeout: null }, true),
       startServer(`${maxVersion} no sessionTimeout`, { maxVersion }, true),
     ]),
   );
@@ -83,7 +88,6 @@ test("tls.createServer refuses a ticket handed back after sessionTimeout has pas
 });
 
 test("https.createServer stamps sessionTimeout into its tickets too", async () => {
-  const GET = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
   const server = https.createServer({ ...COMMON_CERT, sessionTimeout: SESSION_TIMEOUT_SECONDS }, (_, res) => res.end());
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -95,6 +99,25 @@ test("https.createServer stamps sessionTimeout into its tickets too", async () =
     await Bun.sleep(PAST_THE_TIMEOUT_MS);
 
     expect((await handshake(port, fresh.ticket, GET)).reused).toBe(false);
+  } finally {
+    server.close();
+  }
+  await once(server, "close");
+});
+
+// A null sessionTimeout is exempt from validation (Node's check is the same) and
+// has to reach the native option parser as `undefined`, which is the only value
+// that parser reads as absent. The server cases above already cover
+// tls.createServer; these are the other two paths that forward the option.
+test("sessionTimeout: null is accepted as 'not provided'", async () => {
+  expect(tls.createSecureContext({ sessionTimeout: null } as Options)).toBeDefined();
+
+  const server = https.createServer({ ...COMMON_CERT, sessionTimeout: null } as Options, (_, res) => res.end());
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const { reused } = await handshake((server.address() as AddressInfo).port, undefined, GET);
+    expect(reused).toBe(false);
   } finally {
     server.close();
   }

--- a/test/js/node/tls/node-tls-session-timeout.test.ts
+++ b/test/js/node/tls/node-tls-session-timeout.test.ts
@@ -1,0 +1,102 @@
+// `sessionTimeout` is the server's session-lifetime policy: the number of
+// seconds a ticket it mints stays resumable. A server must stamp it into every
+// session it creates and refuse one that comes back after the window closed.
+import { expect, test } from "bun:test";
+import { tls as COMMON_CERT } from "harness";
+import { once } from "node:events";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import tls, { connect, createServer } from "node:tls";
+
+// The session clock has whole-second granularity, so a one-second lifetime is
+// only guaranteed expired once two full seconds of wall clock have elapsed.
+const SESSION_TIMEOUT_SECONDS = 1;
+const PAST_THE_TIMEOUT_MS = SESSION_TIMEOUT_SECONDS * 2000 + 250;
+
+async function startServer(label: string, options: tls.TlsOptions, resumesAfterTheWait: boolean) {
+  const reusedServerSide: boolean[] = [];
+  const server = createServer({ ...COMMON_CERT, ...options }, socket => {
+    reusedServerSide.push(socket.isSessionReused());
+    socket.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { label, server, reusedServerSide, resumesAfterTheWait, port: (server.address() as AddressInfo).port };
+}
+
+// Resolves on close, which is after the NewSessionTicket a TLSv1.3 server only
+// sends post-handshake. `ticket` stays undefined when the server resumes
+// without minting a replacement; `request` drives servers that close on reply.
+function handshake(port: number, session?: Buffer, request?: string) {
+  const { promise, resolve, reject } = Promise.withResolvers<{ reused: boolean; ticket?: Buffer }>();
+  let reused = false;
+  let ticket: Buffer | undefined;
+  const socket = connect({ port, host: "127.0.0.1", rejectUnauthorized: false, session }, () => {
+    reused = socket.isSessionReused();
+    if (request) socket.write(request);
+  });
+  socket.on("session", received => (ticket = received));
+  socket.on("data", () => {});
+  socket.on("error", reject);
+  socket.on("close", () => resolve({ reused, ticket }));
+  return promise;
+}
+
+test("tls.createServer refuses a ticket handed back after sessionTimeout has passed", async () => {
+  const servers = await Promise.all(
+    (["TLSv1.2", "TLSv1.3"] as const).flatMap(maxVersion => [
+      startServer(`${maxVersion} sessionTimeout=1`, { maxVersion, sessionTimeout: SESSION_TIMEOUT_SECONDS }, false),
+      // 0 and "omitted" both mean the TLS library's own (hours-long) default.
+      // Same cert, key and version as the one-second server above, so these
+      // also pin that the SSL_CTX cache keys on sessionTimeout.
+      startServer(`${maxVersion} sessionTimeout=0`, { maxVersion, sessionTimeout: 0 }, true),
+      startServer(`${maxVersion} no sessionTimeout`, { maxVersion }, true),
+    ]),
+  );
+  try {
+    const fresh = await Promise.all(servers.map(({ port }) => handshake(port)));
+    expect(fresh.map(({ reused, ticket }) => ({ reused, gotTicket: ticket !== undefined }))).toEqual(
+      servers.map(() => ({ reused: false, gotTicket: true })),
+    );
+
+    await Bun.sleep(PAST_THE_TIMEOUT_MS);
+
+    const again = await Promise.all(servers.map(({ port }, i) => handshake(port, fresh[i].ticket)));
+
+    expect(
+      servers.map(({ label, reusedServerSide }, i) => ({
+        label,
+        client: again[i].reused,
+        server: reusedServerSide[1],
+      })),
+    ).toEqual(
+      servers.map(({ label, resumesAfterTheWait }) => ({
+        label,
+        client: resumesAfterTheWait,
+        server: resumesAfterTheWait,
+      })),
+    );
+  } finally {
+    for (const { server } of servers) server.close();
+  }
+  await Promise.all(servers.map(({ server }) => once(server, "close")));
+});
+
+test("https.createServer stamps sessionTimeout into its tickets too", async () => {
+  const GET = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+  const server = https.createServer({ ...COMMON_CERT, sessionTimeout: SESSION_TIMEOUT_SECONDS }, (_, res) => res.end());
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const port = (server.address() as AddressInfo).port;
+    const fresh = await handshake(port, undefined, GET);
+    expect({ reused: fresh.reused, gotTicket: fresh.ticket !== undefined }).toEqual({ reused: false, gotTicket: true });
+
+    await Bun.sleep(PAST_THE_TIMEOUT_MS);
+
+    expect((await handshake(port, fresh.ticket, GET)).reused).toBe(false);
+  } finally {
+    server.close();
+  }
+  await once(server, "close");
+});

--- a/test/js/node/tls/node-tls-session-timeout.test.ts
+++ b/test/js/node/tls/node-tls-session-timeout.test.ts
@@ -123,3 +123,17 @@ test("sessionTimeout: null is accepted as 'not provided'", async () => {
   }
   await once(server, "close");
 });
+
+// Node's https.Server extends tls.Server, so both entry points reject the same
+// values, synchronously at construction. Bun's https.Server is http.Server, which
+// builds its TLS options bag by hand, so it has to run the same check.
+test.each([
+  [-1, "ERR_OUT_OF_RANGE"],
+  [2 ** 31, "ERR_OUT_OF_RANGE"],
+  [1.5, "ERR_OUT_OF_RANGE"],
+  ["300", "ERR_INVALID_ARG_TYPE"],
+] as const)("tls.createServer and https.createServer both reject sessionTimeout %p", (sessionTimeout, code) => {
+  const options = { ...COMMON_CERT, sessionTimeout } as unknown as Options;
+  expect(() => createServer(options)).toThrow(expect.objectContaining({ code }));
+  expect(() => https.createServer(options)).toThrow(expect.objectContaining({ code }));
+});


### PR DESCRIPTION
`tls.createServer({ sessionTimeout })` is validated and then discarded. The value never reaches `SSLConfig`, so the `SSL_CTX` keeps BoringSSL's default session lifetime: tickets a server mints stay resumable for hours regardless of what the application configured, and an expired one coming back is still accepted. Same result on TLSv1.2 and TLSv1.3. Reported via a cross-runtime comparison against Node v26.3.0.

### Repro

```js
// server-side session lifetime = 1 second
const srvView = [];
const srv = tls.createServer({ cert, key, maxVersion: "TLSv1.2", sessionTimeout: 1 }, s => {
  srvView.push(s.isSessionReused());
  s.end("x");
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));

const full = await connect(undefined);              // captures the ticket
console.log(`fresh   client=${full.reused} server=${srvView[0]}`);
await new Promise(r => setTimeout(r, 2500));        // >> sessionTimeout of 1s
const resumed = await connect(ticket);
console.log(`expired client=${resumed.reused} server=${srvView[1]}`);
```

```
node v26.3.0:  fresh   client=false server=false
               expired client=false server=false   <- expired ticket refused, full handshake

bun 1.4.0:     fresh   client=false server=false
               expired client=true  server=true    <- resumed long after sessionTimeout
```

### Cause

`validateSecureContextOptions` range-checks `options.sessionTimeout` and nothing else reads it. It is not a member of the `SSLConfig` bindgen dictionary, so it never crosses into native, never lands in `us_bun_socket_context_options_t`, and `us_ssl_ctx_build_raw` never calls `SSL_CTX_set_timeout`. Session lifetime is decided entirely by BoringSSL's defaults. `tls.Server` additionally hand-builds its listen-time options bag, so the option has to be named there explicitly.

### Fix

Carry `sessionTimeout` from JS to the `SSL_CTX`:

- `SSLConfig.bindv2.ts` gains a `sessionTimeout` member, which covers `tls.createSecureContext`, `tls.connect`, `Bun.serve({ tls })` and `Bun.listen({ tls })` at once.
- `tls.Server` stores it in `setSecureContext` and passes it in its `[buntls]` bag; `http.Server` (what `https.createServer` returns) passes it in its own TLS bag.
- The range/type check moves out of `tls.ts` into `internal/tls`, which both modules already import, so every path rejects the same values `tls.createServer` does. In Node the parity is automatic (`https.Server` extends `tls.Server`); in Bun `https.Server` **is** `http.Server`, which hand-builds its TLS bag, and the Bun-only `http.Server.listen({ tls })` override builds yet another, so both call the shared check. Plain `http.createServer` (no TLS) still ignores the option, as in Node.
- `us_ssl_ctx_build_raw` calls `SSL_CTX_set_timeout()` when the value is positive. BoringSSL keeps the TLS 1.3 session lifetime in a separate `SSL_CTX_set_session_psk_dhe_timeout()` knob, while OpenSSL (and so Node) derives both versions from the single timeout value, so both are set. 0 and "omitted" both keep the library default, matching Node.
- The value joins `BunSocketContextOptions::digest()` and `SSLConfig::content_hash()`, so two servers differing only in `sessionTimeout` no longer share one cached `SSL_CTX`.

Negative values are rejected by that validation and, on the `Bun.serve({ tls })` path which has no such layer, skipped by the `> 0` guard in the C. A `null` sessionTimeout is exempt from that validation (Node's `configSecureContext` makes the same exemption and simply skips the native setter), but the generated option parser only reads `undefined` as absent, so the three JS paths that forward the option collapse `null` before it crosses.

### Verification

New test `test/js/node/tls/node-tls-session-timeout.test.ts`, alongside the other per-feature files in that directory (`renegotiation.test.ts`, `ssl-ctx-cache.test.ts`). Servers with `sessionTimeout: 1`, `sessionTimeout: 0`, `sessionTimeout: null` and no `sessionTimeout` are started on both TLSv1.2 and TLSv1.3, then each is handed its own ticket back after the window has passed. Only the one-second servers refuse it, on both the client's and the server's `isSessionReused()`. They all share cert, key and version, so this also pins the `SSL_CTX` cache keying. A second test covers `https.createServer`, a third pins that `null` reaches `tls.createSecureContext` and `https.createServer` as "not provided", and a `test.each` over `-1`, `2**31`, `1.5` and `"300"` pins that both entry points throw the same error code so they cannot drift apart again. All of it matches Node v26.3.0 byte-for-byte on message and code.

Against a build of the base commit (48ff9eb), every `sessionTimeout: 1` server still resumes, while the `0` / omitted controls correctly keep resuming, so neither assertion is vacuous:

```
-     "client": false,          <- expected
+     "client": true,           <- base commit
      "label": "TLSv1.2 sessionTimeout=1",
-     "server": false,
+     "server": true,
      "client": true,
      "label": "TLSv1.2 sessionTimeout=0",     <- unchanged, still resumes
      "server": true,
...same for TLSv1.3...
```

With the fix applied, both tests pass and the repro above matches Node exactly on both protocol versions.



