### PR TITLE
sql(sqlite): decide row-returning via column count, not a tokenizer

### DIFF
--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -13,6 +13,11 @@ const { SQLResultArray, normalizeQuery, pushBindParam } = require("internal/sql/
 const { SQLQueryResultMode } = require("internal/sql/query");
 const { SQLiteError } = require("internal/sql/errors");
 
+/** Errors thrown by bun:sqlite itself, as opposed to plain Errors from its JS wrapper. */
+function isSQLiteError(err: unknown): err is object & { name: "SQLiteError" } {
+  return err !== null && typeof err === "object" && "name" in err && err.name === "SQLiteError";
+}
+
 let lazySQLiteModule: typeof BunSQLiteModule;
 function getSQLiteModule() {
   if (!lazySQLiteModule) {
@@ -186,10 +191,8 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
       try {
         stmt = db.prepare(sql);
       } catch (err) {
-        // SQLite itself refused the statement (syntax error, missing table, SQLITE_BUSY, ...):
-        // report that. Empty or comment-only SQL yields no statement and is a plain Error;
-        // db.run() below reports it with a clearer message.
-        if (err && typeof err === "object" && "name" in err && err.name === "SQLiteError") throw err;
+        if (isSQLiteError(err)) throw err;
+        // Otherwise the SQL compiled to no statement (empty or comment-only); db.run() reports that.
       }
 
       if (stmt && stmt.native.columnsCount > 0) {
@@ -227,7 +230,7 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
       }
     } catch (err) {
       // Convert bun:sqlite errors to SQLiteError
-      if (err && typeof err === "object" && "name" in err && err.name === "SQLiteError") {
+      if (isSQLiteError(err)) {
         // Extract SQLite error properties
         const code = "code" in err ? String(err.code) : "SQLITE_ERROR";
         const errno = "errno" in err ? Number(err.errno) : 1;
@@ -285,7 +288,7 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
       } catch {}
     } catch (err) {
       // Convert bun:sqlite initialization errors to SQLiteError
-      if (err && typeof err === "object" && "name" in err && err.name === "SQLiteError") {
+      if (isSQLiteError(err)) {
         const code = "code" in err ? String(err.code) : "SQLITE_ERROR";
         const errno = "errno" in err ? Number(err.errno) : 1;
         const byteOffset = "byteOffset" in err ? Number(err.byteOffset) : undefined;

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -31,182 +31,126 @@ const enum SQLCommand {
 }
 
 interface SQLParsedInfo {
+  /** Helper command keyword closest to the end of the text. */
   command: SQLCommand;
-  lastToken?: string;
-  canReturnRows: boolean;
+  /** Leading keyword of the statement, upper-cased; used for the result's `command` label. */
+  firstToken: string;
 }
 
-function commandToString(command: SQLCommand, lastToken?: string): string {
-  switch (command) {
-    case SQLCommand.insert:
-      return "INSERT";
-    case SQLCommand.updateSet:
-    case SQLCommand.update:
-      return "UPDATE";
-    case SQLCommand.in:
-    case SQLCommand.where:
-      if (lastToken) return lastToken;
-      return "WHERE";
+function isSQLWordChar(code: number): boolean {
+  // A-Z (text is upper-cased), 0-9, "_", "$", or non-ASCII (SQLite's IdChar accepts bytes >= 0x80).
+  return (code >= 65 && code <= 90) || (code >= 48 && code <= 57) || code === 95 || code === 36 || code >= 0x80;
+}
+
+function keywordToCommand(word: string): SQLCommand {
+  switch (word) {
+    case "INSERT":
+      return SQLCommand.insert;
+    case "UPDATE":
+      return SQLCommand.update;
+    case "SET":
+      return SQLCommand.updateSet;
+    case "WHERE":
+      return SQLCommand.where;
+    case "IN":
+      return SQLCommand.in;
     default:
-      if (lastToken) return lastToken;
-      return "";
+      return SQLCommand.none;
   }
 }
 
 /**
- * Parse the SQL query and return the command and the last token
- * @param query - The SQL query to parse
- * @param partial - Whether to stop on the first command we find
- * @returns The command, the last token, and whether it can return rows
+ * Lexes the query for the `command` label and helper detection only; whether
+ * it returns rows is decided by the prepared statement's column count.
+ * Skips comments, string literals and quoted identifiers.
  */
-function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
-  const text = query.toUpperCase().trim();
-  const text_len = text.length;
+function parseSQLQuery(query: string): SQLParsedInfo {
+  const text = query.toUpperCase();
+  const len = text.length;
 
-  let token = "";
   let command = SQLCommand.none;
-  let lastToken = "";
-  let canReturnRows = false;
-  let quoted: false | "'" | '"' = false;
-  // we need to reverse search so we find the closest command to the parameter
-  for (let i = text_len - 1; i >= 0; i--) {
+  let firstToken = "";
+
+  let i = 0;
+  while (i < len) {
     const char = text[i];
-    switch (char) {
-      case " ":
-      case "\n":
-      case "\t":
-      case "\r":
-      case "\f":
-      case "\v": {
-        switch (token) {
-          case "INSERT": {
-            if (command === SQLCommand.none) {
-              command = SQLCommand.insert;
-            }
-            lastToken = token;
-            token = "";
-            if (partial) {
-              return { command: SQLCommand.insert, lastToken, canReturnRows };
-            }
-            continue;
-          }
-          case "UPDATE": {
-            if (command === SQLCommand.none) {
-              command = SQLCommand.update;
-            }
-            lastToken = token;
-            token = "";
-            if (partial) {
-              return { command: SQLCommand.update, lastToken, canReturnRows };
-            }
-            continue;
-          }
-          case "WHERE": {
-            if (command === SQLCommand.none) {
-              command = SQLCommand.where;
-            }
-            lastToken = token;
-            token = "";
-            if (partial) {
-              return { command: SQLCommand.where, lastToken, canReturnRows };
-            }
-            continue;
-          }
-          case "SET": {
-            if (command === SQLCommand.none) {
-              command = SQLCommand.updateSet;
-            }
-            lastToken = token;
-            token = "";
-            if (partial) {
-              return { command: SQLCommand.updateSet, lastToken, canReturnRows };
-            }
-            continue;
-          }
-          case "IN": {
-            if (command === SQLCommand.none) {
-              command = SQLCommand.in;
-            }
-            lastToken = token;
-            token = "";
-            if (partial) {
-              return { command: SQLCommand.in, lastToken, canReturnRows };
-            }
-            continue;
-          }
-          case "SELECT":
-          case "PRAGMA":
-          case "WITH":
-          case "EXPLAIN":
-          case "RETURNING": {
-            lastToken = token;
-            canReturnRows = true;
-            token = "";
-            continue;
-          }
-          default: {
-            lastToken = token;
-            token = "";
-            continue;
-          }
-        }
-      }
-      default: {
-        // skip quoted commands
-        if (char === '"' || char === "'") {
-          if (quoted === char) {
-            quoted = false;
-          } else {
-            quoted = char;
-          }
-          continue;
-        }
-        if (!quoted) {
-          token = char + token;
-        }
-      }
+
+    // line comment: -- ... end of line
+    if (char === "-" && text[i + 1] === "-") {
+      i += 2;
+      while (i < len && text[i] !== "\n") i++;
+      continue;
     }
-  }
-  if (token) {
-    lastToken = token;
-    switch (token) {
-      case "INSERT":
-        if (command === SQLCommand.none) {
-          command = SQLCommand.insert;
-        }
-        break;
-      case "UPDATE":
-        if (command === SQLCommand.none) command = SQLCommand.update;
-        break;
-      case "WHERE":
-        if (command === SQLCommand.none) {
-          command = SQLCommand.where;
-        }
-        break;
-      case "SET":
-        if (command === SQLCommand.none) {
-          command = SQLCommand.updateSet;
-        }
-        break;
-      case "IN":
-        if (command === SQLCommand.none) {
-          command = SQLCommand.in;
-        }
-        break;
-      case "SELECT":
-      case "PRAGMA":
-      case "WITH":
-      case "EXPLAIN":
-      case "RETURNING": {
-        canReturnRows = true;
-        break;
-      }
-      default:
-        command = SQLCommand.none;
-        break;
+    // block comment: /* ... */
+    if (char === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < len && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+      continue;
     }
+    // string literal: '...' with '' as an escaped quote
+    if (char === "'") {
+      i++;
+      while (i < len) {
+        if (text[i] === "'") {
+          if (text[i + 1] === "'") {
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    // quoted identifier: "..." with "" as an escaped quote
+    if (char === '"') {
+      i++;
+      while (i < len) {
+        if (text[i] === '"') {
+          if (text[i + 1] === '"') {
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    // backtick and bracket identifiers
+    if (char === "`") {
+      i++;
+      while (i < len && text[i] !== "`") i++;
+      i++;
+      continue;
+    }
+    if (char === "[") {
+      i++;
+      while (i < len && text[i] !== "]") i++;
+      i++;
+      continue;
+    }
+    // keyword or identifier word
+    if (isSQLWordChar(text.charCodeAt(i))) {
+      const start = i;
+      i++;
+      while (i < len && isSQLWordChar(text.charCodeAt(i))) i++;
+      const word = text.slice(start, i);
+      if (firstToken === "") firstToken = word;
+      const cmd = keywordToCommand(word);
+      // keep the command keyword closest to the end of the query
+      if (cmd !== SQLCommand.none) command = cmd;
+      continue;
+    }
+
+    // whitespace, punctuation and operators
+    i++;
   }
-  return { command, lastToken, canReturnRows };
+
+  return { command, firstToken };
 }
 
 class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
@@ -214,13 +158,13 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
 
   private readonly sql: string;
   private readonly values: unknown[] | Record<string, unknown>;
-  private readonly parsedInfo: SQLParsedInfo;
+  /** The result's `command` label: the statement's leading keyword. */
+  private readonly command: string;
 
   public constructor(sql: string, values: unknown[] | Record<string, unknown>) {
     this.sql = sql;
     this.values = values;
-    // Parse the SQL query once when creating the handle
-    this.parsedInfo = parseSQLQuery(sql);
+    this.command = parseSQLQuery(sql).firstToken;
   }
 
   setMode(mode: SQLQueryResultMode) {
@@ -235,16 +179,18 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
       });
     }
 
-    const { sql, values, mode, parsedInfo } = this;
+    const { sql, values, mode, command } = this;
     try {
-      const command = parsedInfo.command;
-      // For SELECT queries, we need to use a prepared statement
-      // For other queries, we can check if there are multiple statements and use db.run() if so
-      if (parsedInfo.canReturnRows) {
-        // SELECT queries must use prepared statements for results
-        const stmt = db.prepare(sql);
-        let result: unknown[] | undefined;
+      // A statement with result columns returns rows; preparing does not execute it.
+      let stmt: BunSQLiteModule.Statement | undefined;
+      try {
+        stmt = db.prepare(sql);
+      } catch {
+        // Empty or comment-only SQL does not prepare; db.run() below reports it.
+      }
 
+      if (stmt && stmt.native.columnsCount > 0) {
+        let result: unknown[] | undefined;
         try {
           // Named-parameter objects need $call: $apply would treat them as an empty array-like.
           if (mode === SQLQueryResultMode.values) {
@@ -260,16 +206,17 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
 
         const sqlResult = $isArray(result) ? new SQLResultArray(result) : new SQLResultArray([result]);
 
-        sqlResult.command = commandToString(command, parsedInfo.lastToken);
+        sqlResult.command = command;
         sqlResult.count = $isArray(result) ? result.length : 1;
 
         query.resolve(sqlResult);
       } else {
-        // For INSERT/UPDATE/DELETE/CREATE etc., use db.run() which handles multiple statements natively
+        // db.run() executes every statement in a multi-statement string.
+        stmt?.finalize();
         const changes = $isArray(values) ? db.run.$apply(db, [sql].concat(values)) : db.run.$call(db, sql, values);
         const sqlResult = new SQLResultArray();
 
-        sqlResult.command = commandToString(command, parsedInfo.lastToken);
+        sqlResult.command = command;
         sqlResult.count = changes.changes;
         sqlResult.lastInsertRowid = changes.lastInsertRowid;
 
@@ -404,8 +351,8 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   }
 
   getHelperCommand(query: string): SharedSQLCommand {
-    // when partial is true we stop on the first command we find
-    const { command } = parseSQLQuery(query, true);
+    // detect the command keyword governing the helper (nearest the end)
+    const { command } = parseSQLQuery(query);
 
     // only selectIn, insert, update, updateSet are allowed
     if (command === SQLCommand.none || command === SQLCommand.where) {

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -185,8 +185,11 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
       let stmt: BunSQLiteModule.Statement | undefined;
       try {
         stmt = db.prepare(sql);
-      } catch {
-        // Empty or comment-only SQL does not prepare; db.run() below reports it.
+      } catch (err) {
+        // SQLite itself refused the statement (syntax error, missing table, SQLITE_BUSY, ...):
+        // report that. Empty or comment-only SQL yields no statement and is a plain Error;
+        // db.run() below reports it with a clearer message.
+        if (err && typeof err === "object" && "name" in err && err.name === "SQLiteError") throw err;
       }
 
       if (stmt && stmt.native.columnsCount > 0) {

--- a/test/js/sql/sqlite-sql-row-detection.test.ts
+++ b/test/js/sql/sqlite-sql-row-detection.test.ts
@@ -3,7 +3,10 @@
 // heuristic silently dropped rows for valid SQL it could not tokenize and
 // misreported affected-row counts for INSERT ... SELECT (#30811).
 import { SQL } from "bun";
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
 
 describe("row-returning detection (column count, not tokenizer)", () => {
   test("LIKE predicate containing a double quote returns rows", async () => {
@@ -303,6 +306,31 @@ INSERT INTO t (id, name) SELECT id + 20, name FROM t WHERE id <= 2`;
     for (const q of ["   ", "-- noop", "/* placeholder */", "-- a\n-- b\n"]) {
       await expect(Promise.resolve(sql.unsafe(q))).rejects.toThrow("Query contained no valid SQL statement");
     }
+  });
+
+  test("a SELECT that SQLite refuses to compile rejects instead of resolving empty", async () => {
+    using dir = tempDir("sqlite-sql-busy", {});
+    const filename = join(String(dir), "db.sqlite");
+    using holder = new Database(filename);
+    holder.run("CREATE TABLE t (v TEXT)");
+    holder.run("INSERT INTO t VALUES ('a')");
+    // An exclusive lock makes the probe prepare (which needs the schema) fail
+    // with SQLITE_BUSY; that error must reach the caller, not send the SELECT
+    // through the row-discarding db.run() path.
+    holder.run("BEGIN EXCLUSIVE");
+
+    await using sql = new SQL({ adapter: "sqlite", filename });
+    await expect(Promise.resolve(sql`SELECT v FROM t`)).rejects.toMatchObject({
+      name: "SQLiteError",
+      code: "SQLITE_BUSY",
+    });
+
+    holder.run("ROLLBACK");
+    expect(await sql`SELECT v FROM t`).toEqual([{ v: "a" }]);
+    await expect(Promise.resolve(sql`SELECT v FROM nope`)).rejects.toMatchObject({
+      name: "SQLiteError",
+      message: "no such table: nope",
+    });
   });
 
   test("multi-statement writes still execute every statement", async () => {

--- a/test/js/sql/sqlite-sql-row-detection.test.ts
+++ b/test/js/sql/sqlite-sql-row-detection.test.ts
@@ -1,0 +1,332 @@
+// Bun.SQL (sqlite adapter): whether a query returns rows is now decided by the
+// prepared statement's column count, not by a JavaScript tokenizer. The old
+// heuristic silently dropped rows for valid SQL it could not tokenize and
+// misreported affected-row counts for INSERT ... SELECT (#30811).
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("row-returning detection (column count, not tokenizer)", () => {
+  test("LIKE predicate containing a double quote returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v TEXT)`;
+    await sql`INSERT INTO t VALUES (${"a"}), (${'b"c'}), (${"d"})`;
+
+    const rows = await sql.unsafe(`select v from t where v like '%"%'`);
+    expect(rows).toEqual([{ v: 'b"c' }]);
+  });
+
+  test("leading block comment before SELECT returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+    await sql`INSERT INTO t VALUES (1), (2), (3)`;
+
+    const rows = await sql.unsafe(`/*hdr*/select v from t`);
+    expect(rows).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+  });
+
+  test("leading line comment before SELECT returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+    await sql`INSERT INTO t VALUES (1), (2)`;
+
+    const rows = await sql.unsafe(`-- header\nselect v from t`);
+    expect(rows).toEqual([{ v: 1 }, { v: 2 }]);
+  });
+
+  test("SELECT with no whitespace before punctuation returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+    await sql`INSERT INTO t VALUES (1), (2), (3)`;
+
+    expect(await sql.unsafe(`select*from t`)).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+
+    const paren = await sql.unsafe(`select(v)from t`);
+    expect(paren.map(r => Object.values(r)[0])).toEqual([1, 2, 3]);
+  });
+
+  test("top-level VALUES returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    const rows = await sql.unsafe(`values (1,'a'),(2,'b')`);
+    expect(rows.map(r => Object.values(r))).toEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+  test("INSERT ... RETURNING writes and returns the rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`;
+
+    const returned = await sql.unsafe(`insert into t(v)values('x')returning id,v`);
+    expect(returned).toEqual([{ id: 1, v: "x" }]);
+
+    const rows = await sql`SELECT v FROM t`;
+    expect(rows).toEqual([{ v: "x" }]);
+  });
+
+  test("row-producing PRAGMA returns rows, non-row PRAGMA does not", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+
+    const info = await sql.unsafe(`pragma table_info(t)`);
+    expect(info.length).toBe(1);
+    expect(info[0].name).toBe("v");
+
+    // A PRAGMA that sets a value yields no rows and must not throw.
+    const res = await sql.unsafe(`pragma user_version = 5`);
+    expect(res.length).toBe(0);
+    expect((await sql.unsafe(`pragma user_version`))[0].user_version).toBe(5);
+  });
+
+  test("command label survives comments and punctuation", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+    await sql`INSERT INTO t VALUES (1)`;
+
+    expect((await sql.unsafe(`/*hdr*/select v from t`)).command).toBe("SELECT");
+    expect((await sql.unsafe(`select*from t`)).command).toBe("SELECT");
+  });
+
+  test("command label is the statement's leading keyword, whatever DML keywords its body contains", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+    await sql`CREATE TABLE log (id INTEGER PRIMARY KEY, n INTEGER)`;
+    await sql`INSERT INTO log VALUES (1, 0)`;
+
+    const labels = {
+      createTrigger: (await sql.unsafe(`CREATE TRIGGER trg AFTER INSERT ON t BEGIN UPDATE log SET n = n + 1; END`))
+        .command,
+      transactionString: (await sql.unsafe(`BEGIN; UPDATE log SET n = 5; COMMIT`)).command,
+      upsert: (await sql`INSERT INTO log VALUES (1, 9) ON CONFLICT(id) DO UPDATE SET n = excluded.n`).command,
+      update: (await sql`UPDATE log SET n = 6`).command,
+      deleteWhereIn: (await sql`DELETE FROM log WHERE n IN (${7})`).command,
+      withInsert: (await sql`WITH x AS (SELECT 1 AS v) INSERT INTO t SELECT v FROM x`).command,
+      explainUpdate: (await sql.unsafe(`EXPLAIN UPDATE log SET n = 1`)).command,
+    };
+
+    expect(labels).toEqual({
+      createTrigger: "CREATE",
+      transactionString: "BEGIN",
+      upsert: "INSERT",
+      update: "UPDATE",
+      deleteWhereIn: "DELETE",
+      withInsert: "WITH",
+      explainUpdate: "EXPLAIN",
+    });
+  });
+
+  test("helper after an unquoted non-ASCII identifier", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    // SQLite accepts any byte >= 0x80 in an unquoted identifier. The lexer must not
+    // split "CAFÉIN" at the É and mistake the trailing "IN" for a WHERE IN helper.
+    await sql`CREATE TABLE caféin (name TEXT)`;
+    await sql`CREATE TABLE 数据 (name TEXT)`;
+
+    await sql`INSERT INTO caféin ${sql({ name: "a" })}`;
+    await sql`INSERT INTO 数据 ${sql({ name: "b" })}`;
+    await sql`UPDATE caféin SET ${sql({ name: "c" })}`;
+
+    expect(await sql`SELECT name FROM caféin`).toEqual([{ name: "c" }]);
+    expect(await sql`SELECT name FROM 数据`).toEqual([{ name: "b" }]);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30811
+  test("INSERT ... SELECT without RETURNING reports affected row count", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE company (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
+    await sql`INSERT INTO company (name) VALUES (${"ACME"}), (${"FOO"})`;
+
+    const result = await sql`INSERT INTO company (name) SELECT name || ${" 2"} FROM company`;
+    expect(result.command).toBe("INSERT");
+    expect(result.count).toBe(2);
+    expect(result.lastInsertRowid).toBe(4);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30811
+  test("WITH ... INSERT without RETURNING reports affected row count", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`CREATE TABLE dst (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO src VALUES (1, 'a'), (2, 'b'), (3, 'c')`;
+
+    const ins = await sql`WITH cte AS (SELECT id + 10 AS id, name FROM src) INSERT INTO dst SELECT id, name FROM cte`;
+    expect(ins.count).toBe(3);
+    expect(ins.lastInsertRowid).toBe(13);
+
+    // WITH ... SELECT must still return rows (not over-corrected).
+    const sel = await sql`WITH cte AS (SELECT id, name FROM src WHERE id > 1) SELECT * FROM cte ORDER BY id`;
+    expect(Array.from(sel)).toEqual([
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+    ]);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30811
+  test("UPDATE / DELETE with a subquery and no RETURNING report affected row count", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE src (id INTEGER PRIMARY KEY)`;
+    await sql`CREATE TABLE dst (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO src VALUES (2), (3)`;
+    await sql`INSERT INTO dst VALUES (1, 'x'), (2, 'y'), (3, 'z')`;
+
+    const upd = await sql`
+      UPDATE dst SET name = ${"updated"} WHERE id IN (
+        SELECT id FROM src
+      )`;
+    expect({ command: upd.command, count: upd.count, length: upd.length }).toEqual({
+      command: "UPDATE",
+      count: 2,
+      length: 0,
+    });
+
+    const del = await sql`
+      DELETE FROM dst WHERE id IN (
+        SELECT id FROM src
+      )`;
+    expect({ command: del.command, count: del.count, length: del.length }).toEqual({
+      command: "DELETE",
+      count: 2,
+      length: 0,
+    });
+
+    expect(await sql`SELECT id, name FROM dst`).toEqual([{ id: 1, name: "x" }]);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30811
+  test("WITH ... UPDATE / DELETE / REPLACE INTO without RETURNING report affected row count", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`CREATE TABLE dst (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO src VALUES (1, 'a'), (2, 'b'), (3, 'c')`;
+    await sql`INSERT INTO dst VALUES (1, 'x'), (2, 'y'), (3, 'z')`;
+
+    const upd =
+      await sql`WITH cte AS (SELECT id FROM src WHERE id > 1) UPDATE dst SET name = ${"updated"} WHERE id IN (SELECT id FROM cte)`;
+    expect(upd.count).toBe(2);
+
+    const del =
+      await sql`WITH cte AS (SELECT id FROM src WHERE id > 1) DELETE FROM dst WHERE id IN (SELECT id FROM cte)`;
+    expect(del.count).toBe(2);
+
+    // dst now holds only (1, 'x'); REPLACE INTO replaces it and inserts two more.
+    const rep = await sql`WITH cte AS (SELECT id, name FROM src) REPLACE INTO dst SELECT id, name FROM cte`;
+    expect(rep.count).toBe(3);
+    expect(await sql`SELECT id, name FROM dst ORDER BY id`).toEqual([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+    ]);
+  });
+
+  test("INSERT ... SELECT and WITH ... INSERT with RETURNING return the inserted rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`CREATE TABLE dst (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO src VALUES (1, 'a'), (2, 'b')`;
+
+    const plain = await sql`INSERT INTO dst SELECT id, name FROM src RETURNING id, name`;
+    expect(plain.count).toBe(2);
+    expect(Array.from(plain)).toEqual([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ]);
+
+    const cte =
+      await sql`WITH cte AS (SELECT id + 100 AS id, name FROM src) INSERT INTO dst SELECT id, name FROM cte RETURNING id, name`;
+    expect(cte.count).toBe(2);
+    expect(Array.from(cte)).toEqual([
+      { id: 101, name: "a" },
+      { id: 102, name: "b" },
+    ]);
+  });
+
+  test("leading comment on INSERT ... SELECT still reports affected row count", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO t VALUES (1, 'Alice'), (2, 'Bob')`;
+
+    const block = await sql`/* tag=me */ INSERT INTO t (id, name) SELECT id + 10, name || ${"!"} FROM t`;
+    expect({ command: block.command, count: block.count }).toEqual({ command: "INSERT", count: 2 });
+
+    const line = await sql`-- tag=me
+INSERT INTO t (id, name) SELECT id + 20, name FROM t WHERE id <= 2`;
+    expect({ command: line.command, count: line.count }).toEqual({ command: "INSERT", count: 2 });
+
+    expect((await sql`SELECT count(*) AS n FROM t`)[0].n).toBe(6);
+  });
+
+  test("comment markers inside string literals are data, not comments", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+
+    expect(await sql.unsafe(`SELECT 'hello -- world' AS quoted`)).toEqual([{ quoted: "hello -- world" }]);
+    expect(await sql.unsafe(`SELECT 'x /* not a comment */ y' AS quoted`)).toEqual([
+      { quoted: "x /* not a comment */ y" },
+    ]);
+
+    await sql`CREATE TABLE t (name TEXT)`;
+    const ins = await sql.unsafe(`INSERT INTO t VALUES ('a -- b'), ('c /* d */ e')`);
+    expect({ command: ins.command, count: ins.count }).toEqual({ command: "INSERT", count: 2 });
+  });
+
+  test("REPLACE as a scalar function inside WITH ... SELECT still returns rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (name TEXT)`;
+    await sql`INSERT INTO t VALUES ('apple'), ('banana')`;
+
+    // A keyword-based classifier has to guess whether REPLACE is the statement
+    // or the function; the column count does not care.
+    const spaced = await sql.unsafe(
+      `WITH cte AS (SELECT REPLACE (name, 'a', 'x') AS n FROM t) SELECT * FROM cte ORDER BY n`,
+    );
+    expect(Array.from(spaced)).toEqual([{ n: "bxnxnx" }, { n: "xpple" }]);
+
+    const aliased = await sql.unsafe(`WITH cte AS (SELECT name AS replace FROM t ORDER BY name) SELECT * FROM cte`);
+    expect(Array.from(aliased)).toEqual([{ replace: "apple" }, { replace: "banana" }]);
+  });
+
+  test("EXPLAIN on a write returns the plan rows and does not execute the write", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (v INTEGER)`;
+
+    const plan = await sql.unsafe(`EXPLAIN INSERT INTO t VALUES (1)`);
+    expect(plan.length).toBeGreaterThan(0);
+    expect(plan[0]).toHaveProperty("opcode");
+
+    expect(await sql`SELECT count(*) AS n FROM t`).toEqual([{ n: 0 }]);
+  });
+
+  test("whitespace- and comment-only queries still report 'no valid SQL statement'", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+
+    // These never succeeded pre-PR either; db.run() rejects them with a clear
+    // message. The probe prepare must not leak a confusing "finalized" error.
+    for (const q of ["   ", "-- noop", "/* placeholder */", "-- a\n-- b\n"]) {
+      await expect(Promise.resolve(sql.unsafe(q))).rejects.toThrow("Query contained no valid SQL statement");
+    }
+  });
+
+  test("multi-statement writes still execute every statement", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql.unsafe(`
+      CREATE TABLE m1 (id INTEGER);
+      CREATE TABLE m2 (id INTEGER);
+      INSERT INTO m1 VALUES (1);
+      INSERT INTO m2 VALUES (2);
+    `);
+
+    expect(await sql`SELECT id FROM m1`).toEqual([{ id: 1 }]);
+    expect(await sql`SELECT id FROM m2`).toEqual([{ id: 2 }]);
+  });
+
+  test("INSERT helper detected past a comment containing a quote", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE items (name TEXT)`;
+
+    // The comment holds a lone apostrophe; the old reverse-scan tokenizer let
+    // it hijack the quote state and miss INSERT, throwing a bogus SyntaxError.
+    await sql`INSERT INTO items /* don't */ ${sql({ name: "a" })}`;
+
+    const rows = await sql`SELECT name FROM items`;
+    expect(rows).toEqual([{ name: "a" }]);
+  });
+});


### PR DESCRIPTION
### Problem
- `Bun.SQL` with the SQLite adapter returns `count: 0` for `INSERT ... SELECT` and `WITH ... INSERT/UPDATE/DELETE` without `RETURNING`, even though the rows were written (#30811). The same happens for `UPDATE`/`DELETE` whose subquery `SELECT` sits on its own line.
- It also silently returns `[]` for valid row-returning SQL it cannot tokenize: `select v from t where v like '%"%'`, `/*hdr*/select ...`, `select*from t`, top-level `values (...)`, `insert ... values(...)returning id`.
- Cause: `parseSQLQuery()` in `src/js/internal/sql/sqlite.ts` decided row-returning vs write by tokenizing the SQL in JavaScript. It split on whitespace only, its quote tracking toggled on either quote character regardless of which one opened the string, and it flipped `canReturnRows` on any `SELECT`/`WITH` token anywhere in the statement. A wrong "rows" answer routed a write through `stmt.all()` (count lost); a wrong "no rows" answer routed a query through `db.run()` (rows lost, no error). The same function backed helper detection, so a quote inside a comment made `INSERT INTO t /* don't */ ${sql(obj)}` throw a bogus `Helpers are only allowed for INSERT, UPDATE and WHERE IN commands`.

### Fix
- Prepare the statement and let SQLite decide: a statement with result columns (`stmt.native.columnsCount > 0`, i.e. `sqlite3_column_count`) runs through the prepared statement; a statement with none goes through `db.run()` as before, which also keeps multi-statement strings working. The probe statement is finalized on every path. If SQLite refuses to compile the statement (syntax error, unknown table, `SQLITE_BUSY`, ...) the probe rethrows that `SQLiteError`, exactly as the old prepared-statement branch did; only whitespace or comment-only input, which yields no statement at all (a plain `Error` from `bun:sqlite`), falls through to `db.run()` for its `Query contained no valid SQL statement` message. An earlier revision swallowed every probe error: under lock contention a `SELECT` whose probe hit `SQLITE_BUSY` was then retried through `db.run()`, which discards rows, and resolved to `[]` once the lock was gone (probe: 3000 fresh connections selecting from a file database while another process churns `BEGIN EXCLUSIVE`/`ROLLBACK`: 666 silent empty results with the swallowing catch, 0 with this one, ~1450 `SQLITE_BUSY` rejections either way).
- Correct because the column count is the definition of "returns rows" in SQLite: `SELECT`, `VALUES`, `EXPLAIN`, row-producing `PRAGMA`s and `... RETURNING` have columns; every write and DDL statement, including `INSERT ... SELECT` and `WITH ... INSERT`, has zero. No keyword heuristic can be wrong here because none is used.
- `parseSQLQuery()` now only produces the `.command` label and the helper command. It is a forward lexer that skips `--` and `/* */` comments, `'...'` literals and `"..."`, `` `...` ``, `[...]` identifiers, so text inside those can no longer affect either result. Word characters follow SQLite's `IdChar()` (ASCII alphanumerics, `_`, `$`, and any non-ASCII code unit), so an unquoted identifier such as `caféin` stays one token instead of ending in a spurious `IN`. The helper command is still the keyword nearest the end of the prefix. The result's `.command` label is now simply the statement's leading keyword; previously it was derived from the nearest `INSERT`/`UPDATE`/`SET`, which labeled a `CREATE TRIGGER` body or a `BEGIN; UPDATE ...; COMMIT` string as `UPDATE`, labeled upserts `UPDATE`, and for `WITH ... INSERT` flipped between `INSERT` and `WITH` depending on the trailing clauses. Those now read `CREATE`, `BEGIN`, `INSERT` and `WITH` respectively.
- Cost: writes are now compiled twice (probe, then `db.run()`). In a debug build A/B of 5000 awaited `INSERT`s the new version is still faster than the old one (old tokenizer: ~1085 us/insert, this PR: ~950 us/insert; plain `SELECT`s ~1010 -> ~730 us) because the per-character reverse tokenizer cost more than the extra `sqlite3_prepare`. Debug numbers, but the extra prepare is not a measurable regression.
- Verified with `bun bd test test/js/sql/sqlite-sql-row-detection.test.ts` (23 tests; 12 of them fail on the unfixed build, all pass with the fix). The file covers the quote/comment/punctuation/`VALUES`/`RETURNING`/`PRAGMA` row cases, `INSERT ... SELECT`, `WITH ... INSERT/UPDATE/DELETE/REPLACE INTO`, subquery `UPDATE`/`DELETE`, comment-prefixed writes, `EXPLAIN` on a write, the `.command` labels above, a helper after a non-ASCII identifier, whitespace-only input, multi-statement writes, helper detection past a quoted comment, and (as a contract check, since the race itself is not reproducible deterministically) a `SELECT` against an exclusively locked database rejecting with `SQLITE_BUSY` and working again once the lock is released.
- Rebased over #37109 (named parameters for `unsafe()`): both branches keep its `$isArray(values) ? $apply : $call` binding, and its eight named-parameter tests pass through the new path. `test/js/sql/sqlite-sql.test.ts` (239 tests), `sql-helpers-validation.test.ts`, `adapter-override.test.ts`, `adapter-env-var-precedence.test.ts` and `sqlite-url-parsing.test.ts` all pass on the debug build.

### Background
- `Bun.SQL` (`new SQL("sqlite://...")`) is implemented on top of `bun:sqlite`. The adapter has two ways to execute a string: `stmt.all()/values()/raw()` on a prepared statement, which returns rows but only runs the first statement in the string, and `db.run()`, which runs every statement in the string and reports `changes()`/`lastInsertRowid` but discards any rows. The adapter has to pick one up front, which is the decision this PR moves into SQLite.
- `sqlite3_prepare` compiles a statement without executing it, so probing the column count does not run anything twice; `sqlite3_column_count` is the number of result columns the compiled statement would produce.
- SQL helpers (`${sql(obj)}` / `${sql([1,2])}`) expand differently after `INSERT`, `UPDATE ... SET` and `WHERE x IN`; `getHelperCommand()` looks at the SQL text before the helper to choose, which is why the lexer still exists.

### Related
- Consolidates the three open fixes for #30811: supersedes #30814 (patched the tokenizer with comment stripping and DML tracking; its additional test shapes are folded in here) and #30815 (gated the tokenizer on the command, which also stops plain `SELECT ... WHERE` queries from returning rows and leaves `INSERT ... SELECT` misrouted, because the reverse walk meets the inner `SELECT` first).
- Multi-statement strings are out of scope and behave exactly as before this PR: a string whose first statement has no result columns runs every statement through `db.run()` (covered by a test); a string whose first statement returns rows executes only that statement, on this branch and on the current release alike (verified side by side with `SELECT 1; INSERT ...`). Running the remainder requires the native multi-statement support in #33582, which is complementary to this change.

Fixes #30811

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql-row-detection.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/sql/sqlite-sql-row-detection.test.ts:
10 |     await using sql = new SQL("sqlite://:memory:");
11 |     await sql`CREATE TABLE t (v TEXT)`;
12 |     await sql`INSERT INTO t VALUES (${"a"}), (${'b"c'}), (${"d"})`;
13 | 
14 |     const rows = await sql.unsafe(`select v from t where v like '%"%'`);
15 |     expect(rows).toEqual([{ v: 'b"c' }]);
                      ^
error: expect(received).toEqual(expected)

- [
-   {
-     "v": "b"c",
-   },
- ]
+ []

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/sql/sqlite-sql-row-detection.test.ts:15:18)
(fail) row-returning detection (column count, not tokenizer) > LIKE predicate containing a double quote returns rows [6.13ms]
19 |     await using sql = new SQL("sqlite://:memory:");
20 |     await sql`CREATE TABLE t (v INTEGER)`;
21 |     await sql`INSERT INTO t VALUES (1), (2), (3)`;
22 | 
23 |     const rows = await sql.unsafe(`/*hdr*/select v from t`);
24 |     expect(rows).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
                      ^
error: expect(received).toEqual(expected)

- [
-   {
-     "v": 1,
-   },
-   {
-     "v": 2,
-   },
-   {
-     "
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql-row-detection.test.ts
bun test v1.4.0 (51a96c0bd)

test/js/sql/sqlite-sql-row-detection.test.ts:
(pass) row-returning detection (column count, not tokenizer) > LIKE predicate containing a double quote returns rows [261.30ms]
(pass) row-returning detection (column count, not tokenizer) > leading block comment before SELECT returns rows [23.84ms]
(pass) row-returning detection (column count, not tokenizer) > leading line comment before SELECT returns rows [22.81ms]
(pass) row-returning detection (column count, not tokenizer) > SELECT with no whitespace before punctuation returns rows [29.56ms]
(pass) row-returning detection (column count, not tokenizer) > top-level VALUES returns rows [15.60ms]
(pass) row-returning detection (column count, not tokenizer) > INSERT ... RETURNING writes and returns the rows [23.78ms]
(pass) row-returning detection (column count, not tokenizer) > row-producing PRAGMA returns rows, non-row PRAGMA does not [24.67ms]
(pass) row-returning detection (column count, not tokenizer) > command l
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     51a96c0bd2
  features     baseline

22 deps, 107 codegen, 1176 objects in 1638ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1238] fetch tinycc
[tinycc] up to date
[4/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1237] fetch zlib
[zlib] up to date
[6/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[7/1237] gen bindgenv2
[8/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1237] subst deps/zlib/zlib.h
[10/1237] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeMod
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/sqlite.ts                | 287 ++++++++++-------------
 test/js/sql/sqlite-sql-row-detection.test.ts | 332 +++++++++++++++++++++++++++
 2 files changed, 449 insertions(+), 170 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js/internal/sql/sqlite.ts                    16     28      0
test/js/sql/sqlite-sql-row-detection.test.ts      5      7      0
```

</details>

**root cause** · written by the author bot

The sqlite adapter decided whether a statement could return rows with a best-effort tokenizer in parseSQLQuery() that split only on whitespace and let a double quote toggle the quote state inside a single-quoted literal (or vice versa), so valid row-returning SQL such as a SELECT preceded by a comment or punctuation, a top-level VALUES, or any query containing a mismatched quote inside a string literal was misclassified and routed to db.run(), which silently discarded every row; the same parser made getHelperCommand() reject quote-containing identifiers. The fix removes canReturnRows and in…

<!-- robobun:evidence:end -->

