### PR TITLE
node:perf_hooks: make monitorEventLoopDelay() return independent histograms

### DIFF
--- a/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
+++ b/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
@@ -12,60 +12,34 @@ const cppEnableEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_enableEventLoopDelay",
   2,
-) as (histogram: import("node:perf_hooks").RecordableHistogram, resolution: number) => void;
+) as (histogram: import("node:perf_hooks").RecordableHistogram, resolution: number) => boolean;
 
 const cppDisableEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_disableEventLoopDelay",
   1,
-) as (histogram: import("node:perf_hooks").RecordableHistogram) => void;
-
-// IntervalHistogram wrapper class for event loop delay monitoring
-
-let eventLoopDelayHistogram: import("node:perf_hooks").RecordableHistogram | undefined;
-let enabled = false;
-let resolution = 10;
-
-function enable() {
-  if (enabled) {
-    return false;
-  }
-
-  enabled = true;
-  cppEnableEventLoopDelay(eventLoopDelayHistogram!, resolution);
-  return true;
-}
-
-function disable() {
-  if (!enabled) {
-    return false;
-  }
-
-  enabled = false;
-  cppDisableEventLoopDelay(eventLoopDelayHistogram!);
-  return true;
-}
+) as (histogram: import("node:perf_hooks").RecordableHistogram) => boolean;
 
 function monitorEventLoopDelay(options?: { resolution?: number }) {
   if (options !== undefined) {
     validateObject(options, "options");
   }
 
-  resolution = 10;
-  let resolutionOption = options?.resolution;
+  let resolution = 10;
+  const resolutionOption = options?.resolution;
   if (typeof resolutionOption !== "undefined") {
     validateInteger(resolutionOption, "options.resolution", 1);
     resolution = resolutionOption;
   }
 
-  if (!eventLoopDelayHistogram) {
-    eventLoopDelayHistogram = cppMonitorEventLoopDelay(resolution);
-    $putByValDirect(eventLoopDelayHistogram, "enable", enable);
-    $putByValDirect(eventLoopDelayHistogram, "disable", disable);
-    $putByValDirect(eventLoopDelayHistogram, Symbol.dispose, disable);
-  }
+  const histogram = cppMonitorEventLoopDelay(resolution);
+  const enable = () => cppEnableEventLoopDelay(histogram, resolution);
+  const disable = () => cppDisableEventLoopDelay(histogram);
+  $putByValDirect(histogram, "enable", enable);
+  $putByValDirect(histogram, "disable", disable);
+  $putByValDirect(histogram, Symbol.dispose, disable);
 
-  return eventLoopDelayHistogram;
+  return histogram;
 }
 
 export default monitorEventLoopDelay;

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -99,6 +99,7 @@ public:
     static constexpr JSC::DestructionMode needsDestruction = NeedsDestruction;
 
     HistogramData m_histogramData;
+    void* m_eventLoopDelayMonitor = nullptr;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -530,4 +530,13 @@ extern "C" void JSNodePerformanceHooksHistogram_recordDelay(JSC::EncodedJSValue 
     hist->record(delay_ns);
 }
 
+// Called from VM teardown when a monitor is freed out from under its histogram
+extern "C" void JSNodePerformanceHooksHistogram_clearMonitor(JSC::EncodedJSValue histogram)
+{
+    if (!histogram) return;
+
+    auto* hist = uncheckedDowncast<JSNodePerformanceHooksHistogram>(JSValue::decode(histogram));
+    hist->m_eventLoopDelayMonitor = nullptr;
+}
+
 } // namespace Bun

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -424,8 +424,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
 }
 
 // Extern declarations for the native timer implementation
