### PR TITLE
webcore: File.prototype.slice() returns a plain Blob, not a File

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -438,6 +438,15 @@ impl Blob {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))
     }
 
+    /// `Bytes.stored_name` is the DOM File name carried on the shared store;
+    /// it must not surface on a plain Blob that merely shares that store
+    /// (e.g. the result of `file.slice()`).
+    #[inline]
+    pub fn hides_bytes_stored_name(&self) -> bool {
+        !self.is_jsdom_file.get()
+            && matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::Bytes(_)))
+    }
+
     /// `Blob.getFileName()` — the user-visible name: `Bytes.stored_name`,
     /// the file path, or the S3 key. `None` for fd-backed or unnamed blobs.
     pub fn get_file_name(&self) -> Option<&[u8]> {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2144,11 +2144,7 @@ impl BlobExt for Blob {
         if self.name.get().tag() != bun_core::Tag::Dead {
             return Some(self.name.get());
         }
-        // Bytes.stored_name is the DOM File name carried on the shared store;
-        // only surface it on an actual File so `file.slice().name` stays undefined.
-        if !self.is_jsdom_file.get()
-            && matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::Bytes(_)))
-        {
+        if self.hides_bytes_stored_name() {
             return None;
         }
         if let Some(path) = self.get_file_name() {
@@ -4421,11 +4417,7 @@ pub extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
-    // Bytes.stored_name is the DOM File name on the shared store; don't hand
-    // it to FormData for a plain Blob (e.g. the result of `file.slice()`).
-    if !this.is_jsdom_file.get()
-        && matches!(this.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::Bytes(_)))
-    {
+    if this.hides_bytes_stored_name() {
         return BunString::empty();
     }
     if let Some(filename) = this.get_file_name() {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4421,6 +4421,13 @@ pub extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
+    // Bytes.stored_name is the DOM File name on the shared store; don't hand
+    // it to FormData for a plain Blob (e.g. the result of `file.slice()`).
+    if !this.is_jsdom_file.get()
+        && matches!(this.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::Bytes(_)))
+    {
+        return BunString::empty();
+    }
     if let Some(filename) = this.get_file_name() {
         return BunString::from_bytes(filename);
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2016,6 +2016,12 @@ impl BlobExt for Blob {
         blob.offset.set(offset);
         blob.size.set(len);
 
+        // Per the File API, slice() returns a new plain Blob regardless of the
+        // receiver's subclass, so drop the File brand and its identity fields.
+        blob.is_jsdom_file.set(false);
+        blob.last_modified.set(0.0);
+        blob.name.set(BunString::dead());
+
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
         if content_type.is_empty()
@@ -2137,6 +2143,13 @@ impl BlobExt for Blob {
     fn get_name_string(&self) -> Option<BunString> {
         if self.name.get().tag() != bun_core::Tag::Dead {
             return Some(self.name.get());
+        }
+        // Bytes.stored_name is the DOM File name carried on the shared store;
+        // only surface it on an actual File so `file.slice().name` stays undefined.
+        if !self.is_jsdom_file.get()
+            && matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::Bytes(_)))
+        {
+            return None;
         }
         if let Some(path) = self.get_file_name() {
             self.name.set(BunString::clone_utf8(path));
@@ -2444,6 +2457,12 @@ impl BlobExt for Blob {
             }
             _ => {
                 blob = Blob::get::<false, true>(global_this, args[0])?;
+
+                // `new Blob(parts)` always yields a plain Blob even when `parts`
+                // contains a File, so drop any File identity propagated by dupe().
+                blob.is_jsdom_file.set(false);
+                blob.last_modified.set(0.0);
+                blob.name.set(BunString::dead());
 
                 if args.len() > 1 {
                     let options = args[1];

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2018,9 +2018,13 @@ impl BlobExt for Blob {
 
         // Per the File API, slice() returns a new plain Blob regardless of the
         // receiver's subclass, so drop the File brand and its identity fields.
+        // For File/S3-backed stores the DOM name lives only in `blob.name`;
+        // clearing it would unmask the on-disk path via get_file_name().
         blob.is_jsdom_file.set(false);
         blob.last_modified.set(0.0);
-        blob.name.set(BunString::dead());
+        if blob.hides_bytes_stored_name() {
+            blob.name.set(BunString::dead());
+        }
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
@@ -2456,9 +2460,13 @@ impl BlobExt for Blob {
 
                 // `new Blob(parts)` always yields a plain Blob even when `parts`
                 // contains a File, so drop any File identity propagated by dupe().
+                // For File/S3-backed stores the DOM name lives only in `blob.name`;
+                // clearing it would unmask the on-disk path via get_file_name().
                 blob.is_jsdom_file.set(false);
                 blob.last_modified.set(0.0);
-                blob.name.set(BunString::dead());
+                if blob.hides_bytes_stored_name() {
+                    blob.name.set(BunString::dead());
+                }
 
                 if args.len() > 1 {
                     let options = args[1];

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -244,6 +244,66 @@ describe("new File() lastModified option", () => {
   });
 });
 
+test("File.prototype.slice() returns a Blob, not a File", async () => {
+  const file = new File(["0123456789"], "secret-report.pdf", { type: "text/plain", lastModified: 1234 });
+  const sliced = file.slice(2, 5);
+
+  expect({
+    isFile: sliced instanceof File,
+    isBlob: sliced instanceof Blob,
+    name: (sliced as any).name,
+    size: sliced.size,
+    text: await sliced.text(),
+  }).toEqual({
+    isFile: false,
+    isBlob: true,
+    name: undefined,
+    size: 3,
+    text: "234",
+  });
+  expect((sliced as any).lastModified).not.toBe(1234);
+
+  // empty File: slice() takes the size==0 early return
+  const emptySlice = new File([], "empty.txt", { lastModified: 999 }).slice();
+  expect(emptySlice instanceof File).toBe(false);
+  expect((emptySlice as any).name).toBeUndefined();
+
+  // new Blob([file]) is a plain Blob, not a File
+  const wrapped = new Blob([file]);
+  expect({
+    isFile: wrapped instanceof File,
+    isBlob: wrapped instanceof Blob,
+    name: (wrapped as any).name,
+  }).toEqual({
+    isFile: false,
+    isBlob: true,
+    name: undefined,
+  });
+
+  // original File is untouched
+  expect({
+    isFile: file instanceof File,
+    name: file.name,
+    lastModified: file.lastModified,
+  }).toEqual({
+    isFile: true,
+    name: "secret-report.pdf",
+    lastModified: 1234,
+  });
+
+  // structuredClone of a File still yields a File
+  const cloned = structuredClone(file);
+  expect({
+    isFile: cloned instanceof File,
+    name: cloned.name,
+    lastModified: cloned.lastModified,
+  }).toEqual({
+    isFile: true,
+    name: "secret-report.pdf",
+    lastModified: 1234,
+  });
+});
+
 test("new Blob('123') is NOT supported", async () => {
   expect(() => new Blob("123")).toThrow();
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -313,6 +313,14 @@ test("File.prototype.slice() returns a Blob, not a File", async () => {
     name: "secret-report.pdf",
     lastModified: 1234,
   });
+
+  // slicing a DOM File that wraps a Bun.file() must not unmask the disk path
+  using dir = tempDir("file-slice-bunfile", { "private-secrets.csv": "0123456789" });
+  const diskPath = path.join(String(dir), "private-secrets.csv");
+  const wrapped2 = new File([Bun.file(diskPath)], "public.csv");
+  const sliced2 = wrapped2.slice(0, 5);
+  expect(sliced2 instanceof File).toBe(false);
+  expect((sliced2 as any).name).not.toBe(diskPath);
 });
 
 test("new Blob('123') is NOT supported", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -280,6 +280,17 @@ test("File.prototype.slice() returns a Blob, not a File", async () => {
     name: undefined,
   });
 
+  // FormData must not emit the parent File's name for a slice
+  const fd = new FormData();
+  fd.append("part", file.slice(2, 5));
+  fd.append("whole", file);
+  const multipart = await new Response(fd).text();
+  const filenames = [...multipart.matchAll(/name="([^"]*)"; filename="([^"]*)"/g)].map(m => [m[1], m[2]]);
+  expect(filenames).toEqual([
+    ["part", ""],
+    ["whole", "secret-report.pdf"],
+  ]);
+
   // original File is untouched
   expect({
     isFile: file instanceof File,


### PR DESCRIPTION
## Repro

```js
const f = new File(["0123456789"], "secret-report.pdf", { type: "a/b", lastModified: 1234 });
const s = f.slice(2, 5);
s instanceof File   // bun: true    node/spec: false
s.name              // bun: "secret-report.pdf"   node: undefined
s.lastModified      // bun: 1234    node: undefined
```

Per the [File API slice algorithm](https://w3c.github.io/FileAPI/#slice-method-algo), `slice()` on a File constructs a new plain `Blob`, with no name, no lastModified, and not a `File`. Bun returned a `File` carrying the parent's identity. `x instanceof File` is the standard branch form/upload handlers and FormData encoders use to decide whether to emit a `filename=`, so every byte range sliced from a File took that branch and leaked the parent's name onto arbitrary derived fragments.

The same propagation happened for `new Blob([file])`, which also answered `true` to `instanceof File`.

## Cause

`get_slice_from` and the `Blob` constructor both build the result via `dupe()`, which copies `is_jsdom_file`, `name` and `last_modified` from the source. `instanceof File` is implemented as `is_jsdom_file.get()`, so the slice answered as a File.

The name additionally lives on the shared `Bytes` store as `stored_name` (set by the File constructor), and the `.name` getter fell through to it regardless of the receiver's File brand, so even after clearing `is_jsdom_file` the slice still reported the parent's name.

## Fix

In `get_slice_from` and the `Blob` constructor, clear `is_jsdom_file`, `last_modified` and `name` on the duped result so it is a plain Blob.

In `get_name_string`, skip the `Bytes.stored_name` fallback when the receiver is not a DOM File. This keeps `Bun.file(path).name` and S3 `.name` (non-Bytes stores) working while preventing the shared store's DOM File name from leaking onto plain Blobs that reference it.

`structuredClone` of a File is unaffected: it goes through `Blob__dupe`, which still copies `is_jsdom_file`.

## Verification

```console
$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/blob.test.ts -t "File.prototype.slice"
(fail) File.prototype.slice() returns a Blob, not a File
$ bun bd test test/js/web/fetch/blob.test.ts
27 pass, 0 fail
```

Related: #32430 and #32434 restructure the File prototype chain more broadly; this PR is the minimal behavioral fix for `slice()` and `new Blob([file])`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (33ed42b59)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [19.81ms]
(pass) Blob.slice [44.55ms]
(pass) Bun.file().slice [50.28ms]
(pass) new Blob [4.01ms]
(pass) new Blob stringifies non-Blob object parts in order [11.88ms]
(pass) blob: can be fetched [12.61ms]
(pass) blob: URL has Content-Type [10.66ms]
(pass) blob: can be imported [14.98ms]
(pass) blob: can reliable get type from fetch #10072 [258.25ms]
(pass) new Blob(new Uint8Array()) is supported [5.00ms]
(pass) new File(new Uint8Array()) is supported [4.59ms]
(pass) new File('123', '123') is NOT supported [3.05ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.24ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release without fix: 7 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [0.61ms]
(pass) Blob.slice [0.50ms]
(pass) Bun.file().slice [0.84ms]
(pass) new Blob [0.07ms]
(pass) new Blob stringifies non-Blob object parts in order [0.18ms]
(pass) blob: can be fetched [0.23ms]
(pass) blob: URL has Content-Type [0.17ms]
(pass) blob: can be imported [0.27ms]
(pass) blob: can reliable get type from fetch #10072 [205.39ms]
(pass) new Blob(new Uint8Array()) is supported [0.11ms]
(pass) new File(new Uint8Array()) is supported [0.06ms]
(pass) new File('123', '123') is NOT supported [0.05ms]
217 |     [true, 1],
218 |     ["123", 123],
219 |     [1234, 1234],
220 |     [-1, -1],
221 |   ] as const)("lastModified: %p -> %p", (input, expected) => {
222 |     expect(lm({ lastModified: input })).toBe(expected);
                                              ^
error: expect(received).toBe(expected)

Expected: 0
Received: NaN

      at <anonymous> (/workspace/bun/test/js/web/fetch/blob.test.ts:222:41)
(fail) new File() lastModified option > lastModified: NaN -> 0 [0.20ms]
217 |     [true, 1],
218 |     ["123", 123],
219 |     [1234, 1234],
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (33ed42b59)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.71ms]
(pass) Blob.slice [44.72ms]
(pass) Bun.file().slice [47.69ms]
(pass) new Blob [4.13ms]
(pass) new Blob stringifies non-Blob object parts in order [11.62ms]
(pass) blob: can be fetched [12.85ms]
(pass) blob: URL has Content-Type [10.68ms]
(pass) blob: can be imported [15.23ms]
(pass) blob: can reliable get type from fetch #10072 [253.89ms]
(pass) new Blob(new Uint8Array()) is supported [5.96ms]
(pass) new File(new Uint8Array()) is supported [4.48ms]
(pass) new File('123', '123') is NOT supported [3.02ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.24ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     33ed42b593
  features     (none)

22 deps, 105 codegen, 1168 objects in 823ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1231] gen ErrorCode+*.h
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1231] gen bindgenv2
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch picohttpparser
[picohttpparser] up to date
[8/1230] fetch z
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/webcore_types.rs       |  9 +++++
 src/runtime/webcore/Blob.rs    | 26 ++++++++++++++
 test/js/web/fetch/blob.test.ts | 79 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 114 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/jsc/webcore_types.rs            3      1      0
src/runtime/webcore/Blob.rs        19     11      0
test/js/web/fetch/blob.test.ts      5      7      0
```

</details>

<!-- robobun:evidence:end -->