### PR TITLE
node:https: honor ALPNProtocols and expose socket.alpnProtocol

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2109,6 +2109,21 @@ void *us_internal_ssl_get_native_handle(struct us_socket_t *s) {
   return s->ssl ? s_ssl(s) : NULL;
 }
 
+const char *us_socket_alpn_selected(struct us_socket_t *s, unsigned int *out_len) {
+  *out_len = 0;
+  if (!s->ssl) {
+    return NULL;
+  }
+  const unsigned char *proto = NULL;
+  unsigned int proto_len = 0;
+  SSL_get0_alpn_selected(s_ssl(s), &proto, &proto_len);
+  if (!proto || proto_len == 0) {
+    return NULL;
+  }
+  *out_len = proto_len;
+  return (const char *)proto;
+}
+
 int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   if (us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s) || length == 0) return 0;
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -410,6 +410,10 @@ unsigned char us_connecting_socket_kind(struct us_connecting_socket_t *c) nonnul
 
 struct us_bun_verify_error_t us_socket_verify_error(struct us_socket_t *s);
 
+/* The ALPN protocol negotiated on this socket's handshake, or NULL when the
+ * peer offered none / the socket is not TLS. The bytes belong to the SSL. */
+const char *us_socket_alpn_selected(struct us_socket_t *s, unsigned int *out_len);
+
 /* ── SSL_CTX construction ─────────────────────────────────────────────────
  * The expensive bit (cert/key/CA parse, cipher list, DH params) is decoupled
  * from sockets entirely. Build once per SecureContext / config, share across

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -99,10 +99,4 @@ function convertALPNProtocols(protocols, out) {
   }
 }
 
-export {
-  VALID_TLS_ERROR_MESSAGE_TYPES,
-  convertALPNProtocols,
-  isValidTLSArray,
-  isValidTLSItem,
-  throwOnInvalidTLSArray,
-};
+export { VALID_TLS_ERROR_MESSAGE_TYPES, convertALPNProtocols, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,6 @@
-const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { isArrayBufferView, isTypedArray, isArrayBuffer } = require("node:util/types");
+
+const ArrayPrototypeReduce = Array.prototype.reduce;
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -50,4 +52,57 @@ function isValidTLSArray(obj: unknown) {
 
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, DataView, or BunFile";
 
-export { VALID_TLS_ERROR_MESSAGE_TYPES, isValidTLSArray, isValidTLSItem, throwOnInvalidTLSArray };
+// Convert protocols array into valid OpenSSL protocols list
+// ("\x06spdy/2\x08http/1.1\x08http/1.0")
+function convertProtocols(protocols: string[]): Buffer {
+  const lens = new Array(protocols.length);
+  const buff = Buffer.allocUnsafe(
+    ArrayPrototypeReduce.$call(
+      protocols,
+      (p, c, i) => {
+        const len = Buffer.byteLength(c);
+        if (len > 255) {
+          const err = new RangeError(
+            `The byte length of the protocol at index ${i} exceeds the maximum length. It must be <= 255. Received ${len}`,
+          );
+          (err as any).code = "ERR_OUT_OF_RANGE";
+          throw err;
+        }
+        lens[i] = len;
+        return p + 1 + len;
+      },
+      0,
+    ),
+  );
+
+  let offset = 0;
+  for (let i = 0, c = protocols.length; i < c; i++) {
+    buff[offset++] = lens[i];
+    buff.write(protocols[i], offset);
+    offset += lens[i];
+  }
+
+  return buff;
+}
+
+// Matches Node's convertALPNProtocols:
+// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/tls.js#L268
+function convertALPNProtocols(protocols, out) {
+  // If protocols is Array - translate it into buffer
+  if ($isArray(protocols)) {
+    out.ALPNProtocols = convertProtocols(protocols);
+  } else if (isArrayBufferView(protocols)) {
+    // Copy new buffer not to be modified by user.
+    out.ALPNProtocols = Buffer.from(
+      protocols.buffer.slice(protocols.byteOffset, protocols.byteOffset + protocols.byteLength),
+    );
+  }
+}
+
+export {
+  VALID_TLS_ERROR_MESSAGE_TYPES,
+  convertALPNProtocols,
+  isValidTLSArray,
+  isValidTLSItem,
+  throwOnInvalidTLSArray,
+};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -248,8 +248,9 @@ function normalizeServerTls(tls) {
   // native TLS options want the length-prefixed wire format, so normalize it the
   // way tls.connect / tls.createServer do. Absent leaves Bun.serve to apply its
   // http/1.1 default, which is what node's https.Server offers.
-  if (tls.ALPNProtocols != null) {
-    convertALPNProtocols(tls.ALPNProtocols, tls);
+  const { ALPNProtocols } = tls;
+  if (ALPNProtocols != null) {
+    convertALPNProtocols(ALPNProtocols, tls);
   }
   return tls;
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -19,7 +19,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf } = require("intern
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { convertALPNProtocols, throwOnInvalidTLSArray } = require("internal/tls");
 const {
   kInternalSocketData,
   serverSymbol,
@@ -244,6 +244,13 @@ function normalizeServerTls(tls) {
   const requestCert = !!tls.requestCert;
   tls.requestCert = requestCert;
   tls.rejectUnauthorized = requestCert ? tls.rejectUnauthorized !== false : false;
+  // node:https accepts ALPNProtocols as a string[] (or a Buffer), but Bun.serve's
+  // native TLS options want the length-prefixed wire format, so normalize it the
+  // way tls.connect / tls.createServer do. Absent leaves Bun.serve to apply its
+  // http/1.1 default, which is what node's https.Server offers.
+  if (tls.ALPNProtocols != null) {
+    convertALPNProtocols(tls.ALPNProtocols, tls);
+  }
   return tls;
 }
 
@@ -312,6 +319,7 @@ function Server(options, callback): void {
         secureOptions,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
+        ALPNProtocols: options.ALPNProtocols,
       });
     } else {
       this[tlsSymbol] = null;
@@ -1041,6 +1049,9 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   server: Server;
   _httpMessage;
   _secureEstablished = false;
+  // Only populated for TLS connections, matching tls.TLSSocket. `false` when
+  // the client offered no ALPN extension.
+  alpnProtocol: string | false | undefined = undefined;
   #pendingCallback = null;
   constructor(server: Server, handle, encrypted) {
     super();
@@ -1051,6 +1062,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     handle.duplex = this;
 
     this.encrypted = encrypted;
+    // The handshake is complete by the time a request reaches the handler, and
+    // the handle is released on close, so read the negotiated protocol once.
+    if (encrypted) {
+      this.alpnProtocol = handle?.alpnProtocol ?? false;
+    }
     this.on("timeout", onNodeHTTPServerSocketTimeout);
     // Like Node.js's socketOnError: connection errors are routed to the
     // server's 'clientError' event instead of crashing as unhandled 'error'

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,7 +5,7 @@ const Duplex = require("internal/streams/duplex");
 const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
-const { throwOnInvalidTLSArray } = require("internal/tls");
+const { convertALPNProtocols, throwOnInvalidTLSArray } = require("internal/tls");
 const {
   validateString,
   validateNumber,
@@ -435,7 +435,6 @@ const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypeForEach = Array.prototype.forEach;
 const ArrayPrototypePush = Array.prototype.push;
 const ArrayPrototypeSome = Array.prototype.some;
-const ArrayPrototypeReduce = Array.prototype.reduce;
 
 const ObjectFreeze = Object.freeze;
 
@@ -1559,53 +1558,6 @@ function connect(...args) {
 
 function getCiphers() {
   return getDefaultCiphers().split(":");
-}
-
-// Convert protocols array into valid OpenSSL protocols list
-// ("\x06spdy/2\x08http/1.1\x08http/1.0")
-function convertProtocols(protocols) {
-  const lens = new Array(protocols.length);
-  const buff = Buffer.allocUnsafe(
-    ArrayPrototypeReduce.$call(
-      protocols,
-      (p, c, i) => {
-        const len = Buffer.byteLength(c);
-        if (len > 255) {
-          const err = new RangeError(
-            `The byte length of the protocol at index ${i} exceeds the maximum length. It must be <= 255. Received ${len}`,
-          );
-          (err as any).code = "ERR_OUT_OF_RANGE";
-          throw err;
-        }
-        lens[i] = len;
-        return p + 1 + len;
-      },
-      0,
-    ),
-  );
-
-  let offset = 0;
-  for (let i = 0, c = protocols.length; i < c; i++) {
-    buff[offset++] = lens[i];
-    buff.write(protocols[i], offset);
-    offset += lens[i];
-  }
-
-  return buff;
-}
-
-// Matches Node's convertALPNProtocols:
-// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/tls.js#L268
-function convertALPNProtocols(protocols, out) {
-  // If protocols is Array - translate it into buffer
-  if (Array.isArray(protocols)) {
-    out.ALPNProtocols = convertProtocols(protocols);
-  } else if (isArrayBufferView(protocols)) {
-    // Copy new buffer not to be modified by user.
-    out.ALPNProtocols = Buffer.from(
-      protocols.buffer.slice(protocols.byteOffset, protocols.byteOffset + protocols.byteLength),
-    );
-  }
 }
 
 let bundledRootCertificates: string[] | undefined;

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -10,6 +10,7 @@
 extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
 extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
+extern "C" const char* us_socket_alpn_selected(us_socket_t* socket, unsigned int* out_len);
 
 namespace Bun {
 
@@ -35,6 +36,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterLocalAddress);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterDuplex);
 JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterDuplex);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterIsSecureEstablished);
+JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterAlpnProtocol);
 
 JSC_DEFINE_CUSTOM_SETTER(noOpSetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -59,6 +61,7 @@ static const JSC::HashTableValue JSNodeHTTPServerSocketPrototypeTableValues[] = 
     { "end"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketEnd, 0 } },
     { "upgradeToTunnel"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketUpgradeToTunnel, 0 } },
     { "secureEstablished"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterIsSecureEstablished, noOpSetter } },
+    { "alpnProtocol"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterAlpnProtocol, noOpSetter } },
 };
 
 void JSNodeHTTPServerSocketPrototype::finishCreation(JSC::VM& vm)
@@ -133,6 +136,27 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterIsSecureEstablished, (JSC::
         return JSValue::encode(JSC::jsUndefined());
     }
     return JSValue::encode(JSC::jsBoolean(thisObject->isAuthorized()));
+}
+
+// Matches node:tls's TLSSocket.alpnProtocol: the negotiated protocol, or
+// `false` when the peer offered no ALPN extension.
+JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterAlpnProtocol, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = globalObject->vm();
+    auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(JSC::jsUndefined());
+    }
+    if (!thisObject->is_ssl || !thisObject->socket) {
+        return JSValue::encode(JSC::jsBoolean(false));
+    }
+
+    unsigned int length = 0;
+    const char* protocol = us_socket_alpn_selected(thisObject->socket, &length);
+    if (!protocol || length == 0) {
+        return JSValue::encode(JSC::jsBoolean(false));
+    }
+    return JSValue::encode(jsString(vm, WTF::String::fromUTF8(std::span<const char>(protocol, length))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterDuplex, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))

--- a/test/js/node/http/node-https-alpn.test.ts
+++ b/test/js/node/http/node-https-alpn.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { tls as COMMON_CERT } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import https from "node:https";
+import tlsModule from "node:tls";
+
+async function listen(server: { listen: Function; address: Function }): Promise<number> {
+  server.listen(0, "127.0.0.1");
+  await once(server as any, "listening");
+  return server.address().port;
+}
+
+type Probe = { alpnProtocol: string | false | null; body: string } | { error: string };
+
+/** Opens one TLS connection offering `ALPNProtocols` and reads a single response. */
+function probe(port: number, ALPNProtocols?: string[]): Promise<Probe> {
+  return new Promise(resolve => {
+    let body = "";
+    const socket = tlsModule.connect(
+      { port, host: "127.0.0.1", servername: "localhost", ca: [COMMON_CERT.cert], ALPNProtocols },
+      () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    );
+    socket.on("data", chunk => (body += chunk));
+    socket.on("error", error => resolve({ error: (error as NodeJS.ErrnoException).code! }));
+    socket.on("close", () => resolve({ alpnProtocol: socket.alpnProtocol, body: body.split("\r\n\r\n")[1] ?? "" }));
+  });
+}
+
+/** Echoes the negotiated protocol back so the server side is asserted too. */
+function alpnServer(options: Record<string, unknown> = {}) {
+  const server = https.createServer({ ...COMMON_CERT, ...options }, (req, res) =>
+    res.end(String((req.socket as any).alpnProtocol)),
+  );
+  // A rejected handshake never produces a request; keep the failure quiet.
+  server.on("tlsClientError", () => {});
+  return server;
+}
+
+const NO_OVERLAP = { error: "ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL" };
+
+test("https server defaults its ALPN offer to http/1.1", async () => {
+  const server = alpnServer();
+  try {
+    const port = await listen(server);
+    expect(await probe(port, ["http/1.1"])).toEqual({ alpnProtocol: "http/1.1", body: "http/1.1" });
+  } finally {
+    server.close();
+  }
+});
+
+test("https server serves a client that offers no ALPN at all", async () => {
+  const server = alpnServer();
+  try {
+    const port = await listen(server);
+    expect(await probe(port)).toEqual({ alpnProtocol: false, body: "false" });
+  } finally {
+    server.close();
+  }
+});
+
+test("https server sends no_application_protocol when nothing overlaps", async () => {
+  const server = alpnServer();
+  try {
+    const port = await listen(server);
+    // RFC 7301 §3.2 requires a fatal alert rather than an unnegotiated handshake.
+    expect(await probe(port, ["bogus/9"])).toEqual(NO_OVERLAP);
+  } finally {
+    server.close();
+  }
+});
+
+test("https server honors an ALPNProtocols array, in server preference order", async () => {
+  const server = alpnServer({ ALPNProtocols: ["bun/2", "bun/1"] });
+  try {
+    const port = await listen(server);
+    expect(await probe(port, ["bun/1", "bun/2"])).toEqual({ alpnProtocol: "bun/2", body: "bun/2" });
+    expect(await probe(port, ["bun/1"])).toEqual({ alpnProtocol: "bun/1", body: "bun/1" });
+    expect(await probe(port, ["bun/3"])).toEqual(NO_OVERLAP);
+  } finally {
+    server.close();
+  }
+});
+
+test("https server honors an ALPNProtocols wire-format buffer", async () => {
+  const server = alpnServer({ ALPNProtocols: Buffer.from("\x05bun/1", "latin1") });
+  try {
+    const port = await listen(server);
+    expect(await probe(port, ["bun/1"])).toEqual({ alpnProtocol: "bun/1", body: "bun/1" });
+  } finally {
+    server.close();
+  }
+});
+
+test("https server honors ALPNProtocols passed to listen()", async () => {
+  const server = alpnServer();
+  try {
+    server.listen({ port: 0, host: "127.0.0.1", tls: { ...COMMON_CERT, ALPNProtocols: ["bun/7"] } });
+    await once(server, "listening");
+    const port = (server.address() as { port: number }).port;
+    expect(await probe(port, ["bun/7"])).toEqual({ alpnProtocol: "bun/7", body: "bun/7" });
+    expect(await probe(port, ["http/1.1"])).toEqual(NO_OVERLAP);
+  } finally {
+    server.close();
+  }
+});
+
+test("plain http server has no alpnProtocol on its sockets", async () => {
+  const server = http.createServer((req, res) => res.end(String((req.socket as any).alpnProtocol)));
+  try {
+    const port = await listen(server);
+    const response = await fetch(`http://127.0.0.1:${port}/`);
+    expect(await response.text()).toBe("undefined");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Stacked on #33487 (the `Bun.serve` ALPN support). That PR makes `Bun.serve` negotiate ALPN over TLS and, since `node:https` is `Bun.serve` underneath, already gives a default `node:https` server the `http/1.1` offer node applies. It explicitly left the `node:https`-specific forwarding as a follow-up; this is that follow-up.

Two gaps remained on the `node:https` surface:

- `https.createServer({ ALPNProtocols })` never reached the server. `_http_server.ts` builds the `Bun.serve` `tls` config from a fixed allowlist (`normalizeServerTls({...})`) that omitted `ALPNProtocols`, so an explicit list was dropped before it could be honored.
- `req.socket.alpnProtocol` was never populated, unlike node's `tls.TLSSocket`.

## Repro

```js
import https from "node:https";
import tls from "node:tls";

const server = https.createServer({ key, cert, ALPNProtocols: ["http/1.1"] },
  (req, res) => res.end("served " + req.socket.alpnProtocol));

server.listen(0, "127.0.0.1", () => {
  const { port } = server.address();
  const probe = protos => new Promise(done => {
    const c = tls.connect({ port, host: "127.0.0.1", servername: "localhost", ca: [cert], ALPNProtocols: protos },
      () => c.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n"));
    let body = "";
    c.on("data", d => (body += d));
    c.on("error", e => done(`error ${e.code}`));
    c.on("close", () => done(`alpnProtocol=${JSON.stringify(c.alpnProtocol)} body=${JSON.stringify(body.split("\r\n\r\n")[1])}`));
  });
  console.log(await probe(["http/1.1"]));  // exact match
  console.log(await probe(["bogus/9"]));   // zero overlap
});

// node v26.3.0:
//   alpnProtocol="http/1.1" body="served http/1.1"
//   error ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL
// bun before:
//   alpnProtocol=false body="served null"   <- ALPN never negotiated
//   alpnProtocol=false body="served null"   <- no-overlap client served anyway
```

## Fix

- `normalizeServerTls` forwards `ALPNProtocols` from the https server options (both the `Server` constructor and the `listen({ tls })` path) into `Bun.serve`, converting node's `string[]` form to the length-prefixed wire format that the native TLS options expect. When the option is absent, `Bun.serve` applies its `http/1.1` default (from the stacked PR), which is what node's `https.Server` offers.
- `convertALPNProtocols`/`convertProtocols` move into `internal/tls` so `node:tls` and `_http_server` share one implementation instead of duplicating it.
- `socket.alpnProtocol` is exposed on `node:https` request sockets: the negotiated protocol, or `false` when the client offered no ALPN extension, matching `tls.TLSSocket`. It is backed by a new `us_socket_alpn_selected` (a thin `SSL_get0_alpn_selected` read).

## Verification

New `test/js/node/http/node-https-alpn.test.ts` covers the default `http/1.1` offer, an explicit `ALPNProtocols` array (in server preference order) and wire-format buffer, a client offering no ALPN, no-overlap rejection with the fatal `no_application_protocol` alert (RFC 7301 §3.2), `ALPNProtocols` passed through `listen()`, and the absence of `alpnProtocol` on a plain `http` server. Every negotiation case fails with `src/`/`packages/` reverted to the base and passes with the fix.

Also ran `node-tls-server`, `bun-serve-ssl`, and `fetch-http2-client`: no new failures.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-https-alpn.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0dfb00937)

test/js/node/http/node-https-alpn.test.ts:
41 | 
42 | test("https server defaults its ALPN offer to http/1.1", async () => {
43 |   const server = alpnServer();
44 |   try {
45 |     const port = await listen(server);
46 |     expect(await probe(port, ["http/1.1"])).toEqual({ alpnProtocol: "http/1.1", body: "http/1.1" });
                                                 ^
error: expect(received).toEqual(expected)

  {
    "alpnProtocol": "http/1.1",
-   "body": "http/1.1",
+   "body": "undefined",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/http/node-https-alpn.test.ts:46:45)
(fail) https server defaults its ALPN offer to http/1.1 [785.93ms]
51 | 
52 | test("https serve
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http/node-https-alpn.test.ts:
41 | 
42 | test("https server defaults its ALPN offer to http/1.1", async () => {
43 |   const server = alpnServer();
44 |   try {
45 |     const port = await listen(server);
46 |     expect(await probe(port, ["http/1.1"])).toEqual({ alpnProtocol: "http/1.1", body: "http/1.1" });
                                                 ^
error: expect(received).toEqual(expected)

  {
-   "alpnProtocol": "http/1.1",
-   "body": "http/1.1",
+   "alpnProtocol": false,
+   "body": "undefined",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/http/node-https-alpn.test.ts:46:45)
(fail) https server defaults its ALPN offer to http/1.1 [15.53ms]
51 | 
52 | test("https server serves a client that offers no ALPN at all", async () => {
53 |   const server = alpnServer();
54 |   try {
55 |     const port = await listen(server);
56 |     expect(await probe(port)).toEqual({ alpnProtocol: false, body: "false" });
                                   ^
error: expect(received).toEqual(expected)

  {
    "alpnProtocol": false,
-   "body": "false",
+   "body": "undefined",
  }
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-https-alpn.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0dfb00937)

test/js/node/http/node-https-alpn.test.ts:
(pass) https server defaults its ALPN offer to http/1.1 [763.11ms]
(pass) https server serves a client that offers no ALPN at all [131.43ms]
(pass) https server sends no_application_protocol when nothing overlaps [72.04ms]
(pass) https server honors an ALPNProtocols array, in server preference order [341.74ms]
(pass) https server honors an ALPNProtocols wire-format buffer [202.56ms]
(pass) https server honors ALPNProtocols passed to listen() [214.64ms]
(pass) plain http server has no alpnProtocol on its sockets [67.92ms]

 7 pass
 0 fail
 10 expect() calls
Ran 7 tests across 1 file. [4.75s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0dfb009373
  features     (none)

22 deps, 105 codegen, 1168 objects in 895ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1231] gen ErrorCode+*.h
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1231] gen bindgenv2
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch picohttpparser
[picohttpparser] up to date
[8/1230] fetch 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c         |  15 +++
 packages/bun-usockets/src/libusockets.h            |   4 +
 src/js/internal/tls.ts                             |  53 +++++++++-
 src/js/node/_http_server.ts                        |  19 +++-
 src/js/node/tls.ts                                 |  50 +--------
 .../node/JSNodeHTTPServerSocketPrototype.cpp       |  24 +++++
 test/js/node/http/node-https-alpn.test.ts          | 117 +++++++++++++++++++++
 7 files changed, 230 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c                    5      7      0
packages/bun-usockets/src/libusockets.h                       2      3      0
src/js/internal/tls.ts                                        2      5      0
src/js/node/_http_server.ts                                   9     13      0
src/js/node/tls.ts                                            4      6      0
…c/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp      3     10      0
test/js/node/http/node-https-alpn.test.ts                     0      2      0
```

</details>

<!-- robobun:evidence:end -->