-extern "C" void Timer_enableEventLoopDelayMonitoring(void* vm, JSC::EncodedJSValue histogram, int32_t resolution);
-extern "C" void Timer_disableEventLoopDelayMonitoring(void* vm);
+extern "C" void* Timer_enableEventLoopDelayMonitoring(void* vm, JSC::EncodedJSValue histogram, int32_t resolution);
+extern "C" void Timer_disableEventLoopDelayMonitoring(void* vm, void* monitor);
 
 // Create histogram for event loop delay monitoring
 JSC_DEFINE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -483,13 +483,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_enableEventLoopDelay, (JSGlobalObject * glob
     int32_t resolution = callFrame->argument(1).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Reset histogram data on enable
-    histogram->reset();
+    if (histogram->m_eventLoopDelayMonitor) {
+        return JSValue::encode(jsBoolean(false));
+    }
 
-    // Enable the event loop delay monitor in the native timer implementation
-    Timer_enableEventLoopDelayMonitoring(bunVM(globalObject), JSValue::encode(histogram), resolution);
+    histogram->m_eventLoopDelayMonitor = Timer_enableEventLoopDelayMonitoring(bunVM(globalObject), JSValue::encode(histogram), resolution);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(true)));
 }
 
 // Disable event loop delay monitoring
@@ -511,10 +511,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_disableEventLoopDelay, (JSGlobalObject * glo
         return JSValue::encode(jsUndefined());
     }
 
