### PR TITLE
FileSink: return per-chunk byte count when a write flushes buffered data

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -918,9 +918,16 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Wrote(chunk_len);
             }
             WriteResult::Done(amt) => {
+                // `amt` drains the whole buffer (older chunks first); report
+                // only the portion that belongs to this chunk, like `Wrote`.
+                let old_buffered = self.outgoing.size().saturating_sub(chunk_len);
                 self.outgoing.reset();
                 self.parent_on_write(amt, WriteStatus::EndOfFile);
+                return WriteResult::Done(amt.saturating_sub(old_buffered));
             }
+            // `Pending` returns a promise whose resolution value is accounted
+            // for separately (see `FileSink::bytes_accepted`), so it is left as
+            // the drained count here.
             WriteResult::Pending(amt) => {
                 self.outgoing.wrote(amt);
                 self.parent_on_write(amt, WriteStatus::Pending);

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -887,10 +887,13 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
             return WriteResult::Wrote(buf_len);
         }
 
-        self.try_write_newly_buffered_data()
+        self.try_write_newly_buffered_data(buf_len)
     }
 
-    fn try_write_newly_buffered_data(&mut self) -> WriteResult {
+    /// `chunk_len` is the caller's chunk, already appended to `outgoing`.
+    /// `Wrote(n)` reports bytes of *that chunk* accepted, not bytes drained
+    /// from the buffer (older chunks included) — that is `flush()`'s accounting.
+    fn try_write_newly_buffered_data(&mut self, chunk_len: usize) -> WriteResult {
         debug_assert!(!self.is_done);
 
         // Borrow `self.outgoing` only for the syscall. `try_write` takes `&self`
@@ -903,15 +906,16 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
 
         match rc {
             WriteResult::Wrote(amt) => {
-                if amt == self.outgoing.size() {
-                    self.outgoing.reset();
-                    self.parent_on_write(amt, WriteStatus::Drained);
-                } else {
+                if amt < self.outgoing.size() {
                     self.outgoing.wrote(amt);
                     self.parent_on_write(amt, WriteStatus::Pending);
                     Self::register_poll(self);
                     return WriteResult::Pending(amt);
                 }
+
+                self.outgoing.reset();
+                self.parent_on_write(amt, WriteStatus::Drained);
+                return WriteResult::Wrote(chunk_len);
             }
             WriteResult::Done(amt) => {
                 self.outgoing.reset();
@@ -957,7 +961,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Err(sys::Error::oom());
             }
 
-            return self.try_write_newly_buffered_data();
+            return self.try_write_newly_buffered_data(buf.len());
         }
 
         let rc = self.try_write(self.force_sync, buf);

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -271,6 +271,41 @@ it.skipIf(!isPosix)("a backpressured string write() resolves to its encoded byte
   }
 
   expect(received).toBe(size);
+});
+
+// A chunk big enough to flush the bytes buffered by earlier writes must still
+// report its own size. Writes are issued without `await` in between so the
+// auto-flush microtask cannot drain the buffer first. Skipped on Windows: there
+// every write to a file-backed sink returns a (shared) promise instead.
+it.skipIf(!isPosix)("write result is not cumulative when the chunk flushes buffered bytes", async () => {
+  using dir = tempDir("filesink-cumulative", {});
+  const filename = path.join(String(dir), "test.bin");
+  const writer = Bun.file(filename).writer();
+
+  const ascii = Buffer.alloc(505, "a").toString();
+  const bytes = Buffer.alloc(64 * 1024, "c");
+  const latin1 = Buffer.alloc(40_000, "é").toString();
+  const utf16 = Buffer.alloc(20_000, "😀").toString();
+
+  const results = [
+    writer.write(ascii), // buffered
+    writer.write(bytes), // flushes `ascii` + itself
+    writer.write(Buffer.alloc(10, "d")), // buffered
+    writer.write(latin1), // flushes the 10 bytes + itself
+    writer.write("e"), // buffered
+    writer.write(utf16), // flushes the 1 byte + itself
+  ];
+  await writer.end();
+
+  expect(results).toEqual([
+    Buffer.byteLength(ascii),
+    bytes.byteLength,
+    10,
+    Buffer.byteLength(latin1),
+    1,
+    Buffer.byteLength(utf16),
+  ]);
+  expect(results.reduce((sum, n) => sum + n, 0)).toBe(fs.statSync(filename).size);
 });
 
 if (isWindows) {


### PR DESCRIPTION
Fixes #12194

## What

`FileSink.write()` is documented to return the number of bytes written for the chunk passed to it (`bun-types`: "@returns Number of bytes written"), and `test/js/bun/util/filesink.test.ts` asserts this ("write result is not cumulative"). That test only covers fd-backed sinks with an `await` between writes, so it never exercises the buffered -> flush path.

When a chunk is appended to a non-empty internal buffer and the combined size crosses the streaming writer's `CHUNK_SIZE` (4096), the buffer is drained and `write()` returned the total number of bytes drained (older buffered chunks included) instead of the current chunk's size. Any `written += sink.write(chunk)` accounting loop was then wrong by the amount of previously buffered data.

## Repro

```js
import * as fs from "node:fs";
const p = `${process.env.TMPDIR ?? "/tmp"}/fsink-cum-${process.pid}.bin`;

const w = Bun.file(p).writer();
const r1 = w.write("a".repeat(505));        // 505    (buffered; correct)
const r2 = w.write(new Uint8Array(33060));  // 33565  <- 505 + 33060 (triggers flush)
const r3 = w.write(new Uint8Array(10));     // 10     (buffered; correct)
const r4 = w.write("b".repeat(70000));      // 70010  <- 10 + 70000
await w.end();
console.log("sum of returns:", r1 + r2 + r3 + r4);     // 104090
console.log("actual file size:", fs.statSync(p).size); // 103575
```

The data written to disk is byte-perfect; only the returned counts are wrong.

## Cause

In `src/io/PipeWriter.rs`, `try_write_newly_buffered_data` is reached after the new chunk has already been appended to `outgoing`. On the fully-drained branch it returned `WriteResult::Wrote(amt)` where `amt` is the bytes drained from the whole buffer, not the bytes of the chunk that triggered the drain. `FileSink::to_result` forwards that straight to JS.

## Fix

`try_write_newly_buffered_data` now takes the chunk length and returns `WriteResult::Wrote(chunk_len)` on the fully-drained path. Draining of older buffered bytes is what `flush()`'s return value accounts for. The partial-write / pending / error paths are unchanged.

## Verification

New test in `filesink.test.ts` ("write result is not cumulative when the chunk flushes buffered bytes") covers bytes, latin1, and utf16 chunks that each flush previously buffered data, and asserts the summed returns equal the file size.

- `USE_SYSTEM_BUN=1 bun test` -> fails (returns 66041/40010/20001 instead of 65536/40000/20000)
- `bun bd test` -> passes
- full `filesink.test.ts`, `terminal.test.ts`, `process-stdio.test.ts`, `spawn-streaming-stdin.test.ts` pass (other `StreamingWriter` consumers)
- `bun run rust:check-all` -> 10 ok, 0 failed

