### PR TITLE
install: re-apply patch when cached patched folder lacks its bun-tag marker

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2418,12 +2418,23 @@ impl<'a> PackageInstall<'a> {
         manager: &mut PackageManager,
         package_id: PackageID,
     ) -> bool {
-        let exists =
-            sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath).unwrap_or(false);
-        if exists {
+        // The `_patch_hash=` folder existing is not enough: it must carry the
+        // `.bun-tag-<hash>` marker proving the patch was applied, else a warm
+        // cache that captured unpatched content would be installed as-is.
+        let applied = sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath)
+            .unwrap_or(false)
+            && match self.patch {
+                Some(patch) => crate::patched_cache_folder_has_tag(
+                    self.cache_dir,
+                    self.cache_dir_subpath,
+                    patch.contents_hash,
+                ),
+                None => true,
+            };
+        if applied {
             manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
         }
-        !exists
+        !applied
     }
 
     pub fn install(

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -219,7 +219,18 @@ impl PackageManager {
                     return PreinstallState::Extract;
                 }
 
-                if directories::is_folder_in_cache(self, folder_path) {
+                // A patched folder is only Done if it carries the `.bun-tag-<hash>`
+                // marker. Without it (e.g. a warm cache that captured unpatched
+                // content) fall through below to re-apply the patch or re-extract.
+                if directories::is_folder_in_cache(self, folder_path)
+                    && match patch_hash {
+                        Some(h) => {
+                            let cache_dir = directories::get_cache_directory(self);
+                            bun_install::patched_cache_folder_has_tag(cache_dir, folder_path, h)
+                        }
+                        None => true,
+                    }
+                {
                     self.set_preinstall_state(pkg.meta.id, PreinstallState::Done);
                     return PreinstallState::Done;
                 }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -926,6 +926,23 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
     &mut buf[..BUN_HASH_TAG.len() + digits_len]
 }
 
+/// Whether the patched cache folder `folder` (in `cache_dir`) actually contains
+/// the applied patch: `patch_install::apply` writes a `.bun-tag-<hash>` marker
+/// after applying, so a `_patch_hash=` folder without it must be re-patched.
+pub(crate) fn patched_cache_folder_has_tag(
+    cache_dir: bun_sys::Fd,
+    folder: &ZStr,
+    patch_hash: u64,
+) -> bool {
+    let mut tag_buf: BuntagHashBuf = BuntagHashBuf::default();
+    let tag = buntaghashbuf_make(&mut tag_buf, patch_hash);
+    let marker = bun_paths::resolve_path::join_z::<bun_paths::resolve_path::platform::Posix>(&[
+        folder.as_bytes(),
+        tag,
+    ]);
+    bun_sys::exists_at(cache_dir, marker)
+}
+
 pub struct StorePathFormatter<'a> {
     str: &'a [u8],
 }

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { rmSync } from "fs";
-import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDirWithFiles } from "harness";
+import { readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDirWithFiles, tmpdirSync } from "harness";
 import { join } from "path";
 
 const normalizeBunSnapshot = (str: string) => {
@@ -1021,5 +1021,108 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
     });
     expect(await Bun.file(join(filedir, "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(false);
     expect(await Bun.file(join(filedir, "bun.lock")).text()).not.toContain("patchedDependencies");
+  });
+
+  // https://github.com/oven-sh/bun/issues/33520
+  test("re-applies a patch when the cached patched folder lost its .bun-tag marker", async () => {
+    const original = `module.exports = function () {\n  return "ORIGINAL";\n};\n`;
+
+    // Pack a tiny package we can serve from an in-process npm registry.
+    const pkgSrc = tempDirWithFiles("patch-33520-src", {
+      "package.json": JSON.stringify({ name: "patch-target", version: "1.0.0", main: "index.js" }),
+      "index.js": original,
+    });
+    {
+      await using pack = Bun.spawn({
+        cmd: [bunExe(), "pm", "pack"],
+        cwd: pkgSrc,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([pack.stdout.text(), pack.stderr.text(), pack.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+    const tgz = readFileSync(join(pkgSrc, "patch-target-1.0.0.tgz"));
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        const { pathname } = new URL(req.url);
+        if (pathname.endsWith(".tgz")) return new Response(tgz);
+        const name = pathname.slice(1);
+        return Response.json({
+          name,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name,
+              version: "1.0.0",
+              main: "index.js",
+              dist: { tarball: `http://localhost:${server.port}/${name}-1.0.0.tgz` },
+            },
+          },
+        });
+      },
+    });
+
+    const cache = tmpdirSync();
+    const dir = tempDirWithFiles("patch-33520-proj", {
+      "package.json": JSON.stringify({
+        name: "proj",
+        version: "1.0.0",
+        dependencies: { "patch-target": "1.0.0" },
+        patchedDependencies: { "patch-target@1.0.0": "patches/patch-target.patch" },
+      }),
+      patches: {
+        "patch-target.patch": `diff --git a/index.js b/index.js
+index 1111111111111111111111111111111111111111..2222222222222222222222222222222222222222 100644
+--- a/index.js
++++ b/index.js
+@@ -1,3 +1,3 @@
+ module.exports = function () {
+-  return "ORIGINAL";
++  return "PATCHED";
+ };
+`,
+      },
+      "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\n`,
+    });
+
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cache };
+    const installedIndex = join(dir, "node_modules", "patch-target", "index.js");
+    const install = async () => {
+      await using proc = Bun.spawn({ cmd: [bunExe(), "install"], cwd: dir, env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    };
+
+    // Cold install applies the patch and writes the patched cache folder.
+    let r = await install();
+    expect(r.stderr).not.toContain("error:");
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(installedIndex, "utf8")).toContain("PATCHED");
+
+    // Simulate a warm cache that captured the patched folder without the patch:
+    // the `_patch_hash=` folder is present but its `.bun-tag-<hash>` marker and
+    // patched content are gone (as happens when CI restores an unpatched snapshot).
+    const patchedFolder = readdirSync(cache).find(f => f.includes("_patch_hash="));
+    expect(patchedFolder).toBeDefined();
+    const patchedPath = join(cache, patchedFolder!);
+    for (const entry of readdirSync(patchedPath)) {
+      if (entry.startsWith(".bun-tag-")) unlinkSync(join(patchedPath, entry));
+    }
+    writeFileSync(join(patchedPath, "index.js"), original);
+    rmSync(join(dir, "node_modules"), { recursive: true, force: true });
+
+    // Reinstalling must re-apply the patch instead of silently installing the
+    // stale unpatched cache folder.
+    r = await install();
+    expect(r.stderr).not.toContain("error:");
+    expect(r.exitCode).toBe(0);
+    const reinstalled = readFileSync(installedIndex, "utf8");
+    expect(reinstalled).toContain("PATCHED");
+    expect(reinstalled).not.toContain("ORIGINAL");
   });
 });


