### PR TITLE
node:https: emit tlsClientError on server handshake failures

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -753,6 +753,10 @@ public:
         httpContext->getSocketContextData()->onClientError = std::move(onClientError);
     }
 
+    void setOnHandshakeError(HttpContextData<SSL>::OnHandshakeErrorCallback onHandshakeError) {
+        httpContext->getSocketContextData()->onHandshakeError = std::move(onHandshakeError);
+    }
+
     void setOnSocketUpgraded(HttpContextData<SSL>::OnSocketUpgradedCallback onUpgraded) {
         httpContext->getSocketContextData()->onSocketUpgraded = onUpgraded;
     }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -153,6 +153,16 @@ private:
         // if we are closing or already closed, we don't need to do anything
         if (!us_socket_is_closed(s)) {
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+            if (!success && httpContextData->onHandshakeError) {
+                /* node's 'tlsClientError': the TLS session was never established,
+                 * so there is no request and no response - report the failure and
+                 * let the SSL layer tear the connection down. The handler runs JS,
+                 * which may close this socket. */
+                httpContextData->onHandshakeError(s, verify_error.error, verify_error.code, verify_error.reason);
+                if (us_socket_is_closed(s)) {
+                    return;
+                }
+            }
             // Set per-socket authorization status
             auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
             if(httpContextData->flags.rejectUnauthorized) {

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -48,6 +48,9 @@ private:
     using OnSocketUpgradedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnClientErrorCallback = MoveOnlyFunction<void(int is_ssl, struct us_socket_t *rawSocket, uWS::HttpParserError errorCode, char *rawPacket, int rawPacketLength)>;
     using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
+    /* A TLS handshake this context accepted never completed. `code`/`reason` carry
+     * the us_bun_verify_error_t strings, valid only for the duration of the call. */
+    using OnHandshakeErrorCallback = MoveOnlyFunction<void(struct us_socket_t *rawSocket, int error, const char *code, const char *reason)>;
 
     MoveOnlyFunction<void(const char *hostname)> missingServerNameHandler;
 
@@ -68,6 +71,7 @@ private:
     OnSocketDataCallback onSocketData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
+    OnHandshakeErrorCallback onHandshakeError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -26,6 +26,7 @@ const {
     useStrictMethodValidation: boolean,
     maxHeaderSize: number,
     onClientError: (ssl: boolean, socket: any, errorCode: number, rawPacket: ArrayBuffer) => undefined,
+    onHandshakeError: ((socket: any, verifyError: Error | null) => undefined) | undefined,
   ) => void;
   getCompleteWebRequestOrResponseBodyValueAsArrayBuffer: (arg: any) => ArrayBuffer | undefined;
   drainMicrotasks: () => void;

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,5 @@
 const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { ConnResetException } = require("internal/shared");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -50,4 +51,44 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+/**
+ * Build the Error for a server-side handshake that failed before completing. A
+ * fatal SSL protocol error (wrong version number, bad record, ...) carries the
+ * OpenSSL error string in `verifyError.reason`; everything else is the peer
+ * disconnecting mid-handshake, which Node reports as ECONNRESET.
+ */
+function tlsHandshakeError(verifyError) {
+  const verifyErrorCode = verifyError ? verifyError.code : undefined;
+  if (verifyErrorCode && verifyErrorCode !== "ECONNRESET") {
+    const reason = verifyError.reason || verifyError.message || "TLS handshake failed";
+    const err = new Error(reason) as Error & {
+      code?: string;
+      library?: string;
+      function?: string;
+      reason?: string;
+    };
+    // A fatal SSL-library error carries the full OpenSSL error string
+    // ("error:0a00042e:SSL routines:OPENSSL_internal:TLSV1_ALERT_PROTOCOL_VERSION").
+    // Decompose it into Node's library/function/reason properties and the
+    // ERR_SSL_<REASON> code the way ThrowCryptoError does.
+    const match = /^error:[0-9a-f]+:SSL routines:([^:]*):(.+)$/.exec(reason);
+    if (match) {
+      err.library = "SSL routines";
+      err.function = match[1];
+      err.reason = match[2];
+      err.code = `ERR_SSL_${match[2]}`;
+    } else {
+      err.code = verifyErrorCode;
+    }
+    return err;
+  }
+  return new ConnResetException("socket hang up");
+}
+
+export {
+  VALID_TLS_ERROR_MESSAGE_TYPES,
+  isValidTLSArray,
+  isValidTLSItem,
+  throwOnInvalidTLSArray,
+  tlsHandshakeError,
+};

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -85,10 +85,4 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
-export {
-  VALID_TLS_ERROR_MESSAGE_TYPES,
-  isValidTLSArray,
-  isValidTLSItem,
-  throwOnInvalidTLSArray,
-  tlsHandshakeError,
-};
+export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray, tlsHandshakeError };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { throwOnInvalidTLSArray, tlsHandshakeError } = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -75,6 +75,7 @@ const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
+const kTlsClientErrorMirror = Symbol("http.server.tlsClientErrorMirror");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
 // only created on the first request, and emission is gated per-request on the
@@ -247,6 +248,14 @@ function normalizeServerTls(tls) {
   return tls;
 }
 
+// Only a TLS server can see a handshake failure, and `listen({ tls })` can turn
+// a plain http.Server into one after construction - attach at both points.
+function installTlsClientErrorMirror(server) {
+  if (server[kTlsClientErrorMirror]) return;
+  server[kTlsClientErrorMirror] = true;
+  server.on("tlsClientError", mirrorTlsClientErrorToClientError);
+}
+
 function Server(options, callback): void {
   if (!(this instanceof Server)) return new Server(options, callback);
   EventEmitter.$call(this);
@@ -313,6 +322,7 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });
+      installTlsClientErrorMirror(this);
     } else {
       this[tlsSymbol] = null;
     }
