### PR TITLE
tty: track raw mode per handle instead of per process

### DIFF
--- a/src/bun_core/tty.rs
+++ b/src/bun_core/tty.rs
@@ -1,4 +1,3 @@
-use core::cell::RefCell;
 use core::ffi::{c_int, c_void};
 
 // ─── MOVE-IN: Winsize (TYPE_ONLY from bun_sys → bun_core) ─────────────────
@@ -25,32 +24,30 @@ pub enum Mode {
     Io = 2,
 }
 
-/// Raw-mode state for one terminal handle, mirroring libuv's `uv_tty_t`: the
-/// mode this handle last applied plus the termios snapshot it captured on the
-/// way out of [`Mode::Normal`]. Opaque bytes; the C side copies them in and
-/// out, so a handle restoring cooked mode never clobbers another handle's.
+/// Per-handle raw-mode state (libuv's `uv_tty_t` fields): the mode this handle
+/// last applied plus the termios it captured when leaving [`Mode::Normal`].
+/// `#[repr(C)]` layout matches C++ `BunTTYState`.
+#[repr(C)]
+#[derive(Copy, Clone)]
 pub struct State {
-    bytes: RefCell<Box<[u8]>>,
+    mode: c_int,
+    #[cfg(unix)]
+    orig_termios: libc::termios,
 }
