### PR TITLE
node:vm: thread SourceTextModule identifier into stack frames and fix lineOffset

### DIFF
--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -93,19 +93,25 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, dynamicImportCallback, moduleWrapper));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    WTF::String identifier = identifierValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
     SourceOrigin sourceOrigin { {}, *fetcher };
 
     WTF::String sourceText = sourceTextValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, String {}, SourceTaintedOrigin::Untainted,
+    // The identifier is the module's only debugging handle (there is no file
+    // behind it), so thread it through as the source-provider URL the way
+    // vm.Script threads filename, matching Node's stack frames.
+    Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, String { identifier }, SourceTaintedOrigin::Untainted,
         TextPosition { OrdinalNumber::fromZeroBasedInt(lineOffset), OrdinalNumber::fromZeroBasedInt(columnOffset) }, SourceProviderSourceType::Module);
 
-    SourceCode sourceCode(WTF::move(sourceProvider), lineOffset, columnOffset);
-
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    WTF::String identifier = identifierValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    // JSC's module program line base is one less than its program base for an
+    // identical SourceCode, so bias firstLine by one to match Node's 1-based
+    // lineOffset convention (lineOffset 10 reports line 11, as vm.Script does).
+    SourceCode sourceCode(WTF::move(sourceProvider), lineOffset + 1, columnOffset);
     NodeVMSourceTextModule* ptr = new (NotNull, allocateCell<NodeVMSourceTextModule>(vm)) NodeVMSourceTextModule(
         vm, zigGlobalObject->NodeVMSourceTextModuleStructure(), WTF::move(identifier), contextValue,
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,58 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+test("node:vm SourceTextModule stack frames carry the identifier and honor lineOffset", async () => {
+  // A SourceTextModule has no file behind it, so its identifier is the only
+  // handle a stack frame can show. Frames (from exported functions and from the
+  // module's own evaluation errors) must show the identifier instead of
+  // "unknown", and lineOffset must be applied with Node's 1-based convention.
+  const fixture = `
+    const vm = require("node:vm");
+    (async () => {
+      const results = [];
+      const src = "export function f(){ throw new Error('L') }";
+      for (const [tag, opts] of [
+        ["identifier", { identifier: "myid.mjs" }],
+        ["offsets", { identifier: "off.mjs", lineOffset: 10 }],
+        ["default", {}],
+      ]) {
+        const m = new vm.SourceTextModule(src, opts);
+        await m.link(() => { throw new Error("no imports"); });
+        await m.evaluate();
+        try {
+          m.namespace.f();
+        } catch (e) {
+          results.push(tag + " " + String(e.stack).split("\\n")[1].trim());
+        }
+      }
+      const m2 = new vm.SourceTextModule("\\n\\nnull.x", { identifier: "boom.mjs" });
+      await m2.link(() => { throw new Error("no imports"); });
+      try {
+        await m2.evaluate();
+      } catch (e) {
+        results.push("evalerr " + String(e.stack).split("\\n").find(l => /at /.test(l)).trim());
+      }
+      console.log(results.join("\\n"));
+    })();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  // Column numbers differ between engines, so match the identifier and line.
+  expect(lines[0]).toMatch(/^identifier at .*\bmyid\.mjs:1:\d+/);
+  expect(lines[1]).toMatch(/^offsets at .*\boff\.mjs:11:\d+/);
+  expect(lines[2]).toMatch(/^default at .*\bvm:module\(\d+\):1:\d+/);
+  expect(lines[3]).toMatch(/^evalerr at .*\bboom\.mjs:3:\d+/);
+  expect(stdout).not.toContain("unknown");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What

Stack traces from code inside a `vm.SourceTextModule` never carried the module's `identifier`, so every frame symbolized as `unknown`, and `lineOffset` was applied one line short of Node.

```js
import * as vm from "node:vm";
const src = "export function f(){ throw new Error('L') }";
for (const [tag, opts] of [
  ["identifier", { identifier: "myid.mjs" }],
  ["offsets", { identifier: "off.mjs", lineOffset: 10 }],
  ["default", {}],
]) {
  const m = new vm.SourceTextModule(src, opts);
  await m.link(() => { throw 0; });
  await m.evaluate();
  try { m.namespace.f(); } catch (e) { console.log(tag, String(e.stack).split("\n")[1].trim()); }
}
```

|          | Node `--experimental-vm-modules` | Bun (before) |
| -------- | -------------------------------- | ------------ |
| identifier | `at Module.f (myid.mjs:1:28)` | `at f (unknown:1:37)` |
| offsets  | `at Module.f (off.mjs:11:28)` | `at f (unknown:10:37)` |
| default  | `at Module.f (vm:module(0):1:28)` | `at f (unknown:1:37)` |

### Cause

`NodeVMSourceTextModule::create` built the `StringSourceProvider` with an empty source URL and dropped the `identifier`, so `codeBlock()->ownerExecutable()->sourceURL()` (what a stack frame reports) was empty and fell back to `unknown`. Separately, JSC's module program line base is one less than its program base for an identical `SourceCode`, so the zero-based `lineOffset` landed one line short of Node's 1-based convention (the sibling `vm.Script` path does not hit this because it reports against the program base).

### Fix

- Pass the `identifier` through as the source-provider URL, the same way `vm.Script` threads `filename`. This fixes frames from exported functions and from the module's own evaluation errors.
- Bias `firstLine` by one so `lineOffset` matches Node (`lineOffset: 10` now reports line 11, as `vm.Script` does). `lineOffset: 0` is unchanged because JSC clamps `firstLine` to a minimum of 1.

### Verification

New test in `test/js/node/vm/vm.test.ts` asserts the identifier and line appear in frames for exported-function throws, `lineOffset`, the default `vm:module(N)` name, and module evaluation errors. Fails on the released binary (`unknown:1:37`), passes with the fix. Column numbers still differ between JSC and V8 and are not asserted.