### PR TITLE
Bun.serve: keep static routes ahead of the WebSocket upgrade fallback

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -606,6 +606,15 @@ public:
         return std::move(*this);
     }
 
+    /* A GET handler in the same priority tier as ws() routes. The router sorts high-priority
+     * nodes first, so without this a wildcard ws() route shadows every exact path it overlaps. */
+    TemplatedApp &&getHighPriority(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+        if (httpContext) {
+            httpContext->onHttp("GET", pattern, std::move(handler), true);
+        }
+        return std::move(*this);
+    }
+
     TemplatedApp &&post(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("POST", pattern, std::move(handler));

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -330,6 +330,7 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
     path: &[u8],
     method: http_method::Optional,
     path_has_user_head_route: bool,
+    has_websocket_handler: bool,
 ) where
     T: StaticRouteLike<SSL>,
 {
@@ -398,6 +399,12 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
             }
         }
     }
+    // A WebSocket handshake is a GET, and `ws()` routes claim a higher router priority than the
+    // registrations above, so a `ws("/*")` upgrade fallback would answer it instead of this
+    // route. Claim that tier too, so handshakes are routed like any other GET.
+    if has_websocket_handler && serves_get(&method) {
+        app.get_high_priority(path, Some(handler::<SSL, T>), user_data);
+    }
 }
 
 /// Whether a static route registered for `method` should also answer HEAD.