@@ -558,6 +568,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
+      installTlsClientErrorMirror(this);
     }
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default
@@ -910,6 +921,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       true,
       typeof this.maxHeaderSize !== "undefined" ? this.maxHeaderSize : getMaxHTTPHeaderSize(),
       onServerClientError.bind(this),
+      tls ? onServerHandshakeError.bind(this) : undefined,
     );
 
     if (this?._unref) {
@@ -1013,6 +1025,30 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
   self.emit("clientError", err, nodeSocket);
   if (nodeSocket.listenerCount("error") > 0) {
     nodeSocket.emit("error", err);
+  }
+}
+
+// A TLS handshake on an accepted connection failed: there is no TLS session, so
+// no request will ever arrive on this socket. Node's tls.Server reports it
+// through 'tlsClientError'; https.Server mirrors it to 'clientError' through
+// the listener installed by the Server constructor.
+function onServerHandshakeError(socket: unknown, verifyError: Error | null) {
+  const self = this as Server;
+  const err = tlsHandshakeError(verifyError);
+  const existingDuplex = (socket as any).duplex;
+  const nodeSocket = existingDuplex ?? new NodeHTTPServerSocket(self, socket, true);
+  if (!existingDuplex) {
+    self.emit("connection", nodeSocket);
+  }
+  self.emit("tlsClientError", err, nodeSocket);
+}
+
+// Node's https.Server installs this in its constructor, so it runs before any
+// user 'tlsClientError' listener and a handshake failure reaches 'clientError'
+// first: https://github.com/nodejs/node/blob/v26.3.0/lib/https.js
+function mirrorTlsClientErrorToClientError(this: Server, err, socket) {
+  if (!this.emit("clientError", err, socket)) {
+    socket.destroy(err);
   }
 }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -41,6 +41,7 @@ import type { TLSSocket } from "node:tls";
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
+const { tlsHandshakeError } = require("internal/tls");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -218,40 +219,6 @@ function onConnectEnd() {
     error.localAddress = options.localAddress;
     this.destroy(error);
   }
