### PR TITLE
Bun.serve: accept permessage-deflate BFINAL=1 blocks (dedicated; shared/default >4 KiB)

### DIFF
--- a/packages/bun-uws/src/PerMessageDeflate.h
+++ b/packages/bun-uws/src/PerMessageDeflate.h
@@ -280,6 +280,15 @@ struct InflationStream {
             inflationStream.avail_out = LARGE_BUFFER_SIZE;
 
             err = ::inflate(&inflationStream, Z_SYNC_FLUSH);
+            if (err == Z_STREAM_END) {
+                /* RFC 7692 7.2.3.4: a sender may end a message with a BFINAL=1 block.
+                 * Reset so the next message starts a fresh DEFLATE stream. Remaining
+                 * input (the 00 00 ff ff tail we appended plus any sender padding)
+                 * decodes to nothing; drop it so it cannot poison the reset stream. */
+                inflateReset(&inflationStream);
+                inflationStream.avail_in = 0;
+                err = Z_OK;
+            }
             if (err == Z_OK && inflationStream.avail_out) {
                 break;
             }

--- a/packages/bun-uws/src/PerMessageDeflate.h
+++ b/packages/bun-uws/src/PerMessageDeflate.h
@@ -282,9 +282,8 @@ struct InflationStream {
             err = ::inflate(&inflationStream, Z_SYNC_FLUSH);
             if (err == Z_STREAM_END) {
                 /* RFC 7692 7.2.3.4: a sender may end a message with a BFINAL=1 block.
-                 * Reset so the next message starts a fresh DEFLATE stream. Remaining
-                 * input (the 00 00 ff ff tail we appended plus any sender padding)
-                 * decodes to nothing; drop it so it cannot poison the reset stream. */
+                 * Reset for the next message and drop the rest of this input (our
+                 * appended tail / sender padding); matches the shared libdeflate path. */
                 inflateReset(&inflationStream);
                 inflationStream.avail_in = 0;
                 err = Z_OK;

--- a/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
+++ b/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
@@ -1,0 +1,217 @@
+// RFC 7692 7.2.3.4: a permessage-deflate sender may end a message with a
+// DEFLATE block whose BFINAL bit is set to 1. A receiver must decode it and,
+// with context takeover, reset its inflater so the next message starts a fresh
+// DEFLATE stream. The dedicated decompressor used to treat Z_STREAM_END as a
+// fatal inflate error and drop the TCP connection.
+import { serve } from "bun";
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+import { constants, deflateRawSync } from "node:zlib";
+
+// A permessage-deflate payload sync-flushed with the trailing 0x00 0x00 0xff
+// 0xff removed (RFC 7692 7.2.1): the shape every mainstream sender emits.
+function pmdSyncFlush(payload: Buffer): Buffer {
+  const deflated = deflateRawSync(payload, { finishFlush: constants.Z_SYNC_FLUSH });
+  expect(deflated.subarray(-4)).toEqual(Buffer.from([0x00, 0x00, 0xff, 0xff]));
+  return deflated.subarray(0, -4);
+}
+
+// A complete raw DEFLATE stream ending in a BFINAL=1 block.
+function pmdFinal(payload: Buffer): Buffer {
+  return deflateRawSync(payload);
+}
+
+// The RFC 7692 7.2.3.4 shape: a BFINAL=1 stream followed by one 0x00 octet
+// (header of an empty non-final stored block) so the tail stripped by 7.2.1
+// round-trips.
+function pmdFinalPadded(payload: Buffer): Buffer {
+  return Buffer.concat([deflateRawSync(payload), Buffer.from([0x00])]);
+}
+
+function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean } = {}): Buffer {
+  const { fin = true, rsv1 = false } = opts;
+  if (payload.length > 0xffff) throw new Error("these tests only build short and medium frames");
+  const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+  const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+  const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
+  const head =
+    payload.length < 126
+      ? Buffer.from([flags, 0x80 | payload.length])
+      : Buffer.from([flags, 0x80 | 126, payload.length >> 8, payload.length & 0xff]);
+  return Buffer.concat([head, mask, masked]);
+}
+
+type PerMessageDeflate = boolean | { compress?: true | "shared" | "dedicated"; decompress?: true | "shared" | "dedicated" };
+
+// Raw TCP WebSocket client that negotiates permessage-deflate against a
+// Bun.serve websocket server and exposes exactly what message() saw.
+async function connectDeflated(perMessageDeflate: PerMessageDeflate) {
+  const received: string[] = [];
+  const messageWaiters: ((hex: string) => void)[] = [];
+  const serverClose = Promise.withResolvers<string>();
+  const server = serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("upgrade failed", { status: 400 });
+    },
+    websocket: {
+      perMessageDeflate,
+      message(ws, message) {
+        const hex = Buffer.from(message as Buffer).toString("hex");
+        received.push(hex);
+        messageWaiters.shift()?.(`message:${hex}`);
+      },
+      close(ws, code, reason) {
+        serverClose.resolve(`close:${code}:${reason}`);
+      },
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  socket.setNoDelay(true);
+  const upgraded = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<string>();
+  socket.on("close", () => {
+    closed.resolve("socket-closed-by-server");
+    upgraded.reject(new Error("socket closed before the 101 response"));
+  });
+  socket.on("error", (error: Error) => {
+    closed.resolve("socket-closed-by-server");
+    upgraded.reject(error);
+  });
+
+  let head = Buffer.alloc(0);
+  let negotiated = "";
+  const onHead = (chunk: Buffer) => {
+    head = Buffer.concat([head, chunk]);
+    const end = head.indexOf("\r\n\r\n");
+    if (end === -1) return;
+    socket.off("data", onHead);
+    const headText = head.subarray(0, end).toString();
+    if (!headText.startsWith("HTTP/1.1 101")) {
+      upgraded.reject(new Error(`upgrade failed: ${headText.split("\r\n")[0]}`));
+      return;
+    }
+    negotiated = headText.split("\r\n").find(line => /^sec-websocket-extensions:/i.test(line)) ?? "";
+    upgraded.resolve();
+  };
+  socket.on("data", onHead);
+  socket.write(
+    "GET / HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Upgrade: websocket\r\n" +
+      "Sec-WebSocket-Version: 13\r\n" +
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+      "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
+      "\r\n",
+  );
+  try {
+    await upgraded.promise;
+    expect(negotiated.toLowerCase()).toContain("permessage-deflate");
+  } catch (error) {
+    socket.destroy();
+    server.stop(true);
+    throw error;
+  }
+
+  return {
+    socket,
+    received,
+    serverClose: serverClose.promise,
+    closed: closed.promise,
+    nextMessage(): Promise<string> {
+      const { promise, resolve } = Promise.withResolvers<string>();
+      messageWaiters.push(resolve);
+      return promise;
+    },
+    [Symbol.dispose]() {
+      socket.destroy();
+      server.stop(true);
+    },
+  };
+}
+
+const modes: [string, PerMessageDeflate][] = [
+  ["true", true],
+  ["shared", { compress: "shared", decompress: "shared" }],
+  ["dedicated", { compress: "dedicated", decompress: "dedicated" }],
+];
+
+describe.concurrent.each(modes)("permessage-deflate BFINAL=1 (perMessageDeflate: %s)", (_label, pmd) => {
+  // Large enough that zlib actually compresses it, small enough to fit the
+  // single-chunk inflate buffer so the loop exits on the first iteration.
+  const original = Buffer.alloc(750, "bfinal-interop-");
+
+  it("a sync-flushed message is inflated and delivered (control)", async () => {
+    using raw = await connectDeflated(pmd);
+    const msg = raw.nextMessage();
+    raw.socket.write(frame(0x2, pmdSyncFlush(original), { rsv1: true }));
+    expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${original.toString("hex")}`);
+  });
+
+  it("a BFINAL=1 message is inflated and delivered", async () => {
+    using raw = await connectDeflated(pmd);
+    const msg = raw.nextMessage();
+    raw.socket.write(frame(0x2, pmdFinal(original), { rsv1: true }));
+    expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${original.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex")]);
+  });
+
+  it("a BFINAL=1 message padded with 0x00 is inflated and delivered", async () => {
+    using raw = await connectDeflated(pmd);
+    const msg = raw.nextMessage();
+    raw.socket.write(frame(0x2, pmdFinalPadded(original), { rsv1: true }));
+    expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${original.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex")]);
+  });
+
+  // After Z_STREAM_END the inflater must be reset: the next message on the
+  // same connection starts a fresh DEFLATE stream, not a continuation.
+  it("a sync-flushed message after a BFINAL=1 message is still decoded correctly", async () => {
+    using raw = await connectDeflated(pmd);
+    const first = raw.nextMessage();
+    const second = raw.nextMessage();
+    const followup = Buffer.alloc(200, "after-bfinal-");
+    raw.socket.write(
+      Buffer.concat([
+        frame(0x2, pmdFinal(original), { rsv1: true }),
+        frame(0x2, pmdSyncFlush(followup), { rsv1: true }),
+      ]),
+    );
+    expect(await Promise.race([first, raw.serverClose, raw.closed])).toBe(`message:${original.toString("hex")}`);
+    expect(await Promise.race([second, raw.serverClose, raw.closed])).toBe(`message:${followup.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex"), followup.toString("hex")]);
+  });
+
+  it("two BFINAL=1 messages in a row are both decoded correctly", async () => {
+    using raw = await connectDeflated(pmd);
+    const first = raw.nextMessage();
+    const second = raw.nextMessage();
+    const other = Buffer.alloc(300, "second-bfinal-");
+    raw.socket.write(
+      Buffer.concat([
+        frame(0x2, pmdFinalPadded(original), { rsv1: true }),
+        frame(0x2, pmdFinal(other), { rsv1: true }),
+      ]),
+    );
+    expect(await Promise.race([first, raw.serverClose, raw.closed])).toBe(`message:${original.toString("hex")}`);
+    expect(await Promise.race([second, raw.serverClose, raw.closed])).toBe(`message:${other.toString("hex")}`);
+    expect(raw.received).toEqual([original.toString("hex"), other.toString("hex")]);
+  });
+});
+
+// The zlib inflate loop writes into a 16 KiB scratch buffer per iteration; a
+// BFINAL=1 payload that inflates to more than that must still be reassembled
+// correctly across the chunk boundary.
+it("dedicated: a BFINAL=1 message inflating to more than 16 KiB is delivered intact", async () => {
+  using raw = await connectDeflated({ compress: "dedicated", decompress: "dedicated" });
+  const big = Buffer.alloc(20000, "bfinal-large-chunk-");
+  const compressed = pmdFinal(big);
+  expect(compressed.length).toBeLessThan(0xffff);
+  const msg = raw.nextMessage();
+  raw.socket.write(frame(0x2, compressed, { rsv1: true }));
+  expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${big.toString("hex")}`);
+  expect(raw.received).toEqual([big.toString("hex")]);
+});

--- a/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
+++ b/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
@@ -41,7 +41,9 @@ function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: bo
   return Buffer.concat([head, mask, masked]);
 }
 
-type PerMessageDeflate = boolean | { compress?: true | "shared" | "dedicated"; decompress?: true | "shared" | "dedicated" };
+type PerMessageDeflate =
+  | boolean
+  | { compress?: true | "shared" | "dedicated"; decompress?: true | "shared" | "dedicated" };
 
 // Raw TCP WebSocket client that negotiates permessage-deflate against a
 // Bun.serve websocket server and exposes exactly what message() saw.

--- a/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
+++ b/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
@@ -1,8 +1,10 @@
 // RFC 7692 7.2.3.4: a permessage-deflate sender may end a message with a
 // DEFLATE block whose BFINAL bit is set to 1. A receiver must decode it and,
 // with context takeover, reset its inflater so the next message starts a fresh
-// DEFLATE stream. The dedicated decompressor used to treat Z_STREAM_END as a
-// fatal inflate error and drop the TCP connection.
+// DEFLATE stream. The zlib inflate loop used to treat Z_STREAM_END as a fatal
+// error and drop the TCP connection. That hit the dedicated decompressor at
+// any size, and the shared (default) decompressor once the inflated payload
+// exceeded the 4 KiB libdeflate fast-path output buffer.
 import { serve } from "bun";
 import { describe, expect, it } from "bun:test";
 import net from "node:net";
@@ -202,18 +204,30 @@ describe.concurrent.each(modes)("permessage-deflate BFINAL=1 (perMessageDeflate:
     expect(await Promise.race([second, raw.serverClose, raw.closed])).toBe(`message:${other.toString("hex")}`);
     expect(raw.received).toEqual([original.toString("hex"), other.toString("hex")]);
   });
-});
 
-// The zlib inflate loop writes into a 16 KiB scratch buffer per iteration; a
-// BFINAL=1 payload that inflates to more than that must still be reassembled
-// correctly across the chunk boundary.
-it("dedicated: a BFINAL=1 message inflating to more than 16 KiB is delivered intact", async () => {
-  using raw = await connectDeflated({ compress: "dedicated", decompress: "dedicated" });
-  const big = Buffer.alloc(20000, "bfinal-large-chunk-");
-  const compressed = pmdFinal(big);
-  expect(compressed.length).toBeLessThan(0xffff);
-  const msg = raw.nextMessage();
-  raw.socket.write(frame(0x2, compressed, { rsv1: true }));
-  expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${big.toString("hex")}`);
-  expect(raw.received).toEqual([big.toString("hex")]);
+  // The shared decompressor's libdeflate fast path writes into a 4 KiB output
+  // buffer; anything larger falls through to the zlib loop that used to reject
+  // Z_STREAM_END. 4096 fits the fast path exactly, 4097 does not.
+  it.each([4096, 4097])("a BFINAL=1 message inflating to %d bytes is delivered intact", async size => {
+    using raw = await connectDeflated(pmd);
+    const payload = Buffer.alloc(size, "bfinal-fastpath-");
+    const msg = raw.nextMessage();
+    raw.socket.write(frame(0x2, pmdFinal(payload), { rsv1: true }));
+    expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${payload.toString("hex")}`);
+    expect(raw.received).toEqual([payload.toString("hex")]);
+  });
+
+  // The zlib inflate loop writes into a 16 KiB scratch buffer per iteration; a
+  // BFINAL=1 payload that inflates to more than that must still be reassembled
+  // correctly across the chunk boundary.
+  it("a BFINAL=1 message inflating to more than 16 KiB is delivered intact", async () => {
+    using raw = await connectDeflated(pmd);
+    const big = Buffer.alloc(20000, "bfinal-large-chunk-");
+    const compressed = pmdFinal(big);
+    expect(compressed.length).toBeLessThan(0xffff);
+    const msg = raw.nextMessage();
+    raw.socket.write(frame(0x2, compressed, { rsv1: true }));
+    expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${big.toString("hex")}`);
+    expect(raw.received).toEqual([big.toString("hex")]);
+  });
 });


