### PR TITLE
node:zlib: refuse reset() while a write is in progress

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -22,7 +22,7 @@ bun_output::declare_scope!(zlib, hidden);
 // ─── type defs ────────────────────────────────────────────────────────────
 
 /// This is a mixin: methods all take `this: *T` and access fields on `T`
-/// (write_in_progress, pending_close, pending_reset, closed, stream, this_value,
+/// (write_in_progress, pending_close, closed, stream, this_value,
 /// write_result, task, poll_ref, globalThis) plus `T.js.*` codegen accessors and
 /// `T.ref()/deref()`.
 // Expressed as a marker struct + trait bound. Field accesses on
@@ -241,7 +241,6 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn task(&self) -> &JsCell<WorkPoolTask>;
     fn write_in_progress(&self) -> &Cell<bool>;
     fn pending_close(&self) -> &Cell<bool>;
-    fn pending_reset(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
     /// Recover `*mut Self` from the embedded `WorkPoolTask`.
@@ -563,9 +562,6 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 .run_callback(write_callback, global, this_value, &[]);
         }
 
-        if this.pending_reset().get() {
-            Self::reset_internal(&this, global, this_value);
-        }
         if this.pending_close().get() {
             Self::close_internal(&this);
         }
@@ -707,28 +703,28 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         Ok(JSValue::UNDEFINED)
     }
 
