### PR TITLE
dns: honor the AI_V4MAPPED / AI_ALL hints on the c-ares backend

### DIFF
--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -57,6 +57,36 @@ pub const AI_ALL: c_int = 256;
 #[cfg(not(windows))]
 pub const AI_ALL: c_int = libc::AI_ALL;
 
+/// How an `AF_INET6` lookup treats the name's IPv4 addresses.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub enum V4Mapped {
+    /// No `AI_V4MAPPED`: IPv4 addresses are not returned.
+    #[default]
+    Off,
+    /// `AI_V4MAPPED`: map the IPv4 addresses only when the name has no IPv6 address.
+    Fallback,
+    /// `AI_V4MAPPED | AI_ALL`: return the IPv6 addresses, then the mapped IPv4 ones.
+    All,
+}
+
+/// `node:dns` hands out the platform's `AI_*` hint values, but c-ares numbers its own
+/// `ARES_AI_*` bits differently (on glibc, `AI_V4MAPPED` lands on `ARES_AI_NUMERICSERV`
+/// and `AI_ADDRCONFIG` on `ARES_AI_ALL`). Translate rather than copy.
+fn to_cares_flags(flags: c_int) -> c_int {
+    use bun_cares_sys::c_ares_draft as cares;
+    let mut out: c_int = 0;
+    if flags & AI_V4MAPPED != 0 {
+        out |= cares::ARES_AI_V4MAPPED;
+    }
+    if flags & AI_ALL != 0 {
+        out |= cares::ARES_AI_ALL;
+    }
+    if flags & AI_ADDRCONFIG != 0 {
+        out |= cares::ARES_AI_ADDRCONFIG;
+    }
+    out
+}
+
 #[derive(Default)]
 pub struct GetAddrInfo {
     pub name: Box<[u8]>,
@@ -76,10 +106,16 @@ impl GetAddrInfo {
     pub fn to_cares(&self) -> bun_cares_sys::c_ares_draft::AddrInfo_hints {
         let mut hints: bun_cares_sys::c_ares_draft::AddrInfo_hints = bun_core::ffi::zeroed();
 
-        hints.ai_family = self.options.family.to_libc();
+        // c-ares implements neither `ARES_AI_V4MAPPED` nor `ARES_AI_ALL`, and only queries
+        // A records for `AF_UNSPEC`, so an `AI_V4MAPPED` lookup asks for both families and
+        // the mapping happens once the answers are in.
+        hints.ai_family = match self.options.v4_mapped() {
+            V4Mapped::Off => self.options.family.to_libc(),
+            V4Mapped::Fallback | V4Mapped::All => Family::Unspecified.to_libc(),
+        };
         hints.ai_socktype = self.options.socktype.to_libc();
         hints.ai_protocol = self.options.protocol.to_libc();
-        hints.ai_flags = self.options.flags;
+        hints.ai_flags = to_cares_flags(self.options.flags);
 
         hints
     }
@@ -125,6 +161,18 @@ impl Default for Options {
 }
 
 impl Options {
+    /// POSIX: `AI_V4MAPPED` only applies to `AF_INET6` lookups, and `AI_ALL` only
+    /// applies alongside it.
+    pub fn v4_mapped(self) -> V4Mapped {
+        if self.family != Family::Inet6 || self.flags & AI_V4MAPPED == 0 {
+            V4Mapped::Off
+        } else if self.flags & AI_ALL != 0 {
+            V4Mapped::All
+        } else {
+            V4Mapped::Fallback
+        }
+    }
+
     pub fn to_libc(self) -> Option<sock::addrinfo> {
         if self.family == Family::Unspecified
             && self.socktype == SocketType::Unspecified

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -7,6 +7,7 @@ use core::ffi::c_int;
 use ::bstr::BStr;
 use bun_cares_sys::c_ares_draft as c_ares;
 use bun_core::{self as bstr, strings};
+use bun_dns::V4Mapped;
 use bun_jsc::{
     CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc, SystemError, bun_string_jsc,
 };
@@ -173,44 +174,92 @@ pub(crate) fn nameinfo_to_js_response(
 }
 
 // ── AddrInfo ───────────────────────────────────────────────────────────────
-pub(crate) fn addr_info_to_js_array(
-    addr_info: &mut c_ares::AddrInfo,
+
+/// SAFETY: `head` must be null or the head of a c-ares-owned `AddrInfo_node` chain
+/// that stays alive for `'a`.
+// LIFETIMES.tsv rows 254/256: AddrInfo.node / AddrInfo_node.next are FFI → *mut AddrInfo_node.
+unsafe fn nodes<'a>(
+    head: *mut c_ares::AddrInfo_node,
+) -> impl Iterator<Item = &'a c_ares::AddrInfo_node> {
+    let mut current = head;
+    core::iter::from_fn(move || {
+        // SAFETY: caller contract: `current` is null or a live node of the chain.
+        let node = unsafe { current.as_ref() }?;
+        current = node.next;
+        Some(node)
+    })
+}
+
+fn node_to_js(
+    node: &c_ares::AddrInfo_node,
+    map_v4: bool,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    // LIFETIMES.tsv rows 254/256: AddrInfo.node / AddrInfo_node.next are FFI → *mut AddrInfo_node.
-    if addr_info.node.is_null() {
+    // bun_dns::Address::init_posix copies from the raw sockaddr by family,
+    // so we hand it `node.addr` directly after asserting a known family.
+    debug_assert!(node.family == c_ares::AF::INET || node.family == c_ares::AF::INET6);
+    // SAFETY: addr is non-null sockaddr_in/in6 for AF_INET/AF_INET6 (c-ares contract).
+    let address = unsafe { bun_dns::Address::init_posix(node.addr.cast()) };
+    let address = match map_v4 {
+        true => address.to_v4_mapped().unwrap_or(address),
+        false => address,
+    };
+    result_to_js(
+        &bun_dns::GetAddrInfoResult {
+            address,
+            ttl: node.ttl,
+        },
+        global_this,
+    )
+}
+
+pub(crate) fn addr_info_to_js_array(
+    addr_info: &mut c_ares::AddrInfo,
+    v4_mapped: V4Mapped,
+    global_this: &JSGlobalObject,
+) -> JsResult<JSValue> {
+    let head = addr_info.node;
+    if head.is_null() {
         return JSValue::create_empty_array(global_this, 0);
     }
-    // SAFETY: node is non-null (checked above); c-ares owns the linked list.
-    let array =
-        JSValue::create_empty_array(global_this, unsafe { (*addr_info.node).count() } as usize)?;
 
-    {
-        let mut j: u32 = 0;
-        let mut current: *mut c_ares::AddrInfo_node = addr_info.node;
-        while !current.is_null() {
-            // SAFETY: current is non-null (loop guard); c-ares owns the linked list.
-            let this_node = unsafe { &*current };
-            // bun_dns::Address::init_posix copies from the raw sockaddr by family,
-            // so we hand it `this_node.addr` directly after asserting a known family.
-            debug_assert!(
-                this_node.family == c_ares::AF::INET || this_node.family == c_ares::AF::INET6
-            );
-            // SAFETY: addr is non-null sockaddr_in/in6 for AF_INET/AF_INET6 (c-ares contract).
-            let address = unsafe { bun_dns::Address::init_posix(this_node.addr.cast()) };
-            array.put_index(
-                global_this,
-                j,
-                result_to_js(
-                    &bun_dns::GetAddrInfoResult {
-                        address,
-                        ttl: this_node.ttl,
-                    },
-                    global_this,
-                )?,
-            )?;
+    if v4_mapped == V4Mapped::Off {
+        // SAFETY: `head` is non-null (checked above); c-ares owns the linked list.
+        let array = JSValue::create_empty_array(global_this, unsafe { (*head).count() } as usize)?;
+        // SAFETY: same; the chain outlives this call.
+        for (j, node) in (0_u32..).zip(unsafe { nodes(head) }) {
+            array.put_index(global_this, j, node_to_js(node, false, global_this)?)?;
+        }
+        return Ok(array);
+    }
+
+    let count_family = |family: c_int| {
+        // SAFETY: `head` is non-null; the chain outlives this call.
+        unsafe { nodes(head) }
+            .filter(|n| n.family == family)
+            .count()
+    };
+    let v6_count = count_family(c_ares::AF::INET6);
+    // Without AI_ALL the IPv4 addresses are only mapped when the name has no IPv6 one.
+    let keep_v4 = v4_mapped == V4Mapped::All || v6_count == 0;
+    let v4_count = match keep_v4 {
+        true => count_family(c_ares::AF::INET),
+        false => 0,
+    };
+
+    let array = JSValue::create_empty_array(global_this, v6_count + v4_count)?;
+    let mut j: u32 = 0;
+    // Native IPv6 first, then the mapped IPv4 addresses, matching glibc's order.
+    // SAFETY: `head` is non-null; the chain outlives this call.
+    for node in unsafe { nodes(head) }.filter(|n| n.family == c_ares::AF::INET6) {
+        array.put_index(global_this, j, node_to_js(node, false, global_this)?)?;
+        j += 1;
+    }
+    if keep_v4 {
+        // SAFETY: same.
+        for node in unsafe { nodes(head) }.filter(|n| n.family == c_ares::AF::INET) {
+            array.put_index(global_this, j, node_to_js(node, true, global_this)?)?;
             j += 1;
-            current = this_node.next;
         }
     }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -15,7 +15,7 @@ use bun_core::{ZStr, strings};
 use bun_dns::ResultList as GetAddrInfoResultList;
 use bun_dns::{
     self, Backend as GetAddrInfoBackend, GetAddrInfo, GetAddrInfoResult,
-    Options as GetAddrInfoOptions, ResultAny as GetAddrInfoResultAny,
+    Options as GetAddrInfoOptions, ResultAny as GetAddrInfoResultAny, V4Mapped,
 };
 use bun_io::{self as Async, FilePoll, KeepAlive};
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -32,7 +32,7 @@ use bun_threading::thread_pool;
 use bun_uws::{ConnectingSocket, Loop};
 use bun_wyhash::hash as wyhash;
 
-use super::cares_jsc::error_to_deferred;
+use super::cares_jsc::{self, error_to_deferred};
 use crate::socket::socket_address::inet::INET6_ADDRSTRLEN;
 use crate::timer::{ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 use bun_cares_sys::c_ares_draft as c_ares;
@@ -1129,6 +1129,9 @@ pub struct GetAddrInfoRequest {
     pub resolver_for_caching: Option<*mut Resolver>,
     pub hash: u64,
     pub cache: CacheConfig,
+    /// Read by the c-ares completion path, which synthesizes the IPv4-mapped
+    /// addresses itself. The libc backends get them straight from `getaddrinfo`.
+    pub v4_mapped: V4Mapped,
     pub head: DNSLookup,
     pub tail: *mut DNSLookup, // INTRUSIVE
     pub task: thread_pool::Task,
@@ -1379,6 +1382,7 @@ impl GetAddrInfoRequest {
             resolver_for_caching: resolver,
             hash: query.hash(),
             cache: CacheConfig::default(),
+            v4_mapped: query.options.v4_mapped(),
             head: DNSLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
                 resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
@@ -1567,8 +1571,9 @@ impl GetAddrInfoRequest {
             // Consume the request and move `head` out by value; `ptr::read`
             // + `heap::take` would double-Drop `DNSLookup` (impls Drop).
             let owned = *bun_core::heap::take(this);
+            let v4_mapped = owned.v4_mapped;
             let mut head = owned.head;
-            DNSLookup::process_get_addr_info(&raw mut head, err_, timeout, result);
+            DNSLookup::process_get_addr_info(&raw mut head, err_, timeout, result, v4_mapped);
         }
     }
 
@@ -2012,6 +2017,7 @@ impl DNSLookup {
         err_: Option<c_ares::Error>,
         _timeout: i32,
         result: Option<*mut c_ares::AddrInfo>,
+        v4_mapped: V4Mapped,
     ) {
         bun_output::scoped_log!(DNSLookup, "processGetAddrInfo");
         // This path is reached when the pending-host cache is full (`.disabled`),
@@ -2046,18 +2052,22 @@ impl DNSLookup {
                 Self::destroy(this);
                 return;
             };
-            Self::on_complete(this, r);
+            Self::on_complete(this, r, v4_mapped);
         }
     }
 
     /// SAFETY: see `on_complete_native`.
-    pub(crate) unsafe fn on_complete(this: *mut Self, result: *mut c_ares::AddrInfo) {
+    pub(crate) unsafe fn on_complete(
+        this: *mut Self,
+        result: *mut c_ares::AddrInfo,
+        v4_mapped: V4Mapped,
+    ) {
         bun_output::scoped_log!(DNSLookup, "onComplete");
         // SAFETY: caller contract — `this` is live; result is a live c-ares AddrInfo
         // owned by the caller's scopeguard; JSGlobalObject outlives the request.
         unsafe {
             let array =
-                super::cares_jsc::addr_info_to_js_array(&mut *result, (*this).global_this())
+                cares_jsc::addr_info_to_js_array(&mut *result, v4_mapped, (*this).global_this())
                     .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
             Self::on_complete_with_array(this, array);
         }
@@ -4394,6 +4404,10 @@ impl Resolver {
         // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
+        // Read before the `heap::take`s below free the request.
+        // SAFETY: `key.lookup` is the heap-allocated request stored in the pending-cache slot.
+        let v4_mapped = unsafe { (*key.lookup).v4_mapped };
+
         let Some(addr) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
             // pending-cache slot; consumed via `heap::take` below.
@@ -4404,12 +4418,13 @@ impl Resolver {
                     err,
                     timeout,
                     None,
+                    v4_mapped,
                 );
                 drop(bun_core::heap::take(key.lookup));
 
                 while let Some(value) = pending {
                     pending = (*value.as_ptr()).next;
-                    DNSLookup::process_get_addr_info(value.as_ptr(), err, timeout, None);
+                    DNSLookup::process_get_addr_info(value.as_ptr(), err, timeout, None, v4_mapped);
                 }
             }
             return;
@@ -4420,7 +4435,7 @@ impl Resolver {
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
-            let mut array = super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global)
+            let mut array = cares_jsc::addr_info_to_js_array(&mut *addr, v4_mapped, prev_global)
                 .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
             // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
             // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
@@ -4434,7 +4449,7 @@ impl Resolver {
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
                 if !core::ptr::eq(prev_global, new_global) {
-                    array = super::cares_jsc::addr_info_to_js_array(&mut *addr, new_global)
+                    array = cares_jsc::addr_info_to_js_array(&mut *addr, v4_mapped, new_global)
                         .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
                     prev_global = new_global;
                 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8375,6 +8375,26 @@ pub mod net {
                 _ => core::mem::size_of::<sockaddr_storage>() as u32,
             }
         }
+        /// The IPv4-mapped IPv6 form (`::ffff:a.b.c.d`) of an `AF_INET` address,
+        /// keeping the port. `None` for any other family.
+        pub fn to_v4_mapped(&self) -> Option<Self> {
+            let v4 = self.as_in4()?;
+            // SAFETY: `sin_addr` is 4 bytes of POD on every target (see `Display`).
+            let octets: [u8; 4] = unsafe { *core::ptr::addr_of!(v4.sin_addr).cast::<[u8; 4]>() };
+            let mut addr = [0u8; 16];
+            addr[10] = 0xff;
+            addr[11] = 0xff;
+            addr[12..].copy_from_slice(&octets);
+            let mapped = sockaddr_in6 {
+                family: AF_INET6 as sa_family_t,
+                port: v4.sin_port,
+                addr,
+                ..sockaddr_in6::ZEROED
+            };
+            // SAFETY: `mapped` is a fully-initialized `AF_INET6` sockaddr and this
+            // module's `sockaddr_in6` is layout-identical to the C one (asserted above).
+            Some(unsafe { Self::init_posix((&raw const mapped).cast()) })
+        }
     }
     impl Default for Address {
         // SAFETY: POD, zero-valid — sockaddr union of integer fields.

--- a/test/js/node/dns/dns-v4mapped.test.ts
+++ b/test/js/node/dns/dns-v4mapped.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// `AI_V4MAPPED` (+ `AI_ALL`) on an `AF_INET6` lookup: the name's IPv4 addresses come
+// back as `::ffff:a.b.c.d`. c-ares implements neither hint, so Bun's c-ares backend has
+// to query both families and map the answers itself.
+//
+// Everything runs inside the child: `dns.setServers` is process-global, and the stub
+// server is what keeps the test off the network. `v4only`/`dual` only exist there, so a
+// miss is a hard failure rather than a silent fall-through to the real resolver.
+const fixture = String.raw`
+import dgram from "node:dgram";
+import dns from "node:dns";
+
+const v4 = ip => Buffer.from(ip.split(".").map(Number));
+const v6 = hex => Buffer.from(hex, "hex");
+const A = 1;
+const AAAA = 28;
+const ZONE = {
+  v4only: { [A]: [v4("10.77.0.1")], [AAAA]: [] },
+  dual: { [A]: [v4("10.77.0.2")], [AAAA]: [v6("fd770000000000000000000000000002")] },
+};
+
+function readName(buf, offset) {
+  const labels = [];
+  for (let len = buf[offset++]; len !== 0; len = buf[offset++]) {
+    labels.push(buf.toString("latin1", offset, offset + len));
+    offset += len;
+  }
+  return [labels, offset];
+}
+
+const server = dgram.createSocket("udp4");
+server.on("message", (msg, rinfo) => {
+  const id = msg.readUInt16BE(0);
+  const [labels, nameEnd] = readName(msg, 12);
+  const qtype = msg.readUInt16BE(nameEnd);
+  const qclass = msg.readUInt16BE(nameEnd + 2);
+  const question = msg.subarray(12, nameEnd + 4);
+
+  // Match on the first label so a resolv.conf search domain cannot change the answer.
+  const entry = ZONE[labels[0]];
+  const records = entry?.[qtype] ?? [];
+
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(id, 0);
+  header.writeUInt16BE(entry ? 0x8180 : 0x8183, 2); // QR|RD|RA + NOERROR / NXDOMAIN
+  header.writeUInt16BE(1, 4); // QDCOUNT
+  header.writeUInt16BE(records.length, 6); // ANCOUNT
+
+  const answers = records.map(rdata => {
+    const rr = Buffer.alloc(12 + rdata.length);
+    rr.writeUInt16BE(0xc00c, 0); // NAME: compression pointer at the question's QNAME
+    rr.writeUInt16BE(qtype, 2);
+    rr.writeUInt16BE(qclass, 4);
+    rr.writeUInt32BE(30, 6); // TTL
+    rr.writeUInt16BE(rdata.length, 10); // RDLENGTH
+    rdata.copy(rr, 12);
+    return rr;
+  });
+
+  server.send(Buffer.concat([header, question, ...answers]), rinfo.port, rinfo.address);
+});
+
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.bind(0, "127.0.0.1", resolve);
+});
+dns.setServers(["127.0.0.1:" + server.address().port]);
+
+const fmt = results => results.map(r => r.address + "/" + r.family);
+const cares = (host, options) =>
+  Bun.dns.lookup(host, { ...options, backend: "c-ares" }).then(fmt, e => e.code);
+const lookup = (host, options) =>
+  dns.promises.lookup(host, { all: true, ...options }).then(fmt, e => e.code);
+
+const { V4MAPPED, ALL } = dns;
+const out = {
+  "v4only family:6": await cares("v4only.dnstest", { family: 6 }),
+  "v4only family:6 V4MAPPED": await cares("v4only.dnstest", { family: 6, flags: V4MAPPED }),
+  "v4only family:6 V4MAPPED|ALL": await cares("v4only.dnstest", { family: 6, flags: V4MAPPED | ALL }),
+  "v4only family:0": await cares("v4only.dnstest", { family: 0 }),
+  "v4only family:4 V4MAPPED": await cares("v4only.dnstest", { family: 4, flags: V4MAPPED }),
+  "dual family:6": await cares("dual.dnstest", { family: 6 }),
+  "dual family:6 V4MAPPED": await cares("dual.dnstest", { family: 6, flags: V4MAPPED }),
+  "dual family:6 V4MAPPED|ALL": await cares("dual.dnstest", { family: 6, flags: V4MAPPED | ALL }),
+  "dual family:6 ALL": await cares("dual.dnstest", { family: 6, flags: ALL }),
+};
+
+if (process.env.DEFAULT_BACKEND_IS_CARES === "1") {
+  out["node v4only family:6 V4MAPPED"] = await lookup("v4only.dnstest", { family: 6, hints: V4MAPPED });
+  out["node dual family:6 V4MAPPED|ALL"] = await lookup("dual.dnstest", { family: 6, hints: V4MAPPED | ALL });
+  out["node v4only single"] = await dns.promises
+    .lookup("v4only.dnstest", { family: 6, hints: V4MAPPED })
+    .then(r => r.address + "/" + r.family, e => e.code);
+}
+
+console.log(JSON.stringify(out, null, 2));
+server.close();
+`;
+
+test("dns.lookup maps IPv4 addresses for AI_V4MAPPED on the c-ares backend", async () => {
+  using dir = tempDir("dns-v4mapped", { "fixture.mjs": fixture });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.mjs"],
+    env: { ...bunEnv, DEFAULT_BACKEND_IS_CARES: isLinux ? "1" : "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const expected: Record<string, unknown> = {
+    // No hints: c-ares asks for AAAA only and the name has none.
+    "v4only family:6": "DNS_ENOTFOUND",
+    "v4only family:6 V4MAPPED": ["::ffff:10.77.0.1/6"],
+    "v4only family:6 V4MAPPED|ALL": ["::ffff:10.77.0.1/6"],
+    "v4only family:0": ["10.77.0.1/4"],
+    // AI_V4MAPPED is ignored unless the family is AF_INET6.
+    "v4only family:4 V4MAPPED": ["10.77.0.1/4"],
+    "dual family:6": ["fd77::2/6"],
+    // The name has an IPv6 address, so without AI_ALL nothing is mapped.
+    "dual family:6 V4MAPPED": ["fd77::2/6"],
+    "dual family:6 V4MAPPED|ALL": ["fd77::2/6", "::ffff:10.77.0.2/6"],
+    // AI_ALL is ignored unless AI_V4MAPPED is also set.
+    "dual family:6 ALL": ["fd77::2/6"],
+  };
+  if (isLinux) {
+    expected["node v4only family:6 V4MAPPED"] = ["::ffff:10.77.0.1/6"];
+    expected["node dual family:6 V4MAPPED|ALL"] = ["fd77::2/6", "::ffff:10.77.0.2/6"];
+    expected["node v4only single"] = "::ffff:10.77.0.1/6";
+  }
+
+  expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+    stdout: expected,
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
`dns.lookup(v4onlyHost, { family: 6, hints: dns.V4MAPPED })` fails with `ENOTFOUND` on Bun's default (c-ares) lookup backend, where Node returns `::ffff:a.b.c.d`. Bun's own `libc` backend returns the mapped address for the identical query, so the two backends disagree inside one process.

This is the standard dual-stack pattern (`family: 6` + `V4MAPPED` is what Node does internally for `net.connect({ family: 6 })`), so every such lookup of an IPv4-only host is currently unreachable under Bun.

## Repro

```js
// 127.0.0.1 v4only.example  in /etc/hosts, or any IPv4-only name
import dns from "node:dns";
const show = p => p.then(v => JSON.stringify(v), e => e.code);

console.log("family:6 V4MAPPED    :", await show(dns.promises.lookup("v4only.example", { family: 6, hints: dns.V4MAPPED })));
console.log("family:6 V4MAPPED|ALL:", await show(dns.promises.lookup("v4only.example", { family: 6, hints: dns.V4MAPPED | dns.ALL })));

// node v26:  { "address": "::ffff:127.0.0.1", "family": 6 }  for both
// bun 1.4.0: ENOTFOUND                                       for both
```

## Cause

Two separate defects, both in the c-ares path:

1. `GetAddrInfo::to_cares()` assigned `hints.ai_flags = self.options.flags` verbatim. The `AI_*` values `node:dns` exports come from the platform's `<netdb.h>`, but `ares_addrinfo_hints.ai_flags` uses c-ares' own `ARES_AI_*` bit assignment. On glibc `AI_V4MAPPED` (8) arrives as `ARES_AI_NUMERICSERV` and `AI_ADDRCONFIG` (32) as `ARES_AI_ALL`, so even the hints c-ares does implement were being misread.

2. c-ares implements neither `ARES_AI_V4MAPPED` nor `ARES_AI_ALL` (they are defined in `ares.h` but never consulted in `ares_getaddrinfo.c`), and it only queries A records for `AF_UNSPEC`. An `AF_INET6` query therefore asked for AAAA alone and failed for an IPv4-only name.

## Fix

- `to_cares()` translates `AI_V4MAPPED` / `AI_ALL` / `AI_ADDRCONFIG` (the three hints `options_from_js` accepts) into their `ARES_AI_*` equivalents.
- When `AI_V4MAPPED` is set on an `AF_INET6` lookup, the c-ares query goes out as `AF_UNSPEC` so the A records come back too, and `cares_jsc::addr_info_to_js_array` filters and maps the answers per POSIX: the IPv4 addresses are returned as `::ffff:` only when the name has no IPv6 address, or alongside the IPv6 ones (IPv6 first) when `AI_ALL` is also set.
- `AI_V4MAPPED` stays inert for any family other than `AF_INET6`, and `AI_ALL` stays inert without `AI_V4MAPPED`, matching `getaddrinfo(3)`.

Nothing changes for lookups without `AI_V4MAPPED`: the hint translation only rewrites bits c-ares ignores today, and the result walk keeps its existing verbatim order.

## Verification

New test `test/js/node/dns/dns-v4mapped.test.ts` stands up a stub UDP DNS server, points the resolver at it with `dns.setServers`, and checks the full hint matrix against an IPv4-only name and a dual-stack one. Everything runs in a child process so the process-global `setServers` cannot leak, and no network is touched.

Differentially checked against node v26.3.0 on Linux; both Bun backends now agree with it on every case:

<details>
<summary>c-ares vs libc, dual-stack name (<code>10.11.12.14</code> + <code>fd00::beef</code>)</summary>

```
c-ares  f0 (verbatim)  [{"address":"10.11.12.14","family":4},{"address":"fd00::beef","family":6}]
c-ares  f6             [{"address":"fd00::beef","family":6}]
c-ares  f6 v4m         [{"address":"fd00::beef","family":6}]
c-ares  f6 v4m|all     [{"address":"fd00::beef","family":6},{"address":"::ffff:10.11.12.14","family":6}]
c-ares  f6 all-only    [{"address":"fd00::beef","family":6}]
c-ares  f4 v4m         [{"address":"10.11.12.14","family":4}]
libc    f6 v4m|all     [{"address":"fd00::beef","family":6},{"address":"::ffff:10.11.12.14","family":6}]
```
</details>

`cargo check` / `clippy` clean on linux, macos, windows, freebsd and android targets (`bun_sys::net::Address::to_v4_mapped` touches the cfg-gated BSD `sockaddr_in6.len` field).