### PR TITLE
node:cluster: worker.disconnect() drops queued send() messages and the worker never sees 'disconnect'

### DIFF
--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -1,6 +1,7 @@
 const EventEmitter = require("node:events");
 const Worker = require("internal/cluster/Worker");
 const path = require("node:path");
+const { owner_symbol } = require("internal/shared");
 
 const sendHelper = $newRustFunction("node_cluster_binding.rs", "sendHelperChild", 3);
 const onInternalMessage = $newRustFunction("node_cluster_binding.rs", "onInternalMessageChild", 2);
@@ -15,7 +16,6 @@ const indexes = new Map();
 const noop = FunctionPrototype;
 const TIMEOUT_MAX = 2 ** 31 - 1;
 const kNoFailure = 0;
-const owner_symbol = Symbol("owner_symbol");
 
 export default cluster;
 

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -308,7 +308,6 @@ function send(worker, message, handle?, cb?) {
 Worker.prototype.disconnect = function () {
   this.exitedAfterDisconnect = true;
   send(this, { act: "disconnect" });
-  this.process.disconnect();
   removeHandlesForWorker(this);
   removeWorker(this);
   return this;

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -290,6 +290,9 @@ export default {
   NodeEntryObserver,
 
   kHandle: Symbol("kHandle"),
+  // node:net and internal/cluster/child must agree on this symbol so the
+  // cluster disconnect protocol can find the net.Server owning a faux handle.
+  owner_symbol: Symbol("owner_symbol"),
   kAutoDestroyed: Symbol("kAutoDestroyed"),
   kResistStopPropagation: Symbol("kResistStopPropagation"),
   kWeakHandler: Symbol("kWeak"),

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -34,6 +34,7 @@ const {
   hasObserver,
   startPerf,
   stopPerf,
+  owner_symbol,
 } = require("internal/shared");
 import type { Socket, SocketHandler, SocketListener } from "bun";
 import type { Server as NetServer, Socket as NetSocket, ServerOpts } from "node:net";
@@ -115,7 +116,6 @@ const getBufferedAmount = $newRustFunction("runtime/socket/socket.rs", "jsGetBuf
 
 const bunTlsSymbol = Symbol.for("::buntls::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
-const owner_symbol = Symbol("owner_symbol");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -3642,6 +3642,13 @@ function listenInCluster(
     err = checkBindError(err, port, handle);
     if (err) {
       throw new ExceptionWithHostPort(err, "bind", address, port);
+    }
+    // Bun keeps the real Bun.listen() handle as server._handle rather than the
+    // cluster faux handle, so link them here: Worker#_disconnect finds the
+    // server via owner_symbol, and closing the server closes the faux handle.
+    if (handle) {
+      handle[owner_symbol] = server;
+      server.once("close", () => handle.close());
     }
     server[kRealListen](
       path,

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, joinP, tempDir, tempDirWithFiles } from "harness";
+import path from "node:path";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -184,4 +185,67 @@ test("disconnect() on a cluster.Worker built around a plain object does not abor
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "returned self: true", exitCode: 0 });
+});
+
+// worker.disconnect() must deliver every message already accepted by
+// worker.send() and let the worker observe 'disconnect'. In Node the primary
+// only enqueues {act:'disconnect'} (ordered after the user messages on the
+// same channel); the worker closes the channel from its side once received.
+test("worker.disconnect() delivers queued send() messages and the worker sees 'disconnect'", async () => {
+  using dir = tempDir("cluster-disconnect-drain", {
+    "main.js": `
+      const cluster = require("node:cluster");
+      const fs = require("node:fs");
+      const N = 50;
+      if (cluster.isPrimary) {
+        const OUT = process.argv[2];
+        const worker = cluster.fork({ OUT });
+        worker.once("message", msg => {
+          if (msg !== "ready") return;
+          // 64 KiB per message so the IPC write queue backs up past the
+          // kernel socket buffer before disconnect() is called.
+          const payload = Buffer.alloc(64 * 1024, "z").toString();
+          let acked = 0;
+          for (let i = 0; i < N; i++) worker.send({ q: "p", i, payload }, err => { if (!err) acked++; });
+          worker.disconnect();
+          let sawDisconnect = false;
+          worker.once("disconnect", () => { sawDisconnect = true; });
+          worker.once("exit", (code, signal) => {
+            const got = JSON.parse(fs.readFileSync(OUT, "utf8"));
+            console.log(JSON.stringify({
+              acked, received: got.n, workerSawDisconnect: got.saw,
+              primarySawDisconnect: sawDisconnect, exitedAfterDisconnect: worker.exitedAfterDisconnect,
+              code, signal,
+            }));
+          });
+        });
+      } else {
+        let n = 0, saw = false;
+        const dump = () => { try { fs.writeFileSync(process.env.OUT, JSON.stringify({ n, saw })); } catch {} };
+        process.on("message", m => { if (m && m.q === "p") n++; });
+        process.on("disconnect", () => { saw = true; dump(); process.exit(0); });
+        process.on("exit", dump);
+        process.send("ready");
+      }
+    `,
+  });
+  const out = path.join(String(dir), "out.json");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js", out],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(JSON.parse(stdout.trim())).toEqual({
+    acked: 50,
+    received: 50,
+    workerSawDisconnect: true,
+    primarySawDisconnect: true,
+    exitedAfterDisconnect: true,
+    code: 0,
+    signal: null,
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
`worker.send()` followed by `worker.disconnect()` is the documented graceful-shutdown pattern for cluster workers. In Bun the primary discards every message still queued in the IPC write buffer and the worker never gets its `'disconnect'` event, so rolling-restart / drain loops silently lose work.

## Reproduction

```js
import cluster from "node:cluster";
if (cluster.isPrimary) {
  const w = cluster.fork();
  await new Promise(r => w.once("message", r));
  const payload = Buffer.alloc(64 * 1024, "z").toString();
  for (let i = 0; i < 50; i++) w.send({ i, payload });   // every send() returns true
  w.disconnect();
  // node: worker receives all 50, then 'disconnect', then exits
  // bun:  worker receives ~3, sees the channel abruptly close, exits
} else {
  let n = 0;
  process.on("message", () => n++);
  process.on("disconnect", () => { console.log("got", n); process.exit(0); });
  process.send("ready");
}
```

Node v26: `got 50`. Bun 1.4.0: `got 3` (varies with scheduling) and the worker's `'disconnect'` listener never fires.

## Cause

`Worker.prototype.disconnect` in `internal/cluster/primary.ts` calls `this.process.disconnect()` right after queueing the internal `{act:'disconnect'}` message. Node's `primary.js` has never had this call: the primary only enqueues `{act:'disconnect'}` (ordered after the user's messages on the same channel) and the worker closes the channel from its side once it has drained its servers. Closing the primary's end first discards the still-queued outbound writes, including the internal disconnect message itself, so the worker treats it as an unexpected channel close and exits before user `'disconnect'` listeners run.

Removing that call exposes a second bug in the worker-side `_disconnect`: `internal/cluster/child.ts` and `node:net` each declared their own private `Symbol("owner_symbol")`, so `handle[owner_symbol]` on a cluster faux handle was always `undefined` and `_disconnect` fell through to the faux `close()` (which ignores its callback). `waitingCount` never reached zero and the worker never called `process.disconnect()`. Previously the primary's force-close masked this by closing the channel anyway; without it, a worker holding a `net.Server` would hang forever on `disconnect()`.

## Fix

- `internal/cluster/primary.ts`: drop the `this.process.disconnect()` call so the worker owns channel teardown, matching Node.
- `internal/shared.ts`: a single shared `owner_symbol` that `node:net` and `internal/cluster/child` both import.
- `node:net` `listenInCluster`: set `handle[owner_symbol] = server` on the cluster faux handle and close it when the server closes, so `_disconnect` can call `server.close(cb)` and complete.

This is a subset of the src/ changes in #30548, which reached the same primary-side conclusion while fixing the server-shutdown hang. That PR additionally handles `http.Server` in cluster workers via a new `_trackServer` hook; this PR is narrower so the data-loss fix can land independently.

## Verification

New test in `test/js/node/cluster.test.ts` sends 50 messages with 64 KiB payloads (enough to back up past the kernel socket buffer), calls `worker.disconnect()`, and asserts the worker received all 50 and observed `'disconnect'`. On current main: `received: 3, workerSawDisconnect: false`. With this change it matches Node. `test-cluster-worker-wait-server-close.js`'s in-worker assertion (`serverClosed` before `'disconnect'`) now passes instead of firing in a worker that was already being force-exited. All 54 `test/js/node/test/parallel/test-cluster-*.js` tests pass.