### PR TITLE
spawn: honor the Blob window when a sliced Bun.file is used as stdin

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -586,10 +586,18 @@ impl Stdio {
         // `Bun.file(path).slice(a, b)` narrows the Blob to `[offset, offset + size)`.
         // The fast path below hands the child the fd/path behind the Blob, and an fd
         // carries no end bound, so the child would read the whole file. Read the
-        // range up front and pipe exactly those bytes instead.
-        if i == 0 {
-            if let Some(result) = webcore::blob::read_file_view(&blob) {
-                let bytes = match result {
+        // range up front and pipe exactly those bytes instead. stdout/stderr take a
+        // Blob as a write target, where the range means nothing.
+        if i != 1 && i != 2 {
+            if let Some((offset, size)) = webcore::blob::file_view_range(&blob) {
+                if i != 0 {
+                    // Same limit as an in-memory Blob here: only stdin has a
+                    // parent-side writer to pump the bytes through.
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "A sliced Bun.file() cannot be used for stdio[{i}] yet"
+                    )));
+                }
+                let bytes = match webcore::blob::read_file_range(&blob, offset, size) {
                     Ok(bytes) => bytes,
                     Err(err) => return Err(err.throw(global)),
                 };

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -1,5 +1,5 @@
 use bun_collections::VecExt;
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, SysErrorJsc as _};
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_sys::{self as sys, Fd, FdExt as _};
@@ -578,10 +578,25 @@ impl Stdio {
     pub fn extract_blob(
         &mut self,
         global: &JSGlobalObject,
-        blob: webcore::blob::Any,
+        mut blob: webcore::blob::Any,
         i: i32,
     ) -> JsResult<()> {
         let fd = FdStdio::from_int(i).map(FdStdio::fd);
+
+        // `Bun.file(path).slice(a, b)` narrows the Blob to `[offset, offset + size)`.
+        // The fast path below hands the child the fd/path behind the Blob, and an fd
+        // carries no end bound, so the child would read the whole file. Read the
+        // range up front and pipe exactly those bytes instead.
+        if i == 0 {
+            if let Some(result) = webcore::blob::read_file_view(&blob) {
+                let bytes = match result {
+                    Ok(bytes) => bytes,
+                    Err(err) => return Err(err.throw(global)),
+                };
+                blob.detach();
+                blob = webcore::blob::Any::from_owned_slice(bytes);
+            }
+        }
 
         if blob.needs_to_read_file() {
             if let Some(store) = blob.store() {

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -583,11 +583,9 @@ impl Stdio {
     ) -> JsResult<()> {
         let fd = FdStdio::from_int(i).map(FdStdio::fd);
 
-        // `Bun.file(path).slice(a, b)` narrows the Blob to `[offset, offset + size)`.
-        // The fast path below hands the child the fd/path behind the Blob, and an fd
-        // carries no end bound, so the child would read the whole file. Read the
-        // range up front and pipe exactly those bytes instead. stdout/stderr take a
-        // Blob as a write target, where the range means nothing.
+        // A sliced `Bun.file()` addresses `[offset, offset + size)`, but the fd/path
+        // fast path below carries no end bound, so read the range up front and pipe
+        // those bytes. stdout/stderr are write targets, where the range is moot.
         if i != 1 && i != 2 {
             if let Some((offset, size)) = webcore::blob::file_view_range(&blob) {
                 if i != 0 {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -21,7 +21,7 @@ use bun_core::{
 };
 use bun_http_types::MimeType::MimeType;
 use bun_jsc::StringJsc as _;
-use bun_sys::{self, Fd};
+use bun_sys::{self, Fd, FdExt as _};
 
 use crate::webcore::node_types::{PathOrBlob, PathOrFileDescriptor};
 use crate::webcore::s3_stub as S3;
@@ -6357,6 +6357,99 @@ fn resolve_file_stat(store: &StoreRef) {
             _ => {}
         },
     }
+}
+
+/// The `[offset, offset + size)` range a `Bun.file(path).slice(a, b)` addresses,
+/// clamped to the file's real size. `None` when there is no range to honor: the
+/// Blob covers the whole file, or its length can't be resolved (pipes, ttys,
+/// missing files).
+fn file_view_range(blob: &Any) -> Option<(SizeType, SizeType)> {
+    let Any::Blob(blob) = blob else {
+        return None;
+    };
+    let offset = blob.offset.get();
+    let size = blob.size.get();
+    // `Bun.file(path)` with no `.slice()`: the whole file, length still unknown.
+    if offset == 0 && size == MAX_SIZE {
+        return None;
+    }
+
+    let store = blob.store.get().as_ref()?;
+    // see `resolve_size` — dispatch on the copied tag and re-read via
+    // `StoreRef::data_mut` after `resolve_file_stat` so no `Deref`-produced
+    // `&Data`/`&File` is live across the mutating call.
+    if store.data_mut().tag() != store::DataTag::File {
+        return None;
+    }
+    if store.data_mut().as_file().seekable.is_none() {
+        resolve_file_stat(store);
+    }
+    let file = store.data_mut().as_file();
+    if file.seekable != Some(true) || file.max_size == MAX_SIZE {
+        return None;
+    }
+
+    let file_size = file.max_size;
+    let offset = offset.min(file_size);
+    let size = size.min(file_size - offset);
+    if offset == 0 && size == file_size {
+        return None;
+    }
+    Some((offset, size))
+}
+
+/// Read the byte range a `Bun.file(path).slice(a, b)` narrows its store to.
+///
+/// For callers that would otherwise pass the underlying fd or path on to
+/// someone else (a child process): an fd carries no end bound, so the whole file
+/// would be readable through it. `None` means the Blob addresses the whole file
+/// (or has no resolvable length) and the fd/path can be passed as-is.
+pub fn read_file_view(blob: &Any) -> Option<bun_sys::Maybe<Vec<u8>>> {
+    let (offset, size) = file_view_range(blob)?;
+    Some(read_file_range(blob.store()?.data.as_file(), offset, size))
+}
+
+/// A short read, because the file shrank since it was stat'd, yields fewer bytes.
+fn read_file_range(
+    file: &store::File,
+    offset: SizeType,
+    size: SizeType,
+) -> bun_sys::Maybe<Vec<u8>> {
+    let mut path_buf = bun_paths::PathBuffer::uninit();
+    // `pread` leaves the seek position alone, so the store's own fd would do;
+    // dup it anyway so one guard closes whichever fd we end up with.
+    let fd = match &file.pathlike {
+        PathOrFileDescriptor::Fd(fd) => bun_sys::dup(*fd)?,
+        PathOrFileDescriptor::Path(path) => {
+            let flags = if cfg!(windows) {
+                bun_sys::O::RDONLY
+            } else {
+                bun_sys::O::RDONLY | bun_sys::O::NOCTTY
+            };
+            bun_sys::open(path.slice_z(&mut path_buf), flags, 0)?
+        }
+    };
+    let fd = scopeguard::guard(fd, |fd| fd.close());
+
+    let len = usize::try_from(size).expect("int cast");
+    let mut bytes = Vec::<u8>::new();
+    bytes
+        .try_reserve_exact(len)
+        .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
+    bytes.resize(len, 0);
+
+    let mut read: usize = 0;
+    while read < len {
+        let at = i64::try_from(offset + read as SizeType).expect("int cast");
+        match bun_sys::pread(*fd, &mut bytes[read..], at) {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(err) if err.get_errno() == bun_sys::E::EINTR => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    bytes.truncate(read);
+    Ok(bytes)
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6421,13 +6421,21 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
             bun_sys::open(path.slice_z(&mut path_buf), flags, 0)?
         }
     };
-    let fd = scopeguard::guard(fd, |fd| fd.close());
 
     // POSIX `pread` ignores the file offset. Windows `dup` shares the file
-    // pointer and `pread` (ReadFile + OVERLAPPED) advances it, so save and
-    // restore it to leave a caller reading the same fd afterward unaffected.
+    // pointer and `pread` (ReadFile + OVERLAPPED) advances it, so capture the
+    // offset now and restore it in the close guard (which runs on every exit,
+    // including a mid-read error) to leave a caller reading the same fd after.
     #[cfg(windows)]
-    let saved_offset = bun_sys::lseek(*fd, 0, libc::SEEK_CUR).ok();
+    let saved_offset = bun_sys::lseek(fd, 0, libc::SEEK_CUR).ok();
+
+    let fd = scopeguard::guard(fd, move |fd| {
+        #[cfg(windows)]
+        if let Some(offset) = saved_offset {
+            let _ = bun_sys::set_file_offset(fd, offset as u64);
+        }
+        fd.close();
+    });
 
     let len = usize::try_from(size).expect("int cast");
     let mut bytes = Vec::<u8>::new();
@@ -6445,11 +6453,6 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
             Err(err) if err.get_errno() == bun_sys::E::EINTR => continue,
             Err(err) => return Err(err),
         }
-    }
-
-    #[cfg(windows)]
-    if let Some(offset) = saved_offset {
-        let _ = bun_sys::set_file_offset(*fd, offset as u64);
     }
 
     bytes.truncate(read);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6422,10 +6422,9 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
         }
     };
 
-    // POSIX `pread` ignores the file offset. Windows `dup` shares the file
-    // pointer and `pread` (ReadFile + OVERLAPPED) advances it, so capture the
-    // offset now and restore it in the close guard (which runs on every exit,
-    // including a mid-read error) to leave a caller reading the same fd after.
+    // POSIX `pread` ignores the file offset. On Windows the dup shares the file
+    // pointer and `pread` advances it, so capture the offset now and restore it
+    // in the close guard (runs on every exit) so a caller reading the fd is unaffected.
     #[cfg(windows)]
     let saved_offset = bun_sys::lseek(fd, 0, libc::SEEK_CUR).ok();
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6408,8 +6408,8 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
         .as_file();
 
     let mut path_buf = bun_paths::PathBuffer::uninit();
-    // `pread` leaves the seek position alone, so the store's own fd would do;
-    // dup it anyway so one guard closes whichever fd we end up with.
+    // dup the caller's fd (rather than read through it) so one guard closes
+    // whichever fd we open here without touching the caller's.
     let fd = match &file.pathlike {
         PathOrFileDescriptor::Fd(fd) => bun_sys::dup(*fd)?,
         PathOrFileDescriptor::Path(path) => {
@@ -6422,6 +6422,12 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
         }
     };
     let fd = scopeguard::guard(fd, |fd| fd.close());
+
+    // POSIX `pread` ignores the file offset. Windows `dup` shares the file
+    // pointer and `pread` (ReadFile + OVERLAPPED) advances it, so save and
+    // restore it to leave a caller reading the same fd afterward unaffected.
+    #[cfg(windows)]
+    let saved_offset = bun_sys::lseek(*fd, 0, libc::SEEK_CUR).ok();
 
     let len = usize::try_from(size).expect("int cast");
     let mut bytes = Vec::<u8>::new();
@@ -6440,6 +6446,12 @@ pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys:
             Err(err) => return Err(err),
         }
     }
+
+    #[cfg(windows)]
+    if let Some(offset) = saved_offset {
+        let _ = bun_sys::set_file_offset(*fd, offset as u64);
+    }
+
     bytes.truncate(read);
     Ok(bytes)
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6359,11 +6359,10 @@ fn resolve_file_stat(store: &StoreRef) {
     }
 }
 
-/// The `[offset, offset + size)` range a `Bun.file(path).slice(a, b)` addresses,
-/// clamped to the file's real size. `None` when there is no range to honor: the
-/// Blob covers the whole file, or its length can't be resolved (pipes, ttys,
-/// missing files).
-fn file_view_range(blob: &Any) -> Option<(SizeType, SizeType)> {
+/// The `[offset, offset + size)` range a `Bun.file(path).slice(a, b)` narrows its
+/// store to, clamped to the file's real size. `None` when the Blob covers the
+/// whole file or its length can't be resolved (pipes, ttys, missing files).
+pub fn file_view_range(blob: &Any) -> Option<(SizeType, SizeType)> {
     let Any::Blob(blob) = blob else {
         return None;
     };
@@ -6398,23 +6397,16 @@ fn file_view_range(blob: &Any) -> Option<(SizeType, SizeType)> {
     Some((offset, size))
 }
 
-/// Read the byte range a `Bun.file(path).slice(a, b)` narrows its store to.
-///
-/// For callers that would otherwise pass the underlying fd or path on to
-/// someone else (a child process): an fd carries no end bound, so the whole file
-/// would be readable through it. `None` means the Blob addresses the whole file
-/// (or has no resolvable length) and the fd/path can be passed as-is.
-pub fn read_file_view(blob: &Any) -> Option<bun_sys::Maybe<Vec<u8>>> {
-    let (offset, size) = file_view_range(blob)?;
-    Some(read_file_range(blob.store()?.data.as_file(), offset, size))
-}
+/// Read `[offset, offset + size)` of the file behind `blob`, as returned by
+/// [`file_view_range`] (which proves the store is file-backed). A short read,
+/// because the file shrank since it was stat'd, yields fewer bytes.
+pub fn read_file_range(blob: &Any, offset: SizeType, size: SizeType) -> bun_sys::Maybe<Vec<u8>> {
+    let file = blob
+        .store()
+        .expect("file_view_range() implies a file store")
+        .data
+        .as_file();
 
-/// A short read, because the file shrank since it was stat'd, yields fewer bytes.
-fn read_file_range(
-    file: &store::File,
-    offset: SizeType,
-    size: SizeType,
-) -> bun_sys::Maybe<Vec<u8>> {
     let mut path_buf = bun_paths::PathBuffer::uninit();
     // `pread` leaves the seek position alone, so the store's own fd would do;
     // dup it anyway so one guard closes whichever fd we end up with.

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1,5 +1,5 @@
 import { ArrayBufferSink, readableStreamToText, spawn, spawnSync } from "bun";
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import {
   gcTick as _gcTick,
   bunEnv,
@@ -11,6 +11,7 @@ import {
   isPosix,
   isWindows,
   shellExe,
+  tempDir,
   tmpdirSync,
   withoutAggressiveGC,
 } from "harness";
@@ -929,6 +930,21 @@ describe("close handling", () => {
       }
     });
 
+    // An extra slot is a read source, so the slice window is meaningful there,
+    // but only stdin has a writer to pump the narrowed bytes through. Reject it
+    // rather than hand the child the whole file.
+    it.skipIf(isWindows)("Bun.file(path).slice() at index >= 3 is rejected", () => {
+      const file = join(tmp, "stdio-extra-bunfile-slice.txt");
+      writeFileSync(file, "from-bun-file");
+      expect(() =>
+        spawn({
+          cmd: [bunExe(), "-e", readFd3],
+          env: bunEnv,
+          stdio: ["ignore", "pipe", "pipe", Bun.file(file).slice(5, 9)],
+        }),
+      ).toThrow("A sliced Bun.file() cannot be used for stdio[3] yet");
+    });
+
     it.skipIf(isWindows)("empty Blob at index >= 3 is treated as ignore", async () => {
       await using proc = spawn({
         cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
@@ -1256,21 +1272,28 @@ describe("uid/gid", () => {
   });
 });
 
+// Sequential on purpose: every case spawns a `bun` child, and 5 concurrent
+// ASAN children (the `--max-concurrency` default there) overrun the 5s timeout.
 describe("Bun.file().slice() as stdin", () => {
   const contents = "0123456789".repeat(10);
   const pipeStdin = "process.stdin.pipe(process.stdout)";
 
+  let dir: ReturnType<typeof tempDir>;
   let filePath: string;
   let bigPath: string;
   const bigSize = 1024 * 1024;
 
   beforeAll(() => {
-    const dir = tmpdirSync();
-    filePath = join(dir, "slice-stdin.txt");
-    writeFileSync(filePath, contents);
+    dir = tempDir("slice-stdin", {
+      "slice-stdin.txt": contents,
+      "slice-stdin-big.bin": Buffer.concat([Buffer.alloc(bigSize - 8, "A"), Buffer.alloc(8, "B")]),
+    });
+    filePath = join(String(dir), "slice-stdin.txt");
+    bigPath = join(String(dir), "slice-stdin-big.bin");
+  });
 
-    bigPath = join(dir, "slice-stdin-big.bin");
-    writeFileSync(bigPath, Buffer.concat([Buffer.alloc(bigSize - 8, "A"), Buffer.alloc(8, "B")]));
+  afterAll(() => {
+    dir[Symbol.dispose]();
   });
 
   // `.slice()` narrows a Bun.file() Blob to [offset, offset + size). The spawn
@@ -1376,7 +1399,7 @@ describe("Bun.file().slice() as stdin", () => {
   // A file with no resolvable length (missing, pipe, tty) has no window to read,
   // so it keeps taking the fd/path fast path rather than failing the spawn.
   it("a slice of a missing file behaves like the unsliced file", () => {
-    const missing = join(tmpdirSync(), "nope.txt");
+    const missing = join(String(dir), "nope.txt");
     const { stdout, stderr, exitCode } = spawnSync({
       cmd: [bunExe(), "-e", pipeStdin],
       env: bunEnv,
@@ -1386,5 +1409,21 @@ describe("Bun.file().slice() as stdin", () => {
     });
     expect({ stdout: stdout.toString(), exitCode }).toEqual({ stdout: "", exitCode: 0 });
     expect(stderr.toString()).toBe("");
+  });
+
+  // stdout/stderr take a Blob as a write target; the window means nothing there,
+  // so they keep writing to the whole file.
+  it("a slice used as stdout still writes to the file", async () => {
+    const out = join(String(dir), "slice-stdout.txt");
+    writeFileSync(out, "");
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write('written')"],
+      env: bunEnv,
+      stdout: Bun.file(out).slice(0, 2),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(readFileSync(out, "utf8")).toBe("written");
   });
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1255,3 +1255,136 @@ describe("uid/gid", () => {
     expect(thrown?.code).toBe("EPERM");
   });
 });
+
+describe("Bun.file().slice() as stdin", () => {
+  const contents = "0123456789".repeat(10);
+  const pipeStdin = "process.stdin.pipe(process.stdout)";
+
+  let filePath: string;
+  let bigPath: string;
+  const bigSize = 1024 * 1024;
+
+  beforeAll(() => {
+    const dir = tmpdirSync();
+    filePath = join(dir, "slice-stdin.txt");
+    writeFileSync(filePath, contents);
+
+    bigPath = join(dir, "slice-stdin-big.bin");
+    writeFileSync(bigPath, Buffer.concat([Buffer.alloc(bigSize - 8, "A"), Buffer.alloc(8, "B")]));
+  });
+
+  // `.slice()` narrows a Bun.file() Blob to [offset, offset + size). The spawn
+  // stdio fast path hands the child the fd/path behind the Blob, which carries
+  // no end bound, so the whole file used to leak through.
+  const windows: [label: string, make: () => Blob, expected: () => string][] = [
+    ["slice(3, 9)", () => Bun.file(filePath).slice(3, 9), () => contents.slice(3, 9)],
+    ["slice(3)", () => Bun.file(filePath).slice(3), () => contents.slice(3)],
+    ["slice(0, 10)", () => Bun.file(filePath).slice(0, 10), () => contents.slice(0, 10)],
+    ["slice(3, 3)", () => Bun.file(filePath).slice(3, 3), () => ""],
+    // Windows that cover the whole file keep the zero-copy fd/path fast path.
+    ["no slice", () => Bun.file(filePath), () => contents],
+    ["slice(0, size)", () => Bun.file(filePath).slice(0, contents.length), () => contents],
+    ["slice(0, past end)", () => Bun.file(filePath).slice(0, contents.length * 4), () => contents],
+  ];
+
+  for (const [label, make, expected] of windows) {
+    it(`spawn: ${label}`, async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", pipeStdin],
+        env: bunEnv,
+        stdin: make(),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, exitCode }).toEqual({ stdout: expected(), exitCode: 0 });
+      expect(stderr).toBe("");
+    });
+
+    it(`spawnSync: ${label}`, () => {
+      const { stdout, stderr, exitCode } = spawnSync({
+        cmd: [bunExe(), "-e", pipeStdin],
+        env: bunEnv,
+        stdin: make(),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect({ stdout: stdout.toString(), exitCode }).toEqual({ stdout: expected(), exitCode: 0 });
+      expect(stderr.toString()).toBe("");
+    });
+  }
+
+  it("a window larger than the pipe buffer is written in full", async () => {
+    const size = 200 * 1024;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", pipeStdin],
+      env: bunEnv,
+      stdin: Bun.file(bigPath).slice(0, size),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toEqual(new Uint8Array(Buffer.alloc(size, "A")));
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  });
+
+  it("spawnSync reads a window at the end of a large file", () => {
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", pipeStdin],
+      env: bunEnv,
+      stdin: Bun.file(bigPath).slice(bigSize - 12, bigSize),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect({ stdout: stdout.toString(), exitCode }).toEqual({ stdout: "AAAABBBBBBBB", exitCode: 0 });
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("Response wrapping a file slice is narrowed too", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", pipeStdin],
+      env: bunEnv,
+      stdin: new Response(Bun.file(filePath).slice(3, 9)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "345678", stderr: "", exitCode: 0 });
+  });
+
+  it.skipIf(isWindows)("a fd-backed file slice is narrowed and leaves the fd position alone", async () => {
+    const fd = openSync(filePath, "r");
+    try {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", pipeStdin],
+        env: bunEnv,
+        stdin: Bun.file(fd).slice(3, 9),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "345678", stderr: "", exitCode: 0 });
+
+      const buf = Buffer.alloc(4);
+      expect(readSync(fd, buf, 0, 4, null)).toBe(4);
+      expect(buf.toString()).toBe(contents.slice(0, 4));
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  // A file with no resolvable length (missing, pipe, tty) has no window to read,
+  // so it keeps taking the fd/path fast path rather than failing the spawn.
+  it("a slice of a missing file behaves like the unsliced file", () => {
+    const missing = join(tmpdirSync(), "nope.txt");
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", pipeStdin],
+      env: bunEnv,
+      stdin: Bun.file(missing).slice(0, 5),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect({ stdout: stdout.toString(), exitCode }).toEqual({ stdout: "", exitCode: 0 });
+    expect(stderr.toString()).toBe("");
+  });
+});


### PR DESCRIPTION
### Repro

```js
import { writeFileSync } from "node:fs";
writeFileSync("/tmp/x.txt", "0123456789".repeat(10)); // 100 bytes

const slice = Bun.file("/tmp/x.txt").slice(3, 9);
console.log(slice.size, await slice.text()); // 6 "345678"

console.log(Bun.spawnSync({ cmd: ["cat"], stdin: slice, stdout: "pipe" }).stdout.length);
// before: 100   <- the whole file, not the window
// after:  6
```

Same on `Bun.spawn`. An in-memory `new Blob([...]).slice(3, 9)` as stdin is honored, so only the on-disk Blob is affected. The child silently receives bytes the caller deliberately excluded, and any framing the caller computed from `blob.size` is wrong on the child side.

### Cause

`Stdio::extract_blob` takes a fast path for file-backed Blobs: it hands the child the `fd` or `path` behind the Blob's store and drops the Blob's `[offset, offset + size)` window. An fd carries no end bound, so the child reads to EOF.

### Fix

When a Blob used as stdin addresses only part of its file, read that range with `pread` and pipe exactly those bytes. The window is clamped to the file's real size, so everything that covers the whole file keeps the zero-copy fd/path fast path:

| stdin | behavior |
| --- | --- |
| `Bun.file(p)` | fd/path passed through (unchanged) |
| `Bun.file(p)` after `.size` was resolved | fd/path passed through (unchanged) |
| `Bun.file(p).slice(0)` / `.slice(0, size)` / `.slice(0, pastEnd)` | fd/path passed through (unchanged) |
| `Bun.file(p).slice(3, 9)` | child gets `[3, 9)` |
| `Bun.file(p).slice(3)` | child gets `[3, EOF)` |
| `Bun.file(p).slice(3, 3)` | child gets nothing |
| pipe / tty / missing file | fd/path passed through (unchanged) |

The cost is the window's bytes in memory, which is what the in-memory Blob stdin branch already does, and `spawnSync` has no event loop to pump a streaming read through. Streaming the range into the child's pipe would be a follow-up.

#### The other stdio slots

- **stdout / stderr** take a Blob as a *write target*, so the window has no meaning. Unchanged: they still write to the whole file.
- **`stdio[N >= 3]`** hands the child a readable fd, so the window *is* meaningful and the same bug exists there. Fully honoring it needs a parent-side writer per extra slot, which only stdin has today (an in-memory `new Blob([...])` at an extra slot already throws `Blob cannot be used for stdio[3] yet`). So a sliced `Bun.file()` at an extra slot now throws `A sliced Bun.file() cannot be used for stdio[3] yet` rather than silently handing over the whole file. An unsliced `Bun.file()` at an extra slot is untouched.

### Relationship to #31931

@dylan-conway opened #31931 for this a month ago and it is still open. This is an alternative take; the functional differences are:

- #31931 decides "whole file" with `offset == 0 && size == MAX_SIZE`. Reading `file.size` (or anything else that resolves it) overwrites `size` with the real length, after which an **unsliced** `Bun.file(huge)` would be buffered into memory instead of passed by path. This PR compares against the file's real size, so it stays on the fast path.
- #31931 makes a sliced file Blob at stdout/stderr throw `Blobs are immutable, and cannot be used for stdout/stderr`; this PR leaves those untouched.
- #31931 `pread`s without checking seekability, so `Bun.stdin.slice(...)` (a pipe) would throw `ESPIPE`; this PR leaves non-seekable files on the existing fast path.
- The window/read helpers live in `webcore/Blob.rs` here, next to the `offset`/`size` they interpret, so the other reported sinks for this family can reuse them.

Happy to close this in favour of #31931 if the above are not wanted.

### Verification

`test/js/bun/spawn/spawn.test.ts`: 25 new tests across `spawn` and `spawnSync`, covering each window shape, a window larger than the pipe buffer, a window at the end of a 1 MiB file, fd-backed slices (asserting the parent's seek position is untouched), `Response` wrapping a file slice, a missing file, and a slice used as stdout. One more in the existing `stdio[N>=3]` block for the rejection above.

12 of them fail on `main`, all on the narrowed windows, plus the `stdio[N>=3]` one. The 13 that pass both ways are the whole-file cases that must keep the fast path, and the stdout behavior guard.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn.test.ts -t "as stdin"
 13 pass
 12 fail

$ bun bd test test/js/bun/spawn/spawn.test.ts -t "as stdin"
 25 pass
  0 fail
```

`bun run rust:check-all` is green on all 10 target/platform combos.
