### PR TITLE
Bun.serve: keep delivering a request body that is still arriving after the response finishes

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -314,6 +314,10 @@ private:
              * framing. */
             httpResponseData->noBodyStatus = false;
             httpResponseData->closeDelimited = false;
+            /* Likewise per-request: a stale true would keep the previous
+             * request's inStream/onAborted armed past this response's
+             * markDone(), pointing at a freed request context. */
+            httpResponseData->keepRequestBodyOnDone = false;
 
             /* Select the router based on SNI (only possible for SSL) */
             auto *selectedRouter = &httpContextData->router;
@@ -403,6 +407,9 @@ private:
                  * requests on the same socket won't trigger any previously registered behavior */
                 if (fin) {
                     httpResponseData->inStream = nullptr;
+                    /* The body is complete: a later markDone() has nothing left to
+                     * keep armed, so let it disarm onAborted as it normally would. */
+                    httpResponseData->keepRequestBodyOnDone = false;
                 }
             }
             return user;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -300,6 +300,12 @@ private:
             /* Mark pending request and emit it */
             httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 
+            /* A just-routed request is in-flight, never idle. The onData
+             * prologue already cleared isIdle, but a prior request's teardown
+             * earlier in this same segment (markDone(), or a draining request
+             * body finishing) may have set it true again, so closeIdleConnections()
+             * must not see this new request as idle. */
+            httpResponseData->isIdle = false;
 
             /* Mark this response as connectionClose if ancient or connection: close */
             if (httpRequest->isAncient() || httpRequest->getHeader("connection").length() == 5) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -792,12 +792,18 @@ public:
         return this;
     }
 
+    /* Called by the end/tryEnd/sendTerminatingChunk shims as the response
+     * finishes. Honours keepRequestBodyOnDone exactly like markDone(): a
+     * consumer still reading the request body needs onAborted to survive, or
+     * nothing reports the peer going away and its read never settles. */
     HttpResponse* clearOnWritableAndAborted() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
         httpResponseData->writableUserData = nullptr;
-        httpResponseData->onAborted = nullptr;
+        if (!httpResponseData->keepRequestBodyOnDone) {
+            httpResponseData->onAborted = nullptr;
+        }
         httpResponseData->onTimeout = nullptr;
 
         return this;
@@ -830,7 +836,15 @@ public:
      * consumer that is still reading the request body receives the remaining
      * bytes after the response was sent. The caller owns disarming them. */
     void setKeepRequestBodyOnDone(bool value) {
-        getHttpResponseData()->keepRequestBodyOnDone = value;
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        httpResponseData->keepRequestBodyOnDone = value;
+        /* markDone() held the socket non-idle while the body was still owed to a
+         * consumer, and it does not run a second time for this request. Once the
+         * body is no longer kept and the response is done, the socket really is
+         * idle again: closeIdleConnections() has to be able to see it. */
+        if (!value && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING)) {
+            httpResponseData->isIdle = true;
+        }
     }
 
     void* getSocketData() {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -826,6 +826,13 @@ public:
         data->received_bytes_per_timeout = 0;
     }
 
+    /* Keep the request-body and abort handlers armed past markDone(), so a
+     * consumer that is still reading the request body receives the remaining
+     * bytes after the response was sent. The caller owns disarming them. */
+    void setKeepRequestBodyOnDone(bool value) {
+        getHttpResponseData()->keepRequestBodyOnDone = value;
+    }
+
     void* getSocketData() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -43,21 +43,24 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 
     /* When we are done with a response we mark it like so */
     void markDone(uWS::HttpResponse<SSL> *uwsRes) {
-        onAborted = nullptr;
         /* Also remove onWritable so that we do not emit when draining behind the scenes. */
         onWritable = nullptr;
         writableUserData = nullptr;
-        /* Ignore data after this point */
-        inStream = nullptr;
 
         // Ensure we don't call a timeout callback
         onTimeout = nullptr;
+
+        if (!keepRequestBodyOnDone) {
+            onAborted = nullptr;
+            /* Ignore data after this point */
+            inStream = nullptr;
+        }
 
         /* We are done with this request */
         this->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 
         HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
-        httpResponseData->isIdle = true;
+        httpResponseData->isIdle = !keepRequestBodyOnDone;
     }
 
     /* Caller of onWritable. It is possible onWritable calls markDone so we need to borrow it. */
@@ -126,6 +129,12 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * no Content-Length and no chunked framing, then close. Used by node:http
      * when the user removed the framing headers. */
     bool closeDelimited = false;
+    /* Set while a consumer is still reading the request body. markDone() then
+     * keeps inStream armed so the remaining request bytes are delivered after
+     * the response has been sent (node.js delivers them too), and keeps
+     * onAborted armed so the consumer learns when the peer disappears instead
+     * of waiting forever. Reset per request in HttpContext::onData. */
+    bool keepRequestBodyOnDone = false;
 
 #ifdef UWS_WITH_PROXY
     ProxyParser proxyParser;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4068,25 +4068,25 @@ where
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
             } else {
-                {
-                    // Moved out so the Strong (and its underlying GC handle) is
-                    // released at scope exit via `Drop` on `strong::Optional`.
-                    let _strong = core::mem::take(&mut this.request_body_readable_stream_ref);
-                    this.request_body_take_unref();
+                // Moved out so the Strong (and its underlying GC handle) is
+                // released at scope exit via `Drop` on `strong::Optional`.
+                let _strong = core::mem::take(&mut this.request_body_readable_stream_ref);
+                this.request_body_take_unref();
 
-                    readable.value.ensure_still_alive();
-                    if let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr {
-                        // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
-                        // heap `ByteStream` kept alive by `readable` for this call.
-                        let bytes = bun_ptr::BackRef::from(
-                            NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
-                        );
-                        // TODO: properly propagate exception upwards
-                        let _ = bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
-                    }
-                }
-                // Must run on every `last` path: a parked context is only alive
-                // to deliver this chunk. `self` may be freed after it.
+                readable.value.ensure_still_alive();
+                // `finish_request_body_stage` has to run on every `last` path: a
+                // parked context is only alive to deliver this chunk.
+                let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr else {
+                    this.finish_request_body_stage();
+                    return;
+                };
+                // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
+                // heap `ByteStream` kept alive by `readable` for this call.
+                let bytes = bun_ptr::BackRef::from(
+                    NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
+                );
+                // TODO: properly propagate exception upwards
+                let _ = bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
                 this.finish_request_body_stage();
             }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2452,14 +2452,17 @@ where
         {
             return false;
         }
