### PR TITLE
ci: run release upload step on Linux

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1030,9 +1030,11 @@ function getReleaseStep(buildPlatforms, options, { signed = false } = {}) {
   return {
     key: "release",
     label: getBuildkiteEmoji("rocket"),
-    agents: {
-      queue: "test-darwin",
-    },
+    agents: getEc2Agent(
+      buildPlatforms.find(p => p.os === "linux" && p.arch === "aarch64" && p.distro === "amazonlinux"),
+      options,
+      { instanceType: "c8g.large" },
+    ),
     depends_on,
     env: {
       CANARY: revision,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1012,20 +1012,20 @@ function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {
 const BINARY_SIZE_THRESHOLD_MB = 0.5;
 
 /**
- * @param {Platform[]} buildPlatforms
+ * @param {Platform[]} releasePlatforms
  * @param {PipelineOptions} options
  * @param {{ signed: boolean }} [extra]
  * @returns {Step}
  */
-function getReleaseStep(buildPlatforms, options, { signed = false } = {}) {
+function getReleaseStep(releasePlatforms, options, { signed = false } = {}) {
   const { canary } = options;
   const revision = typeof canary === "number" ? canary : 1;
 
   // When signing ran, depend on windows-sign instead of the raw Windows builds
   // so we wait for signed artifacts before releasing.
   const depends_on = signed
-    ? [...buildPlatforms.filter(p => p.os !== "windows").map(p => `${getTargetKey(p)}-build-bun`), "windows-sign"]
-    : buildPlatforms.map(platform => `${getTargetKey(platform)}-build-bun`);
+    ? [...releasePlatforms.filter(p => p.os !== "windows").map(p => `${getTargetKey(p)}-build-bun`), "windows-sign"]
+    : releasePlatforms.map(platform => `${getTargetKey(platform)}-build-bun`);
 
   return {
     key: "release",

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -61,22 +61,100 @@ function run_command() {
   { set +x; } 2>/dev/null
 }
 
+function maybe_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    run_command "$@"
+  elif command -v sudo &> /dev/null; then
+    run_command sudo "$@"
+  else
+    run_command "$@"
+  fi
+}
+
+function package_manager_install() {
+  if command -v dnf &> /dev/null; then
+    maybe_sudo dnf install -y "$@"
+  elif command -v yum &> /dev/null; then
+    maybe_sudo yum install -y "$@"
+  elif command -v apt-get &> /dev/null; then
+    export DEBIAN_FRONTEND=noninteractive
+    maybe_sudo apt-get install -y "$@"
+  elif command -v apk &> /dev/null; then
+    maybe_sudo apk add "$@"
+  else
+    echo "error: No supported package manager found to install: $*"
+    exit 1
+  fi
+}
+
+function install_gh_linux() {
+  local arch
+  case "$(uname -m)" in
+    x86_64 | amd64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *) echo "error: Unsupported architecture: $(uname -m)"; exit 1 ;;
+  esac
+  local version
+  version="$(curl -fsSL "https://api.github.com/repos/cli/cli/releases/latest" | grep -m1 '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')"
+  if [ -z "$version" ]; then
+    echo "error: Cannot determine latest gh release version"
+    exit 1
+  fi
+  local dir
+  dir="$(mktemp -d)"
+  run_command curl -fsSL "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_${arch}.tar.gz" -o "$dir/gh.tar.gz"
+  run_command tar -xzf "$dir/gh.tar.gz" -C "$dir" --strip-components=1
+  maybe_sudo install -m 0755 "$dir/bin/gh" /usr/local/bin/gh
+  rm -rf "$dir"
+}
+
+function install_aws_linux() {
+  command -v unzip &> /dev/null || package_manager_install unzip
+  local dir
+  dir="$(mktemp -d)"
+  run_command curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "$dir/awscliv2.zip"
+  run_command unzip -q "$dir/awscliv2.zip" -d "$dir"
+  maybe_sudo "$dir/aws/install" --update
+  rm -rf "$dir"
+}
+
+function install_sentry_cli_linux() {
+  # The installer drops a single static binary into INSTALL_DIR.
+  maybe_sudo bash -c "curl -fsSL https://sentry.io/get-cli/ | INSTALL_DIR=/usr/local/bin sh"
+}
+
 function assert_command() {
   local command="$1"
   local package="$2"
   local help_url="$3"
-  if ! command -v "$command" &> /dev/null; then
-    echo "warning: $command is not installed, installing..."
-    if command -v brew &> /dev/null; then
-      HOMEBREW_NO_AUTO_UPDATE=1 run_command brew install "$package"
-    else
-      echo "error: Cannot install $command, please install it"
-      if [ -n "$help_url" ]; then
-        echo ""
-        echo "hint: See $help_url for help"
-      fi
-      exit 1
+  if command -v "$command" &> /dev/null; then
+    return
+  fi
+  echo "warning: $command is not installed, installing..."
+  if command -v brew &> /dev/null; then
+    HOMEBREW_NO_AUTO_UPDATE=1 run_command brew install "$package"
+  elif [ "$(uname -s)" == "Linux" ]; then
+    case "$command" in
+      gh) install_gh_linux ;;
+      aws) install_aws_linux ;;
+      sentry-cli) install_sentry_cli_linux ;;
+      *) echo "error: Don't know how to install $command on Linux"; exit 1 ;;
+    esac
+  else
+    echo "error: Cannot install $command, please install it"
+    if [ -n "$help_url" ]; then
+      echo ""
+      echo "hint: See $help_url for help"
     fi
+    exit 1
+  fi
+  if ! command -v "$command" &> /dev/null; then
+    echo "error: Failed to install $command"
+    if [ -n "$help_url" ]; then
+      echo ""
+      echo "hint: See $help_url for help"
+    fi
+    exit 1
   fi
 }
 


### PR DESCRIPTION
## What

Move the release/canary upload step (`upload-release.sh`) from the macOS fleet to the Linux EC2 fleet.

## Why

The step ran on the `test-darwin` queue purely because `upload-release.sh` installed its tooling (`gh`, `aws`, `sentry-cli`) with Homebrew. It does no platform-specific work: it downloads build artifacts from Buildkite and uploads them to GitHub releases and S3. Running it on Linux frees the smaller macOS pool and matches how the related `binary-size` step already runs (#28992).

## Changes

- `.buildkite/ci.mjs`: the `release` step now uses `getEc2Agent(...)` on the same `linux-aarch64-amazonlinux-2023` image the `binary-size` step uses, instead of `{ queue: "test-darwin" }`.
- `.buildkite/scripts/upload-release.sh`: `assert_command` now installs missing tools on Linux via their official installers, keeping the existing Homebrew path for macOS:
  - `gh`: release tarball from github.com/cli/cli
  - `aws`: the official AWS CLI v2 Linux installer
  - `sentry-cli`: the official `sentry.io/get-cli` installer

  A `maybe_sudo` helper and a small package-manager shim (dnf/yum/apt/apk, used only to pull in `unzip` for the AWS installer) were added. The macOS branch is unchanged.

## Verification

- `bash -n` passes on the script.
- `.buildkite/ci.mjs` imports and regenerates the pipeline cleanly; the generated `release` step now carries the Linux agent tags (`os: linux`, `arch: aarch64`, `distro: amazonlinux`) instead of `queue: test-darwin`.

Full end-to-end exercise only happens on a canary/release build on `main`, since the step is gated by `assert_canary` and `assert_main`.