### PR TITLE
postgres: serialize object params as JSON with prepare: false

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1,6 +1,7 @@
 import type { Query as QueryType } from "./query";
 
 const PublicArray = globalThis.Array;
+const PublicString = globalThis.String;
 const {
   Query,
   SQLQueryFlags,
@@ -63,10 +64,12 @@ type ArrayType =
   | "PG_DATABASE"
   | (string & {});
 export type { ArrayType, SQLArrayParameter, SQLResultArray };
-class SQLArrayParameter {
+// Extends String so native binds it as text on the paths that skip adapter.bindParam (helpers, sql.unsafe).
+class SQLArrayParameter extends PublicString {
   serializedValues: string;
   arrayType: ArrayType;
   constructor(serializedValues: string, arrayType: ArrayType) {
+    super(serializedValues);
     this.serializedValues = serializedValues;
     this.arrayType = arrayType;
   }
@@ -383,22 +386,6 @@ function pushBindParam(
   return adapter.placeholder(index) + " ";
 }
 
-// Never mutates `values`: on the sql.unsafe path it is the caller's own array.
-function unwrapArrayParams(values: unknown[]): unknown[] {
-  let out: unknown[] | undefined;
-  for (let i = 0; i < values.length; i++) {
-    const v = values[i];
-    if (v instanceof SQLArrayParameter) {
-      if (out === undefined) {
-        out = $newArrayWithSize(values.length);
-        for (let j = 0; j < values.length; j++) out[j] = values[j];
-      }
-      out[i] = v.serializedValues;
-    }
-  }
-  return out ?? values;
-}
-
 // This function handles array values in single fields:
 // - JSON/JSONB are the only field types that can be arrays themselves, so we serialize them
 // - SQL array field types (e.g., INTEGER[], TEXT[]) require the sql.array() helper
@@ -411,7 +398,7 @@ function normalizeQuery(
 ): [string, unknown[]] {
   if (typeof strings === "string") {
     // identifier or unsafe query
-    return [strings, unwrapArrayParams(values || [])];
+    return [strings, values || []];
   }
 
   if (!$isArray(strings)) {
@@ -591,7 +578,7 @@ function normalizeQuery(
     }
   }
 
-  return [query, unwrapArrayParams(binding_values)];
+  return [query, binding_values];
 }
 
 const enum PooledConnectionState {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -575,6 +575,14 @@ function normalizeQuery(
     }
   }
 
+  // SQLArrayParameter reaches here as an object when nested inside an UPDATE /
+  // INSERT / WHERE IN helper (those push raw, unlike adapter.bindParam). Send
+  // its pre-serialized string so native never has to special-case the wrapper.
+  for (let i = 0; i < binding_values.length; i++) {
+    const v = binding_values[i];
+    if (v instanceof SQLArrayParameter) binding_values[i] = v.serializedValues;
+  }
+
   return [query, binding_values];
 }
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -575,9 +575,7 @@ function normalizeQuery(
     }
   }
 
-  // SQLArrayParameter reaches here as an object when nested inside an UPDATE /
-  // INSERT / WHERE IN helper (those push raw, unlike adapter.bindParam). Send
-  // its pre-serialized string so native never has to special-case the wrapper.
+  // The INSERT / UPDATE / IN helpers above push values raw, bypassing adapter.bindParam.
   for (let i = 0; i < binding_values.length; i++) {
     const v = binding_values[i];
     if (v instanceof SQLArrayParameter) binding_values[i] = v.serializedValues;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -383,8 +383,7 @@ function pushBindParam(
   return adapter.placeholder(index) + " ";
 }
 
-// Every path except the tagged template (helpers, sql.unsafe, sql.file) hands values to
-// native raw, and native JSON-stringifies objects. Copies lazily: `values` may be the caller's.
+// Never mutates `values`: on the sql.unsafe path it is the caller's own array.
 function unwrapArrayParams(values: unknown[]): unknown[] {
   let out: unknown[] | undefined;
   for (let i = 0; i < values.length; i++) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -390,7 +390,7 @@ function unwrapArrayParams(values: unknown[]): unknown[] {
     const v = values[i];
     if (v instanceof SQLArrayParameter) {
       if (out === undefined) {
-        out = new Array(values.length);
+        out = $newArrayWithSize(values.length);
         for (let j = 0; j < values.length; j++) out[j] = values[j];
       }
       out[i] = v.serializedValues;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -383,6 +383,23 @@ function pushBindParam(
   return adapter.placeholder(index) + " ";
 }
 
+// Every path except the tagged template (helpers, sql.unsafe, sql.file) hands values to
+// native raw, and native JSON-stringifies objects. Copies lazily: `values` may be the caller's.
+function unwrapArrayParams(values: unknown[]): unknown[] {
+  let out: unknown[] | undefined;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v instanceof SQLArrayParameter) {
+      if (out === undefined) {
+        out = new Array(values.length);
+        for (let j = 0; j < values.length; j++) out[j] = values[j];
+      }
+      out[i] = v.serializedValues;
+    }
+  }
+  return out ?? values;
+}
+
 // This function handles array values in single fields:
 // - JSON/JSONB are the only field types that can be arrays themselves, so we serialize them
 // - SQL array field types (e.g., INTEGER[], TEXT[]) require the sql.array() helper
@@ -395,7 +412,7 @@ function normalizeQuery(
 ): [string, unknown[]] {
   if (typeof strings === "string") {
     // identifier or unsafe query
-    return [strings, values || []];
+    return [strings, unwrapArrayParams(values || [])];
   }
 
   if (!$isArray(strings)) {
@@ -575,13 +592,7 @@ function normalizeQuery(
     }
   }
 
-  // The INSERT / UPDATE / IN helpers above push values raw, bypassing adapter.bindParam.
-  for (let i = 0; i < binding_values.length; i++) {
-    const v = binding_values[i];
-    if (v instanceof SQLArrayParameter) binding_values[i] = v.serializedValues;
-  }
-
-  return [query, binding_values];
+  return [query, unwrapArrayParams(binding_values)];
 }
 
 const enum PooledConnectionState {

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,9 +49,7 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
-/// True when a JS value should be serialized to postgres as JSON text: a plain
-/// object or array, matching what `tag_jsc::from_js` classifies as json/jsonb.
-/// Strings, dates, typed arrays/buffers, and bigints are handled by other arms.
+/// Plain object or array, the same set `tag_jsc::from_js` classifies as json.
 fn value_is_json(value: JSValue) -> bool {
     use crate::jsc::JSType;
     if !value.is_cell() {
@@ -185,19 +183,13 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 tag
             }
         } else if value_is_json(value) {
-            // The server-declared OID is unknown (0) or text on the unnamed
-            // one-shot path because Bind is written before ParameterDescription
-            // arrives. Serialize plain objects/arrays as JSON text regardless,
-            // which json, jsonb, and text columns all accept.
+            // With prepare: false the OID is still 0 here (Bind precedes ParameterDescription).
             types::Tag::json
         } else {
             tag
         };
         match effective_tag {
             types::Tag::jsonb | types::Tag::json => {
-                // OwnedString derefs the +1 WTFStringImpl ref from
-                // json_stringify_fast on scope exit; bun_core::String is Copy
-                // with no Drop, so a bare BunString here would leak it.
                 let mut str = bun_core::OwnedString::new(BunString::empty());
                 // Use jsonStringifyFast for SIMD-optimized serialization
                 value

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,6 +49,25 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
+/// True when a JS value should be serialized to postgres as JSON text: a plain
+/// object or array, matching what `tag_jsc::from_js` classifies as json/jsonb.
+/// Strings, dates, typed arrays/buffers, and bigints are handled by other arms.
+fn value_is_json(value: JSValue) -> bool {
+    use crate::jsc::JSType;
+    if !value.is_cell() {
+        return false;
+    }
+    let t = value.js_type();
+    if t.is_string_like()
+        || t == JSType::JSDate
+        || t.is_typed_array_or_array_buffer()
+        || t == JSType::HeapBigInt
+    {
+        return false;
+    }
+    t.is_array_like() || t.is_object()
+}
+
 pub(crate) fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: BunString,
@@ -159,8 +178,18 @@ pub(crate) fn write_bind<Context: WriterContext>(
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
         // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
-            types::Tag::text
+        let effective_tag = if tag.is_binary_format_supported() {
+            if value.is_string() {
+                types::Tag::text
+            } else {
+                tag
+            }
+        } else if value_is_json(value) {
+            // The server-declared OID is unknown (0) or text on the unnamed
+            // one-shot path because Bind is written before ParameterDescription
+            // arrives. Serialize plain objects/arrays as JSON text regardless,
+            // which json, jsonb, and text columns all accept.
+            types::Tag::json
         } else {
             tag
         };

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -195,7 +195,10 @@ pub(crate) fn write_bind<Context: WriterContext>(
         };
         match effective_tag {
             types::Tag::jsonb | types::Tag::json => {
-                let mut str = BunString::empty();
+                // OwnedString derefs the +1 WTFStringImpl ref from
+                // json_stringify_fast on scope exit; bun_core::String is Copy
+                // with no Drop, so a bare BunString here would leak it.
+                let mut str = bun_core::OwnedString::new(BunString::empty());
                 // Use jsonStringifyFast for SIMD-optimized serialization
                 value
                     .json_stringify_fast(global, &mut str)
@@ -204,7 +207,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 let l = writer.length()?;
                 writer.write(slice.slice())?;
                 l.write_excluding_self()?;
-                // `str.deref()` and `slice.deinit()` handled by Drop
             }
             types::Tag::bool => {
                 let l = writer.length()?;

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -170,9 +170,9 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     expect(v).toBe(JSON.stringify(obj));
   });
 
-  // Guard: sql.array nested inside an UPDATE helper reaches native as its
-  // pre-serialized string, not the SQLArrayParameter wrapper object, so the
-  // JSON path above never applies to it.
+  // Guards: helpers and sql.unsafe hand the sql.array() wrapper itself to
+  // native (unlike the tagged template), so it must bind as text, not be
+  // caught by the object-to-JSON path above.
   test("sql.array inside an UPDATE helper still binds as an array literal", async () => {
     await container.ready;
     await using db = new SQL(options());
@@ -185,8 +185,6 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     expect(roles).toEqual(["c", "d"]);
   });
 
-  // Same guard for sql.unsafe, which skips query normalization entirely and
-  // must not mutate the caller's args array while unwrapping.
   test("sql.array passed to sql.unsafe still binds as an array literal", async () => {
     await container.ready;
     await using db = new SQL(options());

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -184,4 +184,16 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
       await db`UPDATE ${db(t)} SET ${db({ name: "b", roles: db.array(["c", "d"], "TEXT") })} WHERE id = ${id} RETURNING *`;
     expect(roles).toEqual(["c", "d"]);
   });
+
+  // Same guard for sql.unsafe, which skips query normalization entirely and
+  // must not mutate the caller's args array while unwrapping.
+  test("sql.array passed to sql.unsafe still binds as an array literal", async () => {
+    await container.ready;
+    await using db = new SQL(options());
+    const args = [db.array(["a", "b"], "TEXT")];
+    const [{ v }] = await db.unsafe("SELECT $1::TEXT[] AS v", args);
+    expect(v).toEqual(["a", "b"]);
+    // The caller's array must still hold the wrapper, not the unwrapped string.
+    expect(typeof args[0]).toBe("object");
+  });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -125,4 +125,35 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
       expect(actual).toBe(expected);
     }
   });
+
+  // https://github.com/oven-sh/bun/issues/30221
+  // On the unnamed one-shot path Bind is written before ParameterDescription
+  // arrives, so the parameter OID is unknown and object values used to be
+  // serialized as the literal string "[object Object]".
+  const obj = { a: 1, b: [null, true], c: "hi" };
+
+  test("object param is JSON for a jsonb column", async () => {
+    await using db = new SQL(options);
+    const [{ v }] = await db`SELECT ${obj}::jsonb AS v`;
+    expect(v).toEqual(obj);
+  });
+
+  test("object param is JSON for a json column", async () => {
+    await using db = new SQL(options);
+    const [{ v }] = await db`SELECT ${obj}::json AS v`;
+    expect(v).toEqual(obj);
+  });
+
+  test("object param is JSON text for a text column, not [object Object]", async () => {
+    await using db = new SQL(options);
+    const [{ v }] = await db`SELECT ${obj}::text AS v`;
+    expect(v).toBe(JSON.stringify(obj));
+  });
+
+  test("array param is JSON for a jsonb column", async () => {
+    await using db = new SQL(options);
+    const arr = [1, "two", { three: 3 }];
+    const [{ v }] = await db`SELECT ${arr}::jsonb AS v`;
+    expect(v).toEqual(arr);
+  });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -133,25 +133,29 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   const obj = { a: 1, b: [null, true], c: "hi" };
 
   test("object param is JSON for a jsonb column", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ v }] = await db`SELECT ${obj}::jsonb AS v`;
     expect(v).toEqual(obj);
   });
 
   test("object param is JSON for a json column", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ v }] = await db`SELECT ${obj}::json AS v`;
     expect(v).toEqual(obj);
   });
 
   test("object param is JSON text for a text column, not [object Object]", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ v }] = await db`SELECT ${obj}::text AS v`;
     expect(v).toBe(JSON.stringify(obj));
   });
 
   test("array param is JSON for a jsonb column", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const arr = [1, "two", { three: 3 }];
     const [{ v }] = await db`SELECT ${arr}::jsonb AS v`;
     expect(v).toEqual(arr);
@@ -160,7 +164,8 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   // The prepared path declares OID 25 (text) for a `::text` slot, which is not
   // a binary type, so an object there also used to become "[object Object]".
   test("object param is JSON text for a text column with prepare: true", async () => {
-    await using db = new SQL({ ...options, prepare: true });
+    await container.ready;
+    await using db = new SQL({ ...options(), prepare: true });
     const [{ v }] = await db`SELECT ${obj}::text AS v`;
     expect(v).toBe(JSON.stringify(obj));
   });
@@ -169,7 +174,8 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   // pre-serialized string, not the SQLArrayParameter wrapper object, so the
   // JSON path above never applies to it.
   test("sql.array inside an UPDATE helper still binds as an array literal", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const t = "prepare_false_arr_" + Date.now();
     await db`CREATE TEMPORARY TABLE ${db(t)} (id SERIAL PRIMARY KEY, name VARCHAR NOT NULL, roles TEXT[])`;
     const [{ id }] =

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -190,10 +190,10 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   test("sql.array passed to sql.unsafe still binds as an array literal", async () => {
     await container.ready;
     await using db = new SQL(options());
-    const args = [db.array(["a", "b"], "TEXT")];
+    const param = db.array(["a", "b"], "TEXT");
+    const args = [param];
     const [{ v }] = await db.unsafe("SELECT $1::TEXT[] AS v", args);
     expect(v).toEqual(["a", "b"]);
-    // The caller's array must still hold the wrapper, not the unwrapped string.
-    expect(typeof args[0]).toBe("object");
+    expect(args[0]).toBe(param);
   });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -164,4 +164,18 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     const [{ v }] = await db`SELECT ${obj}::text AS v`;
     expect(v).toBe(JSON.stringify(obj));
   });
