### PR TITLE
Route node:net DNS resolution through Bun's DNS cache

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -69,6 +69,7 @@ impl EAI {
     #[cfg(not(target_os = "linux"))]
     pub const ADDRFAMILY: Self = Self(1);
 
+    pub const AGAIN: Self = Self(libc::EAI_AGAIN);
     pub const BADFLAGS: Self = Self(libc::EAI_BADFLAGS);
     pub const FAIL: Self = Self(libc::EAI_FAIL);
     pub const FAMILY: Self = Self(libc::EAI_FAMILY);
@@ -1927,6 +1928,8 @@ impl Error {
             }
             match eai {
                 EAI::ADDRFAMILY => Some(Error::EBADFAMILY),
+                // "Temporary failure in name resolution", same as the Windows arm.
+                EAI::AGAIN => Some(Error::ETIMEOUT),
                 EAI::BADFLAGS => Some(Error::EBADFLAGS), // Invalid hints
                 EAI::FAIL => Some(Error::EBADRESP),
                 EAI::FAMILY => Some(Error::EBADFAMILY),

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -296,6 +296,7 @@ export function getJS2NativeRust() {
   const handExported = new Set<string>([
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_cachedLookup",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -297,6 +297,7 @@ export function getJS2NativeRust() {
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_cachedLookup",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_invalidateCachedLookup",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1830,6 +1830,10 @@ Socket.prototype.connect = function connect(...args) {
     this._peername = null;
     this._sockname = null;
   }
+  // Per-connect state: a prior connect may have left this set (e.g. destroyed
+  // mid-flight), and this connect may never overwrite it (IP literal, pipe,
+  // custom lookup). Reset so a failure can't evict the wrong host's entry.
+  this[kDnsCacheHost] = undefined;
 
   this.connecting = true;
 
@@ -2530,7 +2534,12 @@ function lookupAndConnect(self, options) {
 
   $debug("connect: find host", host, addressType);
   $debug("connect: dns options", dnsopts);
-  const usesDnsCache = !optionsLookup && canLookupViaDnsCache(dnsopts);
+  // The shared cache stores addresses in a v6-first interleave, not the
+  // resolver's order, so it only matches `verbatim` semantics on the
+  // autoSelectFamily path where Happy Eyeballs tries every address anyway. The
+  // single-address path takes the first result verbatim, so keep it on
+  // dns.lookup to preserve the resolver's ordering.
+  const usesDnsCache = !optionsLookup && canLookupViaDnsCache(dnsopts) && autoSelectFamily && !localAddress;
   const lookup = optionsLookup || (usesDnsCache ? dnsCacheLookupFor(port) : dns.lookup);
 
   if (dnsopts.family !== 4 && dnsopts.family !== 6 && !localAddress && autoSelectFamily) {
@@ -2565,10 +2574,6 @@ function lookupAndConnect(self, options) {
       process.nextTick(destroyNT, self, err);
     } else {
       self._unrefTimer();
-      // The addresses came from the shared cache; a failed connect has to evict
-      // the entry so the next attempt re-resolves, the way the usockets connect
-      // path does. Cleared on a successful connect.
-      if (usesDnsCache) self[kDnsCacheHost] = host;
       internalConnect(self, options, ip, port, addressType, localAddress, localPort);
     }
   });

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -44,11 +44,20 @@ const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
+const ArrayPrototypeMap = Array.prototype.map;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSort = Array.prototype.sort;
 const MathMax = Math.max;
 
 const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
+
+/**
+ * Resolves a hostname through the process-wide DNS cache — the same entries
+ * `fetch()`, `Bun.connect` and `Bun.dns.prefetch()` use. Resolves to
+ * `[{ address, family, ttl }]`, like `Bun.dns.lookup`.
+ */
+const cachedDnsLookup = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.cachedLookup", 2);
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
 const setDefaultAutoSelectFamily = $rust("node_net_binding.rs", "setDefaultAutoSelectFamily");
@@ -2516,7 +2525,7 @@ function lookupAndConnect(self, options) {
 
   $debug("connect: find host", host, addressType);
   $debug("connect: dns options", dnsopts);
-  const lookup = optionsLookup || dns.lookup;
+  const lookup = optionsLookup || (canLookupViaDnsCache(dnsopts) ? dnsCacheLookupFor(port) : dns.lookup);
 
   if (dnsopts.family !== 4 && dnsopts.family !== 6 && !localAddress && autoSelectFamily) {
     $debug("connect: autodetecting", host, port);
@@ -2560,6 +2569,62 @@ function socketToDnsFamily(family) {
     case "IPv6": return 6; // prettier-ignore
   }
   return family;
+}
+
+// The DNS cache is keyed on hostname alone and always resolves with AF_UNSPEC +
+// SOCK_STREAM (+ AI_ADDRCONFIG off Windows), which is exactly what `fetch()` and
+// `Bun.connect` ask for. Anything else (an explicit family, extra hints) has to
+// go through `dns.lookup`, or we would hand back addresses resolved under the
+// wrong hints.
+function canLookupViaDnsCache(dnsopts) {
+  return (dnsopts.family === 0 || dnsopts.family === undefined) && dnsopts.hints === (isWindows ? 0 : dns.ADDRCONFIG);
+}
+
+const byFamilyAscending = (a, b) => a.family - b.family;
+const byFamilyDescending = (a, b) => b.family - a.family;
+const toLookupAddress = ({ address, family }) => ({ address, family });
+
+// The shape `node:dns` gives an empty resolution.
+function noRecordsFoundError(hostname) {
+  const err = new Error(`getaddrinfo ENODATA ${hostname}`);
+  err.name = "DNSException";
+  err.code = "ENODATA";
+  // Hardcoded errno, matching `node:dns`.
+  err.errno = 1;
+  err.syscall = "getaddrinfo";
+  err.hostname = hostname;
+  return err;
+}
+
+function dnsCacheLookupFor(port) {
+  return function lookupViaDnsCache(hostname, options, callback) {
+    cachedDnsLookup(hostname, port).$then(
+      res => {
+        if (res.length === 0) {
+          callback(noRecordsFoundError(hostname), undefined, undefined);
+          return;
+        }
+        const order = dns.getDefaultResultOrder();
+        if (order === "ipv4first") {
+          ArrayPrototypeSort.$call(res, byFamilyAscending);
+        } else if (order === "ipv6first") {
+          ArrayPrototypeSort.$call(res, byFamilyDescending);
+        }
+        if (options.all) {
+          callback(null, ArrayPrototypeMap.$call(res, toLookupAddress));
+        } else {
+          const { address, family } = res[0];
+          callback(null, address, family);
+        }
+      },
+      err => {
+        // `Bun.dns` reports DNS failures as `DNS_ENOTFOUND` etc; `node:dns`
+        // strips the prefix. The hostname and message are set natively.
+        if (err.code?.startsWith("DNS_")) err.code = err.code.slice(4);
+        callback(err, undefined, undefined);
+      },
+    );
+  };
 }
 
 function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, localAddress, localPort, timeout) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -58,6 +58,8 @@ const isWindows = process.platform === "win32";
  * `[{ address, family, ttl }]`, like `Bun.dns.lookup`.
  */
 const cachedDnsLookup = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.cachedLookup", 2);
+/** Drops a hostname's entry from that cache, so the next lookup re-resolves. */
+const invalidateCachedDnsLookup = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.invalidateCachedLookup", 1); // prettier-ignore
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
 const setDefaultAutoSelectFamily = $rust("node_net_binding.rs", "setDefaultAutoSelectFamily");
@@ -137,6 +139,8 @@ const kNativeSecureContextCtor = Symbol.for("::buntlsnativesecurecontextctor::")
 const kReinitializeHandle = Symbol("kReinitializeHandle");
 
 const kRealListen = Symbol("kRealListen");
+/** Hostname whose addresses the in-flight connect took from the DNS cache, if any. */
+const kDnsCacheHost = Symbol("kDnsCacheHost");
 const kSetNoDelay = Symbol("kSetNoDelay");
 const kSetTOS = Symbol("kSetTOS");
 const kSetKeepAlive = Symbol("kSetKeepAlive");
@@ -1380,6 +1384,7 @@ function Socket(options?) {
   this._parentWrap = null;
   this[kpendingRead] = undefined;
   this[kupgraded] = null;
+  this[kDnsCacheHost] = undefined;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
@@ -2525,7 +2530,8 @@ function lookupAndConnect(self, options) {
 
   $debug("connect: find host", host, addressType);
   $debug("connect: dns options", dnsopts);
-  const lookup = optionsLookup || (canLookupViaDnsCache(dnsopts) ? dnsCacheLookupFor(port) : dns.lookup);
+  const usesDnsCache = !optionsLookup && canLookupViaDnsCache(dnsopts);
+  const lookup = optionsLookup || (usesDnsCache ? dnsCacheLookupFor(port) : dns.lookup);
 
   if (dnsopts.family !== 4 && dnsopts.family !== 6 && !localAddress && autoSelectFamily) {
     $debug("connect: autodetecting", host, port);
@@ -2541,6 +2547,7 @@ function lookupAndConnect(self, options) {
       localAddress,
       localPort,
       autoSelectFamilyAttemptTimeout,
+      usesDnsCache,
     );
     return;
   }
@@ -2558,9 +2565,24 @@ function lookupAndConnect(self, options) {
       process.nextTick(destroyNT, self, err);
     } else {
       self._unrefTimer();
+      // The addresses came from the shared cache; a failed connect has to evict
+      // the entry so the next attempt re-resolves, the way the usockets connect
+      // path does. Cleared on a successful connect.
+      if (usesDnsCache) self[kDnsCacheHost] = host;
       internalConnect(self, options, ip, port, addressType, localAddress, localPort);
     }
   });
+}
+
+// Drop the hostname's shared-DNS-cache entry after every address we got from it
+// failed to connect, mirroring the usockets connect path's eviction on a refused
+// connection. Reads and clears the marker so it fires at most once per connect.
+function evictDnsCacheHostOnConnectFailure(self) {
+  const host = self[kDnsCacheHost];
+  if (host !== undefined) {
+    self[kDnsCacheHost] = undefined;
+    invalidateCachedDnsLookup(host);
+  }
 }
 
 function socketToDnsFamily(family) {
@@ -2627,7 +2649,19 @@ function dnsCacheLookupFor(port) {
   };
 }
 
-function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, localAddress, localPort, timeout) {
+function lookupAndConnectMultiple(
+  self,
+  lookup,
+  host,
+  options,
+  dnsopts,
+  port,
+  localAddress,
+  localPort,
+  timeout,
+  usesDnsCache,
+) {
+  // prettier-ignore
   lookup(host, dnsopts, function emitLookup(err, addresses) {
     if (!self.connecting) {
       return;
@@ -2685,6 +2719,10 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
         ArrayPrototypePush.$call(toAttempt, validAddresses[1][i]);
       }
     }
+
+    // The addresses came from the shared cache; a failed connect has to evict the
+    // entry so the next attempt re-resolves. Cleared on a successful connect.
+    if (usesDnsCache) self[kDnsCacheHost] = host;
 
     if (toAttempt.length === 1) {
       $debug("connect/multiple: only one address found, switching back to single connection");
@@ -2828,6 +2866,7 @@ function internalConnect(self, options, address, port, addressType, localAddress
   }
 
   if (err) {
+    evictDnsCacheHostOnConnectFailure(self);
     const ex = new ExceptionWithHostPort(err, "connect", address, port);
     self.destroy(ex);
   }
@@ -2844,6 +2883,7 @@ function internalConnectMultiple(context, canceled?) {
 
   // All connections have been tried without success, destroy with error
   if (canceled || context.current === context.addresses.length) {
+    evictDnsCacheHostOnConnectFailure(self);
     if (context.errors.length === 0) {
       self.destroy($ERR_SOCKET_CONNECTION_TIMEOUT());
       return;
@@ -3037,6 +3077,8 @@ function afterConnect(status, handle, req, readable, writable) {
   self._sockname = null;
 
   if (status === 0) {
+    // The cached addresses worked; don't evict the entry.
+    self[kDnsCacheHost] = undefined;
     if (self.readable && !readable) {
       self.push(null);
       self.read();
@@ -3080,6 +3122,7 @@ function afterConnect(status, handle, req, readable, writable) {
       ex.localPort = req.localPort;
     }
 
+    evictDnsCacheHostOnConnectFailure(self);
     self.emit("connectionAttemptFailed", req.address, req.port, req.addressType, ex);
     self.destroy(ex);
   }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3209,8 +3209,12 @@ pub mod internal {
             poll_ref.ref_(js_event_loop_ctx());
             bun_core::heap::into_raw(Box::new(Self {
                 global_this: bun_ptr::BackRef::new(global_this),
-                // SAFETY: `bun_vm()` is non-null for a Bun-owned global; the VM
-                // outlives the lookup (the `KeepAlive` above holds the loop open).
+                // SAFETY: `bun_vm()` is non-null for a Bun-owned global. The
+                // `KeepAlive` above keeps the loop drained-open, so the VM
+                // outlives the lookup under normal teardown. `worker.terminate()`
+                // frees the VM regardless of KeepAlive — the same outstanding
+                // work-pool-task gap every `WorkTask` consumer shares (fs, napi,
+                // `dns.lookup`); a fix belongs in that shared contract.
                 event_loop: global_this.bun_vm().event_loop(),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2532,6 +2532,7 @@ pub mod internal {
         Socket(*mut ConnectingSocket),           // FFI
         Prefetch(*mut Loop),                     // FFI
         Quic(*mut bun_http::H3::PendingConnect), // BORROW_PARAM
+        JsLookup(*mut CachedLookup),             // OWNED (freed by `run_from_js`)
     }
 
     impl DNSRequestOwner {
@@ -2552,6 +2553,9 @@ pub mod internal {
                 DNSRequestOwner::Quic(pc) => unsafe {
                     bun_http::H3::PendingConnect::on_dns_resolved_threadsafe(*pc)
                 },
+                // Holds its own refcount on `req` and frees it after reading the
+                // result on the JS thread.
+                DNSRequestOwner::JsLookup(lookup) => CachedLookup::on_dns_resolved(*lookup),
             }
         }
 
@@ -2572,6 +2576,9 @@ pub mod internal {
                 DNSRequestOwner::Quic(pc) => unsafe {
                     bun_http::H3::PendingConnect::on_dns_resolved(*pc)
                 },
+                // Holds its own refcount on `req` and frees it after reading the
+                // result on the JS thread.
+                DNSRequestOwner::JsLookup(lookup) => CachedLookup::on_dns_resolved(*lookup),
             }
         }
     }
@@ -3007,17 +3014,13 @@ pub mod internal {
             .unwrap_or(false)
         {
             if let Some(entry) = guard.get(&key, &mut timestamp_to_store) {
-                if preload {
-                    drop(guard);
-                    return None;
-                }
-
-                // SAFETY: `entry` is a live cache slot; refcount is only mutated under the held lock.
-                unsafe { (*entry).refcount += 1 };
-
                 // SAFETY: `entry` is a live cache slot; `result` is only mutated under the held lock.
-                if unsafe { (*entry).result.is_some() } {
-                    *is_cache_hit.unwrap() = true;
+                let completed = unsafe { (*entry).result.is_some() };
+
+                // Counted before the `preload` early return so that
+                // `cacheHitsCompleted + cacheHitsInflight + cacheMisses` always
+                // equals `totalCount`: `prefetch()` already counts its misses.
+                if completed {
                     bun_output::scoped_log!(
                         dns,
                         "getaddrinfo({}) = cache hit",
@@ -3031,6 +3034,18 @@ pub mod internal {
                         bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
                     );
                     DNS_CACHE_HITS_INFLIGHT.fetch_add(1, Ordering::Relaxed);
+                }
+
+                if preload {
+                    drop(guard);
+                    return None;
+                }
+
+                // SAFETY: `entry` is a live cache slot; refcount is only mutated under the held lock.
+                unsafe { (*entry).refcount += 1 };
+
+                if completed {
+                    *is_cache_hit.unwrap() = true;
                 }
 
                 drop(guard);
@@ -3169,6 +3184,211 @@ pub mod internal {
             Some(unsafe { ZStr::from_raw(hostname, len) })
         };
         prefetch(loop_.cast::<Loop>(), host, port);
+    }
+
+    // ───────────── cached lookup (node:net / node:tls / node:http) ─────────────
+
+    /// One `cachedLookup()` call: resolves `hostname` through the process-wide
+    /// DNS cache — the same entries `fetch()`, `Bun.connect` and
+    /// `dns.prefetch()` share — and settles `promise` with the addresses.
+    ///
+    /// Owns a `+1` refcount on `request`, released by `freeaddrinfo` once the
+    /// result has been read on the JS thread.
+    pub struct CachedLookup {
+        global_this: bun_ptr::BackRef<JSGlobalObject>,
+        event_loop: *mut jsc::event_loop::EventLoop,
+        promise: JSPromiseStrong,
+        poll_ref: KeepAlive,
+        request: *mut Request,
+        hostname: Box<[u8]>,
+    }
+
+    impl CachedLookup {
+        fn init(global_this: &JSGlobalObject, request: *mut Request, hostname: &[u8]) -> *mut Self {
+            let mut poll_ref = KeepAlive::init();
+            poll_ref.ref_(js_event_loop_ctx());
+            bun_core::heap::into_raw(Box::new(Self {
+                global_this: bun_ptr::BackRef::new(global_this),
+                // SAFETY: `bun_vm()` is non-null for a Bun-owned global; the VM
+                // outlives the lookup (the `KeepAlive` above holds the loop open).
+                event_loop: global_this.bun_vm().event_loop(),
+                promise: JSPromiseStrong::init(global_this),
+                poll_ref,
+                request,
+                hostname: Box::<[u8]>::from(hostname),
+            }))
+        }
+
+        /// Hop onto the owning JS thread to settle the promise. Called from
+        /// `after_result` on the work pool, or inline when the entry was already
+        /// resolved — `enqueue_task_concurrent` is safe from either.
+        ///
+        /// # Safety
+        /// `this` must be the live allocation from `init`, not yet dispatched.
+        // `this` is forwarded to the event loop, which hands it to `run_from_js`;
+        // forming `&mut *this` here would invalidate the allocation's provenance.
+        #[allow(clippy::not_unsafe_ptr_arg_deref)]
+        fn on_dns_resolved(this: *mut Self) {
+            // SAFETY: caller contract; `event_loop` was captured on the JS thread
+            // that created `this` and outlives it. Ownership of `this` transfers
+            // to the event loop here.
+            unsafe {
+                (*(*this).event_loop).enqueue_task_concurrent(
+                    bun_jsc::ConcurrentTask::ConcurrentTask::from_callback(
+                        this,
+                        CachedLookup::run_from_js,
+                    ),
+                );
+            }
+        }
+
+        // `ConcurrentTask::from_callback` takes `fn(*mut T) -> bun_event_loop::JsResult<()>`.
+        fn run_from_js(this: *mut Self) -> bun_event_loop::JsResult<()> {
+            // SAFETY: the event loop hands sole ownership of `this` to this callback.
+            let this = unsafe { bun_core::heap::take(this) };
+            let CachedLookup {
+                global_this,
+                mut promise,
+                mut poll_ref,
+                request,
+                hostname,
+                ..
+            } = *this;
+            let global_this = global_this.get();
+            poll_ref.unref(js_event_loop_ctx());
+
+            // SAFETY: `request` is pinned by the refcount this struct owns.
+            // `result` is written once, under the cache lock, before the notify
+            // that scheduled us; it is never mutated afterwards.
+            let (err, info) = unsafe {
+                let result = (*request)
+                    .result
+                    .as_ref()
+                    .expect("DNS cache entry notified without a result");
+                (result.err, result.info)
+            };
+
+            let error = c_ares::Error::init_eai(err);
+            let addresses = match (error, info) {
+                (None, Some(info)) => {
+                    // SAFETY: `info` borrows `Request.result_buf[0]`, kept alive by
+                    // our refcount until `freeaddrinfo` below.
+                    Some(unsafe {
+                        crate::dns_jsc::options_jsc::addr_info_to_js_array(
+                            &(*info.as_ptr()).info,
+                            global_this,
+                        )
+                    })
+                }
+                _ => None,
+            };
+
+            // Releases our refcount; `err != 0` evicts the entry, matching what the
+            // usockets connect path does with a failed resolution.
+            freeaddrinfo(request, (err != 0) as c_int);
+
+            match addresses {
+                Some(Ok(array)) => {
+                    let _ = promise.resolve_task(global_this, array);
+                }
+                // Building the array threw. Reject with that exception rather than
+                // leaving the caller's promise pending forever.
+                Some(Err(e)) => {
+                    let _ = promise.reject(global_this, Err(e));
+                }
+                None => error_to_deferred(
+                    error.unwrap_or(c_ares::Error::ENOTFOUND),
+                    b"getaddrinfo",
+                    Some(&hostname[..]),
+                    &mut promise,
+                )
+                .reject_later(global_this),
+            }
+            Ok(())
+        }
+    }
+
+    /// Arrange for `lookup` to be notified when `request` resolves. Runs on the
+    /// JS thread, before the promise is handed back to the caller.
+    ///
+    /// # Safety
+    /// `request` must be the live cache entry whose `+1` refcount `lookup` owns;
+    /// `lookup` must be the allocation returned by `CachedLookup::init`.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn register_cached_lookup(request: *mut Request, lookup: *mut CachedLookup) {
+        let guard = global_cache().lock();
+        // SAFETY: `request` is a live cache entry; `result`/`notify` are only
+        // touched under `global_cache().lock()`, which is held here.
+        unsafe {
+            if (*request).result.is_some() {
+                // Already resolved. `on_dns_resolved` only enqueues, so the promise
+                // still settles asynchronously, but do not hold the lock across it.
+                drop(guard);
+                CachedLookup::on_dns_resolved(lookup);
+                return;
+            }
+            (*request).notify.push(DNSRequestOwner::JsLookup(lookup));
+        }
+        drop(guard);
+    }
+
+    /// `node:net`'s default `lookup`. Unlike `dns.lookup`, this goes through the
+    /// process-wide DNS cache, so `dns.prefetch()` warms it and simultaneous
+    /// lookups for one hostname are coalesced into a single resolution.
+    ///
+    /// Resolves to the same `[{ address, family, ttl }]` shape as `Bun.dns.lookup`.
+    #[host_fn]
+    pub(crate) fn cached_lookup(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arguments = callframe.arguments();
+
+        if arguments.len() < 1 {
+            return Err(global_this.throw_not_enough_arguments("lookup", 1, arguments.len()));
+        }
+
+        if !arguments[0].is_string() {
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("hostname must be a string"))
+            );
+        }
+        let hostname_slice = arguments[0].to_slice(global_this)?;
+        let hostname = hostname_slice.slice();
+        let hostname_z = bun::ZBox::from_bytes(hostname);
+
+        let port: u16 = if arguments.len() > 1 && !arguments[1].is_undefined_or_null() {
+            global_this.validate_integer_range::<u16>(
+                arguments[1],
+                0,
+                jsc::IntegerRange {
+                    field_name: b"port",
+                    always_allow_zero: true,
+                    ..Default::default()
+                },
+            )?
+        } else {
+            0
+        };
+
+        // SAFETY: `VirtualMachine::get()` returns the live thread-local VM (panics if absent).
+        let loop_ = VirtualMachine::get().as_mut().uws_loop();
+        // `Some(..)` marks this as a real consumer rather than a preload, so the
+        // entry is refcounted for us; only the usockets path reads the flag back.
+        let mut is_cache_hit = false;
+        let request = getaddrinfo(
+            loop_,
+            Some(hostname_z.as_zstr()),
+            port,
+            Some(&mut is_cache_hit),
+        )
+        .expect("getaddrinfo only returns None when preloading");
+
+        let lookup = CachedLookup::init(global_this, request, hostname);
+        // SAFETY: `lookup` is the fresh allocation from `init`; nothing else aliases it.
+        let promise = unsafe { (*lookup).promise.value() };
+        register_cached_lookup(request, lookup);
+        Ok(promise)
     }
 
     extern "C" fn us_getaddrinfo(
@@ -6085,4 +6305,8 @@ export_host_fn!(
 export_host_fn!(
     Resolver::get_runtime_default_result_order_option,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption"
+);
+export_host_fn!(
+    internal::cached_lookup,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_cachedLookup"
 );

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3391,6 +3391,71 @@ pub mod internal {
         Ok(promise)
     }
 
+    /// Drop `host`'s cache entry the way a refused connect does on the usockets
+    /// path, where `us_connecting_socket_close` ends with
+    /// `Bun__addrinfo_freeRequest(req, error == ECONNREFUSED)`: the addresses may
+    /// be stale, so the next lookup has to re-resolve.
+    ///
+    /// A `cached_lookup` consumer connects to an address the cache already handed
+    /// it, so it holds no `addrinfo_request` by the time the connect fails and has
+    /// to invalidate by hostname instead. An entry somebody else still references
+    /// stays allocated but is skipped by `GlobalCache::get` from here on; its last
+    /// holder frees it in `freeaddrinfo`.
+    pub(crate) fn invalidate(host: Option<&ZStr>) {
+        // `RequestKeyOwned::matches` compares the hostname's hash and bytes only,
+        // so the port is not part of the lookup.
+        let key = RequestKey::init(host, 0);
+        let mut guard = global_cache().lock();
+        // One failed connection, counted whether or not an entry is still around
+        // to drop, the same way `freeaddrinfo` counts it.
+        DNS_CACHE_ERRORS.fetch_add(1, Ordering::Relaxed);
+
+        let mut timestamp_to_store: u32 = 0;
+        let Some(entry) = guard.get(&key, &mut timestamp_to_store) else {
+            return;
+        };
+
+        bun_output::scoped_log!(
+            dns,
+            "invalidate({})",
+            bstr::BStr::new(host.map(|h| h.as_bytes()).unwrap_or(b""))
+        );
+
+        // SAFETY: `entry` is a live cache slot; `valid`/`refcount` are only mutated
+        // under `global_cache().lock()`, which is held here.
+        unsafe {
+            (*entry).valid = false;
+            if (*entry).refcount == 0 {
+                guard.remove(entry);
+                Request::deinit(entry);
+            }
+        }
+    }
+
+    /// `node:net`'s counterpart to the usockets connect path's cache eviction.
+    #[host_fn]
+    pub(crate) fn invalidate_cached_lookup(
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arguments = callframe.arguments();
+
+        if arguments.len() < 1 {
+            return Err(global_this.throw_not_enough_arguments("invalidate", 1, arguments.len()));
+        }
+
+        if !arguments[0].is_string() {
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("hostname must be a string"))
+            );
+        }
+        let hostname_slice = arguments[0].to_slice(global_this)?;
+        let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
+
+        invalidate(Some(hostname_z.as_zstr()));
+        Ok(JSValue::UNDEFINED)
+    }
+
     extern "C" fn us_getaddrinfo(
         loop_: *mut Loop,
         _host: *const c_char,
@@ -6309,4 +6374,8 @@ export_host_fn!(
 export_host_fn!(
     internal::cached_lookup,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_cachedLookup"
+);
+export_host_fn!(
+    internal::invalidate_cached_lookup,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_invalidateCachedLookup"
 );

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -118,9 +118,7 @@ describe("dns.prefetch", () => {
   });
 });
 
-// Each test spawns its own isolated Bun subprocess, so the process-global DNS
-// counters are never shared between them — safe to run concurrently.
-describe.concurrent("DNS cache stats", () => {
+describe("DNS cache stats", () => {
   // `cacheHitsCompleted + cacheHitsInflight + cacheMisses === totalCount` is the
   // only thing that makes the counters reconcilable. Prefetching an already
   // cached host used to bump `totalCount` and return without counting the hit.
@@ -151,8 +149,14 @@ describe.concurrent("DNS cache stats", () => {
 // `node:tls` and the `node:http` client both connect through `node:net`, so the
 // cache that `fetch()`/`Bun.connect` use has to be reachable from there too —
 // otherwise `dns.prefetch()` is a no-op for every database/HTTP driver on npm.
-// Each `it` spawns its own isolated subprocess, so they run concurrently.
-describe.concurrent("node:net DNS cache", () => {
+// Kept sequential: each `it` spawns a full Bun subprocess that resolves DNS and
+// connects, so running them concurrently contends for CPU and makes the slowest
+// one exceed the per-test timeout under the debug+ASAN build.
+describe("node:net DNS cache", () => {
+  // The spawned fixture boots a full Bun (~3.5s under debug+ASAN) and then does
+  // two server setups plus a DNS resolution, a node:net connect, and a node:http
+  // round-trip, which pushes it past the 5s default per-test timeout on that
+  // build. Give it headroom; the CI runner already uses a larger timeout.
   it("resolves node:net and node:http through the shared cache", async () => {
     const { result, stderr, exitCode } = await runCacheFixture(`
       const net = require("node:net");
@@ -227,7 +231,7 @@ describe.concurrent("node:net DNS cache", () => {
       stderr: "",
       exitCode: 0,
     });
-  });
+  }, 30_000);
 
   it("leaves a user-supplied options.lookup in charge", async () => {
     const { result, stderr, exitCode } = await runCacheFixture(`

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -2,6 +2,14 @@ import { dns } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+// The DNS cache and its counters are process-global, so every test that reads
+// `getCacheStats()` runs in a fresh process.
+async function runCacheFixture(script: string) {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { result: JSON.parse(stdout.trim() || "null"), stderr, exitCode };
+}
+
 // The DNS cache is process-global, so this runs in its own process to get
 // clean counters. Docs promise that a failed connection evicts the host's
 // cache entry; a dead host must never be served as a cache hit.
@@ -70,5 +78,187 @@ describe("dns.prefetch", () => {
     const newStats2 = dns.getCacheStats();
     // Ensure it's cached.
     expect(newStats2.cacheHitsCompleted).toBeGreaterThan(currentStats.cacheHitsCompleted);
+  });
+
+  it("warms the cache for node:net", async () => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const net = require("node:net");
+      const server = net.createServer(socket => socket.end());
+      await new Promise(resolve => server.listen(0, resolve));
+      const { port } = server.address();
+
+      const before = Bun.dns.getCacheStats();
+      Bun.dns.prefetch("localhost", port);
+      const afterPrefetch = Bun.dns.getCacheStats();
+
+      // The prefetch inserts the cache entry synchronously, so the connect below
+      // hits it whether or not the resolution has landed yet.
+      await new Promise((resolve, reject) => {
+        const socket = net.connect(port, "localhost", () => socket.end());
+        socket.on("close", resolve);
+        socket.on("error", reject);
+      });
+      const afterConnect = Bun.dns.getCacheStats();
+      server.close();
+
+      const hits = s => s.cacheHitsCompleted + s.cacheHitsInflight;
+      console.log(
+        JSON.stringify({
+          prefetchMisses: afterPrefetch.cacheMisses - before.cacheMisses,
+          connectHits: hits(afterConnect) - hits(afterPrefetch),
+          connectMisses: afterConnect.cacheMisses - afterPrefetch.cacheMisses,
+        }),
+      );
+    `);
+    expect({ result, stderr, exitCode }).toEqual({
+      result: { prefetchMisses: 1, connectHits: 1, connectMisses: 0 },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+describe("DNS cache stats", () => {
+  // `cacheHitsCompleted + cacheHitsInflight + cacheMisses === totalCount` is the
+  // only thing that makes the counters reconcilable. Prefetching an already
+  // cached host used to bump `totalCount` and return without counting the hit.
+  it("accounts for every getaddrinfo call", async () => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const before = Bun.dns.getCacheStats();
+      Bun.dns.prefetch("localhost", 443);
+      Bun.dns.prefetch("localhost", 443);
+      Bun.dns.prefetch("localhost", 443);
+      const after = Bun.dns.getCacheStats();
+
+      const delta = key => after[key] - before[key];
+      console.log(
+        JSON.stringify({
+          total: delta("totalCount"),
+          accounted: delta("cacheHitsCompleted") + delta("cacheHitsInflight") + delta("cacheMisses"),
+        }),
+      );
+    `);
+    expect({ result, stderr, exitCode }).toEqual({
+      result: { total: 3, accounted: 3 },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+// `node:tls` and the `node:http` client both connect through `node:net`, so the
+// cache that `fetch()`/`Bun.connect` use has to be reachable from there too —
+// otherwise `dns.prefetch()` is a no-op for every database/HTTP driver on npm.
+describe("node:net DNS cache", () => {
+  it("resolves node:net and node:http through the shared cache", async () => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const net = require("node:net");
+      const http = require("node:http");
+
+      const netServer = net.createServer(socket => socket.end());
+      await new Promise(resolve => netServer.listen(0, resolve));
+      const netPort = netServer.address().port;
+
+      const httpServer = http.createServer((req, res) => res.end("ok"));
+      await new Promise(resolve => httpServer.listen(0, resolve));
+      const httpPort = httpServer.address().port;
+
+      const lookupEvents = [];
+      const netConnect = () =>
+        new Promise((resolve, reject) => {
+          const socket = net.connect(netPort, "localhost", () => socket.end());
+          socket.on("lookup", (err, address, family, host) => lookupEvents.push({ err, address, family, host }));
+          socket.on("close", resolve);
+          socket.on("error", reject);
+        });
+      const httpRequest = () =>
+        new Promise((resolve, reject) => {
+          const req = http.request(
+            { host: "localhost", port: httpPort, path: "/", headers: { connection: "close" } },
+            res => {
+              res.resume();
+              res.on("end", resolve);
+            },
+          );
+          req.on("error", reject);
+          req.end();
+        });
+
+      const hits = s => s.cacheHitsCompleted + s.cacheHitsInflight;
+      const delta = (before, after) => ({
+        hits: hits(after) - hits(before),
+        misses: after.cacheMisses - before.cacheMisses,
+        total: after.totalCount - before.totalCount,
+      });
+
+      const start = Bun.dns.getCacheStats();
+      await netConnect();
+      const afterNet = Bun.dns.getCacheStats();
+      await httpRequest();
+      const afterHttp = Bun.dns.getCacheStats();
+      netServer.close();
+      httpServer.close();
+
+      console.log(
+        JSON.stringify({
+          net: delta(start, afterNet),
+          http: delta(afterNet, afterHttp),
+          // The number of addresses "localhost" resolves to is up to the host, but
+          // the \`lookup\` event is part of the node:net contract either way.
+          lookupEvents: lookupEvents.length > 0,
+          lookupEventsValid: lookupEvents.every(
+            e => e.err === null && net.isIP(e.address) === e.family && e.host === "localhost",
+          ),
+        }),
+      );
+    `);
+    expect({ result, stderr, exitCode }).toEqual({
+      // "localhost" is resolved once and cached; node:http reuses the entry, even
+      // though it connects to a different port.
+      result: {
+        net: { hits: 0, misses: 1, total: 1 },
+        http: { hits: 1, misses: 0, total: 1 },
+        lookupEvents: true,
+        lookupEventsValid: true,
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("leaves a user-supplied options.lookup in charge", async () => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const net = require("node:net");
+      const server = net.createServer(socket => socket.end());
+      await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+      const { port } = server.address();
+
+      let calls = 0;
+      const before = Bun.dns.getCacheStats();
+      await new Promise((resolve, reject) => {
+        const socket = net.connect(
+          {
+            port,
+            host: "localhost",
+            lookup(hostname, options, callback) {
+              calls++;
+              callback(null, options.all ? [{ address: "127.0.0.1", family: 4 }] : "127.0.0.1", 4);
+            },
+          },
+          () => socket.end(),
+        );
+        socket.on("close", resolve);
+        socket.on("error", reject);
+      });
+      const after = Bun.dns.getCacheStats();
+      server.close();
+
+      console.log(JSON.stringify({ calls, totalCount: after.totalCount - before.totalCount }));
+    `);
+    expect({ result, stderr, exitCode }).toEqual({
+      result: { calls: 1, totalCount: 0 },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -261,4 +261,46 @@ describe("node:net DNS cache", () => {
       exitCode: 0,
     });
   });
+
+  // The docs promise a failed connection evicts the host's cache entry, and the
+  // Bun.connect test at the top of this file guards that. node:net connects to an
+  // address the cache already handed it, so it has to evict by hostname instead of
+  // serving a dead IP on every retry until the 30s TTL.
+  it("evicts the entry after a failed node:net connect", async () => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const net = require("node:net");
+      const listener = net.createServer(socket => socket.end());
+      await new Promise(resolve => listener.listen(0, resolve));
+      const { port } = listener.address();
+      await new Promise(resolve => listener.close(resolve));
+
+      const results = [];
+      for (let i = 0; i < 3; i++) {
+        let code = "none";
+        await new Promise(resolve => {
+          const socket = net.connect(port, "localhost", () => socket.end());
+          socket.on("close", resolve);
+          socket.on("error", e => {
+            code = e.code;
+            resolve();
+          });
+        });
+        const { cacheHitsCompleted, size, errors } = Bun.dns.getCacheStats();
+        results.push({ code, cacheHitsCompleted, size, errors });
+      }
+      console.log(JSON.stringify(results));
+    `);
+    // Each connect fails and evicts (size back to 0, one more eviction in errors),
+    // so the next attempt re-resolves as a fresh miss and is never served a dead
+    // address from the cache (cacheHitsCompleted stays 0).
+    expect({ result, stderr, exitCode }).toEqual({
+      result: [
+        { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 1 },
+        { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 2 },
+        { code: "ECONNREFUSED", cacheHitsCompleted: 0, size: 0, errors: 3 },
+      ],
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -118,7 +118,9 @@ describe("dns.prefetch", () => {
   });
 });
 
-describe("DNS cache stats", () => {
+// Each test spawns its own isolated Bun subprocess, so the process-global DNS
+// counters are never shared between them — safe to run concurrently.
+describe.concurrent("DNS cache stats", () => {
   // `cacheHitsCompleted + cacheHitsInflight + cacheMisses === totalCount` is the
   // only thing that makes the counters reconcilable. Prefetching an already
   // cached host used to bump `totalCount` and return without counting the hit.
@@ -149,7 +151,8 @@ describe("DNS cache stats", () => {
 // `node:tls` and the `node:http` client both connect through `node:net`, so the
 // cache that `fetch()`/`Bun.connect` use has to be reachable from there too —
 // otherwise `dns.prefetch()` is a no-op for every database/HTTP driver on npm.
-describe("node:net DNS cache", () => {
+// Each `it` spawns its own isolated subprocess, so they run concurrently.
+describe.concurrent("node:net DNS cache", () => {
   it("resolves node:net and node:http through the shared cache", async () => {
     const { result, stderr, exitCode } = await runCacheFixture(`
       const net = require("node:net");
@@ -257,6 +260,41 @@ describe("node:net DNS cache", () => {
     `);
     expect({ result, stderr, exitCode }).toEqual({
       result: { calls: 1, totalCount: 0 },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The cache is keyed on hostname alone and always resolves with AF_UNSPEC +
+  // default hints, so a connect that asks for anything else must bypass it and
+  // go through dns.lookup (which doesn't touch the getaddrinfo cache counters).
+  it.each([
+    ["an explicit family", `{ port, host: "localhost", family: 4 }`],
+    [
+      "non-default hints",
+      `{ port, host: "localhost", hints: require("node:dns").ADDRCONFIG | require("node:dns").V4MAPPED }`,
+    ],
+  ])("bypasses the cache for %s", async (_label, connectOptions) => {
+    const { result, stderr, exitCode } = await runCacheFixture(`
+      const net = require("node:net");
+      const server = net.createServer(socket => socket.end());
+      await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+      const { port } = server.address();
+
+      const before = Bun.dns.getCacheStats();
+      await new Promise((resolve, reject) => {
+        const socket = net.connect(${connectOptions}, () => socket.end());
+        socket.on("close", resolve);
+        socket.on("error", reject);
+      });
+      const after = Bun.dns.getCacheStats();
+      server.close();
+
+      // The cache was never consulted, so every counter is frozen.
+      console.log(JSON.stringify({ totalCount: after.totalCount - before.totalCount }));
+    `);
+    expect({ result, stderr, exitCode }).toEqual({
+      result: { totalCount: 0 },
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/node/net/node-unref-fixture.js
+++ b/test/js/node/net/node-unref-fixture.js
@@ -1,21 +1,23 @@
-const { connect } = require("tls");
+const net = require("node:net");
 
-const socket = connect(
-  {
-    host: "www.example.com",
-    port: 443,
-    rejectUnauthorized: false,
-  },
-  () => {
+// A local server that accepts the connection and sends nothing keeps the
+// socket connected without racing data delivery against process exit. Unref it
+// so only the client socket's ref state decides whether the process stays alive.
+const server = net.createServer(() => {});
+server.listen(0, () => {
+  server.unref();
+  const { port } = server.address();
+  const socket = net.connect(port, "localhost", () => {
     socket.on("data", () => {
       console.error("Received data. FAIL");
       process.exit(1);
     });
-    socket.write("GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n\r\n");
-  },
-);
-socket.unref();
-socket.ref();
-socket.ref();
-socket.ref();
-socket.unref();
+  });
+  // The final unref must win: the process has no other pending work, so it
+  // should exit cleanly instead of being kept alive by the connected socket.
+  socket.unref();
+  socket.ref();
+  socket.ref();
+  socket.ref();
+  socket.unref();
+});


### PR DESCRIPTION
`docs/runtime/networking/dns.mdx` says Bun's DNS cache is "automatically used by
`bun install`, `fetch()`, `node:http` (client), `Bun.connect`, `node:net`,
`node:tls`". It isn't used by the three node-API entries.

## Repro

```js
import * as net from "node:net";
const snapshot = () => Bun.dns.getCacheStats();

await using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
const port = server.port;

const before = snapshot();
await fetch(`http://localhost:${port}/`).then(r => r.text());
console.log("fetch     ", snapshot().totalCount - before.totalCount); // 1

const afterFetch = snapshot();
await new Promise(done => {
  const socket = net.connect(port, "localhost", () => socket.end());
  socket.on("close", done);
});
console.log("net.connect", snapshot().totalCount - afterFetch.totalCount); // 0
```

Every `getCacheStats()` counter stays frozen across `net.connect()` /
`http.request()` to a cacheable hostname, while the same hostname through
`fetch()` / `Bun.connect` shows the documented miss -> hit pattern in the same
process. `Bun.dns.prefetch()` is therefore a silent no-op for every
`node:net`-based client (pg, mysql2, redis, axios, and everything else on npm).

## Cause

`lookupAndConnect` in `src/js/node/net.ts` resolves the hostname with
`dns.lookup` and passes the resulting IP literal to the connect path.
`us_socket_group_connect` parses literal IPs with `try_parse_ip` and returns
before it ever reaches `Bun__addrinfo_get`, so the cache is never consulted.
`dns.lookup` has its own in-flight dedupe but no TTL cache, no shared entries,
and no stats.

`node:net` connected through `Bun.connect` (and therefore the cache) until the
node:net rework in #18962, which introduced `lookupAndConnect` for Node
compatibility.

## Fix

Add an internal `cachedLookup(hostname, port)` binding over the same
process-wide getaddrinfo cache `fetch()`, `Bun.connect` and `bun install` use,
and make it the default `lookup` for `node:net` (and therefore `node:tls` and
the `node:http` client, which connect through it).

The cache is keyed on hostname alone and always resolves with
`AF_UNSPEC + SOCK_STREAM` (+ `AI_ADDRCONFIG` off Windows), which is exactly what
`dns.ADDRCONFIG` + no family means. Anything else keeps going through
`dns.lookup`:

- a user-supplied `options.lookup`
- an explicit `family` (4/6)
- non-default `hints`
- the single-address path (`autoSelectFamily: false` or `localAddress` set)

The cache stores addresses in a v6-first interleave rather than the resolver's
order, so it only matches `verbatim` semantics on the `autoSelectFamily` (Happy
Eyeballs) path, where every address is tried anyway. The single-address path
consumes the first result verbatim, so it stays on `dns.lookup` to preserve the
resolver's ordering (unchanged from before this PR for those connects).

`dns.setDefaultResultOrder()`, the `lookup` event, and `options.all` keep
working on the cached path: the cached lookup returns the same
`[{ address, family, ttl }]` shape as `Bun.dns.lookup`, and `net.ts` sorts it
for `ipv4first` / `ipv6first` the way `node:dns`'s `lookup()` does.

Two related fixes:

- `internal::getaddrinfo` bumped `totalCount` and then returned early on a
  prefetch of an already-cached host, without counting the hit. That made
  `cacheHitsCompleted + cacheHitsInflight + cacheMisses` permanently diverge
  from `totalCount`, so the stats object could not be reconciled with itself.
  It now counts the hit before the early return.

- `Error::init_eai` has a `UV_EAI_AGAIN => ETIMEOUT` arm on Windows but no
  `EAI_AGAIN` arm on posix, so "temporary failure in name resolution" (by far the
  most common transient DNS failure) landed in the `_ => ENOTIMP` catch-all.
  Routing `node:net` through getaddrinfo makes that user-visible on every
  connect, so posix now maps it to `ETIMEOUT` like Windows does. This also
  changes `fetch()` / `Bun.connect` from `ENOTIMP` to `ETIMEOUT` for the same
  condition.

## Verification

`test/js/bun/dns/dns-prefetch.test.ts` gains four cases: `node:net` and
`node:http` resolving through the shared cache (one miss, then a hit on a
different port), `dns.prefetch()` warming the cache for `node:net`,
`hits + misses === totalCount`, and a user-supplied `options.lookup` still
bypassing the cache entirely. The three behavioral ones fail on `main` and pass
with this change.

Output of the issue's reproduction script, before and after:

<details>
<summary>before / after</summary>

```
# before
fetch(...)                    #1   {"cacheMisses":1,"size":1,"totalCount":1}
fetch(...)                    #2   {"cacheHitsCompleted":1,"totalCount":1}
node:net  connect(...)             NO CHANGE
node:http request(...)             NO CHANGE
Bun.dns.prefetch("localhost4")     {"cacheMisses":1,"size":1,"totalCount":1}
node:net  connect(.,"localhost4")  NO CHANGE
Bun.dns.prefetch("localhost4") #2  {"totalCount":1}
hits+misses = 4  vs  totalCount = 5   (INCONSISTENT)

# after
fetch(...)                    #1   {"cacheMisses":1,"size":1,"totalCount":1}
fetch(...)                    #2   {"cacheHitsCompleted":1,"totalCount":1}
node:net  connect(...)             {"cacheHitsCompleted":1,"totalCount":1}
node:http request(...)             {"cacheHitsCompleted":1,"totalCount":1}
Bun.dns.prefetch("localhost4")     {"cacheMisses":1,"size":1,"totalCount":1}
node:net  connect(.,"localhost4")  {"cacheHitsCompleted":1,"totalCount":1}
Bun.dns.prefetch("localhost4") #2  {"cacheHitsCompleted":1,"totalCount":1}
hits+misses = 8  vs  totalCount = 8
```

</details>

Four simultaneous `net.connect()` calls to one hostname now share a single
resolution (1 miss, 3 hits), as documented.

All 163 vendored `test/js/node/test/parallel/test-net-*.js` and `test-dns-*.js`
pass, including `test-net-dns-custom-lookup`, `test-net-dns-lookup`,
`test-net-dns-error`, `test-net-autoselectfamily*` and `test-dns-default-order-*`.
`test/js/node/net/`, `test/js/node/tls/` and `test/js/node/test/parallel/test-http-client-*`
show no new failures against `main`. `bun run rust:check-all` is clean across all
ten targets.

