### PR TITLE
Prevent deadlock in process.setuid/seteuid family on Linux

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -52,6 +52,7 @@
 
 #include <webcore/SerializedScriptValue.h>
 #include "ProcessBindingTTYWrap.h"
+#include "wtf/Threading.h"
 #include "wtf/text/ASCIILiteral.h"
 #include "wtf/text/StringToIntegerConversion.h"
 #include "wtf/text/OrdinalNumber.h"
@@ -3086,6 +3087,18 @@ static JSValue maybe_gid_by_name(JSC::ThrowScope& throwScope, JSGlobalObject* gl
     return {};
 }
 
+// glibc/musl set*id() broadcast a realtime signal to every thread and block on a
+// barrier; a thread JSC/libpas has signal-suspended can't ack it and wedges the
+// process. Holding the thread-suspend lock guarantees no thread is suspended here.
+template<typename Function>
+static ALWAYS_INLINE int callWithoutThreadSuspension(Function&& function)
+{
+#if OS(LINUX)
+    WTF::ThreadSuspendLocker suspendLocker;
+#endif
+    return function();
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionsetuid, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3098,7 +3111,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetuid, (JSGlobalObject * globalObject,
     if (is_number) Bun::V::validateInteger(scope, globalObject, value, "id"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &id);
     if (!is_number) id = value.toUInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto result = setuid(id);
+    auto result = callWithoutThreadSuspension([&] { return setuid(id); });
     if (result != 0) throwSystemError(scope, globalObject, "setuid"_s, errno);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));
@@ -3116,7 +3129,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionseteuid, (JSGlobalObject * globalObject
     if (is_number) Bun::V::validateInteger(scope, globalObject, value, "id"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &id);
     if (!is_number) id = value.toUInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto result = seteuid(id);
+    auto result = callWithoutThreadSuspension([&] { return seteuid(id); });
     if (result != 0) throwSystemError(scope, globalObject, "seteuid"_s, errno);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));
@@ -3134,7 +3147,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetegid, (JSGlobalObject * globalObject
     if (is_number) Bun::V::validateInteger(scope, globalObject, value, "id"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &id);
     if (!is_number) id = value.toUInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto result = setegid(id);
+    auto result = callWithoutThreadSuspension([&] { return setegid(id); });
     if (result != 0) throwSystemError(scope, globalObject, "setegid"_s, errno);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));
@@ -3152,7 +3165,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgid, (JSGlobalObject * globalObject,
     if (is_number) Bun::V::validateInteger(scope, globalObject, value, "id"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &id);
     if (!is_number) id = value.toUInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto result = setgid(id);
+    auto result = callWithoutThreadSuspension([&] { return setgid(id); });
     if (result != 0) throwSystemError(scope, globalObject, "setgid"_s, errno);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));
@@ -3193,7 +3206,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "number or string"_s, item);
     }
 
