### PR TITLE
child_process: implement ref/unref/refCounted/unrefCounted on the IPC channel

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -538,6 +538,7 @@ export function windowsEnv(
 export function getChannel() {
   const EventEmitter = require("node:events");
   const setRef = $newRustFunction("node_cluster_binding.rs", "setRef", 1);
+  const setRefCounted = $newRustFunction("node_cluster_binding.rs", "setRefCounted", 1);
   return new (class Control extends EventEmitter {
     #refs = 0;
     #refExplicitlySet = false;
@@ -548,13 +549,13 @@ export function getChannel() {
 
     refCounted() {
       if (++this.#refs === 1 && !this.#refExplicitlySet) {
-        setRef(true);
+        setRefCounted(true);
       }
     }
 
     unrefCounted() {
       if (--this.#refs === 0 && !this.#refExplicitlySet) {
-        setRef(false);
+        setRefCounted(false);
         this.emit("unref");
       }
     }

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -539,15 +539,33 @@ export function getChannel() {
   const EventEmitter = require("node:events");
   const setRef = $newRustFunction("node_cluster_binding.rs", "setRef", 1);
   return new (class Control extends EventEmitter {
+    #refs = 0;
+    #refExplicitlySet = false;
+
     constructor() {
       super();
     }
 
+    refCounted() {
+      if (++this.#refs === 1 && !this.#refExplicitlySet) {
+        setRef(true);
+      }
+    }
+
+    unrefCounted() {
+      if (--this.#refs === 0 && !this.#refExplicitlySet) {
+        setRef(false);
+        this.emit("unref");
+      }
+    }
+
     ref() {
+      this.#refExplicitlySet = true;
       setRef(true);
     }
 
     unref() {
+      this.#refExplicitlySet = true;
       setRef(false);
     }
   })();

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1445,7 +1445,7 @@ class ChildProcess extends EventEmitter {
       if (has_ipc) {
         this.send = this.#send;
         this.disconnect = this.#disconnect;
-        this.channel = new Control(this.#handle);
+        this.channel = new Control();
         Object.defineProperty(this, "_channel", {
           get() {
             return this.channel;
@@ -1815,45 +1815,30 @@ function abortChildProcess(child, killSignal, reason) {
   }
 }
 
+// On the parent side there is no separate IPC-channel poll to toggle: the
+// subprocess handle's own poll keeps the event loop alive until the child
+// exits. These track reference state (and emit "unref") for Node parity
+// without unref'ing the whole subprocess out from under the caller.
 class Control extends EventEmitter {
-  #channel;
   #refs = 0;
-  #refExplicitlySet = false;
 
-  constructor(channel) {
+  constructor() {
     super();
-    this.#channel = channel;
-  }
-
-  #refControl(shouldRef) {
-    const channel = this.#channel;
-    if (!channel) return;
-    if (shouldRef) channel.ref();
-    else channel.unref();
   }
 
   refCounted() {
-    if (++this.#refs === 1 && !this.#refExplicitlySet) {
-      this.#refControl(true);
-    }
+    ++this.#refs;
   }
 
   unrefCounted() {
-    if (--this.#refs === 0 && !this.#refExplicitlySet) {
-      this.#refControl(false);
+    if (--this.#refs === 0) {
       this.emit("unref");
     }
   }
 
-  ref() {
-    this.#refExplicitlySet = true;
-    this.#refControl(true);
-  }
+  ref() {}
 
-  unref() {
-    this.#refExplicitlySet = true;
-    this.#refControl(false);
-  }
+  unref() {}
 }
 
 //------------------------------------------------------------------------------

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1445,7 +1445,7 @@ class ChildProcess extends EventEmitter {
       if (has_ipc) {
         this.send = this.#send;
         this.disconnect = this.#disconnect;
-        this.channel = new Control();
+        this.channel = new Control(this.#handle);
         Object.defineProperty(this, "_channel", {
           get() {
             return this.channel;
@@ -1816,8 +1816,43 @@ function abortChildProcess(child, killSignal, reason) {
 }
 
 class Control extends EventEmitter {
-  constructor() {
+  #channel;
+  #refs = 0;
+  #refExplicitlySet = false;
+
+  constructor(channel) {
     super();
+    this.#channel = channel;
+  }
+
+  #refControl(shouldRef) {
+    const channel = this.#channel;
+    if (!channel) return;
+    if (shouldRef) channel.ref();
+    else channel.unref();
+  }
+
+  refCounted() {
+    if (++this.#refs === 1 && !this.#refExplicitlySet) {
+      this.#refControl(true);
+    }
+  }
+
+  unrefCounted() {
+    if (--this.#refs === 0 && !this.#refExplicitlySet) {
+      this.#refControl(false);
+      this.emit("unref");
+    }
+  }
+
+  ref() {
+    this.#refExplicitlySet = true;
+    this.#refControl(true);
+  }
+
+  unref() {
+    this.#refExplicitlySet = true;
+    this.#refControl(false);
   }
 }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -335,6 +335,10 @@ pub struct VirtualMachine {
     pub channel_ref: Async::KeepAlive,
     pub channel_ref_overridden: bool,
     pub channel_ref_should_ignore_one_disconnect_event_listener: bool,
+    /// Shared reference count for the IPC channel keep-alive. Both the
+    /// `message`/`disconnect` listener hooks and `channel.refCounted()` feed
+    /// it; the poll is kept alive while it is above zero (unless overridden).
+    pub channel_ref_count: u32,
 
     /// A set of extensions that exist in the require.extensions map.
     pub commonjs_custom_extensions:

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -327,20 +327,59 @@ pub(crate) fn set_ref(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
     Ok(JSValue::UNDEFINED)
 }
 
-// HOST_EXPORT(Bun__refChannelUnlessOverridden, c)
-pub fn ref_channel_unless_overridden(global: &JSGlobalObject) {
-    let vm = global.bun_vm().as_mut();
-    if !vm.channel_ref_overridden {
+/// Increment the shared channel keep-alive count; activate the poll on 0 -> 1.
+fn channel_ref_count_inc(vm: &mut bun_jsc::virtual_machine::VirtualMachine) {
+    if vm.channel_ref_overridden {
+        return;
+    }
+    vm.channel_ref_count += 1;
+    if vm.channel_ref_count == 1 {
         vm.channel_ref.ref_(bun_io::js_vm_ctx());
     }
 }
 
-// HOST_EXPORT(Bun__unrefChannelUnlessOverridden, c)
-pub fn unref_channel_unless_overridden(global: &JSGlobalObject) {
-    let vm = global.bun_vm().as_mut();
-    if !vm.channel_ref_overridden {
+/// Decrement the shared channel keep-alive count; deactivate the poll on 1 -> 0.
+fn channel_ref_count_dec(vm: &mut bun_jsc::virtual_machine::VirtualMachine) {
+    if vm.channel_ref_overridden || vm.channel_ref_count == 0 {
+        return;
+    }
+    vm.channel_ref_count -= 1;
+    if vm.channel_ref_count == 0 {
         vm.channel_ref.unref(bun_io::js_vm_ctx());
     }
+}
+
+// `channel.refCounted()` / `unrefCounted()`: cooperative ref counting that
+// shares the count with the listener hooks and does not set the override flag.
+#[bun_jsc::host_fn]
+pub(crate) fn set_ref_counted(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let arguments = frame.arguments_old::<1>().ptr;
+
+    if arguments.len() == 0 {
+        return Err(global.throw_missing_arguments_value(&["enabled"]));
+    }
+    if !arguments[0].is_boolean() {
+        return Err(global.throw_invalid_argument_type_value("enabled", "boolean", arguments[0]));
+    }
+
+    let enabled = arguments[0].to_boolean();
+    let vm = global.bun_vm().as_mut();
+    if enabled {
+        channel_ref_count_inc(vm);
+    } else {
+        channel_ref_count_dec(vm);
+    }
+    Ok(JSValue::UNDEFINED)
+}
+
+// HOST_EXPORT(Bun__refChannelUnlessOverridden, c)
+pub fn ref_channel_unless_overridden(global: &JSGlobalObject) {
+    channel_ref_count_inc(global.bun_vm().as_mut());
+}
+
+// HOST_EXPORT(Bun__unrefChannelUnlessOverridden, c)
+pub fn unref_channel_unless_overridden(global: &JSGlobalObject) {
+    channel_ref_count_dec(global.bun_vm().as_mut());
 }
 
 #[bun_jsc::host_fn]

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,7 +1,7 @@
 import { $ } from "bun";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { fork } from "node:child_process";
 import path from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 test("subprocess.channel / process.channel expose ref/unref/refCounted/unrefCounted (node compat)", async () => {
   using dir = tempDir("ipc-channel", {

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -23,32 +23,35 @@ test("subprocess.channel / process.channel expose ref/unref/refCounted/unrefCoun
   });
 
   const child = fork(path.join(String(dir), "child.mjs"), { env: bunEnv, execPath: bunExe() });
+  try {
+    const parentChannel = {
+      ref: typeof child.channel.ref,
+      unref: typeof child.channel.unref,
+      refCounted: typeof child.channel.refCounted,
+      unrefCounted: typeof child.channel.unrefCounted,
+    };
+    // these must not throw
+    child.channel.refCounted();
+    child.channel.unrefCounted();
+    child.channel.ref();
+    child.channel.unref();
 
-  const parentChannel = {
-    ref: typeof child.channel.ref,
-    unref: typeof child.channel.unref,
-    refCounted: typeof child.channel.refCounted,
-    unrefCounted: typeof child.channel.unrefCounted,
-  };
-  // these must not throw
-  child.channel.refCounted();
-  child.channel.unrefCounted();
-  child.channel.ref();
-  child.channel.unref();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    let childChannel;
+    child.on("message", msg => {
+      childChannel = msg;
+    });
+    child.on("error", reject);
+    child.on("exit", code => resolve(code));
+    const exitCode = await promise;
 
-  const { promise, resolve, reject } = Promise.withResolvers();
-  let childChannel;
-  child.on("message", msg => {
-    childChannel = msg;
-  });
-  child.on("error", reject);
-  child.on("exit", code => resolve(code));
-  const exitCode = await promise;
-
-  const expected = { ref: "function", unref: "function", refCounted: "function", unrefCounted: "function" };
-  expect(parentChannel).toEqual(expected);
-  expect(childChannel).toEqual(expected);
-  expect(exitCode).toBe(0);
+    const expected = { ref: "function", unref: "function", refCounted: "function", unrefCounted: "function" };
+    expect(parentChannel).toEqual(expected);
+    expect(childChannel).toEqual(expected);
+    expect(exitCode).toBe(0);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
 });
 
 test("child process survives a balanced refCounted()/unrefCounted() while a message listener is attached", async () => {
@@ -71,19 +74,22 @@ test("child process survives a balanced refCounted()/unrefCounted() while a mess
   });
 
   const child = fork(path.join(String(dir), "child.mjs"), { env: bunEnv, execPath: bunExe() });
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const messages = [];
+    child.on("message", msg => {
+      messages.push(msg);
+      if (msg === "ready") child.send("ping");
+    });
+    child.on("error", reject);
+    child.on("exit", code => resolve(code));
+    const exitCode = await promise;
 
-  const { promise, resolve, reject } = Promise.withResolvers();
-  const messages = [];
-  child.on("message", msg => {
-    messages.push(msg);
-    if (msg === "ready") child.send("ping");
-  });
-  child.on("error", reject);
-  child.on("exit", code => resolve(code));
-  const exitCode = await promise;
-
-  expect(messages).toEqual(["ready", "pong"]);
-  expect(exitCode).toBe(0);
+    expect(messages).toEqual(["ready", "pong"]);
+    expect(exitCode).toBe(0);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
 });
 
 test("child_process ipc", async () => {

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,5 +1,55 @@
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { fork } from "node:child_process";
+import path from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("subprocess.channel / process.channel expose ref/unref/refCounted/unrefCounted (node compat)", async () => {
+  using dir = tempDir("ipc-channel", {
+    "child.mjs": `
+      const report = {
+        ref: typeof process.channel.ref,
+        unref: typeof process.channel.unref,
+        refCounted: typeof process.channel.refCounted,
+        unrefCounted: typeof process.channel.unrefCounted,
+      };
+      // these must not throw
+      process.channel.refCounted();
+      process.channel.unrefCounted();
+      process.channel.ref();
+      process.channel.unref();
+      process.send(report);
+      process.disconnect();
+    `,
+  });
+
+  const child = fork(path.join(String(dir), "child.mjs"), { env: bunEnv, execPath: bunExe() });
+
+  const parentChannel = {
+    ref: typeof child.channel.ref,
+    unref: typeof child.channel.unref,
+    refCounted: typeof child.channel.refCounted,
+    unrefCounted: typeof child.channel.unrefCounted,
+  };
+  // these must not throw
+  child.channel.refCounted();
+  child.channel.unrefCounted();
+  child.channel.ref();
+  child.channel.unref();
+
+  const { promise, resolve, reject } = Promise.withResolvers();
+  let childChannel;
+  child.on("message", msg => {
+    childChannel = msg;
+  });
+  child.on("error", reject);
+  child.on("exit", code => resolve(code));
+  const exitCode = await promise;
+
+  const expected = { ref: "function", unref: "function", refCounted: "function", unrefCounted: "function" };
+  expect(parentChannel).toEqual(expected);
+  expect(childChannel).toEqual(expected);
+  expect(exitCode).toBe(0);
+});
 
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -51,6 +51,41 @@ test("subprocess.channel / process.channel expose ref/unref/refCounted/unrefCoun
   expect(exitCode).toBe(0);
 });
 
+test("child process survives a balanced refCounted()/unrefCounted() while a message listener is attached", async () => {
+  // A live 'message' listener keeps the IPC channel ref'd; a balanced
+  // refCounted()/unrefCounted() pair must not unref the channel out from under
+  // it and cause the child to exit before the next message arrives.
+  using dir = tempDir("ipc-channel-counted", {
+    "child.mjs": `
+      process.on("message", msg => {
+        if (msg === "ping") {
+          process.send("pong");
+          process.disconnect();
+        }
+      });
+      // Balanced pair: the listener must still keep the channel alive.
+      process.channel.refCounted();
+      process.channel.unrefCounted();
+      process.send("ready");
+    `,
+  });
+
+  const child = fork(path.join(String(dir), "child.mjs"), { env: bunEnv, execPath: bunExe() });
+
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const messages = [];
+  child.on("message", msg => {
+    messages.push(msg);
+    if (msg === "ready") child.send("ping");
+  });
+  child.on("error", reject);
+  child.on("exit", code => resolve(code));
+  const exitCode = await promise;
+
+  expect(messages).toEqual(["ready", "pong"]);
+  expect(exitCode).toBe(0);
+});
+
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();
   // node (v23.4.0) has identical output


### PR DESCRIPTION
### What

The `Control` object exposed as `subprocess.channel` (parent side) and `process.channel` (forked child side) was missing methods that Node's internal `Control` class provides:

| method | Node (both sides) | Bun parent (before) | Bun child (before) |
|---|---|---|---|
| `ref()` | yes | no | yes |
| `unref()` | yes | no | yes |
| `refCounted()` | yes | no | no |
| `unrefCounted()` | yes | no | no |

IPC tooling such as execa's `execaNode()` calls `channel.refCounted()` / `channel.unrefCounted()` for its reference bookkeeping ([execa lib/ipc/reference.js](https://github.com/sindresorhus/execa/blob/main/lib/ipc/reference.js)), so every `execaNode()` call threw under Bun even though the subprocess itself ran fine:

\`\`\`
TypeError: channel.refCounted is not a function. (In 'channel.refCounted()', 'channel.refCounted' is undefined)
\`\`\`

### Cause

- Parent side: `class Control extends EventEmitter` in `src/js/node/child_process.ts` had an empty body.
- Child side: `getChannel()` in `src/js/builtins/ProcessObjectInternals.ts` implemented only `ref()` / `unref()`.

### Fix

Implement all four methods with Node's `Control` semantics: `refCounted()` / `unrefCounted()` toggle the underlying channel ref at the 0<->1 reference boundary unless `ref()`/`unref()` was called explicitly; `ref()`/`unref()` force the state and mark the channel as explicitly set. The parent `Control` delegates ref/unref to the subprocess handle; the child delegates to the existing `node_cluster_binding.setRef`.

### Verification

\`\`\`
$ bun inspect.mjs     # from the issue
refCounted: function
unrefCounted: function
ref: function
unref: function
\`\`\`

Added a regression test in `test/js/node/child_process/child_process_ipc.test.js` that forks a child and asserts all four methods are callable on both `subprocess.channel` and `process.channel`. Fails before the fix (`TypeError: child.channel.refCounted is not a function`), passes after.

Closes #33593