### PR TITLE
Blob: encode content_type ownership in the type to fix invalid free of static mime pointer

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -40,6 +40,82 @@ pub enum ClosingState {
     Closing,
 }
 
+/// A Blob's `type` string with ownership encoded in the variant, so assigning
+/// a new value drops the old one and a static pointer can never be freed.
+pub enum BlobContentType {
+    Static(&'static [u8]),
+    Owned(Box<[u8]>),
+}
+
+impl Default for BlobContentType {
+    #[inline]
+    fn default() -> Self {
+        Self::Static(b"")
+    }
+}
+
+impl BlobContentType {
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Static(s) => s,
+            Self::Owned(b) => b,
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+
+    #[inline]
+    pub fn is_owned(&self) -> bool {
+        matches!(self, Self::Owned(_))
+    }
+
+    #[inline]
+    pub fn dupe(&self) -> Self {
+        match self {
+            Self::Static(s) => Self::Static(s),
+            Self::Owned(b) => Self::Owned(b.clone()),
+        }
+    }
+
+    /// Borrow a `MimeType`'s value: `'static` stays static, `Owned` is cloned.
+    #[inline]
+    pub fn from_mime(mime: &MimeType) -> Self {
+        match &mime.value {
+            std::borrow::Cow::Borrowed(s) => Self::Static(s),
+            std::borrow::Cow::Owned(v) => Self::Owned(v.as_slice().into()),
+        }
+    }
+
+    /// Heap-owned ASCII-lowercased copy of `slice`.
+    #[inline]
+    pub fn from_lowercased(slice: &[u8]) -> Self {
+        let mut buf = vec![0u8; slice.len()];
+        bun_core::strings::copy_lowercase(slice, &mut buf);
+        Self::Owned(buf.into_boxed_slice())
+    }
+}
+
+impl From<MimeType> for BlobContentType {
+    #[inline]
+    fn from(mime: MimeType) -> Self {
+        match mime.value {
+            std::borrow::Cow::Borrowed(s) => Self::Static(s),
+            std::borrow::Cow::Owned(v) => Self::Owned(v.into_boxed_slice()),
+        }
+    }
+}
+
+impl From<Box<[u8]>> for BlobContentType {
+    #[inline]
+    fn from(b: Box<[u8]>) -> Self {
+        Self::Owned(b)
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Blob
 // ──────────────────────────────────────────────────────────────────────────
@@ -60,11 +136,7 @@ pub struct Blob {
     /// Intrusively-refcounted backing store. `StoreRef::clone`/`drop` map
     /// directly to `Store::ref_()`/`Store::deref()`.
     pub store: JsCell<Option<StoreRef>>,
-    /// Either a `&'static [u8]` (mime constant / literal) or a heap allocation
-    /// owned by this Blob, discriminated by `content_type_allocated`.
-    /// (`Cow<'static, [u8]>` is not `#[repr(C)]`, so the manual encoding stays.)
-    pub content_type: Cell<*const [u8]>,
-    pub content_type_allocated: Cell<bool>,
+    pub content_type: JsCell<BlobContentType>,
     pub content_type_was_set: Cell<bool>,
     /// Cached encoding probe of `shared_view()`.
     pub charset: Cell<AsciiStatus>,
@@ -83,11 +155,10 @@ pub struct Blob {
     pub name: bun_core::OwnedStringCell,
 }
 
-// SAFETY: `Blob` holds raw pointers (`content_type`, `global_this`) which
-// default to `!Send`/`!Sync`. `Blob` moves across threads
-// under `ObjectURLRegistry`'s mutex and via the work-pool read/write tasks;
-// the pointee data is either `'static`/heap-owned (`content_type`) or an
-// opaque JSC handle only ever dereferenced on its owning JS thread.
+// SAFETY: `Blob` holds a raw `global_this` pointer which defaults to
+// `!Send`/`!Sync`. `Blob` moves across threads under `ObjectURLRegistry`'s
+// mutex and via the work-pool read/write tasks; `global_this` is an opaque
+// JSC handle only ever dereferenced on its owning JS thread.
 unsafe impl Send for Blob {}
 // SAFETY: concurrent `&Blob` access only occurs under `ObjectURLRegistry`'s
 // mutex or on the single owning JS thread; the `Cell` fields are never raced.
@@ -100,8 +171,7 @@ impl Default for Blob {
             size: Cell::new(0),
             offset: Cell::new(0),
             store: JsCell::new(None),
-            content_type: Cell::new(std::ptr::from_ref::<[u8]>(b"" as &'static [u8])),
-            content_type_allocated: Cell::new(false),
+            content_type: JsCell::new(BlobContentType::default()),
             content_type_was_set: Cell::new(false),
             charset: Cell::new(AsciiStatus::Unknown),
             is_jsdom_file: Cell::new(false),
@@ -194,10 +264,7 @@ impl Blob {
 
     #[inline]
     pub fn content_type_slice(&self) -> &[u8] {
-        // SAFETY: `content_type` is always a valid (possibly empty) slice
-        // pointer owned either by `'static` data or by this `Blob` (when
-        // `content_type_allocated`).
-        unsafe { &*self.content_type.get() }
+        self.content_type.get().as_slice()
     }
 
     /// Borrowed accessor for the `JsCell`-wrapped store. R-2: the field is
@@ -228,34 +295,15 @@ impl Blob {
         (!p.is_null()).then(|| JSGlobalObject::opaque_ref(p))
     }
 
-    /// Free a heap-owned `content_type` (if any) and reset to the empty
-    /// static slice. Centralizes the `heap::take` so callers replacing
-    /// `content_type` don't each carry their own `unsafe` block.
-    #[inline]
-    pub fn free_content_type(&self) {
-        if self.content_type_allocated.get() {
-            // SAFETY: `content_type_allocated` implies `content_type` was set
-            // via `heap::alloc(_.into_boxed_slice())` and is solely owned
-            // by this `Blob`.
-            unsafe { drop(bun_core::heap::take(self.content_type.get().cast_mut())) };
-            self.content_type
-                .set(std::ptr::from_ref::<[u8]>(b"" as &'static [u8]));
-            self.content_type_allocated.set(false);
-        }
-    }
-
     /// Accepts both
     /// `Box<Store>` (from `Store::new` / `Store::init*`) and `StoreRef`.
     pub fn init_with_store<S: Into<StoreRef>>(store: S, global_this: &JSGlobalObject) -> Blob {
         let store: StoreRef = store.into();
         let size = store.size();
-        // `MimeType::value` is `Cow<'static, [u8]>`; the raw slice pointer is
-        // stable for the life of `store` (either `'static` or backed by the heap
-        // allocation we hold a ref to in `self.store`).
-        let content_type: *const [u8] = if let store::Data::File(ref f) = store.data {
-            std::ptr::from_ref::<[u8]>(f.mime_type.value.as_ref())
+        let content_type = if let store::Data::File(ref f) = store.data {
+            BlobContentType::from_mime(&f.mime_type)
         } else {
-            std::ptr::from_ref::<[u8]>(b"" as &'static [u8])
+            BlobContentType::default()
         };
         let blob = Blob::default();
         blob.size.set(size);
@@ -334,20 +382,13 @@ impl Blob {
     /// borrow path was removed because it dropped user-supplied parameters
     /// like multipart boundaries on a static-mime miss).
     pub fn dupe_with_content_type(&self, _include_content_type: bool) -> Blob {
-        let content_type = if self.content_type_allocated.get() {
-            let copy = self.content_type_slice().to_vec().into_boxed_slice();
-            bun_core::heap::into_raw(copy).cast_const()
-        } else {
-            self.content_type.get()
-        };
         // `Option<StoreRef>::clone` bumps the intrusive `Store::ref_count`.
         Blob {
             reported_estimated_size: Cell::new(self.reported_estimated_size.get()),
             size: Cell::new(self.size.get()),
             offset: Cell::new(self.offset.get()),
             store: JsCell::new(self.store.get().clone()),
-            content_type: Cell::new(content_type),
-            content_type_allocated: Cell::new(self.content_type_allocated.get()),
+            content_type: JsCell::new(self.content_type.get().dupe()),
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
             is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
@@ -433,19 +474,13 @@ impl Blob {
         self.detach();
         self.name.set(bun_core::String::dead());
 
-        self.free_content_type();
+        self.content_type.set(BlobContentType::default());
 
         if self.is_heap_allocated() {
             // SAFETY: `self` is the `*mut Blob` originally produced by
             // `Blob::new` (`heap::alloc`).
             unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };
         }
-    }
-}
-
-impl Drop for Blob {
-    fn drop(&mut self) {
-        self.free_content_type();
     }
 }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -42,9 +42,11 @@ pub enum ClosingState {
 
 /// A Blob's `type` string with ownership encoded in the variant, so assigning
 /// a new value drops the old one and a static pointer can never be freed.
+/// `Owned` is `Arc` so `clone()` just bumps a refcount.
+#[derive(Clone)]
 pub enum BlobContentType {
     Static(&'static [u8]),
-    Owned(Box<[u8]>),
+    Owned(std::sync::Arc<[u8]>),
 }
 
 impl Default for BlobContentType {
@@ -73,20 +75,12 @@ impl BlobContentType {
         matches!(self, Self::Owned(_))
     }
 
-    #[inline]
-    pub fn dupe(&self) -> Self {
-        match self {
-            Self::Static(s) => Self::Static(s),
-            Self::Owned(b) => Self::Owned(b.clone()),
-        }
-    }
-
-    /// Borrow a `MimeType`'s value: `'static` stays static, `Owned` is cloned.
+    /// Borrow a `MimeType`'s value: `'static` stays static, `Owned` is copied.
     #[inline]
     pub fn from_mime(mime: &MimeType) -> Self {
         match &mime.value {
             std::borrow::Cow::Borrowed(s) => Self::Static(s),
-            std::borrow::Cow::Owned(v) => Self::Owned(v.as_slice().into()),
+            std::borrow::Cow::Owned(v) => Self::Owned(std::sync::Arc::from(v.as_slice())),
         }
     }
 
@@ -95,7 +89,7 @@ impl BlobContentType {
     pub fn from_lowercased(slice: &[u8]) -> Self {
         let mut buf = vec![0u8; slice.len()];
         bun_core::strings::copy_lowercase(slice, &mut buf);
-        Self::Owned(buf.into_boxed_slice())
+        Self::Owned(std::sync::Arc::from(buf))
     }
 }
 
@@ -104,15 +98,8 @@ impl From<MimeType> for BlobContentType {
     fn from(mime: MimeType) -> Self {
         match mime.value {
             std::borrow::Cow::Borrowed(s) => Self::Static(s),
-            std::borrow::Cow::Owned(v) => Self::Owned(v.into_boxed_slice()),
+            std::borrow::Cow::Owned(v) => Self::Owned(std::sync::Arc::from(v)),
         }
-    }
-}
-
-impl From<Box<[u8]>> for BlobContentType {
-    #[inline]
-    fn from(b: Box<[u8]>) -> Self {
-        Self::Owned(b)
     }
 }
 
@@ -388,7 +375,7 @@ impl Blob {
             size: Cell::new(self.size.get()),
             offset: Cell::new(self.offset.get()),
             store: JsCell::new(self.store.get().clone()),
-            content_type: JsCell::new(self.content_type.get().dupe()),
+            content_type: JsCell::new(self.content_type.get().clone()),
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
             is_jsdom_file: Cell::new(self.is_jsdom_file.get()),

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -30,34 +30,14 @@ fn dupe_path_like(path: &[u8]) -> PathLike {
     )
 }
 
-/// Set the store's `mime_type` and point `blob.content_type` at it. The
-/// pointer borrows from `blob.store` (held for the blob's lifetime), so it
-/// stays valid without a separate allocation.
 #[inline]
 fn set_blob_mime(blob: &mut Blob, mime: MimeType) {
+    blob.content_type
+        .set(crate::webcore::blob::BlobContentType::from_mime(&mime));
     if let Some(store) = blob.store.get().as_ref() {
-        let store_ptr = store.as_ptr();
         // SAFETY: `store` is the freshly-allocated backing store uniquely owned
         // by `blob`; no other borrow exists yet.
-        unsafe {
-            (*store_ptr).mime_type = mime;
-            blob.content_type.set(std::ptr::from_ref::<[u8]>(
-                (*store_ptr).mime_type.value.as_ref(),
-            ));
-        }
-    } else {
-        // No store (empty bytes). Loader-derived `mime.value` is `'static` — point at it
-        // directly; boxing it leaked because `BuildArtifact`'s drop never runs `Blob::deinit`.
-        match mime.value {
-            std::borrow::Cow::Borrowed(s) => {
-                blob.content_type.set(std::ptr::from_ref::<[u8]>(s));
-            }
-            std::borrow::Cow::Owned(s) => {
-                blob.content_type
-                    .set(bun_core::heap::into_raw(s.into_boxed_slice()));
-                blob.content_type_allocated.set(true);
-            }
-        }
+        unsafe { (*store.as_ptr()).mime_type = mime };
     }
 }
 

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -66,11 +66,10 @@ impl FileJsc for File {
                 // SAFETY: `store_ptr` is the sole live mutable view; held ref
                 // guarantees liveness for the process lifetime.
                 let store = unsafe { &mut *store_ptr };
-                store.mime_type = mime;
                 b.content_type
-                    .set(std::ptr::from_ref::<[u8]>(store.mime_type.value.as_ref()));
+                    .set(crate::webcore::blob::BlobContentType::from_mime(&mime));
                 b.content_type_was_set.set(true);
-                b.content_type_allocated.set(false);
+                store.mime_type = mime;
             }
 
             // The real name goes here:

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1790,7 +1790,9 @@ impl<'a> PipelineTask<'a> {
                         unsafe { (out.free)(out.bytes.as_ptr().cast(), core::ptr::null_mut()) };
                         let blob = Blob::init(owned, global);
                         blob.content_type
-                            .set(std::ptr::from_ref::<[u8]>(format.mime().as_bytes()));
+                            .set(crate::webcore::blob::BlobContentType::Static(
+                                format.mime().as_bytes(),
+                            ));
                         blob.content_type_was_set.set(true);
                         // UFCS to pick the consuming `JsClass::to_js(self, _)`
                         // (heap-promotes via `Blob::new`) over the inherent

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2499,6 +2499,7 @@ impl BlobExt for Blob {
                                     if !is_valid_blob_type(slice) {
                                         break 'inner;
                                     }
+                                    blob.free_content_type();
                                     blob.content_type_was_set.set(true);
 
                                     if let Some(mime) =
@@ -5756,6 +5757,7 @@ pub fn jsdom_file_construct_(
                         if !is_valid_blob_type(slice) {
                             break 'inner;
                         }
+                        blob.free_content_type();
                         blob.content_type_was_set.set(true);
 
                         // SAFETY: bun_vm() returns the live VM pointer for this global.
@@ -5856,6 +5858,7 @@ pub fn construct_bun_file(
                         if !is_valid_blob_type(slice) {
                             break 'inner;
                         }
+                        blob.free_content_type();
                         blob.content_type_was_set.set(true);
                         // SAFETY: bun_vm() never returns null for a Bun-owned global.
                         if let Some(entry) = global_object.bun_vm().as_mut().mime_type(str.slice())

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -987,7 +987,7 @@ impl BlobExt for Blob {
         ct.extend_from_slice(CONTENT_TYPE_PREFIX);
         ct.extend_from_slice(boundary);
         blob.content_type
-            .set(BlobContentType::Owned(ct.into_boxed_slice()));
+            .set(BlobContentType::Owned(std::sync::Arc::from(ct)));
         blob.content_type_was_set.set(true);
 
         blob
@@ -2016,12 +2016,12 @@ impl BlobExt for Blob {
         blob.offset.set(offset);
         blob.size.set(len);
 
-        let content_type_was_allocated = content_type.is_owned();
+        let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
         if content_type.is_empty()
             && matches!(self.content_type.get(), BlobContentType::Static(s) if !s.is_empty())
         {
-            blob.content_type.set(self.content_type.get().dupe());
+            blob.content_type.set(self.content_type.get().clone());
         } else {
             blob.content_type.set(content_type);
         }
@@ -3392,7 +3392,7 @@ impl BlobExt for Blob {
                                     size: Cell::new(blob.size.get()),
                                     offset: Cell::new(blob.offset.get()),
                                     store: JsCell::new(blob.take_store()), // ← the move
-                                    content_type: JsCell::new(blob.content_type.get().dupe()),
+                                    content_type: JsCell::new(blob.content_type.get().clone()),
                                     content_type_was_set: Cell::new(
                                         blob.content_type_was_set.get(),
                                     ),
@@ -4328,7 +4328,7 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
 
     if !content_type.is_empty() {
         blob.content_type
-            .set(BlobContentType::Owned(content_type.into_boxed_slice()));
+            .set(BlobContentType::Owned(std::sync::Arc::from(content_type)));
         blob.content_type_was_set.set(content_type_was_set);
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -105,7 +105,7 @@ pub trait ReadBytesHandler {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub use bun_jsc::webcore_types::{
-    Blob, BlobContentType, Blob__deref, Blob__ref, ClosingState, MAX_SIZE, SizeType,
+    Blob, Blob__deref, Blob__ref, BlobContentType, ClosingState, MAX_SIZE, SizeType,
 };
 
 pub type Ref = bun_ptr::ExternalShared<Blob>;
@@ -1371,11 +1371,12 @@ impl BlobExt for Blob {
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
                         self.content_type_was_set.set(true);
-                        self.content_type
-                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                        self.content_type.set(
+                            match global_this.bun_vm().as_mut().mime_type(slice) {
                                 Some(mime) => BlobContentType::from(mime),
                                 None => BlobContentType::from_lowercased(slice),
-                            });
+                            },
+                        );
                     }
                 }
             } else if !options_object.is_empty_or_undefined_or_null() {
@@ -1790,11 +1791,12 @@ impl BlobExt for Blob {
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
                         self.content_type_was_set.set(true);
-                        self.content_type
-                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                        self.content_type.set(
+                            match global_this.bun_vm().as_mut().mime_type(slice) {
                                 Some(mime) => BlobContentType::from(mime),
                                 None => BlobContentType::from_lowercased(slice),
-                            });
+                            },
+                        );
                     }
                 }
 
@@ -5678,11 +5680,12 @@ pub fn jsdom_file_construct_(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        blob.content_type
-                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                        blob.content_type.set(
+                            match global_this.bun_vm().as_mut().mime_type(slice) {
                                 Some(mime) => BlobContentType::from(mime),
                                 None => BlobContentType::from_lowercased(slice),
-                            });
+                            },
+                        );
                     }
                 }
             }
@@ -5764,11 +5767,12 @@ pub fn construct_bun_file(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        blob.content_type
-                            .set(match global_object.bun_vm().as_mut().mime_type(slice) {
+                        blob.content_type.set(
+                            match global_object.bun_vm().as_mut().mime_type(slice) {
                                 Some(mime) => BlobContentType::from(mime),
                                 None => BlobContentType::from_lowercased(slice),
-                            });
+                            },
+                        );
                     }
                 }
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -104,7 +104,9 @@ pub trait ReadBytesHandler {
 // This crate layers behaviour via the `BlobExt` extension trait below.
 // ──────────────────────────────────────────────────────────────────────────
 
-pub use bun_jsc::webcore_types::{Blob, Blob__deref, Blob__ref, ClosingState, MAX_SIZE, SizeType};
+pub use bun_jsc::webcore_types::{
+    Blob, BlobContentType, Blob__deref, Blob__ref, ClosingState, MAX_SIZE, SizeType,
+};
 
 pub type Ref = bun_ptr::ExternalShared<Blob>;
 
@@ -250,8 +252,7 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         relative_start: i64,
         relative_end: i64,
-        content_type: &[u8],
-        content_type_was_allocated: bool,
+        content_type: BlobContentType,
     ) -> JSValue;
     fn get_slice(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_mime_type(&self) -> Option<MimeType>;
@@ -871,10 +872,10 @@ impl BlobExt for Blob {
             )
             .to_mime_type();
         }
-        let content_type_ptr = std::ptr::from_ref::<[u8]>(store.mime_type.value.as_ref());
+        let content_type = BlobContentType::from_mime(&store.mime_type);
 
         let blob = Blob::init_with_store(store, global_this);
-        blob.content_type.set(content_type_ptr);
+        blob.content_type.set(content_type);
         blob.content_type_was_set.set(true);
         blob
     }
@@ -981,15 +982,12 @@ impl BlobExt for Blob {
                 .unwrap_or_else(|_| bun_core::out_of_memory()),
         );
         let blob = Blob::init_with_store(store, global_this);
-        // Always allocate content_type with the default allocator so deinit() can
-        // free it unconditionally.
         const CONTENT_TYPE_PREFIX: &[u8] = b"multipart/form-data; boundary=";
         let mut ct = Vec::with_capacity(CONTENT_TYPE_PREFIX.len() + boundary.len());
         ct.extend_from_slice(CONTENT_TYPE_PREFIX);
         ct.extend_from_slice(boundary);
         blob.content_type
-            .set(bun_core::heap::into_raw(ct.into_boxed_slice()));
-        blob.content_type_allocated.set(true);
+            .set(BlobContentType::Owned(ct.into_boxed_slice()));
         blob.content_type_was_set.set(true);
 
         blob
@@ -1372,20 +1370,12 @@ impl BlobExt for Blob {
                     let content_type_str = content_type.to_slice(global_this)?;
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
-                        self.free_content_type();
                         self.content_type_was_set.set(true);
-
-                        // SAFETY: bun_vm() never returns null for a Bun-owned global.
-                        if let Some(mime) = global_this.bun_vm().as_mut().mime_type(slice) {
-                            self.content_type
-                                .set(std::ptr::from_ref::<[u8]>(mime.value.as_ref()));
-                        } else {
-                            let mut buf = vec![0u8; slice.len()];
-                            strings::copy_lowercase(slice, &mut buf);
-                            self.content_type
-                                .set(bun_core::heap::into_raw(buf.into_boxed_slice()));
-                            self.content_type_allocated.set(true);
-                        }
+                        self.content_type
+                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => BlobContentType::from(mime),
+                                None => BlobContentType::from_lowercased(slice),
+                            });
                     }
                 }
             } else if !options_object.is_empty_or_undefined_or_null() {
@@ -1799,19 +1789,12 @@ impl BlobExt for Blob {
                     let content_type_str = content_type.to_slice(global_this)?;
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
-                        self.free_content_type();
                         self.content_type_was_set.set(true);
-                        // SAFETY: see other `mime_type` call sites.
-                        if let Some(mime) = global_this.bun_vm().as_mut().mime_type(slice) {
-                            self.content_type
-                                .set(std::ptr::from_ref::<[u8]>(mime.value.as_ref()));
-                        } else {
-                            let mut buf = vec![0u8; slice.len()];
-                            strings::copy_lowercase(slice, &mut buf);
-                            self.content_type
-                                .set(bun_core::heap::into_raw(buf.into_boxed_slice()));
-                            self.content_type_allocated.set(true);
-                        }
+                        self.content_type
+                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => BlobContentType::from(mime),
+                                None => BlobContentType::from_lowercased(slice),
+                            });
                     }
                 }
 
@@ -2017,8 +2000,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         relative_start: i64,
         relative_end: i64,
-        content_type: &[u8],
-        content_type_was_allocated: bool,
+        content_type: BlobContentType,
     ) -> JSValue {
         let offset = self
             .offset
@@ -2032,21 +2014,15 @@ impl BlobExt for Blob {
         blob.offset.set(offset);
         blob.size.set(len);
 
-        // dupe() deep-copies an allocated content_type; we're about to replace it,
-        // so release that copy first to avoid leaking it.
-        blob.free_content_type();
-
+        let content_type_was_allocated = content_type.is_owned();
         // infer the content type if it was not specified
         if content_type.is_empty()
-            && !self.content_type_slice().is_empty()
-            && !self.content_type_allocated.get()
+            && matches!(self.content_type.get(), BlobContentType::Static(s) if !s.is_empty())
         {
-            blob.content_type.set(self.content_type.get());
+            blob.content_type.set(self.content_type.get().dupe());
         } else {
-            blob.content_type
-                .set(std::ptr::from_ref::<[u8]>(content_type));
+            blob.content_type.set(content_type);
         }
-        blob.content_type_allocated.set(content_type_was_allocated);
         blob.content_type_was_set
             .set(self.content_type_was_set.get() || content_type_was_allocated);
 
@@ -2113,8 +2089,7 @@ impl BlobExt for Blob {
             }
         }
 
-        let mut content_type: *const [u8] = std::ptr::from_ref::<[u8]>(b"" as &'static [u8]);
-        let mut content_type_was_allocated = false;
+        let mut content_type = BlobContentType::default();
         if let Some(content_type_) = args_iter.next_eat() {
             'inner: {
                 if content_type_.is_string() {
@@ -2124,35 +2099,15 @@ impl BlobExt for Blob {
                     if !is_valid_blob_type(slice) {
                         break 'inner;
                     }
-
-                    if let Some(mime) = global_this.bun_vm().as_mut().mime_type(slice) {
-                        content_type = match mime.value {
-                            ::std::borrow::Cow::Borrowed(s) => std::ptr::from_ref::<[u8]>(s),
-                            ::std::borrow::Cow::Owned(v) => {
-                                content_type_was_allocated = true;
-                                bun_core::heap::into_raw(v.into_boxed_slice())
-                            }
-                        };
-                        break 'inner;
-                    }
-
-                    content_type_was_allocated = !slice.is_empty();
-                    let mut buf = vec![0u8; slice.len()];
-                    strings::copy_lowercase(slice, &mut buf);
-                    content_type = bun_core::heap::into_raw(buf.into_boxed_slice());
+                    content_type = match global_this.bun_vm().as_mut().mime_type(slice) {
+                        Some(mime) => BlobContentType::from(mime),
+                        None => BlobContentType::from_lowercased(slice),
+                    };
                 }
             }
         }
 
-        // SAFETY: content_type points to either a static literal, a 'static mime value,
-        // or a freshly-leaked Box<[u8]> (when content_type_was_allocated).
-        Ok(self.get_slice_from(
-            global_this,
-            relative_start,
-            relative_end,
-            unsafe { &*content_type },
-            content_type_was_allocated,
-        ))
+        Ok(self.get_slice_from(global_this, relative_start, relative_end, content_type))
     }
 
     fn get_mime_type(&self) -> Option<MimeType> {
@@ -2499,28 +2454,13 @@ impl BlobExt for Blob {
                                     if !is_valid_blob_type(slice) {
                                         break 'inner;
                                     }
-                                    blob.free_content_type();
                                     blob.content_type_was_set.set(true);
-
-                                    if let Some(mime) =
-                                        global_this.bun_vm().as_mut().mime_type(slice)
-                                    {
-                                        blob.content_type.set(match mime.value {
-                                            ::std::borrow::Cow::Borrowed(s) => {
-                                                std::ptr::from_ref::<[u8]>(s)
-                                            }
-                                            ::std::borrow::Cow::Owned(v) => {
-                                                blob.content_type_allocated.set(true);
-                                                bun_core::heap::into_raw(v.into_boxed_slice())
-                                            }
-                                        });
-                                        break 'inner;
-                                    }
-                                    let mut buf = vec![0u8; slice.len()];
-                                    strings::copy_lowercase(slice, &mut buf);
-                                    blob.content_type
-                                        .set(bun_core::heap::into_raw(buf.into_boxed_slice()));
-                                    blob.content_type_allocated.set(true);
+                                    blob.content_type.set(
+                                        match global_this.bun_vm().as_mut().mime_type(slice) {
+                                            Some(mime) => BlobContentType::from(mime),
+                                            None => BlobContentType::from_lowercased(slice),
+                                        },
+                                    );
                                 }
                             }
                         }
@@ -2528,8 +2468,7 @@ impl BlobExt for Blob {
                 }
 
                 if blob.content_type_slice().is_empty() {
-                    blob.content_type
-                        .set(std::ptr::from_ref::<[u8]>(b"" as &'static [u8]));
+                    blob.content_type.set(BlobContentType::default());
                     blob.content_type_was_set.set(false);
                 }
             }
@@ -2579,9 +2518,8 @@ impl BlobExt for Blob {
             None
         });
         if was_string {
-            blob.content_type.set(std::ptr::from_ref::<[u8]>(
-                bun_http_types::MimeType::TEXT.value.as_ref(),
-            ));
+            blob.content_type
+                .set(BlobContentType::from_mime(&bun_http_types::MimeType::TEXT));
         }
         blob.global_this.set(global_this);
         blob
@@ -2608,9 +2546,8 @@ impl BlobExt for Blob {
                     }));
                     let blob = Blob::init_with_store(store, global_this);
                     if was_string && blob.content_type_slice().is_empty() {
-                        blob.content_type.set(std::ptr::from_ref::<[u8]>(
-                            bun_http_types::MimeType::TEXT.value.as_ref(),
-                        ));
+                        blob.content_type
+                            .set(BlobContentType::from_mime(&bun_http_types::MimeType::TEXT));
                     }
                     return Ok(blob);
                 }
@@ -3446,14 +3383,6 @@ impl BlobExt for Blob {
                                 // (no clone, no into_raw leak) and field-copy the
                                 // rest, deep-owning `name`/`content_type` — net 0 on
                                 // the store refcount.
-                                let content_type = if blob.content_type_allocated.get() {
-                                    bun_core::heap::into_raw(
-                                        blob.content_type_slice().to_vec().into_boxed_slice(),
-                                    )
-                                    .cast_const()
-                                } else {
-                                    blob.content_type.get()
-                                };
                                 let _blob = Blob {
                                     reported_estimated_size: Cell::new(
                                         blob.reported_estimated_size.get(),
@@ -3461,10 +3390,7 @@ impl BlobExt for Blob {
                                     size: Cell::new(blob.size.get()),
                                     offset: Cell::new(blob.offset.get()),
                                     store: JsCell::new(blob.take_store()), // ← the move
-                                    content_type: Cell::new(content_type),
-                                    content_type_allocated: Cell::new(
-                                        blob.content_type_allocated.get(),
-                                    ),
+                                    content_type: JsCell::new(blob.content_type.get().dupe()),
                                     content_type_was_set: Cell::new(
                                         blob.content_type_was_set.get(),
                                     ),
@@ -3761,8 +3687,9 @@ impl BlobExt for Blob {
             }
         }
 
+        let ct = self.content_type.get();
         self.reported_estimated_size.set(
-            size + (self.content_type_slice().len() * (self.content_type_allocated.get() as usize))
+            size + (ct.as_slice().len() * (ct.is_owned() as usize))
                 + self.name.get().byte_slice().len(),
         );
     }
@@ -4265,10 +4192,7 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     let offset = reader.read_int_le::<u64>()?;
 
     let content_type_len = reader.read_int_le::<u32>()?;
-    let mut content_type = read_slice(reader, content_type_len as usize)?;
-    // Ownership transfers to `blob.content_type` at the end of the success
-    // path below; until then `content_type`'s Drop is responsible for it.
-    // (error cleanup is automatic Drop on `?`.)
+    let content_type = read_slice(reader, content_type_len as usize)?;
 
     let content_type_was_set: bool = reader.read_int_le::<u8>()? != 0;
 
@@ -4401,14 +4325,10 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     }
 
     if !content_type.is_empty() {
-        let leaked = content_type.into_boxed_slice();
-        blob.content_type.set(bun_core::heap::into_raw(leaked));
-        blob.content_type_allocated.set(true);
+        blob.content_type
+            .set(BlobContentType::Owned(content_type.into_boxed_slice()));
         blob.content_type_was_set.set(content_type_was_set);
-        // Ownership handed to `blob`; disarm the implicit drop by replacing local.
-        content_type = Vec::new();
     }
-    let _ = content_type;
 
     let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
     // SAFETY: blob_ptr is valid; toJS is infallible. Explicit `&mut *` forces
@@ -4941,7 +4861,7 @@ pub fn write_file_with_source_destination(
     } else if destination_type == store::DataTag::Bytes
         && (source_type == store::DataTag::File || source_type == store::DataTag::S3)
     {
-        let blob_value = source_blob.get_slice_from(ctx, 0, 0, b"", false);
+        let blob_value = source_blob.get_slice_from(ctx, 0, 0, BlobContentType::default());
         return Ok(JSPromise::resolved_promise_value(ctx, blob_value));
     } else if destination_type == store::DataTag::S3 {
         let s3 = destination_store.data.as_s3();
@@ -5757,26 +5677,12 @@ pub fn jsdom_file_construct_(
                         if !is_valid_blob_type(slice) {
                             break 'inner;
                         }
-                        blob.free_content_type();
                         blob.content_type_was_set.set(true);
-
-                        // SAFETY: bun_vm() returns the live VM pointer for this global.
-                        if let Some(mime) = global_this.bun_vm().as_mut().mime_type(slice) {
-                            blob.content_type.set(match mime.value {
-                                ::std::borrow::Cow::Borrowed(s) => std::ptr::from_ref::<[u8]>(s),
-                                ::std::borrow::Cow::Owned(v) => {
-                                    blob.content_type_allocated.set(true);
-                                    bun_core::heap::into_raw(v.into_boxed_slice())
-                                }
+                        blob.content_type
+                            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => BlobContentType::from(mime),
+                                None => BlobContentType::from_lowercased(slice),
                             });
-                            break 'inner;
-                        }
-                        let mut content_type_buf = vec![0u8; slice.len()];
-                        strings::copy_lowercase(slice, &mut content_type_buf);
-                        blob.content_type.set(bun_core::heap::into_raw(
-                            content_type_buf.into_boxed_slice(),
-                        ));
-                        blob.content_type_allocated.set(true);
                     }
                 }
             }
@@ -5796,8 +5702,7 @@ pub fn jsdom_file_construct_(
     }
 
     if blob.content_type_slice().is_empty() {
-        blob.content_type
-            .set(std::ptr::from_ref::<[u8]>(b"" as &'static [u8]));
+        blob.content_type.set(BlobContentType::default());
         blob.content_type_was_set.set(false);
     }
 
@@ -5858,21 +5763,12 @@ pub fn construct_bun_file(
                         if !is_valid_blob_type(slice) {
                             break 'inner;
                         }
-                        blob.free_content_type();
                         blob.content_type_was_set.set(true);
-                        // SAFETY: bun_vm() never returns null for a Bun-owned global.
-                        if let Some(entry) = global_object.bun_vm().as_mut().mime_type(str.slice())
-                        {
-                            blob.content_type
-                                .set(std::ptr::from_ref::<[u8]>(entry.value.as_ref()));
-                            break 'inner;
-                        }
-                        let mut content_type_buf = vec![0u8; slice.len()];
-                        strings::copy_lowercase(slice, &mut content_type_buf);
-                        blob.content_type.set(bun_core::heap::into_raw(
-                            content_type_buf.into_boxed_slice(),
-                        ));
-                        blob.content_type_allocated.set(true);
+                        blob.content_type
+                            .set(match global_object.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => BlobContentType::from(mime),
+                                None => BlobContentType::from_lowercased(slice),
+                            });
                     }
                 }
             }
@@ -6256,10 +6152,8 @@ pub unsafe extern "C" fn Blob__fromBytesWithType(
         unsafe {
             (*blob)
                 .content_type
-                .set(std::ptr::from_ref::<[u8]>(mime_slice));
+                .set(BlobContentType::Owned(mime_slice.into()));
             (*blob).content_type_was_set.set(true);
-            // content_type_allocated stays false — caller guarantees the string
-            // outlives the Blob (it's a C string literal in the caller's .rodata).
         }
     }
     blob
@@ -6299,7 +6193,7 @@ pub unsafe extern "C" fn Blob__fromMmapWithType(
             unsafe {
                 (*blob)
                     .content_type
-                    .set(std::ptr::from_ref::<[u8]>(mime_slice));
+                    .set(BlobContentType::Owned(mime_slice.into()));
                 (*blob).content_type_was_set.set(true);
             }
         }
@@ -6611,7 +6505,6 @@ impl Any {
                     // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
                     let internal = s.data_mut().as_bytes_mut().to_internal_blob();
                     // StoreRef::drop on the replace below releases the store ref.
-                    blob.free_content_type();
                     *self = Any::InternalBlob(internal);
                     return;
                 }
@@ -6906,7 +6799,6 @@ impl Any {
     pub fn detach(&mut self) {
         match self {
             Any::Blob(b) => {
-                b.free_content_type();
                 b.detach();
                 *self = Any::Blob(Blob::default());
             }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -3,7 +3,6 @@
 use bun_collections::VecExt;
 use core::ffi::c_void;
 use core::ptr::NonNull;
-use std::borrow::Cow;
 
 use crate::webcore::jsc::{
     self as jsc, CallFrame, CommonAbortReason, CommonAbortReasonExt as _, DOMFormData,
@@ -60,31 +59,13 @@ fn blob_store_mut(blob: &Blob) -> Option<&mut blob::Store> {
         .map(|s| unsafe { &mut *s.as_ptr() })
 }
 
-fn set_blob_content_type(blob: &Blob, mime_type: MimeType, allocated: bool) {
+fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
     blob.content_type_was_set.set(true);
-    match mime_type.value {
-        Cow::Borrowed(interned) => {
-            if let Some(store) = blob_store_mut(blob) {
-                store.mime_type = MimeType {
-                    value: Cow::Borrowed(interned),
-                    category: mime_type.category,
-                };
-            }
-            blob.content_type.set(std::ptr::from_ref::<[u8]>(interned));
-            blob.content_type_allocated.set(false);
-        }
-        Cow::Owned(owned) => {
-            if let Some(store) = blob_store_mut(blob) {
-                store.mime_type = MimeType {
-                    value: Cow::Owned(owned.clone()),
-                    category: mime_type.category,
-                };
-            }
-            blob.content_type
-                .set(bun_core::heap::into_raw(owned.into_boxed_slice()));
-            blob.content_type_allocated.set(allocated);
-        }
+    if let Some(store) = blob_store_mut(blob) {
+        store.mime_type = mime_type.clone();
     }
+    blob.content_type
+        .set(blob::BlobContentType::from(mime_type));
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1012,7 +993,7 @@ impl Value {
                 drop(encoded);
                 let blob = Blob::init(owned.into_vec(), global_this);
                 blob.content_type
-                    .set(std::ptr::from_ref::<[u8]>(mime.as_bytes()));
+                    .set(blob::BlobContentType::Static(mime.as_bytes()));
                 blob.content_type_was_set.set(true);
                 return Ok(Value::Blob(blob));
             }
@@ -1173,25 +1154,14 @@ impl Value {
                                 fetch_headers.fast_get(HTTPHeaderName::ContentType)
                             {
                                 let content_slice = content_type.to_slice();
-                                let mut allocated = false;
-                                let mime_type = MimeType::init(
-                                    content_slice.slice(),
-                                    true,
-                                    Some(&mut allocated),
-                                );
-                                set_blob_content_type(blob, mime_type, allocated);
+                                let mime_type =
+                                    MimeType::init(content_slice.slice(), true, None);
+                                set_blob_content_type(blob, mime_type);
                                 // content_slice dropped (replaces defer content_slice.deinit())
                             }
                         }
                         if !blob.content_type_was_set.get() && blob.store.get().is_some() {
-                            blob.content_type.set(std::ptr::from_ref::<[u8]>(
-                                bun_http_types::MimeType::TEXT.value.as_ref(),
-                            ));
-                            blob.content_type_allocated.set(false);
-                            blob.content_type_was_set.set(true);
-                            blob_store_mut(blob)
-                                .expect("infallible: checked above")
-                                .mime_type = bun_http_types::MimeType::TEXT;
+                            set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
                         }
                         promise.resolve(global, blob.to_js(global))?;
                     }
@@ -2196,22 +2166,13 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 let fetch_headers = bun_opaque::opaque_deref_mut(fetch_headers.as_ptr());
                 if let Some(content_type) = fetch_headers.fast_get(HTTPHeaderName::ContentType) {
                     let content_slice = content_type.to_slice();
-                    let mut allocated = false;
-                    let mime_type =
-                        MimeType::init(content_slice.slice(), true, Some(&mut allocated));
-                    set_blob_content_type(blob, mime_type, allocated);
+                    let mime_type = MimeType::init(content_slice.slice(), true, None);
+                    set_blob_content_type(blob, mime_type);
                     // content_slice dropped (replaces defer content_slice.deinit())
                 }
             }
             if !blob.content_type_was_set.get() && blob.store.get().is_some() {
-                blob.content_type.set(std::ptr::from_ref::<[u8]>(
-                    bun_http_types::MimeType::TEXT.value.as_ref(),
-                ));
-                blob.content_type_allocated.set(false);
-                blob.content_type_was_set.set(true);
-                blob_store_mut(blob)
-                    .expect("infallible: checked above")
-                    .mime_type = bun_http_types::MimeType::TEXT;
+                set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
             }
         }
         Ok(JSPromise::resolved_promise_value(

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1154,8 +1154,7 @@ impl Value {
                                 fetch_headers.fast_get(HTTPHeaderName::ContentType)
                             {
                                 let content_slice = content_type.to_slice();
-                                let mime_type =
-                                    MimeType::init(content_slice.slice(), true, None);
+                                let mime_type = MimeType::init(content_slice.slice(), true, None);
                                 set_blob_content_type(blob, mime_type);
                                 // content_slice dropped (replaces defer content_slice.deinit())
                             }

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -80,7 +80,7 @@ impl ByteBlobLoader {
         // `Blob` is not `Clone`, so use the non-mutating `resolved_size()` helper.
         let (offset, size) = blob.resolved_size();
         let content_type = if blob.content_type_was_set.get() {
-            blob.content_type.get().dupe()
+            blob.content_type.get().clone()
         } else {
             blob::BlobContentType::default()
         };

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -18,10 +18,7 @@ pub struct ByteBlobLoader {
     /// https://github.com/oven-sh/bun/issues/14988
     /// Necessary for converting a ByteBlobLoader from a Blob -> back into a Blob
     /// Especially for DOMFormData, where the specific content-type might've been serialized into the data.
-    // Always-owned `Box<[u8]>`; the flag is kept because it is
-    // transferred to Blob in to_any_blob.
-    pub content_type: Box<[u8]>,
-    pub content_type_allocated: bool,
+    pub content_type: blob::BlobContentType,
 }
 
 impl Default for ByteBlobLoader {
@@ -33,8 +30,7 @@ impl Default for ByteBlobLoader {
             remain: 1024 * 1024 * 2,
             done: false,
             pulled: false,
-            content_type: Box::default(),
-            content_type_allocated: false,
+            content_type: blob::BlobContentType::default(),
         }
     }
 }
@@ -83,16 +79,10 @@ impl ByteBlobLoader {
         let store = blob.store.get().as_ref().unwrap().clone();
         // `Blob` is not `Clone`, so use the non-mutating `resolved_size()` helper.
         let (offset, size) = blob.resolved_size();
-        // `content_type` is an always-owned `Box<[u8]>` (we dupe in both
-        // arms), so the flag must be `true` whenever the box is non-empty —
-        // it's later transferred verbatim to a `Blob` in `to_any_blob`, and a
-        // `false` there strands the `into_raw`'d allocation behind
-        // `Blob::free_content_type`'s `content_type_allocated` gate.
-        let (content_type, content_type_allocated) = if blob.content_type_was_set.get() {
-            let ct = blob.content_type_slice();
-            (Box::<[u8]>::from(ct), !ct.is_empty())
+        let content_type = if blob.content_type_was_set.get() {
+            blob.content_type.get().dupe()
         } else {
-            (Box::default(), false)
+            blob::BlobContentType::default()
         };
         *self = ByteBlobLoader {
             offset,
@@ -107,7 +97,6 @@ impl ByteBlobLoader {
             done: false,
             pulled: false,
             content_type,
-            content_type_allocated,
         };
     }
 
@@ -178,13 +167,7 @@ impl ByteBlobLoader {
         if !self.content_type.is_empty() {
             let ct = core::mem::take(&mut self.content_type);
             blob.content_type_was_set.set(!ct.is_empty());
-            blob.content_type
-                .set(bun_core::heap::into_raw(ct).cast_const());
-            // `content_type` is an always-owned `Box<[u8]>` in the Rust port
-            // (see `setup`); `into_raw` just handed the new blob a heap
-            // allocation it must free regardless of the flag's prior value.
-            blob.content_type_allocated.set(true);
-            self.content_type_allocated = false;
+            blob.content_type.set(ct);
         }
 
         self.parent_const().is_closed.set(true);
@@ -212,10 +195,7 @@ impl ByteBlobLoader {
     }
 
     fn clear_data(&mut self) {
-        if self.content_type_allocated {
-            self.content_type = Box::default();
-            self.content_type_allocated = false;
-        }
+        self.content_type = blob::BlobContentType::default();
 
         if let Some(store) = self.store.take() {
             drop(store); // store.deref()

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -226,14 +226,10 @@ pub fn to_js_from_multipart_data(
                 let mut blob = Blob::create(value_str, wrap.global, false);
                 let filename = ZigString::init_utf8(filename_str);
 
-                // `MimeType.value` is `Cow<'static,[u8]>`, so split the two
-                // ownership cases instead of unifying through a single
-                // `&[u8]` (avoids borrowing a temporary).
                 if !field.content_type.is_empty() {
                     let ct = field.content_type.slice(buf);
-                    blob.content_type_allocated.set(true);
                     blob.content_type
-                        .set(bun_core::heap::into_raw(Box::<[u8]>::from(ct)).cast_const());
+                        .set(crate::webcore::blob::BlobContentType::Owned(ct.into()));
                     blob.content_type_was_set.set(true);
                 } else {
                     let mime = 'brk: {
@@ -250,22 +246,9 @@ pub fn to_js_from_multipart_data(
                         bun_http::MimeType::sniff(value_str)
                     };
                     if let Some(mime) = mime {
-                        match mime.value {
-                            std::borrow::Cow::Borrowed(s) => {
-                                blob.content_type.set(std::ptr::from_ref::<[u8]>(s));
-                                blob.content_type_was_set.set(false);
-                                blob.content_type_allocated.set(false);
-                            }
-                            std::borrow::Cow::Owned(v) => {
-                                // by_extension/sniff currently always yield Borrowed,
-                                // but handle Owned defensively to avoid a dangling ptr.
-                                blob.content_type.set(
-                                    bun_core::heap::into_raw(v.into_boxed_slice()).cast_const(),
-                                );
-                                blob.content_type_was_set.set(false);
-                                blob.content_type_allocated.set(true);
-                            }
-                        }
+                        blob.content_type
+                            .set(crate::webcore::blob::BlobContentType::from(mime));
+                        blob.content_type_was_set.set(false);
                     }
                 }
 
@@ -275,10 +258,8 @@ pub fn to_js_from_multipart_data(
                     (&raw mut blob).cast::<c_void>(),
                     &filename,
                 );
-                // `append_blob` dupes the content type, so the copy boxed above
-                // is solely owned by this stack-local and must be released here.
+                // `append_blob` dupes the content type; release this stack-local.
                 blob.detach();
-                blob.free_content_type();
             } else {
                 let value = ZigString::init_utf8(
                     // > Each part whose `Content-Disposition` header does not

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -261,17 +261,18 @@ impl Request {
         } else {
             // we don't have a request context, so we need to create an empty headers object
             self.headers.set(Some(HeadersRef::create_empty()));
-            // Snapshot the pointer first; `Blob.content_type` is a raw
-            // `*const [u8]` that stays valid across the field borrow.
+            // Snapshot the pointer first; it stays valid across the field borrow.
             let content_type: Option<*const [u8]> = match self.body_value() {
-                BodyValue::Blob(blob) => Some(blob.content_type.get()),
+                BodyValue::Blob(blob) => {
+                    Some(std::ptr::from_ref::<[u8]>(blob.content_type_slice()))
+                }
                 BodyValue::Locked(locked) => match locked.readable.get(global_this) {
                     Some(readable) => match readable.ptr {
                         crate::webcore::readable_stream::Source::Blob(blob) => {
                             // SAFETY: `Source::Blob` holds a live `*mut ByteBlobLoader`
                             // for as long as the readable stream exists; we only read
                             // its `content_type` slice and immediately copy below.
-                            let ct: &[u8] = unsafe { &(*blob).content_type };
+                            let ct: &[u8] = unsafe { (*blob).content_type.as_slice() };
                             Some(std::ptr::from_ref::<[u8]>(ct))
                         }
                         _ => None,
@@ -282,8 +283,8 @@ impl Request {
             };
 
             if let Some(content_type_) = content_type {
-                // SAFETY: Blob.content_type is always a valid (possibly empty)
-                // slice pointer (see Blob field contract).
+                // SAFETY: the sources above are live for the duration of this
+                // call; the bytes are copied into the header map below.
                 let content_type_ = unsafe { &*content_type_ };
                 if !content_type_.is_empty() {
                     self.headers_mut().as_mut().unwrap().put(

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -398,31 +398,11 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        // SAFETY: bun_vm() returns the live VM raw ptr.
-                        if let Some(entry) = global.bun_vm().as_mut().mime_type(str.slice()) {
-                            // `MimeType.value` is `Cow<'static, [u8]>`; the
-                            // canonical-table hit (via `Compact::to_mime_type`) is always
-                            // `Borrowed(&'static)`. If a future table source ever yields
-                            // `Owned`, hand the buffer to the blob's allocated-content-type
-                            // path so `Blob::deinit` reclaims it.
-                            match entry.value {
-                                std::borrow::Cow::Borrowed(s) => {
-                                    blob.content_type.set(std::ptr::from_ref::<[u8]>(s));
-                                }
-                                std::borrow::Cow::Owned(v) => {
-                                    blob.content_type
-                                        .set(bun_core::heap::into_raw(v.into_boxed_slice()));
-                                    blob.content_type_allocated.set(true);
-                                }
-                            }
-                            break 'inner;
-                        }
-                        let mut content_type_buf = vec![0u8; slice.len()];
-                        strings::copy_lowercase(slice, &mut content_type_buf);
-                        blob.content_type.set(bun_core::heap::into_raw(
-                            content_type_buf.into_boxed_slice(),
-                        ));
-                        blob.content_type_allocated.set(true);
+                        blob.content_type
+                            .set(match global.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => blob::BlobContentType::from(mime),
+                                None => blob::BlobContentType::from_lowercased(slice),
+                            });
                     }
                 }
             }
@@ -465,31 +445,11 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        // SAFETY: bun_vm() returns the live VM raw ptr.
-                        if let Some(entry) = global.bun_vm().as_mut().mime_type(str.slice()) {
-                            // `MimeType.value` is `Cow<'static, [u8]>`; the
-                            // canonical-table hit (via `Compact::to_mime_type`) is always
-                            // `Borrowed(&'static)`. If a future table source ever yields
-                            // `Owned`, hand the buffer to the blob's allocated-content-type
-                            // path so `Blob::deinit` reclaims it.
-                            match entry.value {
-                                std::borrow::Cow::Borrowed(s) => {
-                                    blob.content_type.set(std::ptr::from_ref::<[u8]>(s));
-                                }
-                                std::borrow::Cow::Owned(v) => {
-                                    blob.content_type
-                                        .set(bun_core::heap::into_raw(v.into_boxed_slice()));
-                                    blob.content_type_allocated.set(true);
-                                }
-                            }
-                            break 'inner;
-                        }
-                        let mut content_type_buf = vec![0u8; slice.len()];
-                        strings::copy_lowercase(slice, &mut content_type_buf);
-                        blob.content_type.set(bun_core::heap::into_raw(
-                            content_type_buf.into_boxed_slice(),
-                        ));
-                        blob.content_type_allocated.set(true);
+                        blob.content_type
+                            .set(match global.bun_vm().as_mut().mime_type(slice) {
+                                Some(mime) => blob::BlobContentType::from(mime),
+                                None => blob::BlobContentType::from_lowercased(slice),
+                            });
                     }
                 }
             }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -200,20 +200,9 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
     };
     let blob = Blob::init(data, global_this);
 
-    let mut allocated = false;
-    let mime_type = MimeType::MimeType::init(data_url.mime_type, true, Some(&mut allocated));
-    // `mime_type.value` is `Cow<'static, [u8]>`; Blob.content_type is
-    // `*const [u8]` discriminated by `content_type_allocated` (Blob's Drop reclaims
-    // via `heap::take` when set). Use `heap::alloc` (paired alloc/free), not
-    // leaking.
-    blob.content_type.set(match mime_type.value {
-        std::borrow::Cow::Borrowed(s) => std::ptr::from_ref::<[u8]>(s),
-        std::borrow::Cow::Owned(v) => {
-            blob.content_type_allocated.set(true);
-            bun_core::heap::into_raw(v.into_boxed_slice()).cast_const()
-        }
-    });
-    debug_assert_eq!(allocated, blob.content_type_allocated.get());
+    let mime_type = MimeType::MimeType::init(data_url.mime_type, true, None);
+    blob.content_type
+        .set(crate::webcore::blob::BlobContentType::from(mime_type));
 
     let response = bun_core::heap::into_raw(Box::new(Response::init(
         response::Init {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -564,9 +564,7 @@ test.skipIf(!isASAN).each(["Blob", "File"] as const)(
   "new %s([typedBlob], {type}) with a known mime type does not free a static pointer",
   async Ctor => {
     const make =
-      Ctor === "Blob"
-        ? `new Blob([inner], { type: "text/plain" })`
-        : `new File([inner], "f", { type: "text/plain" })`;
+      Ctor === "Blob" ? `new Blob([inner], { type: "text/plain" })` : `new File([inner], "f", { type: "text/plain" })`;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -556,3 +556,40 @@ describe("slice bounds are respected when streaming and serving", () => {
     expect(await get.text()).toBe("3456");
   });
 });
+
+// Wrapping a Blob whose type is heap-owned (not in the mime table) with a
+// known mime type overwrote content_type with a static pointer without
+// clearing content_type_allocated, so GC sweep freed a static pointer.
+test.skipIf(!isASAN).each(["Blob", "File"] as const)(
+  "new %s([typedBlob], {type}) with a known mime type does not free a static pointer",
+  async Ctor => {
+    const make =
+      Ctor === "Blob"
+        ? `new Blob([inner], { type: "text/plain" })`
+        : `new File([inner], "f", { type: "text/plain" })`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const inner = new Blob(["y"], { type: "x/not-in-the-table" });
+          for (let i = 0; i < 2000; i++) {
+            ${make};
+            if ((i & 127) === 0) Bun.gc(true);
+          }
+          Bun.gc(true); Bun.gc(true);
+          console.log(${make}.type);
+        `,
+      ],
+      env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":") },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: expect.stringMatching(/^text\/plain(;charset=utf-8)?\n$/),
+      stderr: expect.not.stringContaining("AddressSanitizer"),
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);


### PR DESCRIPTION
### Repro

```js
// inner type: NOT in the mime table -> heap-owned content_type
// outer type: IN the table -> static pointer assigned without clearing the flag
for (let i = 0; i < 4000; i++) {
  new Blob([new Blob(["y"], { type: "x/not-in-the-table" })], { type: "text/plain" });
  if ((i & 255) === 0) Bun.gc(true);
}
Bun.gc(true);
```

On an ASAN build of `main`:

```
AddressSanitizer:DEADLYSIGNAL
==...==ERROR: AddressSanitizer: SEGV on unknown address ... (WRITE)
  #0 __asan::Allocator::Deallocate
  ...
  free_content_type  webcore_types.rs:240
  deinit             webcore_types.rs:436
  JSC::JSDestructibleObjectDestroyFunc / MarkedBlock::Handle::specializedSweep
```

On a release build the same `free()` of a `.data` pointer goes to mimalloc, which silently ignores pages it does not own, and the original heap `content_type` is leaked on every construction.

### Cause

`Blob.content_type` was a raw `*const [u8]` with a separate `content_type_allocated: bool`. `new Blob([typedBlob], ...)` takes the single-part fast path and `dupe()`s the inner Blob, so the new Blob starts out owning a heap `content_type` with `content_type_allocated = true`. The `options.type` handler then overwrote `content_type` with the static mime-table pointer without freeing the old allocation or clearing the flag, so `Blob::deinit` later freed a static pointer. The same shape existed in `new File(...)`, `Bun.file(path, {type})`, and the S3 file constructors.

### Fix

Replace the `*const [u8]` + `bool` pair with

```rust
pub enum BlobContentType {
    Static(&'static [u8]),
    Owned(Box<[u8]>),
}
```

stored in a `JsCell`. Assigning via `.set(...)` drops the previous value, so a static pointer can never reach the allocator and the old allocation can never leak. `free_content_type()` and the `content_type_allocated` field are removed. The six near-identical "VM mime lookup then lowercase fallback" blocks across `Blob`/`File`/`Bun.file`/S3 collapse to a single match via `BlobContentType::from(mime)` / `::from_lowercased(slice)`.

Sites that previously borrowed `content_type` from `store.mime_type.value` now go through `BlobContentType::from_mime(&MimeType)`, which matches on the `Cow<'static, [u8]>` so there is no self-reference into the store; this also closes three latent dangling-pointer paths that took `.as_ref()` on a by-value `MimeType` returned from the VM lookup (safe today only because that lookup always returns `Cow::Borrowed(&'static)`).

Net -220 lines across 11 files.

### Verification

```
# without fix (src stashed)
(fail) new Blob([typedBlob], {type}) with a known mime type does not free a static pointer
(fail) new File([typedBlob], {type}) with a known mime type does not free a static pointer
  AddressSanitizer: SEGV ... __asan::Allocator::Deallocate

# with fix
28 pass  0 fail  (test/js/web/fetch/blob.test.ts)
```

`body.test.ts`, `FormData.test.ts`, `structured-clone-blob-file.test.ts`, and the other blob suites pass unchanged. `cargo clippy --workspace` and `bun run rust:check-all` are clean.
