### PR TITLE
console: retry on EAGAIN instead of dropping output when stdout is nonblocking

### DIFF
--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -239,12 +239,9 @@ pub extern "C" fn Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(
     {
         this.force_sync.set(true);
         // SAFETY(JsCell): single-field write; does not call into JS.
-        let fd = this.writer.with_mut(|w| {
-            w.force_sync = true;
-            w.get_fd()
-        });
-        if fd != Fd::INVALID {
-            let _ = sys::update_nonblocking(fd, false);
+        this.writer.with_mut(|w| w.force_sync = true);
+        if this.fd.get() != Fd::INVALID {
+            let _ = sys::update_nonblocking(this.fd.get(), false);
         }
     }
     #[cfg(windows)]

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -239,9 +239,12 @@ pub extern "C" fn Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(
     {
         this.force_sync.set(true);
         // SAFETY(JsCell): single-field write; does not call into JS.
-        this.writer.with_mut(|w| w.force_sync = true);
-        if this.fd.get() != Fd::INVALID {
-            let _ = sys::update_nonblocking(this.fd.get(), false);
+        let fd = this.writer.with_mut(|w| {
+            w.force_sync = true;
+            w.get_fd()
+        });
+        if fd != Fd::INVALID {
+            let _ = sys::update_nonblocking(fd, false);
         }
     }
     #[cfg(windows)]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9405,12 +9405,6 @@ fn qw_set_fd(qw: &mut bun_core::output::QuietWriter, fd: Fd) {
 
 /// Best-effort write-all loop. Returns `false` on I/O error / zero-write so
 /// `ScopedLogger::log` can disable the scope; "quiet" callers discard the bool.
-///
-/// fd 1/2 can be flipped to `O_NONBLOCK` out from under this writer when user
-/// code materializes `process.stdout`/`process.stderr` (the node-compat stream
-/// dups the fd and sets the flag on the shared file description). A plain
-/// `write(2)` then fails with `EAGAIN` on a full pipe, so we block on `poll`
-/// until the fd drains rather than silently discarding the remaining bytes.
 fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
     while !bytes.is_empty() {
         match write(fd, bytes) {
@@ -9420,12 +9414,13 @@ fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
             Err(e) if e.get_errno() == E::EINTR => continue,
             #[cfg(unix)]
             Err(e) if e.get_errno() == E::EAGAIN => {
+                // fd 1/2 may be O_NONBLOCK once `process.stdout`/`stderr` is
+                // materialized; block until writable instead of dropping bytes.
                 let mut pfd = [posix::PollFd {
                     fd: fd.native() as core::ffi::c_int,
                     events: posix::POLL_OUT,
                     revents: 0,
                 }];
-                // A real error (e.g. EPIPE) surfaces on the next `write`.
                 let _ = posix::poll(&mut pfd, -1);
             }
             Err(_) => return false,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9421,7 +9421,9 @@ fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
                     events: posix::POLL_OUT,
                     revents: 0,
                 }];
-                let _ = posix::poll(&mut pfd, -1);
+                if posix::poll(&mut pfd, -1).is_err() {
+                    return false;
+                }
             }
             Err(_) => return false,
         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9405,11 +9405,29 @@ fn qw_set_fd(qw: &mut bun_core::output::QuietWriter, fd: Fd) {
 
 /// Best-effort write-all loop. Returns `false` on I/O error / zero-write so
 /// `ScopedLogger::log` can disable the scope; "quiet" callers discard the bool.
+///
+/// fd 1/2 can be flipped to `O_NONBLOCK` out from under this writer when user
+/// code materializes `process.stdout`/`process.stderr` (the node-compat stream
+/// dups the fd and sets the flag on the shared file description). A plain
+/// `write(2)` then fails with `EAGAIN` on a full pipe, so we block on `poll`
+/// until the fd drains rather than silently discarding the remaining bytes.
 fn fd_write_all_quiet(fd: Fd, mut bytes: &[u8]) -> bool {
     while !bytes.is_empty() {
         match write(fd, bytes) {
             Ok(0) => return false, // short write → give up
             Ok(n) => bytes = &bytes[n..],
+            #[cfg(unix)]
+            Err(e) if e.get_errno() == E::EINTR => continue,
+            #[cfg(unix)]
+            Err(e) if e.get_errno() == E::EAGAIN => {
+                let mut pfd = [posix::PollFd {
+                    fd: fd.native() as core::ffi::c_int,
+                    events: posix::POLL_OUT,
+                    revents: 0,
+                }];
+                // A real error (e.g. EPIPE) surfaces on the next `write`.
+                let _ = posix::poll(&mut pfd, -1);
+            }
             Err(_) => return false,
         }
     }

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -157,5 +157,38 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
+  });
+
+  // Materializing process.stdout dups fd 1 and flips it to O_NONBLOCK. The
+  // native console writer must not silently drop data on the resulting EAGAIN
+  // when the pipe is full: every console.log line has to survive a slow reader.
+  test.skipIf(isWindows)("console.log is not lossy after process.stdout is touched on a slow pipe", async () => {
+    const N = 1500;
+    const pad = Buffer.alloc(500, "x").toString();
+    using dir = tempDir("stdout-nonblock-loss", {
+      "child.mjs": `
+        if (process.argv[2] === "touch") void process.stdout.writableHighWaterMark;
+        const pad = ${JSON.stringify(pad)};
+        for (let i = 0; i < ${N}; i++) console.log("O" + i + " " + pad);
+      `,
+    });
+    // The reader starts 400ms late via a shell fifo, so the 64 KiB pipe fills
+    // and write(2) on the now-nonblocking fd 1 returns EAGAIN mid-run.
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        'exec "$0" "$1" touch | { sleep 0.4; exec cat; }',
+        bunExe(),
+        path.join(String(dir), "child.mjs"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const delivered = stdout.split("\n").filter(l => /^O\d+ x+$/.test(l)).length;
+    expect(delivered).toBe(N);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -172,8 +172,10 @@ describe.concurrent("process-stdio", () => {
         for (let i = 0; i < ${N}; i++) console.log("O" + i + " " + pad);
       `,
     });
-    // The reader starts 400ms late via a shell fifo, so the 64 KiB pipe fills
-    // and write(2) on the now-nonblocking fd 1 returns EAGAIN mid-run.
+    // A separate `cat` reader starts 400ms late behind a shell fifo, so the
+    // 64 KiB pipe fills and write(2) on the now-nonblocking fd 1 returns EAGAIN
+    // mid-run. The pipeline's exit status is cat's, not bun's, so the delivered
+    // count is what proves the regression is gone.
     await using proc = Bun.spawn({
       cmd: [
         "/bin/sh",
@@ -186,9 +188,8 @@ describe.concurrent("process-stdio", () => {
       stdout: "pipe",
       stderr: "inherit",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const stdout = await proc.stdout.text();
     const delivered = stdout.split("\n").filter(l => /^O\d+ x+$/.test(l)).length;
     expect(delivered).toBe(N);
-    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -160,46 +160,19 @@ describe.concurrent("process-stdio", () => {
   });
 });
 
-// Materializing process.stdout dups fd 1 and flips it to O_NONBLOCK. The native
-// console writer must not silently drop data on the resulting EAGAIN when the
-// pipe is full. Kept outside the concurrent block so the extra spawned children
-// don't push the already-slow stdin tests past their default timeout.
-describe.skipIf(isWindows)("console.log after process.stdout is materialized on a pipe", () => {
-  test("many lines survive a slow reader", async () => {
-    const N = 1500;
-    const pad = Buffer.alloc(500, "x").toString();
-    using dir = tempDir("stdout-nonblock-loss", {
-      "child.mjs": `
-        if (process.argv[2] === "touch") void process.stdout.writableHighWaterMark;
-        const pad = ${JSON.stringify(pad)};
-        for (let i = 0; i < ${N}; i++) console.log("O" + i + " " + pad);
-      `,
-    });
-    // A separate `cat` reader starts 400ms late behind a shell fifo, so the
-    // 64 KiB pipe fills and write(2) on the now-nonblocking fd 1 returns EAGAIN
-    // mid-run. The pipeline's exit status is cat's, not bun's, so the delivered
-    // count is what proves the regression is gone.
-    await using proc = Bun.spawn({
-      cmd: [
-        "/bin/sh",
-        "-c",
-        'exec "$0" "$1" touch | { sleep 0.4; exec cat; }',
-        bunExe(),
-        path.join(String(dir), "child.mjs"),
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const stdout = await proc.stdout.text();
-    const delivered = stdout.split("\n").filter(l => /^O\d+ x+$/.test(l)).length;
-    expect(delivered).toBe(N);
-  });
+// Materializing process.stdout / process.stderr puts O_NONBLOCK on the shared
+// open file description of fd 1 / fd 2. The native console writer behind
+// console.log / console.error must then retry on EAGAIN instead of dropping the
+// unwritten tail. A single 1 MiB write is larger than any pipe buffer, so the
+// first write(2) is always short and the next one always sees EAGAIN: the
+// unfixed binary delivers exactly one pipe buffer no matter how fast the reader
+// is, which keeps these deterministic without a sleeping reader. Kept outside the
+// concurrent block above so the extra children don't push the stdin tests past
+// their timeout.
+describe.skipIf(isWindows)("console output is not truncated once the stdio fd is nonblocking", () => {
+  const ONE_MIB_LINE = (1 << 20) + 1;
 
-  test("a single 1 MiB line is not truncated", async () => {
-    // A single 1 MiB write into even a fast `| wc -c` reader exceeds the 64 KiB
-    // pipe, so write(2) on the now-nonblocking fd 1 returns a partial count and
-    // then EAGAIN before the reader drains.
+  test("console.log after touching process.stdout", async () => {
     await using proc = Bun.spawn({
       cmd: [
         "/bin/sh",
@@ -211,50 +184,68 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
       stdout: "pipe",
       stderr: "inherit",
     });
-    const stdout = (await proc.stdout.text()).trim();
-    expect(Number(stdout)).toBe((1 << 20) + 1);
+    expect(Number((await proc.stdout.text()).trim())).toBe(ONE_MIB_LINE);
   });
 
-  test("parent console.log survives a bun child that touches inherited stdout", async () => {
-    // O_NONBLOCK lives on the shared open file description. A bun child with
-    // stdio:'inherit' that materializes its process.stdout flips the PARENT's
-    // fd 1 too; the parent's console writer must still deliver every line.
-    using dir = tempDir("stdout-nonblock-child-inherit", {
-      "parent.mjs": `
-        const { spawnSync } = require("node:child_process");
-        const r = spawnSync(process.execPath, ["-e", 'process.stdout.write("")'],
-                            { stdio: ["ignore", "inherit", "ignore"] });
-        if (r.error || r.status !== 0) throw new Error("child failed: " + (r.error ?? r.status));
-        const pad = Buffer.alloc(190, 120).toString();
-        for (let i = 0; i < 20000; i++) console.log("O" + i + " " + pad);
-      `,
-    });
-    await using proc = Bun.spawn({
-      cmd: ["/bin/sh", "-c", 'exec "$0" "$1" | { sleep 1; wc -l; }', bunExe(), path.join(String(dir), "parent.mjs")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const stdout = (await proc.stdout.text()).trim();
-    expect(Number(stdout)).toBe(20000);
-  });
-
-  test("console.log survives a raw O_NONBLOCK on fd 1 (isolates the writer)", async () => {
-    // Bun.file(1).writer() goes through FileSink.setup (dup + O_NONBLOCK) but is
-    // NOT the process.stdout getter path, so ForceFileSinkToBeSynchronous never
-    // clears the flag. This isolates fd_write_all_quiet's EAGAIN handling.
+  test("console.error after touching process.stderr", async () => {
     await using proc = Bun.spawn({
       cmd: [
         "/bin/sh",
         "-c",
-        'exec "$0" -e "void Bun.file(1).writer(); console.log(Buffer.alloc(1<<20, 65).toString())" | { sleep 0.4; exec wc -c; }',
+        'exec "$0" -e "void process.stderr.isTTY; console.error(Buffer.alloc(1<<20, 66).toString())" 2>&1 >/dev/null | wc -c',
         bunExe(),
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",
     });
-    const stdout = (await proc.stdout.text()).trim();
-    expect(Number(stdout)).toBe((1 << 20) + 1);
+    expect(Number((await proc.stdout.text()).trim())).toBe(ONE_MIB_LINE);
+  });
+
+  test("console.log in a parent after a bun child touched the inherited stdout", async () => {
+    // The flag lives on the open file description, so a child with
+    // stdio: 'inherit' that touches its process.stdout flips the parent's fd 1
+    // too, even though the parent never touched its own stream.
+    using dir = tempDir("stdout-nonblock-inherited", {
+      "parent.ts": `
+        const r = Bun.spawnSync({
+          cmd: [process.execPath, "-e", 'process.stdout.write("")'],
+          stdout: "inherit",
+        });
+        if (!r.success) throw new Error("child failed: " + r.exitCode);
+        console.log(Buffer.alloc(1 << 20, 65).toString());
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", 'exec "$0" "$1" | wc -c', bunExe(), path.join(String(dir), "parent.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    expect(Number((await proc.stdout.text()).trim())).toBe(ONE_MIB_LINE);
+  });
+
+  test("process.stdout.write to a pipe stays asynchronous", async () => {
+    // Pins the contract the console-writer fix must not disturb: like node, a
+    // write larger than the pipe returns false immediately and emits 'drain'
+    // once the reader catches up, rather than blocking the JS thread.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const ret = process.stdout.write(Buffer.alloc(1 << 20, 65));
+          process.stdout.once("drain", () => {
+            process.stderr.write(JSON.stringify({ ret, drained: true }));
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.bytes(), proc.stderr.text()]);
+    expect(stdout.byteLength).toBe(1 << 20);
+    expect(JSON.parse(stderr)).toEqual({ ret: false, drained: true });
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,11 +158,14 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
+});
 
-  // Materializing process.stdout dups fd 1 and flips it to O_NONBLOCK. The
-  // native console writer must not silently drop data on the resulting EAGAIN
-  // when the pipe is full: every console.log line has to survive a slow reader.
-  test.skipIf(isWindows)("console.log is not lossy after process.stdout is touched on a slow pipe", async () => {
+// Materializing process.stdout dups fd 1 and flips it to O_NONBLOCK. The native
+// console writer must not silently drop data on the resulting EAGAIN when the
+// pipe is full. Kept outside the concurrent block so the extra spawned children
+// don't push the already-slow stdin tests past their default timeout.
+describe.skipIf(isWindows)("console.log after process.stdout is materialized on a pipe", () => {
+  test("many lines survive a slow reader", async () => {
     const N = 1500;
     const pad = Buffer.alloc(500, "x").toString();
     using dir = tempDir("stdout-nonblock-loss", {
@@ -191,5 +194,24 @@ describe.concurrent("process-stdio", () => {
     const stdout = await proc.stdout.text();
     const delivered = stdout.split("\n").filter(l => /^O\d+ x+$/.test(l)).length;
     expect(delivered).toBe(N);
+  });
+
+  test("a single 1 MiB line is not truncated", async () => {
+    // A single 1 MiB write into even a fast `| wc -c` reader exceeds the 64 KiB
+    // pipe, so write(2) on the now-nonblocking fd 1 returns a partial count and
+    // then EAGAIN before the reader drains.
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        'exec "$0" -e "void process.stdout.isTTY; console.log(Buffer.alloc(1<<20, 65).toString())" | wc -c',
+        bunExe(),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const stdout = (await proc.stdout.text()).trim();
+    expect(Number(stdout)).toBe((1 << 20) + 1);
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -229,13 +229,7 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
       `,
     });
     await using proc = Bun.spawn({
-      cmd: [
-        "/bin/sh",
-        "-c",
-        'exec "$0" "$1" | { sleep 1; wc -l; }',
-        bunExe(),
-        path.join(String(dir), "parent.mjs"),
-      ],
+      cmd: ["/bin/sh", "-c", 'exec "$0" "$1" | { sleep 1; wc -l; }', bunExe(), path.join(String(dir), "parent.mjs")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "inherit",

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -238,4 +238,23 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
     const stdout = (await proc.stdout.text()).trim();
     expect(Number(stdout)).toBe(20000);
   });
+
+  test("console.log survives a raw O_NONBLOCK on fd 1 (isolates the writer)", async () => {
+    // Bun.file(1).writer() goes through FileSink.setup (dup + O_NONBLOCK) but is
+    // NOT the process.stdout getter path, so ForceFileSinkToBeSynchronous never
+    // clears the flag. This isolates fd_write_all_quiet's EAGAIN handling.
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        'exec "$0" -e "void Bun.file(1).writer(); console.log(Buffer.alloc(1<<20, 65).toString())" | wc -c',
+        bunExe(),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const stdout = (await proc.stdout.text()).trim();
+    expect(Number(stdout)).toBe((1 << 20) + 1);
+  });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -247,7 +247,7 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
       cmd: [
         "/bin/sh",
         "-c",
-        'exec "$0" -e "void Bun.file(1).writer(); console.log(Buffer.alloc(1<<20, 65).toString())" | wc -c',
+        'exec "$0" -e "void Bun.file(1).writer(); console.log(Buffer.alloc(1<<20, 65).toString())" | { sleep 0.4; exec wc -c; }',
         bunExe(),
       ],
       env: bunEnv,

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -214,4 +214,33 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
     const stdout = (await proc.stdout.text()).trim();
     expect(Number(stdout)).toBe((1 << 20) + 1);
   });
+
+  test("parent console.log survives a bun child that touches inherited stdout", async () => {
+    // O_NONBLOCK lives on the shared open file description. A bun child with
+    // stdio:'inherit' that materializes its process.stdout flips the PARENT's
+    // fd 1 too; the parent's console writer must still deliver every line.
+    using dir = tempDir("stdout-nonblock-child-inherit", {
+      "parent.mjs": `
+        const { spawnSync } = require("node:child_process");
+        spawnSync(process.execPath, ["-e", 'process.stdout.write("")'],
+                  { stdio: ["ignore", "inherit", "ignore"] });
+        const pad = Buffer.alloc(190, 120).toString();
+        for (let i = 0; i < 20000; i++) console.log("O" + i + " " + pad);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        "/bin/sh",
+        "-c",
+        'exec "$0" "$1" | { sleep 1; wc -l; }',
+        bunExe(),
+        path.join(String(dir), "parent.mjs"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const stdout = (await proc.stdout.text()).trim();
+    expect(Number(stdout)).toBe(20000);
+  });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -222,8 +222,9 @@ describe.skipIf(isWindows)("console.log after process.stdout is materialized on 
     using dir = tempDir("stdout-nonblock-child-inherit", {
       "parent.mjs": `
         const { spawnSync } = require("node:child_process");
-        spawnSync(process.execPath, ["-e", 'process.stdout.write("")'],
-                  { stdio: ["ignore", "inherit", "ignore"] });
+        const r = spawnSync(process.execPath, ["-e", 'process.stdout.write("")'],
+                            { stdio: ["ignore", "inherit", "ignore"] });
+        if (r.error || r.status !== 0) throw new Error("child failed: " + (r.error ?? r.status));
         const pad = Buffer.alloc(190, 120).toString();
         for (let i = 0; i < 20000; i++) console.log("O" + i + " " + pad);
       `,


### PR DESCRIPTION
## Problem

Once `process.stdout` or `process.stderr` has been touched (reading `.isTTY`, any `write`, etc.), `console.log` / `console.error` to a pipe silently drop output when the pipe is momentarily full. Exit code stays 0 and nothing is reported.

```js
void process.stdout.isTTY;
console.log(Buffer.alloc(1 << 20, "A").toString());
// piped to `wc -c`: node prints 1048577, bun prints one pipe buffer (8192 to 65536) and exits 0.
```

The same thing happens to a bun parent that never touched its own stream, if a child it spawned with inherited stdio touched its `process.stdout`: the `O_NONBLOCK` flag lives on the shared open file description. `bun test --parallel` builds this topology itself and loses worker output.

## Cause

Materializing `process.stdout` creates the FileSink on a `dup` of fd 1 and puts `O_NONBLOCK` on the shared description (`open_for_writing`). The native console writer behind `console.*` is a separate writer on the same fd; its write loop, `fd_write_all_quiet` in `src/sys/lib.rs`, treated the resulting `EAGAIN` like any other error and returned, discarding the unwritten tail.

## Fix

`fd_write_all_quiet` now retries on `EINTR` and, on `EAGAIN`, waits for `POLLOUT` and retries; a `poll` failure or any other write error still ends the loop as before. This restores the blocking-write semantics `console.*` has when the fd is blocking, independent of who flipped the flag (this process, a bun child, or any other program sharing the description).

`process.stdout.write()` itself is unchanged: it keeps returning `false` and emitting `drain` on a full pipe, as on main and in node. An earlier revision of this PR also made `ForceFileSinkToBeSynchronousForProcessObjectStdio` clear `O_NONBLOCK`; that turned `process.stdout.write()` to pipes into a blocking call and has been dropped (see alii's review). A test now pins the async contract.

The flag itself is therefore still set on fd 1 / fd 2 after `process.stdout` / `process.stderr` is materialized. This PR makes bun's own console writer correct under it; a non-bun child that inherits the fd and does plain `write(2)` (alii's `head -c` example) is unchanged and out of scope here, since clearing the flag is what regressed `write()`.

## Tests

`test/js/node/process/process-stdio.test.ts`, POSIX only. Each loss test writes a single 1 MiB line, which exceeds any pipe buffer, so the unfixed binary fails deterministically with no reader delay:

| test | unfixed | fixed |
| --- | --- | --- |
| `console.log` after touching `process.stdout`, into `wc -c` | 8193 | 1048577 |
| `console.error` after touching `process.stderr`, into `wc -c` | 8192 | 1048577 |
| parent `console.log` after a bun child with inherited stdout touched its stream | 8192 | 1048577 |
| `process.stdout.write(1 MiB)` to a pipe returns `false` and emits `drain` | passes | passes (fails with the dropped FileSink change) |

Verified separately (not in CI, timing dependent): the `bun test --parallel=4` fixture from the report goes from losing 29 to 71 percent of worker `console.log` lines to losing none.
