### PR TITLE
postgres: encode array parameters as text array literals

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -96,7 +96,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 && 'brk: {
                     iter.to(i as u32);
                     if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-                        break 'brk value.is_string();
+                        break 'brk value.is_string() || value.is_array();
                     }
                     if iter.any_failed() {
                         return Err(AnyPostgresError::InvalidQueryBinding);
@@ -154,6 +154,18 @@ pub(crate) fn write_bind<Context: WriterContext>(
         }
         bun_core::scoped_log!(Postgres, "  -> {}", tag.tag_name().unwrap_or("(unknown)"));
 
+        // A scalar json/jsonb parameter keeps JSON text (`[1,2]`), handled below.
+        if value.is_array() && !matches!(tag, types::Tag::json | types::Tag::jsonb) {
+            let mut buf: Vec<u8> = Vec::new();
+            write_array_literal(&mut buf, value, global, tag, 0)?;
+            let l = writer.length()?;
+            bun_core::scoped_log!(Postgres, "    array literal {} bytes", buf.len());
+            writer.write(&buf)?;
+            l.write_excluding_self()?;
+            i += 1;
+            continue;
+        }
+
         // If they pass a value as a string, let's avoid attempting to
         // convert it to the binary representation. This minimizes the room
         // for mistakes on our end, such as stripping the timezone
@@ -204,11 +216,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
                 l.write_excluding_self()?;
             }
