### PR TITLE
stdio: enforce write-after-end contract for piped process.stdout/stderr

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -660,6 +660,13 @@ const kWriteMonkeyPatchDefense = Symbol("!");
 function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
 
+  // After end()/destroy()/error the Writable contract requires write() to fail
+  // (ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED) and not reach the sink.
+  const state = this._writableState;
+  if (state !== undefined && (state.ending || state.ended || state.destroyed || state.errored)) {
+    return writablePrototypeWrite.$call(this, data, encoding, cb);
+  }
+
   if (typeof encoding === "function") {
     cb = encoding;
     encoding = undefined;

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -660,10 +660,10 @@ const kWriteMonkeyPatchDefense = Symbol("!");
 function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
 
-  // After end()/destroy()/error the Writable contract requires write() to fail
-  // (ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED) and not reach the sink.
+  // After end() the Writable contract requires write() to fail with
+  // ERR_STREAM_WRITE_AFTER_END and not reach the sink.
   const state = this._writableState;
-  if (state !== undefined && (state.ending || state.ended || state.destroyed || state.errored)) {
+  if (state !== undefined && state.ending) {
     return writablePrototypeWrite.$call(this, data, encoding, cb);
   }
 

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,4 +158,29 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
+
+  test("process.stdout - write after end() errors and is not delivered (piped)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-fixture.mjs")],
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The "C" write after end() must not reach the pipe reader.
+    expect(stdout).toBe("AB");
+
+    const report = JSON.parse(stderr.trim());
+    expect(report).toEqual({
+      writableEnded: true,
+      writable: false,
+      ret: false,
+      cbErr: "ERR_STREAM_WRITE_AFTER_END",
+      ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
+    });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,39 +158,4 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
-
-  test.each(["stdout", "stderr"] as const)(
-    "process.%s - write after end() errors and is not delivered (piped)",
-    async which => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-fixture.mjs"), which],
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: bunEnv,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      // The fixture writes its data to `which` and the JSON report to the other
-      // stream. The report stream may carry benign ASAN/debug noise, so parse
-      // only the last non-empty line.
-      const dataPipe = which === "stderr" ? stderr : stdout;
-      const reportPipe = which === "stderr" ? stdout : stderr;
-      const lines = reportPipe.trim().split("\n");
-      const report = JSON.parse(lines[lines.length - 1]);
-
-      expect(report).toEqual({
-        writableEnded: true,
-        writable: false,
-        ret: false,
-        cbErr: "ERR_STREAM_WRITE_AFTER_END",
-        ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
-      });
-
-      // The "C" write after end() must not reach the pipe reader.
-      expect(dataPipe).toBe("AB");
-      expect(exitCode).toBe(0);
-    },
-  );
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -159,28 +159,38 @@ describe.concurrent("process-stdio", () => {
     );
   });
 
-  test("process.stdout - write after end() errors and is not delivered (piped)", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-fixture.mjs")],
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env: bunEnv,
-    });
+  test.each(["stdout", "stderr"] as const)(
+    "process.%s - write after end() errors and is not delivered (piped)",
+    async which => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-fixture.mjs"), which],
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: bunEnv,
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // The "C" write after end() must not reach the pipe reader.
-    expect(stdout).toBe("AB");
+      // The fixture writes its data to `which` and the JSON report to the other
+      // stream. The report stream may carry benign ASAN/debug noise, so parse
+      // only the last non-empty line.
+      const dataPipe = which === "stderr" ? stderr : stdout;
+      const reportPipe = which === "stderr" ? stdout : stderr;
+      const lines = reportPipe.trim().split("\n");
+      const report = JSON.parse(lines[lines.length - 1]);
 
-    const report = JSON.parse(stderr.trim());
-    expect(report).toEqual({
-      writableEnded: true,
-      writable: false,
-      ret: false,
-      cbErr: "ERR_STREAM_WRITE_AFTER_END",
-      ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
-    });
-    expect(exitCode).toBe(0);
-  });
+      expect(report).toEqual({
+        writableEnded: true,
+        writable: false,
+        ret: false,
+        cbErr: "ERR_STREAM_WRITE_AFTER_END",
+        ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
+      });
+
+      // The "C" write after end() must not reach the pipe reader.
+      expect(dataPipe).toBe("AB");
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/js/node/process/process-stdout-write-after-end-fixture.mjs
+++ b/test/js/node/process/process-stdout-write-after-end-fixture.mjs
@@ -12,9 +12,11 @@ so.on("error", e => ev.push("err:" + code(e)));
 so.write("A");
 so.end("B");
 
