### PR TITLE
Blob/File: do not inherit part metadata on the single-Blob-part fast path

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -357,6 +357,19 @@ impl Blob {
         self.dupe_with_content_type(false)
     }
 
+    /// Shares `self`'s bytes (store + offset/size/charset) but leaves
+    /// `content_type`/`last_modified`/`name`/`is_jsdom_file` at defaults.
+    /// Used by `new Blob([part])`, where parts contribute only bytes.
+    pub fn dupe_without_metadata(&self) -> Blob {
+        let blob = Blob::default();
+        blob.size.set(self.size.get());
+        blob.offset.set(self.offset.get());
+        blob.store.set(self.store.get().clone());
+        blob.charset.set(self.charset.get());
+        blob.global_this.set(self.global_this.get());
+        blob
+    }
+
     /// Alias for [`Self::dupe`].
     #[inline]
     pub fn borrowed_view(&self) -> Blob {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4,11 +4,8 @@
 //! operations like writing `Store::File` to another `Store::File` knows to use a
 //! basic file copy instead of a naive read write loop.
 
-use core::cell::Cell;
 use core::ffi::{c_char, c_void};
 use core::ptr::NonNull;
-
-use bun_jsc::JsCell;
 
 use crate::webcore::jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, VirtualMachine,
@@ -2194,6 +2191,11 @@ impl BlobExt for Blob {
 
     // TODO: Move this to a separate `File` object or BunFile
     fn get_last_modified(&self, _: &JSGlobalObject) -> JSValue {
+        if self.is_jsdom_file.get() {
+            // `new File()` always fills `last_modified` (explicit option or
+            // Date.now()); a file-backed store's live mtime must not override it.
+            return JSValue::js_number(self.last_modified.get());
+        }
         if let Some(store) = self.store.get() {
             if matches!(store.data, store::Data::File(_)) {
                 // do not hold a pattern-bound `&File` across
@@ -2210,10 +2212,6 @@ impl BlobExt for Blob {
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
                 return JSValue::js_number(store.data_mut().as_file().last_modified as f64);
             }
-        }
-
-        if self.is_jsdom_file.get() {
-            return JSValue::js_number(self.last_modified.get());
         }
 
         JSValue::js_number(jsc::INIT_TIMESTAMP as f64)
@@ -3361,44 +3359,18 @@ impl BlobExt for Blob {
                         if let Some(blob_ptr) = top_value.as_::<Blob>() {
                             // SAFETY: JS heap pointer; single-threaded JS execution.
                             let blob = unsafe { &mut *blob_ptr };
+                            // Parts contribute only their bytes: share the store
+                            // (or move it), but never the part's content_type /
+                            // last_modified / name / is_jsdom_file.
+                            let out = blob.dupe_without_metadata();
                             if MOVE {
-                                // Move the store without bumping its refcount, but take
-                                // independent ownership of name/content_type so the
-                                // source's eventual finalize() doesn't double-free them.
-                                // *Take* the StoreRef out of `blob`
-                                // (no clone, no into_raw leak) and field-copy the
-                                // rest, deep-owning `name`/`content_type` — net 0 on
-                                // the store refcount.
-                                let _blob = Blob {
-                                    reported_estimated_size: Cell::new(
-                                        blob.reported_estimated_size.get(),
-                                    ),
-                                    size: Cell::new(blob.size.get()),
-                                    offset: Cell::new(blob.offset.get()),
-                                    store: JsCell::new(blob.take_store()), // ← the move
-                                    content_type: JsCell::new(blob.content_type.get().clone()),
-                                    content_type_was_set: Cell::new(
-                                        blob.content_type_was_set.get(),
-                                    ),
-                                    charset: Cell::new(blob.charset.get()),
-                                    is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
-                                    ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
-                                    global_this: Cell::new(blob.global_this.get()),
-                                    last_modified: Cell::new(blob.last_modified.get()),
-                                    name: blob.name.clone(),
-                                };
-                                return Ok(_blob);
-                            } else {
-                                return Ok(blob.dupe());
+                                out.store.set(blob.take_store());
                             }
+                            return Ok(out);
                         } else if let Some(artifact) =
                             top_value.as_class_ref::<crate::api::BuildArtifact>()
                         {
-                            // The previous "move" path here only nulled the store on a
-                            // local copy and left `build.blob` fully intact, so it was
-                            // never a real move. Share the store and deep-copy owned
-                            // buffers instead — regardless of `MOVE`.
-                            return Ok(artifact.blob.dupe());
+                            return Ok(artifact.blob.dupe_without_metadata());
                         } else {
                             // Dispatch on the `ZigStringSlice` variant to detect an
                             // owned (heap) slice. Pass

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2191,9 +2191,10 @@ impl BlobExt for Blob {
 
     // TODO: Move this to a separate `File` object or BunFile
     fn get_last_modified(&self, _: &JSGlobalObject) -> JSValue {
-        if self.is_jsdom_file.get() {
-            // `new File()` always fills `last_modified` (explicit option or
-            // Date.now()); a file-backed store's live mtime must not override it.
+        // `new File()` always stamps `last_modified`; prefer it over a file
+        // store's live mtime. `Blob__setAsFile` leaves it 0.0, which falls
+        // through so FormData.get() on a Bun.file entry still reports mtime.
+        if self.is_jsdom_file.get() && self.last_modified.get() != 0.0 {
             return JSValue::js_number(self.last_modified.get());
         }
         if let Some(store) = self.store.get() {
@@ -2212,6 +2213,10 @@ impl BlobExt for Blob {
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
                 return JSValue::js_number(store.data_mut().as_file().last_modified as f64);
             }
+        }
+
+        if self.is_jsdom_file.get() {
+            return JSValue::js_number(self.last_modified.get());
         }
 
         JSValue::js_number(jsc::INIT_TIMESTAMP as f64)
@@ -3356,13 +3361,17 @@ impl BlobExt for Blob {
 
                 jsc::JSType::DOMWrapper => {
                     if !fail_if_top_value_is_not_typed_array_like {
+                        // REQUIRE_ARRAY callers reach here only via a length-1
+                        // array: `top_value` is a *part* (bytes only). A bare
+                        // Blob body (REQUIRE_ARRAY=false) keeps its metadata.
                         if let Some(blob_ptr) = top_value.as_::<Blob>() {
                             // SAFETY: JS heap pointer; single-threaded JS execution.
                             let blob = unsafe { &mut *blob_ptr };
-                            // Parts contribute only their bytes: share the store
-                            // (or move it), but never the part's content_type /
-                            // last_modified / name / is_jsdom_file.
-                            let out = blob.dupe_without_metadata();
+                            let out = if REQUIRE_ARRAY {
+                                blob.dupe_without_metadata()
+                            } else {
+                                blob.dupe()
+                            };
                             if MOVE {
                                 out.store.set(blob.take_store());
                             }
@@ -3370,7 +3379,11 @@ impl BlobExt for Blob {
                         } else if let Some(artifact) =
                             top_value.as_class_ref::<crate::api::BuildArtifact>()
                         {
-                            return Ok(artifact.blob.dupe_without_metadata());
+                            return Ok(if REQUIRE_ARRAY {
+                                artifact.blob.dupe_without_metadata()
+                            } else {
+                                artifact.blob.dupe()
+                            });
                         } else {
                             // Dispatch on the `ZigStringSlice` variant to detect an
                             // owned (heap) slice. Pass

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5635,9 +5635,9 @@ pub fn jsdom_file_construct_(
             match store_.data_mut() {
                 store::Data::Bytes(bytes) => {
                     // `get::<_, true>` on a single-Blob sequence returns
-                    // `dupe()` (a shared StoreRef), so this `Bytes` may already
-                    // carry an owned `stored_name` from the source blob; the
-                    // assignment drops (frees) the previous `Box<[u8]>`.
+                    // `dupe_without_metadata()` (a shared StoreRef), so this `Bytes`
+                    // may already carry an owned `stored_name` from the source blob;
+                    // the assignment drops (frees) the previous `Box<[u8]>`.
                     bytes.stored_name = name_value_str.to_owned_slice().into_boxed_slice();
                 }
                 store::Data::S3(_) | store::Data::File(_) => {

--- a/src/runtime/webcore/headers_ref.rs
+++ b/src/runtime/webcore/headers_ref.rs
@@ -10,20 +10,24 @@ use crate::webcore::blob::Any as AnyBlob;
 #[inline]
 pub(crate) fn any_blob_content_type(b: &AnyBlob) -> Option<&[u8]> {
     if b.has_content_type_from_user() {
-        Some(b.content_type())
-    } else {
-        None
+        let ct = b.content_type();
+        if !ct.is_empty() {
+            return Some(ct);
+        }
     }
+    None
 }
 
 /// `Some(ct)` only when the body has a *user-set* content-type.
 #[inline]
 pub(crate) fn blob_content_type(b: &Blob) -> Option<&[u8]> {
     if b.has_content_type_from_user() {
-        Some(b.content_type_slice())
-    } else {
-        None
+        let ct = b.content_type_slice();
+        if !ct.is_empty() {
+            return Some(ct);
+        }
     }
+    None
 }
 
 /// `Some(ct)` only when the body has a *user-set* content-type.

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -766,4 +766,41 @@ describe("new Blob([part]) / new File([part], name) do not inherit part metadata
     expect(wrapped.lastModified).toBeGreaterThanOrEqual(before - 1000);
     expect(wrapped.lastModified).toBeLessThanOrEqual(after + 1000);
   });
+
+  test("a bare Blob body (not a part) keeps its content-type for server.fetch", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(req.headers.get("content-type") ?? "<null>"),
+    });
+    const body = new Blob(['{"a":1}'], { type: "application/json" });
+    const res = await server.fetch(server.url.href, { method: "POST", body });
+    expect(await res.text()).toContain("application/json");
+  });
+
+  test("a Blob body with empty .type contributes no Content-Type header", async () => {
+    using dir = tempDir("blob-empty-ct", { "f.html": "<h1>hi</h1>" });
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req =>
+        Response.json({
+          has: req.headers.has("content-type"),
+          ct: req.headers.get("content-type"),
+        }),
+    });
+    const wrapped = new Blob([Bun.file(path.join(String(dir), "f.html"))]);
+    expect(wrapped.type).toBe("");
+    const res = await fetch(server.url, { method: "POST", body: wrapped });
+    expect(await res.json()).toEqual({ has: false, ct: null });
+  });
+
+  test("FormData.get() on a Bun.file entry still reports the file mtime", async () => {
+    using dir = tempDir("blob-formdata-mtime", { "f.bin": "hi" });
+    const p = path.join(String(dir), "f.bin");
+    const oldMtime = new Date(1_000_000_000_000); // 2001-09-09
+    utimesSync(p, oldMtime, oldMtime);
+    const fd = new FormData();
+    fd.append("f", Bun.file(p));
+    const entry = fd.get("f") as File;
+    expect(entry.lastModified).toBe(1_000_000_000_000);
+  });
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -761,7 +761,9 @@ describe("new Blob([part]) / new File([part], name) do not inherit part metadata
     const before = Date.now();
     const wrapped = new File([Bun.file(p)], "n");
     const after = Date.now();
-    expect(wrapped.lastModified).toBeGreaterThanOrEqual(before);
-    expect(wrapped.lastModified).toBeLessThanOrEqual(after);
+    // Date.now() and the native milli_timestamp() are separate clock reads
+    // and truncate independently, so allow 1s of slack on each side.
+    expect(wrapped.lastModified).toBeGreaterThanOrEqual(before - 1000);
+    expect(wrapped.lastModified).toBeLessThanOrEqual(after + 1000);
   });
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
+import { utimesSync } from "node:fs";
 import path from "node:path";
 
 test("blob: imports have sourcemapped stacktraces", async () => {
@@ -686,5 +687,81 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
     expect(await clone.text()).toBe("56789");
     // Serializing resolves the original's size, clamping the window to EOF.
     expect(s.size).toBe(5);
+  });
+});
+
+describe("new Blob([part]) / new File([part], name) do not inherit part metadata", () => {
+  // Per the File API spec, parts contribute only their bytes; the new Blob's
+  // `type` is "" unless options.type is a valid value, and File's
+  // `lastModified` is the explicit option (or Date.now()), never the part's.
+
+  test("single Blob part does not leak its .type into the wrapper", async () => {
+    const part = new Blob(["y"], { type: "x/secret" });
+    expect({
+      blobNoOpts: new Blob([part]).type,
+      fileNoOpts: new File([part], "n").type,
+      blobInvalidType: new Blob([part], { type: "x/é" }).type,
+      fileInvalidType: new File([part], "n", { type: "x/é" }).type,
+      blobValidType: new Blob([part], { type: "x/ok" }).type,
+      blobTwoParts: new Blob([part, "z"]).type,
+    }).toEqual({
+      blobNoOpts: "",
+      fileNoOpts: "",
+      blobInvalidType: "",
+      fileInvalidType: "",
+      blobValidType: "x/ok",
+      blobTwoParts: "",
+    });
+    // bytes are still copied from the part
+    expect(await new Blob([part]).text()).toBe("y");
+  });
+
+  test("single File part does not turn the wrapper into a File", () => {
+    const part = new File(["y"], "secret.txt", { type: "x/secret", lastModified: 123 });
+    const wrapped = new Blob([part]);
+    expect({
+      type: wrapped.type,
+      isFile: wrapped instanceof File,
+    }).toEqual({
+      type: "",
+      isFile: false,
+    });
+  });
+
+  test("sliced Blob part keeps its byte window but not its .type", async () => {
+    const base = new Blob(["0123456789"], { type: "x/secret" });
+    const slice = base.slice(3, 7, "x/slice");
+    const wrapped = new Blob([slice]);
+    expect(wrapped.type).toBe("");
+    expect(wrapped.size).toBe(4);
+    expect(await wrapped.text()).toBe("3456");
+  });
+
+  test("new File([Bun.file(path)], name, {lastModified}) honors the explicit lastModified", async () => {
+    using dir = tempDir("blob-file-lastmodified", {
+      "f.bin": "OLD",
+    });
+    const p = path.join(String(dir), "f.bin");
+    const bunFile = Bun.file(p);
+    const wrapped = new File([bunFile], "n", { lastModified: 7 });
+    expect(wrapped.lastModified).toBe(7);
+    expect(wrapped.name).toBe("n");
+    // bytes are still the file's bytes
+    expect(await wrapped.text()).toBe("OLD");
+  });
+
+  test("new File([Bun.file(path)], name) without lastModified defaults to now, not the file mtime", async () => {
+    using dir = tempDir("blob-file-lastmodified-default", {
+      "f.bin": "OLD",
+    });
+    const p = path.join(String(dir), "f.bin");
+    // force mtime far into the past so "now" vs "file mtime" are unambiguous
+    const oldMtime = new Date(1_000_000_000_000); // 2001-09-09
+    utimesSync(p, oldMtime, oldMtime);
+    const before = Date.now();
+    const wrapped = new File([Bun.file(p)], "n");
+    const after = Date.now();
+    expect(wrapped.lastModified).toBeGreaterThanOrEqual(before);
+    expect(wrapped.lastModified).toBeLessThanOrEqual(after);
   });
 });


### PR DESCRIPTION
## What

`new Blob([b])` / `new File([b], name)` where `b` is itself a Blob returned a clone of the part rather than a fresh Blob over the part's bytes. The part's `.type` leaked through, a File part turned the wrapper into `instanceof File`, and `new File([Bun.file(p)], name, {lastModified})` stayed a live file reference whose `.lastModified` tracked the file mtime and ignored the explicit option.

## Repro

```js
const t = new Blob(["y"], { type: "x/secret" });
new Blob([t]).type;                   // bun: "x/secret"   spec/node: ""
new File([t], "n").type;              // bun: "x/secret"   spec/node: ""
new Blob([t], { type: "x/é" }).type;  // bun: "x/secret"   spec/node: "" (invalid option -> "")
new Blob([t, "z"]).type;              // bun: ""           (2+ parts: fast path not taken)

const f = Bun.file(path);
new File([f], "n", { lastModified: 7 }).lastModified;  // bun: <live mtime>   spec/node: 7
```

## Cause

`from_js_without_defer_gc`'s single-`DOMWrapper`-part arm returned `blob.dupe()` (or a full field-copy in the move variant), which copies `content_type`, `content_type_was_set`, `last_modified`, `name` and `is_jsdom_file` from the part. The Blob/File constructors then only override `content_type` if `options.type` is a valid value, and only reset it if it is already empty, so the inherited value stayed.

Separately, `get_last_modified` checked for a file-backed store before `is_jsdom_file`, so a `new File()` wrapping a `Bun.file()` reported the store's live mtime instead of the value the File constructor stored.

## Fix

* Add `Blob::dupe_without_metadata()`, which shares `store`/`offset`/`size`/`charset` but leaves `content_type`, `last_modified`, `name` and `is_jsdom_file` at defaults, and use it in the single-Blob-part fast path (both the clone and the move arm, and the `BuildArtifact` arm).
* Hoist the `is_jsdom_file` check to the top of `get_last_modified` so a value set by `new File()` is always returned regardless of the store type.

## Verification

New `describe` block in `test/js/web/fetch/blob.test.ts`. All 5 cases fail on `main` and pass with this change; the rest of `blob.test.ts`, `FormData.test.ts`, `body.test.ts`, `globals.test.js`, `blob-array-fast-path.test.ts`, `structured-clone-blob-file.test.ts` and `blob-file-name-ownership.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c462a8116)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.27ms]
(pass) Blob.slice [44.98ms]
(pass) Bun.file().slice [53.56ms]
(pass) new Blob [4.21ms]
(pass) new Blob stringifies non-Blob object parts in order [12.03ms]
(pass) blob: can be fetched [14.56ms]
(pass) blob: URL has Content-Type [11.29ms]
(pass) blob: can be imported [15.82ms]
(pass) blob: can reliable get type from fetch #10072 [251.59ms]
(pass) new Blob(new Uint8Array()) is supported [5.20ms]
(pass) new File(new Uint8Array()) is supported [4.77ms]
(pass) new File('123', '123') is NOT supported [3.05ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.26ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release without fix: 15 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [0.71ms]
(pass) Blob.slice [0.52ms]
(pass) Bun.file().slice [0.84ms]
(pass) new Blob [0.07ms]
(pass) new Blob stringifies non-Blob object parts in order [0.19ms]
(pass) blob: can be fetched [0.24ms]
(pass) blob: URL has Content-Type [0.18ms]
(pass) blob: can be imported [0.30ms]
(pass) blob: can reliable get type from fetch #10072 [204.94ms]
(pass) new Blob(new Uint8Array()) is supported [0.15ms]
(pass) new File(new Uint8Array()) is supported [0.07ms]
(pass) new File('123', '123') is NOT supported [0.06ms]
218 |     [true, 1],
219 |     ["123", 123],
220 |     [1234, 1234],
221 |     [-1, -1],
222 |   ] as const)("lastModified: %p -> %p", (input, expected) => {
223 |     expect(lm({ lastModified: input })).toBe(expected);
                                              ^
error: expect(received).toBe(expected)

Expected: 0
Received: NaN

      at <anonymous> (/workspace/bun/test/js/web/fetch/blob.test.ts:223:41)
(fail) new File() lastModified option > lastModified: NaN -> 0 [0.24ms]
218 |     [true, 1],
219 |     ["123", 123],
220 |     [1234, 1234],
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c462a8116)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.16ms]
(pass) Blob.slice [46.31ms]
(pass) Bun.file().slice [51.38ms]
(pass) new Blob [4.23ms]
(pass) new Blob stringifies non-Blob object parts in order [11.54ms]
(pass) blob: can be fetched [13.43ms]
(pass) blob: URL has Content-Type [11.10ms]
(pass) blob: can be imported [15.47ms]
(pass) blob: can reliable get type from fetch #10072 [253.11ms]
(pass) new Blob(new Uint8Array()) is supported [5.11ms]
(pass) new File(new Uint8Array()) is supported [4.74ms]
(pass) new File('123', '123') is NOT supported [3.09ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.69ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c462a8116c
  features     (none)

22 deps, 106 codegen, 1168 objects in 843ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[5/1231] gen ErrorCode+*.h
[6/1231] fetch zlib
[zlib] up to date
[7/1231] fetch picohttpparser
[picohttpparser] up to date
[8/1231] fetch tiny
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/webcore_types.rs           |  13 +++++
 src/runtime/webcore/Blob.rs        |  63 ++++++++------------
 src/runtime/webcore/headers_ref.rs |  16 +++--
 test/js/web/fetch/blob.test.ts     | 116 +++++++++++++++++++++++++++++++++++++
 4 files changed, 163 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/webcore_types.rs                3      2      0
src/runtime/webcore/Blob.rs            15     10      0
src/runtime/webcore/headers_ref.rs      1      1      0
test/js/web/fetch/blob.test.ts          6     15      0
```

</details>

<!-- robobun:evidence:end -->