### PR DESCRIPTION
## What

`Bun.serve` with permessage-deflate drops the TCP connection (close code 1006, `Received too big message, or other inflation error`) on any compressed message whose DEFLATE stream ends with a BFINAL=1 block and reaches the zlib inflate loop. RFC 7692 §7.2.3.4 explicitly permits this shape and works it as an example.

The zlib loop is reached:

- for `perMessageDeflate: { decompress: "dedicated" }` at every size, and
- for the default `perMessageDeflate: true` / `{ decompress: "shared" }` whenever the inflated payload exceeds 4096 bytes (the libdeflate fast-path output buffer). 4096 bytes is delivered, 4097 bytes force-closes the socket with no close frame.

## Repro

```ts
import { deflateRawSync } from "node:zlib";
// complete raw DEFLATE stream ending in a BFINAL=1 block:
const payload = deflateRawSync(Buffer.alloc(4097, 0x61));
// send `payload` as a compressed (RSV1) frame to a Bun.serve websocket
// server with perMessageDeflate: true
//   -> connection torn down with close code 1006, no close frame
//   -> message() never fires
// Buffer.alloc(4096, 0x61) is delivered byte-exact on the same config.
```

Sync-flushed (browser/`ws`-style, no BFINAL=1) messages are delivered correctly up to `maxPayloadLength`.

