### PR TITLE
node:perf_hooks: align createHistogram/record/add validation with Node.js

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -1,5 +1,6 @@
 // Hardcoded module "node:perf_hooks"
 const { throwNotImplemented, kNodeEntryTypes, NodeEntryObserver } = require("internal/shared");
+const { validateObject } = require("internal/validators");
 
 const cppCreateHistogram = $newCppFunction("JSNodePerformanceHooksHistogram.cpp", "jsFunction_createHistogram", 3) as (
   min: number,
@@ -268,6 +269,9 @@ export default {
     highest?: number | bigint;
     figures?: number;
   }): import("node:perf_hooks").RecordableHistogram {
+    if (options !== undefined) {
+      validateObject(options, "options");
+    }
     const opts = options || {};
 
     let lowest = 1;

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSMapInlines.h>
+#include <JavaScriptCore/ProxyObject.h>
 
 namespace Bun {
 
@@ -59,12 +60,7 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord, (JSGlob
         return {};
     }
 
-    if (callFrame->argumentCount() < 1) {
-        Bun::ERR::MISSING_ARGS(scope, globalObject, "record requires at least one argument"_s);
-        return {};
-    }
-
-    JSValue arg = callFrame->uncheckedArgument(0);
+    JSValue arg = callFrame->argument(0);
     int64_t value;
     if (arg.isNumber()) {
         value = truncateDoubleToInt64(arg.asNumber());
@@ -72,7 +68,7 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord, (JSGlob
         auto* bigInt = uncheckedDowncast<JSBigInt>(arg);
         value = JSBigInt::toBigInt64(bigInt);
     } else {
-        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "value"_s, "number or BigInt"_s, arg);
+        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "val"_s, "number"_s, arg);
         return {};
     }
 
@@ -111,15 +107,20 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncAdd, (JSGlobalO
         return {};
     }
 
-    if (callFrame->argumentCount() < 1) {
-        Bun::ERR::MISSING_ARGS(scope, globalObject, "add requires at least one argument"_s);
-        return {};
-    }
-
-    JSValue otherArg = callFrame->uncheckedArgument(0);
+    JSValue otherArg = callFrame->argument(0);
     JSNodePerformanceHooksHistogram* otherHistogram = dynamicDowncast<JSNodePerformanceHooksHistogram>(otherArg);
     if (!otherHistogram) [[unlikely]] {
-        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "argument"_s, "Histogram"_s, otherArg);
+        // Node.js reads the native handle via a property lookup, so a Proxy
+        // wrapping a histogram is accepted. Unwrap Proxy chains here.
+        JSValue unwrapped = otherArg;
+        while (auto* proxy = dynamicDowncast<JSC::ProxyObject>(unwrapped)) {
+            if (proxy->isRevoked()) break;
+            unwrapped = proxy->target();
+        }
+        otherHistogram = dynamicDowncast<JSNodePerformanceHooksHistogram>(unwrapped);
+    }
+    if (!otherHistogram) [[unlikely]] {
+        Bun::ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, "other"_s, "RecordableHistogram"_s, otherArg);
         return {};
     }
 

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -574,6 +574,69 @@ describe("Histogram", () => {
     });
   });
 
