### PR TITLE
node:fs: close(0/1/2) must actually close the descriptor

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -761,22 +761,6 @@ mod _async_tasks {
                 NodeFSFunctionEnum::Close => {
                     let args: &args::Close = args_as!(args::Close);
                     let fd = args.fd.uv();
-                    if fd == 1 || fd == 2 {
-                        sys::syslog!("uv close({}) SKIPPED", fd);
-                        // SAFETY: identity write — `R == ret::Close == ()` for this `F`.
-                        unsafe {
-                            core::ptr::write(
-                                &mut task.result as *mut Maybe<R> as *mut Maybe<ret::Close>,
-                                Ok(()),
-                            )
-                        };
-                        let task_ptr: *mut Self = task;
-                        task.global_object()
-                            .bun_vm()
-                            .event_loop_mut()
-                            .enqueue_task(Task::init(task_ptr));
-                        return task.promise.value();
-                    }
                     // SAFETY: libuv async request.
                     let rc = unsafe {
                         uv::uv_fs_close(loop_, &mut task.req, fd, Some(Self::uv_callback))
@@ -4867,7 +4851,10 @@ impl NodeFS {
     }
 
     pub fn close(&mut self, args: &args::Close, _: Flavor) -> Maybe<ret::Close> {
-        if let Some(err) = args.fd.close_allowing_bad_file_descriptor(None) {
+        // Explicit `fs.close`/`fs.closeSync` must close the descriptor the user
+        // asked for, including stdio (0/1/2), and surface EBADF like Node does.
+        // The stdio guard only applies to Bun's own internal closes.
+        if let Some(err) = args.fd.close_allowing_standard_io(None) {
             Err(err)
         } else {
             Ok(())

--- a/src/sys/fd.rs
+++ b/src/sys/fd.rs
@@ -53,14 +53,14 @@ pub trait FdExt: Copy + Sized {
     /// as you see EBADF errors in unrelated places.
     fn close(self);
     /// fd function will NOT CLOSE stdin/stdout/stderr.
-    /// Use fd API to implement `node:fs` close.
     /// Prefer asserting that EBADF does not happen with `.close()`.
     fn close_allowing_bad_file_descriptor(
         self,
         return_address: Option<usize>,
     ) -> Option<sys::Error>;
     /// fd allows you to close standard io. It also returns the error.
-    /// Consider fd the raw close method.
+    /// Use fd API to implement `node:fs` close: stdio must actually close and
+    /// EBADF must surface to the caller. Consider fd the raw close method.
     fn close_allowing_standard_io(self, return_address: Option<usize>) -> Option<sys::Error>;
     /// Assumes given a valid file descriptor. If error, the handle has not been closed.
     fn make_lib_uv_owned(self) -> Result<Fd, MakeLibUvOwnedError>;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5205,7 +5205,9 @@ describe("fs.close on stdio descriptors", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("closeSync throws EBADF on a double close of fd 2", async () => {
+  // On Windows, libuv's fs__close no-ops for fd <= 2 (as does Node), so the
+  // descriptor is never really closed and the second close cannot raise EBADF.
+  it.skipIf(isWindows)("closeSync throws EBADF on a double close of fd 2", async () => {
     using dir = tempDir("fs-close-stdio-dbl", {
       "double-close-fixture.mjs": `
         import fs from "node:fs";

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5173,3 +5173,59 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
   expect(detachedDuringOptions).toBe(false);
   expect(readFileSync(file, "utf8")).toBe("hello world");
 });
+
+describe("fs.close on stdio descriptors", () => {
+  it.skipIf(isWindows)("closeSync(2) actually closes fd 2 and allows redirect", async () => {
+    using dir = tempDir("fs-close-stdio", {
+      "redirect-fixture.mjs": `
+        import fs from "node:fs";
+        fs.writeSync(2, "PRE.");
+        fs.closeSync(2);
+        const fd = fs.openSync(process.argv[2], "w");
+        // On POSIX, open() returns the lowest free descriptor. fd 2 was just
+        // closed, so reopening must hand it back.
+        process.stdout.write(String(fd));
+        fs.writeSync(2, "POST.");
+      `,
+    });
+    const redirected = path.join(String(dir), "redirected.txt");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(dir), "redirect-fixture.mjs"), redirected],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("2");
+    // Writes after the reopen land in the new file; the original stderr pipe
+    // only keeps the byte written before the close.
+    expect(stderr).toBe("PRE.");
+    expect(readFileSync(redirected, "utf8")).toBe("POST.");
+    expect(exitCode).toBe(0);
+  });
+
+  it("closeSync throws EBADF on a double close of fd 2", async () => {
+    using dir = tempDir("fs-close-stdio-dbl", {
+      "double-close-fixture.mjs": `
+        import fs from "node:fs";
+        fs.closeSync(2);
+        try {
+          fs.closeSync(2);
+          console.log("no-throw");
+        } catch (e) {
+          console.log(e.code);
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(dir), "double-close-fixture.mjs")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("EBADF");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`fs.close(fd)` / `fs.closeSync(fd)` on the standard descriptors 0, 1, 2 was a silent no-op. The `node:fs` close path went through `close_allowing_bad_file_descriptor`, which early-returns for any descriptor carrying a stdio tag:

```rust
fn close_allowing_bad_file_descriptor(self, ...) -> Option<sys::Error> {
    if self.stdio_tag().is_some() {
        log!("close({}) SKIPPED", self);
        return None;   // reports success, closes nothing
    }
    ...
}
```

That guard exists to protect Bun's own internal closes (Bun holds fds 0-2), but it was also applied to the explicit user-facing `node:fs` close, which diverges from Node.

### Repro

```js
// redirect.mjs
import fs from "node:fs";
fs.writeSync(2, "PRE.");
fs.closeSync(2);                       // node: closes fd 2. bun: no-op
const fd = fs.openSync("/tmp/out.txt", "w");
console.log("openSync returned fd", fd); // node: 2   bun (before): 11
fs.writeSync(2, "POST.");              // node: out.txt   bun (before): original stderr
```

Before this change: `closeSync(2)` did nothing, `openSync` returned a fresh high fd instead of reusing 2, writes to fd 2 kept landing on the original stderr, and a double `closeSync(2)` never raised `EBADF`.

## Cause

The explicit `node:fs` close reused the internal helper that skips stdio descriptors, so the descriptor the user asked to close stayed open and the call reported success.

## Fix

Route the explicit `node:fs` close through `close_allowing_standard_io`, which performs the real `close(2)` syscall and propagates `EBADF`. The stdio guard is kept for Bun's internal closes. The Windows async libuv close path carried the same `fd == 1 || fd == 2` skip and is removed as well.

After the fix, closing a stdio fd behaves like Node: the descriptor is really closed, `openSync` reuses the freed number, raw `fs.writeSync(fd, ...)` follows the reopened descriptor, and a double close throws `EBADF`.

## Verification

`test/js/node/fs/fs.test.ts`:

- `closeSync(2)` followed by `openSync` reuses fd 2; a subsequent `writeSync(2, ...)` lands in the reopened file while the original stderr keeps only the pre-close bytes.
- A double `closeSync(2)` throws `EBADF`.

Fails on the released binary (`openSync` returns 11, double close is silent), passes on this build.
