### PR TITLE
node:crypto: support SHA-3 digests in sign and verify

### DIFF
--- a/patches/boringssl/sha3-sign.patch
+++ b/patches/boringssl/sha3-sign.patch
@@ -1,0 +1,71 @@
+--- a/crypto/fipsmodule/rsa/rsa.cc.inc
++++ b/crypto/fipsmodule/rsa/rsa.cc.inc
+@@ -413,6 +413,13 @@
+   uint8_t bytes[19];
+ };
+ 
++// SHA-3 is exposed only as an EVP_MD, so there are no SHA3_*_DIGEST_LENGTH
++// macros to reuse here.
++#define SHA3_224_DIGEST_LENGTH 28
++#define SHA3_256_DIGEST_LENGTH 32
++#define SHA3_384_DIGEST_LENGTH 48
++#define SHA3_512_DIGEST_LENGTH 64
++
+ // kPKCS1SigPrefixes contains the ASN.1 prefixes for PKCS#1 signatures with
+ // different hash functions.
+ static const struct pkcs1_sig_prefix kPKCS1SigPrefixes[] = {
+@@ -458,6 +465,37 @@
+         {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+          0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40},
+     },
++    // The SHA-3 DigestInfo values use the id-sha3-* OIDs from the NIST CSOR
++    // arc 2.16.840.1.101.3.4.2.{7,8,9,10}, with the NULL parameters RFC 8017
++    // specifies for PKCS#1 v1.5.
++    {
++        NID_sha3_224,
++        SHA3_224_DIGEST_LENGTH,
++        19,
++        {0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x07, 0x05, 0x00, 0x04, 0x1c},
++    },
++    {
++        NID_sha3_256,
++        SHA3_256_DIGEST_LENGTH,
++        19,
++        {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x08, 0x05, 0x00, 0x04, 0x20},
++    },
++    {
++        NID_sha3_384,
++        SHA3_384_DIGEST_LENGTH,
++        19,
++        {0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x09, 0x05, 0x00, 0x04, 0x30},
++    },
++    {
++        NID_sha3_512,
++        SHA3_512_DIGEST_LENGTH,
++        19,
++        {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x0a, 0x05, 0x00, 0x04, 0x40},
++    },
+     {
+         NID_undef,
+         0,
+--- a/crypto/evp/p_ec.cc
++++ b/crypto/evp/p_ec.cc
+@@ -428,9 +428,13 @@
+     case EVP_PKEY_CTRL_MD: {
+       const EVP_MD *md = reinterpret_cast<const EVP_MD *>(p2);
+       int md_type = EVP_MD_type(md);
++      // pkey_ec_sign/pkey_ec_verify hand the digest straight to ECDSA_sign and
++      // never read dctx->md, so SHA-3 only has to be allowed through here.
+       if (md_type != NID_sha1 && md_type != NID_sha224 &&
+           md_type != NID_sha256 && md_type != NID_sha384 &&
+-          md_type != NID_sha512) {
++          md_type != NID_sha512 && md_type != NID_sha3_224 &&
++          md_type != NID_sha3_256 && md_type != NID_sha3_384 &&
++          md_type != NID_sha3_512) {
+         OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_DIGEST_TYPE);
+         return 0;
+       }

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,6 +36,10 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
+  // Our fork ships EVP_sha3_* but never taught EVP_DigestSign/Verify to use
+  // them. Drop once the fork carries the change and BORINGSSL_COMMIT moves.
+  patches: ["patches/boringssl/sha3-sign.patch"],
+
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)
     // uses gas .S that clang assembles.

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -380,7 +380,7 @@ JSUint8Array* signWithKey(JSC::JSGlobalObject* lexicalGlobalObject, JSSign* this
     };
 
     if (!pkctx.signInto(data, &sigBuf)) {
-        throwTypeError(lexicalGlobalObject, scope, "Failed to create signature"_s);
+        throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to create signature"_s);
         return nullptr;
     }
 

--- a/test/js/node/crypto/crypto.test.ts
+++ b/test/js/node/crypto/crypto.test.ts
@@ -1,6 +1,7 @@
 import { CryptoHasher, MD4, MD5, SHA1, SHA224, SHA256, SHA384, SHA512, SHA512_256, gc } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import crypto from "crypto";
