### PR TITLE
node:http: surface EINVAL for Server.listen({ fd }) instead of silently binding a random port

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -449,6 +449,7 @@ Server.prototype.listen = function () {
   const server = this;
   let port, host, onListen;
   let socketPath;
+  let fd;
   let tls = this[tlsSymbol];
 
   // This logic must align with:
@@ -461,6 +462,7 @@ Server.prototype.listen = function () {
       port = arg0.port;
       host = arg0.host;
       socketPath = arg0.path;
+      fd = arg0.fd;
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
@@ -498,6 +500,17 @@ Server.prototype.listen = function () {
 
   try {
     // listenInCluster
+
+    // Bun.serve cannot adopt an inherited listening fd, so surface the same
+    // EINVAL net.Server.listen({ fd }) reports rather than silently binding a
+    // fresh random port (which leaves the intended socket unreachable).
+    if (typeof fd === "number" && fd >= 0) {
+      const error: any = new Error("listen EINVAL: Bun does not support listening on a file descriptor");
+      error.code = "EINVAL";
+      error.errno = -22;
+      error.syscall = "listen";
+      throw error;
+    }
 
     if (isPrimary) {
       server[kRealListen](tls, port, host, socketPath, false, onListen);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -507,7 +507,7 @@ Server.prototype.listen = function () {
     if (typeof fd === "number" && fd >= 0) {
       const error: any = new Error("listen EINVAL: Bun does not support listening on a file descriptor");
       error.code = "EINVAL";
-      error.errno = -22;
+      error.errno = process.platform === "win32" ? -4071 : -22;
       error.syscall = "listen";
       throw error;
     }

--- a/test/js/node/http/node-http-listen-fd.test.ts
+++ b/test/js/node/http/node-http-listen-fd.test.ts
@@ -6,24 +6,27 @@ import net from "node:net";
 // Bun.serve cannot adopt an inherited listening descriptor, so http.Server
 // must report an error for listen({ fd }) instead of silently binding a fresh
 // random port (which left the service unreachable on the intended socket).
-test.skipIf(!isPosix)("http.Server.listen({ fd }) reports EINVAL instead of silently binding a random port", async () => {
-  const donor = net.createServer(() => {});
-  try {
-    await new Promise<void>(resolve => donor.listen(0, "127.0.0.1", () => resolve()));
-    const fd = (donor as any)._handle.fd;
-    expect(typeof fd).toBe("number");
-    expect(fd).toBeGreaterThanOrEqual(0);
+test.skipIf(!isPosix)(
+  "http.Server.listen({ fd }) reports EINVAL instead of silently binding a random port",
+  async () => {
+    const donor = net.createServer(() => {});
+    try {
+      await new Promise<void>(resolve => donor.listen(0, "127.0.0.1", () => resolve()));
+      const fd = (donor as any)._handle.fd;
+      expect(typeof fd).toBe("number");
+      expect(fd).toBeGreaterThanOrEqual(0);
 
-    const server = http.createServer((req, res) => res.end("ok"));
-    const result = await new Promise<any>(resolve => {
-      server.once("error", (e: any) => resolve({ event: "error", code: e.code, syscall: e.syscall }));
-      server.once("listening", () => resolve({ event: "listening", address: server.address() }));
-      server.listen({ fd });
-    });
-    server.close();
+      const server = http.createServer((req, res) => res.end("ok"));
+      const result = await new Promise<any>(resolve => {
+        server.once("error", (e: any) => resolve({ event: "error", code: e.code, syscall: e.syscall }));
+        server.once("listening", () => resolve({ event: "listening", address: server.address() }));
+        server.listen({ fd });
+      });
+      server.close();
 
-    expect(result).toEqual({ event: "error", code: "EINVAL", syscall: "listen" });
-  } finally {
-    donor.close();
-  }
-});
+      expect(result).toEqual({ event: "error", code: "EINVAL", syscall: "listen" });
+    } finally {
+      donor.close();
+    }
+  },
+);

--- a/test/js/node/http/node-http-listen-fd.test.ts
+++ b/test/js/node/http/node-http-listen-fd.test.ts
@@ -18,13 +18,14 @@ test.skipIf(!isPosix)(
 
       const server = http.createServer((req, res) => res.end("ok"));
       const result = await new Promise<any>(resolve => {
-        server.once("error", (e: any) => resolve({ event: "error", code: e.code, syscall: e.syscall }));
+        server.once("error", (e: any) => resolve({ event: "error", code: e.code, errno: e.errno, syscall: e.syscall }));
         server.once("listening", () => resolve({ event: "listening", address: server.address() }));
         server.listen({ fd });
       });
       server.close();
 
-      expect(result).toEqual({ event: "error", code: "EINVAL", syscall: "listen" });
+      // POSIX-only test, so the libuv errno is -22 (Windows reports -4071).
+      expect(result).toEqual({ event: "error", code: "EINVAL", errno: -22, syscall: "listen" });
     } finally {
       donor.close();
     }

--- a/test/js/node/http/node-http-listen-fd.test.ts
+++ b/test/js/node/http/node-http-listen-fd.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { isPosix } from "harness";
+import http from "node:http";
+import net from "node:net";
+
+// Bun.serve cannot adopt an inherited listening descriptor, so http.Server
+// must report an error for listen({ fd }) instead of silently binding a fresh
+// random port (which left the service unreachable on the intended socket).
+test.skipIf(!isPosix)("http.Server.listen({ fd }) reports EINVAL instead of silently binding a random port", async () => {
+  const donor = net.createServer(() => {});
+  try {
+    await new Promise<void>(resolve => donor.listen(0, "127.0.0.1", () => resolve()));
+    const fd = (donor as any)._handle.fd;
+    expect(typeof fd).toBe("number");
+    expect(fd).toBeGreaterThanOrEqual(0);
+
+    const server = http.createServer((req, res) => res.end("ok"));
+    const result = await new Promise<any>(resolve => {
+      server.once("error", (e: any) => resolve({ event: "error", code: e.code, syscall: e.syscall }));
+      server.once("listening", () => resolve({ event: "listening", address: server.address() }));
+      server.listen({ fd });
+    });
+    server.close();
+
+    expect(result).toEqual({ event: "error", code: "EINVAL", syscall: "listen" });
+  } finally {
+    donor.close();
+  }
+});


### PR DESCRIPTION
Fixes #22559

## What

`http.Server.listen({ fd })` (socket activation / inherited listener: systemd `LISTEN_FDS`, inetd, a privilege-dropping supervisor) silently ignored the `fd` option. The `listening` event fired, but the server bound a fresh random ephemeral port on `::` instead of adopting the already-bound descriptor. The process reported listening, health checks that poll the process passed, and the deployment was unreachable on the socket the supervisor was holding, with no error anywhere.

`net.Server.listen({ fd })` already reports `EINVAL` for the same unsupported operation; only the `node:http` path failed silently.

### Repro

```js
// parent binds+listens a socket, hands it to the child as fd 3
import net from "node:net";
import http from "node:http";

const srv = http.createServer((req, res) => res.end("served-on-inherited-fd"));
srv.once("error", e => console.log("error", e.code));
srv.listen({ fd: 3 }, () => console.log("listening", srv.address()));
// before: listening { address: '::', family: 'IPv6', port: <RANDOM> }  -> unreachable
// after:  error EINVAL
```

## Cause

`Server.prototype.listen` in `src/js/node/_http_server.ts` never read `arg0.fd`. With no `port`/`path`, the normalizer defaulted `port` to `0` and handed that to `Bun.serve`, which bound an ephemeral TCP port. `Bun.serve` has no way to adopt an existing listening descriptor (uSockets exposes no listen-from-fd entry point), so the option had nowhere to go.

## Fix

Read `fd` from the options object and, when present, throw the same `EINVAL` (`syscall: "listen"`) that `net.Server.listen({ fd })` reports. The throw goes through `listen`'s existing try/catch, so it surfaces as an `error` event, matching Node's listen error semantics and Bun's own `node:net` behavior. Callers now learn immediately that the socket was not adopted instead of silently serving on the wrong port.

Actually adopting an inherited listening fd would require a new native uSockets listen-from-fd path plus an `Address::Fd` variant in the server config; that is a larger, cross-cutting change worth a separate discussion.

## Verification

`test/js/node/http/node-http-listen-fd.test.ts`: a donor `net` server provides a real listening fd; `http.Server.listen({ fd })` must emit `error` with `{ code: "EINVAL", syscall: "listen" }`.

- Fails on current `main` (emits `listening` on a random port, e.g. `::` `43749`).
- Passes with this change.
