### PR TITLE
Bun.serve: report handler errors thrown after server.upgrade()

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -953,7 +953,8 @@ where
     /// dropping it.
     fn report_error_after_upgrade(&self, value: JSValue, is_rejection: bool) {
         debug_assert!(self.did_upgrade_web_socket());
-        if value.is_empty_or_undefined_or_null() {
+        // `throw undefined` still threw; only an absent value has nothing to say.
+        if value.is_empty() {
             return;
         }
         let Some(server) = self.server else { return };

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -947,8 +947,32 @@ where
         Ok(JSValue::UNDEFINED)
     }
 
+    /// `server.upgrade()` detaches the response, so an error produced by the
+    /// handler after a successful upgrade can never reach `error()` or the
+    /// client. Surface it through the uncaught-exception path rather than
+    /// dropping it.
+    fn report_error_after_upgrade(&self, value: JSValue, is_rejection: bool) {
+        debug_assert!(self.did_upgrade_web_socket());
+        if value.is_empty_or_undefined_or_null() {
+            return;
+        }
+        let Some(server) = self.server else { return };
+        // SAFETY: BACKREF
+        let server = &*server;
+        let global_this = server.global_this();
+        // `ServerLike::vm()` is the process-static VM `BackRef`; `as_mut()` is
+        // the single audited `&mut VirtualMachine` accessor.
+        let vm = server.vm().as_mut();
+        let _ = vm.uncaught_exception(global_this, value, is_rejection);
+    }
+
     fn handle_reject(ctx: &mut Self, value: JSValue) {
         if ctx.is_aborted_or_ended() {
+            // The rejection was consumed by this reaction, so the VM's
+            // unhandled-rejection reporter will never see it.
+            if ctx.did_upgrade_web_socket() {
+                ctx.report_error_after_upgrade(value, true);
+            }
             return;
         }
 
@@ -2624,6 +2648,14 @@ where
         ctx.drain_microtasks();
 
         if ctx.is_aborted_or_ended() {
+            // A handler that threw after upgrading has no response left to
+            // write, but the exception still has to be reported. A returned
+            // promise keeps its own rejection reporting, so skip those.
+            if ctx.did_upgrade_web_socket()
+                && let Some(err_value) = response_value.to_error()
+            {
+                ctx.report_error_after_upgrade(err_value, false);
+            }
             return;
         }
         // if you return a Response object or a Promise<Response>

--- a/test/js/bun/http/bun-serve-propagate-errors.test.ts
+++ b/test/js/bun/http/bun-serve-propagate-errors.test.ts
@@ -67,10 +67,12 @@ console.log("ws:" + got);
 server.stop(true);
 `;
 
-const syncRoute = `routes: {
+const thrown = `new Error("throw-after-upgrade")`;
+
+const syncRoute = (value: string) => `routes: {
     "/": (req, server) => {
       server.upgrade(req, { data: {} });
-      throw new Error("throw-after-upgrade");
+      throw ${value};
     },
   },`;
 
@@ -78,24 +80,31 @@ const syncRoute = `routes: {
 // is consumed by Bun's own reaction and never reaches the unhandled-rejection
 // reporter. Bun.sleep() parks the continuation on a macrotask, past the
 // microtask drain; the test waits on the websocket, not on the clock.
-const deferredRoute = `routes: {
+const deferredRoute = (value: string) => `routes: {
     "/": async (req, server) => {
       await Bun.sleep(1);
       server.upgrade(req, { data: {} });
-      throw new Error("throw-after-upgrade");
+      throw ${value};
     },
   },`;
 
-const syncFetch = `fetch(req, server) {
+const syncFetch = (value: string) => `fetch(req, server) {
     server.upgrade(req, { data: {} });
-    throw new Error("throw-after-upgrade");
+    throw ${value};
   },`;
 
 test.each([
-  ["routes handler, sync throw", syncRoute],
-  ["routes handler, upgrade after await", deferredRoute],
-  ["fetch handler, sync throw", syncFetch],
-])("Bun.serve() reports a %s that throws after server.upgrade()", async (_name, handler) => {
+  ["routes handler, sync throw", syncRoute(thrown), "error: throw-after-upgrade"],
+  ["routes handler, upgrade after await", deferredRoute(thrown), "error: throw-after-upgrade"],
+  ["fetch handler, sync throw", syncFetch(thrown), "error: throw-after-upgrade"],
+  // A nullish thrown value is still a thrown value, and the non-upgraded path
+  // reports it, so these must not be filtered out on the way to the reporter.
+  // (on_reject() normalizes a nullish rejection reason to undefined, so the
+  // deferred shape cannot tell `throw null` from `throw undefined`.)
+  ["routes handler, sync throw undefined", syncRoute("undefined"), "error: undefined"],
+  ["routes handler, sync throw null", syncRoute("null"), "error: null"],
+  ["routes handler, throw undefined after await", deferredRoute("undefined"), "error: undefined"],
+])("Bun.serve() reports a %s after server.upgrade()", async (_name, handler, expected) => {
   using dir = tempDir("throw-after-upgrade", {
     "index.ts": afterUpgradeFixture(handler),
   });
@@ -111,7 +120,7 @@ test.each([
 
   // The socket was already handed to the WebSocket, so the upgrade still succeeds.
   expect(stdout).toBe("ws:upgraded\n");
-  expect(stderr).toContain("error: throw-after-upgrade");
+  expect(stderr).toContain(expected);
   expect(exitCode).toBe(1);
 });
 
@@ -119,8 +128,8 @@ test.each([
 // uncaughtException, a rejected handler promise keeps the unhandledRejection
 // origin it would have had if Bun had not consumed the rejection itself.
 test.each([
-  ["sync throw", syncRoute, "uncaughtException"],
-  ["upgrade after await", deferredRoute, "unhandledRejection"],
+  ["sync throw", syncRoute(thrown), "uncaughtException"],
+  ["upgrade after await", deferredRoute(thrown), "unhandledRejection"],
 ])("a %s after server.upgrade() reaches process.on('uncaughtException')", async (_name, handler, origin) => {
   using dir = tempDir("throw-after-upgrade-handler", {
     "index.ts": afterUpgradeFixture(

--- a/test/js/bun/http/bun-serve-propagate-errors.test.ts
+++ b/test/js/bun/http/bun-serve-propagate-errors.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 
 test("Bun.serve() propagates errors to the parent fixture", async () => {
   const code = `import { test } from "bun:test";
@@ -37,4 +37,110 @@ test("Bun.serve() propagates errors to the parent", async () => {
 
   expect(exitCode).toBe(1);
   expect(stderr.toString()).toContain("error: Test failed successfully");
+});
+
+// server.upgrade() detaches the response, so nothing the handler does after it
+// can reach error() or the client. The exception still has to be reported.
+const afterUpgradeFixture = (handler: string, prelude = "") => `
+${prelude}
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  ${handler}
+  websocket: {
+    open(ws) {
+      ws.send("upgraded");
+    },
+    message() {},
+    close() {},
+  },
+});
+
+const { promise, resolve } = Promise.withResolvers();
+const ws = new WebSocket(server.url.href.replace("http", "ws"));
+ws.onmessage = e => resolve(String(e.data));
+ws.onclose = () => resolve("closed-without-message");
+ws.onerror = () => {};
+const got = await promise;
+ws.close();
+console.log("ws:" + got);
+server.stop(true);
+`;
+
+const syncRoute = `routes: {
+    "/": (req, server) => {
+      server.upgrade(req, { data: {} });
+      throw new Error("throw-after-upgrade");
+    },
+  },`;
+
+// The promise is still pending when on_response() inspects it, so the rejection
+// is consumed by Bun's own reaction and never reaches the unhandled-rejection
+// reporter. Bun.sleep() parks the continuation on a macrotask, past the
+// microtask drain; the test waits on the websocket, not on the clock.
+const deferredRoute = `routes: {
+    "/": async (req, server) => {
+      await Bun.sleep(1);
+      server.upgrade(req, { data: {} });
+      throw new Error("throw-after-upgrade");
+    },
+  },`;
+
+const syncFetch = `fetch(req, server) {
+    server.upgrade(req, { data: {} });
+    throw new Error("throw-after-upgrade");
+  },`;
+
+test.each([
+  ["routes handler, sync throw", syncRoute],
+  ["routes handler, upgrade after await", deferredRoute],
+  ["fetch handler, sync throw", syncFetch],
+])("Bun.serve() reports a %s that throws after server.upgrade()", async (_name, handler) => {
+  using dir = tempDir("throw-after-upgrade", {
+    "index.ts": afterUpgradeFixture(handler),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The socket was already handed to the WebSocket, so the upgrade still succeeds.
+  expect(stdout).toBe("ws:upgraded\n");
+  expect(stderr).toContain("error: throw-after-upgrade");
+  expect(exitCode).toBe(1);
+});
+
+// `origin` tells the two shapes apart: a synchronous throw is an
+// uncaughtException, a rejected handler promise keeps the unhandledRejection
+// origin it would have had if Bun had not consumed the rejection itself.
+test.each([
+  ["sync throw", syncRoute, "uncaughtException"],
+  ["upgrade after await", deferredRoute, "unhandledRejection"],
+])("a %s after server.upgrade() reaches process.on('uncaughtException')", async (_name, handler, origin) => {
+  using dir = tempDir("throw-after-upgrade-handler", {
+    "index.ts": afterUpgradeFixture(
+      handler,
+      `process.on("uncaughtException", (err, origin) => {
+         console.log("uncaughtException:" + err.message + ":" + origin);
+       });`,
+    ),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe(`uncaughtException:throw-after-upgrade:${origin}\nws:upgraded\n`);
+  expect(stderr).not.toContain("throw-after-upgrade");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/bun-serve-propagate-errors.test.ts
+++ b/test/js/bun/http/bun-serve-propagate-errors.test.ts
@@ -93,7 +93,7 @@ const syncFetch = (value: string) => `fetch(req, server) {
     throw ${value};
   },`;
 
-test.each([
+test.concurrent.each([
   ["routes handler, sync throw", syncRoute(thrown), "error: throw-after-upgrade"],
   ["routes handler, upgrade after await", deferredRoute(thrown), "error: throw-after-upgrade"],
   ["fetch handler, sync throw", syncFetch(thrown), "error: throw-after-upgrade"],
@@ -127,7 +127,7 @@ test.each([
 // `origin` tells the two shapes apart: a synchronous throw is an
 // uncaughtException, a rejected handler promise keeps the unhandledRejection
 // origin it would have had if Bun had not consumed the rejection itself.
-test.each([
+test.concurrent.each([
   ["sync throw", syncRoute(thrown), "uncaughtException"],
   ["upgrade after await", deferredRoute(thrown), "unhandledRejection"],
 ])("a %s after server.upgrade() reaches process.on('uncaughtException')", async (_name, handler, origin) => {

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -7,13 +7,15 @@ describe("WebSocket upgrade", () => {
       hostname: "localhost",
       port: 0,
       fetch(request, server) {
-        expect(server.upgrade(request)).toBeTrue();
+        // Read the headers before upgrade(): a successful upgrade detaches the
+        // request, so request.headers is no longer reliable afterwards.
         const { headers } = request;
-        expect(headers.get("connection")).toBe("upgrade");
+        expect(headers.get("connection")).toBe("Upgrade");
         expect(headers.get("upgrade")).toBe("websocket");
         expect(headers.get("sec-websocket-version")).toBe("13");
         expect(headers.get("sec-websocket-key")).toBeString();
         expect(headers.get("host")).toBe(`localhost:${server.port}`);
+        expect(server.upgrade(request)).toBeTrue();
         return;
         // FIXME: types gets annoyed if this is not here
         return new Response();

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test";
 describe("WebSocket upgrade", () => {
   test("should send correct upgrade headers", async () => {
     const server = serve({
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: 0,
       fetch(request, server) {
         // Read the headers before upgrade(): a successful upgrade detaches the
@@ -14,7 +14,7 @@ describe("WebSocket upgrade", () => {
         expect(headers.get("upgrade")).toBe("websocket");
         expect(headers.get("sec-websocket-version")).toBe("13");
         expect(headers.get("sec-websocket-key")).toBeString();
-        expect(headers.get("host")).toBe(`localhost:${server.port}`);
+        expect(headers.get("host")).toBe(`127.0.0.1:${server.port}`);
         expect(server.upgrade(request)).toBeTrue();
         return;
         // FIXME: types gets annoyed if this is not here
@@ -30,7 +30,7 @@ describe("WebSocket upgrade", () => {
       },
     });
     await new Promise((resolve, reject) => {
-      const ws = new WebSocket(`ws://localhost:${server.port}/`);
+      const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
       ws.addEventListener("open", resolve);
       ws.addEventListener("error", reject);
       ws.addEventListener("close", reject);


### PR DESCRIPTION
## Repro

A synchronous exception thrown by a route (or `fetch`) handler *after* a successful `server.upgrade()` is reported nowhere: no `error()` call, no `uncaughtException`, nothing on stderr.

```js
Bun.serve({
  port: 0,
  routes: {
    "/": (req, server) => {
      server.upgrade(req, { data: {} }); // -> true, 101 already sent
      throw new Error("throw-after-upgrade"); // vanishes
    },
  },
  websocket: { open(ws) { ws.send("upgraded"); }, message() {}, close() {} },
});
```

This is the post-upgrade bookkeeping shape (`ws.subscribe`, session-map insert, auth accounting) failing right after `upgrade()` returned true: the socket stays open and works, the code after `upgrade()` silently never ran, and there is no trace to debug from.

Two more shapes were affected:

- the same throw from a `fetch` handler;
- `await` something, *then* `upgrade()`, then throw. The handler's promise was still pending when `on_response()` inspected it, so Bun attached its own reaction, consumed the rejection, and dropped it. Nothing surfaced, not even `unhandledRejection`.

## Cause

`server.upgrade()` hands the socket to the WebSocket and clears the response (`upgrader.resp = None`). `RequestContext::is_aborted_or_ended()` is `resp.is_none() || aborted || ...`, so it returns true from that point on. Both places that inspect a handler's value bail on exactly that check, before they ever look at the value:

- `RequestContext::on_response()` returns early, dropping the thrown exception (the caller already turned it into a plain `JSValue` via `global.take_exception()`).
- `RequestContext::handle_reject()` returns early, dropping the rejection reason.

A handler that returns an already-rejected promise happened to escape this, only because `on_response()` returns before attaching a reaction, leaving the VM's unhandled-rejection reporter to pick it up.

## Fix

When the request was upgraded, route the value through the uncaught-exception path instead of discarding it, which is the same mechanism Bun's own websocket `open`/`message`/`close` callback throws already use (`WebSocketServerContext::run_error_callback`).

`error()` is still not called: the 101 went out and no response can replace it. But the exception now reaches `process.on("uncaughtException")` (with `origin` set to `"uncaughtException"` for a throw and `"unhandledRejection"` for a rejected handler promise, matching Node's `(err, origin)` contract), and with no listener it prints to stderr and sets exit code 1 — the same as an uncaught throw from a websocket callback or from a route handler with no `error()` handler.

A nullish thrown value (`throw undefined`, `throw null`, bare `Promise.reject()`) is reported too, since the non-upgraded path reports those; only an absent value is skipped.

## Verification

`test/js/bun/http/bun-serve-propagate-errors.test.ts` covers the three shapes (sync throw in `routes`, sync throw in `fetch`, upgrade-after-await) against stderr + exit code, the nullish values at both call sites, and the `process.on("uncaughtException")` contract for both origins. Each case also asserts the websocket still receives its message, so the fix does not disturb the upgrade itself.

Before: 8 of 9 fail. After: 9 pass.

<details>
<summary>stderr on the unfixed build vs. this branch</summary>

```
# before: nothing
$ bun repro.mjs
/sync -> ["upgraded"]

# after
$ bun repro.mjs
 7 |       throw new Error("throw-after-upgrade");
                     ^
error: throw-after-upgrade
      at / (/tmp/repro.mjs:7:17)
/sync -> ["upgraded"]
```

</details>
