### PR TITLE
node:https: expose the TLSSocket surface on the server request socket

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,5 @@
 const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { validateUint32, validateString, validateBuffer, validateFunction } = require("internal/validators");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -50,4 +51,249 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+// The TLS half of `tls.TLSSocket`. Every method reads the negotiated state off
+// `this._handle`, so any object that carries a handle exposing these natives
+// gets the documented TLS surface: `tls.TLSSocket` (a `Bun.connect` socket) and
+// the `https.Server` request socket (a uWS connection, see
+// node:_http_server's NodeHTTPServerTLSSocket). Installed on both prototypes by
+// `installTLSSocketMethods`.
+const kSession = Symbol("kSession");
+const kRenegotiationDisabled = Symbol("kRenegotiationDisabled");
+// Marks the https.Server request socket, which cannot extend TLSSocket (its
+// base class is the uWS-backed Duplex) but is one everywhere it matters.
+// node:tls's TLSSocket[Symbol.hasInstance] consults it.
+const kTLSSocketFacade = Symbol("kTLSSocketFacade");
+
+// The native X509 encoder already hands back the idiomatic shape Node's
+// translatePeerCertificate(node:_tls_common) produces (infoAccess is parsed
+// into an object there), so nothing is translated on the way out.
+function getPeerCertificate(detailed) {
+  const handle = this._handle;
+  if (handle) {
+    // The native parameter means "abbreviated" - the inverse of Node's
+    // `detailed`. Detailed requests get the whole chain with
+    // issuerCertificate links; everything else gets just the leaf.
+    const cert = arguments.length < 1 ? handle.getPeerCertificate?.() : handle.getPeerCertificate?.(!detailed);
+    return cert || {};
+  }
+  return null;
+}
+
+function getCertificate() {
+  return this._handle?.getCertificate?.();
+}
+
+function getPeerX509Certificate() {
+  // Build the X509Certificate chain from the detailed peer-certificate
+  // objects, linking each to its issuer the way Node does. The
+  // `issuerCertificate` own property shadows the prototype getter (which is
+  // always undefined for certificates parsed outside a TLS connection).
+  const cert = this.getPeerCertificate(true);
+  if (!cert || !cert.raw) {
+    return this._handle?.getPeerX509Certificate?.();
+  }
+  const { X509Certificate } = require("node:crypto");
+  const seen = new Map();
+  const toX509 = chainCert => {
+    if (!chainCert || !chainCert.raw) return undefined;
+    const cached = seen.$get(chainCert);
+    if (cached) return cached;
+    const x509 = new X509Certificate(chainCert.raw);
+    seen.$set(chainCert, x509);
+    const issuerCertificate = chainCert.issuerCertificate;
+    if (issuerCertificate && issuerCertificate !== chainCert) {
+      const issuer = toX509(issuerCertificate);
+      if (issuer) {
+        Object.defineProperty(x509, "issuerCertificate", {
+          __proto__: null,
+          value: issuer,
+          configurable: true,
+          enumerable: false,
+        });
+      }
+    }
+    return x509;
+  };
+  return toX509(cert);
+}
+
+function getX509Certificate() {
+  return this._handle?.getX509Certificate?.();
+}
+
+function getSession() {
+  return this._handle?.getSession?.();
+}
+
+function setSession(session) {
+  this[kSession] = session;
+  if (typeof session === "string") session = Buffer.from(session, "latin1");
+  return this._handle?.setSession?.(session);
+}
+
+function getEphemeralKeyInfo() {
+  const info = this._handle?.getEphemeralKeyInfo?.();
+  if (info == null) return info;
+  // Empirically node always surfaces all three keys here (values undefined when
+  // absent): a client socket on a TLS 1.3 ECDHE session observes
+  // Object.keys(...) === ['type','name','size'] under node v26.3.0, so the
+  // reshape below is required for key-set parity with our native return.
+  return { type: info.type, name: info.name, size: info.size };
+}
+
+function getCipher() {
+  return this._handle?.getCipher?.();
+}
+
+function getSharedSigalgs() {
+  return this._handle?.getSharedSigalgs?.();
+}
+
+function getProtocol() {
+  // Node returns the negotiated protocol string, or null once the socket is no
+  // longer connected (e.g. after 'close').
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/_tls_wrap.js#L1455
+  return this._handle?.getTLSVersion?.() ?? null;
+}
+
+function getFinished() {
+  return this._handle?.getTLSFinishedMessage?.() || undefined;
+}
+
+function getPeerFinished() {
+  return this._handle?.getTLSPeerFinishedMessage?.() || undefined;
+}
+
+function isSessionReused() {
+  return this._handle?.isSessionReused?.() ?? false;
+}
+
+function getTLSTicket() {
+  return this._handle?.getTLSTicket?.();
+}
+
+function setMaxSendFragment(size) {
+  return this._handle?.setMaxSendFragment?.(size) || false;
+}
+
+function enableTrace() {
+  // only for debug purposes so we just mock for now
+}
+
+function setServername(name) {
+  validateString(name, "name");
+  if (this.isServer) {
+    throw $ERR_TLS_SNI_FROM_SERVER();
+  }
+  // if the socket is detached we can't set the servername but we set this property so when open will auto set to it
+  this.servername = name;
+  this._handle?.setServername?.(name);
+}
+
+function exportKeyingMaterial(length, label, context) {
+  // https://github.com/nodejs/node/blob/v25.2.1/lib/internal/tls/wrap.js#L1039
+  validateUint32(length, "length", true);
+  validateString(label, "label");
+  if (context !== undefined) validateBuffer(context, "context");
+
+  if (!this._secureEstablished) {
+    throw $ERR_TLS_INVALID_STATE();
+  }
+
+  if (context) {
+    return this._handle?.exportKeyingMaterial?.(length, label, context);
+  }
+  return this._handle?.exportKeyingMaterial?.(length, label);
+}
+
+function renegotiate(options, callback) {
+  // https://github.com/nodejs/node/blob/v25.2.1/lib/_tls_wrap.js#L878
+  if (options === null || typeof options !== "object") {
+    throw $ERR_INVALID_ARG_TYPE("options", "object", options);
+  }
+  if (callback !== undefined) {
+    validateFunction(callback, "callback");
+  }
+
+  if (this.destroyed) {
+    return;
+  }
+
+  if (this[kRenegotiationDisabled]) {
+    // if renegotiation is disabled should emit error event in nextTick for nodejs compatibility
+    const error = $ERR_TLS_RENEGOTIATION_DISABLED();
+    if (typeof callback === "function") process.nextTick(callback, error);
+    return false;
+  }
+
+  const socket = this._handle;
+  // if the socket is detached we can't renegotiate, nodejs do a noop too (we should not return false or true here)
+  if (!socket) return;
+
+  let requestCert = !!this._requestCert;
+  let rejectUnauthorized = !!this._rejectUnauthorized;
+  const { requestCert: requestCertOption, rejectUnauthorized: rejectUnauthorizedOption } = options;
+  if (requestCertOption !== undefined) requestCert = !!requestCertOption;
+  if (rejectUnauthorizedOption !== undefined) rejectUnauthorized = !!rejectUnauthorizedOption;
+  if (requestCert !== this._requestCert || rejectUnauthorized !== this._rejectUnauthorized) {
+    socket.setVerifyMode?.(requestCert, rejectUnauthorized);
+    this._requestCert = requestCert;
+    this._rejectUnauthorized = rejectUnauthorized;
+  }
+
+  // BoringSSL does not implement TLS renegotiation; Node built against
+  // BoringSSL reports exactly this from renegotiate() regardless of the
+  // protocol version, and so do we.
+  const error = $ERR_TLS_RENEGOTIATION_UNSUPPORTED();
+  if (typeof callback === "function") process.nextTick(callback, error);
+  return false;
+}
+
+function disableRenegotiation() {
+  this[kRenegotiationDisabled] = true;
+  // disable renegotiation on the socket
+  return this._handle?.disableRenegotiation?.();
+}
+
+const tlsSocketMethods = {
+  __proto__: null,
+  getPeerCertificate,
+  getCertificate,
+  getPeerX509Certificate,
+  getX509Certificate,
+  getSession,
+  setSession,
+  getEphemeralKeyInfo,
+  getCipher,
+  getSharedSigalgs,
+  getProtocol,
+  getFinished,
+  getPeerFinished,
+  isSessionReused,
+  getTLSTicket,
+  setMaxSendFragment,
+  enableTrace,
+  setServername,
+  exportKeyingMaterial,
+  renegotiate,
+  disableRenegotiation,
+};
+
+function installTLSSocketMethods(prototype) {
+  const names = Object.keys(tlsSocketMethods);
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    prototype[name] = tlsSocketMethods[name];
+  }
+}
+
+export {
+  VALID_TLS_ERROR_MESSAGE_TYPES,
+  installTLSSocketMethods,
+  isValidTLSArray,
+  isValidTLSItem,
+  kRenegotiationDisabled,
+  kSession,
+  kTLSSocketFacade,
+  throwOnInvalidTLSArray,
+};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1402,11 +1402,16 @@ const NodeHTTPServerTLSSocket = class Socket extends NodeHTTPServerSocket {
     }
   }
 