-}
-
-/**
- * Build the Error for a handshake that failed before completing. A fatal SSL
- * protocol error (wrong version number, bad record, ...) carries the OpenSSL
- * error string in `verifyError.reason`; everything else is the peer
- * disconnecting mid-handshake, which Node reports as ECONNRESET.
- */
-function tlsHandshakeError(verifyError) {
-  const verifyErrorCode = verifyError ? verifyError.code : undefined;
-  if (verifyErrorCode && verifyErrorCode !== "ECONNRESET") {
-    const reason = verifyError.reason || verifyError.message || "TLS handshake failed";
-    const err = new Error(reason) as Error & {
-      code?: string;
-      library?: string;
-      function?: string;
-      reason?: string;
-    };
-    // A fatal SSL-library error carries the full OpenSSL error string
-    // ("error:0a00042e:SSL routines:OPENSSL_internal:TLSV1_ALERT_PROTOCOL_VERSION").
-    // Decompose it into Node's library/function/reason properties and the
-    // ERR_SSL_<REASON> code the way ThrowCryptoError does.
-    const match = /^error:[0-9a-f]+:SSL routines:([^:]*):(.+)$/.exec(reason);
-    if (match) {
-      err.library = "SSL routines";
-      err.function = match[1];
-      err.reason = match[2];
-      err.code = `ERR_SSL_${match[2]}`;
-    } else {
-      err.code = verifyErrorCode;
-    }
-    return err;
-  }
-  return new ConnResetException("socket hang up");
 }
 
 const SocketHandlers: SocketHandler = {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -40,6 +40,7 @@ extern "C" bool NodeHTTPResponse__setTimeout(void*, EncodedJSValue, JSC::JSGloba
 extern "C" void Server__setIdleTimeout(EncodedJSValue, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSValue, bool require_host_header, bool use_strict_method_validation);
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
+extern "C" EncodedJSValue Server__setOnHandshakeError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setMaxHTTPHeaderSize(JSC::JSGlobalObject*, EncodedJSValue, uint64_t);
 
 static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
@@ -988,13 +989,14 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ASSERT(callFrame->argumentCount() == 5);
+    ASSERT(callFrame->argumentCount() == 6);
     // This is an internal binding.
     JSValue serverValue = callFrame->uncheckedArgument(0);
     JSValue requireHostHeader = callFrame->uncheckedArgument(1);
     JSValue useStrictMethodValidation = callFrame->uncheckedArgument(2);
     JSValue maxHeaderSize = callFrame->uncheckedArgument(3);
     JSValue callback = callFrame->uncheckedArgument(4);
+    JSValue handshakeErrorCallback = callFrame->uncheckedArgument(5);
 
     double maxHeaderSizeNumber = maxHeaderSize.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1007,6 +1009,12 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
 
     Server__setOnClientError(globalObject, JSValue::encode(serverValue), JSValue::encode(callback));
     RETURN_IF_EXCEPTION(scope, {});
+
+    // Only a TLS server passes one; node:http never emits 'tlsClientError'.
+    if (handshakeErrorCallback.isCallable()) {
+        Server__setOnHandshakeError(globalObject, JSValue::encode(serverValue), JSValue::encode(handshakeErrorCallback));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     return JSValue::encode(jsUndefined());
 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -290,6 +290,9 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
 
     pub on_clienterror: jsc::StrongOptional,
 
+    /// Backs `node:https`' `'tlsClientError'`. Only ever dispatched when `SSL`.
+    pub on_handshake_error: jsc::StrongOptional,
+
     pub inspector_server_id: jsc::DebuggerId,
 }
 
@@ -302,7 +305,8 @@ pub struct UserRoute<const SSL: bool, const DEBUG: bool> {
 impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
     fn drop(&mut self) {
         // The remaining owned fields (config, base_url, h3_alt_svc, dev_server,
-        // user_routes, all_closed_promise, on_clienterror) drop automatically.
+        // user_routes, all_closed_promise, on_clienterror, on_handshake_error)
+        // drop automatically.
         if let Some(p) = self.plugins.take() {
             // SAFETY: `plugins` carries the `heap::alloc` provenance from
             // `ServePlugins::init`; this releases the server's counted ref.
@@ -1846,8 +1850,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         // owned-field cleanup (all_closed_promise / user_routes /
-        // config / on_clienterror / h3_alt_svc / dev_server / plugins) is
-        // handled by the heap::take drop below — see `impl Drop for NewServer`.
+        // config / on_clienterror / on_handshake_error / h3_alt_svc / dev_server /
+        // plugins) is handled by the heap::take drop below — see `impl Drop for NewServer`.
         if Self::HAS_H3 {
             if let Some(h3a) = this_ref.h3_app.take() {
                 // SAFETY: live H3::App handle owned by this server.
@@ -1913,6 +1917,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             plugins: None,
             user_routes: Vec::new(),
             on_clienterror: jsc::StrongOptional::empty(),
+            on_handshake_error: jsc::StrongOptional::empty(),
             inspector_server_id: jsc::DebuggerId::init(0),
         }));
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3525,6 +3525,56 @@ where
         }
     }
 
+    /// A TLS handshake on an accepted connection failed. Hands the failure to
+    /// `node:http`'s `'tlsClientError'` dispatcher along with a socket wrapper
+    /// for the connection that never produced a request.
+    pub fn on_handshake_error_callback(
+        &mut self,
+        socket: &mut uws::Socket,
+        verify_error: &uws_sys::us_bun_verify_error_t,
+    ) {
+        let Some(callback) = self.on_handshake_error.get() else {
+            return;
+        };
+        let global = self.global();
+        let node_socket = match jsc::from_js_host_call(&global, || {
+            Bun__createNodeHTTPServerSocketForClientError(
+                SSL,
+                std::ptr::from_mut(socket).cast::<c_void>(),
+                &global,
+            )
+        }) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        if node_socket.is_undefined_or_null() {
+            return;
+        }
+
+        // A handshake that never reached the peer's certificate (plaintext at the
+        // TLS port, bad record version, ...) has no verify error; JS reports those
+        // as ECONNRESET, the way `node:tls` does.
+        let verify_error_value = if verify_error.error_no == 0 {
+            JSValue::NULL
+        } else {
+            match jsc::system_error::verify_error_to_js(verify_error, &global) {
+                Ok(v) => v,
+                Err(_) => return,
+            }
+        };
+
+        // SAFETY: event_loop() returns a live raw pointer tied to the global.
+        let _scope =
+            unsafe { jsc::event_loop::EventLoop::enter_scope(global.bun_vm().event_loop()) };
+        if let Err(err) = callback.call(
+            &global,
+            JSValue::UNDEFINED,
+            &[node_socket, verify_error_value],
+        ) {
+            global.report_active_exception_as_unhandled(err);
+        }
+    }
+
     // `js_gc_route_list_set` / `ptr_to_js` live on the unbounded
     // `impl NewServer` in mod.rs; do not redefine them here.
 }
@@ -3669,6 +3719,62 @@ pub(super) fn server_set_on_client_error_(
     Ok(JSValue::UNDEFINED)
 }
 
+pub(super) fn server_set_on_handshake_error_(
+    global: &JSGlobalObject,
+    server: JSValue,
+    callback: JSValue,
+) -> JsResult<JSValue> {
+    if !server.is_object() {
+        return Err(global.throw(format_args!(
+            "Failed to set tlsClientError: The 'this' value is not a Server."
+        )));
+    }
+
+    if !callback.is_function() {
+        return Err(global.throw(format_args!(
+            "Failed to set tlsClientError: The provided value is not a function."
+        )));
+    }
+
+    macro_rules! handle {
+        ($T:ty) => {
+            if let Some(this) = server.as_::<$T>() {
+                // SAFETY: as_ returned a non-null *mut to a live server.
+                let this = unsafe { &mut *this };
+                if let Some(app) = this.app {
+                    this.on_handshake_error.deinit();
+                    this.on_handshake_error = StrongOptional::create(callback, global);
+                    // uws_sys::App::on_handshake_error takes the raw C-ABI handler shape;
+                    // reassemble the verify error the uws dispatcher unpacked.
+                    extern "C" fn thunk(
+                        user_data: *mut c_void,
+                        socket: *mut uws_sys::us_socket_t,
+                        error_no: c_int,
+                        code: *const core::ffi::c_char,
+                        reason: *const core::ffi::c_char,
+                    ) {
+                        // SAFETY: user_data is the `*mut Self` registered below; socket is a live
+                        // uWS socket; code/reason are NUL-terminated (or null) for this call.
+                        let this = unsafe { &mut *user_data.cast::<$T>() };
+                        let verify_error = uws_sys::us_bun_verify_error_t { error_no, code, reason };
+                        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+                        this.on_handshake_error_callback(bun_opaque::opaque_deref_mut(socket), &verify_error);
+                    }
+                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                    bun_opaque::opaque_deref_mut(app).on_handshake_error(thunk, core::ptr::from_mut::<$T>(this).cast::<c_void>());
+                }
+                return Ok(JSValue::UNDEFINED);
+            }
+        };
+    }
+    handle!(HTTPServer);
+    handle!(HTTPSServer);
+    handle!(DebugHTTPServer);
+    handle!(DebugHTTPSServer);
+    debug_assert!(false);
+    Ok(JSValue::UNDEFINED)
+}
+
 pub(super) fn server_set_app_flags_(
     global: &JSGlobalObject,
     server: JSValue,
@@ -3769,6 +3875,18 @@ extern "C" fn server_set_on_client_error_shim(
     host_fn::to_js_host_fn_result(
         global,
         server_set_on_client_error_(global, server, callback),
+    )
+}
+
+#[unsafe(export_name = "Server__setOnHandshakeError")]
+extern "C" fn server_set_on_handshake_error_shim(
+    global: &JSGlobalObject,
+    server: JSValue,
+    callback: JSValue,
+) -> JSValue {
+    host_fn::to_js_host_fn_result(
+        global,
+        server_set_on_handshake_error_(global, server, callback),
     )
 }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3756,12 +3756,22 @@ pub(super) fn server_set_on_handshake_error_(
                         // SAFETY: user_data is the `*mut Self` registered below; socket is a live
                         // uWS socket; code/reason are NUL-terminated (or null) for this call.
                         let this = unsafe { &mut *user_data.cast::<$T>() };
-                        let verify_error = uws_sys::us_bun_verify_error_t { error_no, code, reason };
+                        let verify_error = uws_sys::us_bun_verify_error_t {
+                            error_no,
+                            code,
+                            reason,
+                        };
                         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-                        this.on_handshake_error_callback(bun_opaque::opaque_deref_mut(socket), &verify_error);
+                        this.on_handshake_error_callback(
+                            bun_opaque::opaque_deref_mut(socket),
+                            &verify_error,
+                        );
                     }
                     // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).on_handshake_error(thunk, core::ptr::from_mut::<$T>(this).cast::<c_void>());
+                    bun_opaque::opaque_deref_mut(app).on_handshake_error(
+                        thunk,
+                        core::ptr::from_mut::<$T>(this).cast::<c_void>(),
+                    );
                 }
                 return Ok(JSValue::UNDEFINED);
             }

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -261,6 +261,17 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_on_clienterror(Self::SSL_FLAG, self.as_raw(), handler, user_data)
     }
 