+
+  // Guard: sql.array nested inside an UPDATE helper reaches native as its
+  // pre-serialized string, not the SQLArrayParameter wrapper object, so the
+  // JSON path above never applies to it.
+  test("sql.array inside an UPDATE helper still binds as an array literal", async () => {
+    await using db = new SQL(options);
+    const t = "prepare_false_arr_" + Date.now();
+    await db`CREATE TEMPORARY TABLE ${db(t)} (id SERIAL PRIMARY KEY, name VARCHAR NOT NULL, roles TEXT[])`;
+    const [{ id }] =
+      await db`INSERT INTO ${db(t)} (name, roles) VALUES (${"a"}, ${db.array(["a", "b"], "TEXT")}) RETURNING *`;
+    const [{ roles }] =
+      await db`UPDATE ${db(t)} SET ${db({ name: "b", roles: db.array(["c", "d"], "TEXT") })} WHERE id = ${id} RETURNING *`;
+    expect(roles).toEqual(["c", "d"]);
+  });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -156,4 +156,12 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     const [{ v }] = await db`SELECT ${arr}::jsonb AS v`;
     expect(v).toEqual(arr);
   });
+
+  // The prepared path declares OID 25 (text) for a `::text` slot, which is not
+  // a binary type, so an object there also used to become "[object Object]".
+  test("object param is JSON text for a text column with prepare: true", async () => {
+    await using db = new SQL({ ...options, prepare: true });
+    const [{ v }] = await db`SELECT ${obj}::text AS v`;
+    expect(v).toBe(JSON.stringify(obj));
+  });
 });