-  // The TLS readers all dereference `_handle`; route them at the native handle,
+  // The TLS readers all dereference `_handle`; route it at the native handle,
   // which the base class nulls once the connection closes, so a closed socket
-  // answers the way a detached tls.TLSSocket does.
+  // answers the way a detached tls.TLSSocket does. Writable for parity with
+  // net.Socket, where userland (tunnel/proxy middleware) detaches via
+  // `socket._handle = null`.
   get _handle() {
     return this[kHandle];
+  }
+  set _handle(value) {
+    this[kHandle] = value;
   }
 } as unknown as typeof import("node:tls").TLSSocket;
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { installTLSSocketMethods, kTLSSocketFacade, throwOnInvalidTLSArray } = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -606,7 +606,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         const prevIsNextIncomingMessageHTTPS = getIsNextIncomingMessageHTTPS();
         setIsNextIncomingMessageHTTPS(isHTTPS);
         if (!socket) {
-          socket = new NodeHTTPServerSocket(server, socketHandle, !!tls);
+          socket = createServerSocket(server, socketHandle, tls);
         }
 
         const http_req = new RequestClass(kHandle, url, method, headersObject, headersArray, handle, hasBody, socket);
@@ -708,7 +708,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
 
         if (isSocketNew && !reachedRequestsLimit) {
-          server.emit("connection", socket);
+          emitNewConnection(server, socket, tls);
         }
 
         socket[kRequest] = http_req;
@@ -909,7 +909,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.requireHostHeader,
       true,
       typeof this.maxHeaderSize !== "undefined" ? this.maxHeaderSize : getMaxHTTPHeaderSize(),
