### PR TITLE
glob: stop silently failing to match patterns past 10 brace groups

### DIFF
--- a/docs/runtime/glob.mdx
+++ b/docs/runtime/glob.mdx
@@ -141,7 +141,7 @@ glob.match("c.ts"); // => true
 glob.match("d.ts"); // => false
 ```
 
-These patterns can be nested up to 10 levels deep and contain any of the earlier wildcards.
+These patterns can be nested and chained, and contain any of the earlier wildcards.
 
 ### `!` - Negates the result at the start of a pattern
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8133,7 +8133,7 @@ declare module "bun" {
    * - `{a,b}`
    *     Match one of the patterns contained in the braces.
    *     The sub-patterns can use any of the other wildcards.
-   *     Braces may be nested up to 10 levels deep.
+   *     Braces may be nested and chained.
    * - `!`
    *     Negates the result when at the start of the pattern.
    *     Multiple "!" characters negate the pattern multiple times.

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -47,6 +47,13 @@ type BraceStack = SmallList<Brace, 10>;
 /// alternatives. Patterns that exceed this budget fail to match.
 const BRACE_BRANCH_BUDGET: u32 = 10_000;
 
+/// Cap on how deep the `match_brace` -> `match_brace_branch` -> `glob_match_impl`
+/// recursion may go. Each brace group entered along a match path adds one
+/// native frame, so an adversarial pattern of thousands of groups would
+/// otherwise overflow the thread stack. Far above any realistic pattern (a
+/// deep monorepo glob uses tens of groups); patterns beyond it do not match.
+const MAX_BRACE_DEPTH: u32 = 256;
+
 // `pub` because it appears in the signature of `pub fn match` (private-in-public is forbidden).
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum MatchResult {
@@ -132,7 +139,8 @@ struct Wildcard {
 /// "{a,b}"
 ///     Match one of the patterns contained in the braces.
 ///     Any of the wildcards listed above can be used in the sub patterns.
-///     Braces may be nested up to 10 levels deep.
+///     Braces may be nested and chained freely; only pathologically deep
+///     patterns (see `MAX_BRACE_DEPTH`) stop matching.
 /// "!"
 ///     Negates the result when at the start of the pattern.
 ///     Multiple "!" characters negate the pattern multiple times.
@@ -522,6 +530,10 @@ fn match_brace_branch(
         return false;
     }
     *brace_budget -= 1;
+
+    if brace_stack.len() >= MAX_BRACE_DEPTH {
+        return false;
+    }
 
     brace_stack.append(Brace {
         open_brace_idx: open_brace_index,

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -543,7 +543,10 @@ fn match_brace_branch(
     // Clone state
     let mut branch_state = *state;
     branch_state.glob_index = branch_index;
-    branch_state.brace_depth = brace_stack.len();
+    // Open-brace nesting at this position, not the recursion depth: sequential
+    // groups keep their frame on `brace_stack` after closing, so `len()` would
+    // overcount and misroute a literal `,`/`}` after the group as brace syntax.
+    branch_state.brace_depth = state.brace_depth + 1;
 
     let matched = glob_match_impl(
         &mut branch_state,

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -22,20 +22,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use bun_collections::BoundedArray;
+use bun_collections::SmallList;
 use bun_core::strings;
 
-/// used in matchBrace to determine the size of the stack buffer used in the stack fallback allocator
-/// that is created for handling braces
-/// One such stack buffer is created recursively for each pair of braces
-/// therefore this value should be tuned to use a sane amount of memory even at the highest allowed brace depth
-/// and for arbitrarily many non-nested braces (i.e. `{a,b}{c,d}`) while reducing the number of allocations.
+/// Records the branch committed for one open brace along the current match
+/// path, so re-entering the same `{` (during wildcard backtracking) resumes
+/// that branch. One entry per brace group entered, popped when its tail is
+/// fully explored.
 #[derive(Copy, Clone)]
 struct Brace {
     open_brace_idx: u32,
     branch_idx: u32,
 }
-type BraceStack = BoundedArray<Brace, 10>;
+
+/// Sequential and nested brace groups both accumulate one entry per group
+/// along a match path, so the depth is bounded by the pattern's brace count,
+/// not a fixed constant. Stays inline for the common case and spills to the
+/// heap for deeper patterns; `BRACE_BRANCH_BUDGET` bounds total work.
+type BraceStack = SmallList<Brace, 10>;
 
 /// Upper bound on brace-branch alternatives explored per `match` call. Sequential
 /// brace groups multiply (`{a,b}{c,d}` = 4 alternatives), so without a cap an
@@ -67,7 +71,7 @@ struct State {
     wildcard: Wildcard,
     globstar: Wildcard,
 
-    brace_depth: u8,
+    brace_depth: u32,
 }
 
 impl State {
@@ -104,7 +108,7 @@ struct Wildcard {
     // Using u32 rather than usize for these results in 10% faster performance.
     glob_index: u32,
     path_index: u32,
-    brace_depth: u8,
+    brace_depth: u32,
 }
 
 /// This function checks returns a boolean value if the pathname `path` matches
@@ -355,7 +359,7 @@ fn glob_match_impl(
                             }
                         }
                         b'{' => {
-                            for brace in brace_stack.as_slice() {
+                            for brace in brace_stack.slice() {
                                 if brace.open_brace_idx == state.glob_index {
                                     state.glob_index = brace.branch_idx;
                                     state.brace_depth += 1;
@@ -519,18 +523,15 @@ fn match_brace_branch(
     }
     *brace_budget -= 1;
 
-    // exceeded brace depth
-    let Ok(()) = brace_stack.push(Brace {
+    brace_stack.append(Brace {
         open_brace_idx: open_brace_index,
         branch_idx: branch_index,
-    }) else {
-        return false;
-    };
+    });
 
     // Clone state
     let mut branch_state = *state;
     branch_state.glob_index = branch_index;
-    branch_state.brace_depth = u8::try_from(brace_stack.len()).expect("int cast");
+    branch_state.brace_depth = brace_stack.len();
 
     let matched = glob_match_impl(
         &mut branch_state,

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -386,6 +386,24 @@ describe("Glob.match", () => {
     expect(new Glob(pastCap).match(Buffer.alloc(257, "a").toString())).toBeFalse();
   });
 
+  test("literal comma or brace after sequential brace groups", () => {
+    // After 2+ sequential groups, a trailing literal `,` or `}` used to be
+    // misrouted as brace syntax (depth tracked recursion frames, not open
+    // braces). These agree with Node's path.matchesGlob.
+    expect(new Glob("{a,b}{c,d},e").match("ac,e")).toBeTrue();
+    expect(new Glob("{a,b}{c,d},e").match("bd,e")).toBeTrue();
+    expect(new Glob("{a,b}{c,d},e").match("ac,x")).toBeFalse();
+    expect(new Glob("{a,b}{c,d}}").match("ac}")).toBeTrue();
+    expect(new Glob("{a,b}{c,d}}").match("bd}")).toBeTrue();
+    expect(new Glob("{a,b}{c,d}}").match("acx")).toBeFalse();
+
+    // Nested braces still match their open-brace depth correctly.
+    expect(new Glob("{a,{b,c}}").match("a")).toBeTrue();
+    expect(new Glob("{a,{b,c}}").match("b")).toBeTrue();
+    expect(new Glob("{a,{b,c}}").match("c")).toBeTrue();
+    expect(new Glob("{a,{b,c}}").match("ac")).toBeFalse();
+  });
+
   test("pathologically deep brace patterns do not overflow the stack", async () => {
     // Each group along a match path adds a native recursion frame; thousands
     // of sequential groups used to segfault. Run in a child so a regression

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -378,6 +378,19 @@ describe("Glob.match", () => {
     const real = "{packages,apps}/{a,b}/{src,lib}/{x,y}/{u,v}/{p,q}/{c,d}/{e,f}/{g,h}/{i,j}/*.{ts,tsx}";
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.ts")).toBeTrue();
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.go")).toBeFalse();
+
+    // 200 groups (below the depth cap) still matches.
+    const deep = Array.from({ length: 200 }, () => "{a,b}").join("");
+    expect(new Glob(deep).match(Buffer.alloc(200, "a").toString())).toBeTrue();
+  });
+
+  test("pathologically deep brace patterns do not overflow the stack", () => {
+    // Each group along a match path adds a native recursion frame; thousands
+    // of sequential groups used to segfault. The depth cap returns false
+    // instead of crashing.
+    const n = 5000;
+    const flat = Array.from({ length: n }, () => "{a,b}").join("");
+    expect(new Glob(flat).match(Buffer.alloc(n, "a").toString())).toBeFalse();
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -379,9 +379,11 @@ describe("Glob.match", () => {
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.ts")).toBeTrue();
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.go")).toBeFalse();
 
-    // 200 groups (below the depth cap) still matches.
-    const deep = Array.from({ length: 200 }, () => "{a,b}").join("");
-    expect(new Glob(deep).match(Buffer.alloc(200, "a").toString())).toBeTrue();
+    // At the depth cap (MAX_BRACE_DEPTH = 256): 256 groups match, 257 do not.
+    const atCap = Array.from({ length: 256 }, () => "{a,b}").join("");
+    expect(new Glob(atCap).match(Buffer.alloc(256, "a").toString())).toBeTrue();
+    const pastCap = Array.from({ length: 257 }, () => "{a,b}").join("");
+    expect(new Glob(pastCap).match(Buffer.alloc(257, "a").toString())).toBeFalse();
   });
 
   test("pathologically deep brace patterns do not overflow the stack", () => {

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -24,7 +24,7 @@
 
 import { Glob } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { join } from "path";
 
 describe("Glob.match", () => {
@@ -386,13 +386,24 @@ describe("Glob.match", () => {
     expect(new Glob(pastCap).match(Buffer.alloc(257, "a").toString())).toBeFalse();
   });
 
-  test("pathologically deep brace patterns do not overflow the stack", () => {
+  test("pathologically deep brace patterns do not overflow the stack", async () => {
     // Each group along a match path adds a native recursion frame; thousands
-    // of sequential groups used to segfault. The depth cap returns false
-    // instead of crashing.
-    const n = 5000;
-    const flat = Array.from({ length: n }, () => "{a,b}").join("");
-    expect(new Glob(flat).match(Buffer.alloc(n, "a").toString())).toBeFalse();
+    // of sequential groups used to segfault. Run in a child so a regression
+    // is a clean failure instead of crashing the whole test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const n = 5000;
+         const flat = Array.from({ length: n }, () => "{a,b}").join("");
+         if (new Bun.Glob(flat).match(Buffer.alloc(n, "a").toString()) !== false) process.exit(2);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // The depth cap returns false (exit 0); no crash (signalCode null).
+    expect({ exitCode, signalCode: proc.signalCode, stderr }).toMatchObject({ exitCode: 0, signalCode: null });
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -375,8 +375,7 @@ describe("Glob.match", () => {
     }
 
     // Realistic monorepo pattern: one brace per directory level plus a leaf.
-    const real =
-      "{packages,apps}/{a,b}/{src,lib}/{x,y}/{u,v}/{p,q}/{c,d}/{e,f}/{g,h}/{i,j}/*.{ts,tsx}";
+    const real = "{packages,apps}/{a,b}/{src,lib}/{x,y}/{u,v}/{p,q}/{c,d}/{e,f}/{g,h}/{i,j}/*.{ts,tsx}";
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.ts")).toBeTrue();
     expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.go")).toBeFalse();
   });

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -417,11 +417,12 @@ describe("Glob.match", () => {
          if (new Bun.Glob(flat).match(Buffer.alloc(n, "a").toString()) !== false) process.exit(2);`,
       ],
       env: bunEnv,
