### PR TITLE
node:vm: keep already-linked modules linked when a later link() fails

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -703,10 +703,36 @@ bool NodeVMModule::hasAsyncGraph() const
     return false;
 }
 
-// After record->link() succeeds, every reachable record in the graph is
-// linked, but only the root wrapper's status was updated. Mirror the record
-// state onto the dependency wrappers (Node's module status reflects the V8
-// record status, so dependencies read "linked" after the root instantiates).
+// Whether this module's existing record has reached LINKED (or beyond). A
+// source-text record tracks this via CyclicModuleRecord::Status; a synthetic
+// record is fully linked the moment it is created.
+static bool recordReachedLinked(NodeVMModule* module)
+{
+    if (auto* sourceText = dynamicDowncast<NodeVMSourceTextModule>(module)) {
+        JSC::JSModuleRecord* record = sourceText->moduleRecordIfExists();
+        if (!record)
+            return false;
+        using RecordStatus = JSC::CyclicModuleRecord::Status;
+        switch (record->status()) {
+        case RecordStatus::Linked:
+        case RecordStatus::Evaluating:
+        case RecordStatus::EvaluatingAsync:
+        case RecordStatus::Evaluated:
+            return true;
+        default:
+            return false;
+        }
+    }
+    if (auto* synthetic = dynamicDowncast<NodeVMSyntheticModule>(module))
+        return synthetic->hasModuleRecord();
+    return false;
+}
+
+// Mirror the record status onto the dependency wrappers (Node's module status
+// reflects the V8 record status). Runs whether or not record->link() threw: per
+// the ES Link() algorithm, a dependency whose own instantiation already
+// completed stays LINKED even when a later importer aborts linking, and only
+// modules still on the linking stack revert to UNLINKED.
 void NodeVMModule::propagateLinked()
 {
     WTF::HashSet<NodeVMModule*> visited;
@@ -718,7 +744,7 @@ void NodeVMModule::propagateLinked()
         if (!visited.add(module).isNewEntry)
             continue;
 
-        if (module->status() == Status::Unlinked)
+        if (module->status() == Status::Unlinked && recordReachedLinked(module))
             module->status(Status::Linked);
 
         for (const auto& dependency : module->m_resolveCache.values()) {

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -471,10 +471,13 @@ JSValue NodeVMSourceTextModule::instantiate(JSGlobalObject* globalObject)
         record->setStatus(JSC::CyclicModuleRecord::Status::Unlinked);
 
     record->link(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, {});
 
-    status(Status::Linked);
+    // Mirror the record status onto this wrapper and its dependencies even when
+    // link() threw: JSC reverts only the modules still on the linking stack to
+    // UNLINKED, so a dependency whose own instantiation completed stays LINKED
+    // and must remain independently evaluable (matches Node's vm module).
     propagateLinked();
+    RETURN_IF_EXCEPTION(scope, {});
     return jsUndefined();
 }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1176,4 +1176,38 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(stdout.trim()).toBe("ab=B ba=A");
     expect(exitCode).toBe(0);
   });
+
+  test("a failed link() leaves already-linked dependencies linked and evaluable", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const leaf = new vm.SourceTextModule("export const other = 1;", { identifier: "leaf" });
+      const root = new vm.SourceTextModule("import { nope } from 'l';", { identifier: "root" });
+      try {
+        await root.link(() => leaf);
+        console.log("link did not throw");
+      } catch (e) {
+        console.log("link threw " + e.constructor.name);
+      }
+      console.log("statuses " + root.status + " " + leaf.status);
+      try {
+        await leaf.evaluate();
+        console.log("leaf evaluated");
+      } catch (e) {
+        console.log("leaf.evaluate rejected " + e.code);
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["link threw SyntaxError", "statuses unlinked linked", "leaf evaluated"]);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## What

When `vm.SourceTextModule.link()` fails, Bun reset every already-linked member of the dependency graph back to `"unlinked"`. Per the ES `Link()` algorithm (and Node), only modules still on the linking stack revert to `unlinked`; a dependency whose own instantiation already completed stays `"linked"` and remains independently evaluable.

### Repro

```js
import * as vm from "node:vm";
const leaf = new vm.SourceTextModule("export const other=1;", { identifier: "leaf" });
const root = new vm.SourceTextModule("import {nope} from 'l';", { identifier: "root" }); // 'nope' is not exported
try { await root.link(() => leaf); } catch (e) { console.log("link threw", e.constructor.name); }
console.log("statuses", root.status, leaf.status);
try { await leaf.evaluate(); console.log("leaf evaluated fine"); }
catch (e) { console.log("leaf.evaluate() rejected", e.code); }
```

```
node --experimental-vm-modules :  link threw SyntaxError / statuses unlinked linked   / leaf evaluated fine
bun (before)                   :  link threw SyntaxError / statuses unlinked unlinked / leaf.evaluate() rejected ERR_VM_MODULE_STATUS
bun (after)                    :  link threw SyntaxError / statuses unlinked linked   / leaf evaluated fine
```

The documented linker pattern reuses a shared specifier to module cache across graphs. Before this fix, one importer that failed to link would silently drop every already-linked module it touched to `unlinked`, so later `evaluate()` calls on those cached modules rejected with `ERR_VM_MODULE_STATUS`.

## Cause

JSC's `CyclicModuleRecord::link()` already follows the spec: on an abrupt completion it reverts only the modules left on the linking stack (`[[Status]] === "linking"`), leaving dependencies that reached `linked` alone. Bun's `node:vm` wrapper, however, only mirrored the record status onto the dependency wrappers via `propagateLinked()` on success. When `record->link()` threw, `instantiate()` returned early, so a dependency whose record actually reached `linked` was left reporting `"unlinked"`.

## Fix

`NodeVMSourceTextModule::instantiate()` now calls `propagateLinked()` whether or not `record->link()` threw, and `propagateLinked()` promotes a wrapper to `linked` only when its underlying record actually reached `linked` (or beyond). A failed importer's own record stays `unlinked`, so its wrapper stays `unlinked`; a dependency whose record reached `linked` is reported as `linked` and stays evaluable.

## Verification

- New regression test in `test/js/node/vm/vm.test.ts` ("a failed link() leaves already-linked dependencies linked and evaluable"). Fails on the released binary (`statuses unlinked unlinked` / `leaf.evaluate rejected ERR_VM_MODULE_STATUS`), passes with the fix.
- `test/js/node/vm/vm.test.ts`: 206 pass, 0 fail.
- All `test/js/node/test/parallel/test-vm-module-*.js` pass.