### PR TITLE
fs: honor the flag option in appendFile / appendFileSync

### DIFF
--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -493,6 +493,7 @@ impl JSBundleCompletionTask {
                     let write_args = fs_args::WriteFile {
                         encoding: Encoding::Buffer,
                         flag: FileSystemFlags::W,
+                        flag_specified: true,
                         mode: node_fs::DEFAULT_PERMISSION,
                         file: PathOrFileDescriptor::Path(PathLike::String(
                             bun_ptr::cow_slice::CowSlice::init_unchecked(write_path, false),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4198,6 +4198,9 @@ pub mod args {
     pub struct WriteFile {
         pub encoding: Encoding,
         pub flag: FileSystemFlags,
+        /// Whether the caller passed an explicit `flag` option. When false,
+        /// each op applies its own default (`w` for write, `a` for append).
+        pub flag_specified: bool,
         pub mode: Mode,
         pub file: PathOrFileDescriptor,
         pub flush: bool,
@@ -4244,6 +4247,7 @@ pub mod args {
                 .ok_or_else(|| ctx.throw_invalid_arguments(format_args!("data is required")))?;
             let mut encoding = Encoding::Buffer;
             let mut flag = FileSystemFlags::W;
+            let mut flag_specified = false;
             let mut mode: Mode = DEFAULT_PERMISSION;
             let mut abort_signal = scopeguard::guard(None::<AbortSignalRef>, |s| {
                 if let Some(signal) = s {
@@ -4261,7 +4265,10 @@ pub mod args {
                 } else if arg.is_object() {
                     encoding = get_encoding(arg, ctx, encoding)?;
                     if let Some(flag_) = arg.get_truthy(ctx, "flag")? {
-                        flag = FileSystemFlags::from_js(ctx, flag_)?.unwrap_or(flag);
+                        if let Some(parsed) = FileSystemFlags::from_js(ctx, flag_)? {
+                            flag = parsed;
+                            flag_specified = true;
+                        }
                     }
                     if let Some(mode_) = arg.get_truthy(ctx, "mode")? {
                         mode = node::mode_from_js(ctx, mode_)?.unwrap_or(mode);
@@ -4300,6 +4307,7 @@ pub mod args {
                 file: path,
                 encoding,
                 flag,
+                flag_specified,
                 mode,
                 data,
                 dirfd: FD::cwd(),
@@ -4828,26 +4836,16 @@ impl NodeFS {
     }
 
     pub fn append_file(&mut self, args: &args::AppendFile, _: Flavor) -> Maybe<ret::AppendFile> {
-        let mut data = args.data.slice();
-        match &args.file {
-            PathOrFileDescriptor::Fd(fd) => {
-                while !data.is_empty() {
-                    let written = Syscall::write(*fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
-            }
-            PathOrFileDescriptor::Path(path_) => {
-                let path = path_.slice_z(&mut self.sync_error_buf);
-                let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
-                let _close = scopeguard::guard(fd, |fd| fd.close());
-                while !data.is_empty() {
-                    let written = Syscall::write(fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
-            }
-        }
+        // `appendFile` is `writeFile` whose flag defaults to `a` instead of
+        // `w`. An explicit `flag` option is honored as-is (Node does not force
+        // `O_APPEND` on top of it), so `{flag:"wx"}`, `{flag:"w"}`, `{flag:"r+"}`
+        // behave exactly as they would for `writeFile`.
+        let flag = if args.flag_specified {
+            args.flag
+        } else {
+            FileSystemFlags::A
+        };
+        Self::write_file_with_flag(&mut self.sync_error_buf, args, flag)
     }
 
     pub fn close(&mut self, args: &args::Close, _: Flavor) -> Maybe<ret::Close> {
@@ -7414,13 +7412,21 @@ impl NodeFS {
         pathbuf: &mut PathBuffer,
         args: &args::WriteFile,
     ) -> Maybe<ret::WriteFile> {
+        Self::write_file_with_flag(pathbuf, args, args.flag)
+    }
+
+    pub fn write_file_with_flag(
+        pathbuf: &mut PathBuffer,
+        args: &args::WriteFile,
+        flag: FileSystemFlags,
+    ) -> Maybe<ret::WriteFile> {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
                 let path = p.slice_z_with_force_copy::<true>(pathbuf);
                 // O_TRUNC is dropped on purpose: keeping the existing blocks
                 // allocated makes rewriting a large file cheaper, and the resize
                 // below sets the final size. O_APPEND writes at EOF, so it keeps it.
-                let mut flags = args.flag.as_int();
+                let mut flags = flag.as_int();
                 if (flags & sys::O::APPEND) == 0 {
                     flags &= !sys::O::TRUNC;
                 }
@@ -7457,7 +7463,7 @@ impl NodeFS {
                 // the write offset at write() time: an O_APPEND write would land
                 // after the grown end, leaving a hole where the data belongs.
                 let appends = if is_path {
-                    (args.flag.as_int() & sys::O::APPEND) != 0
+                    (flag.as_int() & sys::O::APPEND) != 0
                 } else {
                     // `flag` is the option, not how the caller opened this fd.
                     match sys::get_fcntl_flags(fd) {
@@ -7512,7 +7518,7 @@ impl NodeFS {
         // Resize only when the flags asked to truncate (the open above dropped
         // O_TRUNC): `r+` & co. overwrite in place, and Node never resizes a
         // descriptor it was handed.
-        if (args.flag.as_int() & sys::O::TRUNC) != 0
+        if (flag.as_int() & sys::O::TRUNC) != 0
             && matches!(args.file, PathOrFileDescriptor::Path(_))
         {
             // If this errors, we silently ignore it.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5236,9 +5236,7 @@ describe("appendFile honors the flag option", () => {
   it("appendFileSync { flag: 'wx' } fails with EEXIST on an existing file and does not touch it", () => {
     using dir = tempDir("append-wx", { "f": "0123456789" });
     const file = path.join(String(dir), "f");
-    expect(() => fs.appendFileSync(file, "XX", { flag: "wx" })).toThrow(
-      expect.objectContaining({ code: "EEXIST" }),
-    );
+    expect(() => fs.appendFileSync(file, "XX", { flag: "wx" })).toThrow(expect.objectContaining({ code: "EEXIST" }));
     expect(readFileSync(file, "utf8")).toBe("0123456789");
   });
 
@@ -5252,9 +5250,7 @@ describe("appendFile honors the flag option", () => {
   it("appendFileSync { flag: 'r+' } fails with ENOENT on a missing file and does not create it", () => {
     using dir = tempDir("append-rplus", {});
     const file = path.join(String(dir), "missing");
-    expect(() => fs.appendFileSync(file, "XX", { flag: "r+" })).toThrow(
-      expect.objectContaining({ code: "ENOENT" }),
-    );
+    expect(() => fs.appendFileSync(file, "XX", { flag: "r+" })).toThrow(expect.objectContaining({ code: "ENOENT" }));
     expect(existsSync(file)).toBe(false);
   });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5231,3 +5231,63 @@ describe("fs.close on stdio descriptors", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("appendFile honors the flag option", () => {
+  it("appendFileSync { flag: 'wx' } fails with EEXIST on an existing file and does not touch it", () => {
+    using dir = tempDir("append-wx", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    expect(() => fs.appendFileSync(file, "XX", { flag: "wx" })).toThrow(
+      expect.objectContaining({ code: "EEXIST" }),
+    );
+    expect(readFileSync(file, "utf8")).toBe("0123456789");
+  });
+
+  it("appendFileSync { flag: 'w' } truncates an existing file", () => {
+    using dir = tempDir("append-w", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    fs.appendFileSync(file, "XX", { flag: "w" });
+    expect(readFileSync(file, "utf8")).toBe("XX");
+  });
+
+  it("appendFileSync { flag: 'r+' } fails with ENOENT on a missing file and does not create it", () => {
+    using dir = tempDir("append-rplus", {});
+    const file = path.join(String(dir), "missing");
+    expect(() => fs.appendFileSync(file, "XX", { flag: "r+" })).toThrow(
+      expect.objectContaining({ code: "ENOENT" }),
+    );
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("appendFileSync defaults to appending (flag 'a')", () => {
+    using dir = tempDir("append-default", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    fs.appendFileSync(file, "XX");
+    expect(readFileSync(file, "utf8")).toBe("0123456789XX");
+  });
+
+  it("fs.promises.appendFile honors { flag: 'wx' } on an existing file", async () => {
+    using dir = tempDir("append-promise-wx", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    await expect(fs.promises.appendFile(file, "XX", { flag: "wx" })).rejects.toMatchObject({
+      code: "EEXIST",
+    });
+    expect(readFileSync(file, "utf8")).toBe("0123456789");
+  });
+
+  it("fs.promises.appendFile { flag: 'w' } truncates an existing file", async () => {
+    using dir = tempDir("append-promise-w", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    await fs.promises.appendFile(file, "XX", { flag: "w" });
+    expect(readFileSync(file, "utf8")).toBe("XX");
+  });
+
+  it("callback appendFile honors { flag: 'wx' } on an existing file", async () => {
+    using dir = tempDir("append-cb-wx", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException | null>();
+    fs.appendFile(file, "XX", { flag: "wx" }, resolve);
+    const err = await promise;
+    expect(err?.code).toBe("EEXIST");
+    expect(readFileSync(file, "utf8")).toBe("0123456789");
+  });
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5232,11 +5232,18 @@ describe("fs.close on stdio descriptors", () => {
   });
 });
 
-describe("appendFile honors the flag option", () => {
+describe.concurrent("appendFile honors the flag option", () => {
   it("appendFileSync { flag: 'wx' } fails with EEXIST on an existing file and does not touch it", () => {
     using dir = tempDir("append-wx", { "f": "0123456789" });
     const file = path.join(String(dir), "f");
     expect(() => fs.appendFileSync(file, "XX", { flag: "wx" })).toThrow(expect.objectContaining({ code: "EEXIST" }));
+    expect(readFileSync(file, "utf8")).toBe("0123456789");
+  });
+
+  it("appendFileSync { flag: 'ax' } fails with EEXIST on an existing file and does not touch it", () => {
+    using dir = tempDir("append-ax", { "f": "0123456789" });
+    const file = path.join(String(dir), "f");
+    expect(() => fs.appendFileSync(file, "XX", { flag: "ax" })).toThrow(expect.objectContaining({ code: "EEXIST" }));
     expect(readFileSync(file, "utf8")).toBe("0123456789");
   });
 


### PR DESCRIPTION
### What

`fs.appendFile`, `fs.appendFileSync`, and `fs.promises.appendFile` ignored the caller's `flag` option. The native `append_file` always opened the target with a hard-coded `O_WRONLY | O_APPEND | O_CREAT`, so:

- `{ flag: "wx" }` / `{ flag: "ax" }` on an existing file appended to it instead of failing with `EEXIST`, defeating the documented "create-once / first-writer-wins" guard used by lock files and sentinels.
- `{ flag: "w" }` appended instead of truncating.
- `{ flag: "r+" }` created a missing file instead of failing with `ENOENT`.

### Repro

```js
import * as fs from "node:fs";
const p = `/tmp/af-${process.pid}`;
const reset = () => { fs.rmSync(p, { force: true }); fs.writeFileSync(p, "0123456789"); };

reset(); let r = "ok"; try { fs.appendFileSync(p, "XX", { flag: "wx" }); } catch (e) { r = e.code; }
console.log("wx on EXISTING ->", r, JSON.stringify(fs.readFileSync(p, "utf8")));
// node: EEXIST "0123456789"   bun (before): ok "0123456789XX"

reset(); try { fs.appendFileSync(p, "XX", { flag: "w" }); } catch {}
console.log("w  on EXISTING ->", JSON.stringify(fs.readFileSync(p, "utf8")));
// node: "XX"   bun (before): "0123456789XX"

fs.rmSync(p, { force: true }); r = "ok"; try { fs.appendFileSync(p, "XX", { flag: "r+" }); } catch (e) { r = e.code; }
console.log("r+ on MISSING  ->", r, fs.existsSync(p) ? "created!" : "not created");
// node: ENOENT not created   bun (before): ok created!
```

### Cause

`append_file()` in `src/runtime/node/node_fs.rs` parsed `args.flag` but never used it, opening with the constant `FileSystemFlags::A`.

### Fix

`appendFile` is `writeFile` whose `flag` defaults to `a` instead of `w`. The write path already handles every flag correctly, so `append_file` now routes through that same open logic (`write_file_with_flag`) and applies the `a` default only when the caller did not pass a `flag`. An explicit flag is honored as-is; Node does not force `O_APPEND` on top of a supplied flag, so `wx`/`w`/`r+` behave exactly as they do for `writeFile`. A new `flag_specified` field on the shared args distinguishes an explicit flag from the parser default.

### Verification

New tests in `test/js/node/fs/fs.test.ts` cover `wx`/`w`/`r+`/default across sync, promise, and callback forms. They fail on `main` (6 of 7) and pass with this change; the full `fs.test.ts` suite stays green (386 pass).