### PR TITLE
shell: concatenate backtick command substitution with surrounding word

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2875,6 +2875,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 self.tokens.push(Token::CmdSubstEnd);
                                 return Ok(());
                             } else {
+                                self.break_word(false)?;
                                 self.eat_subshell(SubShellKind::Backtick)?;
                             }
                             fell_through = true;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -687,9 +687,7 @@ bar\n`,
     TestBuilder.command`echo pre${BACKTICK}echo m${BACKTICK}post`
       .stdout("prempost\n")
       .runAsTest("text before and after backtick");
-    TestBuilder.command`echo pre${BACKTICK}echo m${BACKTICK}`
-      .stdout("prem\n")
-      .runAsTest("text before backtick");
+    TestBuilder.command`echo pre${BACKTICK}echo m${BACKTICK}`.stdout("prem\n").runAsTest("text before backtick");
     TestBuilder.command`echo "a${BACKTICK}echo m${BACKTICK}b"`
       .stdout("amb\n")
       .runAsTest("backtick inside double quotes");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -678,6 +678,35 @@ bar\n`,
       .runAsTest("Double Quote Dollar Paren Single Quote");
   });
 
+  // A backtick command substitution must concatenate with surrounding text in
+  // the same word, exactly like $(...). Regression test for backtick subst
+  // preceded by text erasing both the text and its own output.
+  describe("backtick word concatenation", () => {
+    const BACKTICK = { raw: "`" };
+
+    TestBuilder.command`echo pre${BACKTICK}echo m${BACKTICK}post`
+      .stdout("prempost\n")
+      .runAsTest("text before and after backtick");
+    TestBuilder.command`echo pre${BACKTICK}echo m${BACKTICK}`
+      .stdout("prem\n")
+      .runAsTest("text before backtick");
+    TestBuilder.command`echo "a${BACKTICK}echo m${BACKTICK}b"`
+      .stdout("amb\n")
+      .runAsTest("backtick inside double quotes");
+    TestBuilder.command`echo a${BACKTICK}echo b${BACKTICK}c${BACKTICK}echo d${BACKTICK}e`
+      .stdout("abcde\n")
+      .runAsTest("multiple backticks in one word");
+    TestBuilder.command`V=${BACKTICK}echo new${BACKTICK}; echo =$V=`
+      .stdout("=new=\n")
+      .runAsTest("assignment value from backtick subst");
+    TestBuilder.command`V=x${BACKTICK}echo new${BACKTICK}; echo =$V=`
+      .stdout("=xnew=\n")
+      .runAsTest("assignment value from text plus backtick subst");
+    TestBuilder.command`echo ${BACKTICK}echo m${BACKTICK}post`
+      .stdout("mpost\n")
+      .runAsTest("word-initial backtick still works");
+  });
+
   describe("escaped_newline", () => {
     const printArgs = /* ts */ `console.log(JSON.stringify(process.argv))`;
 


### PR DESCRIPTION
## What

In Bun Shell, a backtick command substitution that is preceded by other text in the same word erased both the preceding text and the substitution's own output. An assignment whose value contained a backtick substitution was a silent no-op (the variable kept its old value).

```js
import { $ } from "bun";
$.nothrow();
const run = async s => (await $`${{ raw: s }}`.quiet()).stdout.toString();

await run("echo pre`echo m`post"); // "post\n"   (bash: "prempost\n")
await run("echo pre`echo m`");     // "\n"        (bash: "prem\n")
await run('echo "a`echo m`b"');    // "b\n"       (bash: "amb\n")
await run("V=`echo new`; echo [$V]");  // "[]\n"  (bash: "[new]\n")
```

Every `$(...)` equivalent was already correct, so only the "text then backtick inside one word" case (quoted or not) lost data. The failure was fully silent: exit 0, no stderr.

## Cause

In the shell lexer, the `$(` opening path calls `break_word(false)` before `eat_subshell`, which flushes the text accumulated so far in the current word as a `Text` token so it concatenates with the command substitution. The backtick opening path called `eat_subshell(SubShellKind::Backtick)` directly without that flush, so the pending word text was never emitted and the accumulated atoms were dropped.

## Fix

Flush the pending word with `break_word(false)` before entering a backtick subshell, mirroring the existing `$(` path. The closing backtick already flushes the inner word like the closing `)` does, so backtick substitution now behaves as a word *part* in both the word-concatenation and assignment-value paths.

## Verification

Added regression tests in `test/js/bun/shell/bunshell.test.ts` (`backtick word concatenation`) covering text before/after, double-quoted, multiple backticks in one word, and assignment RHS. They fail on the current release binary and pass with the fix. Full `bunshell.test.ts`, `lex.test.ts`, and `parse.test.ts` suites pass.