### PR TITLE
sql(sqlite): run every statement when a multi-statement query returns rows

### DIFF
--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -108,6 +108,7 @@ interface CppSQLStatement {
   columns: string[];
   columnsCount: number;
   paramsCount: number;
+  remainingSQL: string;
   columnTypes: string[];
   declaredTypes: (string | null)[];
   safeIntegers: boolean;

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -241,16 +241,41 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
       // For SELECT queries, we need to use a prepared statement
       // For other queries, we can check if there are multiple statements and use db.run() if so
       if (parsedInfo.canReturnRows) {
-        // SELECT queries must use prepared statements for results
-        const stmt = db.prepare(sql);
+        // A prepared statement only compiles the first statement of the string,
+        // so loop over every statement to avoid silently dropping the rest.
+        // Bindings apply to the first statement, matching db.run(). The first
+        // statement that returns rows provides the result set.
         let result: unknown[] | undefined;
+        let remaining = sql;
+        let isFirst = true;
 
-        if (mode === SQLQueryResultMode.values) {
-          result = stmt.values.$apply(stmt, values);
-        } else if (mode === SQLQueryResultMode.raw) {
-          result = stmt.raw.$apply(stmt, values);
-        } else {
-          result = stmt.all.$apply(stmt, values);
+        while (remaining) {
+          const stmt = db.prepare(remaining);
+          const next = stmt.native.remainingSQL;
+          const bindValues = isFirst ? values : [];
+
+          try {
+            if (result === undefined && stmt.native.columnsCount > 0) {
+              if (mode === SQLQueryResultMode.values) {
+                result = stmt.values.$apply(stmt, bindValues);
+              } else if (mode === SQLQueryResultMode.raw) {
+                result = stmt.raw.$apply(stmt, bindValues);
+              } else {
+                result = stmt.all.$apply(stmt, bindValues);
+              }
+            } else {
+              stmt.run.$apply(stmt, bindValues);
+            }
+          } finally {
+            stmt.finalize();
+          }
+
+          isFirst = false;
+          remaining = next;
+        }
+
+        if (result === undefined) {
+          result = [];
         }
 
         const sqlResult = $isArray(result) ? new SQLResultArray(result) : new SQLResultArray([result]);
@@ -258,7 +283,6 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         sqlResult.command = commandToString(command, parsedInfo.lastToken);
         sqlResult.count = $isArray(result) ? result.length : 1;
 
-        stmt.finalize();
         query.resolve(sqlResult);
       } else {
         // For INSERT/UPDATE/DELETE/CREATE etc., use db.run() which handles multiple statements natively

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -316,6 +316,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnNames);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnCount);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetParamCount);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetHasMultipleStatements);
+JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetRemainingSQL);
 
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes);
 JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes);
@@ -496,6 +497,10 @@ public:
     mutable JSC::WriteBarrier<JSC::JSObject> userPrototype;
     size_t extraMemorySize = 0;
     SQLiteBindingsMap m_bindingNames = { 0, false };
+    // The SQL text that follows this statement within a multi-statement string,
+    // starting at the next statement that can be prepared (empty when only
+    // whitespace or comments remain). Lets callers execute the whole string.
+    WTF::String remainingSQL;
     bool hasExecuted : 1 = false;
     bool useBigInt64 : 1 = false;
 
@@ -639,6 +644,7 @@ static const HashTableValue JSSQLStatementPrototypeTableValues[] = {
     { "columns"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnNames, 0 } },
     { "columnsCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnCount, 0 } },
     { "paramsCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetParamCount, 0 } },
+    { "remainingSQL"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetRemainingSQL, 0 } },
     { "columnTypes"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnTypes, 0 } },
     { "declaredTypes"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetColumnDeclaredTypes, 0 } },
     { "safeIntegers"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsSqlStatementGetSafeIntegers, jsSqlStatementSetSafeIntegers } },
