### PR TITLE
node:assert: preserve non-ASCII content in generated diffs

### DIFF
--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -191,7 +191,10 @@ impl<S: LineToJs> PojoFields for LineDiff<'_, S> {
         global: &JSGlobalObject,
         mut put: impl FnMut(&'static [u8], JSValue) -> JsResult<()>,
     ) -> JsResult<()> {
-        put(b"kind", JSValue::js_number_from_int32(self.line.kind as i32))?;
+        put(
+            b"kind",
+            JSValue::js_number_from_int32(self.line.kind as i32),
+        )?;
         put(b"value", self.line.value.line_to_js(global, self.encoding)?)?;
         Ok(())
     }

--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -1,7 +1,7 @@
 use bun_core::String as BunString;
 use bun_core::strings::EncodingNonAscii;
 use bun_jsc::js_object::PojoFields;
-use bun_jsc::{FromAny, JSGlobalObject, JSObject, JSValue, JsError, JsResult};
+use bun_jsc::{FromAny, JSGlobalObject, JSObject, JSValue, JsError, JsResult, StringJsc};
 
 use super::assert::myers_diff as MyersDiff;
 use super::assert::myers_diff::{Diff, DiffKind, Line};
@@ -50,21 +50,31 @@ pub(crate) fn myers_diff(
                 actual_utf8.slice(),
                 expected_utf8.slice(),
                 check_comma_disparity,
+                LineEncoding::Utf8,
             );
         }
 
         return match actual_encoding {
-            EncodingNonAscii::Latin1 | EncodingNonAscii::Utf8 => diff_lines::<u8>(
+            EncodingNonAscii::Latin1 => diff_lines::<u8>(
                 global,
                 actual.byte_slice(),
                 expected.byte_slice(),
                 check_comma_disparity,
+                LineEncoding::Latin1,
+            ),
+            EncodingNonAscii::Utf8 => diff_lines::<u8>(
+                global,
+                actual.byte_slice(),
+                expected.byte_slice(),
+                check_comma_disparity,
+                LineEncoding::Utf8,
             ),
             EncodingNonAscii::Utf16 => diff_lines::<u16>(
                 global,
                 actual.utf16(),
                 expected.utf16(),
                 check_comma_disparity,
+                LineEncoding::Utf16,
             ),
         };
     }
@@ -101,10 +111,11 @@ fn diff_lines<'s, T>(
     actual: &'s [T],
     expected: &'s [T],
     check_comma_disparity: bool,
+    encoding: LineEncoding,
 ) -> JsResult<JSValue>
 where
     T: PartialEq + Copy + From<u8>,
-    &'s [T]: Line + FromAny,
+    &'s [T]: Line + LineToJs,
 {
     let a = MyersDiff::split::<T>(actual);
     let e = MyersDiff::split::<T>(expected);
@@ -116,7 +127,74 @@ where
         MyersDiff::Differ::<&'s [T], false>::diff(a.as_slice(), e.as_slice())
             .map_err(|err| map_diff_error(global, err))?
     };
-    diff_list_to_js(global, &diff)
+    diff_lines_to_js(global, &diff, encoding)
+}
+
+/// Encoding of the bytes backing a diffed line. The JS side (`printMyersDiff`)
+/// interpolates line values directly as strings, so each line must be rebuilt
+/// as a `JSString` with the original encoding rather than decoded as UTF-8.
+#[derive(Clone, Copy)]
+enum LineEncoding {
+    Latin1,
+    Utf8,
+    Utf16,
+}
+
+/// Marshals a diff line slice back to a JS string using its source encoding.
+/// A plain UTF-8 decode would turn Latin1 bytes >= 0x80 into U+FFFD, and a
+/// `&[u16]` slice would marshal as an array of char codes.
+trait LineToJs: Copy {
+    fn line_to_js(self, global: &JSGlobalObject, encoding: LineEncoding) -> JsResult<JSValue>;
+}
+
+impl LineToJs for &[u8] {
+    fn line_to_js(self, global: &JSGlobalObject, encoding: LineEncoding) -> JsResult<JSValue> {
+        let mut s = match encoding {
+            LineEncoding::Latin1 => BunString::clone_latin1(self),
+            _ => BunString::clone_utf8(self),
+        };
+        s.transfer_to_js(global)
+    }
+}
+
+impl LineToJs for &[u16] {
+    fn line_to_js(self, global: &JSGlobalObject, _encoding: LineEncoding) -> JsResult<JSValue> {
+        let mut s = BunString::clone_utf16(self);
+        s.transfer_to_js(global)
+    }
+}
+
+/// Marshals a line diff, rebuilding each line value as an encoding-correct
+/// `JSString`. The char diff path uses [`diff_list_to_js`] instead, which
+/// marshals char codes as numbers.
+fn diff_lines_to_js<S: LineToJs>(
+    global: &JSGlobalObject,
+    diff_list: &MyersDiff::DiffList<S>,
+    encoding: LineEncoding,
+) -> JsResult<JSValue> {
+    JSValue::create_array_from_iter(global, diff_list.iter(), |line| {
+        Ok(JSObject::create_null_proto(&LineDiff { line, encoding }, global)?.to_js())
+    })
+}
+
+/// Field reflection for a line [`Diff`] whose `value` is rebuilt as an
+/// encoding-correct `JSString` (see [`LineToJs`]).
+struct LineDiff<'a, S> {
+    line: &'a Diff<S>,
+    encoding: LineEncoding,
+}
+
+impl<S: LineToJs> PojoFields for LineDiff<'_, S> {
+    const FIELD_COUNT: usize = 2;
+    fn put_fields(
+        &self,
+        global: &JSGlobalObject,
+        mut put: impl FnMut(&'static [u8], JSValue) -> JsResult<()>,
+    ) -> JsResult<()> {
+        put(b"kind", JSValue::js_number_from_int32(self.line.kind as i32))?;
+        put(b"value", self.line.value.line_to_js(global, self.encoding)?)?;
+        Ok(())
+    }
 }
 
 fn diff_list_to_js<T>(

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -649,3 +649,41 @@ describe("AssertionError", () => {
     expect(error).toBe(custom);
   });
 });
