### PR TITLE
Resolve long data: URL module specifiers instead of rejecting as NameTooLong

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4228,6 +4228,15 @@ impl VirtualMachine {
         )
     }
 
+    /// Whether a file-path `specifier` is too long to resolve on disk. `data:`
+    /// URLs are resolved by the data-URL resolver, not the filesystem, so their
+    /// length is unbounded by any path limit. Shared with
+    /// `jsc_hooks::resolve_hook` so both resolver paths use one threshold.
+    pub fn specifier_exceeds_path_limit(specifier: &bun_core::String) -> bool {
+        const MAX_LEN: usize = bun_paths::MAX_PATH_BYTES * 3 / 2;
+        specifier.length() > MAX_LEN && !specifier.has_prefix_comptime(b"data:")
+    }
+
     /// Module-resolution core: resolves `specifier` relative to `source`, with path-length checks when `IS_A_FILE_PATH`.
     pub fn resolve_maybe_needs_trailing_slash<const IS_A_FILE_PATH: bool>(
         res: &mut ErrorableString,
@@ -4238,13 +4247,7 @@ impl VirtualMachine {
         is_esm: bool,
         is_user_require_resolve: bool,
     ) -> JsResult<()> {
-        // `data:` URLs are resolved by the data-URL resolver, not the
-        // filesystem, so their length is unbounded by any path limit.
-        const MAX_LEN: usize = (bun_paths::MAX_PATH_BYTES as f64 * 1.5) as usize;
-        if IS_A_FILE_PATH
-            && specifier.length() > MAX_LEN
-            && !specifier.has_prefix_comptime(b"data:")
-        {
+        if IS_A_FILE_PATH && Self::specifier_exceeds_path_limit(&specifier) {
             let specifier_utf8 = specifier.to_utf8();
             let source_utf8 = source.to_utf8();
             let import_kind = if is_esm {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4238,8 +4238,11 @@ impl VirtualMachine {
         is_esm: bool,
         is_user_require_resolve: bool,
     ) -> JsResult<()> {
+        // `data:` URLs are resolved by the data-URL resolver, not the
+        // filesystem, so their length is unbounded by any path limit.
         const MAX_LEN: usize = (bun_paths::MAX_PATH_BYTES as f64 * 1.5) as usize;
-        if IS_A_FILE_PATH && specifier.length() > MAX_LEN {
+        if IS_A_FILE_PATH && specifier.length() > MAX_LEN && !specifier.has_prefix_comptime(b"data:")
+        {
             let specifier_utf8 = specifier.to_utf8();
             let source_utf8 = source.to_utf8();
             let import_kind = if is_esm {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4241,7 +4241,9 @@ impl VirtualMachine {
         // `data:` URLs are resolved by the data-URL resolver, not the
         // filesystem, so their length is unbounded by any path limit.
         const MAX_LEN: usize = (bun_paths::MAX_PATH_BYTES as f64 * 1.5) as usize;
-        if IS_A_FILE_PATH && specifier.length() > MAX_LEN && !specifier.has_prefix_comptime(b"data:")
+        if IS_A_FILE_PATH
+            && specifier.length() > MAX_LEN
+            && !specifier.has_prefix_comptime(b"data:")
         {
             let specifier_utf8 = specifier.to_utf8();
             let source_utf8 = source.to_utf8();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4940,15 +4940,8 @@ unsafe fn resolve_hook(
     // through under Stacked Borrows.
     let vm: *mut VirtualMachine = global_ref.bun_vm_ptr();
 
-    // Overlong specifier guard. `MAX_PATH_BYTES * 1.5`, truncated:
-    // integer `* 3 / 2` is exact for the powers-of-two MAX_PATH_BYTES values.
-    // `data:` URLs are resolved by the data-URL resolver, not the filesystem,
-    // so their length is unbounded by any path limit.
-    const MAX_SPECIFIER_LEN: usize = bun_paths::MAX_PATH_BYTES * 3 / 2;
-    if is_a_file_path
-        && specifier.length() > MAX_SPECIFIER_LEN
-        && !specifier.has_prefix_comptime(b"data:")
-    {
+    // Overlong specifier guard (shared threshold + `data:` exemption).
+    if is_a_file_path && VirtualMachine::specifier_exceeds_path_limit(&specifier) {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
         let import_kind = if is_esm {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4942,8 +4942,13 @@ unsafe fn resolve_hook(
 
     // Overlong specifier guard. `MAX_PATH_BYTES * 1.5`, truncated:
     // integer `* 3 / 2` is exact for the powers-of-two MAX_PATH_BYTES values.
+    // `data:` URLs are resolved by the data-URL resolver, not the filesystem,
+    // so their length is unbounded by any path limit.
     const MAX_SPECIFIER_LEN: usize = bun_paths::MAX_PATH_BYTES * 3 / 2;
-    if is_a_file_path && specifier.length() > MAX_SPECIFIER_LEN {
+    if is_a_file_path
+        && specifier.length() > MAX_SPECIFIER_LEN
+        && !specifier.has_prefix_comptime(b"data:")
+    {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
         let import_kind = if is_esm {

--- a/test/js/web/workers/data-url-module.test.ts
+++ b/test/js/web/workers/data-url-module.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+
+// A data: URL module specifier longer than the filesystem path limit must not
+// be rejected as an overlong file path: it is resolved by the data-URL
+// resolver, not on disk. The overlong-specifier guard trips at
+// MAX_PATH_BYTES * 1.5, which is ~147KB on Windows, so pad well past that to
+// exercise the limit on every platform.
+// https://github.com/oven-sh/bun/issues/33596
+// https://github.com/oven-sh/bun/issues/20374
+const padding = Buffer.alloc(200_000, "x").toString();
+
+test("new Worker() runs a long base64 data: URL", async () => {
+  const source = `/* ${padding} */\nself.onmessage = e => postMessage(e.data + 1);\n`;
+  const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
+  expect(url.length).toBeGreaterThan(150_000);
+
+  const worker = new Worker(url);
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  worker.onerror = e => reject(new Error(e.message));
+  worker.onmessage = e => resolve(e.data);
+  worker.postMessage(41);
+  try {
+    expect(await promise).toBe(42);
+  } finally {
+    worker.terminate();
+  }
+});
+
+test("import() loads a long base64 data: URL", async () => {
+  const source = `/* ${padding} */\nexport default 42;\n`;
+  const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
+  expect(url.length).toBeGreaterThan(150_000);
+
+  const module = await import(url);
+  expect(module.default).toBe(42);
+});

--- a/test/js/web/workers/data-url-module.test.ts
+++ b/test/js/web/workers/data-url-module.test.ts
@@ -1,15 +1,12 @@
 import { expect, test } from "bun:test";
 
-// A data: URL module specifier longer than the filesystem path limit must not
-// be rejected as an overlong file path: it is resolved by the data-URL
-// resolver, not on disk. The overlong-specifier guard trips at
-// MAX_PATH_BYTES * 1.5, which is ~147KB on Windows, so pad well past that to
-// exercise the limit on every platform.
-// https://github.com/oven-sh/bun/issues/33596
-// https://github.com/oven-sh/bun/issues/20374
+// A long data: URL must resolve via the data-URL resolver, not be rejected as
+// an overlong file path. The guard trips at MAX_PATH_BYTES * 1.5 (~147KB on
+// Windows), so pad past that to exercise the limit on every platform.
+// https://github.com/oven-sh/bun/issues/33596 https://github.com/oven-sh/bun/issues/20374
 const padding = Buffer.alloc(200_000, "x").toString();
 
-test("new Worker() runs a long base64 data: URL", async () => {
+test.concurrent("new Worker() runs a long base64 data: URL", async () => {
   const source = `/* ${padding} */\nself.onmessage = e => postMessage(e.data + 1);\n`;
   const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
   expect(url.length).toBeGreaterThan(150_000);
@@ -26,7 +23,7 @@ test("new Worker() runs a long base64 data: URL", async () => {
   }
 });
 
-test("import() loads a long base64 data: URL", async () => {
+test.concurrent("import() loads a long base64 data: URL", async () => {
   const source = `/* ${padding} */\nexport default 42;\n`;
   const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
   expect(url.length).toBeGreaterThan(150_000);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -296,6 +296,20 @@ describe("web worker", () => {
       expect(err.error).toBe(null);
     });
   });
+
+  // A data: URL longer than the filesystem path limit must not be rejected as
+  // an overlong file path: it is resolved by the data-URL resolver.
+  // https://github.com/oven-sh/bun/issues/33596
+  test("runs a long base64 data: URL worker", async () => {
+    const padding = Buffer.alloc(8192, "x").toString();
+    const source = `/* ${padding} */\nself.onmessage = e => postMessage(e.data + 1);\n`;
+    const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
+    expect(url.length).toBeGreaterThan(8192);
+
+    const worker = new Worker(url);
+    const result = await waitForWorkerResult(worker, 41);
+    expect(result).toBe(42);
+  });
 });
 
 // TODO: move to node:worker_threads tests directory

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -296,20 +296,6 @@ describe("web worker", () => {
       expect(err.error).toBe(null);
     });
   });
-
-  // A data: URL longer than the filesystem path limit must not be rejected as
-  // an overlong file path: it is resolved by the data-URL resolver.
-  // https://github.com/oven-sh/bun/issues/33596
-  test("runs a long base64 data: URL worker", async () => {
-    const padding = Buffer.alloc(8192, "x").toString();
-    const source = `/* ${padding} */\nself.onmessage = e => postMessage(e.data + 1);\n`;
-    const url = `data:application/javascript;base64,${Buffer.from(source).toString("base64")}`;
-    expect(url.length).toBeGreaterThan(8192);
-
-    const worker = new Worker(url);
-    const result = await waitForWorkerResult(worker, 41);
-    expect(result).toBe(42);
-  });
 });
 
 // TODO: move to node:worker_threads tests directory


### PR DESCRIPTION
### What

`new Worker(dataUrl)` and `import(dataUrl)` fail with `NameTooLong` when the `data:` URL is longer than ~6KB. Fixes #33596. Fixes #20374 (the dynamic-import variant of the same guard).

### Repro

```js
const padding = Buffer.alloc(8192, "x").toString();
const src = `/* ${padding} */\nself.onmessage = e => postMessage(e.data + 1);\n`;
const url = `data:application/javascript;base64,${Buffer.from(src).toString("base64")}`;
new Worker(url); // error: NameTooLong while resolving package 'data:...' from 'bun:main'
```

The same failure happens for a plain `import(url)` of a large data URL. `ffjavascript` base64-encodes a ~2.6KB worker blob into a `data:` URL and trips this; because it only attaches a `message` listener (no `error`), the worker never replies and the caller hangs forever.

### Cause

The module resolver has an overlong-specifier guard that rejects any specifier longer than `MAX_PATH_BYTES * 1.5` (~6144 bytes on Linux) as `NameTooLong`, to avoid handing absurdly long paths to the filesystem resolver. A `data:` URL is not a filesystem path: it is resolved by the data-URL resolver regardless of length, so the guard fired before resolution could succeed. Short data URLs stayed under the limit, which is why they worked.

The guard exists in both resolution entry points (`VirtualMachine::resolve_maybe_needs_trailing_slash`, used by ESM `import`, and `resolve_hook` in `jsc_hooks.rs`).

### Fix

Exclude `data:` URL specifiers from the overlong-specifier guard in both paths so they flow through to the data-URL resolver.

### Verification

Added a regression test in `test/js/web/workers/worker.test.ts` that spawns a worker from a >8KB base64 `data:` URL and asserts it echoes a message back. Fails on the released build (`NameTooLong`), passes with the fix. Full `worker.test.ts` and `worker_blob.test.ts` suites pass.
