### PR TITLE
shell: export NAME without a value no longer clobbers the variable

### DIFF
--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -29,20 +29,41 @@ impl Export {
             if s.is_empty() {
                 continue;
             }
-            let (name, value) = match s.iter().position(|&b| b == b'=') {
-                Some(eq) => (&s[..eq], &s[eq + 1..]),
-                None => (s, &b""[..]),
-            };
-            // The argv backing is freed when the Cmd retires,
-            // so the key/value MUST be duplicated into ref-counted storage —
-            // `init_slice` here would leave dangling EnvStr in `export_env`.
-            let label = EnvStr::dupe_ref_counted(name);
-            let val = EnvStr::dupe_ref_counted(value);
             let shell = interp.as_cmd(cmd).base.shell;
-            // SAFETY: shell env outlives the Cmd node.
-            unsafe { (*shell).export_env.insert(label, val) };
-            label.deref();
-            val.deref();
+            match s.iter().position(|&b| b == b'=') {
+                Some(eq) => {
+                    let (name, value) = (&s[..eq], &s[eq + 1..]);
+                    // The argv backing is freed when the Cmd retires,
+                    // so the key/value MUST be duplicated into ref-counted storage —
+                    // `init_slice` here would leave dangling EnvStr in `export_env`.
+                    let label = EnvStr::dupe_ref_counted(name);
+                    let val = EnvStr::dupe_ref_counted(value);
+                    // SAFETY: shell env outlives the Cmd node.
+                    unsafe { (*shell).export_env.insert(label, val) };
+                    label.deref();
+                    val.deref();
+                }
+                // `export NAME` without `=` only sets the export attribute: it
+                // exports the current value (shell var first, then an
+                // already-exported/inherited one) and is a no-op if unset. It
+                // must never assign an empty value or clobber a live binding.
+                None => {
+                    let label = EnvStr::dupe_ref_counted(s);
+                    // SAFETY: shell env outlives the Cmd node.
+                    let existing = unsafe {
+                        (*shell)
+                            .shell_env
+                            .get(label)
+                            .or_else(|| (*shell).export_env.get(label))
+                    };
+                    if let Some(val) = existing {
+                        // SAFETY: shell env outlives the Cmd node.
+                        unsafe { (*shell).export_env.insert(label, val) };
+                        val.deref();
+                    }
+                    label.deref();
+                }
+            }
         }
         Builtin::done(interp, cmd, 0)
     }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1278,7 +1278,7 @@ describe("deno_task", () => {
       .runAsTest("exported vars 2");
 
     // `export NAME` without `=` must export the variable's current value, not
-    // assign an empty string. https://github.com/oven-sh/bun/issues/33430
+    // assign an empty string (which would clobber a live binding).
     TestBuilder.command`T=5; export T; ${BUN} -e ${"console.log(process.env.T)"} && echo shellvar=[$T]`
       .env(bunEnv)
       .stdout("5\nshellvar=[5]\n")

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1276,6 +1276,23 @@ describe("deno_task", () => {
     TestBuilder.command`export VAR=1 VAR2=testing VAR3="test this out" && echo $VAR $VAR2 $VAR3`
       .stdout("1 testing test this out\n")
       .runAsTest("exported vars 2");
+
+    // `export NAME` without `=` must export the variable's current value, not
+    // assign an empty string. https://github.com/oven-sh/bun/issues/33430
+    TestBuilder.command`T=5; export T; ${BUN} -e ${"console.log(process.env.T)"} && echo shellvar=[$T]`
+      .env(bunEnv)
+      .stdout("5\nshellvar=[5]\n")
+      .runAsTest("export without value exports current shell var");
+
+    TestBuilder.command`export OUTER; ${BUN} -e ${"console.log(process.env.OUTER)"} && echo shellvar=[$OUTER]`
+      .env({ ...bunEnv, OUTER: "fromenv" })
+      .stdout("fromenv\nshellvar=[fromenv]\n")
+      .runAsTest("export without value preserves inherited env var");
+
+    TestBuilder.command`export NOSUCH; ${BUN} -e ${'console.log(process.env.NOSUCH === undefined ? "UNSET" : "SET:" + process.env.NOSUCH)'}`
+      .env(bunEnv)
+      .stdout("UNSET\n")
+      .runAsTest("export of unset name does not materialize env entry");
   });
 
   describe("pipeline", async () => {


### PR DESCRIPTION
## What

In Bun Shell, the `export` builtin treated every operand as `NAME=<value-after-equals>`. With no `=` present the value parsed as the empty string and was then *assigned* into the exported env table. This broke the canonical POSIX two-step export idiom and, worse, destroyed existing values.

### Repro

```js
import { $ } from "bun";
$.nothrow();
const E = { PATH: "/usr/bin:/bin", OUTER: "fromenv" };
const run = async s => (await $`${{ raw: s }}`.env(E).quiet()).stdout.toString();

// 1) canonical idiom: the child should see "5"
await run("T=5; export T; /usr/bin/printenv T; echo shellvar=[$T]");
//   bun:  "\nshellvar=[5]\n"   (child sees T="")   bash: "5\nshellvar=[5]\n"

// 2) export of an inherited var erased its value
await run("export OUTER; /usr/bin/printenv OUTER; echo shellvar=[$OUTER]");
//   bun:  "\nshellvar=[]\n"    bash: "fromenv\nshellvar=[fromenv]\n"

// 3) export of an unset name invented an empty entry
await run("export NOSUCH; /usr/bin/printenv NOSUCH || echo NOT-IN-ENV");
//   bun:  "\n" (printenv succeeds)    bash: "NOT-IN-ENV\n"
```

## Cause

`src/runtime/shell/builtin/export.rs` split each operand on `=`; the `None` arm fell through to `(name, "")` and inserted that empty value into `export_env`, overwriting any existing binding and materializing entries for unset names.

## Fix

`export NAME` with no `=` now only sets the export attribute: it looks up the current value (shell variable first, then an already-exported/inherited one) and exports that, and does nothing when the name is unset. `export NAME=value` is unchanged.

## Verification

Added three regression tests to `test/js/bun/shell/bunshell.test.ts` (the `export` idiom, export of an inherited var, export of an unset name). All fail on `main` and pass with this change.