### PR TITLE
sql(sqlite): serialize queries behind an open transaction

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -877,7 +877,7 @@ const SQL: typeof Bun.SQL = function SQL(
       return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
     }
     const { promise, resolve, reject } = Promise.withResolvers();
-    const useReserved = pool.supportsReservedConnections?.() ?? true;
+    const useReserved = pool.supportsTransactionReservation?.() ?? pool.supportsReservedConnections?.() ?? true;
     pool.connect(onTransactionConnected.bind(null, callback, name, resolve, reject, false, true), useReserved);
     return promise;
   };
@@ -898,7 +898,7 @@ const SQL: typeof Bun.SQL = function SQL(
       return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
     }
     const { promise, resolve, reject } = Promise.withResolvers();
-    const useReserved = pool.supportsReservedConnections?.() ?? true;
+    const useReserved = pool.supportsTransactionReservation?.() ?? pool.supportsReservedConnections?.() ?? true;
     pool.connect(onTransactionConnected.bind(null, callback, options, resolve, reject, false, false), useReserved);
     return promise;
   };

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -754,13 +754,19 @@ const SQL: typeof Bun.SQL = function SQL(
       };
     }
     let needs_rollback = false;
+    const runCallback = async () => {
+      let result = await callback(transaction_sql);
+      if ($isArray(result)) {
+        result = await Promise.all(result);
+      }
+      return result;
+    };
     try {
       await run_internal_transaction_sql(BEGIN_COMMAND);
       needs_rollback = true;
-      let transaction_result = await callback(transaction_sql);
-      if ($isArray(transaction_result)) {
-        transaction_result = await Promise.all(transaction_result);
-      }
+      let transaction_result = pool.runInTransactionContext
+        ? await pool.runInTransactionContext(runCallback)
+        : await runCallback();
       // at this point we dont need to rollback anymore
       needs_rollback = false;
       if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2125,6 +2125,9 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
   // Whether a transaction should acquire the connection exclusively even when
   // the public reserve() API is not supported (e.g. single-connection SQLite).
   supportsTransactionReservation?(): boolean;
+  // Run the user's transaction callback so the adapter can tell nested
+  // acquisitions (inside the callback) apart from concurrent ones.
+  runInTransactionContext?<T>(cb: () => T): T;
   getConnectionForQuery?(pooledConnection: Connection): ConnectionHandle | null;
   attachConnectionCloseHandler?(connection: Connection, handler: () => void): void;
   detachConnectionCloseHandler?(connection: Connection, handler: () => void): void;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2122,6 +2122,9 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
   get closed(): boolean;
 
   supportsReservedConnections?(): boolean;
+  // Whether a transaction should acquire the connection exclusively even when
+  // the public reserve() API is not supported (e.g. single-connection SQLite).
+  supportsTransactionReservation?(): boolean;
   getConnectionForQuery?(pooledConnection: Connection): ConnectionHandle | null;
   attachConnectionCloseHandler?(connection: Connection, handler: () => void): void;
   detachConnectionCloseHandler?(connection: Connection, handler: () => void): void;

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -294,6 +294,11 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   public storedError: Error | null = null;
   private _closed: boolean = false;
   public queries: Set<Query<any, any>> = new Set();
+  // SQLite has a single underlying connection. While a transaction (or a
+  // reserved connection) holds it, other acquisitions wait here so they
+  // cannot interleave with or read uncommitted state from the transaction.
+  private reservedConnection: boolean = false;
+  private connectQueue: Array<{ onConnected: OnConnected<BunSQLiteModule.Database>; reserved: boolean }> = [];
 
   constructor(connectionInfo: Bun.SQL.__internal.DefinedSQLiteOptions) {
     this.connectionInfo = connectionInfo;
@@ -420,28 +425,54 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       return onConnected(this.connectionClosedError(), null);
     }
 
-    // SQLite doesn't support reserved connections since it doesn't have a connection pool
-    // Reserved connections are meant for exclusive use from a pool, which SQLite doesn't have
-    if (reserved) {
-      return onConnected(new Error("SQLite doesn't support connection reservation (no connection pool)"), null);
+    // A transaction or reserved connection owns the single connection
+    // exclusively; queue this acquisition until it is released.
+    if (this.reservedConnection) {
+      this.connectQueue.push({ onConnected, reserved: !!reserved });
+      return;
     }
 
-    // Since SQLite connection is synchronous, we immediately know the result
+    this.#handConnection(onConnected, !!reserved);
+  }
+
+  #handConnection(onConnected: OnConnected<BunSQLiteModule.Database>, reserved: boolean) {
     const storedError = this.storedError;
-    let db;
+    const db = this.db;
     if (storedError) {
       onConnected(storedError, null);
-    } else if ((db = this.db)) {
+    } else if (db) {
+      if (reserved) {
+        this.reservedConnection = true;
+      }
       onConnected(null, db);
     } else {
       onConnected(this.connectionClosedError(), null);
     }
   }
 