+// A distinctive post-end marker (not a common letter) so the reader-side
+// assertion can't collide with benign ASAN/debug noise on the same fd.
 const { promise, resolve } = Promise.withResolvers();
 let cbErr = "no-callback";
-const ret = so.write("C", e => {
+const ret = so.write("POST_END_MARKER", e => {
   cbErr = code(e);
   resolve();
 });

--- a/test/js/node/process/process-stdout-write-after-end-fixture.mjs
+++ b/test/js/node/process/process-stdout-write-after-end-fixture.mjs
@@ -1,0 +1,26 @@
+const code = e => (e == null ? null : String(e.code || e.name || e));
+const so = process.stdout;
+const ev = [];
+so.on("error", e => ev.push("err:" + code(e)));
+
+so.write("A");
+so.end("B");
+
+await new Promise(r => setTimeout(r, 50));
+
+let cbErr = "no-callback";
+const ret = so.write("C", e => {
+  cbErr = code(e);
+});
+
+await new Promise(r => setTimeout(r, 50));
+
+process.stderr.write(
+  JSON.stringify({
+    writableEnded: so.writableEnded,
+    writable: so.writable,
+    ret,
+    cbErr,
+    ev,
+  }) + "\n",
+);

--- a/test/js/node/process/process-stdout-write-after-end-fixture.mjs
+++ b/test/js/node/process/process-stdout-write-after-end-fixture.mjs
@@ -1,21 +1,29 @@
 const code = e => (e == null ? null : String(e.code || e.name || e));
-const so = process.stdout;
+
+// Which stream to end() and write to after. The JSON report is written to the
+// other stream so the "ended" stream's pipe only ever carries its data writes.
+const which = process.argv[2] === "stderr" ? "stderr" : "stdout";
+const so = process[which];
+const reportStream = which === "stderr" ? process.stdout : process.stderr;
+
 const ev = [];
 so.on("error", e => ev.push("err:" + code(e)));
 
 so.write("A");
 so.end("B");
 
-await new Promise(r => setTimeout(r, 50));
-
+const { promise, resolve } = Promise.withResolvers();
 let cbErr = "no-callback";
 const ret = so.write("C", e => {
   cbErr = code(e);
+  resolve();
 });
+await promise;
+// The write callback and the 'error' event both land on process.nextTick;
+// draining one more tick lets the error event fire before we read `ev`.
+await new Promise(r => process.nextTick(r));
 
-await new Promise(r => setTimeout(r, 50));
-
-process.stderr.write(
+reportStream.write(
   JSON.stringify({
     writableEnded: so.writableEnded,
     writable: so.writable,

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
 

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+test.each(["stdout", "stderr"] as const)(
+  "process.%s - write after end() errors and is not delivered (piped)",
+  async which => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-fixture.mjs"), which],
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The fixture writes its data to `which` and the JSON report to the other
+    // stream. The report stream may carry benign ASAN/debug noise, so parse
+    // only the last non-empty line.
+    const dataPipe = which === "stderr" ? stderr : stdout;
+    const reportPipe = which === "stderr" ? stdout : stderr;
+    const lines = reportPipe.trim().split("\n");
+    const report = JSON.parse(lines[lines.length - 1]);
+
+    expect(report).toEqual({
+      writableEnded: true,
+      writable: false,
+      ret: false,
+      cbErr: "ERR_STREAM_WRITE_AFTER_END",
+      ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
+    });
+
+    // The "C" write after end() must not reach the pipe reader.
+    expect(dataPipe).toBe("AB");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -31,8 +31,14 @@ test.each(["stdout", "stderr"] as const)(
       ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
     });
 
-    // The "C" write after end() must not reach the pipe reader.
-    expect(dataPipe).toBe("AB");
+    // The "C" write after end() must not reach the pipe reader. stdout (fd 1)
+    // is clean; stderr (fd 2) can carry benign ASAN/debug noise, so only assert
+    // that the post-end byte never arrives.
+    if (which === "stdout") {
+      expect(dataPipe).toBe("AB");
+    } else {
+      expect(dataPipe).not.toContain("C");
+    }
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -31,13 +31,13 @@ test.each(["stdout", "stderr"] as const)(
       ev: ["err:ERR_STREAM_WRITE_AFTER_END"],
     });
 
-    // The "C" write after end() must not reach the pipe reader. stdout (fd 1)
-    // is clean; stderr (fd 2) can carry benign ASAN/debug noise, so only assert
-    // that the post-end byte never arrives.
+    // The post-end write must not reach the pipe reader. stdout (fd 1) is
+    // clean; stderr (fd 2) can carry benign ASAN/debug noise, so there assert
+    // only that the distinctive post-end marker never arrives.
     if (which === "stdout") {
       expect(dataPipe).toBe("AB");
     } else {
-      expect(dataPipe).not.toContain("C");
+      expect(dataPipe).not.toContain("POST_END_MARKER");
     }
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
## What

For a piped (non-TTY) `process.stdout`/`process.stderr`, calling `write()` after `end()` succeeds, reports no error, and delivers the bytes to the pipe reader. That violates the `node:stream` Writable contract: a write after `end()` must fail with `ERR_STREAM_WRITE_AFTER_END` and must not reach the underlying fd.

The stream's own state already reports `writableEnded: true, writable: false`, so the public state contradicts what the fd does.

## Repro

```js
// child: parent spawns it with a piped stdout and reads it
const so = process.stdout, ev = [];
so.on("error", e => ev.push("err:" + (e?.code ?? e?.name)));
so.write("A");
so.end("B");
const ret = so.write("C", e => { /* err expected here */ });
```

Before this change the pipe reader receives `"ABC"`, `write()` returns `true`, and the callback gets no error. Node (and this change) deliver `"AB"`, `write()` returns `false`, and the callback plus an `'error'` event fire with `ERR_STREAM_WRITE_AFTER_END`.

## Cause

Piped stdio is backed by a `node:fs` `WriteStream` in "fast path" mode, whose `write` is replaced by `writeFast` in `src/js/internal/fs/streams.ts`. `writeFast` pushes data straight into the `FileSink` and never consults the Writable state, so the `ERR_STREAM_WRITE_AFTER_END` guard that lives in `Writable.prototype.write` is bypassed.

## Fix

`writeFast` now delegates to `Writable.prototype.write` when the stream is ending (`end()` has been called). That path already implements the correct contract (callback + `'error'` with `ERR_STREAM_WRITE_AFTER_END`, no delivery), so the bytes never reach the sink.

Scope note: this covers the `end()` path, which is the reachable write-after-termination mode for `process.stdout`/`process.stderr`. `destroy()` is intentionally a no-op on stdio (the streams override `_destroy` to call `_undestroy()` for Node parity), so it does not latch `destroyed` and `ERR_STREAM_DESTROYED` is not reachable there.

## Verification

`bun bd test test/js/node/process/process-stdout-write-after-end.test.ts` passes for both `stdout` and `stderr`; the same tests fail on the released binary (`"ABC"` delivered).
