### PR TITLE
node:https: enforce server handshakeTimeout

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -753,6 +753,10 @@ public:
         httpContext->getSocketContextData()->onClientError = std::move(onClientError);
     }
 
+    void setHandshakeTimeout(uint64_t timeoutMs, HttpContextData<SSL>::OnHandshakeTimeoutCallback onHandshakeTimeout, void *userData) {
+        httpContext->setHandshakeTimeout(timeoutMs, onHandshakeTimeout, userData);
+    }
+
     void setOnSocketUpgraded(HttpContextData<SSL>::OnSocketUpgradedCallback onUpgraded) {
         httpContext->getSocketContextData()->onSocketUpgraded = onUpgraded;
     }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -33,6 +33,9 @@
 #include <iostream>
 #include "MoveOnlyFunction.h"
 #include "HttpParser.h"
+#include <algorithm>
+#include <chrono>
+#include <climits>
 #include <span>
 #include <array>
 #include <mutex>
@@ -147,11 +150,137 @@ public:
     }
 
 private:
+    /* ── TLS handshake watchdog ──────────────────────────────────────────────
+     * us_socket_timeout only resolves to the 4 second sweep, far too coarse for
+     * a handshakeTimeout the user hands us in milliseconds. Every accepted SSL
+     * socket therefore queues on an intrusive FIFO and a single one-shot timer
+     * is armed at the head's deadline; equal timeouts plus arrival ordering keep
+     * the deadlines non-decreasing, so the head is always the next to expire. */
+
+    static uint64_t nowMs() {
+        return (uint64_t) std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count();
+    }
+
+    static HttpResponseData<SSL> *responseData(us_socket_t *s) {
+        return reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
+    }
+
+    static void unlinkPendingHandshake(HttpContextData<SSL> *httpContextData, us_socket_t *s) {
+        HttpResponseData<SSL> *responseDataS = responseData(s);
+        if (responseDataS->prevPendingHandshake) {
+            responseData(responseDataS->prevPendingHandshake)->nextPendingHandshake = responseDataS->nextPendingHandshake;
+        } else {
+            httpContextData->pendingHandshakeHead = responseDataS->nextPendingHandshake;
+        }
+        if (responseDataS->nextPendingHandshake) {
+            responseData(responseDataS->nextPendingHandshake)->prevPendingHandshake = responseDataS->prevPendingHandshake;
+        } else {
+            httpContextData->pendingHandshakeTail = responseDataS->prevPendingHandshake;
+        }
+        responseDataS->prevPendingHandshake = nullptr;
+        responseDataS->nextPendingHandshake = nullptr;
+        responseDataS->handshakeDeadline = 0;
+    }
+
+    /* Re-point the timer at the current head. Arming is only a syscall when the
+     * head's deadline actually moved, so the common push-to-a-busy-queue is free.
+     * An empty queue leaves any pending shot to fire into an empty loop below. */
+    static void armHandshakeTimer(HttpContext<SSL> *httpContext) {
+        HttpContextData<SSL> *httpContextData = &httpContext->data;
+        us_socket_t *head = httpContextData->pendingHandshakeHead;
+        if (!head) {
+            httpContextData->armedHandshakeDeadline = 0;
+            return;
+        }
+
+        uint64_t deadline = responseData(head)->handshakeDeadline;
+        if (deadline == httpContextData->armedHandshakeDeadline) {
+            return;
+        }
+
+        if (!httpContextData->handshakeTimer) {
+            /* fallthrough: an unref'd server must not be held open by this timer. */
+            httpContextData->handshakeTimer = us_create_timer(us_socket_group_loop(&httpContext->group), 1, sizeof(HttpContext<SSL> *));
+            if (!httpContextData->handshakeTimer) {
+                return;
+            }
+            *reinterpret_cast<HttpContext<SSL> **>(us_timer_ext(httpContextData->handshakeTimer)) = httpContext;
+        }
+
+        httpContextData->armedHandshakeDeadline = deadline;
+        uint64_t now = nowMs();
+        uint64_t delay = deadline > now ? deadline - now : 1;
+        us_timer_set(httpContextData->handshakeTimer, handshakeTimerCallback, (int) std::min<uint64_t>(delay, (uint64_t) INT_MAX), 0);
+    }
+
+    static void pushPendingHandshake(us_socket_t *s) {
+        HttpContext<SSL> *httpContext = fromSocket(s);
+        HttpContextData<SSL> *httpContextData = &httpContext->data;
+        HttpResponseData<SSL> *responseDataS = responseData(s);
+
+        responseDataS->handshakeDeadline = nowMs() + httpContextData->handshakeTimeoutMs;
+        responseDataS->prevPendingHandshake = httpContextData->pendingHandshakeTail;
+        responseDataS->nextPendingHandshake = nullptr;
+        if (httpContextData->pendingHandshakeTail) {
+            responseData(httpContextData->pendingHandshakeTail)->nextPendingHandshake = s;
+        } else {
+            httpContextData->pendingHandshakeHead = s;
+        }
+        httpContextData->pendingHandshakeTail = s;
+
+        armHandshakeTimer(httpContext);
+    }
+
+    /* Idempotent: a socket that already left the queue (timed out, handshaked,
+     * closed) has handshakeDeadline == 0 and is skipped. */
+    static void removePendingHandshake(us_socket_t *s) {
+        HttpResponseData<SSL> *responseDataS = responseData(s);
+        if (!responseDataS->handshakeDeadline) {
+            return;
+        }
+        HttpContext<SSL> *httpContext = fromSocket(s);
+        bool wasHead = httpContext->data.pendingHandshakeHead == s;
+        unlinkPendingHandshake(&httpContext->data, s);
+        if (wasHead) {
+            armHandshakeTimer(httpContext);
+        }
+    }
+
+    static void handshakeTimerCallback(struct us_timer_t *t) {
+        HttpContext<SSL> *httpContext = *reinterpret_cast<HttpContext<SSL> **>(us_timer_ext(t));
+        HttpContextData<SSL> *httpContextData = &httpContext->data;
+        uint64_t now = nowMs();
+
+        while (us_socket_t *s = httpContextData->pendingHandshakeHead) {
+            if (responseData(s)->handshakeDeadline > now) {
+                break;
+            }
+            /* Unlink before reporting: the callback runs JS that may close this
+             * socket (or any other one still queued behind it). */
+            unlinkPendingHandshake(httpContextData, s);
+            if (httpContextData->onHandshakeTimeout) {
+                httpContextData->onHandshakeTimeout(httpContextData->handshakeTimeoutUserData, SSL, s);
+            }
+            if (!us_socket_is_closed(s)) {
+                us_socket_close(s, 0, nullptr);
+            }
+        }
+
+        /* A timer may fire a hair early, and a clamped delay fires early on
+         * purpose; clearing the record forces armHandshakeTimer to re-arm. */
+        httpContextData->armedHandshakeDeadline = 0;
+        armHandshakeTimer(httpContext);
+    }
+
     /* ── vtable handlers ─────────────────────────────────────────────────── */
 
     static void onHandshake(us_socket_t *s, int success, struct us_bun_verify_error_t verify_error, void * /*custom_data*/) {
         // if we are closing or already closed, we don't need to do anything
         if (!us_socket_is_closed(s)) {
+            /* Settled either way: the watchdog has nothing left to guard. */
+            removePendingHandshake(s);
+
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
             // Set per-socket authorization status
             auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
@@ -182,11 +311,20 @@ private:
         }
     }
 