+// SAFETY: `c_int` + `libc::termios` (C POD). All-zero is mode Normal, and the
+// termios is only read after the first non-Normal transition has written it.
+unsafe impl crate::ffi::Zeroable for State {}
 
 impl State {
+    #[inline]
     pub fn new() -> Self {
-        Self {
-            bytes: RefCell::new(vec![0u8; Bun__ttyStateSize()].into_boxed_slice()),
-        }
+        crate::ffi::zeroed()
     }
 
-    pub fn set_mode(&self, fd: c_int, mode: Mode) -> c_int {
-        let mut bytes = self.bytes.borrow_mut();
-        // SAFETY: `bytes` is exactly the `Bun__ttyStateSize()` bytes the C side
-        // reads and writes, and the borrow keeps it alive across the call.
-        unsafe { Bun__ttySetMode(fd, mode as c_int, bytes.as_mut_ptr().cast::<c_void>()) }
-    }
-}
-
-impl Default for State {
-    fn default() -> Self {
-        Self::new()
+    #[inline]
+    pub fn set_mode(&mut self, fd: c_int, mode: Mode) -> c_int {
+        // SAFETY: layout matches C++'s `BunTTYState`; `self` outlives the call.
+        unsafe { Bun__ttySetMode(fd, mode as c_int, core::ptr::from_mut(self).cast()) }
     }
 }
 
@@ -64,7 +61,7 @@ pub struct RawModeGuard {
 impl RawModeGuard {
     #[inline]
     pub fn new(fd: c_int) -> Self {
-        let state = State::new();
+        let mut state = State::new();
         let _ = state.set_mode(fd, Mode::Raw);
         Self { fd, state }
     }
@@ -78,6 +75,5 @@ impl Drop for RawModeGuard {
 }
 
 unsafe extern "C" {
-    safe fn Bun__ttyStateSize() -> usize;
     unsafe fn Bun__ttySetMode(fd: c_int, mode: c_int, state: *mut c_void) -> c_int;
 }

--- a/src/bun_core/tty.rs
+++ b/src/bun_core/tty.rs
@@ -1,4 +1,5 @@
-use core::ffi::c_int;
+use core::cell::RefCell;
+use core::ffi::{c_int, c_void};
 
 // ─── MOVE-IN: Winsize (TYPE_ONLY from bun_sys → bun_core) ─────────────────
 // Used by output.rs::TERMINAL_SIZE. Field names
@@ -24,31 +25,59 @@ pub enum Mode {
     Io = 2,
 }
 
-pub fn set_mode(fd: c_int, mode: Mode) -> c_int {
-    Bun__ttySetMode(fd, mode as c_int)
+/// Raw-mode state for one terminal handle, mirroring libuv's `uv_tty_t`: the
+/// mode this handle last applied plus the termios snapshot it captured on the
+/// way out of [`Mode::Normal`]. Opaque bytes; the C side copies them in and
+/// out, so a handle restoring cooked mode never clobbers another handle's.
+pub struct State {
+    bytes: RefCell<Box<[u8]>>,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            bytes: RefCell::new(vec![0u8; Bun__ttyStateSize()].into_boxed_slice()),
+        }
+    }
+
+    pub fn set_mode(&self, fd: c_int, mode: Mode) -> c_int {
+        let mut bytes = self.bytes.borrow_mut();
+        // SAFETY: `bytes` is exactly the `Bun__ttyStateSize()` bytes the C side
+        // reads and writes, and the borrow keeps it alive across the call.
+        unsafe { Bun__ttySetMode(fd, mode as c_int, bytes.as_mut_ptr().cast::<c_void>()) }
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// RAII guard: sets `fd` to [`Mode::Raw`] on construction and restores
 /// [`Mode::Normal`] on `Drop`.
 pub struct RawModeGuard {
     fd: c_int,
+    state: State,
 }
 
 impl RawModeGuard {
     #[inline]
     pub fn new(fd: c_int) -> Self {
-        let _ = set_mode(fd, Mode::Raw);
-        Self { fd }
+        let state = State::new();
+        let _ = state.set_mode(fd, Mode::Raw);
+        Self { fd, state }
     }
 }
 
 impl Drop for RawModeGuard {
     #[inline]
     fn drop(&mut self) {
-        let _ = set_mode(self.fd, Mode::Normal);
+        let _ = self.state.set_mode(self.fd, Mode::Normal);
     }
 }
 
 unsafe extern "C" {
-    safe fn Bun__ttySetMode(fd: c_int, mode: c_int) -> c_int;
+    safe fn Bun__ttyStateSize() -> usize;
+    unsafe fn Bun__ttySetMode(fd: c_int, mode: c_int, state: *mut c_void) -> c_int;
 }

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -7,10 +7,16 @@ const {
   setRawMode: ttySetMode,
   isatty,
   getWindowSize: _getWindowSize,
+  rawModeStateSize,
 } = $cpp("ProcessBindingTTYWrap.cpp", "createBunTTYFunctions");
 
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");
+
+// libuv stores the mode and the saved termios on each uv_tty_t, so a stream
+// going back to cooked never disturbs another one on the same terminal. Keep
+// that state per ReadStream rather than per process.
+const kRawModeState = Symbol("rawModeState");
 
 function ReadStream(fd): void {
   if (!(this instanceof ReadStream)) {
@@ -83,7 +89,8 @@ Object.defineProperty(ReadStream, "prototype", {
           }
         }
       } else {
-        const err = ttySetMode(this.fd, flag);
+        const state = (this[kRawModeState] ??= new Uint8Array(rawModeStateSize));
+        const err = ttySetMode(this.fd, flag, state);
         if (err) {
           this.emit("error", new Error("setRawMode failed with errno: " + err));
           return this;

--- a/src/jsc/bindings/BunTTYState.h
+++ b/src/jsc/bindings/BunTTYState.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "root.h"
+
+#if !OS(WINDOWS)
+#include <termios.h>
+#endif
+
+// Per-handle raw-mode state, mirroring libuv's `uv_tty_t`: every tty handle
+// keeps its own mode plus the termios snapshot captured when it left normal
+// mode, so one handle going back to cooked never disturbs another.
+struct BunTTYState {
+    int mode = 0;
+#if !OS(WINDOWS)
+    struct termios orig_termios {};
+#endif
+};
+
+// `state` points at `Bun__ttyStateSize()` zero-initialized bytes, owned by the
+// caller for as long as the handle lives. The bytes are copied in and out, so
+// the buffer carries no alignment requirement.
+extern "C" int Bun__ttySetMode(int fd, int mode, void* state);
+extern "C" size_t Bun__ttyStateSize();

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -219,20 +219,21 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
 
     JSValue mode = callFrame->argument(1);
 
-    // The per-stream state buffer node:tty hands back on every call. Holding it
-    // in JS keeps its lifetime tied to the stream that owns the mode.
-    auto* state = dynamicDowncast<JSC::JSUint8Array>(callFrame->argument(2));
-    if (!state || state->isDetached() || state->length() < Bun__ttyStateSize()) {
-        throwTypeError(globalObject, scope, "state must be a Uint8Array of rawModeStateSize bytes"_s);
-        return {};
-    }
-
     auto fdToUse = fd.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
     int mode_ = mode.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
+
+    // The per-stream state buffer node:tty hands back on every call. Holding it
+    // in JS keeps its lifetime tied to the stream that owns the mode. Validated
+    // after the coercions above so a detach triggered from inside them is caught.
+    auto* state = dynamicDowncast<JSC::JSUint8Array>(callFrame->argument(2));
+    if (!state || state->isDetached() || state->length() < Bun__ttyStateSize()) {
+        throwTypeError(globalObject, scope, "state must be a Uint8Array of rawModeStateSize bytes"_s);
+        return {};
+    }
     int err = Bun__ttySetMode(fdToUse, mode_, state->typedVector());
     return JSValue::encode(jsNumber(err));
 #endif

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -1,15 +1,18 @@
 #include "root.h"
 
+#include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSDestructibleObject.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/Identifier.h"
 
 #include <JavaScriptCore/ObjectConstructor.h>
 
+#include "BunTTYState.h"
 #include "ProcessBindingTTYWrap.h"
 #include "NodeTTYModule.h"
 #include "WebCoreJSBuiltins.h"
 #include <JavaScriptCore/FunctionPrototype.h>
+#include <JavaScriptCore/JSTypedArrays.h>
 
 #ifndef WIN32
 #include <errno.h>
@@ -154,6 +157,8 @@ public:
 
 #if OS(WINDOWS)
     UV::TTY* handle;
+#else
+    BunTTYState ttyState {};
 #endif
 
 private:
@@ -187,8 +192,6 @@ const ClassInfo TTYWrapObject::s_info = {
 
 JSC::EncodedJSValue Process_functionInternalGetWindowSize(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame);
 
-extern "C" int Bun__ttySetMode(int fd, int mode);
-
 JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, CallFrame* callFrame))
 {
 #if OS(WINDOWS)
@@ -203,8 +206,8 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() != 2) {
-        throwTypeError(globalObject, scope, "Expected 2 arguments"_s);
+    if (callFrame->argumentCount() != 3) {
+        throwTypeError(globalObject, scope, "Expected 3 arguments"_s);
         return {};
     }
 
@@ -216,13 +219,21 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
 
     JSValue mode = callFrame->argument(1);
 
+    // The per-stream state buffer node:tty hands back on every call. Holding it
+    // in JS keeps its lifetime tied to the stream that owns the mode.
+    auto* state = dynamicDowncast<JSC::JSUint8Array>(callFrame->argument(2));
+    if (!state || state->isDetached() || state->length() < Bun__ttyStateSize()) {
+        throwTypeError(globalObject, scope, "state must be a Uint8Array of rawModeStateSize bytes"_s);
+        return {};
+    }
+
     auto fdToUse = fd.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
     int mode_ = mode.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    int err = Bun__ttySetMode(fdToUse, mode_);
+    int err = Bun__ttySetMode(fdToUse, mode_, state->typedVector());
     return JSValue::encode(jsNumber(err));
 #endif
 }
@@ -259,7 +270,7 @@ JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionSetMode,
     int err = uv_tty_set_mode(ttyWrap->handle->tty(), mode.toInt32(globalObject));
 #else
     // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
-    int err = Bun__ttySetMode(fd, mode.toInt32(globalObject));
+    int err = Bun__ttySetMode(fd, mode.toInt32(globalObject), &ttyWrap->ttyState);
 #endif
     return JSValue::encode(jsNumber(err));
 }
@@ -502,6 +513,8 @@ JSValue createBunTTYFunctions(Zig::GlobalObject* globalObject)
     obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "setRawMode"_s)), JSFunction::create(vm, globalObject, 0, "ttySetMode"_s, jsTTYSetMode, ImplementationVisibility::Public), 0);
 
     obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "getWindowSize"_s)), JSFunction::create(vm, globalObject, 0, "getWindowSize"_s, Bun::Process_functionInternalGetWindowSize, ImplementationVisibility::Public), 0);
