### PR TITLE
node:perf_hooks: add Histogram.prototype.toJSON

### DIFF
--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -261,6 +261,29 @@ void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObjec
     }
 }
 
+JSC::JSObject* JSNodePerformanceHooksHistogram::getPercentilesObject(JSGlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* result = JSC::constructEmptyObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    if (!m_histogramData.histogram) return result;
+
+    struct hdr_iter iter;
+    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
+
+    while (hdr_iter_next(&iter)) {
+        double percentile = iter.specifics.percentiles.percentile;
+        int64_t value = iter.highest_equivalent_value;
+        result->putDirectMayBeIndex(globalObject, Identifier::from(vm, percentile), jsNumber(static_cast<double>(value)));
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+
+    return result;
+}
+
 void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map)
 {
     VM& vm = globalObject->vm();

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -245,20 +245,18 @@ void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!m_histogramData.histogram) return;
-
-    struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
-
-    while (hdr_iter_next(&iter)) {
-        double percentile = iter.specifics.percentiles.percentile;
-        int64_t value = iter.highest_equivalent_value;
-        JSValue jsKey = jsNumber(percentile);
+    forEachPercentile([&](double percentile, int64_t value) {
         JSValue jsValue = JSBigInt::createFrom(globalObject, value);
-        RETURN_IF_EXCEPTION(scope, );
-        map->set(globalObject, jsKey, jsValue);
-        RETURN_IF_EXCEPTION(scope, void());
-    }
+        if (scope.exception()) [[unlikely]]
+            return false;
+        map->set(globalObject, jsNumber(percentile), jsValue);
+        return !scope.exception();
+    });
+}
+
+void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map)
+{
+    getPercentiles(globalObject, map);
 }
 
 JSC::JSObject* JSNodePerformanceHooksHistogram::getPercentilesObject(JSGlobalObject* globalObject)
@@ -269,40 +267,13 @@ JSC::JSObject* JSNodePerformanceHooksHistogram::getPercentilesObject(JSGlobalObj
     JSObject* result = JSC::constructEmptyObject(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (!m_histogramData.histogram) return result;
-
-    struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
-
-    while (hdr_iter_next(&iter)) {
-        double percentile = iter.specifics.percentiles.percentile;
-        int64_t value = iter.highest_equivalent_value;
+    forEachPercentile([&](double percentile, int64_t value) {
         result->putDirectMayBeIndex(globalObject, Identifier::from(vm, percentile), jsNumber(static_cast<double>(value)));
-        RETURN_IF_EXCEPTION(scope, nullptr);
-    }
+        return !scope.exception();
+    });
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return result;
-}
-
-void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!m_histogramData.histogram) return;
-
-    struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
-
-    while (hdr_iter_next(&iter)) {
-        double percentile = iter.specifics.percentiles.percentile;
-        int64_t value = iter.highest_equivalent_value;
-        JSValue jsKey = jsNumber(percentile);
-        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
-        RETURN_IF_EXCEPTION(scope, );
-        map->set(globalObject, jsKey, jsValue);
-        RETURN_IF_EXCEPTION(scope, void());
-    }
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -246,17 +246,23 @@ void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     forEachPercentile([&](double percentile, int64_t value) {
-        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
-        if (scope.exception()) [[unlikely]]
-            return false;
-        map->set(globalObject, jsNumber(percentile), jsValue);
+        map->set(globalObject, jsNumber(percentile), jsNumber(static_cast<double>(value)));
         return !scope.exception();
     });
 }
 
 void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map)
 {
-    getPercentiles(globalObject, map);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    forEachPercentile([&](double percentile, int64_t value) {
+        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
+        if (scope.exception()) [[unlikely]]
+            return false;
+        map->set(globalObject, jsNumber(percentile), jsValue);
+        return !scope.exception();
+    });
 }
 
 JSC::JSObject* JSNodePerformanceHooksHistogram::getPercentilesObject(JSGlobalObject* globalObject)

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -46,6 +46,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsNodePerformanceHooksHistogramGetter_percentilesBigIn
 
 JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncPercentile);
 JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncPercentileBigInt);
+JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncToJSON);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_createHistogram);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay);
@@ -161,6 +162,7 @@ public:
     int64_t getPercentile(double percentile) const;
     void getPercentiles(JSGlobalObject* globalObject, JSC::JSMap* map);
     void getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map);