-    static us_socket_t *onOpen(us_socket_t *s, int /*is_client*/, char * /*ip*/, int /*ip_length*/) {
+    static us_socket_t *onOpen(us_socket_t *s, int is_client, char * /*ip*/, int /*ip_length*/) {
         /* Init socket ext */
         new (us_socket_ext(s)) HttpResponseData<SSL>;
           /* Any connected socket should timeout until it has a request */
         ((HttpResponse<SSL> *) s)->resetTimeout();
+
+        if constexpr (SSL) {
+            /* Accepted before a single handshake byte arrived: start the watchdog.
+             * us_internal_ssl_on_open dispatches this before driving SSL_do_handshake. */
+            HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+            if (!is_client && httpContextData->handshakeTimeoutMs) {
+                pushPendingHandshake(s);
+            }
+        }
 
         if(!SSL) {
             /* Call filter */
@@ -205,6 +343,10 @@ private:
         /* Get socket ext */
         auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
 
+        if constexpr (SSL) {
+            /* Before ~HttpResponseData: the queue links live in there. */
+            removePendingHandshake(s);
+        }
 
         /* Call filter */
         HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
@@ -601,8 +743,23 @@ public:
 
     /* Destruct the HttpContext, it does not follow RAII */
     void free() {
+        /* Closing the group drains the pending-handshake queue through onClose,
+         * which re-arms the timer, so the timer has to outlive the group. */
         us_socket_group_deinit(&group);
+        if (data.handshakeTimer) {
+            us_timer_close(data.handshakeTimer, 1);
+            data.handshakeTimer = nullptr;
+        }
         delete this;
+    }
+
+    /* node's tls.Server handshakeTimeout: drop peers that never finish the TLS
+     * handshake. 0 disables. The callback, when set, reports the socket before
+     * it is closed; it must not destroy this context. */
+    void setHandshakeTimeout(uint64_t timeoutMs, typename HttpContextData<SSL>::OnHandshakeTimeoutCallback handler, void *userData) {
+        data.handshakeTimeoutMs = timeoutMs;
+        data.onHandshakeTimeout = handler;
+        data.handshakeTimeoutUserData = userData;
     }
 
     void filter(MoveOnlyFunction<void(HttpResponse<SSL> *, int)> &&filterHandler) {

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -20,6 +20,7 @@
 
 #include "HttpRouter.h"
 
+#include <libusockets.h>
 #include <vector>
 #include "MoveOnlyFunction.h"
 #include "HttpParser.h"
@@ -48,6 +49,7 @@ private:
     using OnSocketUpgradedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnClientErrorCallback = MoveOnlyFunction<void(int is_ssl, struct us_socket_t *rawSocket, uWS::HttpParserError errorCode, char *rawPacket, int rawPacketLength)>;
     using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
+    using OnHandshakeTimeoutCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
 
     MoveOnlyFunction<void(const char *hostname)> missingServerNameHandler;
 
@@ -68,6 +70,17 @@ private:
     OnSocketDataCallback onSocketData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
+
+    /* TLS handshake watchdog, backing node's tls.Server handshakeTimeout.
+     * 0 disables it. Accepted sockets queue on an intrusive FIFO whose deadlines
+     * are non-decreasing, so one timer armed at the head covers the whole list. */
+    uint64_t handshakeTimeoutMs = 0;
+    uint64_t armedHandshakeDeadline = 0;
+    struct us_timer_t *handshakeTimer = nullptr;
+    struct us_socket_t *pendingHandshakeHead = nullptr;
+    struct us_socket_t *pendingHandshakeTail = nullptr;
+    OnHandshakeTimeoutCallback onHandshakeTimeout = nullptr;
+    void *handshakeTimeoutUserData = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -102,6 +102,13 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     void* writableUserData = nullptr;
     void* socketData = nullptr;
 
+    /* Intrusive FIFO links for HttpContext's TLS handshake watchdog. A zero
+     * handshakeDeadline means "not queued", which is what lets the socket be
+     * unlinked before any user code that might close it runs. */
+    struct us_socket_t *prevPendingHandshake = nullptr;
+    struct us_socket_t *nextPendingHandshake = nullptr;
+    uint64_t handshakeDeadline = 0;
+
     /* Per socket event handlers */
     OnWritableCallback onWritable = nullptr;
     OnAbortedCallback onAborted = nullptr;

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -26,6 +26,8 @@ const {
     useStrictMethodValidation: boolean,
     maxHeaderSize: number,
     onClientError: (ssl: boolean, socket: any, errorCode: number, rawPacket: ArrayBuffer) => undefined,
+    handshakeTimeout: number,
+    onHandshakeTimeout: (ssl: boolean, socket: any) => undefined,
   ) => void;
   getCompleteWebRequestOrResponseBodyValueAsArrayBuffer: (arg: any) => ArrayBuffer | undefined;
   drainMicrotasks: () => void;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -14,6 +14,7 @@ const {
   validateBoolean,
   validateInteger,
   validateFunction,
+  validateNumber,
 } = require("internal/validators");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
@@ -75,6 +76,7 @@ const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
+const kHandshakeTimeout = Symbol("http.server.handshakeTimeout");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
 // only created on the first request, and emission is gated per-request on the
@@ -313,6 +315,12 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });
+      // Matches Node's tls.Server handshakeTimeout default + validation, which
+      // https.Server inherits. Only read for TLS servers - a plain http.Server
+      // has no handshake and Node ignores the option there.
+      const handshakeTimeout = options.handshakeTimeout || 120 * 1000;
+      validateNumber(handshakeTimeout, "options.handshakeTimeout");
+      this[kHandshakeTimeout] = handshakeTimeout;
     } else {
       this[tlsSymbol] = null;
     }
@@ -331,6 +339,9 @@ Server.prototype[kIncomingMessage] = undefined;
 Server.prototype[kServerResponse] = undefined;
 
 Server.prototype[kConnectionsCheckingInterval] = undefined;
+
+// 0 disables the TLS handshake watchdog; only TLS servers ever set it.
+Server.prototype[kHandshakeTimeout] = 0;
 
 function rethrowUncaught(err) {
   throw err;
@@ -910,6 +921,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       true,
       typeof this.maxHeaderSize !== "undefined" ? this.maxHeaderSize : getMaxHTTPHeaderSize(),
       onServerClientError.bind(this),
+      // Negative/NaN/Infinity all disable the watchdog, like node:tls's own
+      // `_handshakeTimeout > 0` guard.
+      tls ? this[kHandshakeTimeout] : 0,
+      onServerHandshakeTimeout.bind(this),
     );
 
     if (this?._unref) {
@@ -1014,6 +1029,20 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
   if (nodeSocket.listenerCount("error") > 0) {
     nodeSocket.emit("error", err);
   }
+}
+
+// A peer that connected but never finished the TLS handshake. Reported like
+// node's tls.Server does, through 'tlsClientError'; the native side closes the
+// socket as soon as this returns.
+function onServerHandshakeTimeout(this: Server, ssl: boolean, socket: unknown) {
+  const self = this as Server;
+  const err = $ERR_TLS_HANDSHAKE_TIMEOUT();
+  const existingDuplex = (socket as any).duplex;
+  const nodeSocket = existingDuplex ?? new NodeHTTPServerSocket(self, socket, ssl);
+  if (!existingDuplex) {
+    self.emit("connection", nodeSocket);
+  }
+  self.emit("tlsClientError", err, nodeSocket);
 }
 
 const kBytesWritten = Symbol("kBytesWritten");

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -41,6 +41,7 @@ extern "C" void Server__setIdleTimeout(EncodedJSValue, EncodedJSValue, JSC::JSGl
 extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSValue, bool require_host_header, bool use_strict_method_validation);
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setMaxHTTPHeaderSize(JSC::JSGlobalObject*, EncodedJSValue, uint64_t);
+extern "C" EncodedJSValue Server__setHandshakeTimeout(JSC::JSGlobalObject*, EncodedJSValue, double timeout_ms, EncodedJSValue);
 
 static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
 {
@@ -988,15 +989,20 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ASSERT(callFrame->argumentCount() == 5);
+    ASSERT(callFrame->argumentCount() == 7);
     // This is an internal binding.
     JSValue serverValue = callFrame->uncheckedArgument(0);
     JSValue requireHostHeader = callFrame->uncheckedArgument(1);
     JSValue useStrictMethodValidation = callFrame->uncheckedArgument(2);
     JSValue maxHeaderSize = callFrame->uncheckedArgument(3);
     JSValue callback = callFrame->uncheckedArgument(4);
+    JSValue handshakeTimeout = callFrame->uncheckedArgument(5);
+    JSValue onHandshakeTimeout = callFrame->uncheckedArgument(6);
 
     double maxHeaderSizeNumber = maxHeaderSize.toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    double handshakeTimeoutNumber = handshakeTimeout.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     Server__setAppFlags(globalObject, JSValue::encode(serverValue), requireHostHeader.toBoolean(globalObject), useStrictMethodValidation.toBoolean(globalObject));
@@ -1006,6 +1012,9 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
     RETURN_IF_EXCEPTION(scope, {});
 
     Server__setOnClientError(globalObject, JSValue::encode(serverValue), JSValue::encode(callback));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    Server__setHandshakeTimeout(globalObject, JSValue::encode(serverValue), handshakeTimeoutNumber, JSValue::encode(onHandshakeTimeout));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsUndefined());

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -290,6 +290,8 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
 
     pub on_clienterror: jsc::StrongOptional,
 
+    pub on_handshake_timeout: jsc::StrongOptional,
+
     pub inspector_server_id: jsc::DebuggerId,
 }
 
