### PR TITLE
shell: honor IFS when field-splitting command substitutions

### DIFF
--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -86,7 +86,7 @@ impl Assigns {
                         io,
                         ExpansionOpts {
                             for_spawn: false,
-                            single: false,
+                            single: true,
                         },
                     );
                     return Expansion::start(interp, child);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -416,14 +416,21 @@ impl Cmd {
                 }
                 CmdState::ExpandingRedirect { ref mut idx } => {
                     *idx += 1;
-                    // NUL-terminate a
-                    // non-empty result; leave an empty expansion empty so the
-                    // ambiguous-redirect check in `Builtin::init_redirections`
-                    // still fires.
-                    let mut buf = out.buf;
-                    if !buf.is_empty() && buf.last() != Some(&0) {
-                        buf.push(0);
-                    }
+                    // A target that field-split into more than one word is an
+                    // ambiguous redirect; leave `redirection_file` empty so the
+                    // check in `init_redirections` / `init_subproc_redirections`
+                    // fires (matching bash). Otherwise NUL-terminate the single
+                    // word; an empty expansion also stays empty and is caught by
+                    // the same check.
+                    let buf = if out.bounds.is_empty() {
+                        let mut buf = out.buf;
+                        if !buf.is_empty() && buf.last() != Some(&0) {
+                            buf.push(0);
+                        }
+                        buf
+                    } else {
+                        Vec::new()
+                    };
                     interp.as_cmd_mut(this).redirection_file = buf;
                 }
                 _ => {}

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -395,10 +395,11 @@ impl Cmd {
                     let me = interp.as_cmd_mut(this);
                     if out.bounds.is_empty() {
                         // An empty
-                        // expansion that did *not* see a `""` literal pushes
-                        // no arg at all — `$unset` vanishes, only `""` yields
-                        // an empty argv word.
-                        if !out.buf.is_empty() || out.has_quoted_empty {
+                        // expansion that did *not* see a `""` literal or a
+                        // field from IFS splitting pushes no arg at all —
+                        // `$unset` vanishes, while `""` and a sole empty IFS
+                        // field each yield one empty argv word.
+                        if !out.buf.is_empty() || out.has_quoted_empty || out.has_empty_field {
                             me.args.push(out.buf);
                         }
                     } else {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -262,9 +262,12 @@ impl Cmd {
                                 atom,
                                 this,
                                 io,
+                                // Redirect targets are field-split (bash errors
+                                // on >1 field; we keep the pre-existing glue),
+                                // so surrounding IFS whitespace is stripped.
                                 ExpansionOpts {
                                     for_spawn: false,
-                                    single: true,
+                                    single: false,
                                 },
                             );
                             return Expansion::start(interp, child);

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -51,8 +51,8 @@ pub struct Expansion {
     /// so `$(false)` as argv0 fails.
     pub out_exit_code: ExitCode,
     /// Expand to a single word: suppress field splitting of command
-    /// substitutions. Set for assignment values, redirect targets, and `[[ ]]`
-    /// operands, which POSIX exempts from field splitting.
+    /// substitutions. Set for assignment values and `[[ ]]` operands, which
+    /// are exempt from field splitting (redirect targets are still split).
     pub single: bool,
 }
 
@@ -625,8 +625,8 @@ impl Expansion {
         if stdout.is_empty() {
             return;
         }
-        // Assignment values, redirect targets and `[[ ]]` operands expand to a
-        // single word: POSIX exempts them from field splitting.
+        // Assignment values and `[[ ]]` operands expand to a single word:
+        // they are exempt from field splitting.
         if me.single {
             me.current_out.extend_from_slice(&stdout);
             return;

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -89,6 +89,11 @@ pub struct ExpansionOut {
     /// word yet" from "one empty word committed" (a leading empty field from
     /// non-whitespace IFS splitting, or a leading empty brace variant).
     pub committed: bool,
+    /// Set when IFS field splitting yielded at least one field, so a result
+    /// that splits down to a single empty field (e.g. `$(echo ,)` with
+    /// `IFS=,`) still produces one empty argv word. Distinct from
+    /// `has_quoted_empty` so it does not affect leading-tilde handling.
+    pub has_empty_field: bool,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -559,8 +564,11 @@ impl Expansion {
     /// unset so the caller applies the default separators. Only `shell_env` is
     /// consulted, never `export_env`: like every POSIX shell, Bun Shell must
     /// not let an inherited environment `IFS` (here, `process.env.IFS`) control
-    /// field splitting. A script-local `IFS=...` assignment lands in
-    /// `shell_env`, so the legitimate use is unaffected.
+    /// field splitting, and `export_env` holds the inherited process
+    /// environment. A bare `IFS=...` assignment lands in `shell_env`, so the
+    /// common idiom works. The `export IFS=...` spelling (which writes only
+    /// `export_env`) is not yet honored for splitting; distinguishing
+    /// script-exported vars from inherited ones needs a separate change.
     fn get_ifs(shell: &ShellExecEnv) -> Option<Vec<u8>> {
         use crate::shell::env_str::EnvStr;
         let entry = shell.shell_env.get(EnvStr::init_slice(b"IFS"))?;
@@ -641,6 +649,10 @@ impl Expansion {
         let Some((last, rest)) = fields.split_last() else {
             return;
         };
+        // At least one field exists, so the expansion yields at least one word
+        // even if it is a single empty field (`$(echo ,)` with `IFS=,`), which
+        // leaves `buf`/`bounds` empty.
+        me.out.has_empty_field = true;
         for field in rest {
             me.current_out.extend_from_slice(field);
             Self::push_current_out(me);

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -87,7 +87,7 @@ pub struct ExpansionOut {
     /// Whether at least one word has been committed to `buf`. Drives boundary
     /// recording instead of `buf`/`bounds` emptiness, which cannot tell "no
     /// word yet" from "one empty word committed" (a leading empty field from
-    /// non-whitespace IFS splitting, or a leading empty brace variant).
+    /// non-whitespace IFS splitting).
     pub committed: bool,
     /// Set when IFS field splitting yielded at least one field, so a result
     /// that splits down to a single empty field (e.g. `$(echo ,)` with
@@ -352,13 +352,14 @@ impl Expansion {
         }
         drop(arena);
 
-        // Push each variant as its own word; word boundaries are recorded
-        // via `bounds`.
-        for s in expanded {
+        // Push each non-empty variant as its own word; word boundaries are
+        // recorded via `bounds`. Empty variants are dropped as unquoted null
+        // words (`{,a}` -> `a`, `{,}` -> nothing), matching bash.
+        for s in expanded.iter().filter(|s| !s.is_empty()) {
             if me.out.committed {
                 me.out.bounds.push(me.out.buf.len() as u32);
             }
-            me.out.buf.extend_from_slice(&s);
+            me.out.buf.extend_from_slice(s);
             me.out.committed = true;
         }
 

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -50,6 +50,10 @@ pub struct Expansion {
     /// Exit code of a sole-command-substitution arg — propagated to `Cmd`
     /// so `$(false)` as argv0 fails.
     pub out_exit_code: ExitCode,
+    /// Expand to a single word: suppress field splitting of command
+    /// substitutions. Set for assignment values, redirect targets, and `[[ ]]`
+    /// operands, which POSIX exempts from field splitting.
+    pub single: bool,
 }
 
 #[derive(Default, strum::IntoStaticStr)]
@@ -80,6 +84,11 @@ pub struct ExpansionOut {
     /// empty, this distinguishes `""` (push one empty arg) from `$unset`
     /// (push no arg). See [`Expansion::has_quoted_empty`].
     pub has_quoted_empty: bool,
+    /// Whether at least one word has been committed to `buf`. Drives boundary
+    /// recording instead of `buf`/`bounds` emptiness, which cannot tell "no
+    /// word yet" from "one empty word committed" (a leading empty field from
+    /// non-whitespace IFS splitting, or a leading empty brace variant).
+    pub committed: bool,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -95,7 +104,7 @@ impl Expansion {
         node: *const ast::Atom,
         parent: NodeId,
         io: IO,
-        _opts: ExpansionOpts,
+        opts: ExpansionOpts,
     ) -> NodeId {
         interp.alloc_node(Node::Expansion(Expansion {
             base: Base::new(StateKind::Expansion, parent, shell),
@@ -115,6 +124,7 @@ impl Expansion {
             cmd_subst_quoted: false,
             has_quoted_empty: false,
             out_exit_code: 0,
+            single: opts.single,
         }))
     }
 
@@ -340,10 +350,11 @@ impl Expansion {
         // Push each variant as its own word; word boundaries are recorded
         // via `bounds`.
         for s in expanded {
-            if !me.out.buf.is_empty() {
+            if me.out.committed {
                 me.out.bounds.push(me.out.buf.len() as u32);
             }
             me.out.buf.extend_from_slice(&s);
+            me.out.committed = true;
         }
 
         let node = me.node;
@@ -533,25 +544,26 @@ impl Expansion {
     /// end-offset so the consumer's `[prev..bound]` slicing reconstructs each
     /// word and the trailing `[prev..]` slice yields the final one.
     fn push_current_out(me: &mut Expansion) {
-        // A non-empty `bounds` means a word was already committed, so this
-        // flush is a subsequent word even when `buf` is still empty (leading
-        // empty fields produced by non-whitespace IFS splitting).
-        if !me.out.buf.is_empty() || !me.out.bounds.is_empty() {
+        // A boundary precedes every word after the first, so record one once a
+        // word has already been committed — even an empty one leaves `buf`
+        // empty, so `committed` (not `buf` emptiness) is the right test.
+        if me.out.committed {
             me.out.bounds.push(me.out.buf.len() as u32);
         }
         me.out.buf.append(&mut me.current_out);
+        me.out.committed = true;
         me.meta_offsets.clear();
     }
 
-    /// Reads the current value of `IFS` (shell env, then exported env). Returns
-    /// `None` when `IFS` is unset so the caller applies the default separators.
+    /// Reads the script-assigned value of `IFS`. Returns `None` when `IFS` is
+    /// unset so the caller applies the default separators. Only `shell_env` is
+    /// consulted, never `export_env`: like every POSIX shell, Bun Shell must
+    /// not let an inherited environment `IFS` (here, `process.env.IFS`) control
+    /// field splitting. A script-local `IFS=...` assignment lands in
+    /// `shell_env`, so the legitimate use is unaffected.
     fn get_ifs(shell: &ShellExecEnv) -> Option<Vec<u8>> {
         use crate::shell::env_str::EnvStr;
-        let key = EnvStr::init_slice(b"IFS");
-        let entry = shell
-            .shell_env
-            .get(key)
-            .or_else(|| shell.export_env.get(key))?;
+        let entry = shell.shell_env.get(EnvStr::init_slice(b"IFS"))?;
         let bytes = entry.slice().to_vec();
         entry.deref();
         Some(bytes)
@@ -605,6 +617,12 @@ impl Expansion {
         if stdout.is_empty() {
             return;
         }
+        // Assignment values, redirect targets and `[[ ]]` operands expand to a
+        // single word: POSIX exempts them from field splitting.
+        if me.single {
+            me.current_out.extend_from_slice(&stdout);
+            return;
+        }
         let ifs = Self::get_ifs(me.base.shell());
         let ifs_bytes: &[u8] = match &ifs {
             // `IFS=` (set to empty) disables field splitting entirely.
@@ -616,30 +634,18 @@ impl Expansion {
             None => b" \t\n",
         };
         let fields = Self::ifs_split_fields(&stdout, ifs_bytes);
-        if fields.is_empty() {
+        // Commit every field but the last as its own word; the last stays in
+        // `current_out` so following atoms can concatenate onto it (it is
+        // flushed later by `push_current_out`). `push_current_out` tracks word
+        // commits via `out.committed`, so leading empty fields are preserved.
+        let Some((last, rest)) = fields.split_last() else {
             return;
-        }
-        // `started` tracks whether a word has already been *committed* to `out`
-        // (so the next commit needs a boundary). Any prefix still in
-        // `current_out` is the start of word 0, not a committed word, so it is
-        // excluded. An empty first field leaves `buf` empty yet still commits
-        // word 0, so this flag, not `buf` emptiness, drives boundary recording.
-        let mut started = !me.out.buf.is_empty() || !me.out.bounds.is_empty();
-        let last = fields.len() - 1;
-        for (idx, field) in fields.iter().enumerate() {
+        };
+        for field in rest {
             me.current_out.extend_from_slice(field);
-            // The final field stays in `current_out` so following atoms can
-            // concatenate onto it; `push_current_out` flushes it later.
-            if idx == last {
-                break;
-            }
-            if started {
-                me.out.bounds.push(me.out.buf.len() as u32);
-            }
-            me.out.buf.append(&mut me.current_out);
-            me.meta_offsets.clear();
-            started = true;
+            Self::push_current_out(me);
         }
+        me.current_out.extend_from_slice(last);
     }
 
     pub fn child_done(
@@ -748,10 +754,11 @@ impl Expansion {
             // Push each match as its own argv word. The
             // walker arena owns the strings, so they were `to_vec`'d already.
             for entry in result {
-                if !me.out.buf.is_empty() {
+                if me.out.committed {
                     me.out.bounds.push(me.out.buf.len() as u32);
                 }
                 me.out.buf.extend_from_slice(&entry);
+                me.out.committed = true;
             }
             me.state = ExpansionState::Done;
         }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -281,7 +281,12 @@ impl Expansion {
             if atom.has_glob_expansion() {
                 return Self::transition_to_glob_state(interp, this);
             }
-            Self::push_current_out(me);
+            // Flush the in-progress word. Skip an empty `current_out` once a
+            // word was already committed: a trailing IFS separator already
+            // committed the last field, so there is no final word to add.
+            if !me.current_out.is_empty() || !me.out.committed {
+                Self::push_current_out(me);
+            }
             me.state = ExpansionState::Done;
         }
         let parent = interp.as_expansion(this).base.parent;
@@ -583,15 +588,24 @@ impl Expansion {
     /// whitespace is ignored, runs of IFS whitespace collapse to one
     /// delimiter, and each non-whitespace IFS byte (with adjacent IFS
     /// whitespace) delimits one field, so consecutive ones yield empty fields.
-    fn ifs_split_fields<'a>(s: &'a [u8], ifs: &[u8]) -> Vec<&'a [u8]> {
+    ///
+    /// Also returns whether a separator touched each edge of the input: leading
+    /// IFS whitespace (`.1`) and a trailing delimiter (`.2`). A leading
+    /// non-whitespace delimiter instead surfaces as an empty first field, so it
+    /// is not reported here. The caller uses these to break the word against an
+    /// adjacent literal (`a$(echo " b")` -> `a`, `b`).
+    fn ifs_split_fields<'a>(s: &'a [u8], ifs: &[u8]) -> (Vec<&'a [u8]>, bool, bool) {
         let is_ifs = |b: u8| ifs.contains(&b);
         let is_ifs_ws = |b: u8| matches!(b, b' ' | b'\t' | b'\n') && ifs.contains(&b);
         let n = s.len();
         let mut fields: Vec<&[u8]> = Vec::new();
         let mut i = 0usize;
+        let ws_start = i;
         while i < n && is_ifs_ws(s[i]) {
             i += 1;
         }
+        let leading_ws_sep = i > ws_start;
+        let mut trailing_sep = false;
         while i < n {
             let start = i;
             while i < n && !is_ifs(s[i]) {
@@ -612,8 +626,13 @@ impl Expansion {
                     i += 1;
                 }
             }
+            // A delimiter that consumed the rest of the input is a trailing
+            // separator: no further field follows it.
+            if i >= n {
+                trailing_sep = true;
+            }
         }
-        fields
+        (fields, leading_ws_sep, trailing_sep)
     }
 
     /// Split an unquoted command-substitution result into argv words using
@@ -642,7 +661,14 @@ impl Expansion {
             Some(v) => v,
             None => b" \t\n",
         };
-        let fields = Self::ifs_split_fields(&stdout, ifs_bytes);
+        let (fields, leading_ws_sep, trailing_sep) = Self::ifs_split_fields(&stdout, ifs_bytes);
+        // Leading IFS whitespace separates a preceding literal (the prefix held
+        // in `current_out`) from the first field, so flush the prefix as its
+        // own word before appending. A leading non-whitespace delimiter needs
+        // no special handling: it surfaces as an empty first field below.
+        if leading_ws_sep && !me.current_out.is_empty() {
+            Self::push_current_out(me);
+        }
         // Commit every field but the last as its own word; the last stays in
         // `current_out` so following atoms can concatenate onto it (it is
         // flushed later by `push_current_out`). `push_current_out` tracks word
@@ -659,6 +685,12 @@ impl Expansion {
             Self::push_current_out(me);
         }
         me.current_out.extend_from_slice(last);
+        // A trailing delimiter separates the last field from a following
+        // literal, so commit it now; the walk-end flush skips the now-empty
+        // `current_out` (see `next`).
+        if trailing_sep {
+            Self::push_current_out(me);
+        }
     }
 
     pub fn child_done(

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -533,59 +533,113 @@ impl Expansion {
     /// end-offset so the consumer's `[prev..bound]` slicing reconstructs each
     /// word and the trailing `[prev..]` slice yields the final one.
     fn push_current_out(me: &mut Expansion) {
-        if !me.out.buf.is_empty() {
+        // A non-empty `bounds` means a word was already committed, so this
+        // flush is a subsequent word even when `buf` is still empty (leading
+        // empty fields produced by non-whitespace IFS splitting).
+        if !me.out.buf.is_empty() || !me.out.bounds.is_empty() {
             me.out.bounds.push(me.out.buf.len() as u32);
         }
         me.out.buf.append(&mut me.current_out);
         me.meta_offsets.clear();
     }
 
-    /// Newlines→spaces, trim, then split on whitespace runs into separate
-    /// argv words.
+    /// Reads the current value of `IFS` (shell env, then exported env). Returns
+    /// `None` when `IFS` is unset so the caller applies the default separators.
+    fn get_ifs(shell: &ShellExecEnv) -> Option<Vec<u8>> {
+        use crate::shell::env_str::EnvStr;
+        let key = EnvStr::init_slice(b"IFS");
+        let entry = shell
+            .shell_env
+            .get(key)
+            .or_else(|| shell.export_env.get(key))?;
+        let bytes = entry.slice().to_vec();
+        entry.deref();
+        Some(bytes)
+    }
+
+    /// POSIX field splitting of a command-substitution result. `ifs` is the
+    /// active separator set (default `" \t\n"`). Leading/trailing IFS
+    /// whitespace is ignored, runs of IFS whitespace collapse to one
+    /// delimiter, and each non-whitespace IFS byte (with adjacent IFS
+    /// whitespace) delimits one field, so consecutive ones yield empty fields.
+    fn ifs_split_fields<'a>(s: &'a [u8], ifs: &[u8]) -> Vec<&'a [u8]> {
+        let is_ifs = |b: u8| ifs.contains(&b);
+        let is_ifs_ws = |b: u8| matches!(b, b' ' | b'\t' | b'\n') && ifs.contains(&b);
+        let n = s.len();
+        let mut fields: Vec<&[u8]> = Vec::new();
+        let mut i = 0usize;
+        while i < n && is_ifs_ws(s[i]) {
+            i += 1;
+        }
+        while i < n {
+            let start = i;
+            while i < n && !is_ifs(s[i]) {
+                i += 1;
+            }
+            fields.push(&s[start..i]);
+            if i >= n {
+                break;
+            }
+            // Consume one delimiter: IFS whitespace, then at most one
+            // non-whitespace IFS byte, then trailing IFS whitespace.
+            while i < n && is_ifs_ws(s[i]) {
+                i += 1;
+            }
+            if i < n && is_ifs(s[i]) {
+                i += 1;
+                while i < n && is_ifs_ws(s[i]) {
+                    i += 1;
+                }
+            }
+        }
+        fields
+    }
+
+    /// Split an unquoted command-substitution result into argv words using
+    /// POSIX field splitting driven by `IFS`.
     fn post_subshell_expansion(me: &mut Expansion, mut stdout: Vec<u8>) {
-        // Strip a single trailing newline, then convert remaining newlines
-        // to spaces.
-        if stdout.last() == Some(&b'\n') {
+        // Command substitution deletes trailing newlines before field splitting.
+        while stdout.last() == Some(&b'\n') {
             stdout.pop();
         }
-        for b in stdout.iter_mut() {
-            if *b == b'\n' {
-                *b = b' ';
-            }
-        }
-        // Trim leading/trailing whitespace.
-        let s: &[u8] = {
-            let mut lo = 0usize;
-            let mut hi = stdout.len();
-            while lo < hi && matches!(stdout[lo], b' ' | b'\n' | b'\r' | b'\t') {
-                lo += 1;
-            }
-            while hi > lo && matches!(stdout[hi - 1], b' ' | b'\n' | b'\r' | b'\t') {
-                hi -= 1;
-            }
-            &stdout[lo..hi]
-        };
-        if s.is_empty() {
+        if stdout.is_empty() {
             return;
         }
-        // Split on runs of spaces — each run is a word boundary.
-        let mut prev_ws = false;
-        let mut a = 0usize;
-        for (i, &c) in s.iter().enumerate() {
-            if prev_ws {
-                if c != b' ' {
-                    a = i;
-                    prev_ws = false;
-                }
-                continue;
+        let ifs = Self::get_ifs(me.base.shell());
+        let ifs_bytes: &[u8] = match &ifs {
+            // `IFS=` (set to empty) disables field splitting entirely.
+            Some(v) if v.is_empty() => {
+                me.current_out.extend_from_slice(&stdout);
+                return;
             }
-            if c == b' ' {
-                prev_ws = true;
-                me.current_out.extend_from_slice(&s[a..i]);
-                Self::push_current_out(me);
-            }
+            Some(v) => v,
+            None => b" \t\n",
+        };
+        let fields = Self::ifs_split_fields(&stdout, ifs_bytes);
+        if fields.is_empty() {
+            return;
         }
-        me.current_out.extend_from_slice(&s[a..]);
+        // `started` tracks whether a word has already been *committed* to `out`
+        // (so the next commit needs a boundary). Any prefix still in
+        // `current_out` is the start of word 0, not a committed word, so it is
+        // excluded. An empty first field leaves `buf` empty yet still commits
+        // word 0, so this flag, not `buf` emptiness, drives boundary recording.
+        let mut started = !me.out.buf.is_empty() || !me.out.bounds.is_empty();
+        let last = fields.len() - 1;
+        for (idx, field) in fields.iter().enumerate() {
+            me.current_out.extend_from_slice(field);
+            // The final field stays in `current_out` so following atoms can
+            // concatenate onto it; `push_current_out` flushes it later.
+            if idx == last {
+                break;
+            }
+            if started {
+                me.out.bounds.push(me.out.buf.len() as u32);
+            }
+            me.out.buf.append(&mut me.current_out);
+            me.meta_offsets.clear();
+            started = true;
+        }
     }
 
     pub fn child_done(

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1283,6 +1283,15 @@ describe("deno_task", () => {
       .stdout(`["","","a"]\n`)
       .runAsTest("non-whitespace IFS keeps consecutive leading empty fields");
 
+    // A result that splits down to a single empty field still yields one
+    // (empty) argv word, distinct from an unset variable which yields none.
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,)`
+      .stdout(`[""]\n`)
+      .runAsTest("non-whitespace IFS: sole delimiter yields one empty field");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,,)`
+      .stdout(`["",""]\n`)
+      .runAsTest("non-whitespace IFS: two delimiters yield two empty fields");
+
     // Empty IFS disables field splitting entirely.
     TestBuilder.command`IFS=; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ${"a b"})`
       .stdout(`["a b"]\n`)

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1324,6 +1324,14 @@ describe("deno_task", () => {
       .env({ ...bunEnv, IFS: "/" })
       .stdout(`["a/b/c"]\n`)
       .runAsTest("IFS from environment does not split");
+
+    // A redirect target is field-split, so surrounding whitespace in the
+    // substitution result is stripped rather than baked into the filename.
+    TestBuilder.command`echo hi > $(echo ${" foo "})`
+      .ensureTempDir()
+      .fileEquals("foo", "hi\n")
+      .doesNotExist(" foo ")
+      .runAsTest("redirect target is field-split");
   });
 
   describe("shell variables", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1255,6 +1255,52 @@ describe("deno_task", () => {
     // TODO Sleep tests
   });
 
+  // Field splitting of an unquoted command substitution must follow $IFS.
+  // `process.argv.slice(1)` reports the exact argv the split produced.
+  describe("IFS field splitting", async () => {
+    const ARGV = "console.log(JSON.stringify(process.argv.slice(1)))";
+    const TAB = "\t";
+
+    // Custom IFS splits on its own delimiters.
+    TestBuilder.command`IFS=:; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a:b:c)`
+      .stdout(`["a","b","c"]\n`)
+      .runAsTest("colon IFS splits on colons");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a,b,c)`
+      .stdout(`["a","b","c"]\n`)
+      .runAsTest("comma IFS splits on commas");
+
+    // A non-whitespace IFS char is a hard delimiter: empty fields are kept.
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a,,b)`
+      .stdout(`["a","","b"]\n`)
+      .runAsTest("non-whitespace IFS keeps empty field");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,a,b)`
+      .stdout(`["","a","b"]\n`)
+      .runAsTest("non-whitespace IFS keeps leading empty field");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,,a)`
+      .stdout(`["","","a"]\n`)
+      .runAsTest("non-whitespace IFS keeps consecutive leading empty fields");
+
+    // Empty IFS disables field splitting entirely.
+    TestBuilder.command`IFS=; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ${"a b"})`
+      .stdout(`["a b"]\n`)
+      .runAsTest("empty IFS disables splitting");
+
+    // The default IFS includes TAB, which must split even when IFS is untouched.
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ${`a${TAB}b`})`
+      .stdout(`["a","b"]\n`)
+      .runAsTest("default IFS splits on tab");
+
+    // IFS whitespace runs collapse and do not produce empty fields.
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ${`a${TAB}${TAB}b  c`})`
+      .stdout(`["a","b","c"]\n`)
+      .runAsTest("default IFS collapses whitespace runs");
+
+    // A quoted command substitution is never field-split.
+    TestBuilder.command`IFS=:; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} "$(echo a:b:c)"`
+      .stdout(`["a:b:c"]\n`)
+      .runAsTest("quoted command substitution is not split");
+  });
+
   describe("shell variables", async () => {
     TestBuilder.command`echo $VAR && VAR=1 && echo $VAR && ${BUN} -e ${"console.log(process.env.VAR)"}`
       .stdout("\n1\nundefined\n")

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1273,6 +1273,9 @@ describe("deno_task", () => {
     TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a,,b)`
       .stdout(`["a","","b"]\n`)
       .runAsTest("non-whitespace IFS keeps empty field");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,a)`
+      .stdout(`["","a"]\n`)
+      .runAsTest("non-whitespace IFS keeps single leading empty field");
     TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ,a,b)`
       .stdout(`["","a","b"]\n`)
       .runAsTest("non-whitespace IFS keeps leading empty field");
@@ -1299,6 +1302,19 @@ describe("deno_task", () => {
     TestBuilder.command`IFS=:; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} "$(echo a:b:c)"`
       .stdout(`["a:b:c"]\n`)
       .runAsTest("quoted command substitution is not split");
+
+    // POSIX exempts assignment values from field splitting even with a custom
+    // IFS; the captured delimiters must survive verbatim.
+    TestBuilder.command`IFS=,; VAR=$(echo a,b,c); BUN_TEST_VAR=1 ${BUN} -e ${ARGV} "$VAR"`
+      .stdout(`["a,b,c"]\n`)
+      .runAsTest("assignment value is not field-split");
+
+    // IFS inherited from the environment (process.env) must not drive
+    // splitting; every POSIX shell ignores it. Only a script-local IFS does.
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a/b/c)`
+      .env({ ...bunEnv, IFS: "/" })
+      .stdout(`["a/b/c"]\n`)
+      .runAsTest("IFS from environment does not split");
   });
 
   describe("shell variables", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1307,6 +1307,21 @@ describe("deno_task", () => {
       .stdout(`["a","b","c"]\n`)
       .runAsTest("default IFS collapses whitespace runs");
 
+    // A separator at the edge of the substitution result breaks the word
+    // against an adjacent literal instead of gluing onto it.
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} a$(echo ${" b"})`
+      .stdout(`["a","b"]\n`)
+      .runAsTest("leading IFS whitespace splits from preceding literal");
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo ${"a "})b`
+      .stdout(`["a","b"]\n`)
+      .runAsTest("trailing IFS whitespace splits from following literal");
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} a$(echo ${"  "})b`
+      .stdout(`["a","b"]\n`)
+      .runAsTest("all-whitespace result splits adjacent literals");
+    TestBuilder.command`IFS=,; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} $(echo a,)x`
+      .stdout(`["a","x"]\n`)
+      .runAsTest("trailing non-whitespace IFS splits from following literal");
+
     // A quoted command substitution is never field-split.
     TestBuilder.command`IFS=:; BUN_TEST_VAR=1 ${BUN} -e ${ARGV} "$(echo a:b:c)"`
       .stdout(`["a:b:c"]\n`)

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1332,6 +1332,39 @@ describe("deno_task", () => {
       .fileEquals("foo", "hi\n")
       .doesNotExist(" foo ")
       .runAsTest("redirect target is field-split");
+
+    // A redirect target that splits into more than one field is an ambiguous
+    // redirect (bash errors), not a glued-together filename.
+    TestBuilder.command`echo hi > $(echo a b)`
+      .ensureTempDir()
+      .stderr("bun: ambiguous redirect: at `echo`\n")
+      .exitCode(1)
+      .doesNotExist("ab")
+      .runAsTest("redirect target splitting to multiple fields is ambiguous");
+    TestBuilder.command`IFS=,; echo hi > $(echo a,b)`
+      .ensureTempDir()
+      .stderr("bun: ambiguous redirect: at `echo`\n")
+      .exitCode(1)
+      .doesNotExist("ab")
+      .runAsTest("redirect target with custom IFS splitting is ambiguous");
+  });
+
+  // Brace expansion drops unquoted-null variants, matching bash:
+  // `{,a}` -> `a`, `{a,}` -> `a`, `{,}` -> nothing.
+  describe("brace empty variants", async () => {
+    const ARGV = "console.log(JSON.stringify(process.argv.slice(1)))";
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} {,a}`
+      .stdout(`["a"]\n`)
+      .runAsTest("leading empty brace variant dropped");
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} {a,}`
+      .stdout(`["a"]\n`)
+      .runAsTest("trailing empty brace variant dropped");
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} {a,,b}`
+      .stdout(`["a","b"]\n`)
+      .runAsTest("middle empty brace variant dropped");
+    TestBuilder.command`BUN_TEST_VAR=1 ${BUN} -e ${ARGV} a{,b}`
+      .stdout(`["a","ab"]\n`)
+      .runAsTest("non-empty brace variants with prefix preserved");
   });
 
   describe("shell variables", async () => {


### PR DESCRIPTION
## What

Bun Shell splits an unquoted command substitution into argv words on a hardcoded `is space || is newline` predicate and never consults the `IFS` shell variable. This produces the wrong argv arity in both directions:

- Custom `IFS` is ignored. `IFS=:` / `IFS=,` / a newline `IFS` (the standard "split this output on my delimiter" idioms) all return one glued-together argument.
- The default `IFS` is `<space><tab><newline>`, but TAB was never a separator, so tab-separated tool output (`cut`, `awk`, TSV pipelines) never split.
- `IFS=` (empty) is documented to disable field splitting, but splitting still happened on spaces.

Everything was exit 0 with no diagnostic; programs just received the wrong number of arguments.

## Repro

```js
import { $ } from "bun";
const run = async s => (await $`${{ raw: s }}`.env({ PATH: "/usr/bin:/bin" }).quiet()).stdout.toString();
const p = "/usr/bin/printf '[%s]'";

await run(`IFS=:; ${p} $(echo a:b:c); echo`);  // before: [a:b:c]   after/bash: [a][b][c]
await run(`IFS=; ${p} $(echo 'a b'); echo`);   // before: [a][b]    after/bash: [a b]
await run(`${p} $(/usr/bin/printf 'a\tb'); echo`); // before: [a\tb] after/bash: [a][b]
```

## Cause

`post_subshell_expansion` in `src/runtime/shell/states/Expansion.rs` converted newlines to spaces, trimmed, then split on runs of spaces. It never read `IFS`.

## Fix

Implement POSIX field splitting in the word-expansion pass:

- Read `IFS` from the shell env (then exported env); default to `" \t\n"` when unset.
- An empty `IFS` disables field splitting.
- IFS whitespace (space/tab/newline that are in `IFS`) runs collapse into one delimiter and leading/trailing IFS whitespace is ignored.
- Each non-whitespace IFS byte delimits one field, so consecutive ones and leading/trailing ones yield empty fields (matching bash).
- Command substitution still deletes trailing newlines before splitting.

Representing a leading empty field required tracking whether a word had already been committed to the output buffer, rather than inferring it from buffer emptiness (an empty first word leaves the buffer empty).

Note: the `IFS=$'\n'` form in the report relies on ANSI-C `$'...'` quoting, which Bun Shell does not implement (it leaves the bytes literal). A real newline in `IFS` splits correctly; that is a separate feature gap, not part of this fix.

## Verification

New tests in `test/js/bun/shell/bunshell.test.ts` (describe `IFS field splitting`) assert exact argv arity via `process.argv.slice(1)` for custom IFS, empty IFS, default TAB, whitespace-run collapse, empty fields (leading/middle/consecutive), and the quoted-substitution control. They fail on the released binary and pass with the fix. Output matches bash 5.2 across the matrix.
