### PR TITLE
node:perf_hooks: split Histogram into base/Recordable/ELD classes

### DIFF
--- a/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
+++ b/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
@@ -1,28 +1,32 @@
 // Internal module for monitorEventLoopDelay implementation
 const { validateObject, validateInteger } = require("internal/validators");
 
+const ObjectCreate = Object.create;
+const ObjectSetPrototypeOf = Object.setPrototypeOf;
+
 // Private C++ bindings for event loop delay monitoring
 const cppMonitorEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_monitorEventLoopDelay",
   1,
-) as (resolution: number) => import("node:perf_hooks").RecordableHistogram;
+) as (resolution: number) => import("node:perf_hooks").IntervalHistogram;
 
 const cppEnableEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_enableEventLoopDelay",
   2,
-) as (histogram: import("node:perf_hooks").RecordableHistogram, resolution: number) => void;
+) as (histogram: import("node:perf_hooks").IntervalHistogram, resolution: number) => void;
 
 const cppDisableEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_disableEventLoopDelay",
   1,
-) as (histogram: import("node:perf_hooks").RecordableHistogram) => void;
+) as (histogram: import("node:perf_hooks").IntervalHistogram) => void;
 
 // IntervalHistogram wrapper class for event loop delay monitoring
 
-let eventLoopDelayHistogram: import("node:perf_hooks").RecordableHistogram | undefined;
+let eventLoopDelayHistogram: import("node:perf_hooks").IntervalHistogram | undefined;
+let eldPrototype: object | undefined;
 let enabled = false;
 let resolution = 10;
 
@@ -46,6 +50,10 @@ function disable() {
   return true;
 }
 
+function ELDHistogram() {
+  throw $ERR_ILLEGAL_CONSTRUCTOR();
+}
+
 function monitorEventLoopDelay(options?: { resolution?: number }) {
   if (options !== undefined) {
     validateObject(options, "options");
@@ -60,9 +68,18 @@ function monitorEventLoopDelay(options?: { resolution?: number }) {
 
   if (!eventLoopDelayHistogram) {
     eventLoopDelayHistogram = cppMonitorEventLoopDelay(resolution);
-    $putByValDirect(eventLoopDelayHistogram, "enable", enable);
-    $putByValDirect(eventLoopDelayHistogram, "disable", disable);
-    $putByValDirect(eventLoopDelayHistogram, Symbol.dispose, disable);
+    if (!eldPrototype) {
+      // The native object's immediate prototype is the shared read-only
+      // Histogram base. Build the ELDHistogram prototype on top of it once.
+      const basePrototype = $getPrototypeOf(eventLoopDelayHistogram);
+      eldPrototype = ObjectCreate(basePrototype);
+      $putByValDirect(eldPrototype, "enable", enable);
+      $putByValDirect(eldPrototype, "disable", disable);
+      $putByValDirect(eldPrototype, Symbol.dispose, disable);
+      $putByValDirect(eldPrototype, "constructor", ELDHistogram);
+      ELDHistogram.prototype = eldPrototype;
+    }
+    ObjectSetPrototypeOf(eventLoopDelayHistogram, eldPrototype);
   }
 
   return eventLoopDelayHistogram;

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -28,7 +28,7 @@ namespace Bun {
 
 using namespace JSC;
 
-const ClassInfo JSNodePerformanceHooksHistogram::s_info = { "RecordableHistogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogram) };
+const ClassInfo JSNodePerformanceHooksHistogram::s_info = { "Histogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogram) };
 
 void JSNodePerformanceHooksHistogram::finishCreation(VM& vm)
 {
@@ -36,7 +36,7 @@ void JSNodePerformanceHooksHistogram::finishCreation(VM& vm)
     ASSERT(inherits(info()));
 }
 
-JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, int64_t lowest, int64_t highest, int figures)
+JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, HistogramKind kind, int64_t lowest, int64_t highest, int figures)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -48,7 +48,7 @@ JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm,
     }
     auto histogramData = HistogramData(raw_histogram);
 
-    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, std::move(histogramData));
+    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, kind, std::move(histogramData));
     ptr->finishCreation(vm);
     if (ptr->m_histogramData.histogram) {
         ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData.histogram);
@@ -57,9 +57,9 @@ JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm,
     return ptr;
 }
 
-JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, HistogramData&& existingHistogramData)
+JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, HistogramKind kind, HistogramData&& existingHistogramData)
 {
-    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, std::move(existingHistogramData));
+    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, kind, std::move(existingHistogramData));
     ptr->finishCreation(vm);
     if (ptr->m_histogramData.histogram) {
         ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData.histogram);

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -26,6 +26,14 @@ class JSNodePerformanceHooksHistogram;
 class JSNodePerformanceHooksHistogramPrototype;
 class JSNodePerformanceHooksHistogramConstructor;
 
+// Node.js exposes two user-visible Histogram subclasses that must not share
+// mutation surface: RecordableHistogram (createHistogram) owns record/add,
+// IntervalHistogram (monitorEventLoopDelay) is read-only except enable/disable.
+enum class HistogramKind : uint8_t {
+    Recordable,
+    Interval,
+};
+
 JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord);
 JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecordDelta);
 JSC_DECLARE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncAdd);
@@ -106,6 +114,7 @@ public:
         JSC::VM& vm,
         JSC::Structure* structure,
         JSC::JSGlobalObject* globalObject,
+        HistogramKind kind,
         int64_t lowest,
         int64_t highest,
         int figures);
@@ -114,6 +123,7 @@ public:
         JSC::VM& vm,
         JSC::Structure* structure,
         JSC::JSGlobalObject* globalObject,
+        HistogramKind kind,
         HistogramData&& existingHistogramData);
 
     void finishCreation(JSC::VM& vm);
@@ -141,15 +151,17 @@ public:
             [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); });
     }
 
-    JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, HistogramData&& histogramData)
+    JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, HistogramKind kind, HistogramData&& histogramData)
         : Base(vm, structure)
         , m_histogramData(std::move(histogramData))
+        , m_kind(kind)
     {
     }
 
     ~JSNodePerformanceHooksHistogram();
 
     hdr_histogram& histogram() { return *m_histogramData.histogram; }
+    HistogramKind kind() const { return m_kind; }
 
     bool record(int64_t value);
     uint64_t recordDelta(JSGlobalObject* globalObject);
@@ -168,9 +180,11 @@ public:
     // std::shared_ptr<HistogramData> getHistogramDataForCloning() const;
 
 private:
+    HistogramKind m_kind;
     uint16_t m_extraMemorySizeForGC = 0;
 };
 
 void setupJSNodePerformanceHooksHistogramClassStructure(JSC::LazyClassStructure::Initializer& init);
