### PR TITLE
node:perf_hooks: make Histogram structured-cloneable

### DIFF
--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -46,23 +46,16 @@ JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm,
         throwTypeError(globalObject, scope, "Failed to initialize histogram"_s);
         return nullptr;
     }
-    auto histogramData = HistogramData(raw_histogram);
 
-    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, std::move(histogramData));
-    ptr->finishCreation(vm);
-    if (ptr->m_histogramData.histogram) {
-        ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData.histogram);
-        vm.heap.reportExtraMemoryAllocated(ptr, ptr->m_extraMemorySizeForGC);
-    }
-    return ptr;
+    return create(vm, structure, globalObject, HistogramData::create(raw_histogram));
 }
 
-JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, HistogramData&& existingHistogramData)
+JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, Ref<HistogramData>&& existingHistogramData)
 {
-    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, std::move(existingHistogramData));
+    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, WTF::move(existingHistogramData));
     ptr->finishCreation(vm);
-    if (ptr->m_histogramData.histogram) {
-        ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData.histogram);
+    if (ptr->m_histogramData->histogram) {
+        ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData->histogram);
         vm.heap.reportExtraMemoryAllocated(ptr, ptr->m_extraMemorySizeForGC);
     }
     return ptr;
@@ -75,8 +68,6 @@ void JSNodePerformanceHooksHistogram::destroy(JSCell* cell)
 
 JSNodePerformanceHooksHistogram::~JSNodePerformanceHooksHistogram()
 {
-    // The shared_ptr will handle the destruction of HistogramData,
-    // which in turn calls hdr_close via HDRHistogramPointer.
 }
 
 template<typename Visitor>