@@ -302,7 +304,8 @@ pub struct UserRoute<const SSL: bool, const DEBUG: bool> {
 impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
     fn drop(&mut self) {
         // The remaining owned fields (config, base_url, h3_alt_svc, dev_server,
-        // user_routes, all_closed_promise, on_clienterror) drop automatically.
+        // user_routes, all_closed_promise, on_clienterror, on_handshake_timeout)
+        // drop automatically.
         if let Some(p) = self.plugins.take() {
             // SAFETY: `plugins` carries the `heap::alloc` provenance from
             // `ServePlugins::init`; this releases the server's counted ref.
@@ -1913,6 +1916,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             plugins: None,
             user_routes: Vec::new(),
             on_clienterror: jsc::StrongOptional::empty(),
+            on_handshake_timeout: jsc::StrongOptional::empty(),
             inspector_server_id: jsc::DebuggerId::init(0),
         }));
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3525,6 +3525,41 @@ where
         }
     }
 
+    /// Reports a peer that never finished its TLS handshake. uWS closes the
+    /// socket right after this returns, so the callback only has to surface the
+    /// error (node's `tlsClientError`).
+    pub fn on_handshake_timeout_callback(&mut self, socket: &mut uws::Socket) {
+        let Some(callback) = self.on_handshake_timeout.get() else {
+            return;
+        };
+        let is_ssl = SSL;
+        let global = self.global();
+        let node_socket = match jsc::from_js_host_call(&global, || {
+            Bun__createNodeHTTPServerSocketForClientError(
+                is_ssl,
+                std::ptr::from_mut(socket).cast::<c_void>(),
+                &global,
+            )
+        }) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        if node_socket.is_undefined_or_null() {
+            return;
+        }
+
+        // SAFETY: event_loop() returns a live raw pointer tied to the global.
+        let _scope =
+            unsafe { jsc::event_loop::EventLoop::enter_scope(global.bun_vm().event_loop()) };
+        if let Err(err) = callback.call(
+            &global,
+            JSValue::UNDEFINED,
+            &[JSValue::from(is_ssl), node_socket],
+        ) {
+            global.report_active_exception_as_unhandled(err);
+        }
+    }
+
     // `js_gc_route_list_set` / `ptr_to_js` live on the unbounded
     // `impl NewServer` in mod.rs; do not redefine them here.
 }
