### PR TITLE
shell: keep a backslash-escaped leading tilde literal

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1713,10 +1713,9 @@ impl<'bump> Parser<'bump> {
         let mut has_brace_close = false;
         let mut has_comma = false;
         let mut has_glob_syntax = false;
-        // A `~` expands only at the start of a word. Brace expansion runs first,
-        // so the start of each brace element (after `{` or `,`) is a word start
-        // iff the brace group itself began at one; `brace_word_start` stacks that
-        // entry state per nesting level (empty until the first `{`).
+        // A `~` expands only at word start. Brace expansion runs first, so each
+        // brace element starts a word iff the brace group did; `brace_word_start`
+        // stacks that entry state per nesting level.
         let mut at_word_start = true;
         let mut brace_word_start: Vec<bool> = Vec::new();
         {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1811,7 +1811,11 @@ impl<'bump> Parser<'bump> {
                     | Token::Text(txtrng) => {
                         let _ = self.advance();
                         let mut txt = self.text(txtrng);
-                        if peeked.tag() == TokenTag::Text && !txt.is_empty() && txt[0] == b'~' {
+                        if peeked.tag() == TokenTag::Text
+                            && atoms.is_empty()
+                            && !txt.is_empty()
+                            && txt[0] == b'~'
+                        {
                             txt = &txt[1..];
                             atoms.push(ast::SimpleAtom::Tilde);
                             if !txt.is_empty() {
@@ -3134,15 +3138,14 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 }
                 continue;
             }
-            // A backslash-escaped leading `~` is quoted, so tilde expansion
-            // must not apply. Flush just that byte as a quoted-text token so
-            // the parser does not read it as a home-directory reference,
-            // matching how `'~'` and `"~"` are handled.
-            else if escaped
-                && char == u32::from(b'~')
+            // A backslash-escaped leading `~` is quoted, so tilde expansion must
+            // not apply. Flush it as a quoted-text token (like `'~'`/`"~"`) so the
+            // parser does not treat it as a home-directory reference.
+            else if char == u32::from(b'~')
                 && self.chars.state == CharState::Normal
                 && self.j == self.word_start
             {
+                debug_assert!(input.escaped);
                 let start = self.word_start;
                 self.append_char_to_str_pool(char)?;
                 self.tokens

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3134,6 +3134,22 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 }
                 continue;
             }
+            // A backslash-escaped leading `~` is quoted, so tilde expansion
+            // must not apply. Flush just that byte as a quoted-text token so
+            // the parser does not read it as a home-directory reference,
+            // matching how `'~'` and `"~"` are handled.
+            else if escaped
+                && char == u32::from(b'~')
+                && self.chars.state == CharState::Normal
+                && self.j == self.word_start
+            {
+                let start = self.word_start;
+                self.append_char_to_str_pool(char)?;
+                self.tokens
+                    .push(Token::DoubleQuotedText(TextRange { start, end: self.j }));
+                self.word_start = self.j;
+                continue;
+            }
 
             self.append_char_to_str_pool(char)?;
         }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1713,6 +1713,12 @@ impl<'bump> Parser<'bump> {
         let mut has_brace_close = false;
         let mut has_comma = false;
         let mut has_glob_syntax = false;
+        // A `~` expands only at the start of a word. Brace expansion runs first,
+        // so the start of each brace element (after `{` or `,`) is a word start
+        // iff the brace group itself began at one; `brace_word_start` stacks that
+        // entry state per nesting level (empty until the first `{`).
+        let mut at_word_start = true;
+        let mut brace_word_start: Vec<bool> = Vec::new();
         {
             while match self.peek() {
                 Token::Delimit => {
@@ -1736,6 +1742,7 @@ impl<'bump> Parser<'bump> {
                 match peeked {
                     Token::Asterisk => {
                         has_glob_syntax = true;
+                        at_word_start = false;
                         let _ = self.expect(TokenTag::Asterisk);
                         atoms.push(ast::SimpleAtom::Asterisk);
                         if next_delimits {
@@ -1745,6 +1752,7 @@ impl<'bump> Parser<'bump> {
                     }
                     Token::DoubleAsterisk => {
                         has_glob_syntax = true;
+                        at_word_start = false;
                         let _ = self.expect(TokenTag::DoubleAsterisk);
                         atoms.push(ast::SimpleAtom::DoubleAsterisk);
                         if next_delimits {
@@ -1754,6 +1762,7 @@ impl<'bump> Parser<'bump> {
                     }
                     Token::BraceBegin => {
                         has_brace_open = true;
+                        brace_word_start.push(at_word_start);
                         let _ = self.expect(TokenTag::BraceBegin);
                         atoms.push(ast::SimpleAtom::BraceBegin);
                         // TODO in this case we know it can't possibly be the beginning of a brace
@@ -1767,6 +1776,11 @@ impl<'bump> Parser<'bump> {
                     }
                     Token::BraceEnd => {
                         has_brace_close = true;
+                        brace_word_start.pop();
+                        // A non-empty brace group makes anything after `}` a suffix,
+                        // not a word start; empty `{,}` is rare enough to leave to a
+                        // future post-expansion pass.
+                        at_word_start = false;
                         let _ = self.expect(TokenTag::BraceEnd);
                         atoms.push(ast::SimpleAtom::BraceEnd);
                         if next_delimits {
@@ -1776,6 +1790,10 @@ impl<'bump> Parser<'bump> {
                     }
                     Token::Comma => {
                         has_comma = true;
+                        // A new brace element begins here, so its word start matches
+                        // the group's entry state. A bare comma (no braces) is
+                        // literal text and never a word start.
+                        at_word_start = brace_word_start.last().copied().unwrap_or(false);
                         let _ = self.expect(TokenTag::Comma);
                         atoms.push(ast::SimpleAtom::Comma);
                         if next_delimits {
@@ -1796,6 +1814,7 @@ impl<'bump> Parser<'bump> {
                                 return Err(e);
                             }
                         };
+                        at_word_start = false;
                         atoms.push(ast::SimpleAtom::CmdSubst(ast::CmdSubst {
                             script,
                             quoted: is_quoted,
@@ -1811,12 +1830,8 @@ impl<'bump> Parser<'bump> {
                     | Token::Text(txtrng) => {
                         let _ = self.advance();
                         let mut txt = self.text(txtrng);
-                        // A `~` expands only at the start of a word, which inside a
-                        // brace group is the start of each element: after `{` or `,`.
-                        let tilde_at_word_start = matches!(
-                            atoms.last(),
-                            None | Some(ast::SimpleAtom::BraceBegin | ast::SimpleAtom::Comma)
-                        );
+                        let tilde_at_word_start = at_word_start;
+                        at_word_start = false;
                         if peeked.tag() == TokenTag::Text
                             && tilde_at_word_start
                             && !txt.is_empty()
@@ -1844,6 +1859,7 @@ impl<'bump> Parser<'bump> {
                         }
                     }
                     Token::Var(txtrng) => {
+                        at_word_start = false;
                         let _ = self.expect(TokenTag::Var);
                         let txt = self.text(txtrng);
                         atoms.push(ast::SimpleAtom::Var(txt));
@@ -1855,6 +1871,7 @@ impl<'bump> Parser<'bump> {
                         }
                     }
                     Token::VarArgv(int) => {
+                        at_word_start = false;
                         let _ = self.expect(TokenTag::VarArgv);
                         atoms.push(ast::SimpleAtom::VarArgv(int));
                         if next_delimits {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1811,8 +1811,14 @@ impl<'bump> Parser<'bump> {
                     | Token::Text(txtrng) => {
                         let _ = self.advance();
                         let mut txt = self.text(txtrng);
+                        // A `~` expands only at the start of a word, which inside a
+                        // brace group is the start of each element: after `{` or `,`.
+                        let tilde_at_word_start = matches!(
+                            atoms.last(),
+                            None | Some(ast::SimpleAtom::BraceBegin | ast::SimpleAtom::Comma)
+                        );
                         if peeked.tag() == TokenTag::Text
-                            && atoms.is_empty()
+                            && tilde_at_word_start
                             && !txt.is_empty()
                             && txt[0] == b'~'
                         {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -547,6 +547,24 @@ describe("bunshell", () => {
       TestBuilder.command`echo "x"~`.stdout("x~\n").runAsTest("tilde after quoted atom stays literal");
     });
 
+    describe("with brace expansion", async () => {
+      // Brace expansion runs first, so a `~` at the start of a brace element
+      // (right after `{` or `,`) is still at a word start and expands.
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {~,foo}`
+        .stdout("/home/user foo\n")
+        .runAsTest("tilde at start of brace element expands");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {foo,~}`
+        .stdout("foo /home/user\n")
+        .runAsTest("tilde after comma expands");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {~/a,~/b}`
+        .stdout("/home/user/a /home/user/b\n")
+        .runAsTest("tilde brace paths expand");
+      // A `~` not at the start of a brace element stays literal.
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {x~,y}`
+        .stdout("x~ y\n")
+        .runAsTest("mid-element tilde stays literal");
+    });
+
     describe("interpolated values", async () => {
       // A `~` that comes from an interpolated value is data, not syntax.
       TestBuilder.command`echo ${"~"}/x`.stdout("~/x\n").runAsTest("interpolated tilde stays literal");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -537,9 +537,14 @@ describe("bunshell", () => {
       TestBuilder.command`echo \~/x`.stdout("~/x\n").runAsTest("escaped tilde with path stays literal");
       TestBuilder.command`echo \~nobody`.stdout("~nobody\n").runAsTest("escaped tilde prefix stays literal");
       TestBuilder.command`echo x\~`.stdout("x~\n").runAsTest("mid-word tilde never expands");
+      // A `~` after the escaped one is no longer at word start, so it is literal too.
+      TestBuilder.command`echo \~~`.stdout("~~\n").runAsTest("escaped then bare tilde stays literal");
+      TestBuilder.command`echo \~~/x`.stdout("~~/x\n").runAsTest("escaped then bare tilde with path stays literal");
       // controls: quoting already suppresses expansion correctly.
       TestBuilder.command`echo '~'`.stdout("~\n").runAsTest("single quotes suppress");
       TestBuilder.command`echo "~"`.stdout("~\n").runAsTest("double quotes suppress");
+      // A tilde only expands at the start of a word, never after another atom.
+      TestBuilder.command`echo "x"~`.stdout("x~\n").runAsTest("tilde after quoted atom stays literal");
     });
 
     describe("interpolated values", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -563,6 +563,17 @@ describe("bunshell", () => {
       TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {x~,y}`
         .stdout("x~ y\n")
         .runAsTest("mid-element tilde stays literal");
+      // A prefix before the brace group means no element is at a word start.
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo x{~,y}`
+        .stdout("x~ xy\n")
+        .runAsTest("tilde in braced group after prefix stays literal");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo x{foo,~}`
+        .stdout("xfoo x~\n")
+        .runAsTest("tilde after comma with prefix stays literal");
+      // A `~` suffix after a non-empty brace group is not at a word start.
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo {a,b}~`
+        .stdout("a~ b~\n")
+        .runAsTest("tilde suffix after brace group stays literal");
     });
 
     describe("interpolated values", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -531,6 +531,17 @@ describe("bunshell", () => {
         .runAsTest("cmd subst as last atom");
     });
 
+    describe("backslash escaped", async () => {
+      // POSIX: a backslash-escaped tilde is quoted, so it is never expanded.
+      TestBuilder.command`echo \~`.stdout("~\n").runAsTest("escaped lone tilde stays literal");
+      TestBuilder.command`echo \~/x`.stdout("~/x\n").runAsTest("escaped tilde with path stays literal");
+      TestBuilder.command`echo \~nobody`.stdout("~nobody\n").runAsTest("escaped tilde prefix stays literal");
+      TestBuilder.command`echo x\~`.stdout("x~\n").runAsTest("mid-word tilde never expands");
+      // controls: quoting already suppresses expansion correctly.
+      TestBuilder.command`echo '~'`.stdout("~\n").runAsTest("single quotes suppress");
+      TestBuilder.command`echo "~"`.stdout("~\n").runAsTest("double quotes suppress");
+    });
+
     describe("interpolated values", async () => {
       // A `~` that comes from an interpolated value is data, not syntax.
       TestBuilder.command`echo ${"~"}/x`.stdout("~/x\n").runAsTest("interpolated tilde stays literal");


### PR DESCRIPTION
## What

In Bun Shell, a backslash-escaped leading tilde (`\~`, `\~/x`) was still being tilde-expanded to `$HOME`. POSIX tilde expansion applies only to an *unquoted* tilde, and a `\~` produces a quoted (literal) `~`.

```js
import { $ } from "bun";
$.nothrow();
const run = async s => (await $`${{ raw: s }}`.env({ PATH: "/usr/bin:/bin", HOME: "/home/dir" }).quiet()).stdout.toString();

await run("echo \\~");    // bun: "/home/dir\n"    <-- BUG   bash: "~\n"
await run("echo \\~/x");  // bun: "/home/dir/x\n"  <-- BUG   bash: "~/x\n"

// already correct:
await run("echo '~'");    // "~\n"
await run("echo \"~\"");  // "~\n"
await run("echo ~");      // "/home/dir\n"  (unquoted still expands)
```

## Cause

The lexer consumes the escape backslash and writes a plain `~` byte into the string pool. The parser then decides tilde expansion purely on "the first byte of the word is `~`", so by the time expansion runs the escaped-ness is lost. The `'~'` / `"~"` forms work because they reach the parser as quoted-text tokens rather than a `Text` token.

## Fix

When the lexer hits a backslash-escaped `~` at the start of a word in the normal (unquoted) state, it flushes just that byte as a quoted-text token, mirroring how `'~'` and `"~"` are already handled. Only the leading byte is quoted, so the rest of the word (paths, globs) is still processed normally (`echo \~*` still globs).

## Verification

Added cases to the `tilde_expansion` group in `test/js/bun/shell/bunshell.test.ts`. The leading-tilde cases fail on the released binary and pass with this change; the quoting controls pass both ways.