-    auto result = setgroups(count, groupsStack);
+    auto result = callWithoutThreadSuspension([&] { return setgroups(count, groupsStack); });
     if (result != 0) throwSystemError(scope, globalObject, "setgid"_s, errno);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsNumber(result));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -665,6 +665,70 @@ describe.concurrent(() => {
     it("process.getuid", () => {
       expect(typeof process.getuid()).toBe("number");
     });
+
+    // Regression: on Linux, glibc/musl implement the set*id() family by broadcasting a
+    // realtime signal to every thread and blocking on a barrier. If JSC's GC (or the
+    // bmalloc scavenger) had signal-suspended a thread, it could never ack the barrier
+    // and the whole process wedged at 0% CPU. The race is probabilistic, so hammer
+    // seteuid under GC pressure from many processes at once and require each to exit.
+    it.skipIf(process.platform !== "linux" || process.getuid() !== 0)(
+      "seteuid under GC pressure does not deadlock",
+      async () => {
+        using dir = tempDir("seteuid-deadlock", {
+          "hammer.js": `
+            const dec = new TextDecoder();
+            const buf = new Uint8Array(60000).fill(65);
+            let n = 0;
+            const t0 = Date.now();
+            const runMs = Number(process.env.HAMMER_MS);
+            function chunk() {
+              for (let j = 0; j < 400; j++) {
+                process.seteuid(65534);
+                let s = "";
+                for (let i = 0; i < 20; i++) s += dec.decode(buf).slice(0, 1000 + (n % 7));
+                process.seteuid(0);
+                if (s.length < 0) console.log(s.length);
+                n++;
+              }
+              if (Date.now() - t0 < runMs) setImmediate(chunk);
+              else process.exit(0);
+            }
+            chunk();
+          `,
+        });
+        const hammerPath = join(String(dir), "hammer.js");
+        const CONCURRENCY = 12;
+        const ROUNDS = 3;
+        const HAMMER_MS = 8_000;
+        const DEADLINE_MS = 30_000;
+
+        const runOne = async () => {
+          const proc = Bun.spawn({
+            cmd: [bunExe(), hammerPath],
+            env: { ...bunEnv, HAMMER_MS: String(HAMMER_MS) },
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+          const { promise, resolve } = Promise.withResolvers();
+          const timer = setTimeout(() => resolve("deadlocked"), DEADLINE_MS);
+          const outcome = await Promise.race([proc.exited.then(() => "exited"), promise]);
+          clearTimeout(timer);
+          // A wedged process sits at 0% CPU forever; a healthy one exits on its own.
+          if (outcome === "deadlocked") {
+            proc.kill("SIGKILL");
+            return { deadlocked: true, exitCode: null };
+          }
+          return { deadlocked: false, exitCode: proc.exitCode };
+        };
+
+        const expected = Array.from({ length: CONCURRENCY }, () => ({ deadlocked: false, exitCode: 0 }));
+        for (let round = 0; round < ROUNDS; round++) {
+          const results = await Promise.all(Array.from({ length: CONCURRENCY }, runOne));
+          expect(results).toEqual(expected);
+        }
+      },
+      120_000,
+    );
   } else {
     it("process.getegid, process.geteuid, process.getgid, process.getgroups, process.getuid, process.getuid are not implemented on Windows", () => {
       expect(process.getegid).toBeUndefined();


### PR DESCRIPTION
## What

`process.setuid`, `process.seteuid`, `process.setgid`, `process.setegid`, and `process.setgroups` can permanently deadlock the whole Bun process on Linux. The process wedges at 0% CPU with no exception, no crash, and no exit. This breaks the canonical "bind to a privileged port, then drop privileges" server startup, and any per-request euid switching.

## Repro

Run as root (the race is probabilistic, so repeat a few times):

```js
// deadlock.mjs
import { spawn } from "node:child_process";
import { fileURLToPath } from "node:url";
const SELF = fileURLToPath(import.meta.url);
if (process.argv[2] === "child") {
  const dec = new TextDecoder(), buf = new Uint8Array(60000).fill(65);
  let n = 0; const t0 = Date.now();
  const chunk = () => {
    for (let j = 0; j < 400; j++) {
      process.seteuid(65534);
      let s = "";
      for (let i = 0; i < 20; i++) s += dec.decode(buf).slice(0, 1000 + (n % 7));
      process.seteuid(0);
      if (s.length < 0) console.log(s); n++;
    }
    if (Date.now() - t0 < 100_000) setImmediate(chunk);
    else { console.log("SURVIVED", n); process.exit(0); }
  };
  chunk();
} else {
  const c = spawn(process.execPath, [SELF, "child"], { stdio: ["ignore", "pipe", "inherit"] });
  let last = Date.now(), done = false;
  c.stdout.on("data", d => { last = Date.now(); if (String(d).includes("SURVIVED")) done = true; });
  const iv = setInterval(() => {
    if (done) return clearInterval(iv);
    if (Date.now() - last > 20_000) { console.log(`DEADLOCK: pid ${c.pid} made no progress for 20s`); clearInterval(iv); c.kill("SIGKILL"); process.exitCode = 1; }
  }, 2000);
  c.on("exit", () => clearInterval(iv));
}
```

`eu-stack` of a wedged process (every thread parked forever at 0% CPU):

```
main:        WTF::ParallelHelperClient::finish <- JSC::Heap::runEndPhase <- ... <- JSC::JSString::create
HeapHelper:  __sigsuspend <- WTF::Thread::signalHandlerSuspendResume   (suspended, never resumed)
```

Node running the identical hammer never wedges (V8 has no signal-based thread suspension).

## Cause

On Linux, glibc and musl implement `set*id()` for a multithreaded process by broadcasting an internal realtime signal (glibc's `SIGSETXID`) to every thread and blocking the caller on a barrier until each thread has run the id-change handler.

JSC's garbage collector (conservative stack scanning) and the bmalloc scavenger suspend threads with their own signal handshake: `WTF::Thread::signalHandlerSuspendResume` parks the target thread in `sigsuspend` with a mask that blocks everything except WTF's resume signal, and therefore blocks the setxid signal too.

When the two overlap, a thread that JSC/libpas has signal-suspended can never acknowledge the setxid barrier, so `set*id()` never returns and the process wedges.

## Fix

Hold WTF's global thread-suspend lock (`WTF::ThreadSuspendLocker`) across each `set*id()` syscall on Linux. Both the GC stack scanner and the bmalloc scavenger acquire this same lock before suspending any thread (and hold it until they resume), so holding it guarantees no thread is signal-suspended for the duration of the setxid barrier. It is released immediately after the syscall returns.

## Verification

New test in `test/js/node/process/process.test.js` (gated on Linux + root): hammers `seteuid` under GC pressure from many processes concurrently and requires every process to exit on its own; a wedged process never exits.

- Without the fix, the debug+ASAN build reliably deadlocks (watchdog detects processes stuck at 0% CPU).
- With the fix, all processes exit cleanly across repeated runs.
