### PR TITLE
bundler: fix BuildArtifact.sourcemap pointing at wrong output for multi-entry builds

### DIFF
--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -441,6 +441,7 @@ impl JSBundleCompletionTask {
         // keep them in the output array. Destroy all other non-entry-point files.
         // With --splitting, there can be multiple sourcemap files (one per chunk).
         let mut kept: usize = 0;
+        let mut old_to_new = vec![u32::MAX; output_files.len()];
         // Swap-compact in place via index iteration so each loop body holds
         // at most one `&mut` into `output_files`.
         for i in 0..output_files.len() {
@@ -527,12 +528,20 @@ impl JSBundleCompletionTask {
             };
 
             if keep_this {
+                old_to_new[i] = kept as u32;
                 output_files.swap(kept, i);
                 kept += 1;
             }
             // Trailing (dropped) entries are freed by `truncate` below.
         }
         output_files.truncate(kept);
+        // `source_map_index` stored pre-compaction positions; remap so the
+        // later `output_files_js[source_map_index]` lookup stays correct.
+        for f in output_files.iter_mut() {
+            if f.source_map_index != u32::MAX {
+                f.source_map_index = old_to_new[f.source_map_index as usize];
+            }
+        }
 
         result
     }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -644,7 +644,6 @@ impl JSBundleCompletionTask {
                 // initialized during VM startup before any `Bun.build` is reachable.
                 let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
 
-                let mut to_assign_on_sourcemap = JSValue::ZERO;
                 for (i, output_file) in output_files.iter_mut().enumerate() {
                     let path: Box<[u8]> = if !outdir.is_empty() {
                         if outdir_is_abs {
@@ -662,27 +661,38 @@ impl JSBundleCompletionTask {
                         output_file.dest_path.clone()
                     };
                     let result = output_file.to_js(Some(&path), global_this);
-                    if to_assign_on_sourcemap != JSValue::ZERO {
-                        crate::generated_classes::js_BuildArtifact::sourcemap_set_cached(
-                            to_assign_on_sourcemap,
-                            global_this,
-                            result,
-                        );
-                        if let Some(artifact) = to_assign_on_sourcemap.as_::<BuildArtifact>() {
-                            // SAFETY: `as_` returned a live `*mut BuildArtifact`
-                            // owned by the JS wrapper; the borrow lasts only for
-                            // this `set` call (no other Rust alias exists).
-                            unsafe { (*artifact).sourcemap.set(global_this, result) };
-                        }
-                        to_assign_on_sourcemap = JSValue::ZERO;
-                    }
-
-                    if output_file.source_map_index != u32::MAX {
-                        to_assign_on_sourcemap = result;
-                    }
-
                     if let Err(e) = output_files_js.put_index(global_this, i as u32, result) {
                         return Ok(promise.reject(global_this, Err(e))?);
+                    }
+                }
+
+                // `output_files` is laid out as [chunks..., sourcemaps/bytecode...,
+                // additional...], so a chunk's sourcemap is at `source_map_index`,
+                // not "the next element".
+                for (i, output_file) in output_files.iter().enumerate() {
+                    if output_file.source_map_index == u32::MAX {
+                        continue;
+                    }
+                    let owner = match output_files_js.get_index(global_this, i as u32) {
+                        Ok(v) => v,
+                        Err(e) => return Ok(promise.reject(global_this, Err(e))?),
+                    };
+                    let sourcemap = match output_files_js
+                        .get_index(global_this, output_file.source_map_index)
+                    {
+                        Ok(v) => v,
+                        Err(e) => return Ok(promise.reject(global_this, Err(e))?),
+                    };
+                    crate::generated_classes::js_BuildArtifact::sourcemap_set_cached(
+                        owner,
+                        global_this,
+                        sourcemap,
+                    );
+                    if let Some(artifact) = owner.as_::<BuildArtifact>() {
+                        // SAFETY: `as_` returned a live `*mut BuildArtifact`
+                        // owned by the JS wrapper; the borrow lasts only for
+                        // this `set` call (no other Rust alias exists).
+                        unsafe { (*artifact).sourcemap.set(global_this, sourcemap) };
                     }
                 }
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -319,6 +319,53 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
+  describe.each([
+    ["two entrypoints", { splitting: false }],
+    ["two entrypoints + splitting", { splitting: true }],
+  ])("BuildArtifact.sourcemap with %s", (_label, { splitting }) => {
+    test.each(["linked", "external"] as const)("sourcemap: %s", async mode => {
+      const dir = tempDirWithFiles("build-artifact-sourcemap-multi", {
+        "shared.ts": `export const S = { n: 1 };\n`,
+        "a.ts": `import { S } from "./shared";\nconsole.log("a", S.n);\n`,
+        "b.ts": `import { S } from "./shared";\nconsole.log("b", S.n);\n`,
+      });
+      const build = await Bun.build({
+        entrypoints: [join(dir, "a.ts"), join(dir, "b.ts")],
+        outdir: join(dir, "out"),
+        target: "node",
+        format: "esm",
+        sourcemap: mode,
+        splitting,
+      });
+      expect(build.success).toBe(true);
+
+      const js = build.outputs.filter(o => o.kind !== "sourcemap");
+      const maps = build.outputs.filter(o => o.kind === "sourcemap");
+      expect(js.length).toBeGreaterThanOrEqual(2);
+      expect(maps.length).toBe(js.length);
+
+      expect(
+        build.outputs.map(o => ({
+          path: path.basename(o.path),
+          kind: o.kind,
+          sourcemap: o.sourcemap ? { path: path.basename(o.sourcemap.path), kind: o.sourcemap.kind } : null,
+        })),
+      ).toEqual(
+        build.outputs.map(o => ({
+          path: path.basename(o.path),
+          kind: o.kind,
+          sourcemap: o.kind === "sourcemap" ? null : { path: path.basename(o.path) + ".map", kind: "sourcemap" },
+        })),
+      );
+
+      for (const o of js) {
+        expect(o.sourcemap).not.toBe(null);
+        expect(maps).toContain(o.sourcemap);
+      }
+      Bun.gc(true);
+    });
+  });
+
   // test("BuildArtifact properties splitting", async () => {
   //   Bun.gc(true);
   //   const x = await Bun.build({

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -112,6 +112,9 @@ main();`,
     // The sourcemap output should appear in build result outputs
     const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
     expect(sourcemapOutputs.length).toBe(1);
+    // The entry-point's .sourcemap should be that artifact.
+    expect(executableOutput.sourcemap).toBe(sourcemapOutputs[0]);
+    expect(executableOutput.sourcemap!.kind).toBe("sourcemap");
 
     // The .map file should exist next to the executable
     const mapPath = sourcemapOutputs[0].path;
@@ -178,6 +181,13 @@ export function greet() {
     // (one for the entry chunk, one for the lazy-loaded chunk)
     const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
     expect(sourcemapOutputs.length).toBeGreaterThanOrEqual(2);
+
+    // The entry-point's .sourcemap must be the entry chunk's own map (a sourcemap
+    // artifact whose JSON lists entry.js as a source), not another chunk's map.
+    expect(executableOutput.sourcemap?.kind).toBe("sourcemap");
+    expect(sourcemapOutputs).toContain(executableOutput.sourcemap);
+    const entryMapContent = JSON.parse(await executableOutput.sourcemap!.text());
+    expect(entryMapContent.sources.some((s: string) => s.endsWith("entry.js"))).toBe(true);
 
     // Each sourcemap should be a valid .map file on disk
     const mapPaths = new Set<string>();


### PR DESCRIPTION
## Problem

`BuildArtifact.sourcemap` is wrong for any `Bun.build()` with more than one JS output (2+ entrypoints, or `splitting: true`). It returns the *next element of `outputs[]`* instead of the sourcemap:

```js
const r = await Bun.build({
  entrypoints: ["a.ts", "b.ts"],
  outdir: "out",
  sourcemap: "linked",
});
// r.outputs = [a.js, b.js, a.js.map, b.js.map]
r.outputs[0].sourcemap;  // b.js          (kind=entry-point), expected a.js.map
r.outputs[1].sourcemap;  // a.js.map      (wrong file's map), expected b.js.map
```

With `splitting: true` this hands back an unrelated chunk's executable JS where a map is expected. The on-disk `//# sourceMappingURL=` comments are correct, so nothing warns; sourcemap-upload and in-memory (`outdir`-less) pipelines silently pair the wrong files.

## Cause

`JSBundleCompletionTask::on_complete` carried a `to_assign_on_sourcemap` handle across loop iterations and assigned the *next materialized artifact* as the previous JS output's `.sourcemap`, assuming `[js, map, js, map, ...]` interleaving.

`OutputFileListBuilder` actually lays `output_files` out as `[all chunks..., all sourcemaps/bytecode..., additional...]`. Each `OutputFile` already carries the correct absolute `source_map_index` into that array; the old loop only used it as a boolean (`!= u32::MAX`).

## Fix

Drop the next-element chaining. After creating all `BuildArtifact` wrappers and storing them in the output array, do a second pass that resolves each JS output's `.sourcemap` directly from `output_files_js[source_map_index]`.

## Tests

Added parameterized coverage in `test/bundler/bun-build-api.test.ts` for two entrypoints with and without `splitting`, in `linked` and `external` modes. Each asserts that every non-sourcemap output's `.sourcemap` is the `kind: "sourcemap"` artifact at `<path>.map`, and that sourcemap outputs have `.sourcemap === null`.

Fails on main:
```
error: expect(received).toEqual(expected)
  {
    "path": "a.js",
    "sourcemap": {
-     "kind": "sourcemap",
-     "path": "a.js.map",
+     "kind": "entry-point",
+     "path": "b.js",
    },
  },
```

Passes with this change (4/4). The existing single-entry "BuildArtifact properties sourcemap" and "sourcemap: true with outdir" tests continue to pass.