+    JSC::JSObject* getPercentilesObject(JSGlobalObject* globalObject);
     size_t getExceeds() const;
     uint64_t getCount() const;
     double add(JSNodePerformanceHooksHistogram* other);

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -156,6 +156,8 @@ public:
     uint64_t recordDelta(JSGlobalObject* globalObject);
     void reset();
     int64_t getMin() const;
+    // Node.js returns min as if it were unsigned when converting to double (INT64_MIN initial-state quirk).
+    double getMinAsDouble() const { return static_cast<double>(static_cast<uint64_t>(getMin())); }
     int64_t getMax() const;
     double getMean() const;
     double getStddev() const;
@@ -170,6 +172,18 @@ public:
     // std::shared_ptr<HistogramData> getHistogramDataForCloning() const;
 
 private:
+    template<typename Callback>
+    void forEachPercentile(Callback&& callback)
+    {
+        if (!m_histogramData.histogram) return;
+        struct hdr_iter iter;
+        hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
+        while (hdr_iter_next(&iter)) {
+            if (!callback(iter.specifics.percentiles.percentile, iter.highest_equivalent_value))
+                return;
+        }
+    }
+
     uint16_t m_extraMemorySizeForGC = 0;
 };
 

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -24,6 +24,7 @@ static const HashTableValue JSNodePerformanceHooksHistogramPrototypeTableValues[
     { "reset"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncReset, 0 } },
     { "percentile"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncPercentile, 1 } },
     { "percentileBigInt"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncPercentileBigInt, 1 } },
+    { "toJSON"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncToJSON, 0 } },
 
     { "count"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsNodePerformanceHooksHistogramGetter_count, 0 } },
     { "countBigInt"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsNodePerformanceHooksHistogramGetter_countBigInt, 0 } },