@@ -3669,6 +3704,70 @@ pub(super) fn server_set_on_client_error_(
     Ok(JSValue::UNDEFINED)
 }
 
+pub(super) fn server_set_handshake_timeout_(
+    global: &JSGlobalObject,
+    server: JSValue,
+    timeout_ms: f64,
+    callback: JSValue,
+) -> JsResult<JSValue> {
+    if !server.is_object() {
+        return Err(global.throw(format_args!(
+            "Failed to set handshakeTimeout: The 'this' value is not a Server."
+        )));
+    }
+
+    if !callback.is_function() {
+        return Err(global.throw(format_args!(
+            "Failed to set handshakeTimeout: The provided value is not a function."
+        )));
+    }
+
+    // NaN, negatives and non-finite values all mean "no watchdog", matching the
+    // `> 0` guard node:tls's server uses before arming its own timer.
+    let timeout_ms: u64 = if timeout_ms.is_finite() && timeout_ms >= 1.0 {
+        timeout_ms.min(u64::MAX as f64) as u64
+    } else {
+        0
+    };
+
+    macro_rules! handle {
+        ($T:ty) => {
+            if let Some(this) = server.as_::<$T>() {
+                // SAFETY: as_ returned a non-null *mut to a live server.
+                let this = unsafe { &mut *this };
+                if let Some(app) = this.app {
+                    this.on_handshake_timeout.deinit();
+                    this.on_handshake_timeout = StrongOptional::create(callback, global);
+                    extern "C" fn thunk(
+                        user_data: *mut c_void,
+                        _ssl: c_int,
+                        socket: *mut uws_sys::us_socket_t,
+                    ) {
+                        // SAFETY: user_data is the `*mut Self` registered below; socket is a
+                        // live uWS socket that uWS closes right after we return.
+                        let this = unsafe { &mut *user_data.cast::<$T>() };
+                        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+                        this.on_handshake_timeout_callback(bun_opaque::opaque_deref_mut(socket));
+                    }
+                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                    bun_opaque::opaque_deref_mut(app).set_handshake_timeout(
+                        timeout_ms,
+                        thunk,
+                        core::ptr::from_mut::<$T>(this).cast::<c_void>(),
+                    );
+                }
+                return Ok(JSValue::UNDEFINED);
+            }
+        };
+    }
+    handle!(HTTPServer);
+    handle!(HTTPSServer);
+    handle!(DebugHTTPServer);
+    handle!(DebugHTTPSServer);
+    debug_assert!(false);
+    Ok(JSValue::UNDEFINED)
+}
+
 pub(super) fn server_set_app_flags_(
     global: &JSGlobalObject,
     server: JSValue,
@@ -3769,6 +3868,19 @@ extern "C" fn server_set_on_client_error_shim(
     host_fn::to_js_host_fn_result(
         global,
         server_set_on_client_error_(global, server, callback),
+    )
+}
+
+#[unsafe(export_name = "Server__setHandshakeTimeout")]
+extern "C" fn server_set_handshake_timeout_shim(
+    global: &JSGlobalObject,
+    server: JSValue,
+    timeout_ms: f64,
+    callback: JSValue,
+) -> JSValue {
+    host_fn::to_js_host_fn_result(
+        global,
+        server_set_handshake_timeout_(global, server, timeout_ms, callback),
     )
 }
 

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -261,6 +261,24 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_on_clienterror(Self::SSL_FLAG, self.as_raw(), handler, user_data)
     }
 
