### PR TITLE
tls: report the Finished messages from getFinished()/getPeerFinished() on TLS 1.3

### DIFF
--- a/patches/boringssl/tls13-finished.patch
+++ b/patches/boringssl/tls13-finished.patch
@@ -1,0 +1,110 @@
+--- a/ssl/internal.h
++++ b/ssl/internal.h
+@@ -2971,9 +2971,11 @@
+   InplaceVector<uint8_t, SSL_MAX_MD_SIZE> read_traffic_secret;
+   InplaceVector<uint8_t, SSL_MAX_MD_SIZE> exporter_secret;
+ 
+-  // Connection binding to prevent renegotiation attacks
+-  InplaceVector<uint8_t, 12> previous_client_finished;
+-  InplaceVector<uint8_t, 12> previous_server_finished;
++  // Connection binding to prevent renegotiation attacks. Sized to also hold a
++  // TLS 1.3 Finished, which is one hash long, so that
++  // SSL_get_finished_all_versions can report it.
++  InplaceVector<uint8_t, SSL_MAX_MD_SIZE> previous_client_finished;
++  InplaceVector<uint8_t, SSL_MAX_MD_SIZE> previous_server_finished;
+ 
+   uint8_t send_alert[2] = {0};
+ 
+--- a/ssl/tls13_both.cc
++++ b/ssl/tls13_both.cc
+@@ -433,6 +433,17 @@
+     return false;
+   }
+ 
++  // Retain the peer's Finished for SSL_get_peer_finished_all_versions. TLS 1.3
++  // has no renegotiation, so unlike ssl_process_finished this is not used for
++  // the renegotiation_info extension.
++  bool ok = ssl->server
++                ? ssl->s3->previous_client_finished.TryCopyFrom(verify_data)
++                : ssl->s3->previous_server_finished.TryCopyFrom(verify_data);
++  if (!ok) {
++    OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
++    return false;
++  }
++
+   return true;
+ }
+ 
+@@ -664,6 +675,18 @@
+     return false;
+   }
+ 
++  // Retain our own Finished for SSL_get_finished_all_versions. TLS 1.3 has no
++  // renegotiation, so unlike ssl_send_finished this is not used for the
++  // renegotiation_info extension.
++  auto finished = Span(verify_data, verify_data_len);
++  bool ok = ssl->server
++                ? ssl->s3->previous_server_finished.TryCopyFrom(finished)
++                : ssl->s3->previous_client_finished.TryCopyFrom(finished);
++  if (!ok) {
++    OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
++    return false;
++  }
++
+   ScopedCBB cbb;
+   CBB body;
+   if (!ssl->method->init_message(ssl, cbb.get(), &body, SSL3_MT_FINISHED) ||
+--- a/ssl/ssl_lib.cc
++++ b/ssl/ssl_lib.cc
+@@ -1566,6 +1566,31 @@
+   return copy_finished(buf, count, ssl->s3->previous_server_finished);
+ }
+ 
++size_t SSL_get_finished_all_versions(const SSL *ssl, void *buf, size_t count) {
++  if (!ssl->s3->initial_handshake_complete) {
++    return 0;
++  }
++
++  if (ssl->server) {
++    return copy_finished(buf, count, ssl->s3->previous_server_finished);
++  }
++
++  return copy_finished(buf, count, ssl->s3->previous_client_finished);
++}
++
++size_t SSL_get_peer_finished_all_versions(const SSL *ssl, void *buf,
++                                          size_t count) {
++  if (!ssl->s3->initial_handshake_complete) {
++    return 0;
++  }
++
++  if (ssl->server) {
++    return copy_finished(buf, count, ssl->s3->previous_client_finished);
++  }
++
++  return copy_finished(buf, count, ssl->s3->previous_server_finished);
++}
++
+ int SSL_get_verify_mode(const SSL *ssl) {
+   if (!ssl->config) {
+     assert(ssl->config);
+--- a/include/openssl/ssl.h
++++ b/include/openssl/ssl.h
+@@ -5988,6 +5988,17 @@
+ OPENSSL_EXPORT size_t SSL_get_peer_finished(const SSL *ssl, void *buf,
+                                             size_t count);
+ 
++// SSL_get_finished_all_versions and SSL_get_peer_finished_all_versions behave
++// like SSL_get_finished and SSL_get_peer_finished, but also report the Finished
++// message at TLS 1.3 and later, matching OpenSSL. Node's tlsSocket.getFinished
++// and tlsSocket.getPeerFinished expose the Finished on every protocol version,
++// so Bun cannot use the zero that the functions above return there.
++OPENSSL_EXPORT size_t SSL_get_finished_all_versions(const SSL *ssl, void *buf,
++                                                    size_t count);
++OPENSSL_EXPORT size_t SSL_get_peer_finished_all_versions(const SSL *ssl,
++                                                         void *buf,
++                                                         size_t count);
++
+ // SSL_alert_type_string returns "!". Use `SSL_alert_type_string_long`
+ // instead.
+ OPENSSL_EXPORT const char *SSL_alert_type_string(int value);

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,6 +36,12 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
+  // Records the TLS 1.3 Finished messages and exposes them as
+  // SSL_get_finished_all_versions / SSL_get_peer_finished_all_versions, which
+  // node:tls's getFinished()/getPeerFinished() need. Upstream's
+  // SSL_get_finished keeps its documented "returns zero at TLS 1.3" contract.
+  patches: ["patches/boringssl/tls13-finished.patch"],
+
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)
     // uses gas .S that clang assembles.

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -68,10 +68,17 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_peer_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_get_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_set_max_send_fragment(ssl: &SSL, max_send_fragment: usize) -> c_int;
+        /// The Finished message this side sent / received. `SSL_get_finished` and
+        /// `SSL_get_peer_finished` report zero at TLS 1.3; these report it on every
+        /// version, the way node:tls expects (see `patches/boringssl/`).
         // SAFETY (unsafe fn): `buf` must be writable for `count` bytes.
-        pub(crate) fn SSL_get_finished(ssl: *const SSL, buf: *mut c_void, count: usize) -> usize;
+        pub(crate) fn SSL_get_finished_all_versions(
+            ssl: *const SSL,
+            buf: *mut c_void,
+            count: usize,
+        ) -> usize;
         // SAFETY (unsafe fn): `buf` must be writable for `count` bytes.
-        pub(crate) fn SSL_get_peer_finished(
+        pub(crate) fn SSL_get_peer_finished_all_versions(
             ssl: *const SSL,
             buf: *mut c_void,
             count: usize,
@@ -642,7 +649,7 @@ pub(super) fn get_tls_finished_message(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
-    // We cannot just pass nullptr to SSL_get_finished()
+    // We cannot just pass nullptr to SSL_get_finished_all_versions()
     // because it would further be propagated to memcpy(),
     // where the standard requirements as described in ISO/IEC 9899:2011
     // sections 7.21.2.1, 7.21.1.2, and 7.1.4, would be violated.
@@ -650,7 +657,7 @@ pub(super) fn get_tls_finished_message(
     let mut dummy: [u8; 1] = [0; 1];
     // SAFETY: ssl_ptr is a live *mut SSL; dummy is a valid 1-byte writable buffer.
     let size = unsafe {
-        ffi::SSL_get_finished(
+        ffi::SSL_get_finished_all_versions(
             ssl_ptr,
             dummy.as_mut_ptr().cast::<c_void>(),
             core::mem::size_of_val(&dummy),
@@ -665,7 +672,8 @@ pub(super) fn get_tls_finished_message(
     let buffer_ptr = buffer.as_array_buffer(global).unwrap().ptr.cast::<c_void>();
 
     // SAFETY: ssl_ptr is a live *mut SSL; buffer_ptr points to a buffer_size-byte JS ArrayBuffer kept alive on the stack.
-    let result_size = unsafe { ffi::SSL_get_finished(ssl_ptr, buffer_ptr, buffer_size) };
+    let result_size =
+        unsafe { ffi::SSL_get_finished_all_versions(ssl_ptr, buffer_ptr, buffer_size) };
     debug_assert!(result_size == size);
     Ok(buffer)
 }
@@ -834,7 +842,7 @@ pub(super) fn get_tls_peer_finished_message(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
-    // We cannot just pass nullptr to SSL_get_peer_finished()
+    // We cannot just pass nullptr to SSL_get_peer_finished_all_versions()
     // because it would further be propagated to memcpy(),
     // where the standard requirements as described in ISO/IEC 9899:2011
     // sections 7.21.2.1, 7.21.1.2, and 7.1.4, would be violated.
@@ -842,7 +850,7 @@ pub(super) fn get_tls_peer_finished_message(
     let mut dummy: [u8; 1] = [0; 1];
     // SAFETY: ssl_ptr is a live *mut SSL; dummy is a valid 1-byte writable buffer.
     let size = unsafe {
-        ffi::SSL_get_peer_finished(
+        ffi::SSL_get_peer_finished_all_versions(
             ssl_ptr,
             dummy.as_mut_ptr().cast::<c_void>(),
             core::mem::size_of_val(&dummy),
@@ -857,7 +865,8 @@ pub(super) fn get_tls_peer_finished_message(
     let buffer_ptr = buffer.as_array_buffer(global).unwrap().ptr.cast::<c_void>();
 
     // SAFETY: ssl_ptr is a live *mut SSL; buffer_ptr points to a buffer_size-byte JS ArrayBuffer kept alive on the stack.
-    let result_size = unsafe { ffi::SSL_get_peer_finished(ssl_ptr, buffer_ptr, buffer_size) };
+    let result_size =
+        unsafe { ffi::SSL_get_peer_finished_all_versions(ssl_ptr, buffer_ptr, buffer_size) };
     debug_assert!(result_size == size);
     Ok(buffer)
 }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -385,9 +385,8 @@ for (const { name, connect } of tests) {
           expect(socket.exportKeyingMaterial(512, "client finished")).toBeInstanceOf(Buffer);
           expect(socket.isSessionReused()).toBe(false);
 
-          // BoringSSL does not support these methods for >= TLSv1.3
-          expect(socket.getFinished()).toBeUndefined();
-          expect(socket.getPeerFinished()).toBeUndefined();
+          expect(socket.getFinished()).toBeInstanceOf(Buffer);
+          expect(socket.getPeerFinished()).toBeInstanceOf(Buffer);
         } finally {
           socket.end();
         }
@@ -717,6 +716,73 @@ it("a write before 'secureConnect' still reports the handshake's own failure", a
   const [error] = await once(client, "error");
   expect(error.code).toBe("ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED");
   expect(secureConnect).toBe(false);
+});
+
+describe.each(["TLSv1.2", "TLSv1.3"] as const)("getFinished()/getPeerFinished() on %s", version => {
+  it("hands back this side's and the peer's Finished message, cross-matching", async () => {
+    // BoringSSL keeps the Finished messages only for the renegotiation_info
+    // extension, which TLS 1.3 dropped, so its SSL_get_finished() reports
+    // nothing there (see patches/boringssl/tls13-finished.patch).
+    const sampled = Promise.withResolvers<{ finished?: Buffer; peerFinished?: Buffer }>();
+    const server = tls.createServer({ ...COMMON_CERT_, minVersion: version, maxVersion: version }, socket => {
+      // A TLS 1.3 server can report the handshake done before the client's
+      // Finished lands, so sample on the first byte the client sends: that
+      // byte cannot arrive before the Finished it follows.
+      socket.once("data", () => {
+        sampled.resolve({ finished: socket.getFinished(), peerFinished: socket.getPeerFinished() });
+        socket.end();
+      });
+      socket.on("error", sampled.reject);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const client = tlsConnect({
+      port: (server.address() as AddressInfo).port,
+      host: "127.0.0.1",
+      rejectUnauthorized: false,
+      minVersion: version,
+      maxVersion: version,
+    });
+    client.on("error", sampled.reject);
+    try {
+      // Nothing has been exchanged yet, so there is no Finished message.
+      expect(client.getFinished()).toBeUndefined();
+      expect(client.getPeerFinished()).toBeUndefined();
+
+      await once(client, "secureConnect");
+      const clientFinished = client.getFinished();
+      const clientPeerFinished = client.getPeerFinished();
+      client.write("ping");
+      const serverSide = await sampled.promise;
+
+      // TLS 1.2's verify_data is always 12 bytes; TLS 1.3's Finished is an
+      // HMAC over the transcript, one hash long.
+      const expectedLength = version === "TLSv1.2" ? 12 : client.getCipher().standardName.endsWith("SHA384") ? 48 : 32;
+      expect({
+        protocol: client.getProtocol(),
+        client: clientFinished?.length,
+        clientPeer: clientPeerFinished?.length,
+        server: serverSide.finished?.length,
+        serverPeer: serverSide.peerFinished?.length,
+      }).toEqual({
+        protocol: version,
+        client: expectedLength,
+        clientPeer: expectedLength,
+        server: expectedLength,
+        serverPeer: expectedLength,
+      });
+
+      // Each side's own Finished is the one the other side received.
+      expect(clientFinished!.toString("hex")).toBe(serverSide.peerFinished!.toString("hex"));
+      expect(clientPeerFinished!.toString("hex")).toBe(serverSide.finished!.toString("hex"));
+      expect(clientFinished!.toString("hex")).not.toBe(clientPeerFinished!.toString("hex"));
+    } finally {
+      client.destroy();
+      server.close();
+    }
+    await once(server, "close");
+  });
 });
 
 it("https.request reports an impossible version window as a TLS error, not a certificate error", async () => {


### PR DESCRIPTION
`TLSSocket.getFinished()` and `getPeerFinished()` return `undefined` on every TLSv1.3 connection, client side and server side. TLS 1.3 is what every default `tls.connect`/`https` call negotiates, so the API is effectively dead: it only answers when the peer happens to be pinned to TLS 1.2. Node returns the Finished messages on both ends of a 1.3 connection.

These exist for channel binding, so anything mixing the Finished message into an application-layer authenticator gets nothing to bind to.

### Repro

```js
import tls from "node:tls";

for (const ver of ["TLSv1.2", "TLSv1.3"]) {
  const srv = tls.createServer({ cert, key, minVersion: ver, maxVersion: ver }, s =>
    s.once("data", () => {
      console.log(ver, "server", s.getFinished()?.length, s.getPeerFinished()?.length);
      s.end();
    }),
  );
  await new Promise(r => srv.listen(0, "127.0.0.1", r));
  await new Promise(res => {
    const c = tls.connect({ port: srv.address().port, rejectUnauthorized: false }, () => {
      console.log(ver, "client", c.getFinished()?.length, c.getPeerFinished()?.length);
      c.write("ping");
    });
    c.on("data", () => {});
    c.on("close", res);
  });
  await new Promise(r => srv.close(r));
}
```

```
bun (before)                node v26.3.0
TLSv1.2 client 12 12        TLSv1.2 client 12 12
TLSv1.2 server 12 12        TLSv1.2 server 12 12
TLSv1.3 client undefined    TLSv1.3 client 48 48
TLSv1.3 server undefined    TLSv1.3 server 48 48
```

### Cause

BoringSSL's `SSL_get_finished()` and `SSL_get_peer_finished()` return 0 at TLS 1.3 by design:

```c
size_t SSL_get_finished(const SSL *ssl, void *buf, size_t count) {
  if (!ssl->s3->initial_handshake_complete ||
      ssl_protocol_version(ssl) >= TLS1_3_VERSION) {
    return 0;
  }
  ...
```

It keeps `previous_client_finished`/`previous_server_finished` only to compare them in the renegotiation_info extension, which TLS 1.3 dropped. So they are 12-byte `InplaceVector`s that `ssl/handshake.cc` populates for TLS 1.2 and `ssl/tls13_both.cc` never touches. Node rides on OpenSSL, which records `s3.tmp.finish_md` unconditionally. Node's own `test-tls-finished.js` pins itself to TLSv1.2 under `process.features.openssl_is_boringssl` for exactly this reason.

### Fix

`patches/boringssl/tls13-finished.patch` records the TLS 1.3 Finished into the buffers BoringSSL already carries, and exposes them:

- `ssl/internal.h`: widen both vectors from 12 bytes to `SSL_MAX_MD_SIZE`, which is what the neighbouring traffic secrets already use, and exactly the longest Finished TLS 1.3 can produce (one hash, SHA-384 at most).
- `ssl/tls13_both.cc`: `tls13_add_finished` and `tls13_process_finished` copy the Finished into the right vector, mirroring what `ssl_send_finished`/`ssl_process_finished` already do for TLS 1.2.
- `ssl/ssl_lib.cc`: add `SSL_get_finished_all_versions` / `SSL_get_peer_finished_all_versions`, which drop the version check but keep the handshake-complete check.

`SSL_get_finished` and `SSL_get_peer_finished` keep their documented "returns zero at TLS 1.3" contract, so no existing BoringSSL consumer changes behavior. The Rust getters call the new pair instead.

The Finished now lives in `SSL3_STATE`, which is already allocated per connection, so there is no new allocation and nothing extra to free. Gating both versions on `initial_handshake_complete` also makes 1.2 and 1.3 behave identically, which they did not before.

TLS 1.3 cannot renegotiate (`ssl_can_renegotiate` returns false for it), so the newly populated vectors are never read by the renegotiation_info extension code, and nothing serializes them.

### Verification

New test in `test/js/node/tls/node-tls-connect.test.ts` runs over both protocol versions and checks that all four values are present, that each is exactly one hash long (12 bytes of verify_data at 1.2, one digest at 1.3), and that they cross-match: `client.getFinished() === server.getPeerFinished()` and `client.getPeerFinished() === server.getFinished()`. It also asserts both are `undefined` before anything is exchanged, and that a side's own Finished differs from its peer's.

Fails before the change with `undefined` in all four slots on TLSv1.3, passes after. The existing assertion that these were `undefined` on a TLSv1.3 connection is now an assertion that they are Buffers. `test/js/node/test/parallel/test-tls-finished.js` still passes.

<details>
<summary>After the change, the repro matches Node's shape</summary>

```
TLSv1.2 cliFin=12 cliPeerFin=12 srvFin=12 srvPeerFin=12 cross=true
TLSv1.3 cliFin=32 cliPeerFin=32 srvFin=32 srvPeerFin=32 cross=true
```

32 rather than Node's 48 because Bun negotiates `TLS_AES_128_GCM_SHA256` where Node prefers `TLS_AES_256_GCM_SHA384`; the Finished is one hash long in both.

`test/js/node/tls/` shows no regressions against the same run on `main`. Also checked under LeakSanitizer, using the env `scripts/runner.node.mjs` sets, that six pooled `fetch()` calls over TLS 1.3 leak nothing.
</details>

### History

The first version of this PR captured the Finished messages in uSockets with `SSL_CTX_set_msg_callback` and stashed them in a 130-byte struct on the SSL's ex_data. It worked, but it allocated on every TLS 1.3 connection in the process, including every `fetch()`, and LeakSanitizer flagged those allocations across eight test files: the HTTP client pools connections, so their SSLs are never freed before exit and the ex_data free hook never runs. Keeping the bytes inside `SSL3_STATE` removes the allocation entirely, which is also what the review feedback on the per-handshake cost was pointing at.