### PR DESCRIPTION
## What

With `prepare: false` (the documented PgBouncer / transaction-pooling mode), every object parameter was serialized as the literal string `"[object Object]"`.

```ts
const sql = new Bun.SQL(url, { prepare: false });
await sql`select ${ {a: 1} }::jsonb`;  // SERVER ERROR: invalid input syntax for type json
await sql`select ${ {a: 1} }::text`;   // silently stored "[object Object]"
```

json/jsonb inserts fail with `invalid input syntax for type json`, and text/varchar columns silently persist `"[object Object]"` with no error. The same `prepare: true` path serializes objects correctly for json/jsonb, so this only surfaced when the flag was flipped for a pooler.

## Cause

The Bind writer (`write_bind` in `src/sql_jsc/postgres/PostgresRequest.rs`) chooses JSON serialization based on the server-declared parameter OID. On the default prepared path that OID is known (from `ParameterDescription`) before Bind is written. On the `prepare: false` unnamed path, the one-shot Parse+Describe+Bind+Execute pipeline writes Bind *before* any `ParameterDescription` arrives, so the parameter OID is `0`/unknown and the object value fell into the generic `ToString` arm, producing `"[object Object]"`.

The same generic arm also affected a text-declared slot on the prepared path (`select $1::text` with an object gave `"[object Object]"`).