+    /// Drop peers that never finish the TLS handshake within `timeout_ms`.
+    /// `0` disables the watchdog. `handler` reports each expired socket right
+    /// before uWS closes it; it must not destroy this app.
+    pub fn set_handshake_timeout(
+        &mut self,
+        timeout_ms: u64,
+        handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t),
+        user_data: *mut c_void,
+    ) {
+        c::uws_app_set_handshake_timeout(
+            Self::SSL_FLAG,
+            self.as_raw(),
+            timeout_ms,
+            handler,
+            user_data,
+        )
+    }
+
     pub fn listen_with_config(
         &mut self,
         handler: c::uws_listen_handler,
@@ -504,6 +522,15 @@ pub mod c {
             ssl: c_int,
             app: &mut uws_app_s,
             handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t, u8, *mut u8, c_int),
+            user_data: *mut c_void,
+        );
+        // safe: same contract as uws_app_set_on_clienterror — `handler`/`user_data`
+        // are stored opaquely by the C++ shim.
+        pub(crate) safe fn uws_app_set_handshake_timeout(
+            ssl: c_int,
+            app: &mut uws_app_s,
+            timeout_ms: u64,
+            handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t),
             user_data: *mut c_void,
         );
         pub(crate) fn uws_create_app(ssl: i32, options: BunSocketContextOptions) -> *mut uws_app_t;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -427,6 +427,18 @@ extern "C"
     }
   }
 