-        // Nothing is left to read the body on once the socket goes away.
-        if self.resp.is_none() || self.should_close_connection() {
-            return false;
-        }
         // `mark_request_body_consumer` set this when the consumer appeared,
         // which is what keeps uws's `inStream`/`onAborted` alive across the
-        // response's `markDone()`. Without it there is nothing to park on.
+        // response's `markDone()`. Without it there is nothing to park on —
+        // and no proof that `resp` is still a live socket, so this has to come
+        // before anything dereferences it (`end_already_responded_stream`
+        // reaches here with a `resp` that may already be freed).
         if !self.flags.has_body_abort_handler() || !self.request_body_has_pending_consumer() {
+            return false;
+        }
+        // Nothing is left to read the body on once the socket goes away.
+        if self.resp.is_none() || self.should_close_connection() {
             return false;
         }
         ctx_log!("parkForRequestBodyDrain");
@@ -2482,6 +2485,14 @@ where
     /// path handed us. `self` may be freed: do not touch it afterwards.
     fn finish_request_body_drain(&mut self) {
         debug_assert!(self.flags.is_draining_request_body());
+        if let Some(resp) = self.resp {
+            // uws disarms the idle timeout when it hands over the body's last
+            // chunk, expecting the response on its way out to re-arm it. Ours
+            // already went out, so nothing else will, and the keep-alive socket
+            // would never be reaped.
+            // SAFETY: FFI handle; `is_draining_request_body` proves it is live.
+            resp.reset_timeout();
+        }
         self.detach_response();
         self.deref();
     }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1144,7 +1144,11 @@ where
     pub fn end(&mut self, data: &[u8], close_connection: bool) {
         ctx_log!("end");
         if let Some(resp) = self.resp {
-            self.detach_response();
+            if self.detach_response_after_complete(close_connection) {
+                // SAFETY: FFI handle
+                resp.end(data, close_connection);
+                return;
+            }
             self.end_request_streaming_and_drain();
             // SAFETY: FFI handle
             resp.end(data, close_connection);
@@ -1157,13 +1161,18 @@ where
     pub fn end_stream(&mut self, close_connection: bool) {
         ctx_log!("endStream");
         if let Some(resp) = self.resp {
-            self.detach_response();
-            self.end_request_streaming_and_drain();
+            let parked = self.detach_response_after_complete(close_connection);
+            if !parked {
+                self.end_request_streaming_and_drain();
+            }
             // This will send a terminating 0\r\n\r\n chunk to the client
             // We only want to do that if they're still expecting a body
             // We cannot call this function if the Content-Length header was previously set
             if resp.state().is_response_pending() {
                 resp.end_stream(close_connection);
+            }
+            if parked {
+                return;
             }
             // No early returns above; explicit deref instead of a scopeguard
             // that would alias `&mut self` through a captured raw pointer.
@@ -1190,6 +1199,21 @@ where
     pub fn end_already_responded_stream(&mut self) {
         ctx_log!("endAlreadyRespondedStream");
         debug_assert!(!HTTP3);
+        if self.resp.is_none() {
+            return;
+        }
+        // `has_body_abort_handler` means uws kept `onAborted` armed across
+        // `markDone()`, which proves the socket is still alive (`on_abort`
+        // would have nulled `resp`). Both branches below may touch `resp`.
+        if self.park_for_request_body_drain(false) {
+            return;
+        }
+        if self.flags.has_body_abort_handler() {
+            self.detach_response();
+            self.end_request_streaming_and_drain();
+            self.deref();
+            return;
+        }
         if self.resp.take().is_some() {
             self.flags.set_is_waiting_for_request_body(false);
             self.flags.set_has_abort_handler(false);
@@ -1205,7 +1229,11 @@ where
     pub fn end_without_body(&mut self, close_connection: bool) {
         ctx_log!("endWithoutBody");
         if let Some(resp) = self.resp {
-            self.detach_response();
+            if self.detach_response_after_complete(close_connection) {
+                // SAFETY: FFI handle
+                resp.end_without_body(close_connection);
+                return;
+            }
             self.end_request_streaming_and_drain();
             // SAFETY: FFI handle
             resp.end_without_body(close_connection);
@@ -1634,9 +1662,12 @@ where
         let write_offset: usize = write_offset_ as usize;
 
         let bytes = &bytes_[bytes_.len().min(write_offset)..];
+        let close_connection = self.should_close_connection();
         // SAFETY: FFI handle
-        if resp.try_end(bytes, bytes_.len(), self.should_close_connection()) {
-            self.detach_response();
+        if resp.try_end(bytes, bytes_.len(), close_connection) {
+            if self.detach_response_after_complete(close_connection) {
+                return true;
+            }
             self.end_request_streaming_and_drain();
             self.deref();
             true
@@ -1671,7 +1702,9 @@ where
         let done = resp.try_end(bytes, total_len, close_connection);
         if done {
             self.response_buf_owned.clear();
-            self.detach_response();
+            if self.detach_response_after_complete(close_connection) {
+                return true;
+            }
             self.end_request_streaming_and_drain();
             self.deref();
         } else {
@@ -1910,6 +1943,9 @@ where
         self.flags.set_has_abort_handler(true);
         self.flags.set_has_marked_pending(true);
 
+        // Sendfile never drains a request body: hand uws back the right to
+        // disarm the handlers FileResponseStream is about to take over.
+        self.stop_keeping_request_body();
         if self.flags.is_waiting_for_request_body() {
             self.flags.set_is_waiting_for_request_body(false);
             resp.clear_on_data();
@@ -2342,6 +2378,125 @@ where
         }
     }
 
+    /// A `.text()`/`.json()`/… promise or a `req.body` stream is waiting on
+    /// request bytes. `Body::Value::Locked` on its own is not enough: every
+    /// request carrying a body starts out `Locked`, even when nobody reads it.
+    fn request_body_has_pending_consumer(&mut self) -> bool {
+        if self.request_body_readable_stream_ref.has() {
+            return true;
+        }
+        match self.request_body_mut() {
+            Some(Body::Value::Locked(locked)) => locked.promise.is_some() || locked.readable.has(),
+            _ => false,
+        }
+    }
+
+    /// A consumer asked for the request body while it is still arriving. Tell
+    /// uws to keep feeding us once the response is finished (node.js keeps
+    /// delivering request bytes past `res.end()`) and arm `onAborted` so the
+    /// consumer is rejected when the peer disappears instead of waiting
+    /// forever.
+    ///
+    /// Invariant: `has_body_abort_handler()` is set exactly while uws's
+    /// `keepRequestBodyOnDone` is, and implies `onAborted` is armed — which in
+    /// turn means `resp` cannot be a freed socket, since `on_abort` nulls it.
+    /// [`stop_keeping_request_body`] and [`detach_response`] undo both.
+    fn mark_request_body_consumer(&mut self) {
+        if HTTP3 || self.flags.has_body_abort_handler() || !self.flags.is_waiting_for_request_body()
+        {
+            return;
+        }
+        let Some(resp) = self.resp else { return };
+        self.flags.set_has_body_abort_handler(true);
+        // SAFETY: FFI handle valid while resp is Some
+        resp.set_keep_request_body_on_done(true);
+        if !self.flags.has_abort_handler() {
+            resp.on_aborted(|this, resp| Self::on_abort(this, resp), self);
+        }
+    }
+
+    /// Undo [`mark_request_body_consumer`] while `resp` is still live: the body
+    /// is complete (or will never be read), so uws may disarm the handlers on
+    /// the next `markDone()` as it normally would.
+    fn stop_keeping_request_body(&mut self) {
+        if !self.flags.has_body_abort_handler() {
+            return;
+        }
+        self.flags.set_has_body_abort_handler(false);
+        let Some(resp) = self.resp else { return };
+        // SAFETY: FFI handle
+        resp.set_keep_request_body_on_done(false);
+        if !self.flags.has_abort_handler() {
+            // It was armed only to report the peer going away mid-body.
+            resp.clear_aborted();
+        }
+    }
+
+    /// The response finished cleanly while a consumer is still waiting on
+    /// request bytes that have not arrived. Stay alive (and keep uws's body
+    /// handler armed) until the body completes or the peer goes away, instead
+    /// of rejecting a body the client is still happily sending.
+    ///
+    /// Returns `true` when parked: the caller must not tear the request body
+    /// down or `deref()` — [`on_buffered_body_chunk`] and [`on_abort`] take
+    /// over that ref.
+    fn park_for_request_body_drain(&mut self, close_connection: bool) -> bool {
+        if HTTP3
+            || close_connection
+            || self.flags.aborted()
+            || self.flags.is_draining_request_body()
+            || !self.flags.is_waiting_for_request_body()
+            || self.server.is_none()
+            // SAFETY: BACKREF, just checked Some
+            || self.server().terminated()
+        {
+            return false;
+        }
+        // Nothing is left to read the body on once the socket goes away.
+        if self.resp.is_none() || self.should_close_connection() {
+            return false;
+        }
+        // `mark_request_body_consumer` set this when the consumer appeared,
+        // which is what keeps uws's `inStream`/`onAborted` alive across the
+        // response's `markDone()`. Without it there is nothing to park on.
+        if !self.flags.has_body_abort_handler() || !self.request_body_has_pending_consumer() {
+            return false;
+        }
+        ctx_log!("parkForRequestBodyDrain");
+        self.flags.set_is_draining_request_body(true);
+        true
+    }
+
+    /// Response-completion teardown. Parks instead when the request body is
+    /// still owed to a consumer; `true` means the caller must skip its
+    /// `end_request_streaming*()` and `deref()`.
+    fn detach_response_after_complete(&mut self, close_connection: bool) -> bool {
+        if self.park_for_request_body_drain(close_connection) {
+            return true;
+        }
+        self.detach_response();
+        false
+    }
+
+    /// The parked request body finished. Release the base ref the completion
+    /// path handed us. `self` may be freed: do not touch it afterwards.
+    fn finish_request_body_drain(&mut self) {
+        debug_assert!(self.flags.is_draining_request_body());
+        self.detach_response();
+        self.deref();
+    }
+
+    /// The last request-body chunk was handed to its consumer. `self` may be
+    /// freed when the context was only alive to finish that delivery: do not
+    /// touch it afterwards.
+    fn finish_request_body_stage(&mut self) {
+        if self.flags.is_draining_request_body() {
+            self.finish_request_body_drain();
+        } else {
+            self.stop_keeping_request_body();
+        }
+    }
+
     fn end_request_streaming(&mut self) -> JsResult<bool> {
         debug_assert!(self.server.is_some());
 
@@ -2369,11 +2524,22 @@ where
         self.request_body_buf = Vec::new();
 
         if let Some(resp) = self.resp.take() {
-            if self.flags.is_waiting_for_request_body() {
+            // `mark_request_body_consumer` asked uws to keep `inStream` and
+            // `onAborted` armed past `markDone()`. Either flag proves `resp` is
+            // a live socket (on_abort nulls it), so disarm both here rather
+            // than leave them pointing at a context on its way to the pool.
+            let body_handlers_kept =
+                self.flags.has_body_abort_handler() || self.flags.is_draining_request_body();
+            if body_handlers_kept {
+                self.flags.set_has_body_abort_handler(false);
+                self.flags.set_is_draining_request_body(false);
+                resp.set_keep_request_body_on_done(false);
+            }
+            if self.flags.is_waiting_for_request_body() || body_handlers_kept {
                 self.flags.set_is_waiting_for_request_body(false);
                 resp.clear_on_data();
             }
-            if self.flags.has_abort_handler() {
+            if self.flags.has_abort_handler() || body_handlers_kept {
                 resp.clear_aborted();
                 self.flags.set_has_abort_handler(false);
             }
@@ -2386,8 +2552,11 @@ where
 
     pub fn is_aborted_or_ended(&self) -> bool {
         // resp == null or aborted or server.stop(true)
+        // A draining context still holds `resp` (uws keeps feeding it the
+        // request body), but the response itself is finished and unwritable.
         self.resp.is_none()
             || self.flags.aborted()
+            || self.flags.is_draining_request_body()
             || self.server.is_none()
             // SAFETY: BACKREF, just checked Some
             || self.server().terminated()
@@ -3749,9 +3918,11 @@ where
         // outlive the `try_end`/`on_writable` calls below; detaching the
         // borrow lets `&mut *self` reborrow disjoint fields without aliasing.
         let bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(self.blob.slice()) };
+        let mut close_connection = false;
         if let Some(resp) = self.resp {
+            close_connection = self.should_close_connection();
             // SAFETY: FFI handle
-            if !resp.try_end(bytes, bytes.len(), self.should_close_connection()) {
+            if !resp.try_end(bytes, bytes.len(), close_connection) {
                 self.flags.set_has_marked_pending(true);
                 // SAFETY: FFI handle
                 resp.on_writable(
@@ -3761,7 +3932,9 @@ where
                 return;
             }
         }
-        self.detach_response();
+        if self.detach_response_after_complete(close_connection) {
+            return;
+        }
         self.end_request_streaming_and_drain();
         self.deref();
     }
@@ -3804,7 +3977,10 @@ where
         debug_assert!(this.resp.is_some());
 
         this.flags.set_is_waiting_for_request_body(!last);
-        if this.is_aborted_or_ended() || this.flags.has_marked_complete() {
+        // A draining context reports ended (its response is finished and
+        // unwritable) but these bytes are exactly what it is still alive for.
+        let draining = this.flags.is_draining_request_body();
+        if (this.is_aborted_or_ended() && !draining) || this.flags.has_marked_complete() {
             return;
         }
         if !last && chunk.is_empty() {
@@ -3812,6 +3988,11 @@ where
             // We have to ignore those chunks unless it's the last one
             return;
         }
+        // Handing the chunk to its consumer runs user JS, which drains
+        // microtasks and can therefore observe a socket close (`on_abort`) and
+        // release the last ref before the bookkeeping below runs. Borrow one.
+        this.ref_();
+        let _ref = RequestContextRef(std::ptr::from_mut::<Self>(this));
         // SAFETY: BACKREF
         let server = this.server();
         let vm = server.vm();
@@ -3850,6 +4031,12 @@ where
                     err.reset();
                 }
 
+                if draining {
+                    // The response already went out; there is no 413 to send.
+                    this.finish_request_body_stage();
+                    return;
+                }
+
                 // Route through the normal end path so this.resp is detached
                 // and the base ref released (see the buffering branch below).
                 // SAFETY: FFI handle
@@ -3881,22 +4068,26 @@ where
                 // TODO: properly propagate exception upwards
                 let _ = bytes.on_data(WebCore::streams::Result::Temporary(borrowed));
             } else {
-                // Moved out so the Strong (and its underlying GC handle) is
-                // released at scope exit via `Drop` on `strong::Optional`.
-                let _strong = core::mem::take(&mut this.request_body_readable_stream_ref);
-                this.request_body_take_unref();
+                {
+                    // Moved out so the Strong (and its underlying GC handle) is
+                    // released at scope exit via `Drop` on `strong::Optional`.
+                    let _strong = core::mem::take(&mut this.request_body_readable_stream_ref);
+                    this.request_body_take_unref();
 
-                readable.value.ensure_still_alive();
-                let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr else {
-                    return;
-                };
-                // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
-                // heap `ByteStream` kept alive by `readable` for this call.
-                let bytes = bun_ptr::BackRef::from(
-                    NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
-                );
-                // TODO: properly propagate exception upwards
-                let _ = bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
+                    readable.value.ensure_still_alive();
+                    if let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr {
+                        // BACKREF: `Source::Bytes` payload is the live non-null `m_ctx`
+                        // heap `ByteStream` kept alive by `readable` for this call.
+                        let bytes = bun_ptr::BackRef::from(
+                            NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
+                        );
+                        // TODO: properly propagate exception upwards
+                        let _ = bytes.on_data(WebCore::streams::Result::TemporaryAndDone(borrowed));
+                    }
+                }
+                // Must run on every `last` path: a parked context is only alive
+                // to deliver this chunk. `self` may be freed after it.
+                this.finish_request_body_stage();
             }
 
             return;
@@ -3928,6 +4119,12 @@ where
                     )),
                     global_this,
                 );
+
+                if draining {
+                    // The response already went out; there is no 413 to send.
+                    this.finish_request_body_stage();
+                    return;
+                }
 
                 // Route through the normal end path so this.resp is
                 // detached and the base ref released. Writing directly on
@@ -3974,6 +4171,7 @@ where
 
                     let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
                 }
+                this.finish_request_body_stage();
                 return;
             }
 
@@ -3989,9 +4187,12 @@ where
 
     pub fn on_start_streaming_request_body(&mut self) -> WebCore::DrainResult {
         ctx_log!("onStartStreamingRequestBody");
-        if self.is_aborted_or_ended() {
+        // A draining context reports ended (the response is unwritable) but the
+        // request body is exactly what it is still alive for.
+        if self.is_aborted_or_ended() && !self.flags.is_draining_request_body() {
             return WebCore::DrainResult::Aborted;
         }
+        self.mark_request_body_consumer();
 
         // This means we have received part of the body but not the whole thing
         if !self.request_body_buf.is_empty() {
@@ -4037,7 +4238,9 @@ where
                     let _ = Body::Value::resolve(&mut old, &mut new_body, global_this, None); // TODO: properly propagate exception upwards
                     *body = new_body;
                 }
+                return;
             }
+            self.mark_request_body_consumer();
         }
     }
 
@@ -4054,6 +4257,7 @@ where
         debug_assert!(!this.request_body_readable_stream_ref.has());
         this.request_body_readable_stream_ref =
             readable_stream::Strong::init(readable, global_this);
+        this.mark_request_body_consumer();
     }
 
     /// # Safety
@@ -4321,7 +4525,7 @@ pub struct SendfileContext {
 // `is_web_browser_navigation` / `has_finalized` accessors on the const params.
 bitflags::bitflags! {
     #[derive(Default, Clone, Copy)]
-    pub struct FlagsBits: u16 {
+    pub struct FlagsBits: u32 {
         const HAS_MARKED_COMPLETE         = 1 << 0;
         const HAS_MARKED_PENDING          = 1 << 1;
         const HAS_ABORT_HANDLER           = 1 << 2;
@@ -4342,6 +4546,13 @@ bitflags::bitflags! {
         const ABORTED                     = 1 << 13;
         const HAS_FINALIZED               = 1 << 14;
         const IS_ERROR_PROMISE_PENDING    = 1 << 15;
+        /// uws `onAborted` armed purely so a pending request-body read learns
+        /// when the peer disappears. Tracked apart from `HAS_ABORT_HANDLER`,
+        /// which additionally means "the request went async".
+        const HAS_BODY_ABORT_HANDLER      = 1 << 16;
+        /// The response is finished, but the request body is still arriving
+        /// and a consumer is waiting for it, so the context stays alive.
+        const IS_DRAINING_REQUEST_BODY    = 1 << 17;
     }
 }
 
@@ -4420,6 +4631,16 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
         is_error_promise_pending,
         set_is_error_promise_pending,
         IS_ERROR_PROMISE_PENDING
+    );
+    flag_accessor!(
+        has_body_abort_handler,
+        set_has_body_abort_handler,
+        HAS_BODY_ABORT_HANDLER
+    );
+    flag_accessor!(
+        is_draining_request_body,
+        set_is_draining_request_body,
+        IS_DRAINING_REQUEST_BODY
     );
 
     #[inline]

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -475,6 +475,13 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_on_data(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
+    /// Keep `on_data`/`on_aborted` armed once the response is finished, so a
+    /// consumer still reading the request body receives the remaining bytes.
+    /// The caller owns disarming them when the body completes.
+    pub fn set_keep_request_body_on_done(&mut self, value: bool) {
+        c::uws_res_set_keep_request_body_on_done(Self::ssl_flag(), self.as_raw(), value)
+    }
+
     pub fn on_data<U, H>(&mut self, _handler: H, optional_data: *mut U)
     where
         H: Fn(*mut U, &mut Response<SSL>, &[u8], bool) + Copy + 'static,
@@ -895,6 +902,24 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.clear_on_data())
     }
 
+    /// Keep `on_data`/`on_aborted` armed once the response is finished, so a
+    /// consumer still reading the request body receives the remaining bytes.
+    /// The caller owns disarming them when the body completes.
+    ///
+    /// HTTP/3 has no equivalent: the QUIC stream carries the body and is torn
+    /// down with the response, so callers gate this on `!HTTP3`.
+    pub fn set_keep_request_body_on_done(self, value: bool) {
+        match self {
+            AnyResponse::SSL(ptr) => {
+                TLSResponse::as_handle(ptr).set_keep_request_body_on_done(value)
+            }
+            AnyResponse::TCP(ptr) => {
+                TCPResponse::as_handle(ptr).set_keep_request_body_on_done(value)
+            }
+            AnyResponse::H3(_) => {}
+        }
+    }
+
     pub fn is_connect_request(self) -> bool {
         any_dispatch!(self, |r| r.is_connect_request())
     }
@@ -1151,6 +1176,11 @@ pub mod c {
                 unsafe extern "C" fn(*mut uws_res, *const u8, usize, bool, *mut c_void),
             >,
             optional_data: *mut c_void,
+        );
+        pub(crate) safe fn uws_res_set_keep_request_body_on_done(
+            ssl: i32,
+            res: &mut uws_res,
+            value: bool,
         );
         pub(crate) fn uws_res_upgrade(
             ssl: i32,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1545,6 +1545,18 @@ extern "C"
     }
   }
 
+  void uws_res_set_keep_request_body_on_done(int ssl, uws_res_r res, bool value)
+  {
+    if (ssl)
+    {
+      ((uWS::HttpResponse<true> *)res)->setKeepRequestBodyOnDone(value);
+    }
+    else
+    {
+      ((uWS::HttpResponse<false> *)res)->setKeepRequestBodyOnDone(value);
+    }
+  }
+
   bool uws_req_is_ancient(uws_req_t *res)
   {
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;

--- a/test/js/bun/http/serve-request-body-after-response.test.ts
+++ b/test/js/bun/http/serve-request-body-after-response.test.ts
@@ -21,50 +21,139 @@ describe("request body outliving the response", () => {
   function rawClient(port: number) {
     const socket = net.connect(port, "127.0.0.1");
     let buffer = "";
-    let pending: { count: number; resolve: () => void } | null = null;
+    let expected = 0;
+    let pending: { resolve: () => void; reject: (err: Error) => void } | null = null;
+    let closedByUs = false;
     const responseCount = () => (buffer.match(/HTTP\/1\.1 \d{3}/g) || []).length;
+
+    // A waiter that only ever resolves turns a server-side regression into an
+    // opaque test timeout; settle it on every way the socket can fail too.
+    const settle = (err?: Error) => {
+      if (!pending) return;
+      const { resolve, reject } = pending;
+      pending = null;
+      if (err) reject(err);
+      else resolve();
+    };
     socket.on("data", chunk => {
       buffer += chunk;
-      if (pending && responseCount() >= pending.count) {
-        const { resolve } = pending;
-        pending = null;
-        resolve();
-      }
+      if (responseCount() >= expected) settle();
     });
-    socket.on("error", () => {});
+    const fail = (err: Error) => {
+      if (!closedByUs) settle(err);
+    };
+    socket.on("error", err => fail(err));
+    socket.on("close", () => fail(new Error(`socket closed after ${responseCount()} response(s)`)));
+
+    const destroy = () => {
+      closedByUs = true;
+      socket.destroy();
+    };
     return {
-      connected: new Promise<void>(resolve => socket.on("connect", () => resolve())),
+      connected: new Promise<void>((resolve, reject) => {
+        socket.on("connect", () => resolve());
+        socket.on("error", reject);
+      }),
       write: (data: string) => socket.write(data),
       waitForResponses(count: number) {
         if (responseCount() >= count) return Promise.resolve();
-        const { promise, resolve } = Promise.withResolvers<void>();
-        pending = { count, resolve };
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        expected = count;
+        pending = { resolve, reject };
         return promise;
       },
-      destroy: () => socket.destroy(),
-      [Symbol.dispose]: () => socket.destroy(),
+      destroy,
+      [Symbol.dispose]: destroy,
     };
   }
 
-  function serveReadingBodyLate(read: (req: Request) => Promise<string>) {
+  // Each shape reaches the parking path through a different uws call, and the
+  // first two differ in whether `to_async()` has already armed the abort handler
+  // by the time the response is rendered:
+  //   sync               - renders inside the request callback, try_end()
+  //   async              - renders from a later microtask, try_end()
+  //   streaming-response - renders from a later microtask, end_stream()
+  type Shape = "sync" | "async" | "streaming-response";
+  const shapes: Shape[] = ["sync", "async", "streaming-response"];
+
+  function serveReadingBodyLate(shape: Shape, read: (req: Request) => Promise<string> = req => req.text()) {
     const body = Promise.withResolvers<string>();
-    const handlerRan = Promise.withResolvers<{ abortedDuringHandler: boolean }>();
+    const responded = Promise.withResolvers<{ abortedDuringHandler: boolean }>();
+
+    // Start reading the body, then answer before it has been consumed.
+    const startReading = (req: Request) => {
+      read(req).then(body.resolve, (err: Error) => body.resolve(`${err.name}: ${err.message}`));
+      return { abortedDuringHandler: req.signal.aborted };
+    };
+    const early = () => new Response("early");
+    const earlyStream = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("early"));
+            controller.close();
+          },
+        }),
+      );
+
+    const syncFetch = (req: Request) => {
+      if (new URL(req.url).pathname !== "/late") return new Response("next");
+      responded.resolve(startReading(req));
+      return early();
+    };
+    const asyncFetch = async (req: Request) => {
+      if (new URL(req.url).pathname !== "/late") return new Response("next");
+      const state = startReading(req);
+      // Resume on a later loop turn so the response renders after `to_async()`.
+      await new Promise<void>(resolve => setImmediate(resolve));
+      responded.resolve(state);
+      return shape === "streaming-response" ? earlyStream() : early();
+    };
+
     const server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
-      fetch(req) {
-        if (new URL(req.url).pathname !== "/late") return new Response("next");
-        // Start reading, then answer before the body has been consumed.
-        read(req).then(body.resolve, err => body.resolve(`${err.name}: ${err.message}`));
-        handlerRan.resolve({ abortedDuringHandler: req.signal.aborted });
-        return new Response("early");
-      },
+      fetch: shape === "sync" ? syncFetch : asyncFetch,
     });
-    return { server, body: body.promise, handlerRan: handlerRan.promise };
+    return { server, body: body.promise, responded: responded.promise };
   }
 
+  describe.each(shapes)("%s handler", shape => {
+    it("delivers a body that arrives after the response was sent", async () => {
+      const { server, body, responded } = serveReadingBodyLate(shape);
+      using _ = server;
+      using client = rawClient(server.port);
+      await client.connected;
+
+      client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\n");
+      expect(await responded).toEqual({ abortedDuringHandler: false });
+      await client.waitForResponses(1);
+      client.write("HELLO-WORLD!");
+
+      expect(await body).toBe("HELLO-WORLD!");
+      await waitForPendingRequests(server, 0);
+    });
+
+    it("rejects the pending body read when the client disconnects mid-upload", async () => {
+      const { server, body, responded } = serveReadingBodyLate(shape);
+      using _ = server;
+      const client = rawClient(server.port);
+      await client.connected;
+
+      // Promise a 12 byte body, send 5, then vanish.
+      client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO");
+      await responded;
+      await client.waitForResponses(1);
+      client.destroy();
+
+      expect(await body).toBe("AbortError: The connection was closed.");
+      // The read settling is not enough: the parked context must be released too.
+      await waitForPendingRequests(server, 0);
+    });
+  });
+
   it("resolves req.text() when the body arrives in the same packet as the headers", async () => {
-    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
+    const { server, body, responded } = serveReadingBodyLate("sync");
     using _ = server;
     using client = rawClient(server.port);
     await client.connected;
@@ -72,7 +161,7 @@ describe("request body outliving the response", () => {
     client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO-WORLD!");
 
     expect(await body).toBe("HELLO-WORLD!");
-    expect(await handlerRan).toEqual({ abortedDuringHandler: false });
+    expect(await responded).toEqual({ abortedDuringHandler: false });
 
     // The connection is still usable: the next keep-alive request is served.
     await client.waitForResponses(1);
@@ -84,22 +173,8 @@ describe("request body outliving the response", () => {
     await waitForPendingRequests(server, 0);
   });
 
-  it("resolves req.text() when the body arrives after the response was sent", async () => {
-    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
-    using _ = server;
-    using client = rawClient(server.port);
-    await client.connected;
-
-    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\n");
-    await handlerRan;
-    await client.waitForResponses(1);
-    client.write("HELLO-WORLD!");
-
-    expect(await body).toBe("HELLO-WORLD!");
-  });
-
   it("delivers a streamed req.body after the response was sent", async () => {
-    const { server, body } = serveReadingBodyLate(async req => {
+    const { server, body, responded } = serveReadingBodyLate("async", async req => {
       const chunks: Uint8Array[] = [];
       for await (const chunk of req.body!) chunks.push(chunk);
       return Buffer.concat(chunks).toString();
@@ -108,24 +183,12 @@ describe("request body outliving the response", () => {
     using client = rawClient(server.port);
     await client.connected;
 
-    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO-WORLD!");
+    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\n");
+    await responded;
+    await client.waitForResponses(1);
+    client.write("HELLO-WORLD!");
 
     expect(await body).toBe("HELLO-WORLD!");
-  });
-
-  it("still rejects the pending body read when the client disconnects mid-upload", async () => {
-    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
-    using _ = server;
-    const client = rawClient(server.port);
-    await client.connected;
-
-    // Promise a 12 byte body, send 5, then vanish.
-    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO");
-    await handlerRan;
-    await client.waitForResponses(1);
-    client.destroy();
-
-    expect(await body).toBe("AbortError: The connection was closed.");
     await waitForPendingRequests(server, 0);
   });
 });

--- a/test/js/bun/http/serve-request-body-after-response.test.ts
+++ b/test/js/bun/http/serve-request-body-after-response.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+
+// A request body that is still arriving when the response finishes must keep
+// being delivered to whoever started reading it. Bun used to reject the pending
+// read with "AbortError: The connection was closed." even though the client was
+// still happily sending on a live keep-alive connection, silently losing the
+// upload of every "respond 202 now, ingest in the background" handler.
+describe("request body outliving the response", () => {
+  // The parked request is released from inside a uws callback, which can run
+  // after the microtask that settles the body promise; poll rather than assume
+  // the counter already dropped.
+  async function waitForPendingRequests(server: ReturnType<typeof Bun.serve>, expected: number) {
+    for (let i = 0; i < 100; i++) {
+      if (server.pendingRequests === expected) return;
+      await Bun.sleep(10);
+    }
+    throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
+  }
+
+  function rawClient(port: number) {
+    const socket = net.connect(port, "127.0.0.1");
+    let buffer = "";
+    let pending: { count: number; resolve: () => void } | null = null;
+    const responseCount = () => (buffer.match(/HTTP\/1\.1 \d{3}/g) || []).length;
+    socket.on("data", chunk => {
+      buffer += chunk;
+      if (pending && responseCount() >= pending.count) {
+        const { resolve } = pending;
+        pending = null;
+        resolve();
+      }
+    });
+    socket.on("error", () => {});
+    return {
+      connected: new Promise<void>(resolve => socket.on("connect", () => resolve())),
+      write: (data: string) => socket.write(data),
+      waitForResponses(count: number) {
+        if (responseCount() >= count) return Promise.resolve();
+        const { promise, resolve } = Promise.withResolvers<void>();
+        pending = { count, resolve };
+        return promise;
+      },
+      destroy: () => socket.destroy(),
+      [Symbol.dispose]: () => socket.destroy(),
+    };
+  }
+
+  function serveReadingBodyLate(read: (req: Request) => Promise<string>) {
+    const body = Promise.withResolvers<string>();
+    const handlerRan = Promise.withResolvers<{ abortedDuringHandler: boolean }>();
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        if (new URL(req.url).pathname !== "/late") return new Response("next");
+        // Start reading, then answer before the body has been consumed.
+        read(req).then(body.resolve, err => body.resolve(`${err.name}: ${err.message}`));
+        handlerRan.resolve({ abortedDuringHandler: req.signal.aborted });
+        return new Response("early");
+      },
+    });
+    return { server, body: body.promise, handlerRan: handlerRan.promise };
+  }
+
+  it("resolves req.text() when the body arrives in the same packet as the headers", async () => {
+    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
+    using _ = server;
+    using client = rawClient(server.port);
+    await client.connected;
+
+    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO-WORLD!");
+
+    expect(await body).toBe("HELLO-WORLD!");
+    expect(await handlerRan).toEqual({ abortedDuringHandler: false });
+
+    // The connection is still usable: the next keep-alive request is served.
+    await client.waitForResponses(1);
+    client.write("GET /next HTTP/1.1\r\nHost: x\r\n\r\n");
+    await client.waitForResponses(2);
+
+    // Outliving the response must not outlive the body: the request is released
+    // once the last chunk is delivered.
+    await waitForPendingRequests(server, 0);
+  });
+
+  it("resolves req.text() when the body arrives after the response was sent", async () => {
+    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
+    using _ = server;
+    using client = rawClient(server.port);
+    await client.connected;
+
+    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\n");
+    await handlerRan;
+    await client.waitForResponses(1);
+    client.write("HELLO-WORLD!");
+
+    expect(await body).toBe("HELLO-WORLD!");
+  });
+
+  it("delivers a streamed req.body after the response was sent", async () => {
+    const { server, body } = serveReadingBodyLate(async req => {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of req.body!) chunks.push(chunk);
+      return Buffer.concat(chunks).toString();
+    });
+    using _ = server;
+    using client = rawClient(server.port);
+    await client.connected;
+
+    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO-WORLD!");
+
+    expect(await body).toBe("HELLO-WORLD!");
+  });
+
+  it("still rejects the pending body read when the client disconnects mid-upload", async () => {
+    const { server, body, handlerRan } = serveReadingBodyLate(req => req.text());
+    using _ = server;
+    const client = rawClient(server.port);
+    await client.connected;
+
+    // Promise a 12 byte body, send 5, then vanish.
+    client.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO");
+    await handlerRan;
+    await client.waitForResponses(1);
+    client.destroy();
+
+    expect(await body).toBe("AbortError: The connection was closed.");
+    await waitForPendingRequests(server, 0);
+  });
+});

--- a/test/js/bun/http/serve-request-body-after-response.test.ts
+++ b/test/js/bun/http/serve-request-body-after-response.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import net from "node:net";
 
-// A request body that is still arriving when the response finishes must keep
-// being delivered to whoever started reading it. Bun used to reject the pending
-// read with "AbortError: The connection was closed." even though the client was
-// still happily sending on a live keep-alive connection, silently losing the
-// upload of every "respond 202 now, ingest in the background" handler.
+// A handler that starts reading the body but responds early must still receive
+// the rest of it, not a spurious AbortError, while the client keeps uploading
+// on a live keep-alive connection ("respond 202 now, ingest in the background").
 describe("request body outliving the response", () => {
   // The parked request is released from inside a uws callback, which can run
   // after the microtask that settles the body promise; poll rather than assume
@@ -67,12 +65,8 @@ describe("request body outliving the response", () => {
     };
   }
 
-  // Each shape reaches the parking path through a different uws call, and the
-  // first two differ in whether `to_async()` has already armed the abort handler
-  // by the time the response is rendered:
-  //   sync               - renders inside the request callback, try_end()
-  //   async              - renders from a later microtask, try_end()
-  //   streaming-response - renders from a later microtask, end_stream()
+  // Distinct parking paths: sync `try_end()`, async `try_end()` (after
+  // `to_async()` has armed the abort handler), and streaming `end_stream()`.
   type Shape = "sync" | "async" | "streaming-response";
   const shapes: Shape[] = ["sync", "async", "streaming-response"];
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2093,33 +2093,34 @@ describe.concurrent("should error with invalid options", async () => {
     }).toThrow("SNI tls object must have a serverName");
   });
 });
+// The client is still uploading, so the pending read resolves with the bytes it
+// was waiting on rather than being force-rejected (node delivers them too). The
+// point of the test is that the promise settles: it must never be left hanging.
 it.concurrent("should resolve pending promise if requested ended with pending read", async () => {
-  let error: Error;
-  function shouldError(e: Error) {
-    error = e;
-  }
-  let is_done = false;
-  function shouldMarkDone(result: { done: boolean; value: any }) {
-    is_done = result.done;
-  }
+  const read = Promise.withResolvers<{ done: boolean; value: Uint8Array } | string>();
   await runTest(
     {
       fetch(req) {
-        // @ts-ignore
-        req.body?.getReader().read().then(shouldMarkDone).catch(shouldError);
+        req.body
+          ?.getReader()
+          .read()
+          .then(read.resolve, (e: Error) => read.resolve(`${e.name}: ${e.message}`));
         return new Response("OK");
       },
     },
     async server => {
       const response = await fetch(server.url.origin, {
         method: "POST",
-        body: "1".repeat(64 * 1024),
+        body: Buffer.alloc(64 * 1024, "1").toString(),
       });
       const text = await response.text();
       expect(text).toContain("OK");
-      expect(is_done).toBe(false);
-      expect(error).toBeDefined();
-      expect(error.name).toContain("AbortError");
+
+      const result = await read.promise;
+      expect(typeof result).not.toBe("string");
+      const { done, value } = result as { done: boolean; value: Uint8Array };
+      expect(done).toBe(false);
+      expect(value.byteLength).toBeGreaterThan(0);
     },
   );
 });


### PR DESCRIPTION
### Repro

```js
// bun repro.mjs
import * as net from "node:net";
const sleep = ms => new Promise(r => setTimeout(r, ms));

const events = [];
const srv = Bun.serve({
  port: 0, hostname: "127.0.0.1",
  fetch(req) {
    // body consumption STARTED synchronously, inside the handler:
    req.text().then(
      t => events.push(`text() resolved len=${t.length}`),
      e => events.push(`text() REJECTED ${e.name}: ${e.message} (req.signal.aborted=${req.signal.aborted})`),
    );
    return new Response("early"); // respond BEFORE the body is consumed
  },
});

// one keep-alive socket: POST with the FULL 12-byte body in the SAME packet as
// the headers, then a second request to prove the connection survived.
const s = net.connect(srv.port, "127.0.0.1");
s.on("error", () => {});
let out = ""; s.on("data", d => (out += d));
await new Promise(r => s.on("connect", r));
s.write("POST /late HTTP/1.1\r\nHost: x\r\nContent-Length: 12\r\n\r\nHELLO-WORLD!");
await sleep(250);
s.write("GET /next HTTP/1.1\r\nHost: x\r\n\r\n");
await sleep(250); s.end();

console.log("responses on the one connection =", (out.match(/HTTP\/1\.1 200/g) || []).length);
console.log("events:", JSON.stringify(events));
srv.stop(true);
```

Before:

```
responses on the one connection = 2          <- the connection stayed ALIVE
events: ["text() REJECTED AbortError: The connection was closed. (req.signal.aborted=false)"]
```

After:

```
responses on the one connection = 2
events: ["text() resolved len=12"]
```

The body had fully arrived, the client never aborted, `req.signal.aborted` is `false`, and the socket went on to serve the next keep-alive request. The "respond 202 immediately, ingest the upload in the background" pattern lost the body every time, with an error indistinguishable from a real client disconnect.

### Cause

Response completion was treated as request completion.

* uWS's `HttpResponseData::markDone()` (run by `end()`/`tryEnd()`) clears `inStream`, so no further request-body bytes can ever reach the handler once the response is out.
* `RequestContext::end_request_streaming()` then rejects a still-`Locked` request body on every response-finalize path, unconditionally, with `CommonAbortReason::ConnectionClosed`.

A pending read therefore only resolved when the last body chunk happened to land *before* the response finalized — which is why the same `req.text()` resolves fine behind a streaming response that is still open when the bytes arrive.

### Fix

* uWS: add an opt-in `HttpResponseData::keepRequestBodyOnDone`. When set, `markDone()` leaves `inStream` and `onAborted` armed instead of clearing them. It is reset per request in `HttpContext::onData`, and once the parser sees the body's last chunk, so a stale flag can never keep handlers pointing at a freed context.
* `RequestContext` sets it (and arms `onAborted`) the moment a consumer asks for the body — `.text()`, `.json()`, `req.body`, … — while the body is still arriving.
* When the response finishes first, the context now *parks* instead of tearing the body down: it keeps `resp` and the body handler, skips `end_request_streaming()`, and hands its base ref to the body callback. The last chunk releases it; `detach_response()` disarms everything on every other exit.
* A peer that genuinely vanishes mid-upload still rejects the read with `AbortError: The connection was closed.` — now reported by the abort handler that parking keeps armed, rather than guessed at from response completion.

Delivering a chunk runs user JS, which drains microtasks and can observe a socket close (and drop the last ref), so the body callback holds a ref across the delivery. Without it the new path is an ASan use-after-poison.

HTTP/3 is unchanged: the QUIC stream carries the body and is torn down with the response, so parking is gated on `!HTTP3`.

### Verification

`test/js/bun/http/serve-request-body-after-response.test.ts` covers the body arriving in the same packet as the headers, arriving after the response was sent, a streamed `req.body`, and a client that disconnects mid-upload (still rejects, and `server.pendingRequests` returns to 0 in all cases). The first three fail on `main` with `AbortError: The connection was closed.`

`serve.test.ts`'s "should resolve pending promise if requested ended with pending read" asserted the old AbortError; it now asserts the read resolves with the bytes. Its point — that the promise settles rather than hanging — is unchanged.

<details>
<summary>Suites run against the debug+ASan build (failures identical to <code>main</code> / the 1.4.0 release binary)</summary>

| suite | result |
| --- | --- |
| `test/js/bun/http/serve.test.ts` | 242 pass, 4 fail — all 4 also fail on the release binary (IPv6 `requestIP`, root-range port, `bun:info` loopback, `#6583`) |
| `test/js/bun/http/` (dir) | failures byte-identical to `main`'s debug build |
| `test/js/node/http/` | 223 pass / 5 fail on both `main` and this branch |
| `test/js/bun/websocket/` | green on release; the 10s-timeout flakes under ASan differ run to run |

</details>

### Not covered here

bun's `node:http` server has the same defect with a different face: the identical pattern emits `end` with **zero** `data` events (real node delivers the bytes). That one additionally needs the `IncomingMessage` readable to be allowed to flow after `res.end()` — `NodeHTTPResponse` decides "nobody is reading the body" synchronously inside `end()`, before `_read()` has run on its `nextTick` — so it is a separate change on top of the `keepRequestBodyOnDone` mechanism this PR adds. Happy to do it as a follow-up.