### PR TITLE
shell: reassigning an exported variable updates the child environment

### DIFF
--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -108,6 +108,14 @@ impl EnvMap {
         Some(val)
     }
 
+    /// Removes `key` if present, dereffing the stored key and value it owned.
+    pub fn remove(&mut self, key: EnvStr) {
+        if let Some((k, v)) = self.map.fetch_swap_remove(&key) {
+            k.deref();
+            v.deref();
+        }
+    }
+
     pub fn clone(&self) -> EnvMap {
         let new = EnvMap {
             map: self.map.clone().expect("OOM"),

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -29,20 +29,47 @@ impl Export {
             if s.is_empty() {
                 continue;
             }
-            let (name, value) = match s.iter().position(|&b| b == b'=') {
-                Some(eq) => (&s[..eq], &s[eq + 1..]),
-                None => (s, &b""[..]),
+            let eq = s.iter().position(|&b| b == b'=');
+            let name = match eq {
+                Some(eq) => &s[..eq],
+                None => s,
             };
             // The argv backing is freed when the Cmd retires,
             // so the key/value MUST be duplicated into ref-counted storage —
             // `init_slice` here would leave dangling EnvStr in `export_env`.
             let label = EnvStr::dupe_ref_counted(name);
-            let val = EnvStr::dupe_ref_counted(value);
             let shell = interp.as_cmd(cmd).base.shell;
             // SAFETY: shell env outlives the Cmd node.
-            unsafe { (*shell).export_env.insert(label, val) };
+            unsafe {
+                match eq {
+                    Some(eq) => {
+                        let val = EnvStr::dupe_ref_counted(&s[eq + 1..]);
+                        // A `NAME=value` shell-local entry must not shadow the
+                        // exported binding: `$VAR` expansion checks `shell_env`
+                        // before `export_env`.
+                        (*shell).shell_env.remove(label);
+                        (*shell).export_env.insert(label, val);
+                        val.deref();
+                    }
+                    // `export NAME` gives NAME the export attribute while keeping
+                    // its current value: promote a shell-local value rather than
+                    // blanking it, and leave an already-exported value untouched.
+                    None => {
+                        if let Some(existing) = (*shell).shell_env.get(label) {
+                            (*shell).shell_env.remove(label);
+                            (*shell).export_env.insert(label, existing);
+                            existing.deref();
+                        } else if let Some(existing) = (*shell).export_env.get(label) {
+                            existing.deref();
+                        } else {
+                            let val = EnvStr::dupe_ref_counted(b"");
+                            (*shell).export_env.insert(label, val);
+                            val.deref();
+                        }
+                    }
+                }
+            }
             label.deref();
-            val.deref();
         }
         Builtin::done(interp, cmd, 0)
     }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2148,6 +2148,10 @@ impl ShellExecEnv {
                 // shadowing it with a shell-local entry.
                 if let Some(existing) = self.export_env.get(label) {
                     existing.deref();
+                    // Drop any shell-local entry so it can't shadow the exported
+                    // value: `$VAR` expansion consults `shell_env` before
+                    // `export_env`.
+                    self.shell_env.remove(label);
                     self.export_env.insert(label, value);
                 } else {
                     self.shell_env.insert(label, value);

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2141,7 +2141,18 @@ impl ShellExecEnv {
     ) {
         match assign_ctx {
             AssignCtx::Cmd => self.cmd_local_env.insert(label, value),
-            AssignCtx::Shell => self.shell_env.insert(label, value),
+            AssignCtx::Shell => {
+                // POSIX: a plain assignment to a name that already carries the
+                // export attribute keeps it exported, so children must see the
+                // new value. Update the exported binding in place rather than
+                // shadowing it with a shell-local entry.
+                if let Some(existing) = self.export_env.get(label) {
+                    existing.deref();
+                    self.export_env.insert(label, value);
+                } else {
+                    self.shell_env.insert(label, value);
+                }
+            }
             AssignCtx::Exported => self.export_env.insert(label, value),
         }
     }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1003,21 +1003,21 @@ booga"
     // POSIX: a plain assignment to a name that already carries the export
     // attribute keeps it exported, so the new value must reach child processes,
     // not just the shell's own `$VAR` view.
-    test("reassigning an exported var updates both the shell and the child", async () => {
+    test.concurrent("reassigning an exported var updates both the shell and the child", async () => {
       const env = { ...bunEnv, OUTER: "fromenv" };
       const code = "process.stdout.write('child=' + (process.env.OUTER ?? '<unset>'))";
       const { stdout } = await $`OUTER=changed; echo shell=$OUTER; ${BUN} -e ${code}`.env(env);
       expect(stdout.toString()).toBe("shell=changed\nchild=changed");
     });
 
-    test("append idiom on an exported var reaches the child", async () => {
+    test.concurrent("append idiom on an exported var reaches the child", async () => {
       const env = { ...bunEnv, OUTER: "fromenv" };
       const code = "process.stdout.write(process.env.OUTER ?? '<unset>')";
       const { stdout } = await $`OUTER="$OUTER+more"; ${BUN} -e ${code}`.env(env);
       expect(stdout.toString()).toBe("fromenv+more");
     });
 
-    test("bare assignment to a non-exported name stays shell-local", async () => {
+    test.concurrent("bare assignment to a non-exported name stays shell-local", async () => {
       const code = "process.stdout.write(process.env.NEWV ?? '<unset>')";
       const { stdout } = await $`NEWV=nv; echo shell=$NEWV; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=nv\n<unset>");
@@ -1026,25 +1026,25 @@ booga"
     // A shell-local var that is later exported and then reassigned must not keep
     // a stale shell-local entry shadowing the exported value: `$VAR` expansion
     // checks shell_env before export_env.
-    test("bare reassignment after export clears the shell-local shadow", async () => {
+    test.concurrent("bare reassignment after export clears the shell-local shadow", async () => {
       const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
       const { stdout } = await $`FOO=a; export FOO=b; FOO=c; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=c\nchild=c");
     });
 
-    test("export NAME=value overrides a prior shell-local value", async () => {
+    test.concurrent("export NAME=value overrides a prior shell-local value", async () => {
       const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
       const { stdout } = await $`FOO=a; export FOO=b; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=b\nchild=b");
     });
 
-    test("export NAME promotes an existing shell-local value", async () => {
+    test.concurrent("export NAME promotes an existing shell-local value", async () => {
       const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
       const { stdout } = await $`FOO=a; export FOO; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=a\nchild=a");
     });
 
-    test("export NAME leaves an already-exported value intact", async () => {
+    test.concurrent("export NAME leaves an already-exported value intact", async () => {
       const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
       const { stdout } = await $`export FOO=b; export FOO; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=b\nchild=b");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1031,6 +1031,24 @@ booga"
       const { stdout } = await $`FOO=a; export FOO=b; FOO=c; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=c\nchild=c");
     });
+
+    test("export NAME=value overrides a prior shell-local value", async () => {
+      const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
+      const { stdout } = await $`FOO=a; export FOO=b; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
+      expect(stdout.toString()).toBe("shell=b\nchild=b");
+    });
+
+    test("export NAME promotes an existing shell-local value", async () => {
+      const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
+      const { stdout } = await $`FOO=a; export FOO; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
+      expect(stdout.toString()).toBe("shell=a\nchild=a");
+    });
+
+    test("export NAME leaves an already-exported value intact", async () => {
+      const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
+      const { stdout } = await $`export FOO=b; export FOO; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
+      expect(stdout.toString()).toBe("shell=b\nchild=b");
+    });
   });
 
   describe("cd & pwd", () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1022,6 +1022,15 @@ booga"
       const { stdout } = await $`NEWV=nv; echo shell=$NEWV; ${BUN} -e ${code}`.env(bunEnv);
       expect(stdout.toString()).toBe("shell=nv\n<unset>");
     });
+
+    // A shell-local var that is later exported and then reassigned must not keep
+    // a stale shell-local entry shadowing the exported value: `$VAR` expansion
+    // checks shell_env before export_env.
+    test("bare reassignment after export clears the shell-local shadow", async () => {
+      const code = "process.stdout.write('child=' + (process.env.FOO ?? '<unset>'))";
+      const { stdout } = await $`FOO=a; export FOO=b; FOO=c; echo shell=$FOO; ${BUN} -e ${code}`.env(bunEnv);
+      expect(stdout.toString()).toBe("shell=c\nchild=c");
+    });
   });
 
   describe("cd & pwd", () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -999,6 +999,29 @@ booga"
 
       expect(procEnv).toEqual({ ...bunEnv, BUN_TEST_VAR: "1", FOO: "bar" });
     });
+
+    // POSIX: a plain assignment to a name that already carries the export
+    // attribute keeps it exported, so the new value must reach child processes,
+    // not just the shell's own `$VAR` view.
+    test("reassigning an exported var updates both the shell and the child", async () => {
+      const env = { ...bunEnv, OUTER: "fromenv" };
+      const code = "process.stdout.write('child=' + (process.env.OUTER ?? '<unset>'))";
+      const { stdout } = await $`OUTER=changed; echo shell=$OUTER; ${BUN} -e ${code}`.env(env);
+      expect(stdout.toString()).toBe("shell=changed\nchild=changed");
+    });
+
+    test("append idiom on an exported var reaches the child", async () => {
+      const env = { ...bunEnv, OUTER: "fromenv" };
+      const code = "process.stdout.write(process.env.OUTER ?? '<unset>')";
+      const { stdout } = await $`OUTER="$OUTER+more"; ${BUN} -e ${code}`.env(env);
+      expect(stdout.toString()).toBe("fromenv+more");
+    });
+
+    test("bare assignment to a non-exported name stays shell-local", async () => {
+      const code = "process.stdout.write(process.env.NEWV ?? '<unset>')";
+      const { stdout } = await $`NEWV=nv; echo shell=$NEWV; ${BUN} -e ${code}`.env(bunEnv);
+      expect(stdout.toString()).toBe("shell=nv\n<unset>");
+    });
   });
 
   describe("cd & pwd", () => {


### PR DESCRIPTION
## What

In Bun Shell, a plain assignment to a variable that is already exported (inherited or set with `export`) updated only the shell's own view. Child processes spawned afterward still received the original value, and the common `PATH=/opt/x/bin:$PATH tool` / `LC_ALL=C sort` idioms silently ran with the stale value.

## Repro

```js
import { $ } from "bun";
$.nothrow();
const E = { PATH: "/usr/bin:/bin", OUTER: "fromenv" };
const run = async s => (await $`${{ raw: s }}`.env(E).quiet()).stdout.toString();

// OUTER is exported; POSIX keeps the export attribute on reassignment.
await run("OUTER=changed; /usr/bin/printenv OUTER");
//   before: "fromenv"   (bash: "changed")
await run('OUTER="$OUTER+more"; /usr/bin/printenv OUTER');
//   before: "fromenv"   (bash: "fromenv+more")
```

`echo $OUTER` inside the shell reported the new value while the child got the old one, with no diagnostics and exit 0.

## Cause

The interpreter keeps three env maps: `shell_env` (shell-local vars), `cmd_local_env` (`NAME=value cmd` prefixes), and `export_env` (exported/inherited vars). A bare `NAME=value` always wrote into `shell_env` (`AssignCtx::Shell`), but the child environment is built from `export_env` + `cmd_local_env` only. So an assignment to an already-exported name landed in `shell_env`, which children never see, while `$NAME` expansion (which checks `shell_env` first) picked up the new value. The two maps disagreed.

## Fix

`assign_var` now checks, for a bare assignment, whether the name already lives in `export_env`. If it does, it updates the exported binding in place (POSIX: a variable that carries the export attribute keeps it on reassignment). Names that are not already exported still become shell-local, so a fresh `NEWV=nv` is correctly not exported.

## Verification

Added three tests to `test/js/bun/shell/bunshell.test.ts` under `variables`:
- reassigning an exported var updates both the shell and the child
- the append idiom `VAR="$VAR+more"` reaches the child
- a bare assignment to a non-exported name stays shell-local (control)

The first two fail on the released binary and pass with the fix; the control passes both ways.