+      stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // The depth cap returns false (exit 0); no crash (signalCode null).
-    expect({ exitCode, signalCode: proc.signalCode, stderr }).toMatchObject({ exitCode: 0, signalCode: null });
+    expect({ exitCode, signalCode: proc.signalCode, stdout, stderr }).toMatchObject({ exitCode: 0, signalCode: null });
   });
 
   // Most of the potential bugs when dealing with non-ASCII patterns is when the

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -360,6 +360,27 @@ describe("Glob.match", () => {
     expect(glob.match("{")).toBeFalse();
   });
 
+  test("many brace groups along one match path", () => {
+    // Sequential and per-segment brace groups accumulate one stack frame each
+    // along the matching path, so more than a handful used to silently stop
+    // matching. None of these hit nesting; they are flat groups in a row.
+    for (const n of [10, 11, 12, 32, 64]) {
+      const flat = Array.from({ length: n }, () => "{a,b}").join(""); // n sequential 2-way groups
+      const aRun = Buffer.alloc(n, "a").toString();
+      expect(new Glob(flat).match(aRun)).toBeTrue();
+
+      const perSegment = Array.from({ length: n }, () => "{a,b}").join("/");
+      const path = Array.from({ length: n }, () => "a").join("/");
+      expect(new Glob(perSegment).match(path)).toBeTrue();
+    }
+
+    // Realistic monorepo pattern: one brace per directory level plus a leaf.
+    const real =
+      "{packages,apps}/{a,b}/{src,lib}/{x,y}/{u,v}/{p,q}/{c,d}/{e,f}/{g,h}/{i,j}/*.{ts,tsx}";
+    expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.ts")).toBeTrue();
+    expect(new Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.go")).toBeFalse();
+  });
+
   // Most of the potential bugs when dealing with non-ASCII patterns is when the
   // pattern matching algorithm wants to deal with single chars, for example
   // using the `[...]` syntax, it tries to match each char in the brackets. With


### PR DESCRIPTION
## What

`Bun.Glob(...).match()` silently returns `false` for any legal pattern that reaches an 11th brace group along a single match path, even though the groups are not nested. Node's `path.matchesGlob`, micromatch, picomatch, minimatch and bash all match these.

```js
new Bun.Glob("{a,b}".repeat(10)).match("a".repeat(10)); // true
new Bun.Glob("{a,b}".repeat(11)).match("a".repeat(11)); // false  <-- should be true

// one brace per directory level, 11 levels deep:
const real = "{packages,apps}/{a,b}/{src,lib}/{x,y}/{u,v}/{p,q}/{c,d}/{e,f}/{g,h}/{i,j}/*.{ts,tsx}";
new Bun.Glob(real).match("packages/a/src/x/u/p/c/e/g/i/z.ts"); // false <-- should be true
```

Because the walker matches component-by-component, `scanSync()` still enumerates a file that `match()` then rejects for the same pattern, breaking the usual "scan then filter with match()" idiom.

## Cause

`src/glob/matcher.rs` memoizes, per open brace, which branch the matcher committed to (so wildcard backtracking can resume it). That memo lived in a fixed `BoundedArray<Brace, 10>`. Sequential groups (`{a,b}{c,d}`) recurse into `glob_match_impl` before their tail is fully explored, so each group on the match path keeps a live frame just like nested groups do. The 11th `push` failed and `match_brace_branch` returned `false`, i.e. "no match", with no error. The depth limit was effectively a group-count limit, contradicting the documented promise that non-nested braces may appear arbitrarily.

## Fix

Back the memo stack with a growable `SmallList<Brace, 10>`: it stays inline for the common case and spills to the heap for deeper patterns. Widen the `brace_depth` counter from `u8` to `u32` so deep patterns cannot overflow it (the `State`/`Wildcard` structs stay the same size after padding).

The old fixed-size array also incidentally capped the `match_brace` -> `match_brace_branch` -> `glob_match_impl` recursion at depth 10. Removing it would let an adversarial pattern of thousands of brace groups recurse deep enough to overflow the native thread stack (confirmed: ~2000 sequential groups segfaults on the unfixed build under ASAN/debug). So this adds an explicit `MAX_BRACE_DEPTH = 256` cap: patterns deeper than that return no-match instead of crashing. 256 is far above any realistic pattern (a deep monorepo glob uses tens of groups) and well below the crash point. Total branches explored remain bounded by the existing `BRACE_BRANCH_BUDGET` of 10,000.

Also refreshes the three doc sites that claimed a fixed 10-level nesting limit (the `r#match` doc, `packages/bun-types/bun.d.ts`, `docs/runtime/glob.mdx`).

## Verification

`bun bd test test/js/bun/glob/match.test.ts`:
- `many brace groups along one match path` (fails on the current release build, passes with the fix)
- `pathologically deep brace patterns do not overflow the stack` (segfaults on the unfixed build, returns `false` with the fix)
- Existing brace/nesting tests, including the >255-deep-nesting overflow test, still pass.

## Follow-up: literal `,`/`}` after sequential groups

While in this code, fixed an adjacent bug of the same class. The branch state inherited `brace_stack.len()` (the recursion-frame count) as its open-brace depth. A closed sequential group keeps its frame on the stack until its recursive call unwinds, so after 2+ sequential groups the count was too high and a trailing literal `,` or `}` was misrouted as brace syntax:

```js
new Bun.Glob("{a,b}{c,d},e").match("ac,e"); // was false, Node returns true
new Bun.Glob("{a,b}{c,d}}").match("ac}");    // was false, Node returns true
```

Now derived from the enclosing open-brace depth (`state.brace_depth + 1`). Covered by the `literal comma or brace after sequential brace groups` test.