-      onServerClientError.bind(this),
+      onServerClientError.bind(this, tls),
     );
 
     if (this?._unref) {
@@ -971,7 +971,7 @@ enum HttpParserError {
   HTTP_PARSER_ERROR_INVALID_METHOD = 9,
   HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN = 10,
 }
-function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, rawPacket: ArrayBuffer) {
+function onServerClientError(tls, _ssl: boolean, socket: unknown, errorCode: number, rawPacket: ArrayBuffer) {
   const self = this as Server;
   let err;
   switch (errorCode) {
@@ -1006,9 +1006,9 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
   // kTrackedConnections. Reuse it, and only announce genuinely new
   // connections - the existing duplex already had its 'connection' event.
   const existingDuplex = (socket as any).duplex;
-  const nodeSocket = existingDuplex ?? new NodeHTTPServerSocket(self, socket, ssl);
+  const nodeSocket = existingDuplex ?? createServerSocket(self, socket, tls);
   if (!existingDuplex) {
-    self.emit("connection", nodeSocket);
+    emitNewConnection(self, nodeSocket, tls);
   }
   self.emit("clientError", err, nodeSocket);
   if (nodeSocket.listenerCount("error") > 0) {
@@ -1364,6 +1364,68 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     return this[kHandle]?.response;
   }
 } as unknown as typeof import("node:net").Socket;
+
+// The accepted socket of an https.Server. Node hands the request handler a
+// tls.TLSSocket; Bun's connection is a uWS handle, so this wraps the same
+// surface around it: the TLS readers in internal/tls all go through `_handle`,
+// which the native JSNodeHTTPServerSocket implements on top of the BoringSSL
+// readers tls.TLSSocket already uses. The handshake has always completed by the
+// time the first request arrives, so the negotiated identity is read once in the
+// constructor, the way Node's onServerSocketSecure assigns it.
+const NodeHTTPServerTLSSocket = class Socket extends NodeHTTPServerSocket {
+  isServer = true;
+  alpnProtocol: string | false = false;
+  servername: string | false = false;
+  authorized = false;
+  authorizationError: string | null = null;
+  _requestCert: boolean;
+  _rejectUnauthorized: boolean;
+
+  constructor(server: Server, handle, requestCert: boolean, rejectUnauthorized: boolean) {
+    super(server, handle, true);
+    this._requestCert = requestCert;
+    this._rejectUnauthorized = rejectUnauthorized;
+    // Both report `false` when nothing was negotiated, like Node's server-side
+    // TLSSocket.
+    this.alpnProtocol = handle.getALPNProtocol();
+    this.servername = handle.getServername() ?? false;
+    // Node only inspects the peer certificate when it asked for one: without
+    // requestCert, `authorized` stays false and `authorizationError` stays null
+    // even though the client presented nothing.
+    if (requestCert) {
+      const verifyError = handle.getVerifyError();
+      if (verifyError) {
+        this.authorizationError = verifyError.code || verifyError.message;
+      } else {
+        this.authorized = true;
+      }
+    }
+  }
+
+  // The TLS readers all dereference `_handle`; route them at the native handle,
+  // which the base class nulls once the connection closes, so a closed socket
+  // answers the way a detached tls.TLSSocket does.
+  get _handle() {
+    return this[kHandle];
+  }
+} as unknown as typeof import("node:tls").TLSSocket;
+
+Object.defineProperty(NodeHTTPServerTLSSocket, "name", { value: "TLSSocket" });
+NodeHTTPServerTLSSocket.prototype[kTLSSocketFacade] = true;
+installTLSSocketMethods(NodeHTTPServerTLSSocket.prototype);
+
+function createServerSocket(server: Server, handle, tls) {
+  if (!tls) return new NodeHTTPServerSocket(server, handle, false);
+  return new NodeHTTPServerTLSSocket(server, handle, !!tls.requestCert, !!tls.rejectUnauthorized);
+}
+
+// `connection` fires for every accepted socket; a TLS server additionally fires
+// `secureConnection` with the same socket, which is where Node surfaces the
+// negotiated identity.
+function emitNewConnection(server: Server, socket, tls) {
+  server.emit("connection", socket);
+  if (tls) server.emit("secureConnection", socket);
+}
 
 function _writeHead(statusCode, reason, obj, response) {
   const originalStatusCode = statusCode;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,14 +5,14 @@ const Duplex = require("internal/streams/duplex");
 const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
-const { throwOnInvalidTLSArray } = require("internal/tls");
 const {
-  validateString,
-  validateNumber,
-  validateUint32,
-  validateBuffer,
-  validateFunction,
-} = require("internal/validators");
+  installTLSSocketMethods,
+  kRenegotiationDisabled,
+  kSession,
+  kTLSSocketFacade,
+  throwOnInvalidTLSArray,
+} = require("internal/tls");
+const { validateString, validateNumber, validateBuffer, validateFunction } = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
 
@@ -828,17 +828,8 @@ function createSecureContext(options) {
   return new InternalSecureContext(options, false);
 }
 
-// Translate some fields from the handle's C-friendly format into more idiomatic
-// javascript object representations before passing them back to the user.  Can
-// be used on any cert object, but changing the name would be semver-major.
-function translatePeerCertificate(c) {
-  return c;
-}
-
 const ksecureContext = Symbol("ksecureContext");
 const kcheckServerIdentity = Symbol("kcheckServerIdentity");
-const ksession = Symbol("ksession");
-const krenegotiationDisabled = Symbol("renegotiationDisabled");
 
 const buntls = Symbol.for("::buntls::");
 // net.ts's SNI dispatch uses this to recognize a raw native SecureContext
@@ -850,7 +841,7 @@ function TLSSocket(socket?, options?) {
   this[ksecureContext] = undefined;
   this.ALPNProtocols = undefined;
   this[kcheckServerIdentity] = undefined;
-  this[ksession] = undefined;
+  this[kSession] = undefined;
   this.alpnProtocol = null;
   this._secureEstablished = false;
   this._rejectUnauthorized = rejectUnauthorizedDefault();
@@ -862,7 +853,7 @@ function TLSSocket(socket?, options?) {
   this.servername = undefined;
   this.authorized = false;
   void this.authorizationError;
-  this[krenegotiationDisabled] = undefined;
+  this[kRenegotiationDisabled] = undefined;
   this.encrypted = true;
 
   const isNetSocketOrDuplex = socket instanceof Duplex;
@@ -936,7 +927,7 @@ function TLSSocket(socket?, options?) {
     validateFunction(checkServerIdentityOption, "options.checkServerIdentity");
   }
   this[kcheckServerIdentity] = checkServerIdentityOption || checkServerIdentity;
-  this[ksession] = options.session || null;
+  this[kSession] = options.session || null;
 
   // `new tls.TLSSocket(socket, { isServer: true })`: drive the server-side TLS
   // handshake over the provided socket via net.ts's native upgrade path (reaches
@@ -980,99 +971,10 @@ TLSSocket.prototype._final = function _final(callback) {
   return NetSocket.prototype._final.$call(this, callback);
 };
 
-TLSSocket.prototype.getSession = function getSession() {
-  return this._handle?.getSession?.();
-};
-
-TLSSocket.prototype.getEphemeralKeyInfo = function getEphemeralKeyInfo() {
-  const info = this._handle?.getEphemeralKeyInfo?.();
-  if (info == null) return info;
-  // Empirically node always surfaces all three keys here (values undefined when
-  // absent): a client socket on a TLS 1.3 ECDHE session observes
-  // Object.keys(...) === ['type','name','size'] under node v26.3.0, so the
-  // reshape below is required for key-set parity with our native return.
-  return { type: info.type, name: info.name, size: info.size };
-};
-
-TLSSocket.prototype.getCipher = function getCipher() {
-  return this._handle?.getCipher?.();
-};
-
-TLSSocket.prototype.getSharedSigalgs = function getSharedSigalgs() {
-  return this._handle?.getSharedSigalgs?.();
-};
-
-TLSSocket.prototype.getProtocol = function getProtocol() {
-  // Node returns the negotiated protocol string, or null once the socket is no
-  // longer connected (e.g. after 'close').
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/_tls_wrap.js#L1455
-  return this._handle?.getTLSVersion?.() ?? null;
-};
-
-TLSSocket.prototype.getFinished = function getFinished() {
-  return this._handle?.getTLSFinishedMessage?.() || undefined;
-};
-
-TLSSocket.prototype.getPeerFinished = function getPeerFinished() {
-  return this._handle?.getTLSPeerFinishedMessage?.() || undefined;
-};
-
-TLSSocket.prototype.isSessionReused = function isSessionReused() {
-  return this._handle?.isSessionReused?.() ?? false;
-};
-
-TLSSocket.prototype.renegotiate = function renegotiate(options, callback) {
-  // https://github.com/nodejs/node/blob/v25.2.1/lib/_tls_wrap.js#L878
-  if (options === null || typeof options !== "object") {
-    throw $ERR_INVALID_ARG_TYPE("options", "object", options);
-  }
-  if (callback !== undefined) {
-    validateFunction(callback, "callback");
-  }
-
-  if (this.destroyed) {
-    return;
-  }
-
-  if (this[krenegotiationDisabled]) {
-    // if renegotiation is disabled should emit error event in nextTick for nodejs compatibility
-    const error = $ERR_TLS_RENEGOTIATION_DISABLED();
-    if (typeof callback === "function") process.nextTick(callback, error);
-    return false;
-  }
-
-  const socket = this._handle;
-  // if the socket is detached we can't renegotiate, nodejs do a noop too (we should not return false or true here)
-  if (!socket) return;
-
-  let requestCert = !!this._requestCert;
-  let rejectUnauthorized = !!this._rejectUnauthorized;
-  const { requestCert: requestCertOption, rejectUnauthorized: rejectUnauthorizedOption } = options;
-  if (requestCertOption !== undefined) requestCert = !!requestCertOption;
-  if (rejectUnauthorizedOption !== undefined) rejectUnauthorized = !!rejectUnauthorizedOption;
-  if (requestCert !== this._requestCert || rejectUnauthorized !== this._rejectUnauthorized) {
-    socket.setVerifyMode?.(requestCert, rejectUnauthorized);
-    this._requestCert = requestCert;
-    this._rejectUnauthorized = rejectUnauthorized;
-  }
-
-  // BoringSSL does not implement TLS renegotiation; Node built against
-  // BoringSSL reports exactly this from renegotiate() regardless of the
-  // protocol version, and so do we.
-  const error = $ERR_TLS_RENEGOTIATION_UNSUPPORTED();
-  if (typeof callback === "function") process.nextTick(callback, error);
-  return false;
-};
-
-TLSSocket.prototype.disableRenegotiation = function disableRenegotiation() {
-  this[krenegotiationDisabled] = true;
-  // disable renegotiation on the socket
-  return this._handle?.disableRenegotiation?.();
-};
-
-TLSSocket.prototype.getTLSTicket = function getTLSTicket() {
-  return this._handle?.getTLSTicket?.();
-};
+// The TLS readers/setters shared with node:_http_server's https request
+// socket: every one reads `this._handle`, which is a Bun.connect socket here
+// and a uWS connection there.
+installTLSSocketMethods(TLSSocket.prototype);
 
 TLSSocket.prototype.setKeyCert = function setKeyCert(context) {
   // Serve this connection's identity from the given context (Node calls this
@@ -1082,107 +984,20 @@ TLSSocket.prototype.setKeyCert = function setKeyCert(context) {
   this._handle?.setKeyCert?.(ctx.context);
 };
 
-TLSSocket.prototype.exportKeyingMaterial = function exportKeyingMaterial(length, label, context) {
-  // https://github.com/nodejs/node/blob/v25.2.1/lib/internal/tls/wrap.js#L1039
-  validateUint32(length, "length", true);
-  validateString(label, "label");
-  if (context !== undefined) validateBuffer(context, "context");
-
-  if (!this._secureEstablished) {
-    throw $ERR_TLS_INVALID_STATE();
-  }
-
-  if (context) {
-    return this._handle?.exportKeyingMaterial?.(length, label, context);
-  }
-  return this._handle?.exportKeyingMaterial?.(length, label);
-};
-
-TLSSocket.prototype.setMaxSendFragment = function setMaxSendFragment(size) {
-  return this._handle?.setMaxSendFragment?.(size) || false;
-};
-
-TLSSocket.prototype.enableTrace = function enableTrace() {
-  // only for debug purposes so we just mock for now
-};
-
-TLSSocket.prototype.setServername = function setServername(name) {
-  validateString(name, "name");
-  if (this.isServer) {
-    throw $ERR_TLS_SNI_FROM_SERVER();
-  }
-  // if the socket is detached we can't set the servername but we set this property so when open will auto set to it
-  this.servername = name;
-  this._handle?.setServername?.(name);
-};
-
-TLSSocket.prototype.setSession = function setSession(session) {
-  this[ksession] = session;
-  if (typeof session === "string") session = Buffer.from(session, "latin1");
-  return this._handle?.setSession?.(session);
-};
-
-TLSSocket.prototype.getPeerCertificate = function getPeerCertificate(detailed) {
-  const handle = this._handle;
-  if (handle) {
-    // The native parameter means "abbreviated" - the inverse of Node's
-    // `detailed`. Detailed requests get the whole chain with
-    // issuerCertificate links; everything else gets just the leaf.
-    const cert = arguments.length < 1 ? handle.getPeerCertificate?.() : handle.getPeerCertificate?.(!detailed);
-    if (cert) {
-      return translatePeerCertificate(cert);
-    }
-    return {};
-  }
-  return null;
-};
-
-TLSSocket.prototype.getCertificate = function getCertificate() {
-  // getCertificate is not yet implemented on the native socket
-  const cert = this._handle?.getCertificate?.();
-  if (cert) {
-    // It's not a peer cert, but the formatting is identical.
-    return translatePeerCertificate(cert);
-  }
-};
-
-TLSSocket.prototype.getPeerX509Certificate = function getPeerX509Certificate() {
-  // Build the X509Certificate chain from the detailed peer-certificate
-  // objects, linking each to its issuer the way Node does. The
-  // `issuerCertificate` own property shadows the prototype getter (which is
-  // always undefined for certificates parsed outside a TLS connection).
-  const cert = this.getPeerCertificate(true);
-  if (!cert || !cert.raw) {
-    return this._handle?.getPeerX509Certificate?.();
-  }
-  const { X509Certificate } = require("node:crypto");
-  const seen = new Map();
-  const toX509 = chainCert => {
-    if (!chainCert || !chainCert.raw) return undefined;
-    const cached = seen.get(chainCert);
-    if (cached) return cached;
-    const x509 = new X509Certificate(chainCert.raw);
-    seen.set(chainCert, x509);
-    const issuerCertificate = chainCert.issuerCertificate;
-    if (issuerCertificate && issuerCertificate !== chainCert) {
-      const issuer = toX509(issuerCertificate);
-      if (issuer) {
-        Object.defineProperty(x509, "issuerCertificate", {
-          __proto__: null,
-          value: issuer,
-          configurable: true,
-          enumerable: false,
-        });
-      }
-    }
-    return x509;
-  };
-  return toX509(cert);
-};
-
-TLSSocket.prototype.getX509Certificate = function getX509Certificate() {
-  return this._handle?.getX509Certificate?.();
-};
+// An https.Server request socket is a TLSSocket facade (node:_http_server)
+// that cannot extend this class - its base is the uWS-backed Duplex - so
+// recognise it here the way Node's Writable/Readable recognise duck-typed
+// streams. Subclasses keep ordinary semantics.
+const FunctionPrototypeSymbolHasInstance = Function.prototype[Symbol.hasInstance];
+Object.defineProperty(TLSSocket, Symbol.hasInstance, {
+  __proto__: null,
+  value: function (instance) {
+    if (this === TLSSocket && instance != null && instance[kTLSSocketFacade] === true) return true;
+    return FunctionPrototypeSymbolHasInstance.$call(this, instance);
+  },
+  writable: true,
+  configurable: true,
+});
 
 TLSSocket.prototype[buntls] = function (port, host) {
   const ctx = this[ksecureContext];
@@ -1197,7 +1012,7 @@ TLSSocket.prototype[buntls] = function (port, host) {
     socket: this._handle,
     ALPNProtocols: this.ALPNProtocols,
     checkServerIdentity: this[kcheckServerIdentity],
-    session: this[ksession],
+    session: this[kSession],
     rejectUnauthorized: this._rejectUnauthorized,
     requestCert: this._requestCert,
     ciphers: this.ciphers,

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -10,6 +10,29 @@
 extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
 extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
+extern "C" void* us_socket_get_native_handle(us_socket_t* s);
+
+// Implemented in Rust (runtime/socket/tls_socket_functions.rs) on top of the
+// same BoringSSL readers `tls.TLSSocket` uses. `ssl` is the live `SSL*`.
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getPeerCertificate(JSC::JSGlobalObject*, void* ssl, JSC::CallFrame*);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getCertificate(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getPeerX509Certificate(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getX509Certificate(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getCipher(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getTLSVersion(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getSession(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getTLSTicket(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getSharedSigalgs(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getTLSFinishedMessage(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getTLSPeerFinishedMessage(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getEphemeralKeyInfo(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getServername(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getALPNProtocol(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__getVerifyError(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__isSessionReused(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__disableRenegotiation(JSC::JSGlobalObject*, void* ssl);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__exportKeyingMaterial(JSC::JSGlobalObject*, void* ssl, JSC::CallFrame*);
+extern "C" EncodedJSValue Bun__NodeHTTPServerSocket__setMaxSendFragment(JSC::JSGlobalObject*, void* ssl, JSC::CallFrame*);
 
 namespace Bun {
 
@@ -41,6 +64,55 @@ JSC_DEFINE_CUSTOM_SETTER(noOpSetter, (JSC::JSGlobalObject * globalObject, JSC::E
     return false;
 }
 
+// The live `SSL*` of an accepted HTTPS connection, or nullptr for plain HTTP
+// and for a socket that is gone. uSockets frees the `SSL` only after on_close
+// runs, and `JSNodeHTTPServerSocket::onClose` nulls `socket` there, so a
+// non-null result is always a live handle. The Rust readers take the null and
+// answer exactly as they do for a detached `tls.TLSSocket`.
+static void* nodeHTTPServerSocketSSL(JSC::JSValue thisValue)
+{
+    auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(thisValue);
+    if (!thisObject || !thisObject->is_ssl || thisObject->isClosed()) [[unlikely]] {
+        return nullptr;
+    }
+    return us_socket_get_native_handle(thisObject->socket);
+}
+
+#define BUN_DEFINE_NODE_HTTP_TLS_READER(name)                                                                               \
+    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame* callFrame))    \
+    {                                                                                                                       \
+        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()));             \
+    }
+
+#define BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS(name)                                                                     \
+    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame* callFrame))    \
+    {                                                                                                                       \
+        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()), callFrame);  \
+    }
+
+BUN_DEFINE_NODE_HTTP_TLS_READER(getCertificate)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getPeerX509Certificate)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getX509Certificate)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getCipher)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getTLSVersion)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getSession)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getTLSTicket)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getSharedSigalgs)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getTLSFinishedMessage)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getTLSPeerFinishedMessage)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getEphemeralKeyInfo)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getServername)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getALPNProtocol)
+BUN_DEFINE_NODE_HTTP_TLS_READER(getVerifyError)
+BUN_DEFINE_NODE_HTTP_TLS_READER(isSessionReused)
+BUN_DEFINE_NODE_HTTP_TLS_READER(disableRenegotiation)
+BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS(getPeerCertificate)
+BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS(exportKeyingMaterial)
+BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS(setMaxSendFragment)
+
+#undef BUN_DEFINE_NODE_HTTP_TLS_READER
+#undef BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS
+
 const JSC::ClassInfo JSNodeHTTPServerSocketPrototype::s_info = { "NodeHTTPServerSocket"_s, &Base::s_info, nullptr, nullptr,
     CREATE_METHOD_TABLE(JSNodeHTTPServerSocketPrototype) };
 
@@ -59,6 +131,29 @@ static const JSC::HashTableValue JSNodeHTTPServerSocketPrototypeTableValues[] = 
     { "end"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketEnd, 0 } },
     { "upgradeToTunnel"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketUpgradeToTunnel, 0 } },
     { "secureEstablished"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterIsSecureEstablished, noOpSetter } },
+    // TLS readers for an accepted https.Server connection. `node:_http_server`
+    // wires the request socket's `_handle` to this object so the shared
+    // `tls.TLSSocket` method bodies (internal/tls) find the same names they use
+    // on a `Bun.connect` socket.
+    { "getPeerCertificate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetPeerCertificate, 1 } },
+    { "getCertificate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetCertificate, 0 } },
+    { "getPeerX509Certificate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetPeerX509Certificate, 0 } },
+    { "getX509Certificate"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetX509Certificate, 0 } },
+    { "getCipher"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetCipher, 0 } },
+    { "getTLSVersion"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetTLSVersion, 0 } },
+    { "getSession"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetSession, 0 } },
+    { "getTLSTicket"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetTLSTicket, 0 } },
+    { "getSharedSigalgs"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetSharedSigalgs, 0 } },
+    { "getTLSFinishedMessage"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetTLSFinishedMessage, 0 } },
+    { "getTLSPeerFinishedMessage"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetTLSPeerFinishedMessage, 0 } },
+    { "getEphemeralKeyInfo"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetEphemeralKeyInfo, 0 } },
+    { "getServername"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetServername, 0 } },
+    { "getALPNProtocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetALPNProtocol, 0 } },
+    { "getVerifyError"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketgetVerifyError, 0 } },
+    { "isSessionReused"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketisSessionReused, 0 } },
+    { "disableRenegotiation"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketdisableRenegotiation, 0 } },
+    { "exportKeyingMaterial"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketexportKeyingMaterial, 3 } },
+    { "setMaxSendFragment"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketsetMaxSendFragment, 1 } },
 };
 
 void JSNodeHTTPServerSocketPrototype::finishCreation(JSC::VM& vm)

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -78,16 +78,16 @@ static void* nodeHTTPServerSocketSSL(JSC::JSValue thisValue)
     return us_socket_get_native_handle(thisObject->socket);
 }
 