+  describe("Node.js argument validation compatibility", () => {
+    test("createHistogram rejects non-object options with ERR_INVALID_ARG_TYPE", () => {
+      for (const options of [null, 1, "str", true, [], () => {}]) {
+        assert.throws(
+          () => createHistogram(options as unknown),
+          err => err.code === "ERR_INVALID_ARG_TYPE" && /"options" argument must be of type object/.test(err.message),
+          `createHistogram(${inspect(options)}) should throw ERR_INVALID_ARG_TYPE`,
+        );
+      }
+      // undefined and a plain object remain accepted
+      assert.strictEqual(createHistogram().count, 0);
+      assert.strictEqual(createHistogram(undefined).count, 0);
+      assert.strictEqual(createHistogram({}).count, 0);
+    });
+
+    test("record() with no argument throws ERR_INVALID_ARG_TYPE for 'val'", () => {
+      const h = createHistogram();
+      assert.throws(
+        () => h.record(),
+        err =>
+          err.code === "ERR_INVALID_ARG_TYPE" &&
+          /"val" argument must be of type number/.test(err.message) &&
+          /undefined/.test(err.message),
+      );
+      assert.throws(
+        () => h.record("str" as unknown),
+        err => err.code === "ERR_INVALID_ARG_TYPE" && /"val" argument must be of type number/.test(err.message),
+      );
+    });
+
+    test("add() accepts a Proxy-wrapped histogram", () => {
+      const h1 = createHistogram();
+      const h2 = createHistogram();
+      h2.record(5);
+      h2.record(10);
+      h1.add(new Proxy(h2, {}));
+      assert.strictEqual(h1.count, 2);
+      assert.strictEqual(h1.min, 5);
+      assert.strictEqual(h1.max, 10);
+
+      // nested proxies
+      const h3 = createHistogram();
+      h3.add(new Proxy(new Proxy(h2, {}), {}));
+      assert.strictEqual(h3.count, 2);
+    });
+
+    test("add() with a non-histogram throws ERR_INVALID_ARG_TYPE for 'other'", () => {
+      const h = createHistogram();
+      for (const other of [{}, new Proxy({}, {}), 1, "str"]) {
+        assert.throws(
+          () => h.add(other as unknown),
+          err =>
+            err.code === "ERR_INVALID_ARG_TYPE" &&
+            /"other" argument must be an instance of RecordableHistogram/.test(err.message),
+          `add(${inspect(other)}) should throw ERR_INVALID_ARG_TYPE`,
+        );
+      }
+      // null/undefined throw in both runtimes (Node: property access on null; Bun: ERR_INVALID_ARG_TYPE)
+      assert.throws(() => h.add(null as unknown), TypeError);
+      assert.throws(() => h.add(undefined as unknown), TypeError);
+    });
+  });
+
   test("inspect output", () => {
     const h = createHistogram();
     h.record(1);

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -631,6 +631,10 @@ describe("Histogram", () => {
           `add(${inspect(other)}) should throw ERR_INVALID_ARG_TYPE`,
         );
       }
+      // revoked proxy: target/handler are detached, must not be accepted
+      const { proxy, revoke } = Proxy.revocable(createHistogram(), {});
+      revoke();
+      assert.throws(() => h.add(proxy as unknown), TypeError);
       // null/undefined throw in both runtimes (Node: property access on null; Bun: ERR_INVALID_ARG_TYPE)
       assert.throws(() => h.add(null as unknown), TypeError);
       assert.throws(() => h.add(undefined as unknown), TypeError);


### PR DESCRIPTION
Three small Node.js compatibility divergences in `node:perf_hooks` histogram argument validation.

## Repro

```js
import { createHistogram } from "node:perf_hooks";
createHistogram(null);                 // node: ERR_INVALID_ARG_TYPE   bun: silently accepted
createHistogram(1);                    // node: ERR_INVALID_ARG_TYPE   bun: silently accepted
createHistogram().record();            // node: ERR_INVALID_ARG_TYPE   bun: ERR_MISSING_ARGS
const h = createHistogram();
h.add(new Proxy(createHistogram(), {})); // node: accepted             bun: ERR_INVALID_ARG_TYPE
```

## Cause

- `createHistogram` did `options || {}` with no type check, so `null` fell through to the default and any primitive was treated as an options bag whose fields are all `undefined`.
- `record()` checked `argumentCount() < 1` and threw `ERR_MISSING_ARGS`; Node.js validates the first argument as a number/bigint and throws `ERR_INVALID_ARG_TYPE` for `"val"`.
- `add()` brand-checks the argument with `dynamicDowncast<JSNodePerformanceHooksHistogram>`, which cannot see through a `Proxy`. Node.js reads the native handle via a property lookup, so a Proxy wrapping a histogram is accepted.

## Fix

- `src/js/node/perf_hooks.ts`: call `validateObject(options, "options")` when `options !== undefined` (same pattern already used in `monitorEventLoopDelay`).
- `src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp`:
  - `record()`: drop the `argumentCount()` guard and validate `argument(0)` directly, throwing `ERR_INVALID_ARG_TYPE("val", "number", ...)` to match Node's message.
  - `add()`: when the direct downcast fails, unwrap `ProxyObject` target chains (skipping revoked proxies) before retrying the downcast; use `ERR_INVALID_ARG_TYPE_INSTANCE("other", "RecordableHistogram", ...)` for the rejection message.

## Verification

```
bun bd test test/js/bun/perf_hooks/histogram.test.ts   # 42 pass
node --test test/js/bun/perf_hooks/histogram.test.ts   # 42 pass
```

The four new tests in `test/js/bun/perf_hooks/histogram.test.ts` fail on released Bun 1.4.0 and pass with this change.