@@ -86,7 +77,7 @@ void JSNodePerformanceHooksHistogram::visitChildrenImpl(JSCell* cell, Visitor& v
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    if (!thisObject->m_histogramData.histogram) {
+    if (!thisObject->m_histogramData || !thisObject->m_histogramData->histogram) {
         visitor.reportExtraMemoryVisited(thisObject->m_extraMemorySizeForGC);
     }
 }
@@ -112,25 +103,25 @@ JSC::Structure* JSNodePerformanceHooksHistogram::createStructure(JSC::VM& vm, JS
 
 bool JSNodePerformanceHooksHistogram::record(int64_t value)
 {
-    if (!m_histogramData.histogram) return false;
+    if (!m_histogramData->histogram) return false;
 
     // Try to record in the HDR histogram first
-    bool recorded = hdr_record_value(m_histogramData.histogram, value);
+    bool recorded = hdr_record_value(m_histogramData->histogram, value);
 
     if (recorded) {
         // Value was within range - count it and update min/max
-        m_histogramData.totalCount++;
+        m_histogramData->totalCount++;
 
         // Update manual min/max tracking for in-range values only
-        if (value < m_histogramData.manualMin) {
-            m_histogramData.manualMin = value;
+        if (value < m_histogramData->manualMin) {
+            m_histogramData->manualMin = value;
         }
-        if (value > m_histogramData.manualMax) {
-            m_histogramData.manualMax = value;
+        if (value > m_histogramData->manualMax) {
+            m_histogramData->manualMax = value;
         }
     } else {
         // Value was out of range
-        m_histogramData.exceedsCount++;
+        m_histogramData->exceedsCount++;
     }
 
     return true;
@@ -142,102 +133,102 @@ uint64_t JSNodePerformanceHooksHistogram::recordDelta(JSGlobalObject* globalObje
     uint64_t nowNs = static_cast<uint64_t>(now.secondsSinceEpoch().milliseconds() * 1000000.0);
 
     uint64_t delta = 0;
-    if (m_histogramData.prevDeltaTime != 0) {
-        delta = nowNs - m_histogramData.prevDeltaTime;
+    if (m_histogramData->prevDeltaTime != 0) {
+        delta = nowNs - m_histogramData->prevDeltaTime;
         record(delta);
     }
-    m_histogramData.prevDeltaTime = nowNs;
+    m_histogramData->prevDeltaTime = nowNs;
     return delta;
 }
 
 void JSNodePerformanceHooksHistogram::reset()
 {
-    if (!m_histogramData.histogram) return;
-    hdr_reset(m_histogramData.histogram);
-    m_histogramData.prevDeltaTime = 0;
-    m_histogramData.totalCount = 0;
-    m_histogramData.manualMin = std::numeric_limits<int64_t>::max();
-    m_histogramData.manualMax = 0;
-    m_histogramData.exceedsCount = 0;
+    if (!m_histogramData->histogram) return;
+    hdr_reset(m_histogramData->histogram);
+    m_histogramData->prevDeltaTime = 0;
+    m_histogramData->totalCount = 0;
+    m_histogramData->manualMin = std::numeric_limits<int64_t>::max();
+    m_histogramData->manualMax = 0;
+    m_histogramData->exceedsCount = 0;
 }
 
 int64_t JSNodePerformanceHooksHistogram::getMin() const
 {
-    if (m_histogramData.totalCount == 0) {
+    if (m_histogramData->totalCount == 0) {
         // Return the same initial value as Node.js when no values recorded
         // Node.js returns 9223372036854776000 which is 0x8000000000000000
         // This is exactly INT64_MIN when interpreted as signed
         return INT64_MIN;
     }
-    return m_histogramData.manualMin;
+    return m_histogramData->manualMin;
 }
 
 int64_t JSNodePerformanceHooksHistogram::getMax() const
 {
-    if (m_histogramData.totalCount == 0) {
+    if (m_histogramData->totalCount == 0) {
         // Return 0 when no values recorded (Node.js behavior)
         return 0;
     }
-    return m_histogramData.manualMax;
+    return m_histogramData->manualMax;
 }
 
 double JSNodePerformanceHooksHistogram::getMean() const
 {
-    if (!m_histogramData.histogram) return NAN;
-    return hdr_mean(m_histogramData.histogram);
+    if (!m_histogramData->histogram) return NAN;
+    return hdr_mean(m_histogramData->histogram);
 }
 
 double JSNodePerformanceHooksHistogram::getStddev() const
 {
-    if (!m_histogramData.histogram) return NAN;
-    return hdr_stddev(m_histogramData.histogram);
+    if (!m_histogramData->histogram) return NAN;
+    return hdr_stddev(m_histogramData->histogram);
 }
 
 int64_t JSNodePerformanceHooksHistogram::getPercentile(double percentile) const
 {
-    if (!m_histogramData.histogram) return 0;
-    return hdr_value_at_percentile(m_histogramData.histogram, percentile);
+    if (!m_histogramData->histogram) return 0;
+    return hdr_value_at_percentile(m_histogramData->histogram, percentile);
 }
 
 size_t JSNodePerformanceHooksHistogram::getExceeds() const
 {
-    return m_histogramData.exceedsCount;
+    return m_histogramData->exceedsCount;
 }
 
 uint64_t JSNodePerformanceHooksHistogram::getCount() const
 {
     // Return our manual count of in-range values only
     // This matches Node.js behavior
-    return m_histogramData.totalCount;
+    return m_histogramData->totalCount;
 }
 
 double JSNodePerformanceHooksHistogram::add(JSNodePerformanceHooksHistogram* other)
 {
-    if (!m_histogramData.histogram || !other || !other->m_histogramData.histogram) return 0;
+    if (!m_histogramData->histogram || !other || !other->m_histogramData->histogram) return 0;
 
     // Add the manual counts and exceeds
-    m_histogramData.totalCount += other->m_histogramData.totalCount;
-    m_histogramData.exceedsCount += other->m_histogramData.exceedsCount;
+    m_histogramData->totalCount += other->m_histogramData->totalCount;
+    m_histogramData->exceedsCount += other->m_histogramData->exceedsCount;
 
     // Update manual min/max from the other histogram
-    if (other->m_histogramData.totalCount > 0) {
-        if (m_histogramData.totalCount == other->m_histogramData.totalCount) {
+    if (other->m_histogramData->totalCount > 0) {
+        if (m_histogramData->totalCount == other->m_histogramData->totalCount) {
             // This was empty, so take the other's values
-            m_histogramData.manualMin = other->m_histogramData.manualMin;
-            m_histogramData.manualMax = other->m_histogramData.manualMax;
+            m_histogramData->manualMin = other->m_histogramData->manualMin;
+            m_histogramData->manualMax = other->m_histogramData->manualMax;
         } else {
             // Merge min/max values
-            if (other->m_histogramData.manualMin < m_histogramData.manualMin) {
-                m_histogramData.manualMin = other->m_histogramData.manualMin;
+            if (other->m_histogramData->manualMin < m_histogramData->manualMin) {
+                m_histogramData->manualMin = other->m_histogramData->manualMin;
             }
-            if (other->m_histogramData.manualMax > m_histogramData.manualMax) {
-                m_histogramData.manualMax = other->m_histogramData.manualMax;
+            if (other->m_histogramData->manualMax > m_histogramData->manualMax) {
+                m_histogramData->manualMax = other->m_histogramData->manualMax;
             }
         }
     }
 
     // hdr_add returns number of dropped values
-    return hdr_add(m_histogramData.histogram, other->m_histogramData.histogram);
+    return hdr_add(m_histogramData->histogram, other->m_histogramData->histogram);
 }
 
 void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObject, JSC::JSMap* map)
@@ -245,10 +236,10 @@ void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!m_histogramData.histogram) return;
+    if (!m_histogramData->histogram) return;
 
     struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
+    hdr_iter_percentile_init(&iter, m_histogramData->histogram, 1.0);
 
     while (hdr_iter_next(&iter)) {
         double percentile = iter.specifics.percentiles.percentile;
@@ -266,10 +257,10 @@ void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!m_histogramData.histogram) return;
+    if (!m_histogramData->histogram) return;
 
     struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData.histogram, 1.0);
+    hdr_iter_percentile_init(&iter, m_histogramData->histogram, 1.0);
 
     while (hdr_iter_next(&iter)) {
         double percentile = iter.specifics.percentiles.percentile;

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -77,9 +77,7 @@ void JSNodePerformanceHooksHistogram::visitChildrenImpl(JSCell* cell, Visitor& v
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    if (!thisObject->m_histogramData || !thisObject->m_histogramData->histogram) {
-        visitor.reportExtraMemoryVisited(thisObject->m_extraMemorySizeForGC);
-    }
+    visitor.reportExtraMemoryVisited(thisObject->m_extraMemorySizeForGC);
 }
 
 DEFINE_VISIT_CHILDREN(JSNodePerformanceHooksHistogram);

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -101,29 +101,34 @@ JSC::Structure* JSNodePerformanceHooksHistogram::createStructure(JSC::VM& vm, JS
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
-bool JSNodePerformanceHooksHistogram::record(int64_t value)
+static ALWAYS_INLINE void recordLocked(HistogramData& data, int64_t value)
 {
-    if (!m_histogramData->histogram) return false;
-
     // Try to record in the HDR histogram first
-    bool recorded = hdr_record_value(m_histogramData->histogram, value);
+    bool recorded = hdr_record_value(data.histogram, value);
 
     if (recorded) {
         // Value was within range - count it and update min/max
-        m_histogramData->totalCount++;
+        data.totalCount++;
 
         // Update manual min/max tracking for in-range values only
-        if (value < m_histogramData->manualMin) {
-            m_histogramData->manualMin = value;
+        if (value < data.manualMin) {
+            data.manualMin = value;
         }
-        if (value > m_histogramData->manualMax) {
-            m_histogramData->manualMax = value;
+        if (value > data.manualMax) {
+            data.manualMax = value;
         }
     } else {
         // Value was out of range
-        m_histogramData->exceedsCount++;
+        data.exceedsCount++;
     }
+}
 
+bool JSNodePerformanceHooksHistogram::record(int64_t value)
+{
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (!data.histogram) return false;
+    recordLocked(data, value);
     return true;
 }
 
@@ -132,145 +137,176 @@ uint64_t JSNodePerformanceHooksHistogram::recordDelta(JSGlobalObject* globalObje
     auto now = WTF::MonotonicTime::now();
     uint64_t nowNs = static_cast<uint64_t>(now.secondsSinceEpoch().milliseconds() * 1000000.0);
 
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
     uint64_t delta = 0;
-    if (m_histogramData->prevDeltaTime != 0) {
-        delta = nowNs - m_histogramData->prevDeltaTime;
-        record(delta);
+    if (data.prevDeltaTime != 0) {
+        delta = nowNs - data.prevDeltaTime;
+        if (data.histogram)
+            recordLocked(data, delta);
     }
-    m_histogramData->prevDeltaTime = nowNs;
+    data.prevDeltaTime = nowNs;
     return delta;
 }
 
 void JSNodePerformanceHooksHistogram::reset()
 {
-    if (!m_histogramData->histogram) return;
-    hdr_reset(m_histogramData->histogram);
-    m_histogramData->prevDeltaTime = 0;
-    m_histogramData->totalCount = 0;
-    m_histogramData->manualMin = std::numeric_limits<int64_t>::max();
-    m_histogramData->manualMax = 0;
-    m_histogramData->exceedsCount = 0;
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (!data.histogram) return;
+    hdr_reset(data.histogram);
+    data.prevDeltaTime = 0;
+    data.totalCount = 0;
+    data.manualMin = std::numeric_limits<int64_t>::max();
+    data.manualMax = 0;
+    data.exceedsCount = 0;
 }
 
 int64_t JSNodePerformanceHooksHistogram::getMin() const
 {
-    if (m_histogramData->totalCount == 0) {
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (data.totalCount == 0) {
         // Return the same initial value as Node.js when no values recorded
         // Node.js returns 9223372036854776000 which is 0x8000000000000000
         // This is exactly INT64_MIN when interpreted as signed
         return INT64_MIN;
     }
-    return m_histogramData->manualMin;
+    return data.manualMin;
 }
 
 int64_t JSNodePerformanceHooksHistogram::getMax() const
 {
-    if (m_histogramData->totalCount == 0) {
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (data.totalCount == 0) {
         // Return 0 when no values recorded (Node.js behavior)
         return 0;
     }
-    return m_histogramData->manualMax;
+    return data.manualMax;
 }
 
 double JSNodePerformanceHooksHistogram::getMean() const
 {
-    if (!m_histogramData->histogram) return NAN;
-    return hdr_mean(m_histogramData->histogram);
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (!data.histogram) return NAN;
+    return hdr_mean(data.histogram);
 }
 
 double JSNodePerformanceHooksHistogram::getStddev() const
 {
-    if (!m_histogramData->histogram) return NAN;
-    return hdr_stddev(m_histogramData->histogram);
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (!data.histogram) return NAN;
+    return hdr_stddev(data.histogram);
 }
 
 int64_t JSNodePerformanceHooksHistogram::getPercentile(double percentile) const
 {
-    if (!m_histogramData->histogram) return 0;
-    return hdr_value_at_percentile(m_histogramData->histogram, percentile);
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    if (!data.histogram) return 0;
+    return hdr_value_at_percentile(data.histogram, percentile);
 }
 
 size_t JSNodePerformanceHooksHistogram::getExceeds() const
 {
-    return m_histogramData->exceedsCount;
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
+    return data.exceedsCount;
 }
 
 uint64_t JSNodePerformanceHooksHistogram::getCount() const
 {
+    auto& data = *m_histogramData;
+    WTF::Locker locker { data.m_lock };
     // Return our manual count of in-range values only
     // This matches Node.js behavior
-    return m_histogramData->totalCount;
+    return data.totalCount;
 }
 
-double JSNodePerformanceHooksHistogram::add(JSNodePerformanceHooksHistogram* other)
+static ALWAYS_INLINE double addLocked(HistogramData& self, HistogramData& other)
 {
-    if (!m_histogramData->histogram || !other || !other->m_histogramData->histogram) return 0;
-
     // Add the manual counts and exceeds
-    m_histogramData->totalCount += other->m_histogramData->totalCount;
-    m_histogramData->exceedsCount += other->m_histogramData->exceedsCount;
+    self.totalCount += other.totalCount;
+    self.exceedsCount += other.exceedsCount;
 
     // Update manual min/max from the other histogram
-    if (other->m_histogramData->totalCount > 0) {
-        if (m_histogramData->totalCount == other->m_histogramData->totalCount) {
+    if (other.totalCount > 0) {
+        if (self.totalCount == other.totalCount) {
             // This was empty, so take the other's values
-            m_histogramData->manualMin = other->m_histogramData->manualMin;
-            m_histogramData->manualMax = other->m_histogramData->manualMax;
+            self.manualMin = other.manualMin;
+            self.manualMax = other.manualMax;
         } else {
             // Merge min/max values
-            if (other->m_histogramData->manualMin < m_histogramData->manualMin) {
-                m_histogramData->manualMin = other->m_histogramData->manualMin;
+            if (other.manualMin < self.manualMin) {
+                self.manualMin = other.manualMin;
             }
-            if (other->m_histogramData->manualMax > m_histogramData->manualMax) {
-                m_histogramData->manualMax = other->m_histogramData->manualMax;
+            if (other.manualMax > self.manualMax) {
+                self.manualMax = other.manualMax;
             }
         }
     }
 
     // hdr_add returns number of dropped values
-    return hdr_add(m_histogramData->histogram, other->m_histogramData->histogram);
+    return hdr_add(self.histogram, other.histogram);
+}
+
+double JSNodePerformanceHooksHistogram::add(JSNodePerformanceHooksHistogram* other)
+{
+    if (!other) return 0;
+    auto& self = *m_histogramData;
+    auto& otherData = *other->m_histogramData;
+
+    if (&self == &otherData) {
+        WTF::Locker locker { self.m_lock };
+        if (!self.histogram) return 0;
+        return addLocked(self, otherData);
+    }
+
+    auto& first = &self < &otherData ? self : otherData;
+    auto& second = &self < &otherData ? otherData : self;
+    WTF::Locker firstLocker { first.m_lock };
+    WTF::Locker secondLocker { second.m_lock };
+    if (!self.histogram || !otherData.histogram) return 0;
+    return addLocked(self, otherData);
+}
+
+static void fillPercentileMap(JSGlobalObject* globalObject, JSC::JSMap* map, HistogramData& data)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    Vector<std::pair<double, int64_t>, 32> entries;
+    {
+        WTF::Locker locker { data.m_lock };
+        if (!data.histogram) return;
+
+        struct hdr_iter iter;
+        hdr_iter_percentile_init(&iter, data.histogram, 1.0);
+        while (hdr_iter_next(&iter)) {
+            entries.append({ iter.specifics.percentiles.percentile, iter.highest_equivalent_value });
+        }
+    }
+
+    for (auto& [percentile, value] : entries) {
+        JSValue jsKey = jsNumber(percentile);
+        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
+        RETURN_IF_EXCEPTION(scope, );
+        map->set(globalObject, jsKey, jsValue);
+        RETURN_IF_EXCEPTION(scope, void());
+    }
 }
 
 void JSNodePerformanceHooksHistogram::getPercentiles(JSGlobalObject* globalObject, JSC::JSMap* map)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!m_histogramData->histogram) return;
-
-    struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData->histogram, 1.0);
-
-    while (hdr_iter_next(&iter)) {
-        double percentile = iter.specifics.percentiles.percentile;
-        int64_t value = iter.highest_equivalent_value;
-        JSValue jsKey = jsNumber(percentile);
-        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
-        RETURN_IF_EXCEPTION(scope, );
-        map->set(globalObject, jsKey, jsValue);
-        RETURN_IF_EXCEPTION(scope, void());
-    }
+    fillPercentileMap(globalObject, map, *m_histogramData);
 }
 
 void JSNodePerformanceHooksHistogram::getPercentilesBigInt(JSGlobalObject* globalObject, JSC::JSMap* map)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!m_histogramData->histogram) return;
-
-    struct hdr_iter iter;
-    hdr_iter_percentile_init(&iter, m_histogramData->histogram, 1.0);
-
-    while (hdr_iter_next(&iter)) {
-        double percentile = iter.specifics.percentiles.percentile;
-        int64_t value = iter.highest_equivalent_value;
-        JSValue jsKey = jsNumber(percentile);
-        JSValue jsValue = JSBigInt::createFrom(globalObject, value);
-        RETURN_IF_EXCEPTION(scope, );
-        map->set(globalObject, jsKey, jsValue);
-        RETURN_IF_EXCEPTION(scope, void());
-    }
+    fillPercentileMap(globalObject, map, *m_histogramData);
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -52,7 +52,9 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_enableEventLoopDelay);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_disableEventLoopDelay);
 
-class HistogramData {
+class HistogramData : public ThreadSafeRefCounted<HistogramData> {
+    WTF_MAKE_NONCOPYABLE(HistogramData);
+
 public:
     hdr_histogram* histogram;
     uint64_t prevDeltaTime = 0;
@@ -61,9 +63,9 @@ public:
     int64_t manualMin = std::numeric_limits<int64_t>::max(); // Manual min tracking
     int64_t manualMax = 0; // Manual max tracking
 
-    HistogramData(hdr_histogram* histogram)
-        : histogram(histogram)
+    static Ref<HistogramData> create(hdr_histogram* histogram)
     {
+        return adoptRef(*new HistogramData(histogram));
     }
 
     ~HistogramData()
@@ -73,22 +75,10 @@ public:
         }
     }
 
-    // Move constructor (does not call destructor)
-    HistogramData(HistogramData&& other) noexcept
-        : histogram(other.histogram)
-        , prevDeltaTime(other.prevDeltaTime)
-        , exceedsCount(other.exceedsCount)
-        , totalCount(other.totalCount)
-        , manualMin(other.manualMin)
-        , manualMax(other.manualMax)
+private:
+    explicit HistogramData(hdr_histogram* histogram)
+        : histogram(histogram)
     {
-        // Invalidate other's histogram pointer to avoid double free
-        other.histogram = nullptr;
-        other.prevDeltaTime = 0;
-        other.exceedsCount = 0;
-        other.totalCount = 0;
-        other.manualMin = std::numeric_limits<int64_t>::max();
-        other.manualMax = 0;
     }
 };
 
@@ -98,7 +88,7 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags;
     static constexpr JSC::DestructionMode needsDestruction = NeedsDestruction;
 
-    HistogramData m_histogramData;
+    RefPtr<HistogramData> m_histogramData;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 
@@ -114,7 +104,7 @@ public:
         JSC::VM& vm,
         JSC::Structure* structure,
         JSC::JSGlobalObject* globalObject,
-        HistogramData&& existingHistogramData);
+        Ref<HistogramData>&& existingHistogramData);
 
     void finishCreation(JSC::VM& vm);
     static void destroy(JSC::JSCell*);
@@ -141,15 +131,15 @@ public:
             [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); });
     }
 
-    JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, HistogramData&& histogramData)
+    JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, Ref<HistogramData>&& histogramData)
         : Base(vm, structure)
-        , m_histogramData(std::move(histogramData))
+        , m_histogramData(WTF::move(histogramData))
     {
     }
 
     ~JSNodePerformanceHooksHistogram();
 
-    hdr_histogram& histogram() { return *m_histogramData.histogram; }
+    hdr_histogram& histogram() { return *m_histogramData->histogram; }
 
     bool record(int64_t value);
     uint64_t recordDelta(JSGlobalObject* globalObject);
@@ -164,8 +154,6 @@ public:
     size_t getExceeds() const;
     uint64_t getCount() const;
     double add(JSNodePerformanceHooksHistogram* other);
-
-    // std::shared_ptr<HistogramData> getHistogramDataForCloning() const;
 
 private:
     uint16_t m_extraMemorySizeForGC = 0;

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -56,6 +56,9 @@ class HistogramData : public ThreadSafeRefCounted<HistogramData> {
     WTF_MAKE_NONCOPYABLE(HistogramData);
 
 public:
+    // Structured clone shares this object across threads, so every accessor
+    // that touches the fields below must hold m_lock.
+    mutable WTF::Lock m_lock;
     hdr_histogram* histogram;
     uint64_t prevDeltaTime = 0;
     size_t exceedsCount = 0;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -940,6 +940,7 @@ public:
 #endif
         Vector<uint8_t>& out, SerializationContext context, ArrayBufferContentsArray& sharedBuffers,
         Vector<void*>& serializedBlockListRefs,
+        Vector<RefPtr<Bun::HistogramData>>& serializedHistograms,
         SerializationForStorage forStorage, SerializationForCrossProcessTransfer forTransfer)
     {
         CloneSerializer serializer(lexicalGlobalObject, messagePorts, arrayBuffers,
@@ -960,6 +961,7 @@ public:
             out, context, sharedBuffers, forStorage, forTransfer);
         auto code = serializer.serialize(value);
         serializedBlockListRefs = WTF::move(serializer.m_serializedBlockListRefs);
+        serializedHistograms = WTF::move(serializer.m_serializedHistograms);
         return code;
     }
 
@@ -2124,26 +2126,27 @@ private:
             }
 
             if (auto* histogram = dynamicDowncast<Bun::JSNodePerformanceHooksHistogram>(obj)) {
-                if (m_context != SerializationContext::WorkerPostMessage && m_context != SerializationContext::WindowPostMessage) {
-                    // Don't allow cloning of histograms if it's not a simple .postMessage().
+                // The clone carries a reference to the same HistogramData, which is only
+                // valid within this process, so reject storage and cross-process transfer.
+                if (m_forStorage == SerializationForStorage::Yes || m_forTransfer == SerializationForCrossProcessTransfer::Yes) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
 
-                // Serialize histogram configuration
-                hdr_histogram* hdr = histogram->m_histogramData.histogram;
-                if (!hdr) {
-                    // Histogram is not initialized
+                auto& data = histogram->m_histogramData;
+                if (!data || !data->histogram) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
 
+                if (checkForDuplicate(histogram))
+                    return true;
+                recordObject(histogram);
+
+                uint32_t index = m_serializedHistograms.size();
+                m_serializedHistograms.append(data.get());
                 write(Bun__NodePerformanceHooksHistogramTag);
-                // TODO: write the index into the histograms vector on SerializedScriptValue
-                // make it ThreadSafeRefCounted
-                // and then we can just write the index
-                code = SerializationReturnCode::DataCloneError;
-
+                write(index);
                 return true;
             }
 
@@ -2667,6 +2670,7 @@ private:
     SerializationContext m_context;
     ArrayBufferContentsArray& m_sharedBuffers;
     Vector<void*> m_serializedBlockListRefs;
+    Vector<RefPtr<Bun::HistogramData>> m_serializedHistograms;
 #if ENABLE(WEBASSEMBLY)
     WasmModuleArray& m_wasmModules;
     WasmMemoryHandleArray& m_wasmMemoryHandles;
@@ -3031,6 +3035,8 @@ public:
         ,
         WasmModuleArray* wasmModules, WasmMemoryHandleArray* wasmMemoryHandles
 #endif
+        ,
+        const Vector<RefPtr<Bun::HistogramData>>* serializedHistograms
 #if ENABLE(WEB_CODECS)
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
@@ -3052,6 +3058,8 @@ public:
                 ,
             wasmModules, wasmMemoryHandles
 #endif
+                ,
+            serializedHistograms
 #if ENABLE(WEB_CODECS)
             ,
             WTF::move(serializedVideoChunks), WTF::move(serializedVideoFrames)
@@ -3186,6 +3194,8 @@ private:
         ,
         WasmModuleArray* wasmModules = nullptr, WasmMemoryHandleArray* wasmMemoryHandles = nullptr
 #endif
+        ,
+        const Vector<RefPtr<Bun::HistogramData>>* serializedHistograms = nullptr
 #if ENABLE(WEB_CODECS)
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks = {}, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames = {}
@@ -3213,6 +3223,7 @@ private:
         , m_wasmModules(wasmModules)
         , m_wasmMemoryHandles(wasmMemoryHandles)
 #endif
+        , m_serializedHistograms(serializedHistograms)
 #if ENABLE(WEB_CODECS)
         , m_serializedVideoChunks(WTF::move(serializedVideoChunks))
         , m_videoChunks(m_serializedVideoChunks.size())
@@ -3293,6 +3304,8 @@ private:
         ,
         WasmModuleArray* wasmModules, WasmMemoryHandleArray* wasmMemoryHandles
 #endif
+        ,
+        const Vector<RefPtr<Bun::HistogramData>>* serializedHistograms
 #if ENABLE(WEB_CODECS)
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks = {}, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames = {}
@@ -3323,6 +3336,7 @@ private:
         , m_wasmModules(wasmModules)
         , m_wasmMemoryHandles(wasmMemoryHandles)
 #endif
+        , m_serializedHistograms(serializedHistograms)
 #if ENABLE(WEB_CODECS)
         , m_serializedVideoChunks(WTF::move(serializedVideoChunks))
         , m_videoChunks(m_serializedVideoChunks.size())
@@ -4808,6 +4822,27 @@ private:
         }
     }
 
+    JSValue readHistogram()
+    {
+        uint32_t index;
+        bool indexSuccessfullyRead = read(index);
+        if (!indexSuccessfullyRead || !m_serializedHistograms || index >= m_serializedHistograms->size()) {
+            fail();
+            return JSValue();
+        }
+        RefPtr<Bun::HistogramData> data = m_serializedHistograms->at(index);
+        if (!data) {
+            fail();
+            return JSValue();
+        }
+        auto* domGlobalObject = defaultGlobalObject(m_globalObject);
+        Structure* structure = domGlobalObject->m_JSNodePerformanceHooksHistogramClassStructure.get(domGlobalObject);
+        auto* obj = Bun::JSNodePerformanceHooksHistogram::create(m_lexicalGlobalObject->vm(), structure, m_globalObject, data.releaseNonNull());
+        m_gcBuffer.appendWithCrashOnOverflow(obj);
+        addTerminalToObjectPool(obj);
+        return obj;
+    }
+
     JSValue readDOMException()
     {
         CachedStringRef message;
@@ -5389,8 +5424,8 @@ private:
         case Bun__KeyObjectTag:
             return readKeyObject();
 
-            // case Bun__NodePerformanceHooksHistogramTag:
-            // ?
+        case Bun__NodePerformanceHooksHistogramTag:
+            return readHistogram();
 
         default:
             m_ptr--; // Push the tag back
@@ -5439,6 +5474,7 @@ private:
     WasmModuleArray* const m_wasmModules;
     WasmMemoryHandleArray* const m_wasmMemoryHandles;
 #endif
+    const Vector<RefPtr<Bun::HistogramData>>* const m_serializedHistograms;
 #if ENABLE(WEB_CODECS)
     Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> m_serializedVideoChunks;
     Vector<RefPtr<WebCodecsEncodedVideoChunk>> m_videoChunks;
@@ -6428,6 +6464,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 #endif
     std::unique_ptr<ArrayBufferContentsArray> sharedBuffers = makeUnique<ArrayBufferContentsArray>();
     Vector<void*> serializedBlockListRefs;
+    Vector<RefPtr<Bun::HistogramData>> serializedHistograms;
 #if ENABLE(WEB_CODECS)
     Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
     Vector<RefPtr<WebCodecsVideoFrame>> serializedVideoFrames;
@@ -6463,7 +6500,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         wasmModules,
         wasmMemoryHandles,
 #endif
-        buffer, context, *sharedBuffers, serializedBlockListRefs, forStorage, forTransfer);
+        buffer, context, *sharedBuffers, serializedBlockListRefs, serializedHistograms, forStorage, forTransfer);
 
     auto releaseSerializedBlockListRefs = [&] {
         for (auto* ptr : serializedBlockListRefs)
@@ -6550,6 +6587,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 #endif
             ));
     result->m_serializedBlockListRefs = WTF::move(serializedBlockListRefs);
+    result->m_serializedHistograms = WTF::move(serializedHistograms);
     return result;
 }
 
@@ -6659,6 +6697,8 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         nullptr, nullptr
 #endif
+        ,
+        nullptr
 #if ENABLE(WEB_CODECS)
         ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
@@ -6916,6 +6956,8 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                                                                ,
         m_wasmModulesArray.get(), m_wasmMemoryHandlesArray.get()
 #endif
+                                      ,
+        &m_serializedHistograms
 #if ENABLE(WEB_CODECS)
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3058,7 +3058,7 @@ public:
                 ,
             wasmModules, wasmMemoryHandles
 #endif
-                ,
+            ,
             serializedHistograms
 #if ENABLE(WEB_CODECS)
             ,
@@ -6959,7 +6959,7 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         &m_serializedHistograms
 #if ENABLE(WEB_CODECS)
-                                      ,
+        ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
     );

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -49,6 +49,10 @@
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef const struct OpaqueJSValue* JSValueRef;
 