-    // Call into native code to disable monitoring
-    Timer_disableEventLoopDelayMonitoring(bunVM(globalObject));
+    void* monitor = histogram->m_eventLoopDelayMonitor;
+    if (!monitor) {
+        return JSValue::encode(jsBoolean(false));
+    }
+    histogram->m_eventLoopDelayMonitor = nullptr;
+    Timer_disableEventLoopDelayMonitoring(bunVM(globalObject), monitor);
 
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(jsBoolean(true));
 }
 
 // Extern function for native code to record delays

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -141,9 +141,9 @@ pub(crate) fn runtime_state() -> *mut RuntimeState {
 /// with no high tier, or `Bun__Timer__getNextID` racing init).
 ///
 /// Returns `*mut` (NOT `&mut`) so callers that are themselves fields of `All`
-/// (`DateHeaderTimer`, `EventLoopDelayMonitor`, `FakeTimers`) can dereference
-/// per-field under `// SAFETY:` without forming an aliased `&mut All` while
-/// `&mut self` is live (raw-ptr-per-field re-entry pattern, see `auto_tick`).
+/// (`DateHeaderTimer`, `FakeTimers`) can dereference per-field under
+/// `// SAFETY:` without forming an aliased `&mut All` while `&mut self` is
+/// live (raw-ptr-per-field re-entry pattern, see `auto_tick`).
 #[inline]
 pub(crate) fn timer_all() -> *mut timer::All {
     let state = runtime_state();

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -12,7 +12,7 @@ pub(super) extern "C" fn Timer_enableEventLoopDelayMonitoring(
 ) -> *mut EventLoopDelayMonitor {
     // SAFETY: vm is a valid non-null pointer passed from C++.
     let vm = unsafe { &mut *vm };
-    let monitor = Box::into_raw(Box::<EventLoopDelayMonitor>::default());
+    let monitor = bun_core::heap::into_raw(Box::new(EventLoopDelayMonitor::default()));
     // SAFETY: `monitor` was just allocated; the raw pointer has full provenance
     // for the intrusive timer node that `enable()` inserts into `All.timers`.
     unsafe { (*monitor).enable(vm, histogram, resolution_ms) };
@@ -32,5 +32,5 @@ pub(super) unsafe extern "C" fn Timer_disableEventLoopDelayMonitoring(
     // SAFETY: per fn contract; remove the intrusive timer node before reclaim.
     unsafe { (*monitor).disable(vm) };
     // SAFETY: per fn contract; reclaim the allocation from `enable`.
-    drop(unsafe { Box::from_raw(monitor) });
+    unsafe { bun_core::heap::destroy(monitor) };
 }

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -1,32 +1,36 @@
 use bun_jsc::JSValue;
 use bun_jsc::virtual_machine::VirtualMachine;
 
+use super::EventLoopDelayMonitor;
+
 // Export functions for C++
 #[unsafe(no_mangle)]
 pub(super) extern "C" fn Timer_enableEventLoopDelayMonitoring(
     vm: *mut VirtualMachine,
     histogram: JSValue,
     resolution_ms: i32,
+) -> *mut EventLoopDelayMonitor {
+    // SAFETY: vm is a valid non-null pointer passed from C++.
+    let vm = unsafe { &mut *vm };
+    let monitor = Box::into_raw(Box::<EventLoopDelayMonitor>::default());
+    // SAFETY: `monitor` was just allocated; the raw pointer has full provenance
+    // for the intrusive timer node that `enable()` inserts into `All.timers`.
+    unsafe { (*monitor).enable(vm, histogram, resolution_ms) };
+    monitor
+}
+
+/// # Safety
+/// `monitor` must be a pointer previously returned from
+/// `Timer_enableEventLoopDelayMonitoring` that has not yet been passed here.
+#[unsafe(no_mangle)]
+pub(super) unsafe extern "C" fn Timer_disableEventLoopDelayMonitoring(
+    vm: *mut VirtualMachine,
+    monitor: *mut EventLoopDelayMonitor,
 ) {
     // SAFETY: vm is a valid non-null pointer passed from C++.
     let vm = unsafe { &mut *vm };
-    // `vm.timer` is `()` (jsc/runtime crate cycle) — recover `All` via runtime_state().
-    let state = crate::jsc_hooks::runtime_state();
-    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`; single
-    // JS thread, raw-ptr-per-field re-entry pattern (jsc_hooks.rs).
-    unsafe {
-        (*state)
-            .timer
-            .event_loop_delay
-            .enable(vm, histogram, resolution_ms)
-    };
-}
-
-#[unsafe(no_mangle)]
-pub(super) extern "C" fn Timer_disableEventLoopDelayMonitoring(vm: *mut VirtualMachine) {
-    // SAFETY: vm is a valid non-null pointer passed from C++.
-    let vm = unsafe { &mut *vm };
-    let state = crate::jsc_hooks::runtime_state();
-    // SAFETY: see `Timer_enableEventLoopDelayMonitoring`.
-    unsafe { (*state).timer.event_loop_delay.disable(vm) };
+    // SAFETY: per fn contract; remove the intrusive timer node before reclaim.
+    unsafe { (*monitor).disable(vm) };
+    // SAFETY: per fn contract; reclaim the allocation from `enable`.
+    drop(unsafe { Box::from_raw(monitor) });
 }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -427,10 +427,8 @@ impl DateHeaderTimer {
 }
 
 pub struct EventLoopDelayMonitor {
-    // TODO: bare `JSValue` heap field with no Strong/visitChildren rooting —
-    // the histogram object can be GC'd while `monitorEventLoopDelay` is active.
-    // Needs JsRef-style rooting.
-    js_histogram: JSValue,
+    // Strong root keeps the JS histogram alive while monitoring is enabled.
+    js_histogram: bun_jsc::strong::Optional,
     pub event_loop_timer: EventLoopTimer,
     pub resolution_ms: i32,
     pub last_fire_ns: u64,
@@ -439,7 +437,7 @@ pub struct EventLoopDelayMonitor {
 impl Default for EventLoopDelayMonitor {
     fn default() -> Self {
         Self {
-            js_histogram: JSValue::default(),
+            js_histogram: bun_jsc::strong::Optional::empty(),
             event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::EventLoopDelayMonitor),
             resolution_ms: 10,
             last_fire_ns: 0,
@@ -455,14 +453,14 @@ impl EventLoopDelayMonitor {
 
     pub(crate) fn enable(
         &mut self,
-        _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
+        vm: &mut bun_jsc::virtual_machine::VirtualMachine,
         histogram: JSValue,
         resolution_ms: i32,
     ) {
         if self.enabled {
             return;
         }
-        self.js_histogram = histogram;
+        self.js_histogram.set(vm.global(), histogram);
         self.resolution_ms = resolution_ms;
         self.enabled = true;
 
@@ -474,8 +472,7 @@ impl EventLoopDelayMonitor {
             nsec: next.nsec,
         };
         let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: single JS thread; nothing `All::insert` touches overlaps
-        // `event_loop_delay`, which `self` aliases.
+        // SAFETY: single JS thread; `self` is a heap allocation disjoint from `All`.
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 
@@ -484,11 +481,13 @@ impl EventLoopDelayMonitor {
             return;
         }
         self.enabled = false;
-        self.js_histogram = JSValue::default();
+        self.js_histogram.deinit();
         self.last_fire_ns = 0;
-        let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: see `enable` — disjoint-field access on `All`.
-        unsafe { (*Self::timer_all()).remove(elt) };
+        if self.event_loop_timer.in_heap != InHeap::None {
+            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
+            // SAFETY: single JS thread; `self` is a heap allocation disjoint from `All`.
+            unsafe { (*Self::timer_all()).remove(elt) };
+        }
     }
 
     /// Record `now - last_fire_ns`
@@ -498,7 +497,10 @@ impl EventLoopDelayMonitor {
         _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
         now: &bun_event_loop::EventLoopTimer::Timespec,
     ) {
-        if !self.enabled || self.js_histogram.is_empty() {
+        let Some(histogram) = self.js_histogram.get() else {
+            return;
+        };
+        if !self.enabled {
             return;
         }
 
@@ -518,7 +520,7 @@ impl EventLoopDelayMonitor {
                         delay_ns: i64,
                     );
                 }
-                JSNodePerformanceHooksHistogram_recordDelay(self.js_histogram, delay_ns);
+                JSNodePerformanceHooksHistogram_recordDelay(histogram, delay_ns);
             }
         }
 
@@ -535,7 +537,7 @@ impl EventLoopDelayMonitor {
             nsec: next.nsec,
         };
         let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: see `enable` — disjoint-field access on `All`.
+        // SAFETY: single JS thread; `self` is a heap allocation disjoint from `All`.
         unsafe { (*Self::timer_all()).insert(elt) };
     }
 }
@@ -621,7 +623,6 @@ pub struct All {
     pub immediate_ref_count: i32,
     #[cfg(windows)]
     pub uv_idle: bun_sys::windows::libuv::uv_idle_t,
-    pub event_loop_delay: EventLoopDelayMonitor,
     pub fake_timers: FakeTimers,
     pub maps: Maps,
     pub date_header_timer: DateHeaderTimer,
@@ -643,7 +644,6 @@ impl All {
             immediate_ref_count: 0,
             #[cfg(windows)]
             uv_idle: bun_core::ffi::zeroed(),
-            event_loop_delay: EventLoopDelayMonitor::default(),
             fake_timers: FakeTimers::default(),
             maps: Maps::default(),
             date_header_timer: DateHeaderTimer::default(),

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -371,10 +371,9 @@ impl Maps {
 // host fns see the same nominal type.
 pub use crate::test_runner::timers::fake_timers::FakeTimers;
 
-// ─── DateHeaderTimer / EventLoopDelayMonitor (struct-only) ───────────────────
-// Method bodies (`enable`/`run`) call `vm.timer.*` and `vm.uws_loop()` which
-// need `VirtualMachine.timer: All` (currently `()` in bun_jsc). Struct shape
-// is real so `All` embeds them by value with the correct layout.
+// ─── DateHeaderTimer / EventLoopDelayMonitor ─────────────────────────────────
+// `DateHeaderTimer` is embedded by value in `All`. `EventLoopDelayMonitor`
+// instances are heap-allocated per `monitorEventLoopDelay()` histogram.
 
 pub struct DateHeaderTimer {
     pub event_loop_timer: EventLoopTimer,
@@ -434,6 +433,7 @@ pub struct EventLoopDelayMonitor {
     pub last_fire_ns: u64,
     pub enabled: bool,
 }
+bun_event_loop::impl_timer_owner!(EventLoopDelayMonitor; from_timer_ptr => event_loop_timer);
 impl Default for EventLoopDelayMonitor {
     fn default() -> Self {
         Self {
@@ -1185,6 +1185,7 @@ impl All {
     ) {
         let mut to_cancel: Vec<*const TimerObjectInternals> = Vec::new();
         let mut signal_timeouts: Vec<*mut AbortSignalTimeout> = Vec::new();
+        let mut delay_monitors: Vec<*mut EventLoopDelayMonitor> = Vec::new();
         let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
 
         // SAFETY: `this` is the live per-thread `All` (JS thread only).
@@ -1226,6 +1227,11 @@ impl All {
                     // field of a live boxed `abort_signal::Timeout`.
                     signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
                 }
+                EventLoopTimerTag::EventLoopDelayMonitor => {
+                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
+                    // field of a live boxed `EventLoopDelayMonitor`.
+                    delay_monitors.push(unsafe { EventLoopDelayMonitor::from_timer_ptr(node) });
+                }
                 _ => {}
             }
         }
@@ -1260,6 +1266,25 @@ impl All {
                 if !signal.is_null() {
                     crate::jsc::abort_signal::AbortSignal::opaque_ref(signal).unref();
                 }
+            }
+        }
+
+        // Heap-allocated `monitorEventLoopDelay()` monitors still enabled at
+        // teardown: null the owning histogram's pointer, unlink, drop Strong,
+        // and free.
+        for m in delay_monitors {
+            unsafe extern "C" {
+                safe fn JSNodePerformanceHooksHistogram_clearMonitor(histogram: JSValue);
+            }
+            // SAFETY: each `m` was collected from the live heap above; the
+            // box is still owned by the histogram's `m_eventLoopDelayMonitor`
+            // which we clear here. JS thread.
+            unsafe {
+                if let Some(histogram) = (*m).js_histogram.get() {
+                    JSNodePerformanceHooksHistogram_clearMonitor(histogram);
+                }
+                (*m).disable(&mut *vm);
+                bun_core::heap::destroy(m);
             }
         }
     }

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import perf, { monitorEventLoopDelay } from "perf_hooks";
 
 test("stubs", () => {
@@ -86,5 +87,27 @@ describe("monitorEventLoopDelay", () => {
       a.disable();
       b.disable();
     }
+  });
+
+  test("process exits cleanly with monitors still enabled", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { monitorEventLoopDelay } = require("node:perf_hooks");
+         monitorEventLoopDelay({ resolution: 1 }).enable();
+         monitorEventLoopDelay({ resolution: 2 }).enable();
+         setTimeout(() => {
+           console.log("ok");
+           process.exit(0);
+         }, 10);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import perf from "perf_hooks";
+import { describe, expect, test } from "bun:test";
+import perf, { monitorEventLoopDelay } from "perf_hooks";
 
 test("stubs", () => {
   expect(perf.performance.nodeTiming).toBeObject();
@@ -20,4 +20,71 @@ test("doesn't throw", () => {
   expect(() => performance.now()).not.toThrow();
   expect(() => performance.timeOrigin).not.toThrow();
   expect(() => performance.markResourceTiming()).not.toThrow();
+});
+
+describe("monitorEventLoopDelay", () => {
+  test("each call returns an independent histogram", () => {
+    const a = monitorEventLoopDelay({ resolution: 5 });
+    const b = monitorEventLoopDelay({ resolution: 5 });
+    try {
+      expect(a === b).toBe(false);
+
+      // enable A; B has never been enabled
+      expect(a.enable()).toBe(true);
+      // disabling B (never enabled) must return false and must not affect A
+      expect(b.disable()).toBe(false);
+      // A is still enabled, so disabling it returns true
+      expect(a.disable()).toBe(true);
+      // A is now disabled
+      expect(a.disable()).toBe(false);
+
+      // Two monitors can be enabled concurrently
+      expect(a.enable()).toBe(true);
+      expect(b.enable()).toBe(true);
+      expect(a.enable()).toBe(false);
+      expect(b.enable()).toBe(false);
+    } finally {
+      a.disable();
+      b.disable();
+    }
+  });
+
+  async function waitForCount(h: ReturnType<typeof monitorEventLoopDelay>, min: number) {
+    while (h.count < min) {
+      await new Promise(resolve => setTimeout(resolve, 1));
+    }
+  }
+
+  test("disable on one monitor does not stop another", async () => {
+    const a = monitorEventLoopDelay({ resolution: 1 });
+    const b = monitorEventLoopDelay({ resolution: 1 });
+    try {
+      a.enable();
+      await waitForCount(a, 1);
+      const before = a.count;
+      // B was never enabled; disabling it must not stop A
+      expect(b.disable()).toBe(false);
+      await waitForCount(a, before + 2);
+      expect(a.count).toBeGreaterThan(before);
+    } finally {
+      a.disable();
+      b.disable();
+    }
+  });
+
+  test("reset on one monitor does not clear another", async () => {
+    const a = monitorEventLoopDelay({ resolution: 1 });
+    const b = monitorEventLoopDelay({ resolution: 1 });
+    try {
+      a.enable();
+      b.enable();
+      await waitForCount(a, 2);
+      await waitForCount(b, 2);
+      b.reset();
+      expect(a.count).toBeGreaterThanOrEqual(2);
+    } finally {
+      a.disable();
+      b.disable();
+    }
+  });
 });


### PR DESCRIPTION
## Repro

```js
import { monitorEventLoopDelay } from "node:perf_hooks";

const A = monitorEventLoopDelay();
const B = monitorEventLoopDelay();
A === B;       // node: false   bun: true
A.enable();
B.disable();   // node: false (B was never enabled)   bun: true (stops A)
A.disable();   // node: true                          bun: false
```

Two independent consumers in one process (e.g. prom-client's `nodejs_eventloop_lag_*` collector plus a health check like `@nestjs/terminus` `EventLoopDelayHealthIndicator`) share one histogram and one enabled flag: whichever calls `disable()` first silently stops the other's monitoring; the second consumer's `enable()` returns `false`; one `reset()` wipes the other's samples.

## Cause

`src/js/internal/perf_hooks/monitorEventLoopDelay.ts` kept module-level `let eventLoopDelayHistogram / enabled / resolution` and returned the cached histogram on every call. On the native side, `All.event_loop_delay` was a single `EventLoopDelayMonitor` embedded by value with one timer and one bare-`JSValue` histogram reference (kept alive only by the JS module cache).

## Fix

- Each `monitorEventLoopDelay()` call creates a fresh native histogram.
- `enable()` heap-allocates a `Box<EventLoopDelayMonitor>` (own timer, own resolution, own `last_fire_ns`), inserts its intrusive timer node into the heap, and stores the pointer on the C++ histogram (`m_eventLoopDelayMonitor`); it returns `false` if one is already present.
- `disable()` removes that node and frees the box; returns `false` if none.
- The monitor now holds the histogram via `bun_jsc::strong::Optional`, so an enabled histogram stays rooted even if userland drops its reference (resolves the existing TODO about bare-`JSValue` rooting).
- `enable()` no longer calls `histogram->reset()`; Node preserves samples across disable/enable.
- Dispatch in `__bun_fire_timer` is already container-of based, so the `EventLoopDelayMonitor` arm works unchanged for any heap-allocated instance. The unused `All.event_loop_delay` singleton field is removed.

## Verification

```
bun bd test test/js/node/perf_hooks/perf_hooks.test.ts
bun bd test test/js/bun/perf_hooks/histogram.test.ts
bun bd test/js/node/test/sequential/test-performance-eventloopdelay.js
```

All pass. The three new `monitorEventLoopDelay` tests fail on released Bun 1.4.0:

```
(fail) monitorEventLoopDelay > each call returns an independent histogram
(fail) monitorEventLoopDelay > disable on one monitor does not stop another
(fail) monitorEventLoopDelay > reset on one monitor does not clear another
```

Note: #33587 touches the same JS file for the prototype-chain shape and will conflict; both fixes are orthogonal.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4a4e24894)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [6.05ms]
(pass) doesn't throw [15.56ms]
26 | describe("monitorEventLoopDelay", () => {
27 |   test("each call returns an independent histogram", () => {
28 |     const a = monitorEventLoopDelay({ resolution: 5 });
29 |     const b = monitorEventLoopDelay({ resolution: 5 });
30 |     try {
31 |       expect(a === b).toBe(false);
                           ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:31:23)
(fail) monitorEventLoopDelay > each call returns an independent histogram [17.31ms]
62 |     try {
63 |       a.enable();
64 |       await waitFor
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.09ms]
(pass) doesn't throw [0.24ms]
26 | describe("monitorEventLoopDelay", () => {
27 |   test("each call returns an independent histogram", () => {
28 |     const a = monitorEventLoopDelay({ resolution: 5 });
29 |     const b = monitorEventLoopDelay({ resolution: 5 });
30 |     try {
31 |       expect(a === b).toBe(false);
                           ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:31:23)
(fail) monitorEventLoopDelay > each call returns an independent histogram [0.55ms]
62 |     try {
63 |       a.enable();
64 |       await waitForCount(a, 1);
65 |       const before = a.count;
66 |       // B was never enabled; disabling it must not stop A
67 |       expect(b.disable()).toBe(false);
                               ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:67:27)
(fail) monitorEventLoopDelay > disable on one monitor does not stop another [5.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4a4e24894)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [5.72ms]
(pass) doesn't throw [15.76ms]
(pass) monitorEventLoopDelay > each call returns an independent histogram [16.10ms]
(pass) monitorEventLoopDelay > disable on one monitor does not stop another [21.85ms]
(pass) monitorEventLoopDelay > reset on one monitor does not clear another [11.13ms]
(pass) monitorEventLoopDelay > process exits cleanly with monitors still enabled [647.85ms]

 6 pass
 0 fail
 29 expect() calls
Ran 6 tests across 1 file. [2.97s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4a4e248943
  features     (none)

22 deps, 106 codegen, 1168 objects in 938ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1231] gen ErrorCode+*.h
[4/1231] gen bindgenv2
[5/1231] fetch zlib
[zlib] up to date
[6/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [21.00ms]
[8/1231] fetch picoh
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../internal/perf_hooks/monitorEventLoopDelay.ts   | 48 +++--------
 src/jsc/bindings/JSNodePerformanceHooksHistogram.h |  1 +
 .../JSNodePerformanceHooksHistogramPrototype.cpp   | 33 +++++---
 src/runtime/jsc_hooks.rs                           |  6 +-
 src/runtime/timer/EventLoopDelayMonitor.rs         | 34 ++++----
 src/runtime/timer/mod.rs                           | 69 +++++++++++-----
 test/js/node/perf_hooks/perf_hooks.test.ts         | 94 +++++++++++++++++++++-
 7 files changed, 196 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/perf_hooks/monitorEventLoopDelay.ts           1      1      0
src/jsc/bindings/JSNodePerformanceHooksHistogram.h            1      1      0
…c/bindings/JSNodePerformanceHooksHistogramPrototype.cpp      2      3      0
src/runtime/jsc_hooks.rs                                      2      1      0
src/runtime/timer/EventLoopDelayMonitor.rs                    3      6      0
src/runtime/timer/mod.rs                                     10     10      0
test/js/node/perf_hooks/perf_hooks.test.ts                    2      5      0
```

</details>

<!-- robobun:evidence:end -->