### PR TITLE
shell: expand tilde in assignment values, ~user, and ~+/~-

### DIFF
--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -87,6 +87,7 @@ impl Assigns {
                         ExpansionOpts {
                             for_spawn: false,
                             single: false,
+                            is_assignment: true,
                         },
                     );
                     return Expansion::start(interp, child);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -265,6 +265,7 @@ impl Cmd {
                                 ExpansionOpts {
                                     for_spawn: false,
                                     single: true,
+                                    is_assignment: false,
                                 },
                             );
                             return Expansion::start(interp, child);
@@ -293,6 +294,7 @@ impl Cmd {
                         ExpansionOpts {
                             for_spawn: true,
                             single: false,
+                            is_assignment: false,
                         },
                     );
                     return Expansion::start(interp, child);

--- a/src/runtime/shell/states/CondExpr.rs
+++ b/src/runtime/shell/states/CondExpr.rs
@@ -77,6 +77,7 @@ impl CondExpr {
                         ExpansionOpts {
                             for_spawn: false,
                             single: true,
+                            is_assignment: false,
                         },
                     );
                     return Expansion::start(interp, child);

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -14,6 +14,71 @@ use crate::shell::states::script::Script;
 use crate::shell::yield_::Yield;
 use crate::shell::{ExitCode, ShellErr};
 