+Structure* createJSNodePerformanceHooksIntervalHistogramStructure(JSC::VM& vm, Zig::GlobalObject* globalObject);
 
 } // namespace Bun

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
@@ -22,11 +22,11 @@ namespace Bun {
 
 using namespace JSC;
 
-const ClassInfo JSNodePerformanceHooksHistogramConstructor::s_info = { "Histogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogramConstructor) };
+const ClassInfo JSNodePerformanceHooksHistogramConstructor::s_info = { "RecordableHistogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogramConstructor) };
 
 void JSNodePerformanceHooksHistogramConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject, JSObject* prototype)
 {
-    Base::finishCreation(vm, 3, "Histogram"_s, PropertyAdditionMode::WithStructureTransition); // lowest, highest, figures
+    Base::finishCreation(vm, 3, "RecordableHistogram"_s, PropertyAdditionMode::WithStructureTransition); // lowest, highest, figures
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
 }
 
@@ -70,7 +70,7 @@ static JSNodePerformanceHooksHistogram* createHistogramInternal(JSGlobalObject* 
     Structure* structure = zigGlobalObject->m_JSNodePerformanceHooksHistogramClassStructure.get(zigGlobalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    return JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, lowest, highest, figures);
+    return JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, HistogramKind::Recordable, lowest, highest, figures);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramConstructorCall, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -94,19 +94,40 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramConstructorConstruct, (J
     return JSValue::encode(histogram);
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramIllegalConstructor, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    Bun::throwError(globalObject, scope, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s);
+    return {};
+}
+
 void setupJSNodePerformanceHooksHistogramClassStructure(LazyClassStructure::Initializer& init)
 {
-    auto* prototypeStructure = JSNodePerformanceHooksHistogramPrototype::createStructure(init.vm, init.global, init.global->objectPrototype());
-    auto* prototype = JSNodePerformanceHooksHistogramPrototype::create(init.vm, init.global, prototypeStructure);
+    auto* baseProtoStructure = JSNodePerformanceHooksHistogramPrototype::createStructure(init.vm, init.global, init.global->objectPrototype());
+    auto* basePrototype = JSNodePerformanceHooksHistogramPrototype::create(init.vm, init.global, baseProtoStructure);
+
+    auto* baseConstructor = JSFunction::create(init.vm, init.global, 0, "Histogram"_s, jsNodePerformanceHooksHistogramIllegalConstructor, ImplementationVisibility::Public);
+    basePrototype->putDirect(init.vm, init.vm.propertyNames->constructor, baseConstructor, JSC::PropertyAttribute::DontEnum | 0);
+
+    auto* recordableProtoStructure = JSNodePerformanceHooksRecordableHistogramPrototype::createStructure(init.vm, init.global, basePrototype);
+    auto* recordablePrototype = JSNodePerformanceHooksRecordableHistogramPrototype::create(init.vm, init.global, recordableProtoStructure);
 
     auto* constructorStructure = JSNodePerformanceHooksHistogramConstructor::createStructure(init.vm, init.global, init.global->functionPrototype());
-    auto* constructor = JSNodePerformanceHooksHistogramConstructor::create(init.vm, init.global, constructorStructure, prototype);
+    auto* constructor = JSNodePerformanceHooksHistogramConstructor::create(init.vm, init.global, constructorStructure, recordablePrototype);
 
-    auto* structure = JSNodePerformanceHooksHistogram::createStructure(init.vm, init.global, prototype);
+    auto* structure = JSNodePerformanceHooksHistogram::createStructure(init.vm, init.global, recordablePrototype);
 
-    init.setPrototype(prototype);
+    init.setPrototype(recordablePrototype);
     init.setStructure(structure);
     init.setConstructor(constructor);
+}
+
+Structure* createJSNodePerformanceHooksIntervalHistogramStructure(JSC::VM& vm, Zig::GlobalObject* globalObject)
+{
+    JSObject* recordablePrototype = globalObject->m_JSNodePerformanceHooksHistogramClassStructure.prototype(globalObject);
+    JSValue basePrototype = recordablePrototype->getPrototypeDirect();
+    ASSERT(basePrototype.inherits<JSNodePerformanceHooksHistogramPrototype>());
+    return JSNodePerformanceHooksHistogram::createStructure(vm, globalObject, basePrototype);
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -18,9 +18,6 @@ namespace Bun {
 using namespace JSC;
 
 static const HashTableValue JSNodePerformanceHooksHistogramPrototypeTableValues[] = {
-    { "record"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncRecord, 1 } },
-    { "recordDelta"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncRecordDelta, 0 } },
-    { "add"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncAdd, 1 } },
     { "reset"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncReset, 0 } },
     { "percentile"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncPercentile, 1 } },
     { "percentileBigInt"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncPercentileBigInt, 1 } },
