### PR TITLE
bundler: implement server-side wrap for "use server" modules

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7058,11 +7058,21 @@ pub mod bv2_impl {
                         .expect("oom");
                     }
 
-                    if let Some(named_exports) = named_exports_for_scb {
-                        if result.use_directive == crate::UseDirective::Server {
-                            bun_core::todo_panic!("\"use server\"");
-                        }
-
+                    // "use server": the parser emits the server-side wrap, but the
+                    // client-side createServerReference proxy is not generated yet.
+                    // Skip the cross-graph boundary and warn instead of crashing.
+                    if result.use_directive == crate::UseDirective::Server
+                        && named_exports_for_scb.is_some()
+                    {
+                        let pretty = this.graph.input_files.items_source()[result_source_index]
+                            .path
+                            .pretty;
+                        bun_core::warn!(
+                            "\"use server\" is partially implemented: the server-side wrap is applied, but client-side server-action proxies are not yet generated. Calling these exports from a client module will fail at runtime. (file: {})",
+                            bstr::BStr::new(pretty)
+                        );
+                        bun_core::Output::flush();
+                    } else if let Some(named_exports) = named_exports_for_scb {
                         let separate_ssr_graph = this
                             .framework
                             .as_ref()

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3202,9 +3202,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         b"registerClientReference",
                     )?;
                 }
-                // TODO: these wrapping modes.
+                options::ServerComponents::WrapExportsForServerReference => {
+                    self.server_components_wrap_ref = self.declare_generated_symbol(
+                        js_ast::symbol::Kind::Other,
+                        b"registerServerReference",
+                    )?;
+                }
+                // TODO: function-level "use server" inside non-"use server" modules.
                 options::ServerComponents::WrapAnonServerFunctions => {}
-                options::ServerComponents::WrapExportsForServerReference => {}
             }
 
             // Server-side components: declare "Response" / "bun:app" upfront.
@@ -7953,26 +7958,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         debug_assert!(self.options.features.server_components.wraps_exports());
         debug_assert!(self.current_scope == self.module_scope);
 
-        if self.options.features.server_components
-            == options::ServerComponents::WrapExportsForServerReference
-        {
-            bun_core::todo_panic!("registerServerReference");
-        }
+        // TODO: production should use BundleV2's chunk-path unique_key so the id is
+        // stable across builds and doesn't leak absolute paths. Both sides of the
+        // dispatch only need to agree on a string, which path.pretty provides.
+        let module_path =
+            self.new_expr(E::String::init(self.source.path.pretty), bun_ast::Loc::EMPTY);
 
-        let module_path = self.new_expr(
-            E::String::init(if self.options.jsx.development {
-                self.source.path.pretty
-            } else {
-                bun_core::todo_panic!("unique_key here")
-            }),
-            bun_ast::Loc::EMPTY,
-        );
+        // Without this the linker tree-shakes the generated import as unused.
+        self.record_usage(self.server_components_wrap_ref);
 