+namespace Bun {
+class HistogramData;
+}
+
 #if ENABLE(WEBASSEMBLY)
 namespace JSC {
 namespace Wasm {
@@ -264,6 +268,9 @@ private:
     // Raw `*mut BlockList` pointers whose refcount was bumped at serialize
     // time so they outlive the wire buffer; released in the destructor.
     Vector<void*> m_serializedBlockListRefs;
+    // Shared histogram state carried alongside the wire buffer so a cloned
+    // perf_hooks Histogram observes the same underlying data as the original.
+    Vector<RefPtr<Bun::HistogramData>> m_serializedHistograms;
     // Vector<std::optional<ImageBitmapBacking>> m_backingStores;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<std::unique_ptr<DetachedOffscreenCanvas>> m_detachedOffscreenCanvases;

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { inspect } from "node:util";
-import { createHistogram } from "perf_hooks";
+import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
+import { MessageChannel } from "node:worker_threads";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("Histogram", () => {
   test("basic histogram creation and initial state", () => {
@@ -581,5 +583,114 @@ describe("Histogram", () => {
     const inspected = inspect(h);
 
     assert.ok(inspected.includes("Histogram"));
+  });
+
+  describe("structured clone", () => {
+    test("structuredClone on a recordable histogram shares state", () => {
+      const h = createHistogram();
+      for (const v of [3, 7, 7, 20]) h.record(v);
+
+      const clone = structuredClone(h);
+      assert.notStrictEqual(clone, h);
+      assert.strictEqual(clone.count, 4);
+      assert.strictEqual(clone.min, 3);
+      assert.strictEqual(clone.max, 20);
+      assert.strictEqual(clone.percentile(50), h.percentile(50));
+
+      h.record(100);
+      assert.strictEqual(clone.count, 5);
+      assert.strictEqual(clone.max, 100);
+
+      clone.record(1);
+      assert.strictEqual(h.count, 6);
+      assert.strictEqual(h.min, 1);
+
+      clone.reset();
+      assert.strictEqual(h.count, 0);
+    });
+
+    test("structuredClone on monitorEventLoopDelay histogram", () => {
+      const eld = monitorEventLoopDelay();
+      const clone = structuredClone(eld);
+      assert.notStrictEqual(clone, eld);
+      assert.strictEqual(clone.count, eld.count);
+      assert.strictEqual(typeof clone.percentile, "function");
+    });
+
+    test("structuredClone preserves identity within a graph", () => {
+      const h = createHistogram();
+      h.record(1);
+      const { a, b } = structuredClone({ a: h, b: h });
+      assert.strictEqual(a, b);
+      assert.strictEqual(a.count, 1);
+    });
+
+    test("MessageChannel postMessage delivers histogram", async () => {
+      const h = createHistogram();
+      h.record(5);
+      h.record(10);
+      const { port1, port2 } = new MessageChannel();
+      const { promise, resolve, reject } = Promise.withResolvers<any>();
+      port2.on("message", resolve);
+      port2.on("messageerror", reject);
+      port1.postMessage(h);
+      const got = await promise;
+      port1.close();
+      port2.close();
+      assert.strictEqual(got.count, 2);
+      assert.strictEqual(got.max, 10);
+
+      const target = createHistogram();
+      target.add(got);
+      assert.strictEqual(target.count, 2);
+    });
+
+    test("Worker postMessage delivers histogram across threads", async () => {
+      using dir = tempDir("histogram-worker", {
+        "main.mjs": `
+          import { Worker } from "node:worker_threads";
+          import { createHistogram } from "node:perf_hooks";
+          const w = new Worker(new URL("./worker.mjs", import.meta.url));
+          const got = await new Promise((resolve, reject) => {
+            w.on("message", resolve);
+            w.on("error", reject);
+          });
+          const target = createHistogram();
+          target.add(got);
+          await w.terminate();
+          Bun.gc(true);
+          console.log(JSON.stringify({
+            count: got.count,
+            min: got.min,
+            max: got.max,
+            added: target.count,
+          }));
+        `,
+        "worker.mjs": `
+          import { parentPort } from "node:worker_threads";
+          import { createHistogram } from "node:perf_hooks";
+          const h = createHistogram();
+          h.record(5);
+          h.record(10);
+          h.record(100);
+          parentPort.postMessage(h);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      assert.strictEqual(stderr, "");
+      assert.deepStrictEqual(JSON.parse(stdout), { count: 3, min: 5, max: 100, added: 3 });
+      assert.strictEqual(exitCode, 0);
+    });
   });
 });

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -684,9 +684,10 @@ describe("Histogram", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      assert.strictEqual(stderr, "");
-      assert.deepStrictEqual(JSON.parse(stdout), { count: 3, min: 5, max: 100, added: 3 });
-      assert.strictEqual(exitCode, 0);
+      assert.deepStrictEqual(
+        { stdout: stdout.trim(), stderr, exitCode },
+        { stdout: JSON.stringify({ count: 3, min: 5, max: 100, added: 3 }), stderr: "", exitCode: 0 },
+      );
     });
   });
 });

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -1,9 +1,9 @@
+import { bunEnv, bunExe, tempDir } from "harness";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { inspect } from "node:util";
-import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
 import { MessageChannel } from "node:worker_threads";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
 
 describe("Histogram", () => {
   test("basic histogram creation and initial state", () => {
@@ -683,11 +683,7 @@ describe("Histogram", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       assert.strictEqual(stderr, "");
       assert.deepStrictEqual(JSON.parse(stdout), { count: 3, min: 5, max: 100, added: 3 });
       assert.strictEqual(exitCode, 0);

--- a/test/js/bun/perf_hooks/histogram.test.ts
+++ b/test/js/bun/perf_hooks/histogram.test.ts
@@ -2,6 +2,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { inspect } from "node:util";
+import { serialize as v8Serialize } from "node:v8";
 import { MessageChannel } from "node:worker_threads";
 import { createHistogram, monitorEventLoopDelay } from "perf_hooks";
 
@@ -625,6 +626,12 @@ describe("Histogram", () => {
       assert.strictEqual(a.count, 1);
     });
 
+    test("v8.serialize rejects a histogram", () => {
+      const h = createHistogram();
+      h.record(5);
+      assert.throws(() => v8Serialize(h), { name: "DataCloneError" });
+    });
+
     test("MessageChannel postMessage delivers histogram", async () => {
       const h = createHistogram();
       h.record(5);
@@ -654,6 +661,7 @@ describe("Histogram", () => {
           const got = await new Promise((resolve, reject) => {
             w.on("message", resolve);
             w.on("error", reject);
+            w.on("exit", code => reject(new Error("worker exited with " + code + " before posting")));
           });
           const target = createHistogram();
           target.add(got);


### PR DESCRIPTION
## Repro

```js
import { createHistogram, monitorEventLoopDelay } from "node:perf_hooks";
import { MessageChannel } from "node:worker_threads";

const h = createHistogram();
for (const v of [3, 7, 7, 20]) h.record(v);

structuredClone(h).count;                         // node: 4        bun: DataCloneError
structuredClone(monitorEventLoopDelay());         // node: Histogram bun: DataCloneError

const { port1, port2 } = new MessageChannel();
port2.on("message", m => console.log(m.count));
port1.postMessage(h);                             // node: 4        bun: DataCloneError
```

Node documents "Cloning a Histogram" so a worker can post its `monitorEventLoopDelay()` / `timerify` histogram to the main thread and have the parent `add()` the clones together. In Bun every path (`structuredClone`, `postMessage`) threw `DataCloneError`.

## Cause

`SerializedScriptValue.cpp` had a stub for `JSNodePerformanceHooksHistogram` that wrote the tag and then returned `DataCloneError` anyway; the deserialize case was commented out.

## Fix

Node's `Histogram[kClone]` shares the underlying `hdr_histogram` via `std::shared_ptr`, so a clone observes the same counts/min/max as the original. This change mirrors that:

- `HistogramData` becomes `ThreadSafeRefCounted<HistogramData>`; `JSNodePerformanceHooksHistogram` holds a `RefPtr` to it.
- The serializer appends the `RefPtr` to a side vector on `SerializedScriptValue` and writes the tag plus the `uint32` index (same pattern as `WasmModuleArray` / `m_serializedBlockListRefs`).
- The deserializer reads the index, bounds-checks against the side vector, and creates a new JS wrapper sharing the `HistogramData`.
- Storage and cross-process serialization still reject, matching Node's `v8.serialize(h)` throwing.

## Verification

New tests in `test/js/bun/perf_hooks/histogram.test.ts` cover `structuredClone` on recordable and event-loop-delay histograms (including that mutations on the original are visible on the clone), identity preservation within a clone graph, `MessageChannel` delivery, and cross-thread `Worker` `postMessage` with `add()` on the receiving side. All fail on `main` with `DataCloneError` and pass with this change; existing `histogram.test.ts` and `structuredClone-classes.test.ts` still pass.