## Fix

- `write_bind`: serialize plain objects and arrays as JSON text whenever the parameter OID is not a recognized binary type, rather than gating JSON on the server OID. json, jsonb, and text columns all accept JSON text, which is what postgres.js does in both modes.
- `write_bind` json arm: wrap the `json_stringify_fast` output in `OwnedString` so the +1 WTFStringImpl ref is released on scope exit (`bun_core::String` is `Copy` with no `Drop`, so the bare `BunString` there was leaking the serialized JSON on every query).
- `SQLArrayParameter` (`src/js/internal/sql/shared.ts`), the object `sql.array()` returns, now extends `String` and carries its serialized array literal as the string value. Only the tagged-template path replaces it with that literal (via `adapter.bindParam`); the INSERT / UPDATE / WHERE IN helpers and `sql.unsafe` / `sql.file` hand the object itself to native. Those paths previously worked only because native's fallback arm happened to call `toString()`; with objects now JSON-stringified, the wrapper's `toJSON()` output would be JSON-quoted and rejected as a malformed array literal. As a `String` object, native classifies it as text on every path (`tag_jsc::from_js`, and the new branch excludes string-like values) and ToStrings it to the literal, so nothing on the JS side has to inspect or rewrite the bound values.

## Behavior change on the prepared path (intentional, flagging for review)