-            types::Tag::int4_array => {
-                let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
-                l.write_excluding_self()?;
-            }
             types::Tag::float8 => {
                 let l = writer.length()?;
                 writer.f64(value.to_number(global).map_err(js_error_to_postgres)?)?;
@@ -252,6 +259,83 @@ pub(crate) fn write_bind<Context: WriterContext>(
 
     length.write()?;
     Ok(())
+}
+
+/// Mirrors `serializeArray` in `src/js/internal/sql/postgres.ts`.
+fn write_array_literal(
+    out: &mut Vec<u8>,
+    value: JSValue,
+    global: &JSGlobalObject,
+    tag: types::Tag,
+    depth: u32,
+) -> Result<(), AnyPostgresError> {
+    const MAX_ARRAY_DEPTH: u32 = 64;
+    if depth >= MAX_ARRAY_DEPTH {
+        return Err(AnyPostgresError::InvalidQueryBinding);
+    }
+    // box is the only built-in type with typdelim ';' (its text form contains commas).
+    let delimiter = if tag == types::Tag::box_array {
+        b';'
+    } else {
+        b','
+    };
+    let is_bytea = tag == types::Tag::bytea_array;
+    let is_json = matches!(tag, types::Tag::json_array | types::Tag::jsonb_array);
+
+    out.push(b'{');
+    let len = value.get_length(global).map_err(js_error_to_postgres)?;
+    for idx in 0..len {
+        if idx > 0 {
+            out.push(delimiter);
+        }
+        let element = value
+            .get_index(global, idx as u32)
+            .map_err(js_error_to_postgres)?;
+        let is_array_buffer_like = element.is_cell() && element.js_type().is_array_buffer_like();
+        if element.is_empty_or_undefined_or_null() {
+            out.extend_from_slice(b"NULL");
+        } else if element.is_array() {
+            write_array_literal(out, element, global, tag, depth + 1)?;
+        } else if is_bytea && is_array_buffer_like {
+            let buf = element.as_array_buffer(global);
+            let bytes: &[u8] = buf.as_ref().map(|b| b.byte_slice()).unwrap_or(b"");
+            let mut text = vec![0u8; 2 + bytes.len() * 2];
+            text[0] = b'\\';
+            text[1] = b'x';
+            bun_fmt::bytes_to_hex_lower(bytes, &mut text[2..]);
+            write_quoted_element(out, &text);
+        } else if is_json || (element.is_object() && !element.is_date() && !is_array_buffer_like) {
+            let str = element
+                .json_stringify_fast(global)
+                .map_err(js_error_to_postgres)?;
+            write_quoted_element(out, str.to_utf8_without_ref().slice());
+        } else if element.is_date() {
+            // JSON.stringify(date) is the ISO string already double-quoted.
+            let str = element
+                .json_stringify_fast(global)
+                .map_err(js_error_to_postgres)?;
+            out.extend_from_slice(str.to_utf8_without_ref().slice());
+        } else {
+            let str = BunString::from_js(element, global).map_err(js_error_to_postgres)?;
+            if str.tag() == bun_core::Tag::Dead {
+                return Err(AnyPostgresError::OutOfMemory);
+            }
+            write_quoted_element(out, str.to_utf8_without_ref().slice());
+        }
+    }
+    out.push(b'}');
+    Ok(())
+}
+
+fn write_quoted_element(out: &mut Vec<u8>, text: &[u8]) {
+    out.push(b'"');
+    for &byte in text {
+        if byte == b'"' || byte == b'\\' {
+            out.push(b'\\');
+        }
+        out.push(byte);
+    }
+    out.push(b'"');
 }
 
 pub(crate) fn write_query<Context: WriterContext>(

--- a/test/js/sql/postgres-bind-array-params.test.ts
+++ b/test/js/sql/postgres-bind-array-params.test.ts
@@ -1,0 +1,152 @@
+// https://github.com/oven-sh/bun/issues/29551
+// A raw JS array bound as a query parameter must be encoded in the Bind message
+// as a PostgreSQL text array literal (`{1,2,3}`) with format code 0. Asserts the
+// exact Bind frame bytes against a mock backend so it needs no real PostgreSQL.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDecodeBind,
+  pgNoData,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  type PgBindMessage,
+} from "./wire-frames";
+
+const BIND = "B".charCodeAt(0);
+const SYNC = "S".charCodeAt(0);
+
+// Drive one prepared query whose single parameter the backend reports as
+// `paramOid`, and return the decoded Bind message the client sent.
+async function captureBind(paramOid: number, param: unknown): Promise<PgBindMessage> {
+  const { promise, resolve, reject } = Promise.withResolvers<PgBindMessage>();
+
+  const { port, server } = await listeningServer(socket => {
+    let startupDone = false;
+    let buffered = Buffer.alloc(0);
+    let bindBody: Buffer | null = null;
+
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      if (!startupDone) {
+        startupDone = true;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      buffered = pgReadFrontendMessages(Buffer.concat([buffered, chunk]), (type, body) => {
+        if (type === BIND) bindBody = Buffer.from(body);
+        if (type !== SYNC) return;
+        // A Sync ends a request batch. The prepare batch (Parse + Describe) has
+        // no Bind; the execute batch does.
+        if (bindBody) {
+          socket.write(Buffer.concat([pgBindComplete(), pgCommandComplete("SELECT 0"), pgReadyForQuery()]));
+          resolve(pgDecodeBind(bindBody));
+        } else {
+          socket.write(
+            Buffer.concat([pgParseComplete(), pgParameterDescription([paramOid]), pgNoData(), pgReadyForQuery()]),
+          );
+        }
+      });
+    });
+  });
+
+  try {
+    await using sql = new SQL({ hostname: "127.0.0.1", port, username: "x", database: "x", max: 1 });
+    try {
+      await sql.unsafe("select $1", [param]);
+    } catch (e) {
+      reject(e as Error);
+    }
+    return await promise;
+  } finally {
+    server.close();
+  }
+}
+
+const text = (b: Buffer | null) => (b === null ? null : b.toString("latin1"));
+
+test("int4[] array parameter is sent as a text array literal, format 0", async () => {
+  const bind = await captureBind(1007 /* int4_array */, [1, 2, 3]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"1","2","3"}`);
+});
+
+test("float4[] array parameter is sent as a text array literal, format 0", async () => {
+  const bind = await captureBind(1021 /* float4_array */, [1.5, 2.5]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"1.5","2.5"}`);
+});
+
+test("text[] array parameter is wrapped in braces", async () => {
+  const bind = await captureBind(1009 /* text_array */, ["a", "b"]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"a","b"}`);
+});
+
+test("int8[] array parameter is wrapped in braces", async () => {
+  const bind = await captureBind(1016 /* int8_array */, [1, 2]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"1","2"}`);
+});
+
+test("null elements become NULL and quotes/backslashes are escaped", async () => {
+  const bind = await captureBind(1009 /* text_array */, ["a,b", `he"llo`, "back\\slash", null]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"a,b","he\\"llo","back\\\\slash",NULL}`);
+});
+
+test("nested arrays produce nested braces", async () => {
+  const bind = await captureBind(1007 /* int4_array */, [
+    [1, 2],
+    [3, 4],
+  ]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{{"1","2"},{"3","4"}}`);
+});
+
+test("empty array becomes {}", async () => {
+  const bind = await captureBind(1007 /* int4_array */, []);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{}`);
+});
+
+test("jsonb array parameter stays JSON, not a pg array literal", async () => {
+  const bind = await captureBind(3802 /* jsonb */, ["a", "b"]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`["a","b"]`);
+});
+
+test("box[] uses ; as the element delimiter", async () => {
+  const bind = await captureBind(1020 /* box_array */, ["(0,0),(1,1)", "(2,2),(3,3)"]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"(0,0),(1,1)";"(2,2),(3,3)"}`);
+});
+
+test("Date elements serialize as ISO strings", async () => {
+  const bind = await captureBind(1185 /* timestamptz_array */, [new Date(Date.UTC(2024, 0, 2, 3, 4, 5))]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"2024-01-02T03:04:05.000Z"}`);
+});
+
+test("object elements in a jsonb[] serialize as JSON", async () => {
+  const bind = await captureBind(3807 /* jsonb_array */, [{ a: 1 }, { b: [2, 3] }]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"{\\"a\\":1}","{\\"b\\":[2,3]}"}`);
+});
+
+test("primitive elements in a jsonb[] serialize as JSON", async () => {
+  const bind = await captureBind(3807 /* jsonb_array */, ["hello", 42, true]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"\\"hello\\"","42","true"}`);
+});
+
+test("Buffer and Uint8Array elements in a bytea[] serialize as hex", async () => {
+  const bind = await captureBind(1001 /* bytea_array */, [Buffer.from([1, 2, 255]), new Uint8Array([0, 170])]);
+  expect(bind.formatCodes).toEqual([0]);
+  expect(text(bind.values[0])).toBe(`{"\\\\x0102ff","\\\\x00aa"}`);
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -231,6 +231,56 @@ export function pgParameterDescription(typeOids: number[]): Buffer {
   return pgRaw("t", body);
 }
 
+// PostgreSQL FE/BE protocol §55.7 NoData: Byte1('n') Int32(4)
+export function pgNoData(): Buffer {
+  return pgRaw("n", Buffer.alloc(0));
+}
+
+export type PgBindMessage = {
+  portal: string;
+  statement: string;
+  /** one entry per declared parameter format code (0 = text, 1 = binary) */
+  formatCodes: number[];
+  /** raw parameter value bytes, or null for a SQL NULL parameter */
+  values: (Buffer | null)[];
+};
+
+// Decode a frontend Bind message body (everything after Byte1('B') Int32(len)) —
+// §55.7: String(portal) String(statement) Int16(C) Int16[C](format) Int16(V)
+// per value Int32(len | -1) Byte[len], then the result-format codes (ignored here).
+export function pgDecodeBind(body: Buffer): PgBindMessage {
+  let o = 0;
+  const readCString = (): string => {
+    const end = body.indexOf(0, o);
+    const s = body.subarray(o, end).toString("latin1");
+    o = end + 1;
+    return s;
+  };
+  const portal = readCString();
+  const statement = readCString();
+  const formatCount = body.readInt16BE(o);
+  o += 2;
+  const formatCodes: number[] = [];
+  for (let i = 0; i < formatCount; i++) {
+    formatCodes.push(body.readInt16BE(o));
+    o += 2;
+  }
+  const valueCount = body.readInt16BE(o);
+  o += 2;
+  const values: (Buffer | null)[] = [];
+  for (let i = 0; i < valueCount; i++) {
+    const len = body.readInt32BE(o);
+    o += 4;
+    if (len === -1) {
+      values.push(null);
+    } else {
+      values.push(body.subarray(o, o + len));
+      o += len;
+    }
+  }
+  return { portal, statement, formatCodes, values };
+}
+
 /**
  * Drain complete PostgreSQL frontend messages from `buffered`, calling
  * onMessage(type, body) for each; returns the leftover bytes. The very first


### PR DESCRIPTION
## What

A raw JavaScript array passed as a query parameter (not via `sql.array`) was encoded as wire garbage, so every array parameter failed against a real PostgreSQL server:

```ts
const sql = new Bun.SQL(url);
await sql.unsafe("select $1::int4[]", [[1, 2, 3]]);   // 08P01 insufficient data left in message
await sql.unsafe("select 3 = any($1::int4[])", [[1, 2, 3]]); // 08P01 insufficient data left in message
await sql.unsafe("select $1::float4[]", [[1.5, 2.5]]);  // number of array dimensions (...) exceeds the maximum
await sql.unsafe("select $1::text[]", [["a", "b"]]);    // malformed array literal: "a,b"
await sql.unsafe("select $1::int8[]", [[1, 2]]);        // malformed array literal: "1,2"
```

This is how you write `IN`-lists (`where id = any($1)`), batch lookups, and `unnest($1)` bulk inserts, so all of those were broken. `postgres.js` / `node-postgres` send `{1,2,3}` / `{"a","b"}` and the same queries work.

## Cause

The Bind writer (`write_bind` in `src/sql_jsc/postgres/PostgresRequest.rs`) had no array value encoder:

- `Tag::int4_array` fell into a scalar `value.coerce::<i32>()` arm and wrote a 4-byte scalar, while still declaring format 1 (binary).
- `Tag::float4_array` fell into the generic `ToString` arm (`[1.5,2.5]` -> `"1.5,2.5"`) but was declared binary, so the server read ASCII as a binary array header.
- Every other array OID (`text[]`, `int8[]`, ...) also hit the `ToString` arm, producing `"1,2"` / `"a,b"` with no `{}` braces, which is not a PostgreSQL array literal.

## Fix

Serialize any JS array parameter as a PostgreSQL text array literal and declare it format 0 (text), matching what `postgres.js` does:

- `[1, 2, 3]` -> `{"1","2","3"}`
- `["a", "b"]` -> `{"a","b"}`
- nested arrays -> nested braces `{{"1","2"},{"3","4"}}`
- `null` / `undefined` elements -> unquoted `NULL`
- `"` and `\` in element text are escaped

`json`/`jsonb` array parameters are excluded and keep their existing JSON-text serialization (`[1,2,3]`), and a recursion-depth guard bounds pathologically nested input.

## Verification

`test/js/sql/postgres-bind-array-params.test.ts` drives the prepared-query flow against a mock backend and asserts the exact bytes of the Bind message (format code + parameter value), so it is deterministic and needs no real PostgreSQL. The array-OID cases fail on the unfixed build (format code 1, scalar/`ToString` payload) and pass with the fix; the `jsonb` case guards against regressing JSON serialization.

Also verified end to end against PostgreSQL 17: all five queries above now return correct results.

Fixes #29551

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-bind-array-params.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/postgres-bind-array-params.test.ts:
70 | 
71 | const text = (b: Buffer | null) => (b === null ? null : b.toString("latin1"));
72 | 
73 | test("int4[] array parameter is sent as a text array literal, format 0", async () => {
74 |   const bind = await captureBind(1007 /* int4_array */, [1, 2, 3]);
75 |   expect(bind.formatCodes).toEqual([0]);
                                ^
error: expect(received).toEqual(expected)

  [
-   0,
+   1,
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/sql/postgres-bind-array-params.test.ts:75:28)
(fail) int4[] array parameter is sent as a text array literal, format 0 [624.18ms]
76 |   expect(text(bind.values[0])).toBe(`{"1","2","3"}`);
77 | });
78 | 
79 | test("float4[] array parameter is sent as a text array literal, format 0", async () => {
80 |   const bind = await captureBind(1021 /* float4_array */, [1.5, 2.5]);
81 |   expect(bind.formatCodes).toEqual([0]);
                       
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/sql/postgres-bind-array-params.test.ts:
70 | 
71 | const text = (b: Buffer | null) => (b === null ? null : b.toString("latin1"));
72 | 
73 | test("int4[] array parameter is sent as a text array literal, format 0", async () => {
74 |   const bind = await captureBind(1007 /* int4_array */, [1, 2, 3]);
75 |   expect(bind.formatCodes).toEqual([0]);
                                ^
error: expect(received).toEqual(expected)

  [
-   0,
+   1,
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/sql/postgres-bind-array-params.test.ts:75:28)
(fail) int4[] array parameter is sent as a text array literal, format 0 [10.14ms]
76 |   expect(text(bind.values[0])).toBe(`{"1","2","3"}`);
77 | });
78 | 
79 | test("float4[] array parameter is sent as a text array literal, format 0", async () => {
80 |   const bind = await captureBind(1021 /* float4_array */, [1.5, 2.5]);
81 |   expect(bind.formatCodes).toEqual([0]);
                                ^
error: expect(received).toEqual(expected)

  [
-   0,
+   1,
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/sql/postgres-bind
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-bind-array-params.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/postgres-bind-array-params.test.ts:
(pass) int4[] array parameter is sent as a text array literal, format 0 [979.88ms]
(pass) float4[] array parameter is sent as a text array literal, format 0 [140.51ms]
(pass) text[] array parameter is wrapped in braces [51.66ms]
(pass) int8[] array parameter is wrapped in braces [51.75ms]
(pass) null elements become NULL and quotes/backslashes are escaped [39.26ms]
(pass) nested arrays produce nested braces [36.14ms]
(pass) empty array becomes {} [35.02ms]
(pass) jsonb array parameter stays JSON, not a pg array literal [37.64ms]
(pass) box[] uses ; as the element delimiter [50.95ms]
(pass) Date elements serialize as ISO strings [52.32ms]
(pass) object elements in a jsonb[] serialize as JSON [45.49ms]
(pass) primitive elements in a jsonb[] serialize as JSON [59.40ms]
(pass) Buffer and Uint8Array elements in a bytea[] serialize as hex [53.64ms]

 13 pass
 0 fail
 26 expect() calls
Ran 13 tests across 1 file. [6.16s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e8df861eb2
  features     baseline

23 deps, 129 codegen, 1172 objects in 1467ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [21.00ms]
[2/1244] fetch zlib
[zlib] up to date
[3/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1217] gen bindgenv2
[5/1217] fetch tinycc
[tinycc] up to date
[6/1216] gen .bind.ts → GeneratedBindings.cpp
[7/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1216] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [2.00ms]
[9/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1216] gen ErrorCode+*.h
[11/1216] gen b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/PostgresRequest.rs        |  96 +++++++++++++++-
 test/js/sql/postgres-bind-array-params.test.ts | 152 +++++++++++++++++++++++++
 test/js/sql/wire-frames.ts                     |  50 ++++++++
 3 files changed, 292 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/sql_jsc/postgres/PostgresRequest.rs            15     35      0
test/js/sql/postgres-bind-array-params.test.ts      2     10      0
test/js/sql/wire-frames.ts                          2      2      0
```

</details>

<!-- robobun:evidence:end -->