## Cause

`InflationStream::inflate` in `packages/bun-uws/src/PerMessageDeflate.h` runs zlib in a loop and only accepts `Z_OK` / `Z_BUF_ERROR` as non-fatal:

```cpp
err = ::inflate(&inflationStream, Z_SYNC_FLUSH);
...
if ((err != Z_BUF_ERROR && err != Z_OK) || ...) {
    return std::nullopt;   // -> forceClose(ERR_TOO_BIG_MESSAGE_INFLATION)
}
```

A BFINAL=1 block makes zlib return `Z_STREAM_END`, which is neither, so `nullopt` is returned and the connection is force-closed. The shared path's libdeflate fast path decodes a complete BFINAL=1 stream fine into its `char buf[4096]`, so this was only visible on the default config once the inflated size exceeded that buffer and fell through to zlib.

Even if `Z_STREAM_END` were accepted, the inflater would still be in its end state, so the next message on the same connection would fail: with context takeover the stream must be reset so the sender's next (fresh) DEFLATE stream starts against an empty sliding window.

## Fix

On `Z_STREAM_END`: `inflateReset()` the stream, clear `avail_in` (remaining input is the `00 00 ff ff` tail we appended plus any sender byte-alignment padding; it decodes to nothing and must not be fed to the freshly reset stream), and treat the call as `Z_OK`. `inflateReset` does not touch `avail_out`, so the existing output-size accounting is unchanged.