The first Fix bullet applies to every parameter whose OID is not one of Bun's binary-encoded types, not only OID 0. On the default `prepare: true` path that means a class instance bound to a uuid / int8 / int2 / date / inet / array column is now `JSON.stringify`'d where it previously went through `toString()`, and the server rejects the JSON for those types. This is deliberate:

- Under `prepare: false` every non-numeric value is declared OID 0 (`Signature.rs`), so such a value is JSON-stringified there no matter how this is gated. Gating the new branch on OID 0 / text / json would only make the result depend on the `prepare` flag, which is the inconsistency this PR removes.
- postgres.js, which the issue cites as the reference, stringifies objects unconditionally; `toJSON()` is honored, and `String(x)` at the call site opts out.
- No test in `test/js/sql` relied on the `toString()` fallthrough.

If narrower scoping is preferred anyway, it is a one-line change to the `else if` in `write_bind` (gate on `tag` being 0 / text / varchar / json / jsonb) and the tests here still pass.

## Relationship to #39452

#39452 fixes the sibling issue #39450 (`Date` and objects under `prepare: false`) in the same `write_bind` block and the same test file, so the two conflict and whichever lands second needs a rebase. How they differ:

- #39452 also encodes `Date` as ISO-8601 on the OID-0 path; this PR does not touch `Date`.
- #39452 gates on OID 0 only; this PR applies to any non-binary OID, which also covers the `prepare: true` `$1::text` case.
- #39452 routes any OID-0 object through `tag_jsc::from_js`, which classifies the `sql.array()` wrapper as json, so `sql.array()` passed through a helper or `sql.unsafe` under `prepare: false` would be JSON-quoted into a malformed array literal. This PR's `SQLArrayParameter extends String` change prevents that for either native change, and the two `sql.array()` guard tests here are that exact case. Either PR's native change needs it; it is not separable.
- Both fix the same `OwnedString` leak in the json arm.

