### PR TITLE
node:dns: match Node.js argument validation in lookup()

### DIFF
--- a/src/js/internal/promisify.ts
+++ b/src/js/internal/promisify.ts
@@ -40,13 +40,9 @@ var promisify = function promisify(original) {
             return reject(err);
           }
 
-          if (callbackArgs !== undefined) {
-            // if (!Array.isArray(callbackArgs)) {
-            //   throw new TypeError('The "customPromisifyArgs" argument must be of type Array');
-            // }
-            // if (callbackArgs.length !== values.length) {
-            //   throw new Error("Mismatched length in promisify callback args");
-            // }
+          // A callback invoked with a single value keeps that value, so
+          // util.promisify(dns.lookup)(host, { all: true }) stays an array.
+          if (callbackArgs !== undefined && values.length > 1) {
             const result = {};
             for (let i = 0; i < callbackArgs.length; i++) {
               result[callbackArgs[i]] = values[i];

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -10,6 +10,7 @@ const {
   validateNumber,
   validateOneOf,
 } = require("internal/validators");
+const { defineCustomPromisifyArgs } = require("internal/promisify");
 
 const errorCodes = {
   NODATA: "ENODATA",
@@ -42,10 +43,9 @@ const IANA_DNS_PORT = 53;
 const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
 const validOrders = ["verbatim", "ipv4first", "ipv6first"];
-// getaddrinfo encodes the hostname into a 256 byte buffer (IDNA ASCII + NUL)
-// before resolving, so a longer name fails with EINVAL before any query.
 const MAX_HOSTNAME_LENGTH = 255;
 const UV_EINVAL = process.platform === "win32" ? -4071 : -22;
+const nonAsciiRE = /[^\x00-\x7f]/;
 
 function translateErrorCode(promise: Promise<any>) {
   return promise.catch(error => {
@@ -272,6 +272,13 @@ function validateLookupOptions(options, allowFamilyStrings) {
   validateOrderOption(options);
 }
 
+// getaddrinfo encodes the hostname into a 256 byte buffer (IDNA ASCII + NUL)
+// before resolving, so a longer name fails with EINVAL before any query. Only
+// an ASCII hostname is its own encoding; the rest are left to the resolver.
+function hostnameIsTooLong(hostname) {
+  return hostname.length > MAX_HOSTNAME_LENGTH && !nonAsciiRE.test(hostname);
+}
+
 function hostnameTooLongError(hostname) {
   const err = new Error(`getaddrinfo EINVAL ${hostname}`);
   err.errno = UV_EINVAL;
@@ -323,7 +330,7 @@ function lookup(hostname, options, callback) {
     return;
   }
 
-  if (hostname.length > MAX_HOSTNAME_LENGTH) {
+  if (hostnameIsTooLong(hostname)) {
     process.nextTick(callback, hostnameTooLongError(hostname));
     return;
   }
@@ -785,7 +792,7 @@ const promises = {
       return Promise.$resolve(options.all ? [obj] : obj);
     }
 
-    if (hostname.length > MAX_HOSTNAME_LENGTH) {
+    if (hostnameIsTooLong(hostname)) {
       return Promise.$reject(hostnameTooLongError(hostname));
     }
 
@@ -986,9 +993,12 @@ const promises = {
   setServers,
 };
 
+// Node.js promisifies the callback `lookup` rather than pointing at
+// `dnsPromises.lookup`, which rejects the "IPv4"/"IPv6" spellings of `family`.
+defineCustomPromisifyArgs(lookup, ["address", "family"]);
+
 // Compatibility with util.promisify(dns[method])
 for (const [method, pMethod] of [
-  [lookup, promises.lookup],
   [lookupService, promises.lookupService],
   [resolve, promises.resolve],
   [reverse, promises.reverse],

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -8,6 +8,7 @@ const {
   validateString,
   validateBoolean,
   validateNumber,
+  validateOneOf,
 } = require("internal/validators");
 
 const errorCodes = {
@@ -40,6 +41,11 @@ const errorCodes = {
 const IANA_DNS_PORT = 53;
 const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
+const validOrders = ["verbatim", "ipv4first", "ipv6first"];
+// getaddrinfo encodes the hostname into a 256 byte buffer (IDNA ASCII + NUL)
+// before resolving, so a longer name fails with EINVAL before any query.
+const MAX_HOSTNAME_LENGTH = 255;
+const UV_EINVAL = process.platform === "win32" ? -4071 : -22;
 
 function translateErrorCode(promise: Promise<any>) {
   return promise.catch(error => {
@@ -87,7 +93,7 @@ function defaultResultOrder() {
 }
 
 function setDefaultResultOrder(order) {
-  validateOrder(order);
+  validateOrder(order, "dnsOrder");
   defaultResultOrder.value = order;
 }
 
@@ -143,65 +149,66 @@ function setServersOn(servers, object) {
 }
 
 function validateFlagsOption(options) {
-  if (options.flags === undefined) {
+  const flags = options.flags;
+  if (flags == null) {
     return;
   }
 
-  const flags = options.flags;
-  validateNumber(flags);
+  validateNumber(flags, "options.hints");
 
   if ((flags & ~(dns.ALL | dns.ADDRCONFIG | dns.V4MAPPED)) != 0) {
     throw $ERR_INVALID_ARG_VALUE("hints", flags, "is invalid");
   }
 }
 
-function validateFamily(family) {
-  if (family !== 6 && family !== 4 && family !== 0) {
-    throw $ERR_INVALID_ARG_VALUE("family", family, "must be one of 0, 4 or 6");
+function validateFamily(family, name) {
+  if (family !== 0 && family !== 4 && family !== 6) {
+    throw $ERR_INVALID_ARG_VALUE(name, family, "must be one of: 0, 4, 6");
   }
 }
 
-function validateFamilyOption(options) {
-  if (options.family != null) {
-    switch (options.family) {
-      case "IPv4":
-        options.family = 4;
-        break;
-      case "IPv6":
-        options.family = 6;
-        break;
-      default:
-        validateFamily(options.family);
-        break;
+// The callback `dns.lookup` also accepts the "IPv4"/"IPv6" spellings of
+// `family`, while `dns.promises.lookup` rejects them.
+function validateFamilyOption(options, allowFamilyStrings) {
+  const family = options.family;
+  if (family == null) {
+    return;
+  }
+
+  if (allowFamilyStrings) {
+    if (family === "IPv4") {
+      options.family = 4;
+      return;
+    }
+    if (family === "IPv6") {
+      options.family = 6;
+      return;
     }
   }
+
+  validateFamily(family, "options.family");
 }
 
 function validateAllOption(options) {
   const all = options.all;
-  if (all !== undefined) {
-    validateBoolean(all);
+  if (all != null) {
+    validateBoolean(all, "options.all");
   }
 }
 
 function validateVerbatimOption(options) {
   const verbatim = options.verbatim;
-  if (verbatim !== undefined) {
-    validateBoolean(verbatim);
+  if (verbatim != null) {
+    validateBoolean(verbatim, "options.verbatim");
   }
 }
 
-function validateOrder(order) {
-  if (!["ipv4first", "ipv6first", "verbatim"].includes(order)) {
-    throw $ERR_INVALID_ARG_VALUE("order", order, "is invalid");
-  }
+function validateOrder(order, name) {
+  validateOneOf(order, name, validOrders);
 }
 
 function validateOrderOption(options) {
-  const order = options.order;
-  if (order !== undefined) {
-    validateOrder(order);
-  }
+  validateOrder(options.order, "options.order");
 }
 
 function validateResolve(hostname, callback) {
@@ -241,7 +248,7 @@ function translateLookupOptions(options) {
 
   let { family, order, verbatim, hints: flags, all } = options;
 
-  if (order === undefined && typeof verbatim === "boolean") {
+  if (order == null && typeof verbatim === "boolean") {
     order = verbatim ? "verbatim" : "ipv4first";
   }
 
@@ -249,19 +256,29 @@ function translateLookupOptions(options) {
 
   return {
     family,
-    flags,
+    // Bun.dns.lookup rejects a null `flags`, node treats a null `hints` as unset.
+    flags: flags ?? undefined,
     all,
     order,
     verbatim,
   };
 }
 
-function validateLookupOptions(options) {
+function validateLookupOptions(options, allowFamilyStrings) {
   validateFlagsOption(options);
-  validateFamilyOption(options);
+  validateFamilyOption(options, allowFamilyStrings);
   validateAllOption(options);
   validateVerbatimOption(options);
   validateOrderOption(options);
+}
+
+function hostnameTooLongError(hostname) {
+  const err = new Error(`getaddrinfo EINVAL ${hostname}`);
+  err.errno = UV_EINVAL;
+  err.code = "EINVAL";
+  err.syscall = "getaddrinfo";
+  err.hostname = hostname;
+  return err;
 }
 
 function lookup(hostname, options, callback) {
@@ -274,7 +291,7 @@ function lookup(hostname, options, callback) {
     options = { family: 0 };
   } else if (typeof options === "number") {
     validateFunction(callback, "callback");
-    validateFamily(options);
+    validateFamily(options, "family");
     options = { family: options };
   } else if (options !== undefined && typeof options !== "object") {
     validateFunction(arguments.length === 2 ? options : callback, "callback");
@@ -284,7 +301,7 @@ function lookup(hostname, options, callback) {
   validateFunction(callback, "callback");
 
   options = translateLookupOptions(options);
-  validateLookupOptions(options);
+  validateLookupOptions(options, true);
 
   if (!hostname) {
     invalidHostname(hostname);
@@ -303,6 +320,11 @@ function lookup(hostname, options, callback) {
     } else {
       process.nextTick(callback, null, hostname, family);
     }
+    return;
+  }
+
+  if (hostname.length > MAX_HOSTNAME_LENGTH) {
+    process.nextTick(callback, hostnameTooLongError(hostname));
     return;
   }
 
@@ -736,14 +758,14 @@ const promises = {
     }
 
     if (typeof options === "number") {
-      validateFamily(options);
+      validateFamily(options, "family");
       options = { family: options };
     } else if (options !== undefined && typeof options !== "object") {
       throw $ERR_INVALID_ARG_TYPE("options", ["integer", "object"], options);
     }
 
     options = translateLookupOptions(options);
-    validateLookupOptions(options);
+    validateLookupOptions(options, false);
 
     if (!hostname) {
       invalidHostname(hostname);
@@ -761,6 +783,10 @@ const promises = {
     if (family) {
       const obj = { address: hostname, family };
       return Promise.$resolve(options.all ? [obj] : obj);
+    }
+
+    if (hostname.length > MAX_HOSTNAME_LENGTH) {
+      return Promise.$reject(hostnameTooLongError(hostname));
     }
 
     if (options.all) {

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1036,11 +1036,16 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
 // for validateOneOf
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue name, JSC::JSValue value, WTF::ASCIILiteral reason, JSC::JSArray* oneOf)
 {
-    WTF::StringBuilder builder;
-    builder.append("The argument '"_s);
-    JSValueToStringSafe(globalObject, builder, name);
-    RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
+    auto* jsNameString = name.toString(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    auto nameView = jsNameString->view(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
+    WTF::StringBuilder builder;
+    builder.append("The "_s);
+    builder.append(nameView->contains('.') ? "property"_s : "argument"_s);
+    builder.append(" '"_s);
+    builder.append(nameView);
     builder.append("' "_s);
     builder.append(reason);
     unsigned length = oneOf->length();

--- a/test/js/node/dns/dns-lookup-validation.test.ts
+++ b/test/js/node/dns/dns-lookup-validation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 import { isWindows } from "harness";
 import * as dns from "node:dns";
 import * as dnsPromises from "node:dns/promises";
+import * as util from "node:util";
 
 // Both entry points validate synchronously, so a thrown error and a rejected
 // promise are the same failure. Returns the resolved value when there is none.
@@ -45,13 +46,26 @@ describe("dns.lookup option validation", () => {
   });
 
   it("dns.lookup (callback) keeps accepting the IPv4/IPv6 family spellings, like Node.js", async () => {
+    // localhost always has a 127.0.0.1 entry, so this reaches the resolver with AF_INET.
     expect(await callbackError({ family: "IPv4" })).toMatchObject({ address: expect.any(String), family: 4 });
-    expect(await callbackError({ family: "IPv6" })).toMatchObject({ address: expect.any(String), family: 6 });
+    // An IP literal short-circuits before the resolver, so no "::1 localhost" entry is needed.
+    expect(await callbackError({ family: "IPv6" }, "::1")).toEqual({ address: "::1", family: 6 });
     // Only those two spellings.
     expect(await callbackError({ family: "ipv4" })).toMatchObject({
       code: "ERR_INVALID_ARG_VALUE",
       message: "The property 'options.family' must be one of: 0, 4, 6. Received 'ipv4'",
     });
+  });
+
+  it("util.promisify(dns.lookup) wraps the callback implementation, like Node.js", async () => {
+    expect(dns.lookup[util.promisify.custom]).toBeUndefined();
+    const lookup = util.promisify(dns.lookup);
+
+    // ...so it accepts the family spellings that dns.promises.lookup rejects.
+    expect(await lookup("localhost", { family: "IPv4" })).toMatchObject({ address: expect.any(String), family: 4 });
+    // A single callback value stays itself rather than becoming { address, family }.
+    expect(await lookup("localhost", { all: true })).toBeArray();
+    expect(await lookup("127.0.0.1")).toEqual({ address: "127.0.0.1", family: 4 });
   });
 
   it.each([
@@ -97,7 +111,8 @@ describe("dns.lookup option validation", () => {
 });
 
 describe("dns.lookup of a hostname longer than 255 characters", () => {
-  const hostname = Buffer.alloc(256, "l").toString();
+  const MAX_HOSTNAME_LENGTH = 255;
+  const hostname = Buffer.alloc(MAX_HOSTNAME_LENGTH + 1, "l").toString();
 
   // getaddrinfo cannot encode it, so Node.js reports EINVAL instead of the
   // ENOTFOUND a missing (but encodable) hostname gets.
@@ -131,9 +146,17 @@ describe("dns.lookup of a hostname longer than 255 characters", () => {
     expect(sync).toBe(false);
   });
 
+  it("a hostname whose IDNA encoding still fits reaches the resolver", async () => {
+    // 128 astral code points: 256 UTF-16 code units, but only 135 bytes of IDNA
+    // ASCII ("xn--971h" + 127 deltas), which getaddrinfo encodes happily.
+    const surrogates = "\u{1D54F}".repeat(128);
+    expect(surrogates.length).toBeGreaterThan(MAX_HOSTNAME_LENGTH);
+    expect((await promisesError(undefined, surrogates))?.code).not.toBe("EINVAL");
+  });
+
   it("a 255 character hostname still reaches the resolver", async () => {
     // It cannot exist, so this only asserts that it was not rejected as EINVAL.
-    const shorter = Buffer.alloc(255, "l").toString();
+    const shorter = Buffer.alloc(MAX_HOSTNAME_LENGTH, "l").toString();
     const error = await new Promise<any>(resolve => dns.lookup(shorter, resolve));
     expect(error?.code).not.toBe("EINVAL");
   });

--- a/test/js/node/dns/dns-lookup-validation.test.ts
+++ b/test/js/node/dns/dns-lookup-validation.test.ts
@@ -1,0 +1,140 @@
+// Argument validation for dns.lookup()/dns.promises.lookup(), checked against
+// Node.js. Everything here resolves out of the hosts file or fails before the
+// resolver is reached, so the file never touches the network.
+import { describe, expect, it } from "bun:test";
+import { isWindows } from "harness";
+import * as dns from "node:dns";
+import * as dnsPromises from "node:dns/promises";
+
+// Both entry points validate synchronously, so a thrown error and a rejected
+// promise are the same failure. Returns the resolved value when there is none.
+async function promisesError(options: unknown, hostname = "localhost") {
+  try {
+    return await dnsPromises.lookup(hostname, options as any);
+  } catch (error) {
+    return error;
+  }
+}
+
+function callbackError(options: unknown, hostname = "localhost") {
+  const { promise, resolve } = Promise.withResolvers<any>();
+  try {
+    dns.lookup(hostname, options as any, (err, address, family) => resolve(err ?? { address, family }));
+  } catch (error) {
+    resolve(error);
+  }
+  return promise;
+}
+
+describe("dns.lookup option validation", () => {
+  it.each([
+    ["IPv4", "The property 'options.family' must be one of: 0, 4, 6. Received 'IPv4'"],
+    ["IPv6", "The property 'options.family' must be one of: 0, 4, 6. Received 'IPv6'"],
+    ["ipv4", "The property 'options.family' must be one of: 0, 4, 6. Received 'ipv4'"],
+    ["4", "The property 'options.family' must be one of: 0, 4, 6. Received '4'"],
+  ])("dns.promises.lookup rejects the string family %p", async (family, message) => {
+    const error = await promisesError({ family });
+    expect(error).toMatchObject({ code: "ERR_INVALID_ARG_VALUE", name: "TypeError" });
+    expect(error.message).toBe(message);
+  });
+
+  it("dns.promises.lookup rejects an out of range numeric family", async () => {
+    const error = await promisesError({ family: 20 });
+    expect(error).toMatchObject({ code: "ERR_INVALID_ARG_VALUE", name: "TypeError" });
+    expect(error.message).toBe("The property 'options.family' must be one of: 0, 4, 6. Received 20");
+  });
+
+  it("dns.lookup (callback) keeps accepting the IPv4/IPv6 family spellings, like Node.js", async () => {
+    expect(await callbackError({ family: "IPv4" })).toMatchObject({ address: expect.any(String), family: 4 });
+    expect(await callbackError({ family: "IPv6" })).toMatchObject({ address: expect.any(String), family: 6 });
+    // Only those two spellings.
+    expect(await callbackError({ family: "ipv4" })).toMatchObject({
+      code: "ERR_INVALID_ARG_VALUE",
+      message: "The property 'options.family' must be one of: 0, 4, 6. Received 'ipv4'",
+    });
+  });
+
+  it.each([
+    ["all", { all: 1 }, `The "options.all" property must be of type boolean. Received type number (1)`],
+    [
+      "verbatim",
+      { verbatim: "yes" },
+      `The "options.verbatim" property must be of type boolean. Received type string ('yes')`,
+    ],
+    ["hints", { hints: "x" }, `The "options.hints" property must be of type number. Received type string ('x')`],
+  ])("names options.%s in its ERR_INVALID_ARG_TYPE", async (_option, options, message) => {
+    for (const error of [await promisesError(options), await callbackError(options)]) {
+      expect(error).toMatchObject({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" });
+      expect(error.message).toBe(message);
+    }
+  });
+
+  it("names the offending property in the ERR_INVALID_ARG_VALUE of a bad order", async () => {
+    const message = "The property 'options.order' must be one of: 'verbatim', 'ipv4first', 'ipv6first'. Received 'x'";
+    for (const error of [await promisesError({ order: "x" }), await callbackError({ order: "x" })]) {
+      expect(error).toMatchObject({ code: "ERR_INVALID_ARG_VALUE", name: "TypeError" });
+      expect(error.message).toBe(message);
+    }
+  });
+
+  it("a numeric family argument is still named 'family'", async () => {
+    const error = await promisesError(5);
+    expect(error).toMatchObject({ code: "ERR_INVALID_ARG_VALUE", name: "TypeError" });
+    expect(error.message).toBe("The argument 'family' must be one of: 0, 4, 6. Received 5");
+  });
+
+  it("dns.setDefaultResultOrder rejects an unknown order", () => {
+    const message = "The argument 'dnsOrder' must be one of: 'verbatim', 'ipv4first', 'ipv6first'. Received 'x'";
+    expect(() => dns.setDefaultResultOrder("x" as any)).toThrow(message);
+    expect(() => dnsPromises.setDefaultResultOrder("x" as any)).toThrow(message);
+  });
+
+  it("a null option means unset, like Node.js", async () => {
+    const options = { family: null, all: null, verbatim: null, hints: null, order: null };
+    expect(await promisesError(options)).toMatchObject({ address: expect.any(String) });
+    expect(await callbackError(options)).toMatchObject({ address: expect.any(String) });
+  });
+});
+
+describe("dns.lookup of a hostname longer than 255 characters", () => {
+  const hostname = Buffer.alloc(256, "l").toString();
+
+  // getaddrinfo cannot encode it, so Node.js reports EINVAL instead of the
+  // ENOTFOUND a missing (but encodable) hostname gets.
+  const expected = {
+    code: "EINVAL",
+    errno: isWindows ? -4071 : -22,
+    syscall: "getaddrinfo",
+    hostname,
+    message: `getaddrinfo EINVAL ${hostname}`,
+  };
+
+  it("dns.promises.lookup rejects with EINVAL", async () => {
+    const error = await promisesError(undefined, hostname);
+    expect(error).toMatchObject(expected);
+    expect(error.name).toBe("Error");
+  });
+
+  it("dns.promises.lookup rejects with EINVAL with { all: true }", async () => {
+    expect(await promisesError({ all: true }, hostname)).toMatchObject(expected);
+  });
+
+  it("dns.lookup (callback) passes EINVAL to the callback, asynchronously", async () => {
+    const { promise, resolve } = Promise.withResolvers<any>();
+    let calledSynchronously = true;
+    dns.lookup(hostname, (err, address) => resolve({ err, address, calledSynchronously }));
+    calledSynchronously = false;
+
+    const { err, address, calledSynchronously: sync } = await promise;
+    expect(err).toMatchObject(expected);
+    expect(address).toBeUndefined();
+    expect(sync).toBe(false);
+  });
+
+  it("a 255 character hostname still reaches the resolver", async () => {
+    // It cannot exist, so this only asserts that it was not rejected as EINVAL.
+    const shorter = Buffer.alloc(255, "l").toString();
+    const error = await new Promise<any>(resolve => dns.lookup(shorter, resolve));
+    expect(error?.code).not.toBe("EINVAL");
+  });
+});

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -518,7 +518,6 @@ describe("lookup deprecated behavior", () => {
 
 describe("uses `dns.promises` implementations for `util.promisify` factory", () => {
   it.each([
-    "lookup",
     "lookupService",
     "resolve",
     "reverse",
@@ -537,6 +536,13 @@ describe("uses `dns.promises` implementations for `util.promisify` factory", () 
   ])("%s", method => {
     expect(dns[method][util.promisify.custom]).toBe(dns_promises[method]);
     expect(dns.promises[method]).toBe(dns_promises[method]);
+  });
+
+  // Node.js promisifies the callback dns.lookup instead, so that the promisified
+  // form keeps accepting the "IPv4"/"IPv6" spellings dns.promises.lookup rejects.
+  it("lookup is promisified from its callback implementation, like Node.js", () => {
+    expect(dns.lookup[util.promisify.custom]).toBeUndefined();
+    expect(dns.promises.lookup).toBe(dns_promises.lookup);
   });
 
   it("util.promisify(dns.lookup) acts like dns.promises.lookup", async () => {

--- a/test/js/node/test/parallel/test-child-process-advanced-serialization.js
+++ b/test/js/node/test/parallel/test-child-process-advanced-serialization.js
@@ -11,7 +11,7 @@ if (process.argv[2] !== 'child') {
       child_process.spawn(process.execPath, [], { serialization: value });
     }, {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The argument 'options.serialization' " +
+      message: "The property 'options.serialization' " +
         "must be one of: undefined, 'json', 'advanced'. " +
         `Received ${inspect(value)}`
     });

--- a/test/js/node/test/parallel/test-dns-lookup.js
+++ b/test/js/node/test/parallel/test-dns-lookup.js
@@ -60,7 +60,7 @@ assert.throws(() => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: /The argument 'hints' is invalid\. Received:? 100/
+    message: "The argument 'hints' is invalid. Received 100"
   };
   const options = {
     hints: 100,
@@ -79,7 +79,7 @@ assert.throws(() => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: /^The property 'options\.family' must be one of: 0, 4, 6\. Received 20$/
+    message: `The property 'options.family' must be one of: 0, 4, 6. Received ${family}`
   };
   const options = {
     hints: 0,

--- a/test/js/node/test/parallel/test-dns-lookup.js
+++ b/test/js/node/test/parallel/test-dns-lookup.js
@@ -79,7 +79,7 @@ assert.throws(() => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: /^The (property 'options.family' must be one of: 0, 4, 6|argument 'family' must be one of 0, 4 or 6)\. Received:? 20$/
+    message: /^The property 'options\.family' must be one of: 0, 4, 6\. Received 20$/
   };
   const options = {
     hints: 0,


### PR DESCRIPTION
`dns.lookup()`'s argument validation diverges from Node.js in three ways, all of which let a caller bug through quietly.

### Repro

```js
import dns from "node:dns";
const show = async fn => {
  try {
    return "resolved: " + JSON.stringify(await fn());
  } catch (e) {
    return `${e.name}[${e.code}] ${e.message.slice(0, 80)}`;
  }
};

console.log("1.", await show(() => dns.promises.lookup("localhost", { family: "IPv4" })));
console.log("2.", await show(() => dns.promises.lookup("localhost", { all: 1 })));
console.log("3.", await show(() => dns.promises.lookup("l".repeat(300))));
```

| | Node.js v26.3.0 | Bun 1.4.0 / main |
| --- | --- | --- |
| 1 | `TypeError[ERR_INVALID_ARG_VALUE] The property 'options.family' must be one of: 0, 4, 6. Received 'IPv4'` | `resolved: {"address":"127.0.0.1","family":4}` |
| 2 | `TypeError[ERR_INVALID_ARG_TYPE] The "options.all" property must be of type boolean. Received type number (1)` | `TypeError[ERR_INVALID_ARG_TYPE] The "undefined" argument must be of type boolean. Received type number (1)` |
| 3 | `Error[EINVAL] getaddrinfo EINVAL llll...` | `DNSException[ENOTFOUND] getaddrinfo ENOTFOUND` |

1. A string `family` that Node.js hard-rejects resolves successfully, so a config parser that relies on the throw to reject a bad `dns.lookup` option object silently proceeds.
2. `The "undefined" argument must be...` names no argument at all, and does not match what Node.js prints.
3. An impossible (over-long) hostname gets the same code as a legitimately missing one, so retry/fallback logic treats a caller bug as a transient resolution miss.

### Cause

1. `validateFamilyOption()` mapped `"IPv4"`/`"IPv6"` to `4`/`6` before validating. That mapping belongs to `Bun.dns.lookup`, and to Node.js's **callback** `dns.lookup` (which does accept those two spellings), but `dns.promises.lookup` rejects them. Bun shared one validator between both entry points.
2. `validateBoolean(all)` / `validateBoolean(verbatim)` / `validateNumber(flags)` were called without their `name` argument, so the message interpolated `undefined`.
3. Nothing checked the hostname length. `getaddrinfo` encodes the name into a 256 byte buffer (IDNA ASCII + NUL), so Node.js fails a longer one with `EINVAL` before any query; Bun handed it to the resolver and surfaced its `ENOTFOUND`.

### Fix

In `src/js/node/dns.ts`:

- `validateFamilyOption()` takes an `allowFamilyStrings` flag: the callback `lookup()` passes `true`, `promises.lookup()` passes `false`. Everything else still goes through `validateFamily()`, which now throws Node's `must be one of: 0, 4, 6`.
- `validateBoolean`/`validateNumber`/`validateOneOf` get `"options.all"`, `"options.verbatim"`, `"options.hints"`, `"options.order"` (and `"dnsOrder"` for `setDefaultResultOrder`).
- An ASCII hostname over 255 characters short-circuits to `getaddrinfo EINVAL <hostname>` (`code: "EINVAL"`, `errno: -22`), delivered on the next tick for the callback form and as a rejection for the promise form, exactly like Node's `dnsException(UV_EINVAL, ...)`. A 255 character hostname still reaches the resolver. The guard is ASCII-only on purpose: an ASCII hostname is its own IDNA encoding, whereas `"𝕏".repeat(128)` has a `.length` of 256 but encodes to 135 bytes, which Node resolves normally. Non-ASCII hostnames keep today's behavior rather than paying for a punycode conversion on every lookup.
- A `null` option now means unset, as in Node.js. `{ all: null }`, `{ verbatim: null }` and `{ hints: null }` used to throw.
- `dns.lookup` no longer carries the `promisify.custom` symbol and gets `customPromisifyArgs = ["address", "family"]`, like Node. Otherwise `util.promisify(dns.lookup)` (which Bun aliased straight to `dnsPromises.lookup`) would have inherited the stricter `family` validation, where Node promisifies the callback implementation and still accepts `"IPv4"`.

Two supporting changes:

- `src/jsc/bindings/ErrorCode.cpp`: the `validateOneOf` overload of `ERR_INVALID_ARG_VALUE` hardcoded `The argument '...'`, while Node.js says `property` whenever the name contains a dot. That also fixes the message for `options.serialization`, `options.microtaskMode`, `options.mode`, `options.execution`, `options.type` and `options.backpressure`, so `test-child-process-advanced-serialization.js` now matches upstream's expectation instead of Bun's old wording.
- `src/js/internal/promisify.ts`: build the `customPromisifyArgs` object only when the callback passed more than one value, as Node does, so `util.promisify(dns.lookup)(host, { all: true })` stays an array. The other users (`fs.read`/`readv`/`write`/`writev`, `crypto.generateKeyPair`) always pass two values.

`Bun.dns.lookup()` is unchanged and still accepts `family: "IPv4"`.

### Verification

`test/js/node/dns/dns-lookup-validation.test.ts` (new, hermetic: hosts-file lookups and pure validation, no network) covers every case above plus the boundaries. 19 tests, 16 of which fail on the released binary. It lives beside `node-dns.test.js` rather than inside it because that file is network-bound.

Node's own suite still passes, with two assertions restored to upstream's text:

```
test-dns-lookup.js                          (options.family, options.hints, options.all, options.verbatim, options.order)
test-dns-set-default-order.js
test-dns-lookup-promises-options-deprecated.js
test-dns-default-order-{ipv4,ipv6,verbatim}.js
test-child-process-advanced-serialization.js
test-console-tty-colors.js
test-http-agent-scheduling.js
test-util-promisify.js, test-util-promisify-custom-names.mjs
test-fs-read-promises-optional-params.js, test-fs-readv-promisify.js
test-crypto-keygen-promisify.js
```

`node-dns.test.js` and `test/js/bun/dns/resolve-dns.test.ts` report the same pass/fail counts before and after (the failures are the network-bound tests, which this sandbox cannot run).

Out of scope, still different from Node.js: `dns.promises.lookup`'s resolver errors are named `DNSException` and omit the hostname from the message (`getaddrinfo ENOTFOUND` vs Node's `getaddrinfo ENOTFOUND example.com`). That is error decoration in the promise path, not argument validation.