-    pub(crate) fn reset(this: &T, global_this: &JSGlobalObject, callframe: &CallFrame) -> JSValue {
-        Self::reset_internal(this, global_this, callframe.this());
-        JSValue::UNDEFINED
-    }
-
-    fn reset_internal(this: &T, global_this: &JSGlobalObject, this_value: JSValue) {
+    pub(crate) fn reset(
+        this: &T,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
         // reset() destroys and re-creates the brotli/zstd encoder state (or
-        // mutates the z_stream). Doing so while an async write is running on
-        // the threadpool would be a use-after-free / data race, so defer it
-        // until the in-flight write completes (mirrors pending_close).
+        // mutates the z_stream), which an async write running on the threadpool
+        // still holds. Refuse the call instead of racing it, like node does.
         if this.write_in_progress().get() {
-            this.pending_reset().set(true);
-            return;
+            let error = global_this.create_error_instance(format_args!(
+                "Cannot reset zlib stream while a write is in progress"
+            ));
+            return Err(global_this.throw_value(error));
         }
-        this.pending_reset().set(false);
         if this.closed().get() {
-            return;
+            return Ok(JSValue::UNDEFINED);
         }
         let err = this.stream().with_mut(|s| s.reset());
         if err.is_error() {
-            Self::emit_error(this, global_this, this_value, err);
+            Self::emit_error(this, global_this, callframe.this(), err);
         }
+        Ok(JSValue::UNDEFINED)
     }
 
     pub(crate) fn close(
@@ -800,10 +796,9 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // Clear write_in_progress *before* invoking the onerror callback.
         // The callback may re-enter write(), which sets write_in_progress=true
         // and schedules a WorkPool task. If we cleared the flag after the
-        // callback, we would clobber that state and closeInternal()/resetInternal()
-        // below could free the native zlib/brotli/zstd state while a task is
-        // still queued, leading to a use-after-free when the worker thread
-        // runs doWork().
+        // callback, we would clobber that state and closeInternal() below could
+        // free the native zlib/brotli/zstd state while a task is still queued,
+        // leading to a use-after-free when the worker thread runs doWork().
         this.write_in_progress().set(false);
 
         let msg_bytes: &[u8] = if err_.msg.is_null() {
@@ -847,9 +842,6 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             );
         }
 
-        if this.pending_reset().get() {
-            Self::reset_internal(this, global_this, this_value);
-        }
         if this.pending_close().get() {
             Self::close_internal(this);
         }
@@ -897,7 +889,7 @@ macro_rules! __compression_stream_mixin_reexports {
                 this: &Self,
                 global: &::bun_jsc::JSGlobalObject,
                 frame: &::bun_jsc::CallFrame,
-            ) -> ::bun_jsc::JSValue {
+            ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
                 $crate::node::node_zlib_binding::CompressionStream::<Self>::reset(
                     this, global, frame,
                 )
@@ -962,7 +954,7 @@ pub(crate) fn native_zstd(global: &JSGlobalObject) -> JSValue {
 ///
 /// All three `Native{Zlib,Brotli,Zstd}` structs share the exact field layout
 /// (`global_this`, `stream`, `poll_ref`, `this_value`,
-/// `write_in_progress`, `pending_close`, `pending_reset`, `closed`, `task`,
+/// `write_in_progress`, `pending_close`, `closed`, `task`,
 /// `ref_count`), so the macro can stamp the impls uniformly.
 ///
 /// `$type_name` is the C++-side class name (matches `.classes.ts`); the macro
@@ -1005,7 +997,6 @@ macro_rules! __impl_compression_stream {
             #[inline] fn task(&self) -> &::bun_jsc::JsCell<::bun_jsc::WorkPoolTask> { &self.task }
             #[inline] fn write_in_progress(&self) -> &::core::cell::Cell<bool> { &self.write_in_progress }
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
-            #[inline] fn pending_reset(&self) -> &::core::cell::Cell<bool> { &self.pending_reset }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
 
             #[inline]

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -82,7 +82,6 @@ mod _impl {
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
         pub write_in_progress: Cell<bool>,
         pub pending_close: Cell<bool>,
-        pub pending_reset: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
         /// External-allocation footprint reported to the GC, fixed at
@@ -145,7 +144,6 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pending_close: Cell::new(false),
-                pending_reset: Cell::new(false),
                 closed: Cell::new(false),
                 // .callback = undefined — overwritten before WorkPool::schedule()
                 task: JsCell::new(WorkPoolTask {

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -47,7 +47,6 @@ mod _impl {
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
         pub pending_close: Cell<bool>,
-        pub pending_reset: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
     }
@@ -99,7 +98,6 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pending_close: Cell::new(false),
-                pending_reset: Cell::new(false),
                 closed: Cell::new(false),
                 task: JsCell::new(WorkPoolTask {
                     node: Default::default(),

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -46,7 +46,6 @@ mod _impl {
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
         pub pending_close: Cell<bool>,
-        pub pending_reset: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
         /// External-allocation footprint reported to the GC, fixed at
@@ -111,7 +110,6 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pending_close: Cell::new(false),
-                pending_reset: Cell::new(false),
                 closed: Cell::new(false),
                 // WorkPoolTask { callback: undefined } — callback is overwritten by
                 // CompressionStream::write before scheduling; placeholder here.

--- a/test/js/node/zlib/zlib-reset-race.test.ts
+++ b/test/js/node/zlib/zlib-reset-race.test.ts
@@ -1,99 +1,202 @@
-// Regression test: calling .reset() on a zlib/brotli/zstd stream while an
-// async write is running on the threadpool must not use-after-free the
-// encoder state.
-//
-// Before the fix, CompressionStream.reset() called this.stream.reset()
-// unconditionally, which for brotli/zstd destroys and re-creates the encoder
-// instance and for zlib calls deflateReset()/inflateReset(). If the
-// threadpool thread was concurrently inside doWork() operating on that state,
-// zstd would read freed memory (heap-use-after-free under ASAN) and brotli
-// would silently corrupt or fail compression.
-//
-// After the fix, reset() is deferred until the in-flight write completes
-// (mirroring pending_close).
+// reset() mutates the z_stream (zlib) or destroys and re-creates the encoder
+// instance (brotli/zstd). While an async write is running on the threadpool
+// that state is owned by the worker thread, so node refuses the call with
+// `Error: Cannot reset zlib stream while a write is in progress` instead of
+// racing it. Bun used to defer the reset until the write retired, so every
+// state below silently returned undefined.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import zlib from "zlib";
 
-const zstdFixture = /* js */ `
+const MESSAGE = "Cannot reset zlib stream while a write is in progress";
+
+// node throws a plain Error here, without a `code`.
+const REFUSED = { threw: true, name: "Error", code: undefined, message: MESSAGE };
+const ALLOWED = { threw: false };
+
+function resetOutcome(z: any) {
+  try {
+    z.reset();
+    return { threw: false };
+  } catch (e: any) {
+    return { threw: true, name: e.name, code: e.code, message: e.message };
+  }
+}
+
+// Incompressible enough that a 300 KB write needs several threadpool round
+// trips, matching the report's reproduction.
+function payload(size = 300_000) {
+  const buf = Buffer.alloc(size);
+  for (let i = 0; i < buf.length; i++) buf[i] = (i * 2654435761) >>> 13;
+  return buf;
+}
+
+test("reset() inside end()'s finish callback is refused", async () => {
+  const z = zlib.createDeflateRaw();
+  z.resume();
+  const { promise, resolve, reject } = Promise.withResolvers<ReturnType<typeof resetOutcome>>();
+  z.on("error", reject);
+  z.write("hello");
+  // `_final` calls back immediately and `_flush` issues the implicit Z_FINISH
+  // write from 'prefinish', so that write is still in flight here.
+  z.end(() => resolve(resetOutcome(z)));
+  expect(await promise).toEqual(REFUSED);
+  z.destroy();
+});
+
+test("reset() inside a decompressor's finish callback is refused", async () => {
+  const z = zlib.createGunzip();
+  z.resume();
+  const { promise, resolve, reject } = Promise.withResolvers<ReturnType<typeof resetOutcome>>();
+  z.on("error", reject);
+  z.end(zlib.gzipSync("hello"), () => resolve(resetOutcome(z)));
+  expect(await promise).toEqual(REFUSED);
+  z.destroy();
+});
+
+test("reset() with a queued write is refused and leaves the stream intact", async () => {
+  const input = payload();
+  const z = zlib.createDeflateRaw({ level: 6 });
+  const out: Buffer[] = [];
+  z.on("data", chunk => out.push(chunk));
+
+  z.write(input);
+  expect(resetOutcome(z)).toEqual(REFUSED);
+  z.write(input.subarray(0, 1000));
+  expect(resetOutcome(z)).toEqual(REFUSED);
+
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  z.on("error", reject);
+  z.on("end", resolve);
+  z.end();
+  await promise;
+
+  const expected = Buffer.concat([input, input.subarray(0, 1000)]);
+  const inflated = zlib.inflateRawSync(Buffer.concat(out));
+  expect({ length: inflated.length, matches: inflated.equals(expected) }).toEqual({
+    length: expected.length,
+    matches: true,
+  });
+});
+
+test.each([
+  ["gzip", () => zlib.createGzip()],
+  ["brotli", () => zlib.createBrotliCompress()],
+  ["zstd", () => zlib.createZstdCompress()],
+] as const)("reset() with a queued write is refused (%s)", async (_name, create) => {
+  const z = create();
+  z.on("data", () => {});
+  z.write(payload());
+  expect(resetOutcome(z)).toEqual(REFUSED);
+
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  z.on("error", reject);
+  z.on("end", resolve);
+  z.end();
+  await promise;
+});
+
+// The guard must only fire while the native write is actually outstanding:
+// every state below is accepted on node too.
+test("reset() is allowed before any write", () => {
+  const z = zlib.createDeflateRaw();
+  expect(resetOutcome(z)).toEqual(ALLOWED);
+  z.destroy();
+});
+
+test("reset() is allowed from the write callback", async () => {
+  const z = zlib.createDeflateRaw();
+  z.resume();
+  const { promise, resolve, reject } = Promise.withResolvers<ReturnType<typeof resetOutcome>>();
+  z.on("error", reject);
+  z.write(payload(), () => resolve(resetOutcome(z)));
+  expect(await promise).toEqual(ALLOWED);
+  z.destroy();
+});
+
+test("reset() is allowed from a 'data' handler", async () => {
+  const z = zlib.createDeflateRaw();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  let outcome: ReturnType<typeof resetOutcome> | undefined;
+  z.on("error", reject);
+  z.on("end", resolve);
+  z.on("data", () => {
+    outcome ??= resetOutcome(z);
+  });
+  z.end(payload());
+  await promise;
+  expect(outcome).toEqual(ALLOWED);
+});
+
+test("reset() is allowed after flush()", async () => {
+  const z = zlib.createDeflateRaw();
+  z.resume();
+  z.write("hello");
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  z.on("error", reject);
+  z.flush(resolve);
+  await promise;
+  expect(resetOutcome(z)).toEqual(ALLOWED);
+  z.destroy();
+});
+
+// Subprocess fixtures: refusing the call is what keeps reset() off state a
+// worker thread is still inside doWork() on. Before the guard existed, zstd
+// read freed memory here (heap-use-after-free under ASAN) and brotli silently
+// corrupted its encoder. The spin keeps the worker mid-compression, so a
+// regression resurfaces as a fault rather than just a missing throw.
+const fixture = (create: string, busyMs: number, buf: string) => /* js */ `
   const zlib = require("zlib");
   const crypto = require("crypto");
 
-  // Random data at a high compression level so each threadpool job is slow
-  // enough that reset() lands while ZSTD_compressStream2 is still running.
-  const buf = crypto.randomBytes(1024 * 1024);
+  const buf = ${buf};
 
   let remaining = 0;
   for (let i = 0; i < 4; i++) {
     remaining++;
-    const z = zlib.createZstdCompress({
+    const z = ${create};
+    z.on("error", () => {});
+    z.on("data", () => {});
+    z.write(buf, () => {
+      z.end();
+      if (--remaining === 0) console.log("OK");
+    });
+    // Spin so the threadpool is inside the compression call before reset().
+    const start = Date.now();
+    while (Date.now() - start < ${busyMs}) {}
+    let message;
+    try { z.reset(); } catch (e) { message = e.message; }
+    if (message !== ${JSON.stringify(MESSAGE)}) {
+      console.error("expected reset() to be refused, got: " + message);
+      process.exit(1);
+    }
+  }
+`;
+
+const zstdFixture = fixture(
+  `zlib.createZstdCompress({
       chunkSize: 1024 * 1024,
       params: { [zlib.constants.ZSTD_c_compressionLevel]: 19 },
-    });
-    z.on("error", () => {});
-    z.on("data", () => {});
-    z.write(buf, () => {
-      z.end();
-      if (--remaining === 0) console.log("OK");
-    });
-    // Spin briefly so the threadpool starts ZSTD_compressStream2 before reset().
-    const start = Date.now();
-    while (Date.now() - start < 30) {}
-    // Before the fix this frees the ZSTD_CCtx while the worker thread is
-    // inside ZSTD_compressStream2 -> heap-use-after-free under ASAN.
-    z.reset();
-  }
-`;
+    })`,
+  30,
+  "crypto.randomBytes(1024 * 1024)",
+);
 
-const brotliFixture = /* js */ `
-  const zlib = require("zlib");
-
-  const buf = Buffer.alloc(2 * 1024 * 1024, "abcdefgh");
-
-  let remaining = 0;
-  for (let i = 0; i < 4; i++) {
-    remaining++;
-    const z = zlib.createBrotliCompress({
+const brotliFixture = fixture(
+  `zlib.createBrotliCompress({
       chunkSize: 1024 * 1024,
       params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 },
-    });
-    z.on("error", () => {});
-    z.on("data", () => {});
-    z.write(buf, () => {
-      z.end();
-      if (--remaining === 0) console.log("OK");
-    });
-    const start = Date.now();
-    while (Date.now() - start < 10) {}
-    // Before the fix this frees the BrotliEncoderState while the worker
-    // thread is inside BrotliEncoderCompressStream.
-    z.reset();
-  }
-`;
+    })`,
+  10,
+  `Buffer.alloc(2 * 1024 * 1024, "abcdefgh")`,
+);
 
-const deflateFixture = /* js */ `
-  const zlib = require("zlib");
-  const crypto = require("crypto");
-
-  const buf = crypto.randomBytes(2 * 1024 * 1024);
-
-  let remaining = 0;
-  for (let i = 0; i < 4; i++) {
-    remaining++;
-    const z = zlib.createDeflate({ chunkSize: 2 * 1024 * 1024, level: 9 });
-    z.on("error", () => {});
-    z.on("data", () => {});
-    z.write(buf, () => {
-      z.end();
-      if (--remaining === 0) console.log("OK");
-    });
-    const start = Date.now();
-    while (Date.now() - start < 10) {}
-    // Before the fix this calls deflateReset() on the z_stream while the
-    // worker thread is inside deflate() -> data race / state corruption.
-    z.reset();
-  }
-`;
+const deflateFixture = fixture(
+  `zlib.createDeflate({ chunkSize: 2 * 1024 * 1024, level: 9 })`,
+  10,
+  "crypto.randomBytes(2 * 1024 * 1024)",
+);
 
 // These tests are intentionally sequential (not test.concurrent): each
 // subprocess launches several threadpool compression jobs at high quality


### PR DESCRIPTION
### Repro

```js
// bun repro.mjs   /   node repro.mjs
import zlib from "node:zlib";
const tryReset = (name, z) => {
  try {
    console.log(`${name}: reset -> returned ${z.reset()} (no throw)`);
  } catch (e) {
    console.log(`${name}: reset -> THREW ${JSON.stringify(e.message)}`);
  }
};

// (1) inside end()'s own 'finish' callback
const z = zlib.createDeflateRaw();
z.resume();
z.write("hello");
z.end(() => tryReset("after-end-finish", z));

// (2) with a queued, un-drained write
const y = zlib.createDeflateRaw({ level: 6 });
y.on("data", () => {});
y.write(Buffer.alloc(300000));
tryReset("write-queued", y);
y.end();
```

```
node v26.3.0:  after-end-finish: reset -> THREW "Cannot reset zlib stream while a write is in progress"
               write-queued:     reset -> THREW "Cannot reset zlib stream while a write is in progress"
bun 1.4.0:     after-end-finish: reset -> returned undefined (no throw)
               write-queued:     reset -> returned undefined (no throw)
```

### Cause

`reset()` mutates the `z_stream` (zlib) or destroys and re-creates the encoder instance (brotli/zstd). While an async write is running on the threadpool that state is owned by the worker thread, so node's native `reset` binding refuses the call with a plain `Error` (no `code`) rather than racing it.

Bun's `CompressionStream::reset` instead set a `pending_reset` flag and replayed the reset once the in-flight write retired, returning `undefined` to the caller. Both states in the repro hit that path: `_final` calls back immediately and `_flush` issues the implicit `Z_FINISH` write from `'prefinish'`, so that write is still outstanding when `end()`'s callback runs; a queued write is outstanding from the moment `write()` returns.

The divergence is observable for zlib, brotli and zstd, compressors and decompressors alike. It only breaks code that uses node's refusal as a "drain first" signal — Bun's output stayed coherent — but the control flow differs.

### Fix

Throw `Cannot reset zlib stream while a write is in progress` from `CompressionStream::reset()` when `write_in_progress` is set, and delete the `pending_reset` deferral, which is unreachable once the call is refused. `pending_close` is untouched: node defers `close()`, it only refuses `reset()`.

`reset()` remains allowed in every state node allows it — before the first write, from the write callback, from a `'data'` handler, and after `flush()` — because `write_in_progress` is cleared before any of those callbacks run.

### Verification

`test/js/node/zlib/zlib-reset-race.test.ts` (the existing home for reset-while-writing) now asserts the refusal in both repro states plus gzip/brotli/zstd, and asserts the four allowed states still succeed. The refused-reset stream is checked to still inflate back byte-exactly.

Its three subprocess fixtures, which spin so the worker thread is mid-compression before calling `reset()`, keep their ASAN regression net: refusing the call is what keeps `reset()` off state `doWork()` still owns. They now assert the throw instead of silence.

<details>
<summary>Every state, bun debug build vs node v26.3.0 (identical)</summary>

```
01 fresh:                    ok
02 write-cb:                 ok
03 data-handler:             ok
04 end-finish deflateRaw:    THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
05 end-finish gunzip:        THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
06 write-queued:             THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
07 write-queued-2:           THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
08 after-end-event:          ok
09 after-flush:              ok
10 brotli write-queued:      THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
10 gzip write-queued:        THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
10 zstd write-queued:        THREW Error(undefined) "Cannot reset zlib stream while a write is in progress"
```

</details>

`bun bd test test/js/node/zlib/zlib-reset-race.test.ts` → 13 pass, and 9 of the 13 fail without the `src/` change. The node suite (`test/js/node/test/parallel/test-zlib-*.js`, 40 files, including `test-zlib-reset-before-write.js`) and `test/regression/brotli-reset-leak.test.ts` stay green.