+
+    obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "rawModeStateSize"_s)), jsNumber(static_cast<unsigned>(Bun__ttyStateSize())), 0);
 
     return obj;
 }

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -1,5 +1,6 @@
 #include "root.h"
 #include "wtf-bindings.h"
+#include "BunTTYState.h"
 #include <wtf/StackBounds.h>
 #include <wtf/StackCheck.h>
 #include <wtf/StackTrace.h>
@@ -23,9 +24,6 @@ static int orig_termios_fd = -1;
 static struct termios orig_termios;
 static std::atomic<int> orig_termios_spinlock;
 static std::once_flag reset_once_flag;
-
-static int current_tty_mode = 0;
-static struct termios orig_tty_termios;
 
 int uv__tcsetattr(int fd, int how, const struct termios* term)
 {
@@ -106,19 +104,27 @@ extern "C" void Bun__atexit(void (*func)(void));
 extern "C" volatile sig_atomic_t bun_stdio_modified[3];
 #endif
 
-extern "C" int Bun__ttySetMode(int fd, int mode)
+extern "C" size_t Bun__ttyStateSize()
 {
+    return sizeof(BunTTYState);
+}
+
 #if !OS(WINDOWS)
+// Port of libuv's uv_tty_set_mode(), with `state` standing in for the
+// per-handle fields of uv_tty_t. The file statics above are only the
+// uv_tty_reset_mode() snapshot, which is process-wide in libuv too.
+static int ttySetMode(int fd, int mode, BunTTYState& state)
+{
     struct termios tmp;
     int expected;
     int rc;
 
-    if (current_tty_mode == mode)
+    if (state.mode == mode)
         return 0;
 
-    if (current_tty_mode == 0 && mode != 0) {
+    if (state.mode == 0 && mode != 0) {
         do {
-            rc = tcgetattr(fd, &orig_tty_termios);
+            rc = tcgetattr(fd, &state.orig_termios);
         } while (rc == -1 && errno == EINTR);
 
         if (rc == -1)
@@ -130,14 +136,14 @@ extern "C" int Bun__ttySetMode(int fd, int mode)
         } while (!atomic_compare_exchange_strong(&orig_termios_spinlock, &expected, 1));
 
         if (orig_termios_fd == -1) {
-            orig_termios = orig_tty_termios;
+            orig_termios = state.orig_termios;
             orig_termios_fd = fd;
         }
 
         atomic_store(&orig_termios_spinlock, 0);
     }
 
-    tmp = orig_tty_termios;
+    tmp = state.orig_termios;
     switch (mode) {
     case 0: // normal
         break;
@@ -185,13 +191,28 @@ extern "C" int Bun__ttySetMode(int fd, int mode)
     /* Apply changes after draining */
     rc = uv__tcsetattr(fd, TCSADRAIN, &tmp);
     if (rc == 0) {
-        current_tty_mode = mode;
+        state.mode = mode;
     }
 
     return rc;
-#else
-    return 0;
+}
+#endif
 
+extern "C" int Bun__ttySetMode(int fd, int mode, void* rawState)
+{
+#if !OS(WINDOWS)
+    // Copied in and out so callers can hand us an unaligned byte buffer (the
+    // JS streams keep theirs in a Uint8Array, Rust in a boxed slice).
+    BunTTYState state;
+    memcpy(&state, rawState, sizeof(state));
+    int rc = ttySetMode(fd, mode, state);
+    memcpy(rawState, &state, sizeof(state));
+    return rc;
+#else
+    UNUSED_PARAM(fd);
+    UNUSED_PARAM(mode);
+    UNUSED_PARAM(rawState);
+    return 0;
 #endif
 }
 

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -201,8 +201,8 @@ static int ttySetMode(int fd, int mode, BunTTYState& state)
 extern "C" int Bun__ttySetMode(int fd, int mode, void* rawState)
 {
 #if !OS(WINDOWS)
-    // Copied in and out so callers can hand us an unaligned byte buffer (the
-    // JS streams keep theirs in a Uint8Array, Rust in a boxed slice).
+    // Copied in and out so callers can hand us an unaligned byte buffer: the
+    // JS streams keep theirs in a Uint8Array.
     BunTTYState state;
     memcpy(&state, rawState, sizeof(state));
     int rc = ttySetMode(fd, mode, state);

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2541,10 +2541,11 @@ fn probe_kitty_graphics() -> bool {
             Ok(t) => t,
             Err(_) => return false,
         };
-        let _ = bun_core::tty::set_mode(0, bun_core::tty::Mode::Raw);
+        let tty_state = bun_core::tty::State::new();
+        let _ = tty_state.set_mode(0, bun_core::tty::Mode::Raw);
         let _restore = scopeguard::guard(saved_termios, |saved| {
             if bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Now, &saved).is_err() {
-                let _ = bun_core::tty::set_mode(0, bun_core::tty::Mode::Normal);
+                let _ = tty_state.set_mode(0, bun_core::tty::Mode::Normal);
             }
         });
 

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2541,11 +2541,11 @@ fn probe_kitty_graphics() -> bool {
             Ok(t) => t,
             Err(_) => return false,
         };
-        let tty_state = bun_core::tty::State::new();
+        let mut tty_state = bun_core::tty::State::new();
         let _ = tty_state.set_mode(0, bun_core::tty::Mode::Raw);
-        let _restore = scopeguard::guard(saved_termios, |saved| {
+        let _restore = scopeguard::guard((saved_termios, tty_state), |(saved, mut state)| {
             if bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Now, &saved).is_err() {
-                let _ = tty_state.set_mode(0, bun_core::tty::Mode::Normal);
+                let _ = state.set_mode(0, bun_core::tty::Mode::Normal);
             }
         });
 

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -165,7 +165,7 @@ pub struct Terminal {
     /// This PTY's own raw-mode state (mode + saved termios), so one terminal
     /// going raw never makes another terminal's setRawMode a no-op.
     #[cfg(unix)]
-    tty_state: bun_core::tty::State,
+    tty_state: Cell<bun_core::tty::State>,
 }
 
 bitflags::bitflags! {
@@ -464,7 +464,7 @@ impl Terminal {
             this_value: JsCell::new(JsRef::empty()),
             flags: Cell::new(Flags::empty()),
             #[cfg(unix)]
-            tty_state: bun_core::tty::State::new(),
+            tty_state: Cell::new(bun_core::tty::State::new()),
         }));
         // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
         // (not `&mut`) — every method below takes `&self`; field writes go
@@ -1565,7 +1565,8 @@ impl Terminal {
         #[cfg(unix)]
         {
             // Use the existing TTY mode function
-            let tty_result = self.tty_state.set_mode(
+            let mut state = self.tty_state.get();
+            let tty_result = state.set_mode(
                 self.master_fd.get().native(),
                 if enabled {
                     bun_core::tty::Mode::Raw
@@ -1573,6 +1574,7 @@ impl Terminal {
                     bun_core::tty::Mode::Normal
                 },
             );
+            self.tty_state.set(state);
             if tty_result != 0 {
                 return Err(global_object.throw(format_args!("Failed to set raw mode")));
             }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -161,6 +161,11 @@ pub struct Terminal {
 
     /// State flags
     flags: Cell<Flags>,
+
+    /// This PTY's own raw-mode state (mode + saved termios), so one terminal
+    /// going raw never makes another terminal's setRawMode a no-op.
+    #[cfg(unix)]
+    tty_state: bun_core::tty::State,
 }
 
 bitflags::bitflags! {
@@ -458,6 +463,8 @@ impl Terminal {
             reader: JsCell::new(IOReader::init::<Terminal>()),
             this_value: JsCell::new(JsRef::empty()),
             flags: Cell::new(Flags::empty()),
+            #[cfg(unix)]
+            tty_state: bun_core::tty::State::new(),
         }));
         // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
         // (not `&mut`) — every method below takes `&self`; field writes go
@@ -1558,7 +1565,7 @@ impl Terminal {
         #[cfg(unix)]
         {
             // Use the existing TTY mode function
-            let tty_result = bun_core::tty::set_mode(
+            let tty_result = self.tty_state.set_mode(
                 self.master_fd.get().native(),
                 if enabled {
                     bun_core::tty::Mode::Raw

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -861,6 +861,10 @@ pub(super) struct Repl<'a> {
     // Windows: saved console mode for restoration
     #[cfg(windows)]
     original_windows_mode: Option<bun_sys::windows::DWORD>,
+
+    // POSIX: the REPL's own stdin raw-mode state
+    #[cfg(unix)]
+    tty_state: tty::State,
 }
 
 impl<'a> Repl<'a> {
@@ -889,6 +893,8 @@ impl<'a> Repl<'a> {
             last_error: ProtectedJSValue::adopt(JSValue::UNDEFINED),
             #[cfg(windows)]
             original_windows_mode: None,
+            #[cfg(unix)]
+            tty_state: tty::State::new(),
         }
     }
 
@@ -927,7 +933,7 @@ impl<'a> Repl<'a> {
         // Enable raw mode
         #[cfg(unix)]
         {
-            let _ = tty::set_mode(0, tty::Mode::Raw);
+            let _ = self.tty_state.set_mode(0, tty::Mode::Raw);
         }
         #[cfg(windows)]
         {
@@ -947,7 +953,7 @@ impl<'a> Repl<'a> {
     fn restore_terminal(&mut self) {
         #[cfg(unix)]
         {
-            let _ = tty::set_mode(0, tty::Mode::Normal);
+            let _ = self.tty_state.set_mode(0, tty::Mode::Normal);
         }
         #[cfg(windows)]
         {
@@ -972,7 +978,7 @@ impl<'a> Repl<'a> {
         #[cfg(unix)]
         {
             // Switch to normal terminal mode (has ISIG) so Ctrl+C generates SIGINT
-            let _ = tty::set_mode(0, tty::Mode::Normal);
+            let _ = self.tty_state.set_mode(0, tty::Mode::Normal);
 
             // Install SIGINT handler
             // SAFETY: zeroed `sigaction` is a valid empty mask + null restorer; we set
@@ -994,7 +1000,7 @@ impl<'a> Repl<'a> {
         #[cfg(unix)]
         {
             // Back to raw mode
-            let _ = tty::set_mode(0, tty::Mode::Raw);
+            let _ = self.tty_state.set_mode(0, tty::Mode::Raw);
 
             // Restore default SIGINT handling
             // SAFETY: zeroed `sigaction` is a valid empty mask + null restorer; SIG_DFL

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -292,6 +292,30 @@ describe("Bun.Terminal", () => {
 
       expect(() => terminal.setRawMode(true)).toThrow("Terminal is closed");
     });
+
+    // The mode and the saved termios used to be one process-wide pair, so once
+    // any terminal was raw, setRawMode(true) on a second one returned success
+    // without ever touching that terminal's own PTY.
+    test.skipIf(isWindows)("each terminal keeps its own raw mode", async () => {
+      const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
+      const ECHO = 0x8;
+      const isRaw = (terminal: Bun.Terminal) => (terminal.localFlags & (ICANON | ECHO)) === 0;
+
+      await using first = new Bun.Terminal({});
+      await using second = new Bun.Terminal({});
+
+      first.setRawMode(true);
+      second.setRawMode(true);
+      const bothRaw = { first: isRaw(first), second: isRaw(second) };
+
+      second.setRawMode(false);
+      const afterSecondRestored = { first: isRaw(first), second: isRaw(second) };
+
+      expect({ bothRaw, afterSecondRestored }).toEqual({
+        bothRaw: { first: true, second: true },
+        afterSecondRestored: { first: true, second: false },
+      });
+    });
   });
 
   describe("termios flags", () => {

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -81,6 +81,115 @@ describe("ReadStream.prototype.setRawMode", () => {
       returnsThis: true,
     });
   });
+
+  // Raw mode is per-stream in libuv (each uv_tty_t holds its own mode and its
+  // own saved termios), so a second tty.ReadStream on the same fd must not be
+  // able to restore the terminal out from under the stream that raw'd it.
+  // Bun used to keep one process-wide mode + termios snapshot, which turned
+  // `setRawMode(false)` on a never-raw stream into a real tcsetattr.
+  test.skipIf(isWindows)("a second ReadStream's setRawMode does not disturb process.stdin", async () => {
+    const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
+    const ECHO = 0x8;
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const waiters: { marker: string; resolve: () => void }[] = [];
+
+    await using terminal = new Bun.Terminal({
+      data(_terminal, chunk: Uint8Array) {
+        buffer += decoder.decode(chunk, { stream: true });
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (buffer.includes(waiters[i].marker)) {
+            waiters[i].resolve();
+            waiters.splice(i, 1);
+          }
+        }
+      },
+    });
+
+    const isRaw = () => (terminal.localFlags & (ICANON | ECHO)) === 0;
+    const observed: Record<string, boolean> = { beforeSpawn: isRaw() };
+
+    // Each phase announces itself, then blocks on stdin so the parent can read
+    // termios while the child is still alive, and releases on the ack byte.
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const tty = require("node:tty");
+          const { TTY } = process.binding("tty_wrap");
+          const say = s => process.stdout.write(s + "\\n");
+          const ack = () => new Promise(resolve => process.stdin.once("data", () => resolve()));
+          (async () => {
+            process.stdin.resume();
+            process.stdin.setRawMode(true);
+            say("P1"); await ack();
+
+            const second = new tty.ReadStream(0);
+            second.setRawMode(false); // never raw: must be a no-op
+            say("P2"); await ack();
+
+            second.setRawMode(true);
+            second.setRawMode(false); // restores its own snapshot, which was already raw
+            say("P3"); await ack();
+
+            new TTY(0).setRawMode(0); // same, through the tty_wrap binding
+            say("P4"); await ack();
+
+            process.stdin.setRawMode(false); // the stream that raw'd it restores cooked
+            say("P5"); await ack();
+            process.exit(0);
+          })();
+        `,
+      ],
+      env: bunEnv,
+      terminal,
+    });
+
+    // A child that dies early must reject the phase waits rather than hang them.
+    const exitedEarly = proc.exited.then(code => {
+      throw new Error(`child exited early with code ${code}; terminal output: ${JSON.stringify(buffer)}`);
+    });
+    exitedEarly.catch(() => {});
+
+    const phase = (marker: string) => {
+      const seen = buffer.includes(marker)
+        ? Promise.resolve()
+        : new Promise<void>(resolve => waiters.push({ marker, resolve }));
+      return Promise.race([seen, exitedEarly]);
+    };
+
+    await phase("P1");
+    observed.afterStdinRaw = isRaw();
+    terminal.write("\n");
+
+    await phase("P2");
+    observed.afterSecondStreamCooked = isRaw();
+    terminal.write("\n");
+
+    await phase("P3");
+    observed.afterSecondStreamRoundTrip = isRaw();
+    terminal.write("\n");
+
+    await phase("P4");
+    observed.afterTTYWrapCooked = isRaw();
+    terminal.write("\n");
+
+    await phase("P5");
+    observed.afterStdinCooked = isRaw();
+    terminal.write("\n");
+
+    expect(observed).toEqual({
+      beforeSpawn: false,
+      afterStdinRaw: true,
+      afterSecondStreamCooked: true,
+      afterSecondStreamRoundTrip: true,
+      afterTTYWrapCooked: true,
+      afterStdinCooked: false,
+    });
+    expect(await proc.exited).toBe(0);
+  });
 });
 
 describe("WriteStream.prototype.getColorDepth", () => {


### PR DESCRIPTION
`setRawMode` state is process-global in Bun, not per-stream. Calling `setRawMode(false)` on a second, never-raw `tty.ReadStream(0)` silently restores the shared terminal to cooked out from under a raw `process.stdin`, while `process.stdin.isRaw` keeps reporting `true`. There is no event, no error, and no JS-visible signal: the app just stops receiving keystrokes and the kernel starts echoing them.

Prompt, TUI and REPL libraries build their own `tty.ReadStream(0)` and call `setRawMode(false)` on a cleanup path, so this is an order-dependent, whole-process failure of the most basic TUI primitive.

## Repro

```js
// needs a real pty: `script -qec "bun raw.mjs" /dev/null`
import tty from "node:tty";

const got = [];
process.stdin.on("data", b => got.push(...b));
process.stdin.resume();
process.stdin.setRawMode(true); // stdin is RAW

const second = new tty.ReadStream(0); // SECOND ReadStream on the same tty
second.setRawMode(false); // never raw -> node: no-op. bun: un-raws the terminal.

// type "xy" with no newline, then after a moment:
//   node: process.stdin.isRaw === true, got === "xy"
//   bun:  process.stdin.isRaw === true, got === ""   <-- the kernel line editor
//                                                        buffered and echoed it
```

The converse hole falls out of the same state: once any stream is raw, `setRawMode(true)` on a *different* tty fd is a silent, success-returning no-op. Two `Bun.Terminal`s hit exactly that: the second one's `setRawMode(true)` never touches its own PTY.

## Cause

`Bun__ttySetMode(fd, mode)` is a port of libuv's `uv_tty_set_mode()`, but the two fields libuv keeps on each `uv_tty_t` were lifted to file statics:

```c
static int current_tty_mode = 0;
static struct termios orig_tty_termios;
```

So the `current_tty_mode == mode` early-return and the "restore the saved termios" path are shared by every stream, every fd, and every `Bun.Terminal`. In the repro, the second stream's `setRawMode(false)` sees `current_tty_mode == 1`, so it takes the restore branch and runs a real `tcsetattr` with the cooked snapshot.

## Fix

Put the mode and the saved termios back on the handle, as in libuv:

- `Bun__ttySetMode(fd, mode, state)` reads and writes a caller-owned `BunTTYState { mode, orig_termios }`.
- `node:tty` keeps one state buffer per `ReadStream`, allocated lazily on the first `setRawMode`.
- `tty_wrap`'s `TTY` keeps one per `TTYWrapObject`.
- `Bun.Terminal` keeps one per PTY, and the Rust callers (REPL, interactive prompts, the kitty-graphics probe) one per owner.

The `uv_tty_reset_mode()` snapshot (`orig_termios_fd` / `orig_termios`, used by the atexit restore) stays process-wide, exactly as it is in libuv.

This also makes the second-raw-stream case match Node: a stream that goes raw while the device is already raw captures the raw termios as its own snapshot, so its later `setRawMode(false)` is a no-op rather than cooking the terminal under the stream that owns it.

## Verification

The reporter's self-checking repro now matches Node byte for byte:

```
node v26.3.0      { isRawReported: true, rawPhaseBytes: 'xy', afterNewline: '\n' }  exit 0
bun (this branch) { isRawReported: true, rawPhaseBytes: "xy", afterNewline: "\n" }  exit 0
bun (main)        { isRawReported: true, rawPhaseBytes: "",   afterNewline: "xy\n" } exit 1
```

Two tests, both driven over a real PTY via `Bun.Terminal` and asserting on `terminal.localFlags` (`ICANON`/`ECHO`), which is the terminal's actual termios rather than Bun's bookkeeping:

- `test/js/node/tty.test.ts` walks a child through a handshake: `process.stdin` goes raw, then a second `tty.ReadStream(0)` does `setRawMode(false)`, a raw/cooked round trip, and a `tty_wrap` `TTY(0).setRawMode(0)`. The device must stay raw through all of them, and only `process.stdin.setRawMode(false)` may cook it.
- `test/js/bun/terminal/terminal.test.ts` asserts two `Bun.Terminal`s keep independent modes.

On `main` the first reports `afterSecondStreamCooked: false`, `afterSecondStreamRoundTrip: false`, `afterTTYWrapCooked: false`; the second reports the second terminal never went raw.

<details>
<summary>Suites run locally (<code>bun bd test</code>, linux-x64)</summary>

```
test/js/node/tty.test.ts
test/js/node/nodettywrap.test.ts
test/js/bun/terminal/{terminal,terminal-spawn,terminal-platform-gaps}.test.ts
test/regression/issue/{tty-reopen-after-stdin-eof,tty-readstream-ref-unref,tui-app-tty-pattern}.test.ts
test/js/node/stream/
  -> 230 pass, 0 fail

test/js/node/test/parallel/test-{readline-set-raw-mode,tty-backwards-api,tty-stdin-end,tty-stdin-pipe,console-tty-colors}.js
  -> all OK
```

`bun run rust:check-all` is clean across linux/macos/windows x x64/aarch64.
`test/js/node/readline` has 2 pre-existing failures (`readline should unref`, `stdin pause should stop reading so child can read from stdin`) that reproduce identically on `main` without this diff.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts test/js/node/tty.test.ts

<!-- robobun:evidence:end -->