Closes #30221

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-prepare-false.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [213.92ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [43.89ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [62.53ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [84.44ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [21.48ms]
(pass) PostgreSQL prepare: false > query without params still works [20.04ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [91.42ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [166.20ms]
PostgresError: invalid input syntax for type json
    errno: "22P02",
   detail: "Token \"object\" is invalid.",
 severity: "ERROR",
    where: "JSON data, line 1: [obje
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (40f119ffe)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [6.51ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [3.59ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [3.22ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [11.55ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [2.48ms]
(pass) PostgreSQL prepare: false > query without params still works [2.20ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [6.74ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [4.43ms]
(pass) PostgreSQL prepare: false > object param is JSON for a jsonb column [2.32ms]
(pass) PostgreSQL prepare: false > object param is JSON for a json column [2.06ms]
(pass) PostgreSQL prepare: false > object param is JSON text for a text column, not [object Object] [2.01ms]
(pass) PostgreSQL prepare: false > array param is JSON for a jso
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-prepare-false.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [217.13ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [44.71ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [62.71ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [83.44ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [21.78ms]
(pass) PostgreSQL prepare: false > query without params still works [20.60ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [92.22ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [166.92ms]
(pass) PostgreSQL prepare: false > object param is JSON for a jsonb column [23.19ms]
(pass) PostgreSQL prepare: false > object param is JSON for a json column [60.97ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7869ms)
Bundle modules (62ms)
Postprocesss modules (224ms)
Bundle Functions (739ms)
Generate Code (28ms)

[8.94s] Bundled "src/js" for production
  2631 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/shared.ts           |  5 ++-
 src/sql_jsc/postgres/PostgresRequest.rs | 31 +++++++++++++--
 test/js/sql/sql-prepare-false.test.ts   | 69 +++++++++++++++++++++++++++++++++
 3 files changed, 100 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/internal/sql/shared.ts               12     14      0
src/sql_jsc/postgres/PostgresRequest.rs     11      9      0
test/js/sql/sql-prepare-false.test.ts        9     11      0
```

</details>

<!-- robobun:evidence:end -->