-        // registerClientReference(
-        //   Comp,
-        //   "src/filepath.tsx",
-        //   "Comp"
-        // );
         let name_expr = self.new_expr(E::String::init(original_name), bun_ast::Loc::EMPTY);
         self.new_expr(
             E::Call {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3194,6 +3194,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         {
+            // The runtime import for this wrap symbol is emitted by the parse
+            // entry prologue, which selects the import name by the same mode.
             match self.options.features.server_components {
                 options::ServerComponents::None | options::ServerComponents::ClientSide => {}
                 options::ServerComponents::WrapExportsForClientReference => {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2158,11 +2158,21 @@ impl<'a> Parser<'a> {
                 panic!("server components requires a framework configured, but none was set")
             });
             let sc = fw.server_components.as_ref().unwrap();
+            // server_components_wrap_ref is only declared for these two modes.
+            let import_name = match p.options.features.server_components {
+                options::ServerComponents::WrapExportsForClientReference => {
+                    &sc.server_register_client_reference[..]
+                }
+                options::ServerComponents::WrapExportsForServerReference => {
+                    &sc.server_register_server_reference[..]
+                }
+                _ => unreachable!(),
+            };
             p.generate_react_refresh_import(
                 &mut before,
                 &sc.server_runtime_import[..],
                 &[crate::p::ReactRefreshImportClause {
-                    name: &sc.server_register_client_reference[..],
+                    name: import_name,
                     r#ref: p.server_components_wrap_ref,
                     enabled: true,
                 }],

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2158,7 +2158,9 @@ impl<'a> Parser<'a> {
                 panic!("server components requires a framework configured, but none was set")
             });
             let sc = fw.server_components.as_ref().unwrap();
-            // server_components_wrap_ref is only declared for these two modes.
+            // Kept in sync with the wrap-symbol declaration in
+            // `prepare_for_visit_pass`: both handle exactly these two wrap modes,
+            // so a new wrap mode must map its import name here too.
             let import_name = match p.options.features.server_components {
                 options::ServerComponents::WrapExportsForClientReference => {
                     &sc.server_register_client_reference[..]
@@ -2166,7 +2168,7 @@ impl<'a> Parser<'a> {
                 options::ServerComponents::WrapExportsForServerReference => {
                     &sc.server_register_server_reference[..]
                 }
-                _ => unreachable!(),
+                _ => unreachable!("server_components_wrap_ref set for a mode with no import name"),
             };
             p.generate_react_refresh_import(
                 &mut before,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -594,4 +594,83 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  test('"use server" module exports are wrapped with registerServerReference', async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-use-server", {
+      // Disable minification so the server bundle stays greppable.
+      "src/index.tsx": `const bundlerOptions = { minify: { whitespace: false, identifiers: false, syntax: false } };
+export default { app: { framework: "react", bundlerOptions: { server: bundlerOptions, client: bundlerOptions, ssr: bundlerOptions } } };`,
+      // Reference every export (named + default) so tree-shaking keeps each
+      // wrap. typeof avoids serializing a server reference at SSG time.
+      "pages/index.tsx": `import logIt, { greet, increment } from "../app/actions";
+
+export default function IndexPage() {
+  return (
+    <div>
+      <span>{typeof greet}</span>
+      <span>{typeof increment}</span>
+      <span>{typeof logIt}</span>
+    </div>
+  );
+}`,
+      "app/actions.ts": `"use server";
+
+export async function greet(formData: FormData) {
+  return "hi " + formData.get("name");
+}
+
+export async function increment(by: number) {
+  return by + 1;
+}
+
+export default async function logIt(message: string) {
+  console.log(message);
+}`,
+      "package.json": JSON.stringify({
+        "name": "test-app",
+        "version": "1.0.0",
+        "devDependencies": {
+          "react": "^18.0.0",
+          "react-dom": "^18.0.0",
+        },
+      }),
+    });
+
+    // --debug-dump-server-files (gated behind BAKE_DEBUGGING_FEATURES, on for
+    // debug/canary builds) writes the in-memory server chunks to dist/.
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app --debug-dump-server-files ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    const stderrText = stderr.toString();
+
+    // The client-side createServerReference proxy is still unimplemented, so the
+    // bundler warns instead of panicking. This asserts the warn+skip path ran.
+    expect(stderrText).toContain('"use server" is partially implemented');
+
+    // Find the dumped server bundle carrying the wrapped exports.
+    const distFiles = [...new Bun.Glob("dist/**/*.js").scanSync(dir)].map(p => path.join(dir, p));
+    let actionsBundle: string | null = null;
+    for (const file of distFiles) {
+      const content = await Bun.file(file).text();
+      if (content.includes("registerServerReference") && content.includes("greet")) {
+        actionsBundle = content;
+        break;
+      }
+    }
+    expect(actionsBundle).not.toBeNull();
+
+    // Each named export and the default export is the third argument (the action
+    // name) of a wrap call, after the module-id string. Pinning the tail keeps
+    // this robust to the temporary module id (path.pretty, see the parser TODO).
+    expect(actionsBundle!).toMatch(/,\s*"[^"]*",\s*"greet"\)/);
+    expect(actionsBundle!).toMatch(/,\s*"[^"]*",\s*"increment"\)/);
+    expect(actionsBundle!).toMatch(/,\s*"[^"]*",\s*"default"\)/);
+
+    // The symbol is imported, not a free reference — record_usage keeps the
+    // generated import from being tree-shaken.
+    expect(actionsBundle!).toMatch(/import\s*\{[^}]*\bregisterServerReference\b[^}]*\}\s*from/);
+
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Implements the server-side bundler transform for React 19's `"use server"` directive on the Bake server-components graph. Module-level `"use server"` exports are now wrapped with `registerServerReference(fn, moduleId, exportName)` so React's RSC serializer recognises them as server references.

This is a Rust rewrite of #29848 (opened before Bun's Zig→Rust migration). The same `todo_panic!` sites the original PR removed still exist in the migrated code:

1. **`src/js_parser/p.rs` — `todo_panic!("registerServerReference")`** fired on every `"use server"` module during parsing, killing the build before any output. The wrap call sites already existed in `visit_stmt.rs` (default exports, function exports, `var` exports) but bailed at the first call.
2. **`src/js_parser/p.rs` — `todo_panic!("unique_key here")`** in the production module-id path. Dev used `path.pretty`; prod had no implementation.
3. **`src/js_parser/p.rs` (`prepareForVisitPass`)** left `WrapExportsForServerReference` as an empty match arm, so the wrap symbol (`registerServerReference`) was never declared — the wrap call would have been emitted against an undeclared ref.
4. **`src/bundler/bundle_v2.rs` — `todo_panic!("\"use server\"")`** crashed the build during cross-graph indexing for any `"use server"` source file.

### Root cause / why this approach

The transform mirrors the existing `registerClientReference` path used for `"use client"` modules in `WrapExportsForClientReference` mode — same shape (`(fn, moduleId, exportName)`), same place in the AST visitor, same prologue import mechanism. Under Bake's React preset `WrapExportsForClientReference` is unreachable (it requires `separate_ssr_graph: false`, the preset uses `true`), so this is the first time the parser-level wrap path actually runs — which exposed a tree-shaking bug on the first try (see Fix point 2).

The output shape matches what `react-server-dom-bun/server` exports as `registerServerReference(proxy, ref, encodeFormAction)`.

### Fix

- **`src/js_parser/p.rs`**: declare `registerServerReference` in the `WrapExportsForServerReference` arm of `prepareForVisitPass` (sibling of the existing client arm). Remove both `todo_panic!`s in `wrap_value_for_server_component_reference`; use `self.source.path.pretty` as the module identifier for dev and prod alike (a TODO notes prod should eventually use BundleV2's chunk-path `unique_key` for stability — that's a wider plumbing change, deferred).
- **`src/js_parser/p.rs`**: call `self.record_usage(self.server_components_wrap_ref)` on every wrap. Without it, the linker's tree-shaking pass treats the generated `import { registerServerReference } from "react-server-dom-bun/server"` as unused and drops it, leaving the wrapped calls against a free reference that errors at SSG time with `ReferenceError: registerServerReference is not defined`. The neighbouring `emit_react_refresh_register` calls `record_usage` for the same reason.
- **`src/js_parser/parse/parse_entry.rs`**: in the prologue that emits the runtime import, pick the framework-configured name (`server_register_server_reference` vs. `server_register_client_reference`) based on the active wrap mode. Previously the import always used `server_register_client_reference`.
- **`src/bundler/bundle_v2.rs`**: convert the cross-graph `todo_panic!("\"use server\"")` into a `bun_core::warn!` and skip the server-component-boundary enqueue. Server-to-server action calls (the path this PR implements) work today; calls *from* a `"use client"` module *into* a `"use server"` module still need a `createServerReference`-shaped client-side proxy, which is unimplemented and called out in the warning. Skipping the boundary `put` for server directives also leaves the two remaining `todo_panic!` sites for the unimplemented paths (the server-reference manifest in `process_server_component_manifest_files` and `LinkerGraph`'s `UseDirective::Server` arm) provably unreachable for `"use server"` files — the boundary list is the only thing that feeds them.

### Out of scope (follow-up PRs)

- Client-side `createServerReference` proxy generation for `"use server"` files imported from `"use client"` modules.
- Framework dispatch handler in `bun-framework-react` (`POST /<route>` with `decodeReply` → lookup → `renderToReadableStream`).
- The server-reference manifest surface.
- Function-level inline `"use server"` (`WrapAnonServerFunctions` mode is still empty).
- Stable production module-id (chunk-path `unique_key` plumbing).

### How did you verify your code works?

- `bun bd test test/bake/dev/production.test.ts -t "use server"` — passes.
- `USE_SYSTEM_BUN=1 bun test test/bake/dev/production.test.ts -t "use server"` — fails (stock Bun panics on `"use server"`), confirming the test exercises the fix.
- `cargo check -p bun_js_parser -p bun_bundler` — clean.

The new test builds a fixture with a `"use server"` module exporting `greet`, `increment`, and a `default` function, plus a server-component page that imports and references each. It runs the full Bake production pipeline (`bun build --app --debug-dump-server-files`), asserts the build exits 0, that the cross-graph warning is surfaced, and that the dumped server bundle imports `registerServerReference` from a real import statement and wraps each export with the correct export-name string (`"greet"`, `"increment"`, `"default"`).