+  void uws_app_set_handshake_timeout(int ssl, uws_app_t *app, uint64_t timeout_ms, void (*handler)(void *user_data, int is_ssl, struct us_socket_t *rawSocket), void *user_data)
+  {
+    if (ssl)
+    {
+      ((uWS::SSLApp *)app)->setHandshakeTimeout(timeout_ms, handler, user_data);
+    }
+    else
+    {
+      ((uWS::App *)app)->setHandshakeTimeout(timeout_ms, handler, user_data);
+    }
+  }
+
   void uws_app_listen(int ssl, uws_app_t *app, int port,
                       uws_listen_handler handler, void *user_data)
   {

--- a/test/js/node/http/node-https-handshake-timeout-fixture.mjs
+++ b/test/js/node/http/node-https-handshake-timeout-fixture.mjs
@@ -24,13 +24,14 @@ async function silentPeer() {
   server.on("tlsClientError", err => {
     code = err.code;
   });
+  let guard;
   server.listen(0, "127.0.0.1", () => {
     const c = net.connect(server.address().port, "127.0.0.1");
     c.on("error", () => {});
     c.on("close", () => resolve(true));
     // Generous upper bound: if the watchdog never armed the peer stays open and
     // this resolves with the socket still alive, failing the assertion below.
-    const guard = setTimeout(() => {
+    guard = setTimeout(() => {
       emit("silent_still_open", !c.destroyed);
       c.destroy();
       resolve(false);
@@ -38,14 +39,19 @@ async function silentPeer() {
     guard.unref?.();
   });
   await promise;
+  // Clear the guard so it cannot fire during the later scenarios and emit a
+  // stray RESULT line (the test asserts on the exact key set).
+  clearTimeout(guard);
   emit("silent_code", code);
   await new Promise(r => server.close(r));
 }
 
-// 2. A real request that completes the handshake well inside the window must
-//    not be killed by the watchdog.
+// 2. A real request that completes the handshake must not be killed by the
+//    watchdog. A generous timeout here costs nothing: a completed handshake is
+//    dequeued immediately (onHandshake cancels the timer), so this only guards
+//    against the watchdog racing a slow debug+ASAN loopback handshake.
 async function liveRequest() {
-  const server = https.createServer({ key, cert, handshakeTimeout: 200 }, (_req, res) => res.end("ok"));
+  const server = https.createServer({ key, cert, handshakeTimeout: 10_000 }, (_req, res) => res.end("ok"));
   let sawClientError = false;
   server.on("tlsClientError", () => {
     sawClientError = true;

--- a/test/js/node/http/node-https-handshake-timeout-fixture.mjs
+++ b/test/js/node/http/node-https-handshake-timeout-fixture.mjs
@@ -1,0 +1,88 @@
+// Exercises https.createServer's handshakeTimeout in one process (TLS accept is
+// slow under debug+ASAN, so amortize the startup cost across all scenarios).
+// Prints one RESULT line per scenario; the test file asserts on them.
+import https from "node:https";
+import net from "node:net";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const key = readFileSync(join(keys, "agent1-key.pem"), "utf8");
+const cert = readFileSync(join(keys, "agent1-cert.pem"), "utf8");
+const ca = readFileSync(join(keys, "ca1-cert.pem"), "utf8");
+
+function emit(name, value) {
+  console.log(`RESULT ${name} ${value}`);
+}
+
+// 1. A peer that connects over TCP but never starts the handshake must be
+//    dropped via 'tlsClientError' with ERR_TLS_HANDSHAKE_TIMEOUT.
+async function silentPeer() {
+  const server = https.createServer({ key, cert, handshakeTimeout: 200 }, () => {});
+  const { promise, resolve } = Promise.withResolvers();
+  let code = "NONE";
+  server.on("tlsClientError", err => {
+    code = err.code;
+  });
+  server.listen(0, "127.0.0.1", () => {
+    const c = net.connect(server.address().port, "127.0.0.1");
+    c.on("error", () => {});
+    c.on("close", () => resolve(true));
+    // Generous upper bound: if the watchdog never armed the peer stays open and
+    // this resolves with the socket still alive, failing the assertion below.
+    const guard = setTimeout(() => {
+      emit("silent_still_open", !c.destroyed);
+      c.destroy();
+      resolve(false);
+    }, 8000);
+    guard.unref?.();
+  });
+  await promise;
+  emit("silent_code", code);
+  await new Promise(r => server.close(r));
+}
+
+// 2. A real request that completes the handshake well inside the window must
+//    not be killed by the watchdog.
+async function liveRequest() {
+  const server = https.createServer({ key, cert, handshakeTimeout: 200 }, (_req, res) => res.end("ok"));
+  let sawClientError = false;
+  server.on("tlsClientError", () => {
+    sawClientError = true;
+  });
+  const { promise, resolve } = Promise.withResolvers();
+  server.listen(0, "127.0.0.1", () => {
+    const req = https.request(
+      { port: server.address().port, host: "127.0.0.1", ca, servername: "agent1" },
+      res => {
+        const chunks = [];
+        res.on("data", d => chunks.push(d));
+        res.on("end", () => resolve(Buffer.concat(chunks).toString()));
+      },
+    );
+    req.on("error", err => {
+      emit("live_req_error", err.code);
+      resolve("ERROR");
+    });
+    req.end();
+  });
+  const body = await promise;
+  emit("live_body", body);
+  emit("live_client_error", sawClientError);
+  await new Promise(r => server.close(r));
+}
+
+// 3. A non-numeric handshakeTimeout is rejected, like node:tls's own validation.
+function invalidOption() {
+  try {
+    https.createServer({ key, cert, handshakeTimeout: "soon" });
+    emit("invalid_throw", "NO_THROW");
+  } catch (err) {
+    emit("invalid_throw", err.code);
+  }
+}
+
+await silentPeer();
+await liveRequest();
+invalidOption();
+process.exit(0);

--- a/test/js/node/http/node-https-handshake-timeout.test.ts
+++ b/test/js/node/http/node-https-handshake-timeout.test.ts
@@ -1,0 +1,42 @@
+// https.createServer is backed by Bun.serve (idleTimeout: 0), not node:tls's
+// Server, so its handshakeTimeout option used to be dropped on the floor: a
+// peer that connected over TCP and never started the TLS handshake was kept
+// open indefinitely (a slowloris against the handshake). The watchdog now fires
+// 'tlsClientError' with ERR_TLS_HANDSHAKE_TIMEOUT and closes the peer, while a
+// real handshake within the window is left alone.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+test("https.createServer enforces handshakeTimeout", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "node-https-handshake-timeout-fixture.mjs")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = Object.fromEntries(
+    stdout
+      .trim()
+      .split("\n")
+      .filter(l => l.startsWith("RESULT "))
+      .map(l => {
+        const rest = l.slice("RESULT ".length);
+        const sp = rest.indexOf(" ");
+        return [rest.slice(0, sp), rest.slice(sp + 1)];
+      }),
+  );
+
+  expect(results).toEqual({
+    silent_code: "ERR_TLS_HANDSHAKE_TIMEOUT",
+    live_body: "ok",
+    live_client_error: "false",
+    invalid_throw: "ERR_INVALID_ARG_TYPE",
+  });
+  expect(exitCode).toBe(0);
+  // Debug+ASAN TLS accept is slow; the scenarios run in one process but each
+  // handshake still takes seconds, so this needs headroom over the 5s default.
+}, 30_000);


### PR DESCRIPTION
## Problem

`https.createServer({ handshakeTimeout })` never enforced the timeout. A peer that opened a TCP connection and never began the TLS handshake was kept open indefinitely, holding a socket and BoringSSL state bounded only by the fd limit (a slowloris against the handshake). Bun's own `tls.createServer` enforces the same option correctly, which localizes the bug: `https.Server` is backed by `Bun.serve` (`idleTimeout: 0`), not by `node:tls`'s `Server`, so the option was dropped on the floor.

```js
import https from "node:https";
import net from "node:net";
// ...cert setup...
const server = https.createServer({ key, cert, handshakeTimeout: 150 }, () => {});
server.on("tlsClientError", e => console.log("tlsClientError", e.code));
server.listen(0, "127.0.0.1", () => {
  const c = net.connect(server.address().port, "127.0.0.1"); // connects, never sends a byte
  c.on("error", () => {});
});

// node v26:  tlsClientError ERR_TLS_HANDSHAKE_TIMEOUT, peer closed ~160ms
// bun (before): peer stays open forever
```

## Cause

`node:tls`'s `Server` arms a per-socket timer in JS for every accepted connection (`src/js/node/net.ts`). `Bun.serve` never surfaces a pre-handshake socket to JS, so there is nothing to hang a JS timer on, and uSockets' only per-socket timer is the 4 second sweep wheel, too coarse to express a millisecond `handshakeTimeout`.

## Fix

Add a TLS handshake watchdog to the uWS `HttpContext`. Every accepted SSL socket queues on an intrusive FIFO, and a single one-shot `us_timer_t` is armed at the head's deadline. Arrival order keeps the deadlines non-decreasing, so the head is always the next to expire and one timer covers the whole list. When it fires, the socket is reported through node's `tlsClientError` with `ERR_TLS_HANDSHAKE_TIMEOUT` and closed. The entry is removed when the handshake settles (either way) or the socket closes first; the timer outlives the socket group so the drain on shutdown is safe.

`node:http`'s server forwards `handshakeTimeout` (default 120s, matching node) into the server and validates it the same way `tls.Server` does. It is only read for TLS servers; a plain `http.Server` has no handshake and ignores it, like node.

## Verification

`test/js/node/http/node-https-handshake-timeout.test.ts` (driven by a single fixture process, since debug+ASAN TLS accept is slow) covers:
- a silent peer is dropped via `tlsClientError: ERR_TLS_HANDSHAKE_TIMEOUT`
- a real request completing the handshake in time is not killed
- a non-numeric `handshakeTimeout` throws `ERR_INVALID_ARG_TYPE`

Fails on the unfixed build (peer stays open, no event, option unvalidated); passes with the fix.