### PR TITLE
postgres: decode float4 text to f32 precision to match binary protocol

### DIFF
--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -516,9 +516,11 @@ fn parse_array(
                             }
                             let element = &slice[0..current_idx];
                             if is_float || array_type == types::Tag::float8_array {
-                                array.push(SQLDataCell::float8(
-                                    bun_core::parse_double(element).unwrap_or(f64::NAN),
-                                ));
+                                let mut value = bun_core::parse_double(element).unwrap_or(f64::NAN);
+                                if array_type == types::Tag::float4_array {
+                                    value = value as f32 as f64;
+                                }
+                                array.push(SQLDataCell::float8(value));
                                 slice = try_slice(slice, current_idx);
                                 continue;
                             }
@@ -790,8 +792,10 @@ pub(crate) fn from_bytes(
             if binary && bytes.len() == 4 {
                 Ok(SQLDataCell::float8(parse_binary_float4(bytes)? as f64))
             } else {
+                // float4 text is the shortest round-trip decimal for an f32, so
+                // narrow to f32 before widening to match the binary wire value.
                 Ok(SQLDataCell::float8(
-                    bun_core::parse_double(bytes).unwrap_or(f64::NAN),
+                    bun_core::parse_double(bytes).unwrap_or(f64::NAN) as f32 as f64,
                 ))
             }
         }

--- a/test/js/sql/postgres-float4-text-binary.test.ts
+++ b/test/js/sql/postgres-float4-text-binary.test.ts
@@ -1,0 +1,56 @@
+// A float4 value must decode to the same JS number regardless of protocol.
+// The simple protocol returns the result as text; the extended protocol (used
+// when the query carries a parameter) requests binary for float4 (OID 700, see
+// is_binary_format_supported in src/sql/postgres/types/Tag.rs). The binary arm
+// reads the real 4-byte IEEE f32 and widens it, so the text arm must narrow the
+// parsed decimal to f32 first (Math.fround) instead of keeping full f64
+// precision. Otherwise 0.1::float4 is 0.1 unparameterized but
+// 0.10000000149011612 parameterized.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+const cases: string[] = [
+  "0.1",
+  "(1.0/3.0)",
+  "1.5",
+  "3.14159",
+  "1e-40", // subnormal f32
+  "1e20",
+  "-0.1",
+  "0",
+];
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  test.each(cases)("float4 %s decodes identically on both protocols", async literal => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+    // simple protocol -> TEXT result
+    const text = (await sql.unsafe(`select ${literal}::float4 as v`))[0].v;
+    // extended protocol -> BINARY result
+    const binary = (await sql.unsafe(`select ${literal}::float4 as v where $1 = 1`, [1]))[0].v;
+
+    expect(text).toBe(binary);
+    // the value both paths agree on is the f32-rounded one
+    expect(text).toBe(Math.fround(Number(eval(literal))));
+  });
+
+  test("float4[] decodes identically on both protocols", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+    const text = (await sql.unsafe(`select '{0.1, 0.3333333, 1.5}'::float4[] as v`))[0].v;
+    const binary = (await sql.unsafe(`select '{0.1, 0.3333333, 1.5}'::float4[] as v where $1 = 1`, [1]))[0].v;
+
+    expect(Array.from(text)).toEqual(Array.from(binary));
+    expect(Array.from(text)).toEqual([0.1, 0.3333333, 1.5].map(Math.fround));
+  });
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -7796,7 +7796,7 @@ CREATE TABLE ${table_name} (
           -3.45
         ]::float4[] as negative_values
       `;
-        expect(result[0].negative_values).toEqual([-1.23, -2.34, -3.45]);
+        expect(result[0].negative_values).toEqual([-1.23, -2.34, -3.45].map(Math.fround));
       });
 
       test("float4[] - zero values", async () => {
@@ -7820,7 +7820,7 @@ CREATE TABLE ${table_name} (
           1.23e+4
         ]::float4[] as scientific_notation
       `;