+    /// Register the TLS-handshake-failure handler. A no-op on the plain-HTTP app,
+    /// whose socket vtable has no `on_handshake` slot.
+    pub fn on_handshake_error(
+        &mut self,
+        handler: extern "C" fn(*mut c_void, *mut us_socket_t, c_int, *const c_char, *const c_char),
+        user_data: *mut c_void,
+    ) {
+        // Callers receive the raw C args; `code`/`reason` are borrowed for the call.
+        c::uws_app_set_on_handshake_error(Self::SSL_FLAG, self.as_raw(), handler, user_data)
+    }
+
     pub fn listen_with_config(
         &mut self,
         handler: c::uws_listen_handler,
@@ -504,6 +515,20 @@ pub mod c {
             ssl: c_int,
             app: &mut uws_app_s,
             handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t, u8, *mut u8, c_int),
+            user_data: *mut c_void,
+        );
+        // safe: same as `uws_app_set_on_clienterror` — the handler/user_data pair
+        // is stored opaquely by the C++ shim.
+        pub(crate) safe fn uws_app_set_on_handshake_error(
+            ssl: c_int,
+            app: &mut uws_app_s,
+            handler: extern "C" fn(
+                *mut c_void,
+                *mut us_socket_t,
+                c_int,
+                *const c_char,
+                *const c_char,
+            ),
             user_data: *mut c_void,
         );
         pub(crate) fn uws_create_app(ssl: i32, options: BunSocketContextOptions) -> *mut uws_app_t;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -427,6 +427,24 @@ extern "C"
     }
   }
 