+
+describe("generated diff preserves non-ASCII content", () => {
+  const messageOf = (a: unknown, b: unknown): string => {
+    const error = caught(() => assert.deepStrictEqual(a, b));
+    expect(error).not.toBeNull();
+    return error!.message;
+  };
+
+  test("Latin1 characters (U+0080 to U+00FF) are not replaced with U+FFFD", () => {
+    const message = messageOf({ a: "café", b: 1 }, { a: "café", b: 2 });
+    expect(message).toContain("a: 'café'");
+    expect(message).not.toContain("\uFFFD");
+  });
+
+  test("characters above U+00FF render as text, not arrays of char codes", () => {
+    const message = messageOf(["☃"], ["☃x"]);
+    expect(message).toContain("'☃'");
+    expect(message).toContain("'☃x'");
+    // The old bug marshalled UTF-16 lines as arrays of char codes, e.g.
+    // `32,32,39,9731,39` (the code point of ☃ is 9731).
+    expect(message).not.toContain("9731");
+    expect(message).not.toMatch(/\d+,\d+/);
+  });
+
+  test("astral (surrogate-pair) characters survive the diff", () => {
+    const message = messageOf(["😀"], ["😀x"]);
+    expect(message).toContain("'😀'");
+    expect(message).toContain("'😀x'");
+    expect(message).not.toContain("\uFFFD");
+  });
+
+  test("mixed Latin1 and UTF-16 operands both render correctly", () => {
+    const message = messageOf({ v: "café\nend" }, { v: "snowman ☃\nend" });
+    expect(message).toContain("café");
+    expect(message).toContain("☃");
+    expect(message).not.toContain("\uFFFD");
+  });
+});


### PR DESCRIPTION
## What

`assert.deepStrictEqual` / `assert.strictEqual` failure messages (the `+ actual - expected` diff) garble any non-ASCII content:

- Latin1 characters (U+0080 to U+00FF) become U+FFFD.
- Any character above U+00FF turns the whole diff body into comma-separated char-code lists.

```js
import assert from "node:assert";
const show = (a, b) => { try { assert.deepStrictEqual(a, b); } catch (e) { console.log(e.message); } };

show({ a: "café", b: 1 }, { a: "café", b: 2 });   // a: 'caf\uFFFD'  (é lost)
show(["☃"], ["☃x"]);                              // 91 / 32,32,39,9731,39 / ...
```

This is the default assertion-failure output, so any `node:assert` suite whose fixtures contain an accented name, CJK string, snowman, or emoji gets an unreadable message. `util.inspect` renders these strings correctly on its own; the corruption is in the assert diff layer.

## Cause

The Myers diff lives in a native binding (`src/runtime/node/node_assert.rs`). After splitting the two inspected strings into lines, it marshalled each diff line back to JS through the generic value conversion:

- The Latin1 / UTF-8 arm passed raw `&[u8]` line slices, which the generic conversion decodes as UTF-8. Latin1 bytes >= 0x80 are not valid UTF-8, so they became U+FFFD.
- The UTF-16 arm produced `&[u16]` line slices, for which the generic conversion builds an array of numbers. The JS printer (`printMyersDiff`) then stringified each as `32,32,...`.

## Fix

Rebuild each line as a `JSString` with its source encoding instead of routing through the UTF-8 / array conversion:

- Latin1 byte slices -> `clone_latin1`
- `u16` slices -> `clone_utf16`
- the mixed-encoding path (both operands converted to UTF-8 before diffing) -> `clone_utf8`

The char-diff path (which marshals single char codes as numbers, consumed by `String.fromCharCode` on the JS side) is unchanged.

## Verification

Added tests in `test/js/node/assert/deep-equal.test.ts` covering Latin1, BMP-above-U+00FF, astral surrogate pairs, and mixed Latin1/UTF-16 operands. They fail on the released build (U+FFFD / char-code arrays) and pass with the fix.