-        expect(result[0].scientific_notation.map(n => Number(n.toExponential()))).toEqual([1.23e-4, 1.23e4, 1.23e4]);
+        expect(result[0].scientific_notation).toEqual([1.23e-4, 1.23e4, 1.23e4].map(Math.fround));
       });
 
       test("float4[] - special values", async () => {
@@ -7845,9 +7845,7 @@ CREATE TABLE ${table_name} (
         ]::float4[] as boundary_values
       `;
 
-        expect(result[0].boundary_values[0]).toBeCloseTo(3.4028235e38);
-        expect(result[0].boundary_values[1]).toBeCloseTo(-3.4028235e38);
-        expect(result[0].boundary_values[2]).toBeCloseTo(1.175494e-38);
+        expect(result[0].boundary_values).toEqual([3.4028235e38, -3.4028235e38, 1.175494e-38].map(Math.fround));
       });
 
       test("float4[] - array element access", async () => {
@@ -7859,9 +7857,9 @@ CREATE TABLE ${table_name} (
           (ARRAY[1.1, 2.2, 3.3]::float4[])[3] as third_element
       `;
 
-        expect(result[0].first_element).toBe(1.1);
-        expect(result[0].second_element).toBe(2.2);
-        expect(result[0].third_element).toBe(3.3);
+        expect(result[0].first_element).toBe(Math.fround(1.1));
+        expect(result[0].second_element).toBe(Math.fround(2.2));
+        expect(result[0].third_element).toBe(Math.fround(3.3));
       });
 
       test("float4[] - array contains operator", async () => {
@@ -7899,7 +7897,7 @@ CREATE TABLE ${table_name} (
           ARRAY[1.1, 2.2]::float4[] || ARRAY[3.3, 4.4]::float4[] as concatenated
       `;
 
-        expect(result[0].concatenated).toEqual([1.1, 2.2, 3.3, 4.4]);
+        expect(result[0].concatenated).toEqual([1.1, 2.2, 3.3, 4.4].map(Math.fround));
       });
 
       test("float4[] - mathematical operations", async () => {
@@ -7910,8 +7908,8 @@ CREATE TABLE ${table_name} (
           (SELECT array_agg((value + 1)::float4) FROM unnest(ARRAY[1.1, 2.2, 3.3]::float4[]) as value) as addition
       `;
 
-        expect(result[0].multiplication).toEqual([2.2, 4.4, 6.6]);
-        expect(result[0].addition).toEqual([2.1, 3.2, 4.3]);
+        expect(result[0].multiplication).toEqual([2.2, 4.4, 6.6].map(Math.fround));
+        expect(result[0].addition).toEqual([2.1, 3.2, 4.3].map(Math.fround));
       });
 
       test("float4[] - array dimensions", async () => {


### PR DESCRIPTION
## What

A `float4` value decodes to a different JS number depending on whether the query is parameterized.

```ts
const sql = new Bun.SQL("postgres://postgres@127.0.0.1:5432/postgres");
const t = (await sql.unsafe(`select 0.1::float4 as v`))[0].v;              // simple protocol  -> text
const x = (await sql.unsafe(`select 0.1::float4 as v where $1 = 1`, [1]))[0].v; // extended protocol -> binary
console.log(t, x); // 0.1   0.10000000149011612   <- same stored value, two numbers
```

`float4` is the only binary-supported type where a valid value comes back as a different number on the two paths.

## Cause

In `src/sql_jsc/postgres/DataCell.rs`, the two arms disagree:

- Simple protocol returns the result as text. The text arm parsed PostgreSQL's shortest-round-trip decimal straight into an `f64` (`"0.1"` -> the `f64` 0.1), keeping full double precision.
- The extended protocol (any parameterized query) requests binary for `float4` (OID 700). The binary arm reads the real 4-byte IEEE `f32` off the wire and widens it (`0.1f` -> 0.10000000149011612).

Both are "a" float, but not the same float. The binary value is the one that matches the actual on-disk 4-byte value.

## Fix

Narrow the text `float4` value to `f32` before widening to `f64`, so both protocol paths yield the on-disk 4-byte value. The same rounding is applied to `float4[]` text elements.

## Verification

New test `test/js/sql/postgres-float4-text-binary.test.ts` runs each literal through both protocols against a real Postgres and asserts they agree (and equal the f32-rounded value).

Fails before, passes after:

```
Expected: -0.10000000149011612
Received: -0.1
  expect(text).toBe(binary)
```

```
 9 pass
 0 fail
```