+/// Look up a user's home directory by name (`~user`). POSIX-only; Windows has
+/// no `getpwnam`, so there it always leaves `~user` literal (as bash does).
+#[cfg(not(windows))]
+fn lookup_user_home(name: &[u8]) -> Option<Vec<u8>> {
+    use core::ffi::{c_char, c_int};
+    // getpwnam_r needs a NUL-terminated name; a name with an embedded NUL can
+    // never be a real user.
+    if name.is_empty() || name.contains(&0) {
+        return None;
+    }
+    let mut cname: Vec<u8> = Vec::with_capacity(name.len() + 1);
+    cname.extend_from_slice(name);
+    cname.push(0);
+
+    // Try a stack buffer first, doubling onto the heap on ERANGE.
+    let mut stack_buf = [0u8; 1024];
+    let mut heap_buf: Vec<u8>;
+    let mut buf: &mut [u8] = &mut stack_buf[..];
+    // SAFETY: `passwd` is a C POD; a zeroed value is a valid initial state.
+    let mut pw: libc::passwd = bun_core::ffi::zeroed();
+    let mut result: *mut libc::passwd = core::ptr::null_mut();
+
+    loop {
+        // SAFETY: NUL-terminated name, live output struct, live scratch buffer.
+        let ret = unsafe {
+            libc::getpwnam_r(
+                cname.as_ptr().cast::<c_char>(),
+                &raw mut pw,
+                buf.as_mut_ptr().cast::<c_char>(),
+                buf.len(),
+                &raw mut result,
+            )
+        };
+        if ret == bun_sys::E::EINTR as c_int {
+            continue;
+        }
+        if ret == bun_sys::E::ERANGE as c_int {
+            let len = buf.len();
+            if len >= 1 << 20 {
+                return None;
+            }
+            heap_buf = vec![0u8; len * 2];
+            buf = &mut heap_buf[..];
+            continue;
+        }
+        if ret != 0 {
+            return None;
+        }
+        break;
+    }
+
+    // A null result means no such user (ret was 0 but nothing matched).
+    if result.is_null() || pw.pw_dir.is_null() {
+        return None;
+    }
+    // SAFETY: pw_dir is a NUL-terminated C string owned by `buf`.
+    let dir = unsafe { bun_core::ffi::cstr(pw.pw_dir) }.to_bytes();
+    (!dir.is_empty()).then(|| dir.to_vec())
+}
+
+#[cfg(windows)]
+fn lookup_user_home(_name: &[u8]) -> Option<Vec<u8>> {
+    None
+}
+
 pub struct Expansion {
     pub base: Base,
     pub node: bun_ptr::BackRef<ast::Atom>,
@@ -37,6 +102,13 @@ pub struct Expansion {
     /// (JS interpolation, quoted text, `$var`, command substitution) are data
     /// and must not change the expansion structure or broaden the glob.
     pub meta_offsets: Vec<u32>,
+    /// Byte offsets in `current_out` of non-leading `~` atoms (assignment
+    /// values, where a tilde expands after each `:`). Resolved after the walk
+    /// by [`Expansion::resolve_inner_tildes`].
+    pub tilde_offsets: Vec<u32>,
+    /// Whether this expansion is an assignment value (`FOO=~/x`). Enables
+    /// tilde expansion after each `:`, not just at the word start.
+    pub is_assignment: bool,
     pub child_script: Option<NodeId>,
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
@@ -86,6 +158,9 @@ pub struct ExpansionOut {
 pub struct ExpansionOpts {
     pub for_spawn: bool,
     pub single: bool,
+    /// Set for assignment values so `~` expands after each `:` as well as at
+    /// the start (the `PATH=~/bin:$PATH` idiom).
+    pub is_assignment: bool,
 }
 
 impl Expansion {
@@ -95,7 +170,7 @@ impl Expansion {
         node: *const ast::Atom,
         parent: NodeId,
         io: IO,
-        _opts: ExpansionOpts,
+        opts: ExpansionOpts,
     ) -> NodeId {
         interp.alloc_node(Node::Expansion(Expansion {
             base: Base::new(StateKind::Expansion, parent, shell),
@@ -111,6 +186,8 @@ impl Expansion {
             out: ExpansionOut::default(),
             current_out: Vec::new(),
             meta_offsets: Vec::new(),
+            tilde_offsets: Vec::new(),
+            is_assignment: opts.is_assignment,
             child_script: None,
             cmd_subst_quoted: false,
             has_quoted_empty: false,
@@ -180,6 +257,13 @@ impl Expansion {
                     ast::Atom::Simple(s) => s,
                     ast::Atom::Compound(c) => &c.atoms[me.word_idx as usize],
                 };
+                // A non-leading `~` in an assignment value (after a `:`) is
+                // resolved after the walk once its prefix text is assembled.
+                if me.is_assignment && matches!(simple, ast::SimpleAtom::Tilde) {
+                    me.tilde_offsets.push(me.current_out.len() as u32);
+                    me.word_idx += 1;
+                    continue;
+                }
                 let shell = me.base.shell();
                 let is_cmd_subst = Self::expand_simple_no_io(
                     shell,
@@ -230,32 +314,59 @@ impl Expansion {
 
             // All sub-atoms expanded — post-process leading tilde then finish.
             if leading_tilde {
-                let home = me.base.shell().get_homedir();
                 let len_before = me.current_out.len();
                 match me.current_out.first() {
                     Some(b'/') | Some(b'\\') => {
+                        let home = me.base.shell().get_homedir();
                         me.current_out.splice(0..0, home.slice().iter().copied());
+                        home.deref();
                     }
-                    Some(_) => me.current_out.insert(0, b'~'),
                     // `~""` expands to $HOME,
                     // but `~$unset` expands to nothing (word is dropped).
                     None if me.has_quoted_empty => {
+                        let home = me.base.shell().get_homedir();
                         me.current_out.extend_from_slice(home.slice());
+                        home.deref();
                     }
                     None => {}
-                }
-                // The first two arms prepend; shift the recorded brace
-                // metacharacter offsets so they keep pointing at the same
-                // bytes. The `extend_from_slice` arm only runs when
-                // `current_out` (and therefore `meta_offsets`) is
-                // empty, so the shift is a no-op there.
-                let prepended = (me.current_out.len() - len_before) as u32;
-                if prepended != 0 {
-                    for off in &mut me.meta_offsets {
-                        *off += prepended;
+                    // `~name`, `~+`, `~-`, or `~:…`: resolve the prefix up to the
+                    // first `/`, `\`, or `:`. On failure the `~` is left literal.
+                    Some(_) => {
+                        let prefix_len = me
+                            .current_out
+                            .iter()
+                            .position(|&b| matches!(b, b'/' | b'\\' | b':'))
+                            .unwrap_or(me.current_out.len());
+                        let resolved = Self::resolve_tilde_prefix(
+                            me.base.shell(),
+                            &me.current_out[..prefix_len],
+                        );
+                        match resolved {
+                            Some(dir) => {
+                                me.current_out.splice(0..prefix_len, dir.iter().copied());
+                            }
+                            None => me.current_out.insert(0, b'~'),
+                        }
                     }
                 }
-                home.deref();
+                // Every arm edits the front of `current_out`; shift the recorded
+                // brace/glob and inner-tilde offsets by the net size change so
+                // they keep pointing at the same bytes.
+                let delta = me.current_out.len() as isize - len_before as isize;
+                if delta != 0 {
+                    for off in me
+                        .meta_offsets
+                        .iter_mut()
+                        .chain(me.tilde_offsets.iter_mut())
+                    {
+                        *off = (*off as isize + delta) as u32;
+                    }
+                }
+            }
+            // Resolve non-leading `~` atoms recorded during the walk (assignment
+            // values, where `~` expands after each `:`).
+            if !me.tilde_offsets.is_empty() {
+                Self::resolve_inner_tildes(me);
             }
             // Brace expansion
             // first, then glob, else flush as a single word.
@@ -526,6 +637,67 @@ impl Expansion {
             ast::SimpleAtom::CmdSubst(_) => return true,
         }
         false
+    }
+
+    /// Resolve a tilde prefix (the bytes between `~` and the first `/`, `\`, or
+    /// `:`) to a directory. `""` → `$HOME`, `+` → `$PWD`, `-` → `$OLDPWD`, and
+    /// any other name → that user's home directory. Returns `None` when the
+    /// prefix cannot be resolved (unknown user, unset `$OLDPWD`), so the caller
+    /// keeps the `~` literal, matching bash.
+    fn resolve_tilde_prefix(shell: &ShellExecEnv, prefix: &[u8]) -> Option<Vec<u8>> {
+        match prefix {
+            b"" => {
+                let home = shell.get_homedir();
+                let v = home.slice().to_vec();
+                home.deref();
+                Some(v)
+            }
+            b"+" => {
+                let cwd = shell.cwd();
+                (!cwd.is_empty()).then(|| cwd.to_vec())
+            }
+            b"-" => {
+                let prev = shell.prev_cwd();
+                (!prev.is_empty()).then(|| prev.to_vec())
+            }
+            name => lookup_user_home(name),
+        }
+    }
+
+    /// Resolve the non-leading `~` atoms recorded in `tilde_offsets` (assignment
+    /// values expand a `~` after each `:`). Offsets are processed in the order
+    /// recorded, with a running delta so each splice keeps later offsets valid.
+    fn resolve_inner_tildes(me: &mut Expansion) {
+        let offsets = core::mem::take(&mut me.tilde_offsets);
+        let mut running: isize = 0;
+        for raw in offsets {
+            let at = (raw as isize + running) as usize;
+            if at > me.current_out.len() {
+                continue;
+            }
+            let prefix_len = me.current_out[at..]
+                .iter()
+                .position(|&b| matches!(b, b'/' | b'\\' | b':'))
+                .unwrap_or(me.current_out.len() - at);
+            let resolved =
+                Self::resolve_tilde_prefix(me.base.shell(), &me.current_out[at..at + prefix_len]);
+            let len_before = me.current_out.len();
+            match resolved {
+                Some(dir) => {
+                    me.current_out.splice(at..at + prefix_len, dir.iter().copied());
+                }
+                None => me.current_out.insert(at, b'~'),
+            }
+            let delta = me.current_out.len() as isize - len_before as isize;
+            running += delta;
+            if delta != 0 {
+                for off in &mut me.meta_offsets {
+                    if (*off as usize) >= at {
+                        *off = (*off as isize + delta) as u32;
+                    }
+                }
+            }
+        }
     }
 
     /// Flush `current_out` into `out`

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -265,7 +265,10 @@ impl Expansion {
                 if me.is_assignment && matches!(simple, ast::SimpleAtom::Tilde) {
                     let next_is_literal = match atom {
                         ast::Atom::Compound(c) => {
-                            matches!(c.atoms.get((me.word_idx + 1) as usize), Some(ast::SimpleAtom::Text(_)) | None)
+                            matches!(
+                                c.atoms.get((me.word_idx + 1) as usize),
+                                Some(ast::SimpleAtom::Text(_)) | None
+                            )
                         }
                         ast::Atom::Simple(_) => true,
                     };
@@ -360,7 +363,8 @@ impl Expansion {
                                 .iter()
                                 .position(|&b| matches!(b, b'/' | b'\\' | b':'))
                                 .unwrap_or(t.len());
-                            Self::resolve_tilde_prefix(me.base.shell(), &t[..plen]).map(|d| (plen, d))
+                            Self::resolve_tilde_prefix(me.base.shell(), &t[..plen])
+                                .map(|d| (plen, d))
                         });
                         match resolved {
                             Some((plen, dir)) => {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -684,7 +684,8 @@ impl Expansion {
             let len_before = me.current_out.len();
             match resolved {
                 Some(dir) => {
-                    me.current_out.splice(at..at + prefix_len, dir.iter().copied());
+                    me.current_out
+                        .splice(at..at + prefix_len, dir.iter().copied());
                 }
                 None => me.current_out.insert(at, b'~'),
             }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -351,24 +351,24 @@ impl Expansion {
                     // so a `~` followed by `$var`/`$(...)`/quoting stays literal.
                     // On any resolution failure the `~` is left literal too.
                     Some(_) => {
-                        let lit = match atom {
+                        // The leading `~`'s prefix is bounded to the literal
+                        // `Text` atom that follows it (`current_out` starts with
+                        // that atom's bytes); a non-`Text` follower keeps `~`
+                        // literal.
+                        let plen = match atom {
                             ast::Atom::Compound(c) => match c.atoms.get(1) {
-                                Some(ast::SimpleAtom::Text(t)) => Some(*t),
+                                Some(ast::SimpleAtom::Text(t)) => Some(
+                                    t.iter()
+                                        .position(|&b| matches!(b, b'/' | b'\\' | b':'))
+                                        .unwrap_or(t.len()),
+                                ),
                                 _ => None,
                             },
                             ast::Atom::Simple(_) => None,
                         };
-                        let resolved = lit.and_then(|t| {
-                            let plen = t
-                                .iter()
-                                .position(|&b| matches!(b, b'/' | b'\\' | b':'))
-                                .unwrap_or(t.len());
-                            Self::resolve_tilde_prefix(me.base.shell(), &t[..plen])
-                                .map(|d| (plen, d))
-                        });
-                        match resolved {
-                            Some((plen, dir)) => {
-                                me.current_out.splice(0..plen, dir.iter().copied());
+                        match plen {
+                            Some(plen) => {
+                                Self::apply_tilde_at(me, 0, plen);
                             }
                             None => me.current_out.insert(0, b'~'),
                         }
@@ -689,6 +689,22 @@ impl Expansion {
         }
     }
 
+    /// Resolve the tilde prefix `current_out[at..at + prefix_len]` in place:
+    /// splice the resolved directory over it, or keep a literal `~` on failure.
+    /// Returns the net byte-length change of `current_out`.
+    fn apply_tilde_at(me: &mut Expansion, at: usize, prefix_len: usize) -> isize {
+        let resolved =
+            Self::resolve_tilde_prefix(me.base.shell(), &me.current_out[at..at + prefix_len]);
+        let len_before = me.current_out.len();
+        match resolved {
+            Some(dir) => {
+                me.current_out.splice(at..at + prefix_len, dir.iter().copied());
+            }
+            None => me.current_out.insert(at, b'~'),
+        }
+        me.current_out.len() as isize - len_before as isize
+    }
+
     /// Resolve the non-leading `~` atoms recorded in `tilde_offsets` (assignment
     /// values expand a `~` after each `:`). Offsets are processed in the order
     /// recorded, with a running delta so each splice keeps later offsets valid.
@@ -704,17 +720,7 @@ impl Expansion {
                 .iter()
                 .position(|&b| matches!(b, b'/' | b'\\' | b':'))
                 .unwrap_or(me.current_out.len() - at);
-            let resolved =
-                Self::resolve_tilde_prefix(me.base.shell(), &me.current_out[at..at + prefix_len]);
-            let len_before = me.current_out.len();
-            match resolved {
-                Some(dir) => {
-                    me.current_out
-                        .splice(at..at + prefix_len, dir.iter().copied());
-                }
-                None => me.current_out.insert(at, b'~'),
-            }
-            let delta = me.current_out.len() as isize - len_before as isize;
+            let delta = Self::apply_tilde_at(me, at, prefix_len);
             running += delta;
             if delta != 0 {
                 for off in &mut me.meta_offsets {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -698,7 +698,8 @@ impl Expansion {
         let len_before = me.current_out.len();
         match resolved {
             Some(dir) => {
-                me.current_out.splice(at..at + prefix_len, dir.iter().copied());
+                me.current_out
+                    .splice(at..at + prefix_len, dir.iter().copied());
             }
             None => me.current_out.insert(at, b'~'),
         }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -258,9 +258,22 @@ impl Expansion {
                     ast::Atom::Compound(c) => &c.atoms[me.word_idx as usize],
                 };
                 // A non-leading `~` in an assignment value (after a `:`) is
-                // resolved after the walk once its prefix text is assembled.
+                // resolved after the walk once its prefix text is assembled. Its
+                // prefix is only a tilde-prefix when it is literal text, so only
+                // record it when the next atom is literal `Text` or the word ends
+                // (`x:~`); a following `$var`/`$(...)`/quoting keeps `~` literal.
                 if me.is_assignment && matches!(simple, ast::SimpleAtom::Tilde) {
-                    me.tilde_offsets.push(me.current_out.len() as u32);
+                    let next_is_literal = match atom {
+                        ast::Atom::Compound(c) => {
+                            matches!(c.atoms.get((me.word_idx + 1) as usize), Some(ast::SimpleAtom::Text(_)) | None)
+                        }
+                        ast::Atom::Simple(_) => true,
+                    };
+                    if next_is_literal {
+                        me.tilde_offsets.push(me.current_out.len() as u32);
+                    } else {
+                        me.current_out.push(b'~');
+                    }
                     me.word_idx += 1;
                     continue;
                 }
@@ -330,20 +343,28 @@ impl Expansion {
                     }
                     None => {}
                     // `~name`, `~+`, `~-`, or `~:…`: resolve the prefix up to the
-                    // first `/`, `\`, or `:`. On failure the `~` is left literal.
+                    // first `/`, `\`, or `:`. The prefix is only a tilde-prefix
+                    // when it is literal text (bash forms it before expansion),
+                    // so a `~` followed by `$var`/`$(...)`/quoting stays literal.
+                    // On any resolution failure the `~` is left literal too.
                     Some(_) => {
-                        let prefix_len = me
-                            .current_out
-                            .iter()
-                            .position(|&b| matches!(b, b'/' | b'\\' | b':'))
-                            .unwrap_or(me.current_out.len());
-                        let resolved = Self::resolve_tilde_prefix(
-                            me.base.shell(),
-                            &me.current_out[..prefix_len],
-                        );
+                        let lit = match atom {
+                            ast::Atom::Compound(c) => match c.atoms.get(1) {
+                                Some(ast::SimpleAtom::Text(t)) => Some(*t),
+                                _ => None,
+                            },
+                            ast::Atom::Simple(_) => None,
+                        };
+                        let resolved = lit.and_then(|t| {
+                            let plen = t
+                                .iter()
+                                .position(|&b| matches!(b, b'/' | b'\\' | b':'))
+                                .unwrap_or(t.len());
+                            Self::resolve_tilde_prefix(me.base.shell(), &t[..plen]).map(|d| (plen, d))
+                        });
                         match resolved {
-                            Some(dir) => {
-                                me.current_out.splice(0..prefix_len, dir.iter().copied());
+                            Some((plen, dir)) => {
+                                me.current_out.splice(0..plen, dir.iter().copied());
                             }
                             None => me.current_out.insert(0, b'~'),
                         }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1676,7 +1676,7 @@ impl<'bump> Parser<'bump> {
                             // into `Tilde` atoms. Quoted text never reaches here,
                             // so it correctly stays literal.
                             let txt_value = &txt[eq_idx as usize + 1..];
-                            let left = self.split_value_tildes(txt_value);
+                            let left = self.split_value_tildes(txt_value, txtrng.start + eq_idx + 1);
                             if self.delimits(self.peek()) {
                                 let _ = self.expect_delimit();
                                 left
@@ -1712,8 +1712,10 @@ impl<'bump> Parser<'bump> {
     /// `Tilde` atoms. A `~` is a tilde-expansion point at the start of the
     /// value and immediately after a `:` (the `PATH=~/bin:$PATH` idiom). The
     /// prefix following each `~` (`+`, `-`, or a user name) is resolved later
-    /// during expansion.
-    fn split_value_tildes(&self, bytes: &'bump [u8]) -> ast::Atom<'bump> {
+    /// during expansion. `base` is the strpool offset of `bytes[0]`, used to
+    /// skip `~`/`:` bytes that came from an interpolated value (data, not shell
+    /// syntax), so `A=x${":"}~` keeps its literal `~`.
+    fn split_value_tildes(&self, bytes: &'bump [u8], base: u32) -> ast::Atom<'bump> {
         use ast::SimpleAtom as SA;
         let mut out: bun_alloc::ArenaVec<'bump, SA<'bump>> =
             bun_alloc::ArenaVec::with_capacity_in(1, self.alloc);
@@ -1723,7 +1725,8 @@ impl<'bump> Parser<'bump> {
         let mut i = 0usize;
         while i < bytes.len() {
             let b = bytes[i];
-            if at_point && b == b'~' {
+            let interpolated = self.is_interpolated_position(base + i as u32);
+            if at_point && b == b'~' && !interpolated {
                 if i > seg_start {
                     out.push(SA::Text(&bytes[seg_start..i]));
                 }
@@ -1733,7 +1736,7 @@ impl<'bump> Parser<'bump> {
                 seg_start = i;
                 continue;
             }
-            at_point = b == b':';
+            at_point = b == b':' && !interpolated;
             i += 1;
         }
         if bytes.len() > seg_start {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1651,46 +1651,47 @@ impl<'bump> Parser<'bump> {
                             break 'var_decl None;
                         }
 
-                        if eq_idx as usize == txt.len() - 1 {
+                        let value: ast::Atom<'bump> = if eq_idx as usize == txt.len() - 1 {
+                            // The value starts in a later token (`FOO=$bar`,
+                            // `FOO="x"`). The literal part carrying a word-initial
+                            // `~` only ever lands in the `txt_value` branch below,
+                            // so nothing here needs tilde marking.
                             if self.delimits(self.peek()) {
                                 let _ = self.expect_delimit();
-                                break 'var_decl Some(ast::Assign {
-                                    label,
-                                    value: ast::Atom::Simple(ast::SimpleAtom::Text(b"")),
-                                });
-                            }
-                            let atom = match self.parse_atom()? {
-                                Some(a) => a,
-                                None => {
-                                    self.add_error(format_args!("Expected an atom"))?;
-                                    return Err(ParseError::Expected.into());
+                                ast::Atom::Simple(ast::SimpleAtom::Text(b""))
+                            } else {
+                                match self.parse_atom()? {
+                                    Some(a) => a,
+                                    None => {
+                                        self.add_error(format_args!("Expected an atom"))?;
+                                        return Err(ParseError::Expected.into());
+                                    }
                                 }
-                            };
-                            break 'var_decl Some(ast::Assign { label, value: atom });
-                        }
-
-                        let txt_value = &txt[eq_idx as usize + 1..];
-                        if self.delimits(self.peek()) {
-                            let _ = self.expect_delimit();
-                            break 'var_decl Some(ast::Assign {
-                                label,
-                                value: ast::Atom::Simple(ast::SimpleAtom::Text(txt_value)),
-                            });
-                        }
-
-                        let right = match self.parse_atom()? {
-                            Some(a) => a,
-                            None => {
-                                self.add_error(format_args!("Expected an atom"))?;
-                                return Err(ParseError::Expected.into());
+                            }
+                        } else {
+                            // `txt_value` is the unquoted literal text after `=`.
+                            // In an assignment value a `~` is expanded at the
+                            // start and after every unquoted `:` (the
+                            // `PATH=~/bin:$PATH` idiom), so split those positions
+                            // into `Tilde` atoms. Quoted text never reaches here,
+                            // so it correctly stays literal.
+                            let txt_value = &txt[eq_idx as usize + 1..];
+                            let left = self.split_value_tildes(txt_value);
+                            if self.delimits(self.peek()) {
+                                let _ = self.expect_delimit();
+                                left
+                            } else {
+                                let right = match self.parse_atom()? {
+                                    Some(a) => a,
+                                    None => {
+                                        self.add_error(format_args!("Expected an atom"))?;
+                                        return Err(ParseError::Expected.into());
+                                    }
+                                };
+                                left.merge(&right, self.alloc)?
                             }
                         };
-                        let left = ast::Atom::Simple(ast::SimpleAtom::Text(txt_value));
-                        let merged = left.merge(&right, self.alloc)?;
-                        break 'var_decl Some(ast::Assign {
-                            label,
-                            value: merged,
-                        });
+                        break 'var_decl Some(ast::Assign { label, value });
                     }
                     None
                 };
@@ -1704,6 +1705,48 @@ impl<'bump> Parser<'bump> {
                 Ok(None)
             }
             _ => Ok(None),
+        }
+    }
+
+    /// Split the unquoted literal text of an assignment value into `Text` and
+    /// `Tilde` atoms. A `~` is a tilde-expansion point at the start of the
+    /// value and immediately after a `:` (the `PATH=~/bin:$PATH` idiom). The
+    /// prefix following each `~` (`+`, `-`, or a user name) is resolved later
+    /// during expansion.
+    fn split_value_tildes(&self, bytes: &'bump [u8]) -> ast::Atom<'bump> {
+        use ast::SimpleAtom as SA;
+        let mut out: bun_alloc::ArenaVec<'bump, SA<'bump>> =
+            bun_alloc::ArenaVec::with_capacity_in(1, self.alloc);
+        // The start of the value is a tilde-expansion point.
+        let mut at_point = true;
+        let mut seg_start = 0usize;
+        let mut i = 0usize;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if at_point && b == b'~' {
+                if i > seg_start {
+                    out.push(SA::Text(&bytes[seg_start..i]));
+                }
+                out.push(SA::Tilde);
+                at_point = false;
+                i += 1;
+                seg_start = i;
+                continue;
+            }
+            at_point = b == b':';
+            i += 1;
+        }
+        if bytes.len() > seg_start {
+            out.push(SA::Text(&bytes[seg_start..]));
+        }
+        match out.len() {
+            0 => ast::Atom::Simple(SA::Text(b"")),
+            1 => ast::Atom::Simple(out.into_iter().next().unwrap()),
+            _ => ast::Atom::Compound(ast::CompoundAtom {
+                atoms: out.into_bump_slice(),
+                brace_expansion_hint: false,
+                glob_hint: false,
+            }),
         }
     }
 

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1676,7 +1676,8 @@ impl<'bump> Parser<'bump> {
                             // into `Tilde` atoms. Quoted text never reaches here,
                             // so it correctly stays literal.
                             let txt_value = &txt[eq_idx as usize + 1..];
-                            let left = self.split_value_tildes(txt_value, txtrng.start + eq_idx + 1);
+                            let left =
+                                self.split_value_tildes(txt_value, txtrng.start + eq_idx + 1);
                             if self.delimits(self.peek()) {
                                 let _ = self.expect_delimit();
                                 left

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -560,6 +560,45 @@ describe("bunshell", () => {
         .runAsTest("PATH idiom");
       // A `~` that is neither at the start nor right after a `:` stays literal.
       TestBuilder.command`A=a~/b; echo $A`.env(homeEnv).stdout("a~/b\n").runAsTest("tilde mid-value stays literal");
+      // A `~` after `:` followed by `$var`/quoting is not a literal prefix, so
+      // it stays literal (bash forms the tilde-prefix before expansion).
+      TestBuilder.command`A=x:~$U; echo $A`
+        .env({ ...homeEnv, U: "root" })
+        .stdout("x:~root\n")
+        .runAsTest("tilde after colon before a variable stays literal");
+      // Quoted tilde values never expand.
+      TestBuilder.command`A="~"; echo $A`.env(homeEnv).stdout("~\n").runAsTest("double-quoted tilde stays literal");
+      TestBuilder.command`A='~/x'; echo $A`.env(homeEnv).stdout("~/x\n").runAsTest("single-quoted tilde stays literal");
+
+      // Non-bare prefixes after a `:` (exercises the inner-tilde resolver).
+      TestBuilder.command`A=x:~+; echo $A && pwd`
+        .stdout(out => {
+          const [a, pwd] = out.split("\n");
+          expect(a).toBe(`x:${pwd}`);
+        })
+        .runAsTest("~+ after colon is $PWD");
+      // Unresolvable prefix after a `:` stays literal (inner-tilde None path).
+      TestBuilder.command`A=x:~no-such-user-zz; echo $A`
+        .stdout("x:~no-such-user-zz\n")
+        .runAsTest("unknown user after colon stays literal");
+      if (isPosix) {
+        TestBuilder.command`A=x:~root/y; echo $A`
+          .stdout(out => {
+            expect(out).not.toContain("~");
+            expect(out.startsWith("x:/")).toBe(true);
+            expect(out.endsWith("/y\n")).toBe(true);
+          })
+          .runAsTest("~user after colon resolves");
+      }
+
+      // An inner `~` composed with brace expansion: the `~` resolves first and
+      // its length change must keep the recorded brace metacharacter offsets
+      // aligned. Bun brace-expands assignment values (see the "glob expansion"
+      // suite); bash does not, so this output is intentionally Bun-specific.
+      TestBuilder.command`A=x:~/{a,b}; echo $A`
+        .env(homeEnv)
+        .stdout("x:/home/test/a x:/home/test/b\n")
+        .runAsTest("inner tilde composes with brace expansion");
     });
 
     // `~+` / `~-` and `~user` resolve the prefix between `~` and the first

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -541,6 +541,54 @@ describe("bunshell", () => {
         .stdout("a b~bak\n")
         .runAsTest("backup-suffix idiom after interpolated value");
     });
+
+    // In an assignment value a `~` expands at the start and after every
+    // unquoted `:` (e.g. the `PATH=~/bin:$PATH` idiom), not only at the start
+    // of a command word.
+    describe("in assignment values", async () => {
+      const homeEnv = { ...process.env, HOME: "/home/test", USERPROFILE: "/home/test" };
+      TestBuilder.command`A=~; echo $A`.env(homeEnv).stdout("/home/test\n").runAsTest("bare tilde");
+      TestBuilder.command`A=~/sub; echo $A`.env(homeEnv).stdout("/home/test/sub\n").runAsTest("tilde path");
+      TestBuilder.command`A=x:~; echo $A`.env(homeEnv).stdout("x:/home/test\n").runAsTest("tilde after colon");
+      TestBuilder.command`A=~/b:~/c; echo $A`
+        .env(homeEnv)
+        .stdout("/home/test/b:/home/test/c\n")
+        .runAsTest("multiple colon-separated tildes");
+      TestBuilder.command`MYPATH=~/bin:/usr/bin; echo $MYPATH`
+        .env(homeEnv)
+        .stdout("/home/test/bin:/usr/bin\n")
+        .runAsTest("PATH idiom");
+      // A `~` that is neither at the start nor right after a `:` stays literal.
+      TestBuilder.command`A=a~/b; echo $A`.env(homeEnv).stdout("a~/b\n").runAsTest("tilde mid-value stays literal");
+    });
+
+    // `~+` / `~-` and `~user` resolve the prefix between `~` and the first
+    // `/` or `:`. `~user` needs getpwnam, which only exists on POSIX.
+    describe("prefixes", async () => {
+      TestBuilder.command`echo ~+ && pwd`
+        .stdout(out => {
+          const [tildePlus, pwd] = out.split("\n");
+          expect(tildePlus).toBe(pwd);
+        })
+        .runAsTest("~+ is $PWD");
+
+      if (isPosix) {
+        TestBuilder.command`echo ~root`
+          .stdout(out => {
+            expect(out).not.toContain("~");
+            expect(out.startsWith("/")).toBe(true);
+          })
+          .runAsTest("~user resolves to the user home directory");
+
+        TestBuilder.command`cd / && cd /tmp && echo ~-`.stdout("/\n").runAsTest("~- is $OLDPWD");
+
+        const homeEnv = { ...process.env, HOME: "/home/test", USERPROFILE: "/home/test" };
+        TestBuilder.command`echo ~:x`.env(homeEnv).stdout("/home/test:x\n").runAsTest("colon terminates tilde prefix");
+        TestBuilder.command`echo ~no-such-user-zz`
+          .stdout("~no-such-user-zz\n")
+          .runAsTest("unknown user stays literal");
+      }
+    });
   });
 
   // Ported from GNU bash "quote.tests"

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -569,6 +569,12 @@ describe("bunshell", () => {
       // Quoted tilde values never expand.
       TestBuilder.command`A="~"; echo $A`.env(homeEnv).stdout("~\n").runAsTest("double-quoted tilde stays literal");
       TestBuilder.command`A='~/x'; echo $A`.env(homeEnv).stdout("~/x\n").runAsTest("single-quoted tilde stays literal");
+      // A `~` from an interpolated value is data, not shell syntax: `$`
+      // backslash-escapes it, so it stays literal.
+      TestBuilder.command`${{ raw: "A=x" }}${":~"}${{ raw: "; echo $A" }}`
+        .env(homeEnv)
+        .stdout("x:~\n")
+        .runAsTest("interpolated tilde in an assignment value stays literal");
 
       // Non-bare prefixes after a `:` (exercises the inner-tilde resolver).
       TestBuilder.command`A=x:~+; echo $A && pwd`
@@ -611,6 +617,12 @@ describe("bunshell", () => {
         })
         .runAsTest("~+ is $PWD");
 
+      // `:` terminates the prefix and an unknown user stays literal on every
+      // platform (unknown `~user` is always literal; Windows has no getpwnam).
+      const homeEnv = { ...process.env, HOME: "/home/test", USERPROFILE: "/home/test" };
+      TestBuilder.command`echo ~:x`.env(homeEnv).stdout("/home/test:x\n").runAsTest("colon terminates tilde prefix");
+      TestBuilder.command`echo ~no-such-user-zz`.stdout("~no-such-user-zz\n").runAsTest("unknown user stays literal");
+
       if (isPosix) {
         TestBuilder.command`echo ~root`
           .stdout(out => {
@@ -620,10 +632,6 @@ describe("bunshell", () => {
           .runAsTest("~user resolves to the user home directory");
 
         TestBuilder.command`cd / && cd /tmp && echo ~-`.stdout("/\n").runAsTest("~- is $OLDPWD");
-
-        const homeEnv = { ...process.env, HOME: "/home/test", USERPROFILE: "/home/test" };
-        TestBuilder.command`echo ~:x`.env(homeEnv).stdout("/home/test:x\n").runAsTest("colon terminates tilde prefix");
-        TestBuilder.command`echo ~no-such-user-zz`.stdout("~no-such-user-zz\n").runAsTest("unknown user stays literal");
       }
     });
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -584,9 +584,7 @@ describe("bunshell", () => {
 
         const homeEnv = { ...process.env, HOME: "/home/test", USERPROFILE: "/home/test" };
         TestBuilder.command`echo ~:x`.env(homeEnv).stdout("/home/test:x\n").runAsTest("colon terminates tilde prefix");
-        TestBuilder.command`echo ~no-such-user-zz`
-          .stdout("~no-such-user-zz\n")
-          .runAsTest("unknown user stays literal");
+        TestBuilder.command`echo ~no-such-user-zz`.stdout("~no-such-user-zz\n").runAsTest("unknown user stays literal");
       }
     });
   });


### PR DESCRIPTION
## What

Bun Shell did not perform POSIX tilde expansion in three documented contexts. This PR adds them:

1. **Assignment values.** A `~` in an assignment value is expanded at the start and after every unquoted `:` (POSIX 2.6.1). This is the damaging case: `DIR=~/data`, `PATH=~/bin:$PATH`, `KUBECONFIG=~/.kube/config` previously kept the literal `~/`, so the value was used as a relative path and a directory literally named `~` was created next to the script.
2. **`~user`.** A named user's home directory, resolved with `getpwnam` (POSIX only; Windows has no `getpwnam`, so `~user` stays literal there, matching bash).
3. **`~+` / `~-`.** `$PWD` and `$OLDPWD`.

A tilde prefix is only expanded when it is **literal text**, matching bash (which forms the tilde-prefix before expansion). So quoted tildes (`A="~"`, `A='~'`, `A=x"~"`) and prefixes produced by a variable or command substitution (`~$USER`, `~$(echo root)`, `A=x:~$USER`) stay literal. A `~` that is neither at the start of an assignment value nor right after a `:` (`A=a~/b`) also stays literal.

## Before

```
A=~; echo $A        # ~          (bash: /home/dir)
A=~/sub; echo $A    # ~/sub      (bash: /home/dir/sub)
A=x:~; echo $A      # x:~        (bash: x:/home/dir)
echo ~root          # ~root      (bash: /root)
echo ~+             # ~+         (bash: the cwd)
```

## Cause

- The parser left the literal text after `=` as a single `Text` atom, so no `Tilde` atom was produced for an assignment value.
- Word-initial tilde expansion only handled a bare `~` and `~/…` (resolving to `$HOME`); it treated any other prefix (`~root`, `~+`, `~-`) as literal.

## Fix

- `split_value_tildes` (parser) splits the unquoted literal text of an assignment value into `Text`/`Tilde` atoms at the start and after each `:`. Quoted text never reaches this path, so it stays literal.
- `resolve_tilde_prefix` (expansion) resolves the prefix between `~` and the first `/`, `\`, or `:`: `""` → `$HOME`, `+` → `$PWD`, `-` → `$OLDPWD`, any other name → that user's home (via `getpwnam`). The prefix is only resolved when the atom following the `~` is literal `Text`; a `$var`/`$(...)`/quoted follower keeps the `~` literal. Unresolvable prefixes (unknown user, unset `$OLDPWD`) also stay literal. Non-leading tildes from assignment values are resolved in a second pass over the assembled word, with the recorded brace/glob metacharacter offsets shifted to stay aligned.

## Verification

New tests in `test/js/bun/shell/bunshell.test.ts` under `tilde_expansion` cover assignment values, the `PATH=~/bin:$PATH` idiom, `~user`, `~+`/`~-`, the `:` terminator, non-bare prefixes after a `:`, composition with brace expansion, and the literal cases (quoted, mid-value, unknown user, variable-sourced prefix). Output was diffed against bash 5.2; all literal and expanding cases match. The assignment and prefix tests fail on the released binary and pass with this change.

Notes (unchanged, out of scope):
- `export FOO=~/x` (tilde in a declaration-builtin argument) is a separate mechanism and is not changed here.
- Bun already brace- and glob-expands assignment values (existing behavior with tests, e.g. `FOO=hi*`); bash does not. This PR does not change that, and verifies tilde expansion composes with it correctly.
