### PR TITLE
tls: accept the { pem, passphrase } object form of the key option

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,16 +1,8 @@
 const { isTypedArray, isArrayBuffer } = require("node:util/types");
-
-function isPemObject(obj: unknown): obj is { pem: unknown } {
-  return $isObject(obj) && "pem" in obj;
-}
-
-function isPemArray(obj: unknown): obj is [{ pem: unknown }] {
-  // if (obj instanceof Object && "pem" in obj) return isValidTLSArray(obj.pem);
-  return $isArray(obj) && obj.every(isPemObject);
-}
+const { validateString } = require("internal/validators");
 
 function isValidTLSItem(obj: unknown) {
-  if (typeof obj === "string" || isTypedArray(obj) || isArrayBuffer(obj) || $inheritsBlob(obj) || isPemArray(obj)) {
+  if (typeof obj === "string" || isTypedArray(obj) || isArrayBuffer(obj) || $inheritsBlob(obj)) {
     return true;
   }
 
@@ -50,4 +42,60 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+// `{ pem, passphrase? }` is only an element form of the `key` array; `cert` and
+// `ca` take the raw forms only.
+function isPemObject(entry: unknown): entry is { pem: unknown; passphrase?: unknown } {
+  return $isObject(entry) && (entry as { pem?: unknown }).pem !== undefined;
+}
+
+/**
+ * Validates `options.key` and unwraps the `{ pem, passphrase? }` array elements
+ * documented by `tls.createSecureContext`. An entry's own passphrase applies to
+ * that key alone, which a native secure context (one passphrase per SSL_CTX)
+ * cannot express, so that entry's key is decrypted here instead. Returns `key`
+ * untouched when there is nothing to unwrap.
+ * https://github.com/nodejs/node/blob/main/lib/internal/tls/secure-context.js
+ */
+function normalizeKeyOption(key: unknown) {
+  if (!$isArray(key)) {
+    throwOnInvalidTLSArray("options.key", key);
+    return key;
+  }
+
+  const length = key.length;
+  let hasPemObject = false;
+  for (let i = 0; i < length; i++) {
+    if (isPemObject(key[i])) {
+      hasPemObject = true;
+      break;
+    }
+  }
+  if (!hasPemObject) {
+    throwOnInvalidTLSArray("options.key", key);
+    return key;
+  }
+
+  let createPrivateKey;
+  const normalized = $newArrayWithSize(length);
+  for (let i = 0; i < length; i++) {
+    const entry = key[i];
+    const isPem = isPemObject(entry);
+    const pem = isPem ? entry.pem : entry;
+    if (!isValidTLSItem(pem)) {
+      throw $ERR_INVALID_ARG_TYPE("options.key", VALID_TLS_ERROR_MESSAGE_TYPES, pem);
+    }
+
+    const passphrase = isPem ? entry.passphrase : undefined;
+    if ($isUndefinedOrNull(passphrase)) {
+      normalized[i] = pem;
+      continue;
+    }
+
+    validateString(passphrase, "options.passphrase");
+    createPrivateKey ??= require("node:crypto").createPrivateKey;
+    normalized[i] = createPrivateKey({ key: pem, passphrase }).export({ type: "pkcs8", format: "pem" });
+  }
+  return normalized;
+}
+
+export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, normalizeKeyOption, throwOnInvalidTLSArray };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { normalizeKeyOption, throwOnInvalidTLSArray } = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -277,7 +277,7 @@ function Server(options, callback): void {
 
     let key = options.key;
     if (key) {
-      throwOnInvalidTLSArray("options.key", key);
+      key = normalizeKeyOption(key);
       this[isTlsSymbol] = true;
     }
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,7 +5,7 @@ const Duplex = require("internal/streams/duplex");
 const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { normalizeKeyOption, throwOnInvalidTLSArray } = require("internal/tls");
 const {
   validateString,
   validateNumber,
@@ -782,7 +782,12 @@ var InternalSecureContext = class SecureContext {
       const cert = options.cert;
       if (cert) throwOnInvalidTLSArray("options.cert", cert);
       const key = options.key;
-      if (key) throwOnInvalidTLSArray("options.key", key);
+      if (key) {
+        // `normalizeKeyOption` returns a new array only when it unwrapped a
+        // `{ pem, passphrase? }` element, so the common path stays copy-free.
+        const normalizedKey = normalizeKeyOption(key);
+        if (normalizedKey !== key) options = { ...options, key: normalizedKey };
+      }
       const ca = options.ca;
       if (ca) throwOnInvalidTLSArray("options.ca", ca);
       if (options.servername != null && typeof options.servername !== "string")
@@ -1299,7 +1304,7 @@ function Server(options, secureConnectionListener): void {
 
       let key = options.key;
       if (key) {
-        throwOnInvalidTLSArray("options.key", key);
+        key = normalizeKeyOption(key);
       }
       this.key = key;
 

--- a/test/js/node/tls/node-tls-key-pem-object.test.ts
+++ b/test/js/node/tls/node-tls-key-pem-object.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import tls, { connect, createServer, type PeerCertificate, type Server, type TLSSocket } from "node:tls";
+
+// `tls.createSecureContext`'s documented object form of `key`:
+// `key: [{ pem, passphrase? }]`, where a per-entry passphrase decrypts that key
+// alone. rsa_private_encrypted.pem is rsa_private.pem encrypted with "password";
+// both match rsa_cert.crt (self-signed, CN=localhost).
+const fixtures = join(import.meta.dir, "fixtures");
+const passKey = readFileSync(join(fixtures, "rsa_private_encrypted.pem"));
+const rawKey = readFileSync(join(fixtures, "rsa_private.pem"));
+const cert = readFileSync(join(fixtures, "rsa_cert.crt"));
+
+describe("key: [{ pem, passphrase }]", () => {
+  async function servedCertCN(serverOptions: object) {
+    const server: Server = createServer(serverOptions, socket => socket.end());
+    const { promise: failed, reject } = Promise.withResolvers<never>();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1");
+    await Promise.race([once(server, "listening"), failed]);
+    let client: TLSSocket | undefined;
+    try {
+      const { port } = server.address() as AddressInfo;
+      client = connect({ port, host: "127.0.0.1", ca: [cert], servername: "localhost" });
+      client.on("error", reject);
+      await Promise.race([once(client, "secureConnect"), failed]);
+      expect(client.authorized).toBe(true);
+      return (client.getPeerCertificate() as PeerCertificate).subject.CN;
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  }
+
+  it("unwraps { pem } and serves the certificate", async () => {
+    expect(await servedCertCN({ key: [{ pem: rawKey }], cert: [cert] })).toBe("localhost");
+  });
+
+  it("applies a per-entry passphrase", async () => {
+    expect(await servedCertCN({ key: [{ pem: passKey, passphrase: "password" }], cert })).toBe("localhost");
+  });
+
+  it("falls back to options.passphrase when the entry has none", async () => {
+    expect(await servedCertCN({ key: [{ pem: passKey }], passphrase: "password", cert })).toBe("localhost");
+  });
+
+  it("prefers the per-entry passphrase over options.passphrase", async () => {
+    const options = { key: [{ pem: passKey, passphrase: "password" }], passphrase: "wrong", cert };
+    expect(await servedCertCN(options)).toBe("localhost");
+  });
+
+  it("accepts raw entries alongside { pem } entries", async () => {
+    const key = [rawKey, { pem: passKey, passphrase: "password" }];
+    expect(await servedCertCN({ key, cert: [cert, cert] })).toBe("localhost");
+  });
+
+  it("works on https.createServer", async () => {
+    const server = https.createServer({ key: [{ pem: rawKey }], cert }, (_req, res) => res.end("served"));
+    const { promise: body, resolve, reject } = Promise.withResolvers<string>();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1");
+    await Promise.race([once(server, "listening"), body]);
+    try {
+      const { port } = server.address() as AddressInfo;
+      const req = https.get({ host: "127.0.0.1", port, ca: cert, servername: "localhost" }, res => {
+        res.setEncoding("utf8");
+        let text = "";
+        res.on("data", chunk => (text += chunk));
+        res.on("end", () => resolve(text));
+        res.on("error", reject);
+      });
+      req.on("error", reject);
+      expect(await body).toBe("served");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("works on a tls.connect client certificate", async () => {
+    const server: Server = createServer({
+      key: rawKey,
+      cert,
+      ca: [cert],
+      requestCert: true,
+      rejectUnauthorized: true,
+    });
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    server.on("secureConnection", socket => {
+      resolve(socket.authorized);
+      socket.end();
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1");
+    await Promise.race([once(server, "listening"), promise]);
+    let client: TLSSocket | undefined;
+    try {
+      const { port } = server.address() as AddressInfo;
+      client = connect({
+        port,
+        host: "127.0.0.1",
+        key: [{ pem: passKey, passphrase: "password" }],
+        cert,
+        ca: [cert],
+        servername: "localhost",
+      });
+      client.on("error", reject);
+      expect(await promise).toBe(true);
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  it("builds a secure context", () => {
+    expect(() => tls.createSecureContext({ key: [{ pem: passKey, passphrase: "password" }], cert })).not.toThrow();
+  });
+
+  it("rejects a wrong per-entry passphrase", () => {
+    expect(() => createServer({ key: [{ pem: passKey, passphrase: "wrong" }], cert })).toThrow(
+      expect.objectContaining({ code: "ERR_OSSL_BAD_DECRYPT" }),
+    );
+  });
+
+  it("rejects a non-string per-entry passphrase", () => {
+    expect(() => createServer({ key: [{ pem: rawKey, passphrase: 7 }], cert })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('The "options.passphrase" property must be of type string'),
+      }),
+    );
+  });
+
+  it("rejects an invalid pem value", () => {
+    expect(() => createServer({ key: [{ pem: true }], cert })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('The "options.key" property must be of type string'),
+      }),
+    );
+  });
+
+  it("rejects the object form outside of an array", () => {
+    expect(() => createServer({ key: { pem: rawKey }, cert })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('The "options.key" property must be of type string'),
+      }),
+    );
+  });
+
+  it("rejects the object form for cert, which only node's key option accepts", () => {
+    expect(() => createServer({ key: rawKey, cert: [{ pem: cert }] })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('The "options.cert" property must be of type string'),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What

`node:tls` and `node:https` accept the documented `tls.createSecureContext` form of `key`: an array of `{ pem, passphrase? }` objects, where a per-entry `passphrase` decrypts that key alone. This is specifically how per-key passphrases are supplied. Bun rejected it.

## Repro

```js
// bun repro.mjs  /  node repro.mjs   (needs `openssl` on PATH)
import https from "node:https";
import tls from "node:tls";
import fs from "node:fs";
import { execSync } from "node:child_process";
const D = fs.mkdtempSync("/tmp/httpssrv-");
execSync(`openssl req -x509 -newkey rsa:2048 -nodes -keyout ${D}/k.pem -out ${D}/c.pem -days 2 ` +
  `-subj /CN=127.0.0.1 -addext subjectAltName=IP:127.0.0.1,DNS:localhost`, { stdio: "ignore" });
const KEY = fs.readFileSync(`${D}/k.pem`, "utf8"), CERT = fs.readFileSync(`${D}/c.pem`, "utf8");

const srv = https.createServer({ key: [{ pem: KEY }], cert: [CERT] }, (q, s) => s.end("served"));
srv.on("error", e => { console.log("server 'error' event:", e.code); process.exit(0); });
srv.listen(0, "127.0.0.1", () => {
  const c = tls.connect({ port: srv.address().port, host: "127.0.0.1", ca: [CERT], servername: "localhost" },
    () => { console.log("client connected"); process.exit(0); });
  c.on("error", e => console.log("client error", e.code));
});
```

Node serves the request. Bun before this change:

```
server 'error' event: ERR_INVALID_ARG_TYPE
  (element of TLSOptions.key must be of type string, ArrayBuffer, or Blob)
```

## Cause

Bun's validation layer tolerated the `{ pem }` wrapper but nothing unwrapped `.pem` before the options crossed into native, so the bindgen SSL config union rejected the array element. Node does this unwrap in `lib/internal/tls/secure-context.js`; Bun had no equivalent.

## Fix

Unwrap the wrapper in the shared key normalizer used by `tls.createSecureContext`, `tls.Server.setSecureContext`, and the `http`/`https` `Server` constructor, so both the server and client (`tls.connect` / `https.request`) paths are covered. Because a native secure context carries a single passphrase per `SSL_CTX`, an entry that supplies its own passphrase is decrypted in JS via `createPrivateKey` and folded to plain PEM before crossing into native. The `{ pem }` wrapper now applies to `key` only, matching Node (`cert`/`ca` still take only the raw forms).

## Verification

New tests in `test/js/node/tls/node-tls-key-pem-object.test.ts` cover: unwrapping `{ pem }`, per-entry passphrase (including precedence over `options.passphrase` and fallback to it), mixed raw + `{ pem }` arrays, `https.createServer`, a `tls.connect` client certificate, `createSecureContext`, and the rejection cases (wrong/non-string passphrase, invalid pem, object form outside an array, object form for `cert`). Each fails on `USE_SYSTEM_BUN=1` and passes with the debug build. The existing Node compat tests `test-tls-options-boolean-check.js` and `test-https-options-boolean-check.js` still pass.