+  /* Only the SSL app ever dispatches on_handshake; the plain-HTTP vtable has no
+   * such slot, so there is nothing to register on uWS::App. */
+  void uws_app_set_on_handshake_error(int ssl, uws_app_t *app, void (*handler)(void *user_data, struct us_socket_t *rawSocket, int error, const char *code, const char *reason), void *user_data)
+  {
+    if (!ssl)
+    {
+      return;
+    }
+    uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    if (handler == nullptr) {
+      uwsApp->setOnHandshakeError(nullptr);
+      return;
+    }
+    uwsApp->setOnHandshakeError([handler, user_data](struct us_socket_t *rawSocket, int error, const char *code, const char *reason) {
+      handler(user_data, rawSocket, error, code, reason);
+    });
+  }
+
   void uws_app_listen(int ssl, uws_app_t *app, int port,
                       uws_listen_handler handler, void *user_data)
   {

--- a/test/js/node/http/node-https-tlsClientError.test.ts
+++ b/test/js/node/http/node-https-tlsClientError.test.ts
@@ -1,0 +1,209 @@
+// A TLS handshake that fails on an https.Server must reach JS: node's tls.Server
+// emits 'tlsClientError' and https.Server mirrors it to 'clientError'. Bun's
+// https.Server is backed by Bun.serve, whose uWS listener used to drop handshake
+// failures on the floor, so every class below was silent.
+import { expect, test } from "bun:test";
+import { tls as COMMON_CERT } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import tls from "node:tls";
+import { constants as cryptoConstants } from "node:crypto";
+
+type Probe = (port: number) => Promise<unknown>;
+
+// Runs `probe` against an https.Server and resolves once the server reports the
+// handshake failure. Both events are recorded so their order (node emits
+// 'clientError' first, from the listener https.Server installs in its
+// constructor) is observable.
+async function collectHandshakeFailure(serverOptions: https.ServerOptions, probe: Probe) {
+  const events: string[] = [];
+  const errors: (Error & { code?: string })[] = [];
+  const server = https.createServer({ ...COMMON_CERT, ...serverOptions }, (_req, res) => res.end("unexpected"));
+  const reported = Promise.withResolvers<void>();
+
+  server.on("connection", () => events.push("connection"));
+  server.on("clientError", (err: Error & { code?: string }, socket: net.Socket) => {
+    events.push(`clientError:${err.code}`);
+    socket.destroy();
+  });
+  server.on("tlsClientError", (err: Error & { code?: string }) => {
+    events.push(`tlsClientError:${err.code}`);
+    errors.push(err);
+    reported.resolve();
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    await probe((server.address() as AddressInfo).port);
+    await reported.promise;
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+  return { events, errors };
+}
+
+// Writes raw (non-TLS) bytes at the TLS port, then waits for the server to hang
+// up on it. Never resolves on its own, so the caller's `reported` promise is
+// what actually gates the assertions.
+function writeRawBytes(bytes: string | null): Probe {
+  return port =>
+    new Promise<void>(resolve => {
+      const socket = net.connect(port, "127.0.0.1", () => {
+        if (bytes === null) socket.destroy();
+        else socket.write(bytes);
+      });
+      socket.on("error", () => {});
+      socket.on("close", () => resolve());
+    });
+}
+
+test("plaintext HTTP at the TLS port reports ERR_SSL_HTTP_REQUEST", async () => {
+  const { events, errors } = await collectHandshakeFailure({}, writeRawBytes("GET / HTTP/1.1\r\nHost: h\r\n\r\n"));
+
+  expect(events).toEqual(["connection", "clientError:ERR_SSL_HTTP_REQUEST", "tlsClientError:ERR_SSL_HTTP_REQUEST"]);
+  expect(errors[0].message).toContain("HTTP_REQUEST");
+  // Node decomposes the OpenSSL error string the same way ThrowCryptoError does.
+  expect(errors[0]).toMatchObject({ library: "SSL routines", reason: "HTTP_REQUEST" });
+});
+
+test("garbage bytes at the TLS port report ERR_SSL_WRONG_VERSION_NUMBER", async () => {
+  const { events } = await collectHandshakeFailure(
+    {},
+    writeRawBytes("\x80\x81\x82not-tls-at-all-012345678901234567890123456789"),
+  );
+
+  expect(events).toEqual([
+    "connection",
+    "clientError:ERR_SSL_WRONG_VERSION_NUMBER",
+    "tlsClientError:ERR_SSL_WRONG_VERSION_NUMBER",
+  ]);
+});
+
+test("a client that disconnects before the handshake reports ECONNRESET", async () => {
+  const { events, errors } = await collectHandshakeFailure({}, writeRawBytes(null));
+
+  expect(events).toEqual(["connection", "clientError:ECONNRESET", "tlsClientError:ECONNRESET"]);
+  expect(errors[0].message).toBe("socket hang up");
+});
+
+test("a client offering only an excluded protocol version reports ERR_SSL_UNSUPPORTED_PROTOCOL", async () => {
+  const { events } = await collectHandshakeFailure(
+    {
+      secureOptions:
+        cryptoConstants.SSL_OP_NO_TLSv1 | cryptoConstants.SSL_OP_NO_TLSv1_1 | cryptoConstants.SSL_OP_NO_TLSv1_2,
+    },
+    port =>
+      new Promise<void>(resolve => {
+        const socket = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false, maxVersion: "TLSv1.2" });
+        socket.on("error", () => resolve());
+        socket.on("secureConnect", () => {
+          socket.destroy();
+          resolve();
+        });
+      }),
+  );
+
+  expect(events).toEqual([
+    "connection",
+    "clientError:ERR_SSL_UNSUPPORTED_PROTOCOL",
+    "tlsClientError:ERR_SSL_UNSUPPORTED_PROTOCOL",
+  ]);
+});
+
+test("requestCert + rejectUnauthorized reports ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE", async () => {
+  const { events } = await collectHandshakeFailure(
+    { requestCert: true, rejectUnauthorized: true, ca: [COMMON_CERT.cert] },
+    port =>
+      new Promise<void>(resolve => {
+        const socket = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+        socket.on("error", () => resolve());
+        socket.on("secureConnect", () => socket.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n"));
+        socket.on("close", () => resolve());
+      }),
+  );
+
+  expect(events).toEqual([
+    "connection",
+    "clientError:ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE",
+    "tlsClientError:ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE",
+  ]);
+});
+
+test("with no clientError listener the failed connection is destroyed", async () => {
+  const server = https.createServer(COMMON_CERT, (_req, res) => res.end("unexpected"));
+  const destroyed = Promise.withResolvers<boolean>();
+  server.on("tlsClientError", (_err, socket: net.Socket) => {
+    // The listener https.Server installs in its constructor runs first: with no
+    // 'clientError' listener it destroys the socket before user listeners see it.
+    destroyed.resolve(socket.destroyed);
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const port = (server.address() as AddressInfo).port;
+    const socket = net.connect(port, "127.0.0.1", () => socket.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n"));
+    socket.on("error", () => {});
+    expect(await destroyed.promise).toBe(true);
+    socket.destroy();
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("a TLS handshake failure still lets later connections succeed", async () => {
+  const server = https.createServer(COMMON_CERT, (_req, res) => res.end("ok"));
+  const reported = Promise.withResolvers<void>();
+  server.on("tlsClientError", () => reported.resolve());
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const port = (server.address() as AddressInfo).port;
+    const bad = net.connect(port, "127.0.0.1", () => bad.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n"));
+    bad.on("error", () => {});
+    await reported.promise;
+    bad.destroy();
+
+    const res = await fetch(`https://127.0.0.1:${port}/`, { tls: { rejectUnauthorized: false } });
+    expect(await res.text()).toBe("ok");
+    expect(res.status).toBe(200);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("http.Server never emits tlsClientError and keeps its own clientError", async () => {
+  const server = http.createServer((_req, res) => res.end("ok"));
+  const events: string[] = [];
+  const reported = Promise.withResolvers<void>();
+  server.on("tlsClientError", () => events.push("tlsClientError"));
+  server.on("clientError", (err: Error & { code?: string }, socket: net.Socket) => {
+    events.push(`clientError:${err.code}`);
+    socket.destroy();
+    reported.resolve();
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const port = (server.address() as AddressInfo).port;
+    const socket = net.connect(port, "127.0.0.1", () => socket.write("GET / HTTP/1.1\r\nBad Header\r\n\r\n"));
+    socket.on("error", () => {});
+    await reported.promise;
+    socket.destroy();
+    // No 'tlsClientError' mirror is installed on a plain http.Server, so its
+    // 'clientError' fires exactly once, from the HTTP parser.
+    expect(events).toEqual(["clientError:HPE_INVALID_HEADER_TOKEN"]);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});

--- a/test/js/node/http/node-https-tlsClientError.test.ts
+++ b/test/js/node/http/node-https-tlsClientError.test.ts
@@ -4,13 +4,13 @@
 // failures on the floor, so every class below was silent.
 import { expect, test } from "bun:test";
 import { tls as COMMON_CERT } from "harness";
+import { constants as cryptoConstants } from "node:crypto";
 import { once } from "node:events";
 import http from "node:http";
 import https from "node:https";
-import net from "node:net";
 import type { AddressInfo } from "node:net";
+import net from "node:net";
 import tls from "node:tls";
-import { constants as cryptoConstants } from "node:crypto";
 
 type Probe = (port: number) => Promise<unknown>;
 


### PR DESCRIPTION
## What

An `https.Server` never emitted `'tlsClientError'` (nor its `'clientError'` mirror). Every class of TLS handshake failure was silent in JS: plaintext HTTP at the TLS port, garbage bytes, a client/server protocol-version mismatch, a missing client certificate under `requestCert`, and a client that disconnects mid-handshake. `'tlsClientError'` is the only JS hook an https server has for handshake failures (logging, abuse/scanner detection, per-client-cert diagnostics), so anything counting handshake failures on Bun saw zero forever.

`node:tls`'s `tls.Server` already emitted these correctly; only the `Bun.serve`-backed `https.Server` was affected.

## Repro

```js
import https from "node:https";
import net from "node:net";
// ... key/cert omitted
const srv = https.createServer({ key, cert }, (_q, s) => s.end("x"));
srv.on("tlsClientError", e => console.log("tlsClientError:" + e.code));
srv.listen(0, "127.0.0.1", () => {
  const port = srv.address().port;
  const c = net.connect(port, "127.0.0.1", () => c.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n"));
  c.on("error", () => {});
});
```

Node v26 prints `tlsClientError:ERR_SSL_HTTP_REQUEST`. Bun printed nothing.

## Cause

`https.Server` runs on `Bun.serve`, whose uWS `HttpContext` dropped the TLS-layer `onHandshake(success=false)` callback on the floor. The connection was torn down on the wire (the peer got a fatal alert or a close), but the owning JS `https.Server` object was never told, so the documented `'tlsClientError'`/`'clientError'` events could not fire.

## Fix

- Add an `onHandshakeError` slot to the uWS `HttpContext` (SSL only) that fires when a handshake on an accepted connection fails, before the connection is closed.
- Plumb it through `uws_sys` / `NodeHTTP.cpp` / `bun_runtime`'s server to a JS callback that emits `'tlsClientError'` with the node-shaped `code`, carrying a socket wrapper for the connection that never produced a request.
- Install, in the `https.Server` constructor (and the `listen({ tls })` path), the same listener Node uses to mirror `'tlsClientError'` to `'clientError'` and destroy the socket when no `'clientError'` listener is present.
- Share the error-shaping helper (`tlsHandshakeError`) with `node:tls` so `tls.Server` and `https.Server` report identical codes.

## Verification

New test `test/js/node/http/node-https-tlsClientError.test.ts` covers all five failure classes plus the no-listener destroy behavior, event ordering (`connection` then `clientError` then `tlsClientError`), that a handshake failure does not break later connections, and that a plain `http.Server` still never emits `'tlsClientError'`.

Fail-before/fail-after (released bun times out waiting for the events; this build passes):

```
USE_SYSTEM_BUN=1 bun test node-https-tlsClientError.test.ts   # 7 fail (timeout), 1 pass
bun bd test node-https-tlsClientError.test.ts                 # 8 pass
```

Codes match Node v26.3.0 exactly: `ERR_SSL_HTTP_REQUEST`, `ERR_SSL_WRONG_VERSION_NUMBER`, `ERR_SSL_UNSUPPORTED_PROTOCOL`, `ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE`, `ECONNRESET`.