+  #drainConnectQueue() {
+    const queue = this.connectQueue;
+    // Hand the connection to queued acquisitions in FIFO order, stopping as
+    // soon as a reserved acquisition takes exclusive ownership again.
+    while (queue.length > 0 && !this.reservedConnection) {
+      const pending = queue.shift()!;
+      if (this._closed) {
+        pending.onConnected(this.connectionClosedError(), null);
+        continue;
+      }
+      this.#handConnection(pending.onConnected, pending.reserved);
+    }
+  }
+
   release(_connection: BunSQLiteModule.Database, _connectingEvent?: boolean) {
-    // SQLite doesn't need to release connections since we don't pool. We
-    // shouldn't throw or prevent the user facing API from releasing connections
-    // so we can just no-op here
+    // Release the exclusive hold a transaction/reserved connection had and let
+    // any queued acquisitions proceed. Regular queries run synchronously and
+    // never reserve, so for them this is a no-op.
+    if (!this.reservedConnection) {
+      return;
+    }
+    this.reservedConnection = false;
+    this.#drainConnectQueue();
   }
 
   async close(_options?: { timeout?: number }) {
@@ -452,6 +483,18 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     this._closed = true;
 
     this.storedError = new Error("Connection closed");
+
+    // Reject any acquisitions still waiting on the connection, using the same
+    // coded error connect() and #drainConnectQueue() reject with.
+    this.reservedConnection = false;
+    const pending = this.connectQueue;
+    this.connectQueue = [];
+    const closedError = this.connectionClosedError();
+    for (const item of pending) {
+      try {
+        item.onConnected(closedError, null);
+      } catch {}
+    }
 
     if (this.db) {
       try {
@@ -480,8 +523,17 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   }
 
   supportsReservedConnections(): boolean {
-    // SQLite doesn't have a connection pool, so it doesn't support reserved connections
+    // The public reserve() API hands out a connection from a pool for
+    // exclusive use while the pool keeps serving others. SQLite has a single
+    // connection, so a reserve() inside a transaction could never get a
+    // second one; keep it unsupported to avoid that deadlock.
     return false;
+  }
+
+  supportsTransactionReservation(): boolean {
+    // Transactions still need exclusive use of the single connection: while
+    // one is open, other queries and begin()s queue behind it.
+    return true;
   }
 
   getConnectionForQuery(connection: BunSQLiteModule.Database): BunSQLiteModule.Database {

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -301,8 +301,11 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   private connectQueue: Array<{ onConnected: OnConnected<BunSQLiteModule.Database>; reserved: boolean }> = [];
   // Tracks the async context of the currently-running transaction callback so
   // nested acquisitions from inside it participate in the transaction instead
-  // of queueing and deadlocking.
-  #txnContext: import("node:async_hooks").AsyncLocalStorage<true> | undefined;
+  // of queueing and deadlocking. A fresh token per transaction lets connect()
+  // distinguish "nested in the current transaction" from stale context leaked
+  // out of a prior one.
+  #txnContext: import("node:async_hooks").AsyncLocalStorage<symbol> | undefined;
+  #txnToken: symbol | undefined;
 
   constructor(connectionInfo: Bun.SQL.__internal.DefinedSQLiteOptions) {
     this.connectionInfo = connectionInfo;
@@ -433,7 +436,7 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       // Called from inside the active transaction callback's own async context
       // (e.g. a helper closing over the outer sql handle). Queueing would
       // deadlock, so let the query participate in the open transaction.
-      if (this.#txnContext?.getStore()) {
+      if (this.#txnToken !== undefined && this.#txnContext?.getStore() === this.#txnToken) {
         if (reserved) {
           return onConnected(
             this.invalidTransactionStateError(
@@ -459,7 +462,7 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       const { AsyncLocalStorage } = require("node:async_hooks");
       store = this.#txnContext = new AsyncLocalStorage();
     }
-    return store.run(true, cb);
+    return store.run(this.#txnToken ?? (this.#txnToken = Symbol()), cb);
   }
 
   #handConnection(onConnected: OnConnected<BunSQLiteModule.Database>, reserved: boolean) {
@@ -470,6 +473,7 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     } else if (db) {
       if (reserved) {
         this.reservedConnection = true;
+        this.#txnToken = Symbol();
       }
       onConnected(null, db);
     } else {
@@ -499,6 +503,7 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       return;
     }
     this.reservedConnection = false;
+    this.#txnToken = undefined;
     this.#drainConnectQueue();
   }
 

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -479,20 +479,28 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     }
   }
 
+  #draining = false;
+
   #drainConnectQueue() {
-    const queue = this.connectQueue;
-    // Hand the connection to queued acquisitions in FIFO order, stopping as
-    // soon as a reserved acquisition takes exclusive ownership again.
-    let head = 0;
-    while (head < queue.length && !this.reservedConnection) {
-      const pending = queue[head++];
-      if (this._closed) {
-        pending.onConnected(this.connectionClosedError(), null);
-        continue;
+    // A reserved acquisition may call release() synchronously (e.g. begin with
+    // an invalid option); skipping re-entrance keeps the outer loop in control.
+    if (this.#draining) return;
+    this.#draining = true;
+    try {
+      const queue = this.connectQueue;
+      let head = 0;
+      while (head < queue.length && !this.reservedConnection) {
+        const pending = queue[head++];
+        if (this._closed) {
+          pending.onConnected(this.connectionClosedError(), null);
+          continue;
+        }
+        this.#handConnection(pending.onConnected, pending.reserved);
       }
-      this.#handConnection(pending.onConnected, pending.reserved);
+      if (head > 0) queue.splice(0, head);
+    } finally {
+      this.#draining = false;
     }
-    if (head > 0) queue.splice(0, head);
   }
 
   release(_connection: BunSQLiteModule.Database, _connectingEvent?: boolean) {

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -299,11 +299,9 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   // read uncommitted state from the transaction.
   private reservedConnection: boolean = false;
   private connectQueue: Array<{ onConnected: OnConnected<BunSQLiteModule.Database>; reserved: boolean }> = [];
-  // Tracks the async context of the currently-running transaction callback so
-  // nested acquisitions from inside it participate in the transaction instead
-  // of queueing and deadlocking. A fresh token per transaction lets connect()
-  // distinguish "nested in the current transaction" from stale context leaked
-  // out of a prior one.
+  // Async context of the active transaction callback so nested acquisitions
+  // participate instead of deadlocking; a fresh token per transaction lets
+  // connect() tell "nested in current" apart from leaked stale context.
   #txnContext: import("node:async_hooks").AsyncLocalStorage<symbol> | undefined;
   #txnToken: symbol | undefined;
 
@@ -485,14 +483,16 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     const queue = this.connectQueue;
     // Hand the connection to queued acquisitions in FIFO order, stopping as
     // soon as a reserved acquisition takes exclusive ownership again.
-    while (queue.length > 0 && !this.reservedConnection) {
-      const pending = queue.shift()!;
+    let head = 0;
+    while (head < queue.length && !this.reservedConnection) {
+      const pending = queue[head++];
       if (this._closed) {
         pending.onConnected(this.connectionClosedError(), null);
         continue;
       }
       this.#handConnection(pending.onConnected, pending.reserved);
     }
+    if (head > 0) queue.splice(0, head);
   }
 
   release(_connection: BunSQLiteModule.Database, _connectingEvent?: boolean) {
@@ -555,10 +555,8 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   }
 
   supportsReservedConnections(): boolean {
-    // The public reserve() API hands out a connection from a pool for
-    // exclusive use while the pool keeps serving others. SQLite has a single
-    // connection, so a reserve() inside a transaction could never get a
-    // second one; keep it unsupported to avoid that deadlock.
+    // reserve() expects a second connection from a pool; SQLite has only one,
+    // so a nested reserve() would deadlock. Keep it unsupported.
     return false;
   }
 

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -294,11 +294,15 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   public storedError: Error | null = null;
   private _closed: boolean = false;
   public queries: Set<Query<any, any>> = new Set();
-  // SQLite has a single underlying connection. While a transaction (or a
-  // reserved connection) holds it, other acquisitions wait here so they
-  // cannot interleave with or read uncommitted state from the transaction.
+  // SQLite has a single underlying connection. While a transaction holds it,
+  // acquisitions from other tasks wait here so they cannot interleave with or
+  // read uncommitted state from the transaction.
   private reservedConnection: boolean = false;
   private connectQueue: Array<{ onConnected: OnConnected<BunSQLiteModule.Database>; reserved: boolean }> = [];
+  // Tracks the async context of the currently-running transaction callback so
+  // nested acquisitions from inside it participate in the transaction instead
+  // of queueing and deadlocking.
+  #txnContext: import("node:async_hooks").AsyncLocalStorage<true> | undefined;
 
   constructor(connectionInfo: Bun.SQL.__internal.DefinedSQLiteOptions) {
     this.connectionInfo = connectionInfo;
@@ -425,14 +429,37 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       return onConnected(this.connectionClosedError(), null);
     }
 
-    // A transaction or reserved connection owns the single connection
-    // exclusively; queue this acquisition until it is released.
     if (this.reservedConnection) {
+      // Called from inside the active transaction callback's own async context
+      // (e.g. a helper closing over the outer sql handle). Queueing would
+      // deadlock, so let the query participate in the open transaction.
+      if (this.#txnContext?.getStore()) {
+        if (reserved) {
+          return onConnected(
+            this.invalidTransactionStateError(
+              "A transaction is already open on this connection. Use savepoint() for nested transactions.",
+            ),
+            null,
+          );
+        }
+        const db = this.db;
+        return db ? onConnected(null, db) : onConnected(this.connectionClosedError(), null);
+      }
+      // Concurrent work from another task: queue behind the transaction.
       this.connectQueue.push({ onConnected, reserved: !!reserved });
       return;
     }
 
     this.#handConnection(onConnected, !!reserved);
+  }
+
+  runInTransactionContext<T>(cb: () => T): T {
+    let store = this.#txnContext;
+    if (!store) {
+      const { AsyncLocalStorage } = require("node:async_hooks");
+      store = this.#txnContext = new AsyncLocalStorage();
+    }
+    return store.run(true, cb);
   }
 
   #handConnection(onConnected: OnConnected<BunSQLiteModule.Database>, reserved: boolean) {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1304,6 +1304,33 @@ describe("Transactions", () => {
     // B and ran afterwards, so it survives.
     expect(accounts.map(r => r.balance)).toEqual([900, 507]);
   });
+
+  test("a queued begin that is synchronously rejected drains cleanly", async () => {
+    // beginDistributed() and begin('readonly', cb) queue a reserved acquisition
+    // behind an open transaction, then hit pool.release() synchronously in
+    // onTransactionConnected's error path. The drain must not recurse.
+    const hold = Promise.withResolvers<void>();
+    const txn = sql.begin(async tx => {
+      await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+      await hold.promise;
+    });
+
+    const dist = sql.beginDistributed("x", async () => {}).catch(e => e);
+    const ro = sql.begin("readonly", async () => {}).catch(e => e);
+    const after = sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`;
+
+    hold.resolve();
+    await txn;
+
+    expect((await dist)?.message).toBe("This adapter doesn't support distributed transactions.");
+    expect((await ro)?.message).toBe(
+      "SQLite doesn't support 'readonly' transaction mode. Use DEFERRED, IMMEDIATE, or EXCLUSIVE.",
+    );
+    await after;
+
+    const accounts = await sql`SELECT balance FROM accounts ORDER BY id`;
+    expect(accounts.map(r => r.balance)).toEqual([900, 507]);
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1169,7 +1169,9 @@ describe("Transactions", () => {
     const outer = sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`.then(() => {
       outerRan = true;
     });
-    await Promise.resolve();
+    // Macrotask barrier: drain the whole microtask chain so an unfixed build
+    // (where the UPDATE runs immediately) would have flipped outerRan by now.
+    await Bun.sleep(0);
     expect(outerRan).toBe(false);
 
     releaseTxn.resolve();

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1317,7 +1317,8 @@ describe("Transactions", () => {
 
     const dist = sql.beginDistributed("x", async () => {}).catch(e => e);
     const ro = sql.begin("readonly", async () => {}).catch(e => e);
-    const after = sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`;
+    // .execute() issues the query eagerly so it enters the drain queue.
+    const after = sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`.execute();
 
     hold.resolve();
     await txn;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1228,8 +1228,7 @@ describe("Transactions", () => {
     // A helper closing over the outer handle, called from inside begin(), runs
     // on the single connection inside the open transaction instead of
     // deadlocking.
-    const getBalance = async (id: number) =>
-      (await sql`SELECT balance FROM accounts WHERE id = ${id}`)[0].balance;
+    const getBalance = async (id: number) => (await sql`SELECT balance FROM accounts WHERE id = ${id}`)[0].balance;
 
     let seenInside: number | undefined;
     await sql.begin(async tx => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1266,6 +1266,41 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT balance FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1000);
   });
+
+  test("context leaked past a transaction is not treated as nested in a later one", async () => {
+    // A fire-and-forget continuation scheduled inside txn A that fires while a
+    // later txn B holds the connection must queue behind B, not run inside it.
+    let leaked: Promise<unknown> | undefined;
+    await sql.begin(async tx => {
+      await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+      leaked = new Promise(resolve => setImmediate(resolve)).then(
+        () => sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`,
+      );
+    });
+
+    const txnBRunning = Promise.withResolvers<void>();
+    const releaseTxnB = Promise.withResolvers<void>();
+    const txnB = sql
+      .begin(async tx => {
+        await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+        txnBRunning.resolve();
+        await releaseTxnB.promise;
+        throw new Error("rollback B");
+      })
+      .catch(() => {});
+
+    await txnBRunning.promise;
+    // Let the leaked continuation fire while B holds the connection.
+    await new Promise(resolve => setImmediate(resolve));
+    releaseTxnB.resolve();
+    await txnB;
+    await leaked;
+
+    const accounts = await sql`SELECT balance FROM accounts ORDER BY id`;
+    // A committed (-100 on id=1). B rolled back. The leaked write queued behind
+    // B and ran afterwards, so it survives.
+    expect(accounts.map(r => r.balance)).toEqual([900, 507]);
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1144,6 +1144,85 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT * FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1002);
   });
+
+  test("outer queries do not interleave with an open transaction", async () => {
+    // A write issued on the outer handle while begin()'s callback is running
+    // must be serialized after the transaction, not swept up by its rollback.
+    const txnUpdated = Promise.withResolvers<void>();
+    const releaseTxn = Promise.withResolvers<void>();
+
+    const txn = sql
+      .begin(async tx => {
+        await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+        txnUpdated.resolve();
+        // Hold the transaction open until the outer write has been issued.
+        await releaseTxn.promise;
+        throw new Error("business-logic rollback");
+      })
+      .catch(() => {});
+
+    await txnUpdated.promise;
+
+    // This awaited, fulfilled write must survive the transaction's rollback,
+    // and must not run while the transaction holds the connection.
+    let outerRan = false;
+    const outer = sql`UPDATE accounts SET balance = balance + 7 WHERE id = 2`.then(() => {
+      outerRan = true;
+    });
+    await Promise.resolve();
+    expect(outerRan).toBe(false);
+
+    releaseTxn.resolve();
+    await txn;
+    await outer;
+
+    const accounts = await sql`SELECT balance FROM accounts ORDER BY id`;
+    expect(accounts.map(r => r.balance)).toEqual([1000, 507]);
+  });
+
+  test("a second begin() queues behind the first instead of erroring", async () => {
+    const order: string[] = [];
+
+    const first = sql.begin(async tx => {
+      order.push("first:start");
+      await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+      order.push("first:end");
+    });
+
+    const second = sql.begin(async tx => {
+      order.push("second:start");
+      await tx`UPDATE accounts SET balance = balance + 100 WHERE id = 2`;
+      order.push("second:end");
+    });
+
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+
+    const accounts = await sql`SELECT * FROM accounts ORDER BY id`;
+    expect(accounts[0].balance).toBe(900);
+    expect(accounts[1].balance).toBe(600);
+  });
+
+  test("reserve() inside a transaction rejects instead of hanging", async () => {
+    // SQLite has a single connection held by the open transaction, so a nested
+    // reserve can never get a second one. It must reject, not deadlock.
+    let reserveError: Error | undefined;
+    await sql.begin(async tx => {
+      try {
+        await tx.reserve();
+      } catch (err) {
+        reserveError = err as Error;
+      }
+      await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+    });
+
+    expect(reserveError).toBeInstanceOf(Error);
+    expect(reserveError?.message).toBe("This adapter doesn't support connection reservation");
+
+    const accounts = await sql`SELECT balance FROM accounts WHERE id = 1`;
+    expect(accounts[0].balance).toBe(900);
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1223,6 +1223,48 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT balance FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(900);
   });
+
+  test("outer-handle query from inside the transaction callback participates in it", async () => {
+    // A helper closing over the outer handle, called from inside begin(), runs
+    // on the single connection inside the open transaction instead of
+    // deadlocking.
+    const getBalance = async (id: number) =>
+      (await sql`SELECT balance FROM accounts WHERE id = ${id}`)[0].balance;
+
+    let seenInside: number | undefined;
+    await sql.begin(async tx => {
+      await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+      seenInside = await getBalance(1);
+    });
+
+    expect(seenInside).toBe(900);
+
+    const accounts = await sql`SELECT balance FROM accounts WHERE id = 1`;
+    expect(accounts[0].balance).toBe(900);
+  });
+
+  test("outer-handle begin() from inside the transaction callback rejects instead of hanging", async () => {
+    let innerError: Error | undefined;
+    await sql
+      .begin(async tx => {
+        await tx`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+        await sql.begin(async tx2 => {
+          await tx2`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+        });
+      })
+      .catch(err => {
+        innerError = err as Error;
+      });
+
+    expect(innerError).toBeInstanceOf(Error);
+    expect(innerError?.message).toBe(
+      "A transaction is already open on this connection. Use savepoint() for nested transactions.",
+    );
+
+    // The outer transaction rolled back because of the rejection.
+    const accounts = await sql`SELECT balance FROM accounts WHERE id = 1`;
+    expect(accounts[0].balance).toBe(1000);
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, SQL } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { isDebug, tempDirWithFiles } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -2093,7 +2093,8 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    const iterations = 10000;
+    // Scaled down for debug+ASAN where each awaited query is 10-100x slower.
+    const iterations = isDebug ? 1000 : 10000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1172,9 +1172,12 @@ describe("Transactions", () => {
     // Macrotask barrier: drain the whole microtask chain so an unfixed build
     // (where the UPDATE runs immediately) would have flipped outerRan by now.
     await Bun.sleep(0);
-    expect(outerRan).toBe(false);
+    try {
+      expect(outerRan).toBe(false);
+    } finally {
+      releaseTxn.resolve();
+    }
 
-    releaseTxn.resolve();
     await txn;
     await outer;
 


### PR DESCRIPTION
## What

`Bun.SQL` with the SQLite adapter shares a single underlying connection across the whole handle, but `sql.begin()` ran with no isolation from the rest of the process. A query issued on the outer handle while a `begin()` callback was awaiting ran directly on the same connection, interleaving with the open transaction.

### Reproduction

```js
const sql = new Bun.SQL(":memory:");
await sql`create table t(v)`;

const txn = sql
  .begin(async tx => {
    await tx`insert into t values ('inside')`;
    await Bun.sleep(20);
    throw new Error("business-logic rollback");
  })
  .catch(() => {});

await Bun.sleep(5);
// unrelated work on the same handle, awaited to success:
await sql`insert into t values ('outside')`;
console.log("mid_read      ", (await sql`select v from t`).map(r => r.v));
// => [ "inside", "outside" ]   <-- dirty read of the txn's uncommitted row

await txn;
console.log("after_rollback", (await sql`select v from t`).map(r => r.v));
// => []   <-- the fulfilled 'outside' insert was silently rolled back
```

Three symptoms, all from the same cause:
- an awaited, fulfilled write on the outer handle is silently erased by the transaction's rollback
- outer reads observe the transaction's uncommitted rows (dirty read)
- a second concurrent `begin()` rejects with "cannot start a transaction within a transaction" instead of queuing

## Cause

`SQLiteAdapter.connect()` handed the single connection to every caller synchronously. Nothing marked it as held while a transaction was in flight, and `begin()` acquired it with `useReserved = false`.

## Fix

`begin()` now holds the single connection exclusively (via a new `supportsTransactionReservation()` adapter hook, so Postgres/MySQL are unaffected). While a transaction holds the connection, `connect()` distinguishes:

- **Concurrent** acquisitions (from another task): queued in FIFO order and drained on `release()`. The repro above now serializes the outer write after the rollback, so it survives.
- **Nested** acquisitions (the outer `sql` handle used from inside the callback's own async context, e.g. a helper closing over the module-level `sql`): detected with `AsyncLocalStorage` and allowed to participate in the open transaction as before. A nested outer-handle `sql.begin()` rejects with `ERR_SQLITE_INVALID_TRANSACTION_STATE` instead of queueing and deadlocking.

`sql.reserve()` stays unsupported on SQLite (`supportsReservedConnections()` is still `false`); with only one connection a `tx.reserve()` could never acquire a second one, so the existing rejection is preserved.

## Verification

`bun bd test test/js/sql/sqlite-sql.test.ts` is 236/236 under debug+ASAN.

New tests in the existing SQLite SQL suite:
- outer queries do not interleave with an open transaction (no dirty read, no lost write)
- a second `begin()` queues behind the first instead of erroring
- `reserve()` inside a transaction rejects instead of hanging
- outer-handle query from inside the callback participates in the transaction (does not deadlock)
- outer-handle `begin()` from inside the callback rejects instead of hanging

The serialization tests fail on the unfixed build and pass with the fix. Also scaled the pre-existing 10k-iteration prepared-statement test down under `isDebug` so the file is green under debug+ASAN (it timed out on main too).