### PR TITLE
node:https: forward minVersion/maxVersion/secureProtocol to the server TLS context

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,5 @@
 const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { validateString } = require("internal/validators");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -50,4 +51,153 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+// BoringSSL TLS1_x_VERSION constants (from openssl/tls1.h). The native context
+// applies these via SSL_CTX_set_min/max_proto_version.
+const TLS1_VERSION = 0x0301;
+const TLS1_1_VERSION = 0x0302;
+const TLS1_2_VERSION = 0x0303;
+const TLS1_3_VERSION = 0x0304;
+
+const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
+
+// Backs tls.DEFAULT_MIN_VERSION / tls.DEFAULT_MAX_VERSION. Kept here so node:tls
+// and the node:http(s) server resolve version bounds from one source of truth.
+// https://github.com/Jarred-Sumner/uSockets/blob/fafc241e8664243fc0c51d69684d5d02b9805134/src/crypto/openssl.c#L519-L523
+const defaultProtocolVersions = { min: "TLSv1.2", max: "TLSv1.3" };
+
+// Node seeds the protocol-version defaults from its --tls-min-vX.Y /
+// --tls-max-vX.Y CLI flags; the equivalent flags reach us through
+// process.execArgv. The lowest requested minimum and the highest requested
+// maximum win when several are passed, matching node_options precedence.
+{
+  const execArgv = process.execArgv;
+  const hasFlag = (flag: string) => execArgv.includes(flag);
+  if (hasFlag("--tls-min-v1.0")) defaultProtocolVersions.min = "TLSv1";
+  else if (hasFlag("--tls-min-v1.1")) defaultProtocolVersions.min = "TLSv1.1";
+  else if (hasFlag("--tls-min-v1.2")) defaultProtocolVersions.min = "TLSv1.2";
+  else if (hasFlag("--tls-min-v1.3")) defaultProtocolVersions.min = "TLSv1.3";
+  if (hasFlag("--tls-max-v1.3")) defaultProtocolVersions.max = "TLSv1.3";
+  else if (hasFlag("--tls-max-v1.2")) defaultProtocolVersions.max = "TLSv1.2";
+}
+
+function tlsStringToProtocolVersion(v) {
+  switch (v) {
+    case "TLSv1":
+      return TLS1_VERSION;
+    case "TLSv1.1":
+      return TLS1_1_VERSION;
+    case "TLSv1.2":
+      return TLS1_2_VERSION;
+    case "TLSv1.3":
+      return TLS1_3_VERSION;
+    default:
+      return 0;
+  }
+}
+
+// Node's legacy secureProtocol string pins both bounds to a single version
+// (e.g. 'TLSv1_2_method'); 'TLS_method'/'SSLv23_method' leave the range open.
+// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L120
+function secureProtocolToVersionRange(secureProtocol) {
+  if (typeof secureProtocol !== "string") return null;
+  if (
+    secureProtocol === "TLSv1_method" ||
+    secureProtocol === "TLSv1_client_method" ||
+    secureProtocol === "TLSv1_server_method"
+  )
+    return [TLS1_VERSION, TLS1_VERSION];
+  if (
+    secureProtocol === "TLSv1_1_method" ||
+    secureProtocol === "TLSv1_1_client_method" ||
+    secureProtocol === "TLSv1_1_server_method"
+  )
+    return [TLS1_1_VERSION, TLS1_1_VERSION];
+  if (
+    secureProtocol === "TLSv1_2_method" ||
+    secureProtocol === "TLSv1_2_client_method" ||
+    secureProtocol === "TLSv1_2_server_method"
+  )
+    return [TLS1_2_VERSION, TLS1_2_VERSION];
+  return null;
+}
+
+/**
+ * Translate minVersion/maxVersion/secureProtocol into the integer protocol
+ * range the native TLS context applies. secureProtocol wins over the explicit
+ * bounds, like Node's SecureContext::Init; unset bounds fall back to
+ * tls.DEFAULT_MIN_VERSION / tls.DEFAULT_MAX_VERSION.
+ */
+function resolveProtocolVersionRange(minVersion, maxVersion, secureProtocol) {
+  const range = secureProtocolToVersionRange(secureProtocol);
+  if (range) return { minVersion: range[0], maxVersion: range[1] };
+  return {
+    minVersion: tlsStringToProtocolVersion(minVersion ?? defaultProtocolVersions.min),
+    maxVersion: tlsStringToProtocolVersion(maxVersion ?? defaultProtocolVersions.max),
+  };
+}
+
+function validateProtocolVersions(minVersion, maxVersion) {
+  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
+  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
+}
+
+// Valid OpenSSL/BoringSSL secureProtocol method names (legacy API). Built lazily
+// so the Set is only allocated when a secureProtocol option is actually used.
+let _SECURE_PROTOCOL_METHODS: Set<string> | undefined;
+function getSecureProtocolMethods() {
+  if (!_SECURE_PROTOCOL_METHODS) {
+    _SECURE_PROTOCOL_METHODS = new Set([
+      "TLS_method",
+      "TLS_client_method",
+      "TLS_server_method",
+      "SSLv23_method",
+      "SSLv23_client_method",
+      "SSLv23_server_method",
+      "TLSv1_method",
+      "TLSv1_client_method",
+      "TLSv1_server_method",
+      "TLSv1_1_method",
+      "TLSv1_1_client_method",
+      "TLSv1_1_server_method",
+      "TLSv1_2_method",
+      "TLSv1_2_client_method",
+      "TLSv1_2_server_method",
+    ]);
+  }
+  return _SECURE_PROTOCOL_METHODS;
+}
+
+// Matches Node: SSLv2/SSLv3 methods are disabled, anything unrecognized is an
+// unknown method.
+// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L100
+function invalidProtocolMethod(message) {
+  // Node throws all secureProtocol failures (SSLv2/SSLv3 disabled + unknown
+  // method) via THROW_ERR_TLS_INVALID_PROTOCOL_METHOD: a TypeError carrying the
+  // ERR_TLS_INVALID_PROTOCOL_METHOD code, varying only the message.
+  const error = new TypeError(message);
+  error.code = "ERR_TLS_INVALID_PROTOCOL_METHOD";
+  return error;
+}
+
+function validateSecureProtocol(secureProtocol) {
+  if (secureProtocol === undefined || secureProtocol === null) return;
+  validateString(secureProtocol, "options.secureProtocol");
+  if (secureProtocol.startsWith("SSLv2_")) throw invalidProtocolMethod("SSLv2 methods disabled");
+  if (secureProtocol.startsWith("SSLv3_")) throw invalidProtocolMethod("SSLv3 methods disabled");
+  if (!getSecureProtocolMethods().has(secureProtocol)) {
+    throw invalidProtocolMethod(`Unknown method: ${secureProtocol}`);
+  }
+}
+
+export {
+  VALID_TLS_ERROR_MESSAGE_TYPES,
+  defaultProtocolVersions,
+  isValidTLSArray,
+  isValidTLSItem,
+  resolveProtocolVersionRange,
+  throwOnInvalidTLSArray,
+  validateProtocolVersions,
+  validateSecureProtocol,
+};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,12 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const {
+  resolveProtocolVersionRange,
+  throwOnInvalidTLSArray,
+  validateProtocolVersions,
+  validateSecureProtocol,
+} = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -303,6 +308,13 @@ function Server(options, callback): void {
     }
 
     if (this[isTlsSymbol]) {
+      // Node's https.Server runs its options through tls.createSecureContext(),
+      // so the protocol-version bounds have to reach Bun.serve()'s TLS context
+      // as well, as the integer range the native layer applies.
+      const { minVersion, maxVersion, secureProtocol } = options;
+      validateSecureProtocol(secureProtocol);
+      validateProtocolVersions(minVersion, maxVersion);
+
       this[tlsSymbol] = normalizeServerTls({
         serverName,
         key,
@@ -312,6 +324,7 @@ function Server(options, callback): void {
         secureOptions,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
+        ...resolveProtocolVersionRange(minVersion, maxVersion, secureProtocol),
       });
     } else {
       this[tlsSymbol] = null;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,7 +5,13 @@ const Duplex = require("internal/streams/duplex");
 const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const {
+  defaultProtocolVersions,
+  resolveProtocolVersionRange,
+  throwOnInvalidTLSArray,
+  validateProtocolVersions,
+  validateSecureProtocol,
+} = require("internal/tls");
 const {
   validateString,
   validateNumber,
@@ -302,56 +308,8 @@ function validateCiphers(ciphers: string, name: string = "options") {
   }
 }
 
-const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
-
 // Subset of Node's configSecureContext() validations:
 // https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/internal/tls/secure-context.js#L318
-// Valid OpenSSL/BoringSSL secureProtocol method names (legacy API). Built lazily
-// so the Set is only allocated when a secureProtocol option is actually used.
-let _SECURE_PROTOCOL_METHODS: Set<string> | undefined;
-function getSecureProtocolMethods() {
-  if (!_SECURE_PROTOCOL_METHODS) {
-    _SECURE_PROTOCOL_METHODS = new Set([
-      "TLS_method",
-      "TLS_client_method",
-      "TLS_server_method",
-      "SSLv23_method",
-      "SSLv23_client_method",
-      "SSLv23_server_method",
-      "TLSv1_method",
-      "TLSv1_client_method",
-      "TLSv1_server_method",
-      "TLSv1_1_method",
-      "TLSv1_1_client_method",
-      "TLSv1_1_server_method",
-      "TLSv1_2_method",
-      "TLSv1_2_client_method",
-      "TLSv1_2_server_method",
-    ]);
-  }
-  return _SECURE_PROTOCOL_METHODS;
-}
-// Matches Node: SSLv2/SSLv3 methods are disabled, anything unrecognized is an
-// unknown method.
-// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L100
-function invalidProtocolMethod(message) {
-  // Node throws all secureProtocol failures (SSLv2/SSLv3 disabled + unknown
-  // method) via THROW_ERR_TLS_INVALID_PROTOCOL_METHOD: a TypeError carrying the
-  // ERR_TLS_INVALID_PROTOCOL_METHOD code, varying only the message.
-  const error = new TypeError(message);
-  error.code = "ERR_TLS_INVALID_PROTOCOL_METHOD";
-  return error;
-}
-function validateSecureProtocol(secureProtocol) {
-  if (secureProtocol === undefined || secureProtocol === null) return;
-  validateString(secureProtocol, "options.secureProtocol");
-  if (secureProtocol.startsWith("SSLv2_")) throw invalidProtocolMethod("SSLv2 methods disabled");
-  if (secureProtocol.startsWith("SSLv3_")) throw invalidProtocolMethod("SSLv3 methods disabled");
-  if (!getSecureProtocolMethods().has(secureProtocol)) {
-    throw invalidProtocolMethod(`Unknown method: ${secureProtocol}`);
-  }
-}
-
 function validateSecureContextOptions(options) {
   const {
     ciphers,
@@ -385,10 +343,7 @@ function validateSecureContextOptions(options) {
   if (dhparam === "auto") {
     throw $ERR_CRYPTO_UNSUPPORTED_OPERATION("Automatic DH parameter selection is not supported");
   }
-  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
-  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
+  validateProtocolVersions(minVersion, maxVersion);
   if (ticketKeys !== undefined && ticketKeys !== null) {
     validateBuffer(ticketKeys, "options.ticketKeys");
     const ticketKeysByteLength = ticketKeys.byteLength;
@@ -616,57 +571,6 @@ function checkServerIdentity(hostname, cert) {
 // that used to live in this file.
 const NativeSecureContext = $rust("SecureContext.rs", "js.getConstructor");
 
-// Node treats any falsy key/cert/ca as "not provided" (test-tls-options-
-// boolean-check.js exercises false/0/""). The bindgen SSLConfigFile union only
-// accepts null|string|ArrayBuffer|Blob|array, so coerce falsy → null before
-// crossing into native so `{ key: false }` etc. doesn't throw
-// ERR_INVALID_ARG_TYPE from the bindgen layer.
-// BoringSSL TLS1_x_VERSION constants (from openssl/tls1.h). The native context
-// applies these via SSL_CTX_set_min/max_proto_version.
-const TLS1_VERSION = 0x0301;
-const TLS1_1_VERSION = 0x0302;
-const TLS1_2_VERSION = 0x0303;
-const TLS1_3_VERSION = 0x0304;
-function tlsStringToProtocolVersion(v) {
-  switch (v) {
-    case "TLSv1":
-      return TLS1_VERSION;
-    case "TLSv1.1":
-      return TLS1_1_VERSION;
-    case "TLSv1.2":
-      return TLS1_2_VERSION;
-    case "TLSv1.3":
-      return TLS1_3_VERSION;
-    default:
-      return 0;
-  }
-}
-// Node's legacy secureProtocol string pins both bounds to a single version
-// (e.g. 'TLSv1_2_method'); 'TLS_method'/'SSLv23_method' leave the range open.
-// https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L120
-function secureProtocolToVersionRange(secureProtocol) {
-  if (typeof secureProtocol !== "string") return null;
-  if (
-    secureProtocol === "TLSv1_method" ||
-    secureProtocol === "TLSv1_client_method" ||
-    secureProtocol === "TLSv1_server_method"
-  )
-    return [TLS1_VERSION, TLS1_VERSION];
-  if (
-    secureProtocol === "TLSv1_1_method" ||
-    secureProtocol === "TLSv1_1_client_method" ||
-    secureProtocol === "TLSv1_1_server_method"
-  )
-    return [TLS1_1_VERSION, TLS1_1_VERSION];
-  if (
-    secureProtocol === "TLSv1_2_method" ||
-    secureProtocol === "TLSv1_2_client_method" ||
-    secureProtocol === "TLSv1_2_server_method"
-  )
-    return [TLS1_2_VERSION, TLS1_2_VERSION];
-  return null;
-}
-
 /**
  * Node's `pfx` option: parse each PKCS#12 blob into PEM key/cert/ca and fold
  * them into the regular options so every downstream consumer (the native
@@ -727,6 +631,11 @@ function newNativeSecureContext(options, cached = true) {
     options = { ...options, ALPNProtocols: normalized.ALPNProtocols };
   }
   if (options) {
+    // Node treats any falsy key/cert/ca as "not provided" (test-tls-options-
+    // boolean-check.js exercises false/0/""). The bindgen SSLConfigFile union only
+    // accepts null|string|ArrayBuffer|Blob|array, so coerce falsy → null before
+    // crossing into native so `{ key: false }` etc. doesn't throw
+    // ERR_INVALID_ARG_TYPE from the bindgen layer.
     const { key, cert, ca } = options;
     if (!key || !cert || !ca) {
       options = {
@@ -736,26 +645,11 @@ function newNativeSecureContext(options, cached = true) {
         ca: ca || null,
       };
     }
-  }
-  if (options) {
-    // Read each option once. Translate minVersion/maxVersion/secureProtocol to
-    // the integer protocol range the native layer applies, so the bindings
-    // receive numbers, not the user-facing strings. When none are given the
-    // module-level tls.DEFAULT_MIN_VERSION / DEFAULT_MAX_VERSION apply, the
-    // way Node's createSecureContext does.
-    const { minVersion: optMinVersion, maxVersion: optMaxVersion, secureProtocol: optSecureProtocol } = options;
-    {
-      let minVersion, maxVersion;
-      const range = secureProtocolToVersionRange(optSecureProtocol);
-      if (range) {
-        minVersion = range[0];
-        maxVersion = range[1];
-      } else {
-        minVersion = tlsStringToProtocolVersion(optMinVersion ?? DEFAULT_MIN_VERSION);
-        maxVersion = tlsStringToProtocolVersion(optMaxVersion ?? DEFAULT_MAX_VERSION);
-      }
-      options = { ...options, minVersion, maxVersion };
-    }
+    // The bindings take the protocol range as numbers, not user-facing strings.
+    options = {
+      ...options,
+      ...resolveProtocolVersionRange(options.minVersion, options.maxVersion, options.secureProtocol),
+    };
   }
   const ctx = (cached ? NativeSecureContext.intern : NativeSecureContext.createPrivate)(options);
   if (pfxExtraCAs) {
@@ -1447,22 +1341,7 @@ function Server(options, secureConnectionListener): void {
         clientRenegotiationWindow: CLIENT_RENEG_WINDOW,
         contexts: contexts,
         ciphers: this.ciphers,
-        // Translate minVersion/maxVersion/secureProtocol to the integer
-        // protocol range the native layer applies (secureProtocol wins, like
-        // Node's SecureContext::Init). When none are given the module-level
-        // tls.DEFAULT_MIN_VERSION / DEFAULT_MAX_VERSION apply.
-        ...(() => {
-          let minVersion, maxVersion;
-          const range = secureProtocolToVersionRange(this.secureProtocol);
-          if (range) {
-            minVersion = range[0];
-            maxVersion = range[1];
-          } else {
-            minVersion = tlsStringToProtocolVersion(this.minVersion ?? DEFAULT_MIN_VERSION);
-            maxVersion = tlsStringToProtocolVersion(this.maxVersion ?? DEFAULT_MAX_VERSION);
-          }
-          return { minVersion, maxVersion };
-        })(),
+        ...resolveProtocolVersionRange(this.minVersion, this.maxVersion, this.secureProtocol),
       },
       TLSSocket,
     ];
@@ -1482,24 +1361,6 @@ function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
 }
 const DEFAULT_ECDH_CURVE = "auto";
-// https://github.com/Jarred-Sumner/uSockets/blob/fafc241e8664243fc0c51d69684d5d02b9805134/src/crypto/openssl.c#L519-L523
-let DEFAULT_MIN_VERSION = "TLSv1.2",
-  DEFAULT_MAX_VERSION = "TLSv1.3";
-
-// Node seeds the protocol-version defaults from its --tls-min-vX.Y /
-// --tls-max-vX.Y CLI flags; the equivalent flags reach us through
-// process.execArgv. The lowest requested minimum and the highest requested
-// maximum win when several are passed, matching node_options precedence.
-{
-  const execArgv = process.execArgv;
-  const hasFlag = (flag: string) => execArgv.includes(flag);
-  if (hasFlag("--tls-min-v1.0")) DEFAULT_MIN_VERSION = "TLSv1";
-  else if (hasFlag("--tls-min-v1.1")) DEFAULT_MIN_VERSION = "TLSv1.1";
-  else if (hasFlag("--tls-min-v1.2")) DEFAULT_MIN_VERSION = "TLSv1.2";
-  else if (hasFlag("--tls-min-v1.3")) DEFAULT_MIN_VERSION = "TLSv1.3";
-  if (hasFlag("--tls-max-v1.3")) DEFAULT_MAX_VERSION = "TLSv1.3";
-  else if (hasFlag("--tls-max-v1.2")) DEFAULT_MAX_VERSION = "TLSv1.2";
-}
 
 function normalizeConnectArgs(listArgs) {
   const args = net._normalizeArgs(listArgs);
@@ -1804,20 +1665,20 @@ export default {
     setTLSDefaultCiphers(value);
   },
   DEFAULT_ECDH_CURVE,
-  // Accessors so `tls.DEFAULT_MAX_VERSION = 'TLSv1.2'` reaches the
-  // module-level variables that context construction reads (Node mutates the
-  // exports object the same way).
+  // Accessors so `tls.DEFAULT_MAX_VERSION = 'TLSv1.2'` reaches the state that
+  // every context construction reads (Node mutates the exports object the same
+  // way).
   get DEFAULT_MAX_VERSION() {
-    return DEFAULT_MAX_VERSION;
+    return defaultProtocolVersions.max;
   },
   set DEFAULT_MAX_VERSION(value) {
-    DEFAULT_MAX_VERSION = value;
+    defaultProtocolVersions.max = value;
   },
   get DEFAULT_MIN_VERSION() {
-    return DEFAULT_MIN_VERSION;
+    return defaultProtocolVersions.min;
   },
   set DEFAULT_MIN_VERSION(value) {
-    DEFAULT_MIN_VERSION = value;
+    defaultProtocolVersions.min = value;
   },
   getCiphers,
   setDefaultCACertificates,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -28,6 +28,7 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
+import { connect as tlsConnect } from "node:tls";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
@@ -1327,6 +1328,70 @@ describe("node https server", async () => {
     } finally {
       done();
     }
+  });
+
+  // Resolves to the protocol the client negotiated, or the error code the
+  // handshake failed with.
+  async function negotiate(serverOptions: object, clientOptions: object) {
+    const server = createHttpsServer({ ...httpsOptions, ...serverOptions }, (req, res) => res.end("served"));
+    try {
+      const url = await listen(server, "https");
+      const { promise, resolve } = Promise.withResolvers<{ protocol?: string | null; code?: string }>();
+      const socket = tlsConnect(
+        { port: Number(url.port), host: "127.0.0.1", rejectUnauthorized: false, ...clientOptions },
+        () => resolve({ protocol: socket.getProtocol() }),
+      );
+      socket.on("error", err => resolve({ code: (err as NodeJS.ErrnoException).code }));
+      const result = await promise;
+      socket.destroy();
+      await once(socket, "close");
+      return result;
+    } finally {
+      server.close();
+    }
+  }
+
+  it("enforces minVersion against a client that caps below it", async () => {
+    expect(await negotiate({ minVersion: "TLSv1.3", maxVersion: "TLSv1.3" }, { maxVersion: "TLSv1.2" })).toEqual({
+      code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION",
+    });
+  });
+
+  it("still serves a client that can reach the pinned minVersion", async () => {
+    expect(await negotiate({ minVersion: "TLSv1.3", maxVersion: "TLSv1.3" }, {})).toEqual({ protocol: "TLSv1.3" });
+  });
+
+  it("enforces maxVersion against a client that floors above it", async () => {
+    expect(await negotiate({ maxVersion: "TLSv1.2" }, { minVersion: "TLSv1.3" })).toEqual({
+      code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION",
+    });
+  });
+
+  it("caps an unconstrained client at maxVersion", async () => {
+    expect(await negotiate({ maxVersion: "TLSv1.2" }, {})).toEqual({ protocol: "TLSv1.2" });
+  });
+
+  it("pins both bounds from the legacy secureProtocol option", async () => {
+    expect(await negotiate({ secureProtocol: "TLSv1_2_method" }, {})).toEqual({ protocol: "TLSv1.2" });
+    expect(await negotiate({ secureProtocol: "TLSv1_2_method" }, { minVersion: "TLSv1.3" })).toEqual({
+      code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION",
+    });
+  });
+
+  it("negotiates TLSv1.3 by default", async () => {
+    expect(await negotiate({}, {})).toEqual({ protocol: "TLSv1.3" });
+  });
+
+  it("rejects invalid protocol version options", () => {
+    expect(() => createHttpsServer({ ...httpsOptions, minVersion: "TLSv9" })).toThrow(
+      "TLSv9 is not a valid minimum TLS protocol version",
+    );
+    expect(() => createHttpsServer({ ...httpsOptions, maxVersion: "TLSv9" })).toThrow(
+      "TLSv9 is not a valid maximum TLS protocol version",
+    );
+    expect(() => createHttpsServer({ ...httpsOptions, secureProtocol: "TLSv9_method" })).toThrow(
+      "Unknown method: TLSv9_method",
+    );
   });
 });
 


### PR DESCRIPTION
### What

`https.createServer({ minVersion, maxVersion, secureProtocol })` silently ignored the TLS protocol-version bounds. A server pinned to `minVersion: "TLSv1.3"` would still serve a TLS1.2-only client, and a `maxVersion: "TLSv1.2"` server would negotiate TLS1.3, with no error, no event, and no other signal to the operator.

`tls.createServer()` already enforced the same options correctly, so this was specific to the `node:http(s)` server path.

### Repro

```js
import https from "node:https";
import tls from "node:tls";

const srv = https.createServer({ key, cert, minVersion: "TLSv1.3", maxVersion: "TLSv1.3" }, (q, s) => s.end("served"));
srv.listen(0, "127.0.0.1", () => {
  const c = tls.connect({ port: srv.address().port, host: "127.0.0.1", ca: [cert], maxVersion: "TLSv1.2" }, () => {
    console.log("CONNECTED proto=" + c.getProtocol()); // Bun: TLSv1.2 (below the floor). Node: refused.
  });
  c.on("error", e => console.log("client refused " + e.code));
});
```

Node refuses with `ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION`; Bun connected at TLSv1.2, below the configured floor.

### Cause

`Server()` in `src/js/node/_http_server.ts` builds the `Bun.serve({ tls })` config from a hardcoded subset of TLS options. `minVersion` / `maxVersion` / `secureProtocol` were never forwarded into the native TLS context, so the uSockets default range (TLS1.2 floor, open ceiling) was always used.

### Fix

Move the `minVersion` / `maxVersion` / `secureProtocol` resolution and validation into `src/js/internal/tls.ts` (`resolveProtocolVersionRange`, `validateProtocolVersions`, `validateSecureProtocol`, and the `DEFAULT_MIN_VERSION` / `DEFAULT_MAX_VERSION` state) so `node:tls` and the `node:http(s)` server share one implementation, and forward the resolved integer range from the https `Server` constructor. `secureProtocol` wins over the explicit bounds, matching Node's `SecureContext::Init`.

### Verification

New tests in `test/js/node/http/node-http.test.ts` negotiate a real handshake across the server/client version matrix (floor enforced, ceiling enforced, both-reachable serves, default TLSv1.3, legacy `secureProtocol`) and assert the invalid-version options throw. They pass with the debug build and fail against the released binary.