@@ -39,13 +36,26 @@ static const HashTableValue JSNodePerformanceHooksHistogramPrototypeTableValues[
     { "percentilesBigInt"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsNodePerformanceHooksHistogramGetter_percentilesBigInt, 0 } },
 };
 
-const ClassInfo JSNodePerformanceHooksHistogramPrototype::s_info = { "RecordableHistogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogramPrototype) };
+const ClassInfo JSNodePerformanceHooksHistogramPrototype::s_info = { "Histogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksHistogramPrototype) };
 
 void JSNodePerformanceHooksHistogramPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSNodePerformanceHooksHistogram::info(), JSNodePerformanceHooksHistogramPrototypeTableValues, *this);
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+}
+
+static const HashTableValue JSNodePerformanceHooksRecordableHistogramPrototypeTableValues[] = {
+    { "record"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncRecord, 1 } },
+    { "recordDelta"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncRecordDelta, 0 } },
+    { "add"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodePerformanceHooksHistogramProtoFuncAdd, 1 } },
+};
+
+const ClassInfo JSNodePerformanceHooksRecordableHistogramPrototype::s_info = { "RecordableHistogram"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNodePerformanceHooksRecordableHistogramPrototype) };
+
+void JSNodePerformanceHooksRecordableHistogramPrototype::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    reifyStaticProperties(vm, JSNodePerformanceHooksHistogram::info(), JSNodePerformanceHooksRecordableHistogramPrototypeTableValues, *this);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -54,9 +64,8 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord, (JSGlob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSNodePerformanceHooksHistogram* thisObject = dynamicDowncast<JSNodePerformanceHooksHistogram>(callFrame->thisValue());
-    if (!thisObject) [[unlikely]] {
-        WebCore::throwThisTypeError(*globalObject, scope, "Histogram"_s, "record"_s);
-        return {};
+    if (!thisObject || thisObject->kind() != HistogramKind::Recordable) [[unlikely]] {
+        return Bun::ERR::INVALID_THIS(scope, globalObject, "RecordableHistogram"_s);
     }
 
     if (callFrame->argumentCount() < 1) {
@@ -91,9 +100,8 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecordDelta, (J
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSNodePerformanceHooksHistogram* thisObject = dynamicDowncast<JSNodePerformanceHooksHistogram>(callFrame->thisValue());
-    if (!thisObject) [[unlikely]] {
-        WebCore::throwThisTypeError(*globalObject, scope, "Histogram"_s, "recordDelta"_s);
-        return {};
+    if (!thisObject || thisObject->kind() != HistogramKind::Recordable) [[unlikely]] {
+        return Bun::ERR::INVALID_THIS(scope, globalObject, "RecordableHistogram"_s);
     }
 
     thisObject->recordDelta(globalObject);
@@ -106,25 +114,18 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncAdd, (JSGlobalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSNodePerformanceHooksHistogram* thisObject = dynamicDowncast<JSNodePerformanceHooksHistogram>(callFrame->thisValue());
-    if (!thisObject) [[unlikely]] {
-        WebCore::throwThisTypeError(*globalObject, scope, "Histogram"_s, "add"_s);
-        return {};
+    if (!thisObject || thisObject->kind() != HistogramKind::Recordable) [[unlikely]] {
+        return Bun::ERR::INVALID_THIS(scope, globalObject, "RecordableHistogram"_s);
     }
 
-    if (callFrame->argumentCount() < 1) {
-        Bun::ERR::MISSING_ARGS(scope, globalObject, "add requires at least one argument"_s);
-        return {};
-    }
-
-    JSValue otherArg = callFrame->uncheckedArgument(0);
+    JSValue otherArg = callFrame->argument(0);
     JSNodePerformanceHooksHistogram* otherHistogram = dynamicDowncast<JSNodePerformanceHooksHistogram>(otherArg);
-    if (!otherHistogram) [[unlikely]] {
-        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "argument"_s, "Histogram"_s, otherArg);
-        return {};
+    if (!otherHistogram || otherHistogram->kind() != HistogramKind::Recordable) [[unlikely]] {
+        return Bun::ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, "other"_s, "RecordableHistogram"_s, otherArg);
     }
 
-    double dropped = thisObject->add(otherHistogram);
-    return JSValue::encode(jsNumber(dropped));
+    thisObject->add(otherHistogram);
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncReset, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -417,7 +418,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
     Structure* structure = zigGlobalObject->m_JSNodePerformanceHooksHistogramClassStructure.get(zigGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    JSNodePerformanceHooksHistogram* histogram = JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, lowest, highest, figures);
+    JSNodePerformanceHooksHistogram* histogram = JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, HistogramKind::Recordable, lowest, highest, figures);
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(histogram);
@@ -446,11 +447,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay, (JSGlobalObject * glo
 
     // Create histogram with range for event loop delays (1ns to 1 hour)
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    Structure* structure = zigGlobalObject->m_JSNodePerformanceHooksHistogramClassStructure.get(zigGlobalObject);
+    Structure* structure = zigGlobalObject->m_JSNodePerformanceHooksIntervalHistogramStructure.get(zigGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     JSNodePerformanceHooksHistogram* histogram = JSNodePerformanceHooksHistogram::create(
-        vm, structure, globalObject,
+        vm, structure, globalObject, HistogramKind::Interval,
         1, // lowest: 1 nanosecond
         3600000000000LL, // highest: 1 hour in nanoseconds
         3 // figures: 3 significant digits

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.h
@@ -43,4 +43,40 @@ private:
     void finishCreation(JSC::VM& vm);
 };
 
+class JSNodePerformanceHooksRecordableHistogramPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSNodePerformanceHooksRecordableHistogramPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSNodePerformanceHooksRecordableHistogramPrototype* prototype = new (NotNull, allocateCell<JSNodePerformanceHooksRecordableHistogramPrototype>(vm)) JSNodePerformanceHooksRecordableHistogramPrototype(vm, structure);
+        prototype->finishCreation(vm);
+        return prototype;
+    }
+
+    template<typename, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return &vm.plainObjectSpace();
+    }
+
+    DECLARE_INFO;
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        auto* structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+        structure->setMayBePrototype(true);
+        return structure;
+    }
+
+private:
+    JSNodePerformanceHooksRecordableHistogramPrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm);
+};
+
 } // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2000,6 +2000,11 @@ void GlobalObject::finishCreation(VM& vm)
             Bun::setupJSNodePerformanceHooksHistogramClassStructure(init);
         });
 