-#define BUN_DEFINE_NODE_HTTP_TLS_READER(name)                                                                               \
-    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame* callFrame))    \
-    {                                                                                                                       \
-        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()));             \
+#define BUN_DEFINE_NODE_HTTP_TLS_READER(name)                                                                              \
+    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame * callFrame)) \
+    {                                                                                                                      \
+        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()));           \
     }
 
 #define BUN_DEFINE_NODE_HTTP_TLS_READER_WITH_ARGS(name)                                                                     \
-    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame* callFrame))    \
+    JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocket##name, (JSGlobalObject * globalObject, CallFrame * callFrame))  \
     {                                                                                                                       \
-        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()), callFrame);  \
+        return Bun__NodeHTTPServerSocket__##name(globalObject, nodeHTTPServerSocketSSL(callFrame->thisValue()), callFrame); \
     }
 
 BUN_DEFINE_NODE_HTTP_TLS_READER(getCertificate)

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3736,19 +3736,23 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub fn disable_renegotiation(
         this: &Self,
-        g: &JSGlobalObject,
-        f: &CallFrame,
+        _g: &JSGlobalObject,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::disable_renegotiation(Self::as_tls(this), g, f)
+            tls_socket_functions::disable_renegotiation(this.socket.get().ssl())
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn is_session_reused(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn is_session_reused(
+        this: &Self,
+        _g: &JSGlobalObject,
+        _f: &CallFrame,
+    ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::is_session_reused(Self::as_tls(this), g, f)
+            tls_socket_functions::is_session_reused(this.socket.get().ssl())
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3770,9 +3774,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_tls_ticket(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_tls_ticket(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_tls_ticket(Self::as_tls(this), g, f)
+            tls_socket_functions::get_tls_ticket(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3786,9 +3790,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_session(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_session(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_session(Self::as_tls(this), g, f)
+            tls_socket_functions::get_session(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3796,7 +3800,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(getter)]
     pub fn get_alpn_protocol(this: &Self, g: &JSGlobalObject) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_alpn_protocol(Self::as_tls(this), g)
+            tls_socket_functions::get_alpn_protocol(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3816,7 +3820,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::export_keying_material(Self::as_tls(this), g, f)
+            tls_socket_functions::export_keying_material(this.socket.get().ssl(), g, f)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3825,18 +3829,22 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn get_ephemeral_key_info(
         this: &Self,
         g: &JSGlobalObject,
-        f: &CallFrame,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_ephemeral_key_info(Self::as_tls(this), g, f)
+            tls_socket_functions::get_ephemeral_key_info(
+                this.socket.get().ssl(),
+                Self::as_tls(this).is_server(),
+                g,
+            )
         } else {
             Ok(JSValue::NULL)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_cipher(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_cipher(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_cipher(Self::as_tls(this), g, f)
+            tls_socket_functions::get_cipher(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3845,10 +3853,10 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn get_tls_peer_finished_message(
         this: &Self,
         g: &JSGlobalObject,
-        f: &CallFrame,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_tls_peer_finished_message(Self::as_tls(this), g, f)
+            tls_socket_functions::get_tls_peer_finished_message(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3857,26 +3865,30 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn get_tls_finished_message(
         this: &Self,
         g: &JSGlobalObject,
-        f: &CallFrame,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_tls_finished_message(Self::as_tls(this), g, f)
+            tls_socket_functions::get_tls_finished_message(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_shared_sigalgs(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_shared_sigalgs(
+        this: &Self,
+        g: &JSGlobalObject,
+        _f: &CallFrame,
+    ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_shared_sigalgs(Self::as_tls(this), g, f)
+            tls_socket_functions::get_shared_sigalgs(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_tls_version(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_tls_version(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_tls_version(Self::as_tls(this), g, f)
+            tls_socket_functions::get_tls_version(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::NULL)
         }
@@ -3888,7 +3900,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::set_max_send_fragment(Self::as_tls(this), g, f)
+            tls_socket_functions::set_max_send_fragment(this.socket.get().ssl(), g, f)
         } else {
             Ok(JSValue::FALSE)
         }
@@ -3900,15 +3912,20 @@ impl<const SSL: bool> NewSocket<SSL> {
         f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_peer_certificate(Self::as_tls(this), g, f)
+            tls_socket_functions::get_peer_certificate(
+                this.socket.get().ssl(),
+                Self::as_tls(this).is_server(),
+                g,
+                f,
+            )
         } else {
             Ok(JSValue::NULL)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_certificate(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_certificate(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_certificate(Self::as_tls(this), g, f)
+            tls_socket_functions::get_certificate(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3917,10 +3934,10 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn get_peer_x509_certificate(
         this: &Self,
         g: &JSGlobalObject,
-        f: &CallFrame,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_peer_x509_certificate(Self::as_tls(this), g, f)
+            tls_socket_functions::get_peer_x509_certificate(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
@@ -3929,18 +3946,18 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub fn get_x509_certificate(
         this: &Self,
         g: &JSGlobalObject,
-        f: &CallFrame,
+        _f: &CallFrame,
     ) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_x509_certificate(Self::as_tls(this), g, f)
+            tls_socket_functions::get_x509_certificate(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }
     }
     #[bun_jsc::host_fn(method)]
-    pub fn get_servername(this: &Self, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
+    pub fn get_servername(this: &Self, g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         if SSL {
-            tls_socket_functions::get_servername(Self::as_tls(this), g, f)
+            tls_socket_functions::get_servername(this.socket.get().ssl(), g)
         } else {
             Ok(JSValue::UNDEFINED)
         }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -266,6 +266,14 @@ pub(super) mod ffi {
         ) -> c_int;
         // Returns X509_V_OK (0) when `issuer` could have issued `subject`.
         pub(crate) fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> c_int;
+
+        // ── uSockets ──────────────────────────────────────────────────────
+        // Maps SSL_get_verify_result onto the C `us_bun_verify_error_t`
+        // (crypto/openssl.c); `code`/`reason` point into static tables.
+        // SAFETY (unsafe fn): `ssl` must be a live `SSL*`.
+        pub(crate) fn us_ssl_socket_verify_error_from_ssl(
+            ssl: *mut SSL,
+        ) -> bun_uws::us_bun_verify_error_t;
     }
 }
 use crate::node::StringOrBuffer;
@@ -279,12 +287,15 @@ use crate::node::StringOrBuffer;
 // `socket_body` instance.
 type This = super::TLSSocket;
 
-pub(super) fn get_servername(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+/// The live `SSL*` of a TLS connection, `None` once it is detached or closed.
+/// The readers below take this rather than a socket object so the `node:http`
+/// server socket — which owns a uWS `us_socket_t*`, not a `NewSocket` — shares
+/// the same BoringSSL-backed implementations through the shims at the bottom
+/// of this file.
+type Ssl = Option<*mut boringssl::SSL>;
+
+pub(super) fn get_servername(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
 
@@ -346,12 +357,8 @@ pub(super) fn set_servername(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn get_peer_x509_certificate(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_peer_x509_certificate(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -361,12 +368,8 @@ pub(super) fn get_peer_x509_certificate(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn get_x509_certificate(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_x509_certificate(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let cert = ffi::SSL_get_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -378,14 +381,10 @@ pub(super) fn get_x509_certificate(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn get_tls_version(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
+pub(super) fn get_tls_version(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
     jsc::mark_binding();
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::NULL);
     };
     let version = ffi::SSL_get_version(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -401,7 +400,7 @@ pub(super) fn get_tls_version(
 }
 
 pub(super) fn set_max_send_fragment(
-    this: &This,
+    ssl: Ssl,
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
@@ -425,7 +424,7 @@ pub(super) fn set_max_send_fragment(
         return Err(global.throw(format_args!("Expected size to be less than 16385")));
     }
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::FALSE);
     };
     Ok(JSValue::from(
@@ -437,7 +436,8 @@ pub(super) fn set_max_send_fragment(
 }
 
 pub(super) fn get_peer_certificate(
-    this: &This,
+    ssl: Ssl,
+    is_server: bool,
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
@@ -453,12 +453,12 @@ pub(super) fn get_peer_certificate(
         abbreviated = arg.to_boolean();
     }
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
 
     if abbreviated {
-        if this.is_server() {
+        if is_server {
             // SSL_get_peer_certificate returns a +1 reference; we must free it.
             // X509::to_js only borrows the pointer (X509View is non-owning).
             let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -481,7 +481,7 @@ pub(super) fn get_peer_certificate(
     }
 
     let mut cert: *mut boringssl::X509 = core::ptr::null_mut();
-    if this.is_server() {
+    if is_server {
         // SSL_get_peer_certificate returns a +1 reference; we must free it.
         cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
     }
@@ -618,12 +618,8 @@ pub(super) fn get_peer_certificate(
     Ok(first_obj)
 }
 
-pub(super) fn get_certificate(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_certificate(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let cert = ffi::SSL_get_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -634,12 +630,8 @@ pub(super) fn get_certificate(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn get_tls_finished_message(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_tls_finished_message(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     // We cannot just pass nullptr to SSL_get_finished()
@@ -670,14 +662,10 @@ pub(super) fn get_tls_finished_message(
     Ok(buffer)
 }
 
-pub(super) fn get_shared_sigalgs(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
+pub(super) fn get_shared_sigalgs(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
     jsc::mark_binding();
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::NULL);
     };
 
@@ -773,12 +761,8 @@ pub(super) fn get_shared_sigalgs(
     Ok(array)
 }
 
-pub(super) fn get_cipher(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_cipher(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let cipher = ffi::SSL_get_current_cipher(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -827,11 +811,10 @@ pub(super) fn get_cipher(
 }
 
 pub(super) fn get_tls_peer_finished_message(
-    this: &This,
+    ssl: Ssl,
     global: &JSGlobalObject,
-    _frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     // We cannot just pass nullptr to SSL_get_peer_finished()
@@ -912,14 +895,10 @@ pub(crate) fn set_key_cert(
 }
 
 pub(crate) fn export_keying_material(
-    this: &This,
+    ssl: Ssl,
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    if this.socket.get().is_detached() {
-        return Ok(JSValue::UNDEFINED);
-    }
-
     let args = frame.arguments_old::<3>();
     if args.len < 2 {
         return Err(global.throw(format_args!("Expected length and label to be provided")));
@@ -941,7 +920,7 @@ pub(crate) fn export_keying_material(
 
     let label = label_arg.to_slice_or_null(global)?;
     let label_slice = label.slice();
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
 
@@ -1009,16 +988,16 @@ pub(crate) fn export_keying_material(
 }
 
 pub(super) fn get_ephemeral_key_info(
-    this: &This,
+    ssl: Ssl,
+    is_server: bool,
     global: &JSGlobalObject,
-    _frame: &CallFrame,
 ) -> JsResult<JSValue> {
     // only available for clients
-    if this.is_server() {
+    if is_server {
         return Ok(JSValue::NULL);
     }
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::NULL);
     };
     let result = JSValue::create_empty_object(global, 0);
@@ -1082,11 +1061,11 @@ pub(super) fn get_ephemeral_key_info(
     Ok(result)
 }
 
-pub(super) fn get_alpn_protocol(this: &This, global: &JSGlobalObject) -> JsResult<JSValue> {
+pub(super) fn get_alpn_protocol(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
     let mut alpn_proto: *const u8 = core::ptr::null();
     let mut alpn_proto_len: u32 = 0;
 
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::FALSE);
     };
 
@@ -1110,12 +1089,8 @@ pub(super) fn get_alpn_protocol(this: &This, global: &JSGlobalObject) -> JsResul
     Ok(ZigString::from_utf8(slice).to_js(global))
 }
 
-pub(super) fn get_session(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_session(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let session = ffi::SSL_get_session(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -1193,12 +1168,8 @@ pub(super) fn set_session(
     }
 }
 
-pub(super) fn get_tls_ticket(
-    this: &This,
-    global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn get_tls_ticket(ssl: Ssl, global: &JSGlobalObject) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     let session = ffi::SSL_get_session(boringssl::SSL::opaque_ref(ssl_ptr));
@@ -1238,12 +1209,8 @@ pub(super) fn renegotiate(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn disable_renegotiation(
-    this: &This,
-    _global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn disable_renegotiation(ssl: Ssl) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::UNDEFINED);
     };
     ffi::SSL_set_renegotiate_mode(
@@ -1253,12 +1220,8 @@ pub(super) fn disable_renegotiation(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(super) fn is_session_reused(
-    this: &This,
-    _global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let Some(ssl_ptr) = this.socket.get().ssl() else {
+pub(super) fn is_session_reused(ssl: Ssl) -> JsResult<JSValue> {
+    let Some(ssl_ptr) = ssl else {
         return Ok(JSValue::FALSE);
     };
     Ok(JSValue::from(
@@ -1413,4 +1376,176 @@ fn get_ssl_exception(global: &JSGlobalObject, default_message: &[u8]) -> JSValue
     exception.ensure_still_alive();
 
     exception
+}
+
+// ─── node:https request-socket shims ────────────────────────────────────────
+// An accepted `https.Server` connection is a uWS `us_socket_t*` owned by
+// `JSNodeHTTPServerSocket` (bindings/node/JSNodeHTTPServerSocket.cpp), not a
+// `NewSocket`, so it cannot reach the `TLSSocket` host functions above. The
+// prototype there resolves the live `SSL*` and calls these, giving
+// `req.socket` the same TLS readers `tls.TLSSocket` exposes.
+//
+// Plain `extern "C"` (NOT `#[bun_jsc::host_call]` / sysv64): the C++
+// declarations are bare `extern "C"` with no `SYSV_ABI`, so on Windows the
+// caller uses the Win64 ABI — see the note on `Server__setAppFlags`.
+//
+// `ssl` is the `SSL*` returned by `us_socket_get_native_handle`, already
+// null-checked by the caller; every accepted HTTPS socket is server-side.
+mod node_http {
+    use super::{Ssl, boringssl, ffi};
+    use bun_jsc::{CallFrame, JSGlobalObject, JSValue, host_fn};
+
+    #[inline]
+    fn ssl_of(ssl: *mut boringssl::SSL) -> Ssl {
+        if ssl.is_null() { None } else { Some(ssl) }
+    }
+
+    macro_rules! reader {
+        ($export:literal, $name:ident, $inner:path) => {
+            #[unsafe(export_name = $export)]
+            extern "C" fn $name(global: &JSGlobalObject, ssl: *mut boringssl::SSL) -> JSValue {
+                host_fn::to_js_host_fn_result(global, $inner(ssl_of(ssl), global))
+            }
+        };
+    }
+
+    reader!(
+        "Bun__NodeHTTPServerSocket__getCertificate",
+        get_certificate,
+        super::get_certificate
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getPeerX509Certificate",
+        get_peer_x509_certificate,
+        super::get_peer_x509_certificate
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getX509Certificate",
+        get_x509_certificate,
+        super::get_x509_certificate
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getCipher",
+        get_cipher,
+        super::get_cipher
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getTLSVersion",
+        get_tls_version,
+        super::get_tls_version
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getSession",
+        get_session,
+        super::get_session
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getTLSTicket",
+        get_tls_ticket,
+        super::get_tls_ticket
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getSharedSigalgs",
+        get_shared_sigalgs,
+        super::get_shared_sigalgs
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getTLSFinishedMessage",
+        get_tls_finished_message,
+        super::get_tls_finished_message
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getTLSPeerFinishedMessage",
+        get_tls_peer_finished_message,
+        super::get_tls_peer_finished_message
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getServername",
+        get_servername,
+        super::get_servername
+    );
+    reader!(
+        "Bun__NodeHTTPServerSocket__getALPNProtocol",
+        get_alpn_protocol,
+        super::get_alpn_protocol
+    );
+
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__getPeerCertificate")]
+    extern "C" fn get_peer_certificate(
+        global: &JSGlobalObject,
+        ssl: *mut boringssl::SSL,
+        frame: &CallFrame,
+    ) -> JSValue {
+        host_fn::to_js_host_fn_result(
+            global,
+            super::get_peer_certificate(ssl_of(ssl), true, global, frame),
+        )
+    }
+
+    // `getEphemeralKeyInfo()` is documented as client-only; the shared reader
+    // returns null for a server socket, which is what Node does.
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__getEphemeralKeyInfo")]
+    extern "C" fn get_ephemeral_key_info(
+        global: &JSGlobalObject,
+        ssl: *mut boringssl::SSL,
+    ) -> JSValue {
+        host_fn::to_js_host_fn_result(
+            global,
+            super::get_ephemeral_key_info(ssl_of(ssl), true, global),
+        )
+    }
+
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__isSessionReused")]
+    extern "C" fn is_session_reused(global: &JSGlobalObject, ssl: *mut boringssl::SSL) -> JSValue {
+        host_fn::to_js_host_fn_result(global, super::is_session_reused(ssl_of(ssl)))
+    }
+
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__disableRenegotiation")]
+    extern "C" fn disable_renegotiation(
+        global: &JSGlobalObject,
+        ssl: *mut boringssl::SSL,
+    ) -> JSValue {
+        host_fn::to_js_host_fn_result(global, super::disable_renegotiation(ssl_of(ssl)))
+    }
+
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__exportKeyingMaterial")]
+    extern "C" fn export_keying_material(
+        global: &JSGlobalObject,
+        ssl: *mut boringssl::SSL,
+        frame: &CallFrame,
+    ) -> JSValue {
+        host_fn::to_js_host_fn_result(
+            global,
+            super::export_keying_material(ssl_of(ssl), global, frame),
+        )
+    }
+
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__setMaxSendFragment")]
+    extern "C" fn set_max_send_fragment(
+        global: &JSGlobalObject,
+        ssl: *mut boringssl::SSL,
+        frame: &CallFrame,
+    ) -> JSValue {
+        host_fn::to_js_host_fn_result(
+            global,
+            super::set_max_send_fragment(ssl_of(ssl), global, frame),
+        )
+    }
+
+    /// `null` when the peer certificate verified (or none was requested and the
+    /// handshake is a PSK/resumed session), otherwise the `SystemError`-shaped
+    /// error carrying the `X509_V_*` code, the way `net.ts` surfaces it from the
+    /// handshake callback.
+    #[unsafe(export_name = "Bun__NodeHTTPServerSocket__getVerifyError")]
+    extern "C" fn get_verify_error(global: &JSGlobalObject, ssl: *mut boringssl::SSL) -> JSValue {
+        if ssl.is_null() {
+            return JSValue::NULL;
+        }
+        // SAFETY: the caller resolved `ssl` from a live, unclosed `us_socket_t*`.
+        let err = unsafe { ffi::us_ssl_socket_verify_error_from_ssl(ssl) };
+        if err.error_no == 0 {
+            return JSValue::NULL;
+        }
+        host_fn::to_js_host_fn_result(global, bun_jsc::system_error::verify_error_to_js(&err, global))
+    }
 }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -1546,6 +1546,9 @@ mod node_http {
         if err.error_no == 0 {
             return JSValue::NULL;
         }
-        host_fn::to_js_host_fn_result(global, bun_jsc::system_error::verify_error_to_js(&err, global))
+        host_fn::to_js_host_fn_result(
+            global,
+            bun_jsc::system_error::verify_error_to_js(&err, global),
+        )
     }
 }

--- a/test/js/node/http/node-https-server-tls-socket.test.ts
+++ b/test/js/node/http/node-https-server-tls-socket.test.ts
@@ -1,0 +1,167 @@
+// An accepted https.Server connection must hand the request handler a
+// tls.TLSSocket, not a bare Socket: `req.socket instanceof tls.TLSSocket`, the
+// getPeerCertificate/getCipher/getProtocol/... TLS methods, the
+// authorized/authorizationError/servername/encrypted fields, and the
+// 'secureConnection' event are how mTLS (requestCert + client certificate) auth
+// and TLS-aware routing are done on a Node https server.
+
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { AddressInfo } from "node:net";
+import { join } from "node:path";
+import tls from "node:tls";
+
+const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const agent1 = {
+  key: readFileSync(join(keys, "agent1-key.pem"), "utf8"), // CN=agent1, signed by ca1
+  cert: readFileSync(join(keys, "agent1-cert.pem"), "utf8"),
+};
+const ca1 = readFileSync(join(keys, "ca1-cert.pem"), "utf8");
+
+// The cert CN is "agent1", not the connection host, so skip the client-side
+// hostname check - it is irrelevant to the server-side surface under test.
+const skipServerIdentity = () => undefined;
+
+test("https server: req.socket is a TLSSocket exposing the mTLS surface", async () => {
+  const secureConnectionSockets: unknown[] = [];
+
+  await using server = https.createServer(
+    { key: agent1.key, cert: agent1.cert, ca: [ca1], requestCert: true, rejectUnauthorized: false },
+    (req, res) => {
+      const s = req.socket as tls.TLSSocket;
+      res.end(
+        JSON.stringify({
+          isTLSSocket: s instanceof tls.TLSSocket,
+          ctor: s.constructor.name,
+          encrypted: s.encrypted,
+          authorized: s.authorized,
+          authorizationError: s.authorizationError ?? null,
+          peerCN: s.getPeerCertificate()?.subject?.CN ?? null,
+          cipherName: s.getCipher()?.name ?? null,
+          protocol: s.getProtocol(),
+          isSessionReused: s.isSessionReused(),
+          hasMethods: ["getPeerCertificate", "getCipher", "getProtocol", "getSession", "exportKeyingMaterial"].every(
+            m => typeof s[m] === "function",
+          ),
+        }),
+      );
+    },
+  );
+  server.on("secureConnection", s => secureConnectionSockets.push(s.constructor.name));
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const body = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    const req = https.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "GET",
+        key: agent1.key, // present a client certificate for mTLS
+        cert: agent1.cert,
+        ca: [ca1],
+        checkServerIdentity: skipServerIdentity,
+      },
+      res => {
+        res.setEncoding("utf8");
+        res.on("data", d => (buf += d));
+        res.on("end", () => resolve(buf));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+
+  expect(JSON.parse(body)).toEqual({
+    isTLSSocket: true,
+    ctor: "TLSSocket",
+    encrypted: true,
+    authorized: true,
+    authorizationError: null,
+    peerCN: "agent1",
+    cipherName: expect.any(String),
+    protocol: expect.stringMatching(/^TLSv/),
+    isSessionReused: false,
+    hasMethods: true,
+  });
+  expect(secureConnectionSockets).toEqual(["TLSSocket"]);
+});
+
+test("https server: requestCert without a client certificate leaves authorized false", async () => {
+  await using server = https.createServer(
+    { key: agent1.key, cert: agent1.cert, ca: [ca1], requestCert: true, rejectUnauthorized: false },
+    (req, res) => {
+      const s = req.socket as tls.TLSSocket;
+      res.end(
+        JSON.stringify({
+          authorized: s.authorized,
+          // With requestCert and no client cert, the verify result is an
+          // issuer-lookup failure, like Node.
+          hasAuthorizationError: typeof s.authorizationError === "string",
+          peerEmpty: JSON.stringify(s.getPeerCertificate()) === "{}",
+        }),
+      );
+    },
+  );
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const body = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    const req = https.request(
+      { host: "127.0.0.1", port, method: "GET", ca: [ca1], checkServerIdentity: skipServerIdentity },
+      res => {
+        res.setEncoding("utf8");
+        res.on("data", d => (buf += d));
+        res.on("end", () => resolve(buf));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+
+  expect(JSON.parse(body)).toEqual({
+    authorized: false,
+    hasAuthorizationError: true,
+    peerEmpty: true,
+  });
+});
+
+test("http server: req.socket is a plain Socket, not a TLSSocket", async () => {
+  await using server = http.createServer((req, res) => {
+    res.end(
+      JSON.stringify({
+        isTLSSocket: req.socket instanceof tls.TLSSocket,
+        hasGetPeerCertificate: typeof (req.socket as any).getPeerCertificate,
+      }),
+    );
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const body = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    const req = http.request({ host: "127.0.0.1", port, method: "GET" }, res => {
+      res.setEncoding("utf8");
+      res.on("data", d => (buf += d));
+      res.on("end", () => resolve(buf));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  expect(JSON.parse(body)).toEqual({
+    isTLSSocket: false,
+    hasGetPeerCertificate: "undefined",
+  });
+});

--- a/test/js/node/http/node-https-server-tls-socket.test.ts
+++ b/test/js/node/http/node-https-server-tls-socket.test.ts
@@ -46,6 +46,17 @@ test("https server: req.socket is a TLSSocket exposing the mTLS surface", async 
           hasMethods: ["getPeerCertificate", "getCipher", "getProtocol", "getSession", "exportKeyingMaterial"].every(
             m => typeof s[m] === "function",
           ),
+          // `_handle` must be writable like net.Socket (tunnel/proxy middleware
+          // detaches via `socket._handle = x`); a getter-only accessor throws
+          // here in strict mode.
+          handleWritable: (() => {
+            try {
+              s._handle = s._handle;
+              return true;
+            } catch {
+              return false;
+            }
+          })(),
         }),
       );
     },
@@ -89,6 +100,7 @@ test("https server: req.socket is a TLSSocket exposing the mTLS surface", async 
     protocol: expect.stringMatching(/^TLSv/),
     isSessionReused: false,
     hasMethods: true,
+    handleWritable: true,
   });
   expect(secureConnectionSockets).toEqual(["TLSSocket"]);
 });


### PR DESCRIPTION
## What

An accepted `https.Server` connection handed the request handler a plain `Socket`, so on the server side:

- `req.socket instanceof tls.TLSSocket` was `false` (`constructor.name` was `"Socket"`)
- `getPeerCertificate`, `getCipher`, `getProtocol`, `getSession`, `exportKeyingMaterial`, `getCertificate`, `renegotiate`, ... did not exist (calling them threw `TypeError`)
- `authorized` / `authorizationError` were `undefined`, `servername` was `null`
- the server never emitted `'secureConnection'`

Only `encrypted === true` was present. This made the documented mTLS flow impossible: `requestCert: true` + `req.socket.authorized` + `req.socket.getPeerCertificate()` (what express `req.client` and every mTLS middleware use), plus per-client authorization, audit logging, and TLS-aware routing.

The handshake-level verification itself was already enforced (a bad/absent client cert is refused when `rejectUnauthorized: true`); the accepted identity just wasn't readable from JS.

## Repro

```js
import https from "node:https";
import tls from "node:tls";
// key/cert/ca omitted
const srv = https.createServer(
  { key, cert, ca: [cert], requestCert: true, rejectUnauthorized: false },
  (req, res) => {
    const s = req.socket;
    res.end(JSON.stringify({
      isTLSSocket: s instanceof tls.TLSSocket,
      authorized: s.authorized,
      peerCertCN: s.getPeerCertificate().subject?.CN ?? null,
    }));
  },
);
srv.on("secureConnection", () => console.log("secureConnection"));
```

Before: `{"isTLSSocket":false,"peerCertCN":"THROWS:TypeError"}`, no `secureConnection`, `authorized` absent.
After (matches Node): `{"isTLSSocket":true,"authorized":true,"peerCertCN":"127.0.0.1"}`, `secureConnection` fires.

## How

- The native `JSNodeHTTPServerSocket` (the uWS connection wrapper) now exposes the same TLS readers `tls.TLSSocket` uses.
- The BoringSSL-backed helpers in `tls_socket_functions.rs` were refactored to take an `SSL*` instead of a `NewSocket`, so the `Bun.connect` socket and the `https` server socket share one implementation. The server socket resolves its live `SSL*` from the uWS handle via `us_socket_get_native_handle`.
- `node:_http_server` wraps an `https` connection in a `TLSSocket`-shaped subclass of `NodeHTTPServerSocket` whose `_handle` routes the shared `node:tls` method bodies (extracted into `internal/tls`) at these natives, reads the negotiated identity once in the constructor, and fires `'secureConnection'`.
- `tls.TLSSocket[Symbol.hasInstance]` recognizes the facade (it cannot extend `TLSSocket`; its base is the uWS-backed `Duplex`).

## Known limitation

Server-side ALPN selection is still unimplemented in uSockets, so `alpnProtocol` reads `false` (exactly what Node reports when nothing is negotiated). That is a separate piece of work.

## Verification

New test `test/js/node/http/node-https-server-tls-socket.test.ts` covers the mTLS surface, the requestCert-without-client-cert case, and the plain-http negative (socket stays a non-TLS `Socket`). Fails on `main`, passes with this change. The existing `node:tls` connect/server/cert/renegotiation suites and the server-side `getPeerCertificate()` leak test still pass (the refactored readers are shared with them).


Fixes #16834
Fixes #16254
Fixes #14097