@@ -407,6 +414,14 @@ fn serves_head(method: &http_method::Optional) -> bool {
         http_method::Optional::Method(set) => {
             set.contains(Method::GET) || set.contains(Method::HEAD)
         }
+    }
+}
+
+/// Whether a static route registered for `method` answers GET.
+fn serves_get(method: &http_method::Optional) -> bool {
+    match method {
+        http_method::Optional::Any => true,
+        http_method::Optional::Method(set) => set.contains(Method::GET),
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2170,6 +2170,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // --- 5. Register static routes & track "/*" coverage ---
         let mut needs_plugins = dev_server.is_some();
         let mut has_static_route_for_star_path = false;
+        let has_websocket_handler = websocket_ptr.is_some();
 
         for entry in &self.config.static_routes {
             if &*entry.path == b"/*" {
@@ -2215,6 +2216,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
+                        has_websocket_handler,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
@@ -2238,6 +2240,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
+                        has_websocket_handler,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {
@@ -2261,6 +2264,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
+                        has_websocket_handler,
                     );
                     if Self::HAS_H3 {
                         if let Some(h3_app) = self.h3_app {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -56,12 +56,13 @@ pub struct App<const SSL: bool> {
 /// Legacy name alias.
 pub type NewApp<const SSL: bool> = App<SSL>;
 
-/// Stamps one `pub fn $name(&mut self, pattern, handler, user_data)` per HTTP
-/// verb. Bodies are byte-identical modulo the C symbol — see `uws_app_get` &co
-/// in capi.rs. uWS copies `pattern` internally, so the slice need only live for
-/// the call.
+/// Stamps one `pub fn $name(&mut self, pattern, handler, user_data)` per route
+/// registration entrypoint. Bodies are byte-identical modulo the C symbol — see
+/// `uws_app_get` &co in capi.rs. uWS copies `pattern` internally, so the slice
+/// need only live for the call.
 macro_rules! uws_app_route_methods {
-    ($($name:ident => $cfn:ident),* $(,)?) => {$(
+    ($($(#[$meta:meta])* $name:ident => $cfn:ident),* $(,)?) => {$(
+        $(#[$meta])*
         pub fn $name(
             &mut self,
             pattern: &[u8],
@@ -191,6 +192,11 @@ impl<const SSL: bool> App<SSL> {
         connect => uws_app_connect,
         trace   => uws_app_trace,
         any     => uws_app_any,
+
+        /// `get()` in the same router priority tier as [`Self::ws`]. The router sorts
+        /// high-priority nodes ahead of everything else, so a `ws("/*")` route otherwise
+        /// shadows every exact path it overlaps for requests carrying a WebSocket handshake.
+        get_high_priority => uws_app_get_high_priority,
     }
 
     /// Alias matching uWS C++ `del()` naming (Rust `delete` is not reserved, but callers
@@ -520,6 +526,14 @@ pub mod c {
             max_header_size: u64,
         );
         pub(crate) fn uws_app_get(
+            ssl: i32,
+            app: *mut uws_app_t,
+            pattern: *const u8,
+            pattern_len: usize,
+            handler: uws_method_handler,
+            user_data: *mut c_void,
+        );
+        pub(crate) fn uws_app_get_high_priority(
             ssl: i32,
             app: *mut uws_app_t,
             pattern: *const u8,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -89,6 +89,33 @@ extern "C"
     }
   }
 
+  void uws_app_get_high_priority(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  {
+    std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      if (handler == nullptr)
+      {
+        uwsApp->getHighPriority(pattern, nullptr);
+        return;
+      }
+      uwsApp->getHighPriority(pattern, [handler, user_data](auto *res, auto *req)
+                              { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      if (handler == nullptr)
+      {
+        uwsApp->getHighPriority(pattern, nullptr);
+        return;
+      }
+      uwsApp->getHighPriority(pattern, [handler, user_data](auto *res, auto *req)
+                              { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
+    }
+  }
+
   void uws_app_post(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1,6 +1,8 @@
 import type { BunRequest, ServeOptions, Server } from "bun";
-import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
 import net from "node:net";
+import { join } from "node:path";
 
 describe("path parameters", () => {
   let server: Server;
@@ -991,4 +993,138 @@ it("routes absolute-form request targets by path and derives request.url from th
     expect(rawUrl.pathname).toBe("/");
     expect(rawUrl.search).toBe(new URL(target).search);
   }
+});
+
+// A WebSocket handshake is a GET, so every route in the table answers it the same way it
+// answers any other GET. Only paths the table does not serve reach `fetch` + `upgrade()`.
+describe("websocket upgrade precedence", () => {
+  /** Sends a well-formed RFC 6455 handshake, resolves with the complete raw response. */
+  function handshake(port: number, path: string): Promise<string> {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const socket = net.connect(port, "127.0.0.1");
+    let raw = "";
+    let done = false;
+    socket.on("error", reject);
+    socket.on("close", () => {
+      if (!done) reject(new Error(`socket closed before the response completed: ${JSON.stringify(raw)}`));
+    });
+    socket.on("data", chunk => {
+      raw += chunk.toString("latin1");
+      const headerEnd = raw.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      const head = raw.slice(0, headerEnd);
+      // A 101 carries no body; anything else is framed by Content-Length.
+      const contentLength = head.startsWith("HTTP/1.1 101")
+        ? 0
+        : Number(/\r\ncontent-length: *(\d+)/i.exec(head)?.[1] ?? -1);
+      if (raw.length - headerEnd - 4 < contentLength) return;
+      done = true;
+      socket.destroy();
+      resolve(raw);
+    });
+    socket.on("connect", () => {
+      socket.write(
+        `GET ${path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+      );
+    });
+    return promise;
+  }
+
+  let server: Server;
+  let upgraded: string[];
+  let firstUpgrade: PromiseWithResolvers<string>;
+
+  beforeAll(() => {
+    const dir = tempDirWithFiles("serve-routes-ws", { "file.txt": "file-body" });
+    server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: {
+        "/static": new Response("static-body"),
+        "/file": new Response(Bun.file(join(dir, "file.txt"))),
+        "/nested/*": new Response("wildcard-body"),
+        "/post-only": { POST: new Response("post-body") },
+        "/handler": () => new Response("handler-body"),
+      },
+      fetch(req, server) {
+        if (server.upgrade(req, { data: { path: new URL(req.url).pathname } })) return;
+        return new Response("fetch-fallback");
+      },
+      websocket: {
+        open(ws) {
+          const { path } = ws.data as { path: string };
+          upgraded.push(path);
+          firstUpgrade.resolve(path);
+          ws.close();
+        },
+        message() {},
+      },
+    });
+    server.unref();
+  });
+
+  beforeEach(() => {
+    upgraded = [];
+    firstUpgrade = Promise.withResolvers<string>();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it.each([
+    ["a static Response route", "/static", "static-body"],
+    ["a Bun.file route", "/file", "file-body"],
+    ["a nested wildcard static route", "/nested/anything", "wildcard-body"],
+    ["a function route", "/handler", "handler-body"],
+  ])("answers a handshake on %s with the route's response", async (_label, path, body) => {
+    expect(await (await fetch(new URL(path, server.url))).text()).toBe(body);
+
+    const response = await handshake(server.port, path);
+    expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
+    expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe(body);
+    expect(upgraded).toEqual([]);
+  });
+
+  it("upgrades a handshake on a path the route table does not serve", async () => {
+    const response = await handshake(server.port, "/unrouted");
+    expect(response.split("\r\n")[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(await firstUpgrade.promise).toBe("/unrouted");
+  });
+
+  it("upgrades a handshake on a static route that does not serve GET", async () => {
+    expect(await (await fetch(new URL("/post-only", server.url))).text()).toBe("fetch-fallback");
+
+    const response = await handshake(server.port, "/post-only");
+    expect(response.split("\r\n")[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(await firstUpgrade.promise).toBe("/post-only");
+  });
+
+  // `"/*"` is the pattern the upgrade fallback itself registers, and uWS keeps the last
+  // registration for a method and pattern, so `fetch` still owns handshakes there.
+  it("upgrades a handshake when a static route is bound to the catch-all pattern", async () => {
+    await using catchAll = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: { "/*": new Response("catch-all-body") },
+      fetch(req, server) {
+        if (server.upgrade(req, { data: { path: new URL(req.url).pathname } })) return;
+        return new Response("fetch-fallback");
+      },
+      websocket: {
+        open(ws) {
+          firstUpgrade.resolve((ws.data as { path: string }).path);
+          ws.close();
+        },
+        message() {},
+      },
+    });
+
+    expect(await (await fetch(new URL("/anything", catchAll.url))).text()).toBe("catch-all-body");
+
+    const response = await handshake(catchAll.port, "/anything");
+    expect(response.split("\r\n")[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(await firstUpgrade.promise).toBe("/anything");
+  });
 });


### PR DESCRIPTION
A static `Response` route bound in `routes` is unreachable for any client that sends a well-formed WebSocket handshake. The request is handed to the `fetch` fallback instead, and with the documented `fetch` + `server.upgrade()` pattern it is upgraded straight into the app's generic `websocket` handler. A function route on the same table answers correctly, so whether the routing contract holds depends on the value type bound to the path.

## Repro

```js
import net from "node:net";

const srv = Bun.serve({
  port: 0, hostname: "127.0.0.1",
  routes: {
    "/static":  new Response("static-body"),        // static Response route
    "/handler": () => new Response("handler-body"), // function route (control)
  },
  fetch(req, s) {
    if (s.upgrade(req, { data: { path: new URL(req.url).pathname } })) return;
    return new Response("FETCH-FALLBACK");
  },
  websocket: { open(ws) { console.log("upgraded:", ws.data.path); }, message() {}, close() {} },
});

const handshake = path => new Promise(done => {
  let out = "";
  const s = net.connect(srv.port, "127.0.0.1", () => s.write(
    `GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
    `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`));
  s.on("data", d => { out += d; if (out.includes("\r\n\r\n")) { s.destroy(); done(out.split("\r\n")[0]); } });
});

console.log("plain GET    /static  ->", await (await fetch(`http://127.0.0.1:${srv.port}/static`)).text());
console.log("ws handshake /handler ->", await handshake("/handler"));
console.log("ws handshake /static  ->", await handshake("/static"));
```

Before:

```
plain GET    /static  -> static-body
ws handshake /handler -> HTTP/1.1 200 OK
upgraded: /static
ws handshake /static  -> HTTP/1.1 101 Switching Protocols   <-- static route bypassed
```

After, `/static` answers `HTTP/1.1 200 OK` with `static-body`, like it does for the plain GET, and nothing is upgraded.

## Cause

`TemplatedApp::ws()` registers its upgrade handler as a GET route with `onHttp(..., /* upgrade */ true)`, which means `HIGH_PRIORITY` in `HttpRouter`. `HttpRouter::getNode` keys nodes on `(name, isHighPriority)` and sorts high-priority children ahead of everything else, and `executeHandlers` walks children in that order. So the high-priority `*` node created by the `ws("/*")` upgrade fallback is visited before the node for any concrete path, and a request carrying a valid `sec-websocket-key` is upgraded there. Without the handshake header that handler calls `setYield(true)` and the router falls through to the static route, which is why a plain GET still works.

`prepare_or_reload_app` registers an `app.ws(path, ...)` alongside every user *function* route, which re-claims that priority tier for those paths. `apply_static_route` (StaticRoute / FileRoute / `html_bundle::Route`) only ever registered HTTP handlers, so static routes had nothing in the tier the fallback sorts into.

## Fix

`apply_static_route` now also registers its GET handler at the ws priority tier, via a new `getHighPriority` entrypoint on the uWS app, when the route serves GET and a `websocket` handler is configured (the only case where a ws route exists to shadow it). A handshake then reaches the static route like any other GET. Two exact-path high-priority nodes sort by the router's existing wildcard-after-alphanum rule, so `/static` still wins over the fallback's `/*`.

One case is deliberately unchanged: a static route bound to exactly `"/*"`. `HttpRouter::add` removes any existing handler for the same method, pattern and priority before inserting, so the later `ws("/*")` fallback registration replaces it. `fetch` therefore keeps owning handshakes on servers that serve an SPA from a `"/*"` route, which is how those servers upgrade today. A test pins it.

HTTP/3 is untouched: `h3::App` has no ws router, so nothing shadows static routes there.

## Verification

`test/js/bun/http/bun-serve-routes.test.ts` gains a `websocket upgrade precedence` block. Against the released binary the three static-route cases fail with `101 Switching Protocols`; the four control cases already pass and must keep passing.

```
(fail) answers a handshake on a static Response route with the route's response
(fail) answers a handshake on a Bun.file route with the route's response
(fail) answers a handshake on a nested wildcard static route with the route's response
(pass) answers a handshake on a function route with the route's response
(pass) upgrades a handshake on a path the route table does not serve
(pass) upgrades a handshake on a static route that does not serve GET
(pass) upgrades a handshake when a static route is bound to the catch-all pattern
```

All seven pass with the fix. `bun-serve-routes.test.ts` (59), `bun-serve-static.test.ts` and `websocket-server.test.ts` are green; `bun-serve-html.test.ts`, `bun-server.test.ts` and `bun-serve-file.test.ts` show the same six failures with and without this diff.