+    m_JSNodePerformanceHooksIntervalHistogramStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(Bun::createJSNodePerformanceHooksIntervalHistogramStructure(init.vm, defaultGlobalObject(init.owner)));
+        });
+
     m_lazyStackCustomGetterSetter.initLater(
         [](const Initializer<CustomGetterSetter>& init) {
             init.set(CustomGetterSetter::create(init.vm, errorInstanceLazyStackCustomGetter, errorInstanceLazyStackCustomSetter));

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -579,6 +579,7 @@ public:
     V(public, LazyClassStructure, m_JSMIMEParamsClassStructure)                                              \
     V(public, LazyClassStructure, m_JSMIMETypeClassStructure)                                                \
     V(public, LazyClassStructure, m_JSNodePerformanceHooksHistogramClassStructure)                           \
+    V(public, LazyPropertyOfGlobalObject<Structure>, m_JSNodePerformanceHooksIntervalHistogramStructure)     \
                                                                                                              \
     V(public, LazyClassStructure, m_JSConnectionsListClassStructure)                                         \
     V(public, LazyClassStructure, m_JSHTTPParserClassStructure)                                              \

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -613,7 +613,8 @@ describe("Histogram", () => {
       const eld = monitorEventLoopDelay();
       assert.throws(
         () => h.add(eld),
-        err => err.name === "TypeError" && err.code === "ERR_INVALID_ARG_TYPE" && /RecordableHistogram/.test(err.message),
+        err =>
+          err.name === "TypeError" && err.code === "ERR_INVALID_ARG_TYPE" && /RecordableHistogram/.test(err.message),
       );
       assert.strictEqual(h.count, 1);
     });

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { inspect } from "node:util";
-import { createHistogram } from "perf_hooks";
+import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
 
 describe("Histogram", () => {
   test("basic histogram creation and initial state", () => {
@@ -581,5 +581,91 @@ describe("Histogram", () => {
     const inspected = inspect(h);
 
     assert.ok(inspected.includes("Histogram"));
+  });
+
+  describe("class hierarchy", () => {
+    test("monitorEventLoopDelay() histogram does not expose record/recordDelta/add", () => {
+      const eld = monitorEventLoopDelay();
+      assert.strictEqual(typeof eld.record, "undefined");
+      assert.strictEqual(typeof eld.recordDelta, "undefined");
+      assert.strictEqual(typeof eld.add, "undefined");
+      assert.strictEqual(typeof eld.enable, "function");
+      assert.strictEqual(typeof eld.disable, "function");
+      assert.strictEqual(typeof eld[Symbol.dispose], "function");
+      // base Histogram surface is still reachable
+      assert.strictEqual(typeof eld.reset, "function");
+      assert.strictEqual(typeof eld.percentile, "function");
+      assert.strictEqual(eld.count, 0);
+    });
+
+    test("createHistogram() histogram does not expose enable/disable", () => {
+      const h = createHistogram();
+      assert.strictEqual(typeof h.record, "function");
+      assert.strictEqual(typeof h.recordDelta, "function");
+      assert.strictEqual(typeof h.add, "function");
+      assert.strictEqual(typeof h.enable, "undefined");
+      assert.strictEqual(typeof h.disable, "undefined");
+    });
+
+    test("add() rejects an event-loop-delay histogram", () => {
+      const h = createHistogram();
+      h.record(5);
+      const eld = monitorEventLoopDelay();
+      assert.throws(
+        () => h.add(eld),
+        err => err.name === "TypeError" && err.code === "ERR_INVALID_ARG_TYPE" && /RecordableHistogram/.test(err.message),
+      );
+      assert.strictEqual(h.count, 1);
+    });
+
+    test("add() rejects non-histogram values", () => {
+      const h = createHistogram();
+      for (const bad of [{}, 42, "str", null, undefined]) {
+        assert.throws(
+          () => h.add(bad),
+          err => err.name === "TypeError" && err.code === "ERR_INVALID_ARG_TYPE",
+        );
+      }
+    });
+
+    test("add() returns undefined", () => {
+      const h1 = createHistogram();
+      const h2 = createHistogram();
+      h2.record(1);
+      assert.strictEqual(h1.add(h2), undefined);
+    });
+
+    test("record()/add() borrowed onto an event-loop-delay histogram throws ERR_INVALID_THIS", () => {
+      const eld = monitorEventLoopDelay();
+      const rec = createHistogram();
+      const { record, recordDelta, add } = Object.getPrototypeOf(rec);
+      for (const fn of [() => record.call(eld, 1), () => recordDelta.call(eld), () => add.call(eld, rec)]) {
+        assert.throws(fn, err => err.name === "TypeError" && err.code === "ERR_INVALID_THIS");
+      }
+      assert.strictEqual(eld.count, 0);
+    });
+
+    test("prototype chain", () => {
+      const rec = createHistogram();
+      const eld = monitorEventLoopDelay();
+
+      const recProto = Object.getPrototypeOf(rec);
+      const eldProto = Object.getPrototypeOf(eld);
+      assert.notStrictEqual(recProto, eldProto);
+
+      const baseProto = Object.getPrototypeOf(recProto);
+      assert.strictEqual(Object.getPrototypeOf(eldProto), baseProto);
+      assert.strictEqual(Object.getPrototypeOf(baseProto), Object.prototype);
+
+      assert.ok(Object.prototype.hasOwnProperty.call(recProto, "record"));
+      assert.ok(Object.prototype.hasOwnProperty.call(baseProto, "reset"));
+      assert.ok(!Object.prototype.hasOwnProperty.call(baseProto, "record"));
+
+      assert.strictEqual(rec.constructor.name, "RecordableHistogram");
+      assert.strictEqual(eld.constructor.name, "ELDHistogram");
+
+      assert.strictEqual(Object.prototype.toString.call(rec), "[object Object]");
+      assert.strictEqual(Object.prototype.toString.call(eld), "[object Object]");
+    });
   });
 });


### PR DESCRIPTION
## Repro

```js
import { createHistogram, monitorEventLoopDelay } from "node:perf_hooks";

const eld = monitorEventLoopDelay();
typeof eld.record;        // node: "undefined"   bun: "function"
eld.record(123456789);    // node: TypeError     bun: injects a fake 123ms loop-delay sample

const h = createHistogram(); h.record(5);
h.add(eld);               // node: TypeError ERR_INVALID_ARG_TYPE   bun: accepted, count=2
h.add(createHistogram()); // node: undefined     bun: 0
```

Bun 1.4.0 and current main put every Histogram method on one prototype, so the `monitorEventLoopDelay()` result exposes `record`/`recordDelta`/`add` and `RecordableHistogram.prototype.add` accepts it as an argument. Node's hierarchy keeps the event-loop-delay histogram read-only so its samples can only come from the timer.

## Cause

`JSNodePerformanceHooksHistogram` had a single prototype carrying both the read-only stat surface and the mutation methods, and `jsFunction_monitorEventLoopDelay` allocated with the same structure as `createHistogram`. `add()` accepted any native histogram instance and returned the dropped-sample count.

## Fix

- Split the native prototype: `JSNodePerformanceHooksHistogramPrototype` keeps the read-only getters plus `reset`/`percentile`/`percentileBigInt`; a new `JSNodePerformanceHooksRecordableHistogramPrototype` (chained to the base) owns `record`/`recordDelta`/`add`. The `Symbol.toStringTag` is dropped so both variants stringify as `[object Object]`.
- Add `HistogramKind { Recordable, Interval }` to the instance. `record`/`recordDelta`/`add` reject a non-recordable receiver with `ERR_INVALID_THIS`; `add()` rejects a non-recordable argument with `ERR_INVALID_ARG_TYPE("other", "RecordableHistogram", …)` and returns `undefined`.
- Add `m_JSNodePerformanceHooksIntervalHistogramStructure` so `jsFunction_monitorEventLoopDelay` allocates with a structure whose prototype is the read-only base.
- `monitorEventLoopDelay.ts` builds an `ELDHistogram` prototype (enable/disable/`Symbol.dispose`) on top of the base and installs it on the native instance, giving `eld.constructor.name === "ELDHistogram"` and the `ELDHistogram -> Histogram -> Object` chain.
- Rename the constructor to `RecordableHistogram` so `createHistogram().constructor.name` matches Node.

## Verification

```
bun bd test test/js/bun/perf_hooks/histogram.test.ts                  # 45 pass
bun bd test/js/node/test/sequential/test-performance-eventloopdelay.js # exit 0
```

The new `class hierarchy` describe block fails on released Bun 1.4.0:

```
(fail) Histogram > class hierarchy > monitorEventLoopDelay() histogram does not expose record/recordDelta/add
(fail) Histogram > class hierarchy > add() rejects an event-loop-delay histogram
(fail) Histogram > class hierarchy > add() returns undefined
(fail) Histogram > class hierarchy > record()/add() borrowed onto an event-loop-delay histogram throws ERR_INVALID_THIS
(fail) Histogram > class hierarchy > prototype chain
```