### PR TITLE
Compare DataView contents in deepEquals

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1330,6 +1330,37 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
         break;
     }
+    case DataViewType: {
+        if (c2Type != DataViewType) {
+            return false;
+        }
+
+        JSC::JSArrayBufferView* left = uncheckedDowncast<JSArrayBufferView>(c1);
+        JSC::JSArrayBufferView* right = uncheckedDowncast<JSArrayBufferView>(c2);
+        size_t byteLength = left->byteLength();
+
+        if (right->byteLength() != byteLength) {
+            return false;
+        }
+
+        if (byteLength == 0)
+            return true;
+
+        if (right->isDetached() || left->isDetached()) [[unlikely]] {
+            return false;
+        }
+
+        const void* vector = left->vector();
+        const void* rightVector = right->vector();
+        if (!vector || !rightVector) [[unlikely]] {
+            return false;
+        }
+
+        if (vector == rightVector) [[unlikely]]
+            return true;
+
+        return (memcmp(vector, rightVector, byteLength) == 0);
+    }
     case Int8ArrayType:
     case Uint8ArrayType:
     case Uint8ClampedArrayType:

--- a/test/js/bun/bun-object/deep-equals.spec.ts
+++ b/test/js/bun/bun-object/deep-equals.spec.ts
@@ -78,6 +78,33 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
   });
 });
 
+describe.each([true, false])("DataView comparison (strict: %p)", strict => {
+  const dv = (bytes: number[]) => new DataView(new Uint8Array(bytes).buffer);
+
+  it("equal DataViews are equal", () => {
+    expect(Bun.deepEquals(dv([1, 2, 3]), dv([1, 2, 3]), strict)).toBe(true);
+    expect(Bun.deepEquals(dv([]), dv([]), strict)).toBe(true);
+  });
+
+  it("DataViews with different bytes are not equal", () => {
+    expect(Bun.deepEquals(dv([1, 2, 3]), dv([1, 9, 3]), strict)).toBe(false);
+  });
+
+  it("DataViews with different byteLength are not equal", () => {
+    expect(Bun.deepEquals(dv([1, 2, 3]), dv([1, 2]), strict)).toBe(false);
+  });
+
+  it("a DataView is not equal to a typed array over the same bytes", () => {
+    expect(Bun.deepEquals(dv([1, 2, 3]), new Uint8Array([1, 2, 3]), strict)).toBe(false);
+  });
+
+  it("expect().toEqual compares DataView contents", () => {
+    expect(dv([1, 2, 3])).toEqual(dv([1, 2, 3]));
+    expect(dv([1, 2, 3])).not.toEqual(dv([1, 9, 3]));
+    expect(dv([1, 2, 3])).not.toEqual(dv([1, 2]));
+  });
+});
+
 // The cases documented at https://bun.sh/docs/api/utils#bun-deepequals as the
 // differences between the default and strict modes.
 describe("Bun.deepEquals strict mode", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -993,6 +993,17 @@ describe("expect()", () => {
     expect(new Float32Array([0])).not.toEqual(new Uint8Array([0, 0, 0, 0]));
   });
 
+  test("deepEquals and DataView", () => {
+    const dv = bytes => new DataView(new Uint8Array(bytes).buffer);
+    expect(dv([1, 2, 3])).toEqual(dv([1, 2, 3]));
+    expect(dv([])).toEqual(dv([]));
+    expect(dv([1, 2, 3])).not.toEqual(dv([1, 9, 3]));
+    expect(dv([1, 2, 3])).not.toEqual(dv([1, 2]));
+    expect(dv([1, 2, 3])).not.toEqual(new Uint8Array([1, 2, 3]));
+    expect(dv([1, 2, 3])).toStrictEqual(dv([1, 2, 3]));
+    expect(dv([1, 2, 3])).not.toStrictEqual(dv([1, 9, 3]));
+  });
+
   test("deepEquals throw getters", () => {
     let a = {
       get x() {


### PR DESCRIPTION
## What

`Bun.deepEquals` (and everything built on it: `expect().toEqual`/`toStrictEqual`, `node:assert` `deepEqual`/`deepStrictEqual`/`notDeepStrictEqual`, and `util.isDeepStrictEqual`) treats any two `DataView` values as deeply equal, ignoring both byte contents and `byteLength`.

```js
const dv = b => new DataView(new Uint8Array(b).buffer);
Bun.deepEquals(dv([1, 2, 3]), dv([1, 9, 3]), true); // true (should be false)
Bun.deepEquals(dv([1, 2, 3]), dv([1, 2]), true);     // true (should be false)
```

Node compares DataViews byte-wise like every other ArrayBuffer view, so any test whose fixture carries a DataView is a silent false green: a regression in the bytes can never fail it, and `notDeepStrictEqual` guards fire spuriously.

## Cause

`Bun__deepEquals` in `src/jsc/bindings/bindings.cpp` switches on `JSType` and handles `ArrayBufferType` plus every typed-array type, but has no `DataViewType` case. DataViews fall through to the generic own-enumerable-property walk, and a DataView has no own enumerable properties, so the comparison always returns equal.

## Fix

Add a `DataViewType` arm that compares `byteLength` then the viewed byte range with `memcmp`, matching the shape of the existing typed-array arm (detached/empty/same-vector guards included). A DataView is still unequal to a typed array over the same bytes, since the type must match.

## Verification

Added cases to `test/js/bun/bun-object/deep-equals.spec.ts` covering equal/unequal bytes, differing byteLength, DataView-vs-typed-array, and `expect().toEqual`, across strict and loose modes.

- `USE_SYSTEM_BUN=1 bun test`: 6 fail (bug present)
- `bun bd test`: 54 pass, 0 fail