## Verification

New `test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts` drives a raw-TCP WebSocket client against `Bun.serve` with each of `perMessageDeflate: true` / `"shared"` / `"dedicated"` and checks:

- a sync-flushed message (control)
- a bare BFINAL=1 message
- a BFINAL=1 message padded with `0x00` (the RFC 7692 §7.2.3.4 shape)
- a sync-flushed message following a BFINAL=1 message on the same connection (stream is reset)
- two BFINAL=1 messages back to back
- BFINAL=1 messages inflating to 4096 and 4097 bytes (the libdeflate fast-path boundary)
- a BFINAL=1 message inflating to more than 16 KiB (multi-chunk zlib path)

Before the fix, the 7 `dedicated` BFINAL cases fail at every size, and the `true`/`shared` cases fail at 4097 and 20000 bytes, with `close:1006:Received too big message, or other inflation error`. After, all 24 tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
bun test v1.4.0 (0a804f991)

test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts:
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a sync-flushed message is inflated and delivered (control) [627.61ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message is inflated and delivered [426.84ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message padded with 0x00 is inflated and delivered [415.74ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a sync-flushed message after a BFINAL=1 message is still decoded correctly [416.76ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > two BFINAL=1 messages in a row are both decoded correctly [409.63ms]
211 |   it.each([4096, 4097])("a BFINAL=1 message inflating to %d bytes is delivered intact", async size => {
212 |     using raw = await connectDeflated(pmd);
213 |     const payload = Buffer.alloc(size, "bfinal-fastpath-");
214 |     
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts:
211 |   it.each([4096, 4097])("a BFINAL=1 message inflating to %d bytes is delivered intact", async size => {
212 |     using raw = await connectDeflated(pmd);
213 |     const payload = Buffer.alloc(size, "bfinal-fastpath-");
214 |     const msg = raw.nextMessage();
215 |     raw.socket.write(frame(0x2, pmdFinal(payload), { rsv1: true }));
216 |     expect(await Promise.race([msg, raw.serverClose, raw.closed])).toBe(`message:${payload.toString("hex")}`);
                                                                         ^
error: expect(received).toBe(expected)

Expected: "message:6266696e616c2d66617374706174682d6266696e616c2d66617374706174682d6266696e616c2d6661737470617... (8004 bytes truncated) ...d6266696e616c2d66617374706174682d6266696e616c2d66617374706174682d6266696e616c2d66617374706174682d62"
Received: "close:1006:Received too big message, or other inflation error"

      at <anonymous> (/workspace/bun/test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts:216:68)
225 |     const big = Buffer.alloc(20000, "bfinal-large-chunk-");
226 |     const compressed =
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts
bun test v1.4.0 (0a804f991)

test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts:
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a sync-flushed message is inflated and delivered (control) [620.34ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message is inflated and delivered [421.66ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message padded with 0x00 is inflated and delivered [409.92ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a sync-flushed message after a BFINAL=1 message is still decoded correctly [414.35ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > two BFINAL=1 messages in a row are both decoded correctly [405.69ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message inflating to 4096 bytes is delivered intact [248.72ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message inflating to 4097
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 679ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 34.36s
[7/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revision
1.4.0-canary.1+0a804f991
[11/11] strip bun
[build] done
bun test v1.4.0-canary.1 (0a804f991)

test/js/bun/websocket/websocket-server-pmd-bfinal.test.ts:
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a sync-flushed message is inflated and delivered (control) [26.53ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message is inflated and delivered [23.65ms]
(pass) permessage-deflate BFINAL=1 (perMessageDeflate: true) > a BFINAL=1 message padded with 0x00 is inflated and delivered [23.44ms]
(pass) permessage-deflate BFINAL=
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/PerMessageDeflate.h           |   8 +
 .../websocket/websocket-server-pmd-bfinal.test.ts  | 233 +++++++++++++++++++++
 2 files changed, 241 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-uws/src/PerMessageDeflate.h                      2      2      0
…st/js/bun/websocket/websocket-server-pmd-bfinal.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->