@@ -198,6 +199,34 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncPercentileBigIn
     RETURN_IF_EXCEPTION(scope, {});
 
     RELEASE_AND_RETURN(scope, JSValue::encode(JSBigInt::createFrom(globalObject, thisObject->getPercentile(percentile))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncToJSON, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSNodePerformanceHooksHistogram* thisObject = dynamicDowncast<JSNodePerformanceHooksHistogram>(callFrame->thisValue());
+    if (!thisObject) [[unlikely]] {
+        WebCore::throwThisTypeError(*globalObject, scope, "Histogram"_s, "toJSON"_s);
+        return {};
+    }
+
+    JSObject* result = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 7);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    result->putDirect(vm, Identifier::fromString(vm, "count"_s), jsNumber(static_cast<double>(thisObject->getCount())));
+    result->putDirect(vm, Identifier::fromString(vm, "min"_s), jsNumber(static_cast<double>(static_cast<uint64_t>(thisObject->getMin()))));
+    result->putDirect(vm, Identifier::fromString(vm, "max"_s), jsNumber(static_cast<double>(thisObject->getMax())));
+    result->putDirect(vm, Identifier::fromString(vm, "mean"_s), jsNumber(thisObject->getMean()));
+    result->putDirect(vm, Identifier::fromString(vm, "exceeds"_s), jsNumber(static_cast<double>(thisObject->getExceeds())));
+    result->putDirect(vm, Identifier::fromString(vm, "stddev"_s), jsNumber(thisObject->getStddev()));
+
+    JSObject* percentiles = thisObject->getPercentilesObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    result->putDirect(vm, Identifier::fromString(vm, "percentiles"_s), percentiles);
+
+    return JSValue::encode(result);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodePerformanceHooksHistogramGetter_count, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncToJSON, (JSGlob
     RETURN_IF_EXCEPTION(scope, {});
 
     result->putDirect(vm, Identifier::fromString(vm, "count"_s), jsNumber(static_cast<double>(thisObject->getCount())));
-    result->putDirect(vm, Identifier::fromString(vm, "min"_s), jsNumber(static_cast<double>(static_cast<uint64_t>(thisObject->getMin()))));
+    result->putDirect(vm, Identifier::fromString(vm, "min"_s), jsNumber(thisObject->getMinAsDouble()));
     result->putDirect(vm, Identifier::fromString(vm, "max"_s), jsNumber(static_cast<double>(thisObject->getMax())));
     result->putDirect(vm, Identifier::fromString(vm, "mean"_s), jsNumber(thisObject->getMean()));
     result->putDirect(vm, Identifier::fromString(vm, "exceeds"_s), jsNumber(static_cast<double>(thisObject->getExceeds())));
@@ -266,11 +266,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodePerformanceHooksHistogramGetter_min, (JSGlobalObj
         return {};
     }
 
-    int64_t minValue = thisObject->getMin();
-
-    // Node.js returns the value as if it were unsigned when converting to double
-    // This handles the special case where the initial value is INT64_MIN
-    return JSValue::encode(jsNumber(static_cast<double>(static_cast<uint64_t>(minValue))));
+    return JSValue::encode(jsNumber(thisObject->getMinAsDouble()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodePerformanceHooksHistogramGetter_minBigInt, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { inspect } from "node:util";
-import { createHistogram } from "perf_hooks";
+import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
 
 describe("Histogram", () => {
   test("basic histogram creation and initial state", () => {
@@ -519,23 +519,71 @@ describe("Histogram", () => {
       h.record(20);
       h.record(30);
 
-      if (typeof h.toJSON === "function") {
-        const json = h.toJSON();
+      assert.strictEqual(typeof h.toJSON, "function");
+      const json = h.toJSON();
 
-        assert.strictEqual(typeof json, "object");
-        assert.strictEqual(json.count, 3);
-        assert.strictEqual(json.min, 10);
-        assert.strictEqual(json.max, 30);
-        assert.strictEqual(json.mean, 20);
-        assert.strictEqual(json.exceeds, 0);
-        assert.strictEqual(typeof json.stddev, "number");
-        assert.strictEqual(typeof json.percentiles, "object");
+      assert.strictEqual(typeof json, "object");
+      assert.strictEqual(json.count, 3);
+      assert.strictEqual(json.min, 10);
+      assert.strictEqual(json.max, 30);
+      assert.strictEqual(json.mean, 20);
+      assert.strictEqual(json.exceeds, 0);
+      assert.strictEqual(typeof json.stddev, "number");
+      assert.strictEqual(typeof json.percentiles, "object");
 
-        assert.ok(!json.percentiles.has);
-        assert.ok(typeof json.percentiles === "object");
-      } else {
-        console.log("toJSON method not implemented yet - skipping test");
+      assert.ok(!(json.percentiles instanceof Map));
+      assert.deepStrictEqual(Object.keys(json), ["count", "min", "max", "mean", "exceeds", "stddev", "percentiles"]);
+    });
+
+    test("toJSON percentiles shape matches Node.js", () => {
+      const h = createHistogram();
+      h.record(5);
+      h.record(9);
+
+      const json = h.toJSON();
+      assert.deepStrictEqual(json.percentiles, { "0": 5, "50": 5, "75": 9, "100": 9 });
+      for (const value of Object.values(json.percentiles)) {
+        assert.strictEqual(typeof value, "number");
       }
+    });
+
+    test("toJSON on empty histogram", () => {
+      const h = createHistogram();
+      const json = h.toJSON();
+
+      assert.strictEqual(json.count, 0);
+      assert.strictEqual(json.min, 9223372036854776000);
+      assert.strictEqual(json.max, 0);
+      assert.ok(Number.isNaN(json.mean));
+      assert.strictEqual(json.exceeds, 0);
+      assert.ok(Number.isNaN(json.stddev));
+      assert.deepStrictEqual(json.percentiles, { "100": 0 });
+    });
+
+    test("JSON.stringify(histogram) is not '{}'", () => {
+      const h = createHistogram();
+      h.record(5);
+      h.record(9);
+
+      const serialized = JSON.stringify(h);
+      assert.notStrictEqual(serialized, "{}");
+
+      const parsed = JSON.parse(serialized);
+      assert.strictEqual(parsed.count, 2);
+      assert.strictEqual(parsed.min, 5);
+      assert.strictEqual(parsed.max, 9);
+      assert.strictEqual(parsed.mean, 7);
+      assert.strictEqual(parsed.exceeds, 0);
+      assert.deepStrictEqual(parsed.percentiles, { "0": 5, "50": 5, "75": 9, "100": 9 });
+    });
+
+    test("monitorEventLoopDelay histogram has toJSON", () => {
+      const eld = monitorEventLoopDelay();
+      assert.strictEqual(typeof eld.toJSON, "function");
+
+      const json = eld.toJSON();
+      assert.deepStrictEqual(Object.keys(json), ["count", "min", "max", "mean", "exceeds", "stddev", "percentiles"]);
+      assert.notStrictEqual(JSON.stringify(eld), "{}");
     });
 
     test("extreme value handling", () => {

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -464,14 +464,25 @@ describe("Histogram", () => {
 
       assert.strictEqual(percentiles.size, percentilesBigInt.size);
 
-      for (const [key, value] of percentiles) {
+      for (const [key, value] of percentilesBigInt) {
         assert.strictEqual(typeof key, "number");
         assert.strictEqual(typeof value, "bigint");
+        assert.ok(percentiles.has(key));
+      }
+    });
 
-        assert.ok(percentilesBigInt.has(key));
-        const bigIntValue = percentilesBigInt.get(key);
-        assert.strictEqual(typeof bigIntValue, "bigint");
-        assert.strictEqual(value, bigIntValue);
+    test("percentiles returns number values, percentilesBigInt returns bigint values", () => {
+      const h = createHistogram();
+      for (let i = 1; i <= 10; i++) h.record(i);
+
+      for (const [key, value] of h.percentiles) {
+        assert.strictEqual(typeof key, "number");
+        assert.strictEqual(typeof value, "number");
+      }
+
+      for (const [key, value] of h.percentilesBigInt) {
+        assert.strictEqual(typeof key, "number");
+        assert.strictEqual(typeof value, "bigint");
       }
     });
 

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -547,6 +547,24 @@ describe("Histogram", () => {
       }
     });
 
+    test("toJSON percentiles with fractional keys", () => {
+      const h = createHistogram();
+      for (let i = 1; i <= 100; i++) h.record(i);
+
+      const json = h.toJSON();
+      assert.deepStrictEqual(json.percentiles, {
+        "0": 1,
+        "50": 50,
+        "75": 75,
+        "87.5": 88,
+        "93.75": 94,
+        "96.875": 97,
+        "98.4375": 99,
+        "99.21875": 100,
+        "100": 100,
+      });
+    });
+
     test("toJSON on empty histogram", () => {
       const h = createHistogram();
       const json = h.toJSON();


### PR DESCRIPTION
`JSON.stringify(histogram)` returned `"{}"` because the histogram prototype had no `toJSON` and no enumerable own properties. Node.js has defined `toJSON()` on the `Histogram` base class since v17, and "snapshot the histogram with `JSON.stringify`" is the standard pattern in metrics exporters, which on Bun silently shipped empty objects.

## Repro

```js
import { createHistogram, monitorEventLoopDelay } from "node:perf_hooks";
const h = createHistogram();
h.record(5); h.record(9);
console.log(typeof h.toJSON);                    // node: function   bun: undefined
console.log(typeof monitorEventLoopDelay().toJSON); // node: function   bun: undefined
console.log(JSON.stringify(h));
// node: {"count":2,"min":5,"max":9,"mean":7,"exceeds":0,"stddev":2,"percentiles":{"0":5,"50":5,"75":9,"100":9}}
// bun:  {}
```

## Fix

Add `toJSON` to `JSNodePerformanceHooksHistogramPrototype` returning `{count, min, max, mean, exceeds, stddev, percentiles}` to match Node.js. The `percentiles` field is built as a plain object directly from the `hdr_histogram` percentile iterator (number values, not bigints), using `putDirectMayBeIndex` so both integer keys (`0`, `50`, `100`) and non-integer keys (`87.5`, `93.75`) are handled.

Applies to both `createHistogram()` and `monitorEventLoopDelay()` since they share the same prototype.

Along the way:
- Extracted a `forEachPercentile` template helper and `getMinAsDouble()` so the hdr iteration loop and the `INT64_MIN` initial-state conversion each live in one place.
- Fixed `histogram.percentiles` to return `Map<number, number>` instead of `Map<number, bigint>`, matching Node's documented behavior. `histogram.percentilesBigInt` continues to return bigint values. (In Node these two getters actually return the same cached `Map` instance and overwrite it in place; Bun returns a fresh `Map` per access, which is intentionally kept.)

## Verification

```
$ bun bd test test/js/bun/perf_hooks/histogram.test.ts
 44 pass
 0 fail

$ node --test test/js/bun/perf_hooks/histogram.test.ts
 tests 44 / pass 44 / fail 0
```

`toJSON()` output is byte-identical to Node v26.3.0 including the empty-histogram case (`{"count":0,"min":9223372036854776000,"max":0,"mean":null,"exceeds":0,"stddev":null,"percentiles":{"100":0}}`). The seven new/updated tests fail on released Bun 1.4.0 and pass with this change.
