### PR TITLE
install: create patch parent dirs with directory mode, not file mode

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -135,7 +135,7 @@ impl<'a> PatchFile<'a> {
                         // (resolving `filedir` against the process CWD would be
                         // inconsistent when `patch_dir != cwd`).
                         if let sys::Result::Err(e) =
-                            sys::mkdir_recursive_at_mode(patch_dir, filedir, mode.to_bun_mode())
+                            sys::mkdir_recursive_at_mode(patch_dir, filedir, 0o755)
                         {
                             return Some(e.without_path());
                         }

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -282,7 +282,8 @@ new file mode 100644
     if (asRoot) {
       // Hand the whole tree to the unprivileged uid so it can write the cache,
       // staging tree and node_modules.
-      Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
+      const chown = Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
+      expect(chown.exitCode).toBe(0);
     }
 
     await using proc = Bun.spawn({

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1,15 +1,16 @@
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { rmSync } from "fs";
+import { chmodSync, mkdirSync, rmSync, statSync } from "fs";
 import {
   bunEnv,
   bunExe,
+  isWindows,
   normalizeBunSnapshot as normalizeBunSnapshot_,
   runBunInstall,
   tempDir,
   VerdaccioRegistry,
 } from "harness";
-import { join } from "path";
+import { dirname, join } from "path";
 import { pathToFileURL } from "url";
 
 const normalizeBunSnapshot = (str: string) => {
@@ -238,6 +239,68 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
     const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
     expect(stderr.toString()).toBe("");
     expect(stdout.toString()).toContain("Hi from isOdd!\n");
+  });
+
+  // https://github.com/oven-sh/bun/issues/33571
+  // Root bypasses the missing-execute-bit check (DAC_OVERRIDE) and the staging
+  // tree is copied into node_modules with fresh 0o755 dirs, so the bug is only
+  // observable as a non-root user, where creating the staging subdirectory at
+  // the file's 0o644 mode fails with EACCES. When running as root (CI), drop to
+  // an unprivileged uid so the failure is reproducible.
+  test.skipIf(isWindows)("should apply a patch that adds a file in a directory absent from the package", async () => {
+    const version = "0.1.2";
+    const patchFilename = filepathEscape(`is-odd@${version}.patch`);
+    const create_dir_patch = /* patch */ `diff --git a/android/build/x/results.bin b/android/build/x/results.bin
+new file mode 100644
+--- /dev/null
++++ b/android/build/x/results.bin
+@@ -0,0 +1 @@
++hi
+`;
+    await using filedir = tempDir("patch-create-dir", {
+      "project/package.json": JSON.stringify({
+        "name": "bun-patch-test",
+        "module": "index.ts",
+        "type": "module",
+        "patchedDependencies": {
+          [`is-odd@${version}`]: `patches/${patchFilename}`,
+        },
+        "dependencies": {
+          "is-odd": version,
+        },
+      }),
+      [`project/patches/${patchFilename}`]: create_dir_patch,
+    });
+    const projectDir = join(String(filedir), "project");
+    const cacheDir = join(String(filedir), "cache");
+    const homeDir = join(String(filedir), "home");
+    mkdirSync(cacheDir);
+    mkdirSync(homeDir);
+
+    const NOBODY = 65534;
+    const asRoot = process.getuid?.() === 0;
+    if (asRoot) {
+      // Hand the whole tree to the unprivileged uid so it can write the cache,
+      // staging tree and node_modules.
+      Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      env: { ...bunEnv, HOME: homeDir, BUN_INSTALL_CACHE_DIR: cacheDir },
+      ...(asRoot ? { uid: NOBODY, gid: NOBODY } : {}),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("EACCES");
+    expect(stderr).not.toContain("failed to apply patchfile");
+    expect(exitCode).toBe(0);
+
+    const createdFile = join(projectDir, "node_modules", "is-odd", "android", "build", "x", "results.bin");
+    expect(await Bun.file(createdFile).text()).toBe("hi\n");
   });
 
   describe("should patch a dependency after it was already installed", async () => {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -274,34 +274,57 @@ new file mode 100644
     const projectDir = join(String(filedir), "project");
     const cacheDir = join(String(filedir), "cache");
     const homeDir = join(String(filedir), "home");
+    const childTmpDir = join(String(filedir), "tmp");
     mkdirSync(cacheDir);
     mkdirSync(homeDir);
+    mkdirSync(childTmpDir);
 
     const NOBODY = 65534;
     const asRoot = process.getuid?.() === 0;
+    const restoreAncestors: [path: string, mode: number][] = [];
     if (asRoot) {
+      // CI's runner.node.mjs points TMPDIR at a mode-0700 root-owned mkdtemp
+      // dir, so every ancestor of filedir needs +x for uid 65534 or the child
+      // fails at path resolution before it ever reaches the patch logic.
+      for (let p = dirname(String(filedir)); p !== dirname(p); p = dirname(p)) {
+        const mode = statSync(p).mode & 0o7777;
+        if ((mode & 0o011) !== 0o011) {
+          restoreAncestors.push([p, mode]);
+          chmodSync(p, mode | 0o011);
+        }
+      }
       // Hand the whole tree to the unprivileged uid so it can write the cache,
       // staging tree and node_modules.
       const chown = Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
       expect(chown.exitCode).toBe(0);
     }
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: projectDir,
-      env: { ...bunEnv, HOME: homeDir, BUN_INSTALL_CACHE_DIR: cacheDir },
-      ...(asRoot ? { uid: NOBODY, gid: NOBODY } : {}),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: projectDir,
+        env: {
+          ...bunEnv,
+          HOME: homeDir,
+          BUN_INSTALL_CACHE_DIR: cacheDir,
+          TMPDIR: childTmpDir,
+          BUN_TMPDIR: childTmpDir,
+        },
+        ...(asRoot ? { uid: NOBODY, gid: NOBODY } : {}),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("EACCES");
-    expect(stderr).not.toContain("failed to apply patchfile");
-    expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("EACCES");
+      expect(stderr).not.toContain("failed to apply patchfile");
+      expect(exitCode).toBe(0);
 
-    const createdFile = join(projectDir, "node_modules", "is-odd", "android", "build", "x", "results.bin");
-    expect(await Bun.file(createdFile).text()).toBe("hi\n");
+      const createdFile = join(projectDir, "node_modules", "is-odd", "android", "build", "x", "results.bin");
+      expect(await Bun.file(createdFile).text()).toBe("hi\n");
+    } finally {
+      for (const [p, mode] of restoreAncestors) chmodSync(p, mode);
+    }
   });
 
   describe("should patch a dependency after it was already installed", async () => {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -282,24 +282,24 @@ new file mode 100644
     const NOBODY = 65534;
     const asRoot = process.getuid?.() === 0;
     const restoreAncestors: [path: string, mode: number][] = [];
-    if (asRoot) {
-      // CI's runner.node.mjs points TMPDIR at a mode-0700 root-owned mkdtemp
-      // dir, so every ancestor of filedir needs +x for uid 65534 or the child
-      // fails at path resolution before it ever reaches the patch logic.
-      for (let p = dirname(String(filedir)); p !== dirname(p); p = dirname(p)) {
-        const mode = statSync(p).mode & 0o7777;
-        if ((mode & 0o011) !== 0o011) {
-          restoreAncestors.push([p, mode]);
-          chmodSync(p, mode | 0o011);
-        }
-      }
-      // Hand the whole tree to the unprivileged uid so it can write the cache,
-      // staging tree and node_modules.
-      const chown = Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
-      expect(chown.exitCode).toBe(0);
-    }
-
     try {
+      if (asRoot) {
+        // CI's runner.node.mjs points TMPDIR at a mode-0700 root-owned mkdtemp
+        // dir, so every ancestor of filedir needs +x for uid 65534 or the child
+        // fails at path resolution before it ever reaches the patch logic.
+        for (let p = dirname(String(filedir)); p !== dirname(p); p = dirname(p)) {
+          const mode = statSync(p).mode & 0o7777;
+          if ((mode & 0o011) !== 0o011) {
+            restoreAncestors.push([p, mode]);
+            chmodSync(p, mode | 0o011);
+          }
+        }
+        // Hand the whole tree to the unprivileged uid so it can write the cache,
+        // staging tree and node_modules.
+        const chown = Bun.spawnSync(["chown", "-R", `${NOBODY}:${NOBODY}`, String(filedir)]);
+        expect(chown.exitCode).toBe(0);
+      }
+
       await using proc = Bun.spawn({
         cmd: [bunExe(), "install"],
         cwd: projectDir,


### PR DESCRIPTION
Fixes #33571
Fixes #13330
Fixes #38569

### Repro

A patch that adds a file inside a directory absent from the published package fails for any non-root user:

```bash
mkdir repro && cd repro
cat > package.json <<'PKG'
{ "name": "repro", "version": "1.0.0",
  "dependencies": { "is-odd": "3.0.1" },
  "patchedDependencies": { "is-odd@3.0.1": "patches/is-odd.patch" } }
PKG
mkdir patches
cat > patches/is-odd.patch <<'PATCH'
diff --git a/android/build/x/results.bin b/android/build/x/results.bin
new file mode 100644
--- /dev/null
+++ b/android/build/x/results.bin
@@ -0,0 +1 @@
+hi
PATCH
bun install
# error: failed applying patch file: EACCES: Permission denied (mkdir())
# error: failed to apply patchfile (patches/is-odd.patch)
```

### Cause

In `src/patch/lib.rs`, the `FileCreation` branch created the new file's parent directories with the **file's** mode (`mode.to_bun_mode()`, e.g. `0o644` for a normal `new file mode 100644`) instead of a directory mode. A directory without the execute/search bit cannot be descended into, so the next nested `mkdir` (nested dir case) or the `openat(... O_CREAT ...)` for the file (single new dir case) fails with `EACCES` for any non-root user. Root masks this via `DAC_OVERRIDE`, which is why it only reproduced outside CI.

The sibling `FileRename` branch already creates parent dirs with `0o755`.

### Fix

Create the parent directories with `0o755`. The created file still uses its own mode in the `openat` call.

### Verification

Regression test in `test/cli/install/bun-install-patch.test.ts`. The bug is only observable as a non-root user (root bypasses the missing-exec-bit check and the staging tree is copied into `node_modules` with fresh `0o755` dirs), so the test drops to an unprivileged uid when run as root. Fails on the unfixed build with `EACCES: Permission denied (mkdir())`, passes with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-patch.test.ts

<!-- robobun:evidence:end -->