### PR TITLE
Bun.serve: parse If-None-Match honoring commas inside quoted entity-tags

### DIFF
--- a/src/http_types/ETag.rs
+++ b/src/http_types/ETag.rs
@@ -101,7 +101,10 @@ impl<'a> Iterator for EntityTagSplit<'a> {
 }
 
 fn split_entity_tags(list: &[u8]) -> EntityTagSplit<'_> {
-    EntityTagSplit { rest: list, done: false }
+    EntityTagSplit {
+        rest: list,
+        done: false,
+    }
 }
 
 pub fn if_none_match(

--- a/src/http_types/ETag.rs
+++ b/src/http_types/ETag.rs
@@ -67,6 +67,43 @@ fn xxhash64(seed: u64, bytes: &[u8]) -> u64 {
     bun_core::hash::xxhash64(seed, bytes)
 }
 
+/// Split an `If-None-Match` list into entity-tag fragments, honoring RFC 9110
+/// DQUOTE boundaries: a comma inside an opaque-tag (e.g. `"ab,cd"`) is part of
+/// the tag, not a list separator.
+struct EntityTagSplit<'a> {
+    rest: &'a [u8],
+    done: bool,
+}
+
+impl<'a> Iterator for EntityTagSplit<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<&'a [u8]> {
+        if self.done {
+            return None;
+        }
+        let bytes = self.rest;
+        let mut in_quotes = false;
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'"' => in_quotes = !in_quotes,
+                b',' if !in_quotes => {
+                    let (head, tail) = bytes.split_at(i);
+                    self.rest = &tail[1..];
+                    return Some(head);
+                }
+                _ => {}
+            }
+        }
+        self.done = true;
+        Some(bytes)
+    }
+}
+
+fn split_entity_tags(list: &[u8]) -> EntityTagSplit<'_> {
+    EntityTagSplit { rest: list, done: false }
+}
+
 pub fn if_none_match(
     // "ETag" header
     etag: &[u8],
@@ -81,7 +118,7 @@ pub fn if_none_match(
     }
 
     // Parse comma-separated list of entity tags
-    for tag_str in if_none_match.split(|&b| b == b',') {
+    for tag_str in split_entity_tags(if_none_match) {
         let parsed = parse(tag_str);
         if weak_match(
             our_parsed.tag,

--- a/test/js/bun/http/serve-if-none-match.test.ts
+++ b/test/js/bun/http/serve-if-none-match.test.ts
@@ -22,6 +22,12 @@ describe("If-None-Match Support", () => {
         "ETag": 'W/"weak-etag"',
       },
     }),
+    "/comma-etag": new Response("Comma content", {
+      headers: {
+        "Content-Type": "text/plain",
+        "ETag": '"ab,cd"',
+      },
+    }),
   };
 
   beforeAll(async () => {
@@ -161,6 +167,46 @@ describe("If-None-Match Support", () => {
 
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(testContent);
+    });
+
+    it("should not 304 when a list member merely contains the ETag between commas", async () => {
+      // RFC 9110 §8.8.3: a comma is a legal byte inside a quoted opaque-tag, so
+      // `"a,xx,b"` is ONE tag, not a list whose members include the server tag.
+      const etag = (await fetch(`${server.url}basic`)).headers.get("ETag")!;
+      const inner = etag.slice(1, -1); // strip surrounding quotes
+
+      const res = await fetch(`${server.url}basic`, {
+        headers: {
+          "If-None-Match": `"a,${inner},b"`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(testContent);
+    });
+
+    it("should 304 when a comma-containing ETag is echoed back exactly", async () => {
+      const res = await fetch(`${server.url}comma-etag`, {
+        headers: {
+          "If-None-Match": '"ab,cd"',
+        },
+      });
+
+      expect(res.status).toBe(304);
+      expect(res.headers.get("ETag")).toBe('"ab,cd"');
+      expect(await res.text()).toBe("");
+    });
+
+    it("should 304 when a comma-containing ETag is a member of a list", async () => {
+      const res = await fetch(`${server.url}comma-etag`, {
+        headers: {
+          "If-None-Match": '"zzz", "ab,cd"',
+        },
+      });
+
+      expect(res.status).toBe(304);
+      expect(res.headers.get("ETag")).toBe('"ab,cd"');
+      expect(await res.text()).toBe("");
     });
 
     it("should handle whitespace in If-None-Match", async () => {


### PR DESCRIPTION
## What

`Bun.serve` static routes split the `If-None-Match` header on every raw comma, including commas that are a legal part of a quoted opaque-tag. RFC 9110 §8.8.3 allows a comma byte (`%x2C`) inside a quoted entity-tag, and §13.1.2 makes `If-None-Match` a comma-separated list of whole entity-tags, so the split has to honor `DQUOTE` boundaries.

Two observable bugs:

- A single tag whose opaque value merely contains `,xx,` (e.g. `"a,xx,b"`) was split into the fragments `"a`, `xx`, `b"`, and the bare `xx` fragment string-equaled the server's opaque tag `"xx"`, producing a false `304 Not Modified` for a validator the origin never issued.
- A resource whose own ETag contains a comma (e.g. `"ab,cd"`) could never revalidate: its exact echo was split mid-tag and never matched, so every request refetched the full body.

## Repro

```js
const srv = Bun.serve({
  port: 0,
  routes: {
    "/x": new Response("body-x", { headers: { etag: '"xx"' } }),
    "/c": new Response("body-c", { headers: { etag: '"ab,cd"' } }),
  },
  fetch: () => new Response("nf", { status: 404 }),
});
const st = async (p, inm) =>
  (await fetch(srv.url.href.slice(0, -1) + p, { headers: { "If-None-Match": inm } })).status;

await st("/x", '"a,xx,b"');     // was 304, should be 200
await st("/c", '"ab,cd"');      // was 200, should be 304
await st("/c", '"zzz", "ab,cd"'); // was 200, should be 304
```

## Cause

`if_none_match` in `src/http_types/ETag.rs` split the list with `split(|&b| b == b',')`, and `parse()` only strips quotes when both ends are quotes, so an embedded comma broke the tag apart.

## Fix

Replace the naive split with a quoted-string-aware iterator that only treats a comma as a list separator when it is outside `DQUOTE`s. Whole entity-tags are then compared as before.

## Verification

Added tests in `test/js/bun/http/serve-if-none-match.test.ts` covering the false-304 case and the comma-containing ETag (exact echo and list member). They fail on the current build and pass with the fix.