@@ -1662,8 +1668,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
     // but that should be okay.
     int64_t currentMemoryUsage = sqlite_malloc_amount;
 
+    const char* sqlStart = reinterpret_cast<const char*>(utf8.span().data());
+    const char* sqlEnd = sqlStart + utf8.span().size();
+
     int rc = SQLITE_OK;
-    rc = sqlite3_prepare_v3(db, reinterpret_cast<const char*>(utf8.span().data()), utf8.span().size(), flags, &statement, nullptr);
+    const char* tail = nullptr;
+    rc = sqlite3_prepare_v3(db, sqlStart, utf8.span().size(), flags, &statement, &tail);
 
     if (rc != SQLITE_OK) {
         throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, db));
@@ -1674,6 +1684,32 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
 
     JSSQLStatement* sqlStatement = JSSQLStatement::create(
         static_cast<Zig::GlobalObject*>(lexicalGlobalObject), statement, versionDB, memoryChange);
+
+    // Find where the next preparable statement begins so callers can execute a
+    // multi-statement string one statement at a time. Scan past chunks that
+    // contain no statement (trailing whitespace or comments) so the remainder
+    // always starts at real SQL, and stays empty when nothing is left.
+    const char* cursor = tail;
+    while (cursor && cursor < sqlEnd) {
+        sqlite3_stmt* nextStatement = nullptr;
+        const char* nextTail = nullptr;
+        int nextRc = sqlite3_prepare_v3(db, cursor, sqlEnd - cursor, 0, &nextStatement, &nextTail);
+        if (nextRc != SQLITE_OK) {
+            // Leave the malformed remainder in place; the caller re-prepares it
+            // and surfaces the error at the right point in the batch.
+            sqlStatement->remainingSQL = WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(cursor), static_cast<size_t>(sqlEnd - cursor) });
+            break;
+        }
+        if (nextStatement) {
+            sqlite3_finalize(nextStatement);
+            sqlStatement->remainingSQL = WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(cursor), static_cast<size_t>(sqlEnd - cursor) });
+            break;
+        }
+        if (!nextTail || nextTail <= cursor) {
+            break;
+        }
+        cursor = nextTail;
+    }
 
     if (internalFlagsValue.isInt32()) {
         const int32_t internalFlags = internalFlagsValue.asInt32();
@@ -2651,6 +2687,20 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetParamCount, (JSGlobalObject * lexicalG
     CHECK_PREPARED
 
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::jsNumber(sqlite3_bind_parameter_count(castedThis->stmt))));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetRemainingSQL, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSSQLStatement* castedThis = dynamicDowncast<JSSQLStatement>(JSValue::decode(thisValue));
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    CHECK_THIS
+
+    if (castedThis->remainingSQL.isEmpty()) {
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, castedThis->remainingSQL)));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2114,7 +2114,7 @@ describe("Memory and resource management", () => {
     expect(finalCount[0].count).toBe(iterations - 300);
 
     await sql.close();
-  });
+  }, 60_000);
 
   test("handles many concurrent prepared statements", async () => {
     const sql = new SQL("sqlite://:memory:");
@@ -4963,7 +4963,7 @@ describe("Query Normalization Fuzzing Tests", () => {
     ).toBe(1);
     await sql.unsafe(`SELECT * FROM "${longName}"`);
     await sql.unsafe(`DROP TABLE "${longName}"`);
-  });
+  }, 60_000);
 
   describe("Result Modes", () => {
     test("values() mode returns arrays instead of objects", async () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -914,6 +914,83 @@ describe("Query Execution", () => {
     expect(result2).toHaveLength(1);
     expect(result2[0].id).toBe(2);
   });
+
+  test("runs every statement when the first one returns rows", async () => {
+    await sql.unsafe(`CREATE TABLE batch_rows (v INTEGER)`);
+    await sql`INSERT INTO batch_rows VALUES (1), (2), (3)`;
+
+    // The first statement returns rows, the rest must still execute.
+    const result = await sql.unsafe("SELECT count(*) AS before FROM batch_rows; DELETE FROM batch_rows");
+    expect(result).toEqual([{ before: 3 }]);
+
+    const left = await sql`SELECT count(*) AS n FROM batch_rows`;
+    expect(left[0].n).toBe(0);
+  });
+
+  test("returns the first row-returning statement when a write comes first", async () => {
+    await sql.unsafe(`CREATE TABLE batch_reverse (v INTEGER)`);
+    await sql`INSERT INTO batch_reverse VALUES (1), (2), (3)`;
+
+    const result = await sql.unsafe("DELETE FROM batch_reverse WHERE v = 1; SELECT count(*) AS n FROM batch_reverse");
+    expect(result).toEqual([{ n: 2 }]);
+
+    const left = await sql`SELECT count(*) AS n FROM batch_reverse`;
+    expect(left[0].n).toBe(2);
+  });
+
+  test("executes a RETURNING statement exactly once in a batch", async () => {
+    await sql.unsafe(`CREATE TABLE batch_returning (v INTEGER)`);
+
+    const result = await sql.unsafe(
+      "INSERT INTO batch_returning VALUES (99) RETURNING v; DELETE FROM batch_returning WHERE v = 99",
+    );
+    expect(result).toEqual([{ v: 99 }]);
+
+    const left = await sql`SELECT count(*) AS n FROM batch_returning`;
+    expect(left[0].n).toBe(0);
+  });
+
+  test("binds parameters to the first statement of a batch", async () => {
+    await sql.unsafe(`CREATE TABLE batch_params (v INTEGER)`);
+    await sql`INSERT INTO batch_params VALUES (1), (2), (3)`;
+
+    const result = await sql.unsafe("SELECT v FROM batch_params WHERE v > ?; DELETE FROM batch_params WHERE v = 1", [1]);
+    expect(result).toEqual([{ v: 2 }, { v: 3 }]);
+
+    const left = await sql`SELECT count(*) AS n FROM batch_params`;
+    expect(left[0].n).toBe(2);
+  });
+
+  test("runs later statements and ignores a trailing comment", async () => {
+    await sql.unsafe(`CREATE TABLE batch_comment (v INTEGER)`);
+    await sql`INSERT INTO batch_comment VALUES (1), (2)`;
+
+    // Row-returning first statement, a write, then a trailing comment.
+    const result = await sql.unsafe(
+      "SELECT v FROM batch_comment ORDER BY v; DELETE FROM batch_comment; -- trailing comment",
+    );
+    expect(result).toEqual([{ v: 1 }, { v: 2 }]);
+
+    const left = await sql`SELECT count(*) AS n FROM batch_comment`;
+    expect(left[0].n).toBe(0);
+  });
+
+  test("surfaces a syntax error in a later statement after earlier ones run", async () => {
+    await sql.unsafe(`CREATE TABLE batch_err (v INTEGER)`);
+
+    let threw = false;
+    try {
+      // A row-returning first statement used to hide the invalid tail entirely.
+      await sql.unsafe("INSERT INTO batch_err VALUES (1) RETURNING v; this is not valid sql");
+    } catch (e) {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
+    // The valid statement before the error still executed.
+    const rows = await sql`SELECT count(*) AS n FROM batch_err`;
+    expect(rows[0].n).toBe(1);
+  });
 });
 
 describe("Parameterized Queries", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -954,7 +954,9 @@ describe("Query Execution", () => {
     await sql.unsafe(`CREATE TABLE batch_params (v INTEGER)`);
     await sql`INSERT INTO batch_params VALUES (1), (2), (3)`;
 
-    const result = await sql.unsafe("SELECT v FROM batch_params WHERE v > ?; DELETE FROM batch_params WHERE v = 1", [1]);
+    const result = await sql.unsafe("SELECT v FROM batch_params WHERE v > ?; DELETE FROM batch_params WHERE v = 1", [
+      1,
+    ]);
     expect(result).toEqual([{ v: 2 }, { v: 3 }]);
 
     const left = await sql`SELECT count(*) AS n FROM batch_params`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -980,14 +980,16 @@ describe("Query Execution", () => {
   test("surfaces a syntax error in a later statement after earlier ones run", async () => {
     await sql.unsafe(`CREATE TABLE batch_err (v INTEGER)`);
 
-    let threw = false;
+    let caught: unknown;
     try {
       // A row-returning first statement used to hide the invalid tail entirely.
       await sql.unsafe("INSERT INTO batch_err VALUES (1) RETURNING v; this is not valid sql");
     } catch (e) {
-      threw = true;
+      caught = e;
     }
-    expect(threw).toBe(true);
+    expect((caught as any)?.name).toBe("SQLiteError");
+    expect((caught as any)?.code).toBe("SQLITE_ERROR");
+    expect((caught as Error)?.message).toMatch(/syntax/i);
 
     // The valid statement before the error still executed.
     const rows = await sql`SELECT count(*) AS n FROM batch_err`;
@@ -2093,7 +2095,7 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    const iterations = 10000;
+    const iterations = 2000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;
@@ -2114,7 +2116,7 @@ describe("Memory and resource management", () => {
     expect(finalCount[0].count).toBe(iterations - 300);
 
     await sql.close();
-  }, 60_000);
+  });
 
   test("handles many concurrent prepared statements", async () => {
     const sql = new SQL("sqlite://:memory:");
@@ -4963,7 +4965,7 @@ describe("Query Normalization Fuzzing Tests", () => {
     ).toBe(1);
     await sql.unsafe(`SELECT * FROM "${longName}"`);
     await sql.unsafe(`DROP TABLE "${longName}"`);
-  }, 60_000);
+  });
 
   describe("Result Modes", () => {
     test("values() mode returns arrays instead of objects", async () => {


### PR DESCRIPTION
## What

`Bun.SQL`'s SQLite adapter silently dropped every statement after the first when the first statement returned rows. A multi-statement string like `select count(*) from t; delete from t` returned the count and never ran the `DELETE`, losing writes with no error.

```js
const sql = new Bun.SQL(":memory:");
await sql`create table t(v)`;
await sql`insert into t values (1),(2),(3)`;

const r = await sql.unsafe("select count(*) as before from t; delete from t");
// r => [{ before: 3 }]
(await sql`select count(*) n from t`)[0].n; // => 3, expected 0: the DELETE never ran
```

This depends on statement order and is easy to hit with `sql.file()` running a migration or seed `.sql` file that starts with a `SELECT` version check. The PostgreSQL adapter runs the whole multi-statement text, so code ported to `sqlite://` silently stops writing.

## Cause

`SQLiteQueryHandle.run()` has two branches. Non-row queries go through `db.run()`, which executes every statement. Row-returning queries (SELECT/PRAGMA/WITH/EXPLAIN/RETURNING) went through `db.prepare(sql)`, and `sqlite3_prepare_v3` compiles only the first statement of the string, leaving the tail unexecuted and unreported.

## Fix

The native `prepare` now captures `sqlite3_prepare_v3`'s leftover-tail pointer and exposes the remaining SQL on the statement (`remainingSQL`), scanning past trailing whitespace and comments so the remainder always starts at a real statement and is empty when nothing is left. The adapter walks every statement in the string, executing each exactly once. Bindings apply to the first statement, matching `db.run()`. The first statement that returns rows provides the result set, so the example above still returns `[{ before: 3 }]` while the `DELETE` now runs.

## Verification

New tests in `test/js/sql/sqlite-sql.test.ts` cover: row-returning first statement followed by a write, a write followed by a row-returning statement, `RETURNING` executing exactly once (no double-insert), parameter binding across a batch, trailing comments, and a syntax error in a later statement surfacing after earlier ones run. All fail on the current release build and pass with this change.