### PR DESCRIPTION
## What

`bun install` can silently skip a `patchedDependencies` patch when the global cache is warm. The dependency lands in `node_modules` unpatched, with exit 0 and no warning. Reported on Expo EAS Linux builders where the global cache is restored between builds (#33520).

## Repro

1. A `patchedDependencies` entry whose version key matches the installed version.
2. The global cache already contains the package's `<pkg>@<ver>@@@<cacheVer>_patch_hash=<hash>` folder, but that folder holds unpatched content (a cache snapshot captured before the patch was applied, an interrupted write, a folder left by an older install).
3. `bun install` copies the folder into `node_modules` as-is. No patch, no error.

## Cause

The hoisted installer decides a patched cache folder is usable from its directory existence alone:

- `determine_preinstall_state` returns `PreinstallState::Done` as soon as the `_patch_hash=` folder exists.
- `patched_package_missing_from_cache` returns `false` (not missing) as soon as the folder exists.

Neither checks that the patch was actually applied. The patch-apply task writes a `.bun-tag-<hash>` marker into the folder precisely to record that, and the isolated installer already requires it, but the hoisted installer never did.

## Fix

Require the `.bun-tag-<hash>` marker before reusing a patched cache folder, at both probe sites (new shared helper `patched_cache_folder_has_tag`). A `_patch_hash=` folder without the marker now falls through to re-applying the patch, or re-extracting the base package first when the unpatched folder is also gone. The hash in the folder's `_patch_hash=` suffix and the marker's `.bun-tag-` suffix are the same value, so the check is exact.

## Test

`test/cli/install/bun-install-patch.test.ts`: cold-install a patched dependency from an in-process registry into an isolated cache, strip the `.bun-tag-*` marker and revert the cached file, wipe `node_modules`, reinstall, and assert the installed file is patched. Fails before the fix (installs `ORIGINAL`), passes after.

Fixes #33520