### PR TITLE
dns.lookup: resolve root-anchored localhost names ("localhost.") to loopback

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -503,20 +503,49 @@ pub(super) mod lib_uv_backend {
 // normalizeDNSName
 // ──────────────────────────────────────────────────────────────────────────
 
+/// A single trailing dot is the root-anchored spelling of the same name: it
+/// suppresses search-list expansion but does not change which name is being
+/// asked for. The bare root (`"."`) has no name to unanchor.
+fn strip_root_dot(name: &[u8]) -> &[u8] {
+    match name.split_last() {
+        Some((b'.', unanchored)) if !unanchored.is_empty() => unanchored,
+        _ => name,
+    }
+}
+
+fn ends_with_caseless(name: &[u8], suffix: &[u8]) -> bool {
+    name.len() >= suffix.len()
+        && strings::eql_case_insensitive_ascii_check_length(
+            &name[name.len() - suffix.len()..],
+            suffix,
+        )
+}
+
 pub(super) fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &'a [u8] {
-    if *backend == GetAddrInfoBackend::CAres {
-        // https://github.com/c-ares/c-ares/issues/477
-        if name.ends_with(b".localhost") {
-            *backend = GetAddrInfoBackend::System;
-            return b"localhost";
-        } else if name.ends_with(b".local")
-            // https://github.com/c-ares/c-ares/pull/463
-            || strings::is_ipv6_address(name)
-            // getaddrinfo() is inconsistent with ares_getaddrinfo() when using localhost
-            || name == b"localhost"
-        {
+    // Match on the unanchored, case-folded spelling: "LOCALHOST." names the same
+    // host as "localhost", and a root-anchored name must never be matched only
+    // when it is written without its trailing dot.
+    let unanchored = strip_root_dot(name);
+
+    // RFC 6761 6.3: "localhost." and anything under ".localhost." always resolve
+    // to loopback and are never sent to a configured nameserver. c-ares misses
+    // the root-anchored spellings. https://github.com/c-ares/c-ares/issues/477
+    if strings::eql_case_insensitive_ascii_check_length(unanchored, b"localhost")
+        || ends_with_caseless(unanchored, b".localhost")
+    {
+        // getaddrinfo() is inconsistent with ares_getaddrinfo() when using localhost
+        if *backend == GetAddrInfoBackend::CAres {
             *backend = GetAddrInfoBackend::System;
         }
+        return b"localhost";
+    }
+
+    if *backend == GetAddrInfoBackend::CAres
+        // https://github.com/c-ares/c-ares/pull/463
+        && (ends_with_caseless(unanchored, b".local") || strings::is_ipv6_address(name))
+    {
+        *backend = GetAddrInfoBackend::System;
+        return unanchored;
     }
 
     name

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -533,11 +533,14 @@ pub(super) fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBa
     if strings::eql_case_insensitive_ascii_check_length(unanchored, b"localhost")
         || ends_with_caseless(unanchored, b".localhost")
     {
-        // getaddrinfo() is inconsistent with ares_getaddrinfo() when using localhost
         if *backend == GetAddrInfoBackend::CAres {
+            // getaddrinfo() is inconsistent with ares_getaddrinfo() when using localhost
             *backend = GetAddrInfoBackend::System;
+            return b"localhost";
         }
-        return b"localhost";
+        // getaddrinfo() resolves these itself. Hand it the real subdomain so a
+        // hosts-file entry for it still wins; only the root dot comes off.
+        return unanchored;
     }
 
     if *backend == GetAddrInfoBackend::CAres

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -601,10 +601,14 @@ describe("root-anchored localhost names", () => {
     await new Promise(resolve => server.bind(0, "127.0.0.1", resolve));
     dns.setServers(["127.0.0.1:" + server.address().port]);
 
-    const result = { queries };
-    for (const name of ["localhost", "localhost.", "sub.localhost.", "LOCALHOST."]) {
-      const all = await dns.promises.lookup(name, { all: true });
-      result[name] = all.map(entry => entry.address).sort();
+    const addresses = all => all.map(entry => entry.address).sort();
+    const loopback = addresses(await dns.promises.lookup("localhost", { all: true }));
+
+    const result = { queries, loopback };
+    for (const name of ["localhost.", "LOCALHOST.", "sub.localhost", "sub.localhost."]) {
+      result[name] = await dns.promises
+        .lookup(name, { all: true })
+        .then(addresses, err => "error " + err.code);
     }
     server.close();
     console.log(JSON.stringify(result));
@@ -624,14 +628,15 @@ describe("root-anchored localhost names", () => {
     }
 
     const result = JSON.parse(stdout);
-    const loopback = result["localhost"];
-    expect(loopback).not.toEqual([]);
-    expect(loopback.filter(address => address === "127.0.0.1" || address === "::1")).toEqual(loopback);
+    expect(result.loopback).not.toEqual([]);
+    expect(result.loopback.filter(address => address === "127.0.0.1" || address === "::1")).toEqual(result.loopback);
 
     // A trailing dot only suppresses search-list expansion; it names the same host.
-    expect(result["localhost."]).toEqual(loopback);
-    expect(result["sub.localhost."]).toEqual(loopback);
-    expect(result["LOCALHOST."]).toEqual(loopback);
+    expect(result["localhost."]).toEqual(result.loopback);
+    expect(result["LOCALHOST."]).toEqual(result.loopback);
+    // How "sub.localhost" itself resolves is the platform resolver's call; all the
+    // trailing dot may do is not change the answer.
+    expect(result["sub.localhost."]).toEqual(result["sub.localhost"]);
     expect(result.queries).toEqual([]);
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
 import * as fs from "node:fs";
@@ -570,5 +570,69 @@ describe("hostnames containing NUL bytes", () => {
   it("plain localhost still resolves", async () => {
     const { address } = await dns_promises.lookup("localhost");
     expect(["127.0.0.1", "::1"]).toContain(address);
+  });
+});
+
+describe("root-anchored localhost names", () => {
+  // Runs in a child process: dns.setServers() is process-global, and the point of
+  // the fixture is that the nameserver it installs never receives a single query.
+  const fixture = `
+    const dns = require("node:dns");
+    const dgram = require("node:dgram");
+
+    const queries = [];
+    const server = dgram.createSocket("udp4");
+    server.on("message", (msg, rinfo) => {
+      let offset = 12;
+      const labels = [];
+      while (msg[offset]) {
+        labels.push(msg.subarray(offset + 1, offset + 1 + msg[offset]).toString());
+        offset += msg[offset] + 1;
+      }
+      queries.push(labels.join(".") + " type=" + msg.readUInt16BE(offset + 1));
+
+      // Answer NXDOMAIN so a leaked query fails immediately instead of retrying.
+      const header = Buffer.alloc(12);
+      msg.copy(header, 0, 0, 2);
+      header.writeUInt16BE(0x8183, 2);
+      header.writeUInt16BE(1, 4);
+      server.send(Buffer.concat([header, msg.subarray(12, offset + 5)]), rinfo.port, rinfo.address);
+    });
+    await new Promise(resolve => server.bind(0, "127.0.0.1", resolve));
+    dns.setServers(["127.0.0.1:" + server.address().port]);
+
+    const result = { queries };
+    for (const name of ["localhost", "localhost.", "sub.localhost.", "LOCALHOST."]) {
+      const all = await dns.promises.lookup(name, { all: true });
+      result[name] = all.map(entry => entry.address).sort();
+    }
+    server.close();
+    console.log(JSON.stringify(result));
+  `;
+
+  it("resolve to loopback without reaching the configured nameserver", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (!stdout.trim()) {
+      throw new Error(`fixture printed nothing (exit code ${exitCode})\n${stderr}`);
+    }
+
+    const result = JSON.parse(stdout);
+    const loopback = result["localhost"];
+    expect(loopback).not.toEqual([]);
+    expect(loopback.filter(address => address === "127.0.0.1" || address === "::1")).toEqual(loopback);
+
+    // A trailing dot only suppresses search-list expansion; it names the same host.
+    expect(result["localhost."]).toEqual(loopback);
+    expect(result["sub.localhost."]).toEqual(loopback);
+    expect(result["LOCALHOST."]).toEqual(loopback);
+    expect(result.queries).toEqual([]);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
`dns.lookup("localhost.")` fails on Linux and sends the query to the configured nameserver, while `dns.lookup("localhost")` resolves to loopback without touching the wire. RFC 6761 6.3 says `localhost.` and anything under `.localhost.` must always resolve to loopback and must not be sent to a caching DNS server.

## Repro

```js
import dns from "node:dns";
import dgram from "node:dgram";

const seen = [];
const u = dgram.createSocket("udp4");
u.on("message", (m, ri) => {
  let i = 12;
  const labels = [];
  while (m[i]) { labels.push(m.subarray(i + 1, i + 1 + m[i]).toString()); i += m[i] + 1; }
  seen.push(labels.join("."));
  const h = Buffer.alloc(12);
  m.copy(h, 0, 0, 2);
  h.writeUInt16BE(0x8183, 2); // NXDOMAIN
  h.writeUInt16BE(1, 4);
  u.send(Buffer.concat([h, m.subarray(12, i + 5)]), ri.port, ri.address);
});
await new Promise(r => u.bind(0, "127.0.0.1", r));
dns.setServers([`127.0.0.1:${u.address().port}`]);

for (const name of ["localhost", "localhost.", "sub.localhost."]) {
  seen.length = 0;
  const res = await dns.promises.lookup(name, { all: true }).then(JSON.stringify, e => e.code);
  console.log(name.padEnd(16), res.padEnd(56), "wire:", JSON.stringify(seen));
}
u.close();
```

```
localhost        [{"address":"::1","family":6},{"address":"127.0.0.1","family":4}]  wire: []
localhost.       ENOTFOUND                                                          wire: ["localhost","localhost"]
sub.localhost.   ENOTFOUND                                                          wire: ["sub.localhost","sub.localhost"]
```

## Cause

A trailing dot is the root-anchored spelling of a hostname. It suppresses search-list expansion, but it does not change which name is being asked for. `normalize_dns_name()` in `src/runtime/dns_jsc/dns.rs` compared the raw hostname:

```rust
if name.ends_with(b".localhost") { ... }
else if name.ends_with(b".local") || strings::is_ipv6_address(name) || name == b"localhost" { ... }
```

so `localhost.` matched nothing, kept the default c-ares backend, and went out on the wire. c-ares has the same blind spot: `ares_is_localhost()` is commented with the RFC's `"localhost."` spelling but compares against `localhost` / `.localhost`, and `ares_hosts_search_host()` looks the hostname up in the hosts-file hash verbatim. Case has the same problem: `LOCALHOST` resolves (c-ares matches case-insensitively) but `LOCALHOST.` does not.

## Fix

Strip a single trailing dot (never the bare root `"."`) and compare case-insensitively before matching `localhost` / `.localhost` / `.local`.

The existing `*.localhost` → `localhost` rewrite stays scoped to the c-ares backend, the one that actually has the blind spot. The getaddrinfo backends (the default on macOS/Windows) only get the root dot stripped, so `api.localhost` still reaches `getaddrinfo()` intact and a `127.0.0.2 api.localhost` hosts entry still wins. Resulting behavior, measured on Linux via `Bun.dns.lookup` (`node:dns` does not forward the `backend` option):

| hostname | `c-ares` | `libc` / `system` |
| --- | --- | --- |
| `localhost.` | loopback | loopback |
| `LOCALHOST.` | loopback | loopback |
| `sub.localhost` | loopback | `ENOTIMP` (glibc has no `.localhost` rule) |
| `sub.localhost.` | loopback | `ENOTIMP`, i.e. unchanged from `sub.localhost` |

Every other hostname keeps its trailing dot on the way to c-ares, because that dot is what makes `ares_search_eligible()` skip the search list:

```
example.com.   wire: ["example.com", "example.com"]                             # A + AAAA, no search
example.com    wire: [..., "example.com.us-east-2.compute.internal", ...]       # search list applied
```

## Verification

`test/js/node/dns/node-dns.test.js` spawns a child process (`dns.setServers()` is process-global), points it at an in-process NXDOMAIN nameserver that logs every query, and asserts:

- `localhost.` and `LOCALHOST.` return exactly what `localhost` returns,
- `sub.localhost.` returns exactly what `sub.localhost` returns, whatever the platform resolver makes of the `.localhost` TLD,
- zero queries reach the nameserver.

Fails on the unfixed build (`"error ENOTFOUND"` where the loopback addresses are expected). `node-dns.test.js` and `resolve-dns.test.ts` show no change in pass/fail counts beyond the new test (the remaining failures in this sandbox are the tests that need external DNS).