+import { readFileSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import path from "path";
 import { hashesFixture } from "./fixtures/sign.fixture.ts";
@@ -233,6 +234,125 @@ describe("crypto.createSign()/.verifySign()", () => {
       expect(verify).toBeTrue();
     },
   );
+});
+
+describe("SHA-3 sign/verify", () => {
+  const digests = ["sha3-224", "sha3-256", "sha3-384", "sha3-512"];
+  const message = Buffer.from("sha3 signature conformance");
+  const fixture = (name: string) => readFileSync(`${__dirname}/fixtures/${name}`, "utf8");
+
+  const rsaPrivate = fixture("rsa_private_2048.pem");
+  const rsaPublic = fixture("rsa_public_2048.pem");
+  const ecPrivate = fixture("ec_p256_private.pem");
+  const ecPublic = fixture("ec_p256_public.pem");
+
+  // Signatures produced by Node.js (OpenSSL) over `message` with the fixtures
+  // above. RSA PKCS#1 v1.5 is deterministic, so these pin the exact DigestInfo
+  // encoding rather than just proving we can verify what we sign.
+  const rsaPkcs1: Record<string, string> = {
+    "sha3-224":
+      "cwg74JeWAJXCefVOYQgIxnlbFi3m1SffbUkF0IULmqNsveVeTaJCGFIVHw2b7GkxbkoWZ8wqBf5dNkcS3KuwPqg2qqPCXQ6lec5kr9guPML8ElsxC5lHtggHqGYmx+sVKSBQCikhkOIr0KrpiHFbYFeObmThMJGAHdoq5jag/AQMdgTCYT+4dvnFtNqrgzZIlkw9NRkGcARA7UubOpxGI3y6zk8VEQU7RTbftdrah5y4s28TskKvGlqRNGrW/5/v5gcau+9JE9K+Q6AP0NmjEkMxEX5yWMA8LxMFCrMYFDRKqwkE78LD1k787c7Q3I6fRFDShWFlpyWrY+TLF+XJpg==",
+    "sha3-256":
+      "k3SvWv55Mc5CiM/gzYvRhWvpGz3viwy4eCmjioa4WB/BlEoINJLpZvVd5YwX/y3X2/4Ty6Iepebb1/v2DdoMReNAva18eziMdFSiTtnGmmx+p21jySrDxFAv/bQJBQFEXVMv8S62wlCo93X+qHMGl5KG/dvrDZDz571pjfjI+AchRZcpPO70GPY8fQ0e8IB7Mu0PqEXgRS7aF1C/J4hFciC4iO6w6GOnnn/SGp/QiP0+26g3yGDXGUIpyYjI9dcRAW2ZXwmhwTMB5ub421WwbZTDtVst+irnvnGFXmzEfiKq0bRmTXFtOfoToAjhWOkaiBju4QxBlzPALEzawj6Ofg==",
+    "sha3-384":
+      "XGbLh+G95zyRZBTFV2Xd5wJkySWVhe/Rrepp+w9vAxAAkyaCLFYzHdvmGGfFq6iD9aUNSf8OPmoZlsGdmE2NN7cUS6G2npk89oLu14HAs+UhBXGf476YKXPuGOC92Poqu9QTZOE+x0ez1QcPLW3o8Z0Uc4lklLwQJnfxsdCG3Dd24WR1xG352Db6iGl6KO01WRLH8YC0M3rkc4+I6a7sJRtXrnxpkepK/fDxnw9cZEdZZ0wX2a7E+q4fG13NvNVBDOpfU/kUjz5X27wmveq+FPqFl2FWTsryBC/FawItCMCJJU7Aj3CNAAoj1FPWBowErKRua62an0tmOC+bLruXvA==",
+    "sha3-512":
+      "o1KRgi1cc3DdEfUUZZMMo+G+/Bvq48JtU/Q3mx7dCtwR5utC8XpgWzpimiHdKVrVPbxoy/G9mdYX+l2m6HbxnwaPrkz1v7WnvODZF6idH85DZysaWDMkjSn/HzsKcHFMQupaOQKe4LPFdYZlgzmTwz0Prp0Pdu1wXFjjWUU/yncCPbEe7QLFPeoSrtIYOBsWm/L1o9OMOzKhLg4KNp6Pf9gKwIiCkf8MzT0gEoiXE3v/g54TAsDFl3pSr5bWBIlaveJUL0LNkRN/jOYFH8DNqtRjadAtwmlxZeXvY6HxBEHFA40UNq7nmrsrTnuQEd7bU+n0xFvDwydY/DtlPtBRqg==",
+  };
+
+  // PSS and ECDSA are randomized, so these only exercise the verify path.
+  const rsaPss: Record<string, string> = {
+    "sha3-224":
+      "SnseUwZpHfKQjiYxxGSi3aT+ztuCSFaxzKe63jqr2Xqym5wkXGQkIBImI17wYAGed6n26mzKMzeCWZATF6I9QIsKs0LeB94NMR5czejrHiGCSM1TNfcisYhYGUFE0GLcDmIWCT6KPV6v13UQtlZgBJjuIpia3nhDQe6lg5n2sG991eAMftYhUDxcJtaJgIGCDJ/0JIz326o39xXBVFdRMmh4O4iEUt+5Ze/hoIqabYi6JmVfXucrmVj86CLV6Vfm2TJqGFgwtWS4MuGvLAGPs8wz4WskBezDd3n7n8K89bGis/YP043BLM2b/pn1rNyvKzMBLK6fsx8p7QT6Xy+YaQ==",
+    "sha3-256":
+      "krVNLzVUZhXhVY0amrYbQXLqN+snC6wfgkeaqQ1YzlyCV7/pBg4pBsUZ7os+TkOCAB98w8EV9UDMiPzMIcWzbOCS5ajRbY3TTsgEw7oZheAst4IOoUfDO+mecLdzd2wPY2ROFKPzQn3Y+U2mrUKy7DKW1XefttW0YmLX8Dvq5C3stZK+HugvokQlcrFQxcQZ5hg/7uKARHNVYzcBF/FoVAO6Z02G9GnWD5I/d/Bx6Te1PV7RBnsEKn6Q/UQassRslUzwism1+aYCOwAXuCfniwznlnW5TKKKcrVy28763Bv7Qxx9l8gqFySjf82gmiaqQTHKbKVnVFCCFsd8783Crg==",
+    "sha3-384":
+      "RIVSIoiFztt2H8m5H58h+aS2s724SlFyOvvT8+/LaatIIqfnDEi7OZbaBSTtob+QjG4ZaOext8eMx473KppmbxautH+spKSWX2ObPjzN4xuQRFnXCvoO3oDy4kWaIhbfCNr5ZpSDcj+ob66PmNBCw+73CMXxr1RapNyG40nCVbLR4GZmetBMOHMaUfertLI/lbeh0HqPwMs24XMw2f4B5AK/bgVy7EAXj5rIvxIA0wG0mTWMDV9wesqIiL29qrZhJqDGM2VU7/sehw3Tyc3+Ug3+54CvffM9NQpekyVW6W6ygaD2aISV4mwJgZ3r2gbIWoAiOaJUEyLBPCF9ySpi6A==",
+    "sha3-512":
+      "ovdYhzGTXGxL2yDWnIE78V39FI3ex1io9I/FwLzTYJgShW4q1F1xdCP6OqzcFGKHw/BKbKO28OYH682YCHhW48PvgfJfxF9CKcHg6O4fEAKvQiuJ3sgGY4yiwOpTqeKOgKICBDQJ7H7zhHPINuNMjxrNVwKfaGCGbyum+7vnPDBd32f2MOhVaYZcBRRwaeGUJD3QvKqVL7+u/8fiYFh4nrzGhyJ+K5jVUdAS3U1BsH+UGb/3Ypq6AhX4Vjpwe/Ed8WCFeGO3iiWIKyh1fGWNViWokgKPO4VEfK2Y8w32zbq/DV1y2tPXkaUyEoCWKQYTZeoBzmZ7PRpQi9ugJosIXA==",
+  };
+
+  const ecdsa: Record<string, string> = {
+    "sha3-224": "MEUCIG5dISk+pWQw9/WdZOIn9rGPtHOcHzpQt3yrSIbl9st3AiEAv7KOnT3qZ+HiuD8ILscMW7qfnZ1WFQvf/uIVskdZiFI=",
+    "sha3-256": "MEUCIGS2+YLUUBSo+X75ydaCsPwBgxp8lta06qvsR+tXuiTTAiEAuSIId6BzVqktRWe5kDjvUlQbUPFxzZEdiKPaecH2mXM=",
+    "sha3-384": "MEUCIQCBYf0P9HW/S4YYmLZQi6d17Mxs47fPK8M3a2NEh7TLXwIgVjjYG9t6qz2P0gHm/LPj5O/9X2MIpeVodlmerf5+YAY=",
+    "sha3-512": "MEUCIFINSe6XmIatanHebPIwsvcYc5JGY8meV/SZD62A53FeAiEAzamJEHod/DFtAQtd+ylU+0413FWUUxQmtf1GsRSzO6Y=",
+  };
+
+  describe.each(digests)("%s", digest => {
+    test("crypto.sign() and createSign() reproduce OpenSSL's RSA PKCS#1 v1.5 bytes", () => {
+      expect({
+        oneShot: crypto.sign(digest, message, rsaPrivate).toString("base64"),
+        streaming: crypto.createSign(digest).update(message).sign(rsaPrivate, "base64"),
+      }).toEqual({ oneShot: rsaPkcs1[digest], streaming: rsaPkcs1[digest] });
+    });
+
+    test("crypto.verify() accepts OpenSSL's signatures", () => {
+      expect({
+        pkcs1: crypto.verify(digest, message, rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+        pss: crypto.verify(
+          digest,
+          message,
+          { key: rsaPublic, padding: crypto.constants.RSA_PKCS1_PSS_PADDING },
+          Buffer.from(rsaPss[digest], "base64"),
+        ),
+        ecdsa: crypto.verify(digest, message, ecPublic, Buffer.from(ecdsa[digest], "base64")),
+      }).toEqual({ pkcs1: true, pss: true, ecdsa: true });
+    });
+
+    test("createVerify() accepts OpenSSL's signatures", () => {
+      expect({
+        pkcs1: crypto.createVerify(digest).update(message).verify(rsaPublic, rsaPkcs1[digest], "base64"),
+        ecdsa: crypto.createVerify(digest).update(message).verify(ecPublic, ecdsa[digest], "base64"),
+      }).toEqual({ pkcs1: true, ecdsa: true });
+    });
+
+    test("ECDSA signatures round-trip", () => {
+      // ECDSA is randomized, so assert a round-trip instead of exact bytes.
+      const oneShot = crypto.sign(digest, message, ecPrivate);
+      const streaming = crypto.createSign(digest).update(message).sign(ecPrivate);
+      expect({
+        oneShot: crypto.verify(digest, message, ecPublic, oneShot),
+        streaming: crypto.createVerify(digest).update(message).verify(ecPublic, streaming),
+      }).toEqual({ oneShot: true, streaming: true });
+    });
+
+    test("bad signatures are rejected", () => {
+      const tamperedRsa = Buffer.from(rsaPkcs1[digest], "base64");
+      tamperedRsa[tamperedRsa.length - 1] ^= 1;
+      const tamperedEcdsa = Buffer.from(ecdsa[digest], "base64");
+      tamperedEcdsa[tamperedEcdsa.length - 1] ^= 1;
+
+      expect({
+        tamperedRsa: crypto.verify(digest, message, rsaPublic, tamperedRsa),
+        tamperedEcdsa: crypto.verify(digest, message, ecPublic, tamperedEcdsa),
+        wrongMessage: crypto.verify(digest, Buffer.from("other"), rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+        wrongDigest: crypto.verify("sha256", message, rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+      }).toEqual({ tamperedRsa: false, tamperedEcdsa: false, wrongMessage: false, wrongDigest: false });
+    });
+  });
+});
+
+test("createSign().sign() surfaces the OpenSSL error the way crypto.sign() does", () => {
+  // A 512-bit modulus cannot hold a SHA-512 PKCS#1 v1.5 block, so both entry
+  // points hit the same OpenSSL failure and must report it the same way.
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 512 });
+  const message = Buffer.from("too big for this key");
+
+  const capture = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (err) {
+      return err as Error & { code?: string };
+    }
+    throw new Error("expected signing to throw");
+  };
+
+  const oneShot = capture(() => crypto.sign("sha512", message, privateKey));
+  const streaming = capture(() => crypto.createSign("sha512").update(message).sign(privateKey));
+
+  expect(oneShot.code).toMatch(/^ERR_OSSL_/);
+  expect({ name: streaming.name, code: streaming.code }).toEqual({ name: oneShot.name, code: oneShot.code });
 });
 
 it("should send cipher events in the right order", async () => {


### PR DESCRIPTION
## Repro

`crypto.getHashes()` advertises `sha3-256` and `createHash()`/`createHmac()` compute it correctly, but every signing entry point throws, for both RSA and EC keys.

```js
const msg = Buffer.from("sha3 probe");
const rsa = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
const ec = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });

crypto.getHashes().includes("sha3-256");                  // true
crypto.createHash("sha3-256").update(msg).digest("hex");  // works

crypto.sign("sha3-256", msg, rsa.privateKey);             // ERR_OSSL_UNKNOWN_ALGORITHM_TYPE
crypto.createSign("sha3-256").update(msg).sign(rsa.privateKey); // TypeError: Failed to create signature
crypto.sign("sha3-256", msg, ec.privateKey);              // ERR_OSSL_INVALID_DIGEST_TYPE
```

Node signs and verifies `sha3-*` for RSA and EC, so code that feature-detects a digest via `getHashes()` before signing (the jose/jsonwebtoken pattern) is correct on Node and fails at runtime on Bun.

## Cause

Our BoringSSL fork ships `EVP_sha3_*` (added in #29323) but never wired them into the signing paths:

- `kPKCS1SigPrefixes` in `crypto/fipsmodule/rsa/rsa.cc.inc` has no SHA-3 `DigestInfo` entries, so `RSA_sign()` bails with `RSA_R_UNKNOWN_ALGORITHM_TYPE`.
- `pkey_ec_ctrl()` in `crypto/evp/p_ec.cc` rejects any digest outside SHA-1/SHA-2 with `EVP_R_INVALID_DIGEST_TYPE` — even though `pkey_ec_sign()`/`pkey_ec_verify()` hand the digest straight to `ECDSA_sign()`/`ECDSA_verify()` and never read `dctx->md`.

RSA-PSS was already fine: it routes through `RSA_sign_pss_mgf1()`, which takes the `EVP_MD` directly and needs no `DigestInfo`.

Separately, `Sign.prototype.sign()` threw a bare `TypeError` when the signing operation itself failed, so `err.code` was `undefined` where the one-shot `crypto.sign()` reports `ERR_OSSL_*`. The three sibling failure sites in the same function already use `throwCryptoError()`.

## Fix

`patches/boringssl/sha3-sign.patch` (the build system's mechanism for source patches to a `github-archive` dep):

- Add the four `id-sha3-*` `DigestInfo` prefixes. The OIDs come from the NIST CSOR arc `2.16.840.1.101.3.4.2.{7,8,9,10}`, with the NULL parameters RFC 8017 specifies for PKCS#1 v1.5. The exact bytes were read back out of OpenSSL's own output rather than transcribed: sign with Node, raw-modexp the signature with the public key, and read the EM block.
- Allow `NID_sha3_{224,256,384,512}` through the ECDSA digest check.

`JSSign.cpp`: route the `signInto()` failure through `throwCryptoError(..., ERR_get_error(), ...)`, matching the one-shot path and `CryptoErrorList::capture()`. `createCryptoError()` falls back to a plain `Error` with the original message when OpenSSL queued nothing, so this is never worse than the `TypeError` it replaces.

## Verification

Signatures are interoperable with OpenSSL, not merely self-consistent:

- **Known-answer vectors.** BoringSSL already ships wycheproof vectors for exactly this. All **2334** `rsa_signature_*_sha3_*` and `ecdsa_*_sha3_*` cases pass, matching Node 1:1 — including every negative vector (wrong OID, BER-encoded padding, tampered signatures), so malformed signatures are still rejected.
- **Byte identity.** RSA PKCS#1 v1.5 is deterministic; with a fixed key Bun now produces byte-identical signatures to Node for all four digests, and each runtime verifies the other's RSA and ECDSA output.

The regression test pins the Node-produced signatures rather than round-tripping, so a wrong `DigestInfo` encoding would fail it.

<details>
<summary>Fail-before / pass-after, per half</summary>

| build | result |
| --- | --- |
| released Bun (neither fix) | 21 of the new tests fail |
| BoringSSL patch reverted, `JSSign.cpp` fix kept | the 20 SHA-3 tests fail |
| `src/` reverted, BoringSSL patch kept | the error-code test fails |
| both applied | `905 pass, 0 fail` across `test/js/node/crypto/` |

Note the patch lives in `patches/` + `scripts/build/`, so a `src/`-only revert does not exercise it; the middle row is the fail-before for that half.

Unchanged: `test/js/web/crypto/` (40 pass). The three `test/js/node/tls/` failures on this branch reproduce on released Bun or are a 5s default-timeout on a debug+ASAN test that spawns three TLS children (passes at 30s).
</details>

Scope: `shake128`/`shake256` and BLAKE2 still throw for signing, as they do on Node for RSA. The `RSA-SHA3-*` signature-algorithm aliases are still missing, but `getHashes()` does not advertise them either, so there is no contradiction there.

The patch can be dropped once the fork carries the change and `BORINGSSL_COMMIT` moves.