### PR TITLE
fs: recursive rm deletes children before surfacing top-dir permission error

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9770,20 +9770,16 @@ fn dt_delete_file(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
         Ok(()) => Ok(()),
         Err(e) => {
             let errno = e.get_errno();
-            // Non-Linux POSIX (macOS/BSD) returns
-            // a *permission* error (EPERM, occasionally EACCES) from `unlinkat(2)`
-            // without `AT_REMOVEDIR` when the target is a directory — Linux returns
-            // EISDIR directly. Stat to disambiguate so the recursive-rm dir fallback
+            // A permission error from `unlinkat(2)` without `AT_REMOVEDIR` can
+            // mask the fact that the target is a directory we should recurse
+            // into: macOS/BSD return EPERM/EACCES when the target itself is a
+            // directory, and on every POSIX system unlinking a directory whose
+            // parent is not writable fails with EACCES before any EISDIR check.
+            // Stat to disambiguate so the recursive-rm dir fallback
             // (`Err(EISDIR) => treat_as_dir`) fires; a genuine permission error
-            // (immutable file, unwritable parent dir, …) still propagates.
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd",
-                target_os = "dragonfly",
-            ))]
+            // (immutable file, unwritable parent dir on a regular file, …) still
+            // propagates.
+            #[cfg(unix)]
             if matches!(errno, E::EPERM | E::EACCES) {
                 // No-follow stat — don't follow symlinks, to match unlinkat.
                 // `z` (a `&ZStr`, `Copy`) is still valid — `unlinkat` only borrowed it.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5289,11 +5289,7 @@ it.skipIf(!isLinux || (process.getuid?.() ?? -1) !== 0)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Each top dir removal still fails (its parent is not writable), but every
     // deletable child must be gone.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5231,3 +5231,75 @@ describe("fs.close on stdio descriptors", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Recursive rm must delete every deletable child depth-first and only then
+// surface a failure removing the top directory itself, matching Node/libuv and
+// POSIX `rm -rf`. Requires root so the harness can hand the subtree to an
+// unprivileged uid whose top directory lives in a parent it cannot write.
+it.skipIf(!isLinux || (process.getuid?.() ?? -1) !== 0)(
+  "fs.rmSync(recursive) removes deletable children even when the top dir cannot be removed",
+  async () => {
+    const NOBODY = 65534;
+    // One subtree per entry point: the sync `fs.rmSync` and the async
+    // `fs.promises.rm` both funnel through the same native recursive walk.
+    using dir = tempDir("rm-partial-eacces", {
+      "sync/a": "x",
+      "sync/b": "x",
+      "sync/sub/c": "x",
+      "async/a": "x",
+      "async/b": "x",
+      "async/sub/c": "x",
+    });
+    const root = String(dir);
+
+    // Parent stays root-owned and searchable but not writable by `nobody`;
+    // each subtree is handed to `nobody` and made writable.
+    fs.chmodSync(root, 0o755);
+    for (const top of ["sync", "async"]) {
+      for (const f of ["a", "b", "sub/c", "sub", ""]) {
+        fs.chownSync(join(root, top, f), NOBODY, NOBODY);
+      }
+      fs.chmodSync(join(root, top), 0o777);
+    }
+
+    const script = `
+      const fs = require("node:fs");
+      const { join } = require("node:path");
+      const root = ${JSON.stringify(root)};
+      const sync = join(root, "sync"), async = join(root, "async");
+      (async () => {
+        process.seteuid(${NOBODY});
+        let syncCode = "ok";
+        try { fs.rmSync(sync, { recursive: true }); } catch (e) { syncCode = e.code; }
+        let asyncCode = "ok";
+        try { await fs.promises.rm(async, { recursive: true }); } catch (e) { asyncCode = e.code; }
+        process.seteuid(0);
+        process.stdout.write(JSON.stringify({
+          syncCode,
+          syncLeft: fs.readdirSync(sync, { recursive: true }).sort(),
+          asyncCode,
+          asyncLeft: fs.readdirSync(async, { recursive: true }).sort(),
+        }));
+      })();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Each top dir removal still fails (its parent is not writable), but every
+    // deletable child must be gone.
+    expect({ stdout: JSON.parse(stdout.trim()), exitCode }).toEqual({
+      stdout: { syncCode: "EACCES", syncLeft: [], asyncCode: "EACCES", asyncLeft: [] },
+      exitCode: 0,
+    });
+  },
+);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5292,9 +5292,11 @@ it.skipIf(!isLinux || (process.getuid?.() ?? -1) !== 0)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Each top dir removal still fails (its parent is not writable), but every
-    // deletable child must be gone.
-    expect({ stdout: JSON.parse(stdout.trim()), exitCode }).toEqual({
-      stdout: { syncCode: "EACCES", syncLeft: [], asyncCode: "EACCES", asyncLeft: [] },
+    // deletable child must be gone. Fall back to stderr if the child crashed
+    // before writing its JSON result, so failures self-diagnose.
+    const result = stdout.trim() ? JSON.parse(stdout.trim()) : { crashed: stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { syncCode: "EACCES", syncLeft: [], asyncCode: "EACCES", asyncLeft: [] },
       exitCode: 0,
     });
   },


### PR DESCRIPTION
## What

Recursive `fs.rmSync` / `fs.rm` (`{ recursive: true }`) on Linux aborted the entire walk when the top directory itself could not be removed, deleting **none** of its deletable children. Node (libuv) and POSIX `rm -rf` delete every deletable child depth-first and only then report the error.

## Repro

Run as root (it drops euid to `nobody` itself):

```js
// rmpartial.mjs
import * as fs from "node:fs";
const R = `/tmp/rmpartial-${process.pid}`;
fs.mkdirSync(R, { mode: 0o755 });                      // root-owned parent, NOT writable by nobody
fs.mkdirSync(`${R}/own`); fs.mkdirSync(`${R}/own/sub`);
for (const f of ["own/a", "own/b", "own/sub/c"]) fs.writeFileSync(`${R}/${f}`, "x");
for (const f of ["own/a", "own/b", "own/sub/c", "own/sub", "own"]) fs.chownSync(`${R}/${f}`, 65534, 65534);
fs.chmodSync(`${R}/own`, 0o777);

process.seteuid(65534);                                // -> nobody
let err = "ok";
try { fs.rmSync(`${R}/own`, { recursive: true }); } catch (e) { err = e.code; }
process.seteuid(0);
console.log("threw:", err, " left behind:",
  JSON.stringify(fs.readdirSync(`${R}/own`, { recursive: true }).sort()));
fs.rmSync(R, { recursive: true, force: true });
```

```
node : threw: EACCES  left behind: []                       <- children removed
bun  : threw: EACCES  left behind: ["a","b","sub","sub/c"]  <- NOTHING removed
```

Same error code, opposite filesystem outcome: cleanup jobs running as a service uid whose top directory sits in a root-owned parent reclaim nothing, silently.

## Cause

The recursive walk (`zig_delete_tree`) optimistically unlinks the top path as a file first, then falls back to directory handling when `unlink(2)` reports `EISDIR`. On Linux, unlinking a directory whose **parent** is not writable fails with `EACCES` *before* the kernel's `EISDIR` check, so the directory fallback never fired and the walk returned immediately, having deleted nothing.

The `EISDIR`-on-permission-error disambiguation in `dt_delete_file` (on a permission error, `lstat` the target and report `EISDIR` if it is a directory) was gated to macOS/BSD only.

## Fix

Extend that disambiguation to all unix. When `unlinkat` without `AT_REMOVEDIR` returns `EPERM`/`EACCES` and the target is actually a directory, report `EISDIR` so the recursive-rm directory fallback fires: the walk recurses into the directory, deletes its contents depth-first, and surfaces the top-level `EACCES` afterwards. A genuine permission error on a regular file still propagates unchanged.

## Verification

New test in `test/js/node/fs/fs.test.ts` covering both the sync (`fs.rmSync`) and async (`fs.promises.rm`) entry points. It reproduces the layout above (requires root, skipped otherwise) and asserts `EACCES` is still thrown while every deletable child is gone.

- Fails on current `bun` (children left behind), passes with the fix.
- Full `fs.test.ts` suite green (380 pass).