### PR TITLE
Blob: store explicit user type verbatim; typeless slice() has empty type

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -59,11 +59,13 @@ impl<'a> Default for InitOptions<'a> {
     }
 }
 
-use crate::webcore::headers_ref::blob_content_type;
-
 #[inline]
 fn headers_from(fetch_headers: Option<&FetchHeaders>, blob: &Blob) -> Headers {
-    bun_http_jsc::headers_jsc::from_fetch_headers(fetch_headers, blob_content_type(blob))
+    // Match `RequestContext::get_content_type`: fall back to the File/S3 store's
+    // extension-sniffed mime so a sliced Bun.file() serves the same Content-Type
+    // as the unsliced file.
+    let ct = blob.content_type_or_mime_type().filter(|ct| !ct.is_empty());
+    bun_http_jsc::headers_jsc::from_fetch_headers(fetch_headers, ct)
 }
 
 #[inline]

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4501,14 +4501,12 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
             }
         }
 
-        if !blob.content_type().is_empty() {
-            bun_http_types::MimeType::by_name(blob.content_type())
+        if let Some(ct) = blob.content_type_or_mime_type().filter(|ct| !ct.is_empty()) {
+            bun_http_types::MimeType::by_name(ct)
         } else if let Some(content) = bun_http_types::MimeType::sniff(blob.slice()) {
             content
         } else if blob.was_string() {
             bun_http_types::MimeType::TEXT
-            // TODO: should we get the mime type off of the Blob.Store if it exists?
-            // A little wary of doing this right now due to causing some breaking change
         } else {
             bun_http_types::MimeType::OTHER
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1371,12 +1371,8 @@ impl BlobExt for Blob {
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
                         self.content_type_was_set.set(true);
-                        self.content_type.set(
-                            match global_this.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
+                        self.content_type
+                            .set(BlobContentType::from_lowercased(slice));
                     }
                 }
             } else if !options_object.is_empty_or_undefined_or_null() {
@@ -1791,12 +1787,8 @@ impl BlobExt for Blob {
                     let slice = content_type_str.slice();
                     if is_valid_blob_type(slice) {
                         self.content_type_was_set.set(true);
-                        self.content_type.set(
-                            match global_this.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
+                        self.content_type
+                            .set(BlobContentType::from_lowercased(slice));
                     }
                 }
 
@@ -2016,17 +2008,10 @@ impl BlobExt for Blob {
         blob.offset.set(offset);
         blob.size.set(len);
 
-        let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
-        // infer the content type if it was not specified
-        if content_type.is_empty()
-            && matches!(self.content_type.get(), BlobContentType::Static(s) if !s.is_empty())
-        {
-            blob.content_type.set(self.content_type.get().clone());
-        } else {
-            blob.content_type.set(content_type);
-        }
-        blob.content_type_was_set
-            .set(self.content_type_was_set.get() || content_type_was_allocated);
+        // File API: a slice()'s type is the caller-supplied contentType (or "" if
+        // omitted/invalid); it never inherits the parent blob's type.
+        blob.content_type_was_set.set(!content_type.is_empty());
+        blob.content_type.set(content_type);
 
         let ptr = Blob::new(blob);
         // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Explicit
@@ -2101,10 +2086,7 @@ impl BlobExt for Blob {
                     if !is_valid_blob_type(slice) {
                         break 'inner;
                     }
-                    content_type = match global_this.bun_vm().as_mut().mime_type(slice) {
-                        Some(mime) => BlobContentType::from(mime),
-                        None => BlobContentType::from_lowercased(slice),
-                    };
+                    content_type = BlobContentType::from_lowercased(slice);
                 }
             }
         }
@@ -2457,12 +2439,8 @@ impl BlobExt for Blob {
                                         break 'inner;
                                     }
                                     blob.content_type_was_set.set(true);
-                                    blob.content_type.set(
-                                        match global_this.bun_vm().as_mut().mime_type(slice) {
-                                            Some(mime) => BlobContentType::from(mime),
-                                            None => BlobContentType::from_lowercased(slice),
-                                        },
-                                    );
+                                    blob.content_type
+                                        .set(BlobContentType::from_lowercased(slice));
                                 }
                             }
                         }
@@ -5680,12 +5658,8 @@ pub fn jsdom_file_construct_(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        blob.content_type.set(
-                            match global_this.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
+                        blob.content_type
+                            .set(BlobContentType::from_lowercased(slice));
                     }
                 }
             }
@@ -5767,12 +5741,8 @@ pub fn construct_bun_file(
                             break 'inner;
                         }
                         blob.content_type_was_set.set(true);
-                        blob.content_type.set(
-                            match global_object.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
+                        blob.content_type
+                            .set(BlobContentType::from_lowercased(slice));
                     }
                 }
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6732,6 +6732,15 @@ impl Any {
         }
     }
 
+    /// `content_type()`, or for a File-/S3-backed Blob with no explicit type,
+    /// the extension-sniffed `mime_type` held on the store.
+    pub fn content_type_or_mime_type(&self) -> Option<&[u8]> {
+        match self {
+            Any::Blob(b) => b.content_type_or_mime_type(),
+            _ => Some(self.content_type()),
+        }
+    }
+
     pub fn was_string(&self) -> bool {
         match self {
             Any::Blob(b) => b.charset.get() == strings::AsciiStatus::AllAscii,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2027,13 +2027,6 @@ impl BlobExt for Blob {
         // index the full fixed-3 array (args[2] is written below regardless of len).
         let args = &mut arguments_.ptr[..];
 
-        if self.size.get() == 0 {
-            let ptr = Blob::new(Blob::init_empty(global_this));
-            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; force
-            // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js`.
-            return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
-        }
-
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
         let mut relative_start: i64 = 0;
         // If the optional end parameter is not used, let relativeEnd be size.

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -75,12 +75,10 @@ where
         )?;
 
         formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
-        if offset > 0 {
-            writer.write_str("\n")?;
-        }
     }
 
     if offset > 0 {
+        writer.write_str("\n")?;
         let mut formatter = formatter.indented();
         formatter.write_indent(writer)?;
 

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -399,10 +399,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
                         }
                         blob.content_type_was_set.set(true);
                         blob.content_type
-                            .set(match global.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => blob::BlobContentType::from(mime),
-                                None => blob::BlobContentType::from_lowercased(slice),
-                            });
+                            .set(blob::BlobContentType::from_lowercased(slice));
                     }
                 }
             }
@@ -446,10 +443,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
                         }
                         blob.content_type_was_set.set(true);
                         blob.content_type
-                            .set(match global.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => blob::BlobContentType::from(mime),
-                                None => blob::BlobContentType::from_lowercased(slice),
-                            });
+                            .set(blob::BlobContentType::from_lowercased(slice));
                     }
                 }
             }

--- a/src/runtime/webcore/headers_ref.rs
+++ b/src/runtime/webcore/headers_ref.rs
@@ -6,21 +6,23 @@
 use crate::webcore::Blob;
 use crate::webcore::blob::Any as AnyBlob;
 
-/// `Some(ct)` only when the body has a *user-set* content-type.
+/// `Some(ct)` only when the body has a non-empty user-set content-type.
 #[inline]
 pub(crate) fn any_blob_content_type(b: &AnyBlob) -> Option<&[u8]> {
     if b.has_content_type_from_user() {
-        Some(b.content_type())
+        let ct = b.content_type();
+        (!ct.is_empty()).then_some(ct)
     } else {
         None
     }
 }
 
-/// `Some(ct)` only when the body has a *user-set* content-type.
+/// `Some(ct)` only when the body has a non-empty user-set content-type.
 #[inline]
 pub(crate) fn blob_content_type(b: &Blob) -> Option<&[u8]> {
     if b.has_content_type_from_user() {
-        Some(b.content_type_slice())
+        let ct = b.content_type_slice();
+        (!ct.is_empty()).then_some(ct)
     } else {
         None
     }

--- a/src/runtime/webcore/headers_ref.rs
+++ b/src/runtime/webcore/headers_ref.rs
@@ -1,9 +1,7 @@
 //! Helpers for extracting the body content-type byte slice that
 //! `bun_http_jsc::headers_jsc::from_fetch_headers` consumes. Shared by
-//! `webcore::fetch`, `server::StaticRoute`, `server::FileRoute`, and
-//! `bake::DevServer`.
+//! `webcore::fetch`, `server::StaticRoute`, and `bake::DevServer`.
 
-use crate::webcore::Blob;
 use crate::webcore::blob::Any as AnyBlob;
 
 /// `Some(ct)` only when the body has a non-empty user-set content-type.
@@ -11,17 +9,6 @@ use crate::webcore::blob::Any as AnyBlob;
 pub(crate) fn any_blob_content_type(b: &AnyBlob) -> Option<&[u8]> {
     if b.has_content_type_from_user() {
         let ct = b.content_type();
-        (!ct.is_empty()).then_some(ct)
-    } else {
-        None
-    }
-}
-
-/// `Some(ct)` only when the body has a non-empty user-set content-type.
-#[inline]
-pub(crate) fn blob_content_type(b: &Blob) -> Option<&[u8]> {
-    if b.has_content_type_from_user() {
-        let ct = b.content_type_slice();
         (!ct.is_empty()).then_some(ct)
     } else {
         None

--- a/src/runtime/webcore/headers_ref.rs
+++ b/src/runtime/webcore/headers_ref.rs
@@ -28,7 +28,7 @@ pub(crate) fn blob_content_type(b: &Blob) -> Option<&[u8]> {
     }
 }
 
-/// `Some(ct)` only when the body has a *user-set* content-type.
+/// `Some(ct)` only when the body has a non-empty user-set content-type.
 #[inline]
 pub(crate) fn any_blob_content_type_opt(b: Option<&AnyBlob>) -> Option<&[u8]> {
     b.and_then(any_blob_content_type)

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -208,11 +208,7 @@ describe("static route Content-Type", () => {
   // change the Content-Type the next registration of the same Response produces.
   test.each([
     ["string body", () => new Response("hello"), "text/plain;charset=utf-8"],
-    [
-      "typed Blob body",
-      () => new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" })),
-      "text/html;charset=utf-8",
-    ],
+    ["typed Blob body", () => new Response(new Blob(["<h1>hi</h1>"], { type: "text/html" })), "text/html"],
     ["explicit header", () => new Response("hello", { headers: { "Content-Type": "text/foo" } }), "text/foo"],
     ["Response.json", () => Response.json({ a: 1 }), "application/json;charset=utf-8"],
     ["Uint8Array body", () => new Response(new Uint8Array([1, 2, 3])), null],
@@ -252,8 +248,8 @@ describe("static route Content-Type", () => {
       untouched: await contentTypeOf(server, "/untouched"),
       touched: await contentTypeOf(server, "/touched"),
     }).toEqual({
-      untouched: "text/html;charset=utf-8",
-      touched: "text/html;charset=utf-8",
+      untouched: "text/html",
+      touched: "text/html",
     });
   });
 

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -165,13 +165,9 @@ describe.concurrent.skipIf(!r2Credentials.endpoint && !isCI)("Virtual Hosted-Sty
       );
     }
     {
-      const file = client
-        .file("filename.txt", {
-          type: "text/plain",
-        })
-        .slice(10);
+      const file = client.file("filename.txt").slice(10, "text/plain");
       expect(Bun.inspect(file)).toBe(
-        'S3Ref ("bucket/filename.txt") {\n  type: "text/plain;charset=utf-8",\n  offset: 10,\n  endpoint: "bucket.test.r2.cloudflarestorage.com",\n  region: "auto",\n  accessKeyId: "[REDACTED]",\n  secretAccessKey: "[REDACTED]",\n  partSize: 5242880,\n  queueSize: 5,\n  retry: 3\n}',
+        'S3Ref ("bucket/filename.txt") {\n  type: "text/plain",\n  offset: 10,\n  endpoint: "bucket.test.r2.cloudflarestorage.com",\n  region: "auto",\n  accessKeyId: "[REDACTED]",\n  secretAccessKey: "[REDACTED]",\n  partSize: 5242880,\n  queueSize: 5,\n  retry: 3\n}',
       );
     }
   });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -619,23 +619,23 @@ describe("console.logging class displays names and extends", async () => {
 
 it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain"\n}');
   blob.name = "bar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar",\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar",\n  type: "text/plain"\n}');
   blob.name = "foobar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8"\n}');
+  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar",\n  type: "text/plain"\n}');
 
   const file = new File(["foo"], "bar.txt", { type: "text/plain" });
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "bar.txt",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "bar.txt",\n  type: "text/plain",\n  lastModified: ${file.lastModified}\n}`,
   );
   file.name = "foobar";
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "foobar",\n  type: "text/plain",\n  lastModified: ${file.lastModified}\n}`,
   );
   file.name = "";
   expect(Bun.inspect(file)).toBe(
-    `File (3 bytes) {\n  name: "",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
+    `File (3 bytes) {\n  name: "",\n  type: "text/plain",\n  lastModified: ${file.lastModified}\n}`,
   );
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -124,6 +124,7 @@ describe("Blob type", () => {
     expect(new File([], "f", { type: input }).type).toBe(expected);
     expect(new File(["x"], "f", { type: input }).type).toBe(expected);
     expect(new Blob(["x"]).slice(0, 1, input).type).toBe(expected);
+    expect(new Blob([]).slice(0, 0, input).type).toBe(expected);
   });
 
   // https://w3c.github.io/FileAPI/#slice-method-algo

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -103,6 +103,60 @@ test("new Blob", () => {
   expect(blob.type).toBe("");
 });
 
+describe("Blob type", () => {
+  // https://w3c.github.io/FileAPI/#dom-blob-type
+  // An explicit user-supplied `type` must be returned verbatim (lowercased),
+  // without Bun appending `;charset=utf-8` for recognised MIME types.
+  test.each([
+    ["text/plain", "text/plain"],
+    ["application/json", "application/json"],
+    ["text/html", "text/html"],
+    ["text/css", "text/css"],
+    ["text/javascript", "text/javascript"],
+    ["Text/PLAIN", "text/plain"],
+    ["text/plain;charset=utf-8", "text/plain;charset=utf-8"],
+    ["application/octet-stream", "application/octet-stream"],
+    ["a/b", "a/b"],
+    ["", ""],
+  ])("new Blob/File/slice type %j -> %j", (input, expected) => {
+    expect(new Blob([], { type: input }).type).toBe(expected);
+    expect(new Blob(["x"], { type: input }).type).toBe(expected);
+    expect(new File([], "f", { type: input }).type).toBe(expected);
+    expect(new File(["x"], "f", { type: input }).type).toBe(expected);
+    expect(new Blob(["x"]).slice(0, 1, input).type).toBe(expected);
+  });
+
+  // https://w3c.github.io/FileAPI/#slice-method-algo
+  // A slice() with no contentType, "", or an invalid contentType has type "";
+  // it must not inherit the parent's type (regardless of whether the parent's
+  // type happens to be in Bun's MIME table).
+  test.each(["text/plain", "application/json", "a/b", "x-weird/y-type"])(
+    "slice() does not inherit parent type %j",
+    parentType => {
+      const parent = new Blob(["x"], { type: parentType });
+      expect(parent.slice(0, 1).type).toBe("");
+      expect(parent.slice(0, 1, "").type).toBe("");
+      expect(parent.slice(0, 1, "x/\u00e9").type).toBe("");
+      expect(parent.slice(0, 1, "\u1234").type).toBe("");
+      // parent is not mutated
+      expect(parent.type).toBe(parentType);
+    },
+  );
+
+  test("Bun.file() explicit type is not canonicalized", async () => {
+    expect(Bun.file("x", { type: "text/plain" }).type).toBe("text/plain");
+    expect(Bun.file("x", { type: "application/json" }).type).toBe("application/json");
+    // extension-sniffed default is still Bun's canonical form
+    expect(Bun.file("x.txt").type).toBe("text/plain;charset=utf-8");
+
+    // .write({type}) must not canonicalize either
+    using dir = tempDir("blob-type-write", { "f": "" });
+    const f = Bun.file(path.join(String(dir), "f"));
+    await f.write("hello", { type: "text/plain" });
+    expect(f.type).toBe("text/plain");
+  });
+});
+
 test("new Blob stringifies non-Blob object parts in order", async () => {
   const url = new URL("https://example.com/path");
   expect(await new Blob([url]).text()).toBe("https://example.com/path");

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -161,9 +161,7 @@ describe("Blob type", () => {
     await using server = Bun.serve({
       port: 0,
       fetch: req =>
-        new Response(
-          JSON.stringify({ ct: req.headers.get("content-type"), hasCt: req.headers.has("content-type") }),
-        ),
+        new Response(JSON.stringify({ ct: req.headers.get("content-type"), hasCt: req.headers.has("content-type") })),
     });
     const post = (body: BodyInit) => fetch(server.url, { method: "POST", body }).then(r => r.json());
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -182,11 +182,15 @@ describe("Blob type", () => {
     });
   });
 
-  test("serving a typeless file slice from a dynamic handler falls back to the file's mime type", async () => {
+  test("serving a typeless file slice falls back to the file's mime type", async () => {
     using dir = tempDir("blob-type-slice-serve", { "f.txt": "hello world" });
     const file = path.join(String(dir), "f.txt");
     await using server = Bun.serve({
       port: 0,
+      static: {
+        "/static-slice": new Response(Bun.file(file).slice(0, 5)),
+        "/static-full": new Response(Bun.file(file)),
+      },
       fetch: req =>
         new URL(req.url).pathname === "/slice"
           ? new Response(Bun.file(file).slice(0, 5))
@@ -196,10 +200,12 @@ describe("Blob type", () => {
       const r = await fetch(server.url.href + p);
       return { ct: r.headers.get("content-type"), cd: r.headers.get("content-disposition"), body: await r.text() };
     };
-    // Matches the unsliced file: extension-sniffed type, no Content-Disposition
-    // (not application/octet-stream, not an empty-valued header).
+    // Matches the unsliced file on both the dynamic and static route paths:
+    // extension-sniffed type, no Content-Disposition, not application/octet-stream.
     expect(await headers("slice")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello" });
     expect(await headers("full")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello world" });
+    expect(await headers("static-slice")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello" });
+    expect(await headers("static-full")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello world" });
   });
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -181,6 +181,26 @@ describe("Blob type", () => {
       hasCt: true,
     });
   });
+
+  test("serving a typeless file slice from a dynamic handler falls back to the file's mime type", async () => {
+    using dir = tempDir("blob-type-slice-serve", { "f.txt": "hello world" });
+    const file = path.join(String(dir), "f.txt");
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req =>
+        new URL(req.url).pathname === "/slice"
+          ? new Response(Bun.file(file).slice(0, 5))
+          : new Response(Bun.file(file)),
+    });
+    const headers = async (p: string) => {
+      const r = await fetch(server.url.href + p);
+      return { ct: r.headers.get("content-type"), cd: r.headers.get("content-disposition"), body: await r.text() };
+    };
+    // Matches the unsliced file: extension-sniffed type, no Content-Disposition
+    // (not application/octet-stream, not an empty-valued header).
+    expect(await headers("slice")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello" });
+    expect(await headers("full")).toEqual({ ct: "text/plain;charset=utf-8", cd: null, body: "hello world" });
+  });
 });
 
 test("new Blob stringifies non-Blob object parts in order", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -155,6 +155,33 @@ describe("Blob type", () => {
     await f.write("hello", { type: "text/plain" });
     expect(f.type).toBe("text/plain");
   });
+
+  test("typeless slice body omits the Content-Type header", async () => {
+    using dir = tempDir("blob-type-slice-ct", { "f.txt": "hello world" });
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req =>
+        new Response(
+          JSON.stringify({ ct: req.headers.get("content-type"), hasCt: req.headers.has("content-type") }),
+        ),
+    });
+    const post = (body: BodyInit) => fetch(server.url, { method: "POST", body }).then(r => r.json());
+
+    // A typeless slice's type is "", so per Fetch "extract a body" the header
+    // is omitted, never sent with an empty value (this was already latently
+    // broken for the non-table-MIME case before this change).
+    expect(await post(Bun.file(path.join(String(dir), "f.txt")).slice(0, 5))).toEqual({ ct: null, hasCt: false });
+    expect(await post(Bun.file(path.join(String(dir), "f.txt"), { type: "custom/x" }).slice(0, 5))).toEqual({
+      ct: null,
+      hasCt: false,
+    });
+    expect(await post(new Blob(["hello"], { type: "text/plain" }).slice(0, 3))).toEqual({ ct: null, hasCt: false });
+    // control: the unsliced file still carries its extension-sniffed type
+    expect(await post(Bun.file(path.join(String(dir), "f.txt")))).toEqual({
+      ct: "text/plain;charset=utf-8",
+      hasCt: true,
+    });
+  });
 });
 
 test("new Blob stringifies non-Blob object parts in order", async () => {

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -48,7 +48,7 @@ describe("multipart serialization (new Response(formData))", () => {
         `Content-Type: application/octet-stream\r\n\r\nnamed-bytes\r\n`,
         `--${boundary}\r\n`,
         `Content-Disposition: form-data; name="typed-file"; filename="weird%22file%0D%0Aname.html"\r\n`,
-        `Content-Type: text/html;charset=utf-8\r\n\r\n<p>hi</p>\r\n`,
+        `Content-Type: text/html\r\n\r\n<p>hi</p>\r\n`,
         `--${boundary}--\r\n`,
       ].join(""),
     );

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -60,7 +60,7 @@ describe("structuredClone with Blob and File", () => {
       const cloned = structuredClone(blob);
       expect(cloned).toBeInstanceOf(Blob);
       expect(cloned.size).toBe(11);
-      expect(cloned.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.type).toBe("text/plain");
 
       const originalText = await blob.text();
       const clonedText = await cloned.text();
@@ -108,11 +108,11 @@ describe("structuredClone with Blob and File", () => {
 
       expect(cloned.first).toBeInstanceOf(Blob);
       expect(cloned.first.size).toBe(5);
-      expect(cloned.first.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.first.type).toBe("text/plain");
 
       expect(cloned.second).toBeInstanceOf(Blob);
       expect(cloned.second.size).toBe(5);
-      expect(cloned.second.type).toBe("text/html;charset=utf-8");
+      expect(cloned.second.type).toBe("text/html");
     });
 
     test("deeply nested Blob", () => {
@@ -159,7 +159,7 @@ describe("structuredClone with Blob and File", () => {
       expect(cloned).toBeInstanceOf(File);
       expect(cloned.name).toBe("test.txt");
       expect(cloned.size).toBe(7);
-      expect(cloned.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.type).toBe("text/plain");
       expect(cloned.lastModified).toBe(1234567890000);
     });
 
@@ -170,7 +170,7 @@ describe("structuredClone with Blob and File", () => {
       expect(cloned).toBeInstanceOf(File);
       expect(cloned.name).toBe("test.txt");
       expect(cloned.size).toBe(7);
-      expect(cloned.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.type).toBe("text/plain");
       expect(cloned.lastModified).toBeGreaterThan(0);
     });
 
@@ -192,7 +192,7 @@ describe("structuredClone with Blob and File", () => {
       expect(cloned.file).toBeInstanceOf(File);
       expect(cloned.file.name).toBe("test.txt");
       expect(cloned.file.size).toBe(4);
-      expect(cloned.file.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.file.type).toBe("text/plain");
     });
 
     test("multiple Files in object", () => {
@@ -203,11 +203,11 @@ describe("structuredClone with Blob and File", () => {
 
       expect(cloned.txt).toBeInstanceOf(File);
       expect(cloned.txt.name).toBe("hello.txt");
-      expect(cloned.txt.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.txt.type).toBe("text/plain");
 
       expect(cloned.html).toBeInstanceOf(File);
       expect(cloned.html.name).toBe("world.html");
-      expect(cloned.html.type).toBe("text/html;charset=utf-8");
+      expect(cloned.html.type).toBe("text/html");
     });
   });
 
@@ -220,12 +220,12 @@ describe("structuredClone with Blob and File", () => {
 
       expect(cloned.blob).toBeInstanceOf(Blob);
       expect(cloned.blob.size).toBe(12);
-      expect(cloned.blob.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.blob.type).toBe("text/plain");
 
       expect(cloned.file).toBeInstanceOf(File);
       expect(cloned.file.name).toBe("test.txt");
       expect(cloned.file.size).toBe(12);
-      expect(cloned.file.type).toBe("text/plain;charset=utf-8");
+      expect(cloned.file.type).toBe("text/plain");
     });
 
     test("array with mixed Blob and File", () => {

--- a/test/vendor.json
+++ b/test/vendor.json
@@ -6,7 +6,8 @@
     "skipTests": {
       "ws*connection.test.ts": "TEMPORARY: elysia 1.4.28 asserts wasClean=false for a server-initiated ws.close(), but that's a clean Close handshake — Bun now reports wasClean=true to match Node/WHATWG (oven-sh/bun#31518). Fixed upstream in elysiajs/elysia#1908; remove this skip on the next elysia bump. (glob * = path separator, so it also matches Windows backslash paths)",
       "adapter*web-standard*map-response.test.ts": "TEMPORARY: Bun's Response.redirect now puts the WHATWG serialization of the url into Location (oven-sh/bun#33126), matching Node and https://fetch.spec.whatwg.org/#dom-response-redirect, so Response.redirect('https://cunny.school') yields 'https://cunny.school/'. elysia 1.4.28's 'map redirect' test asserts the unserialized string; remove this skip once the upstream assertion expects the trailing slash.",
-      "adapter*web-standard*map-early-response.test.ts": "TEMPORARY: same as adapter*web-standard*map-response.test.ts; its 'map redirect' test asserts the unserialized Response.redirect Location value."
+      "adapter*web-standard*map-early-response.test.ts": "TEMPORARY: same as adapter*web-standard*map-response.test.ts; its 'map redirect' test asserts the unserialized Response.redirect Location value.",
+      "path*path.test.ts": "TEMPORARY: Bun now stores an explicit Blob/File `type` verbatim (oven-sh/bun#15078) instead of appending `;charset=utf-8`, matching Node and the File API spec. elysia 1.4.28's \"return web api's File\" test asserts Content-Type is 'text/plain;charset=utf-8' for `new File([...], name, {type: 'text/plain'})`; remove this skip once the upstream assertion expects 'text/plain'."
     }
   }
 ]


### PR DESCRIPTION
## What

`new Blob({type})`, `new File({type})`, `blob.slice(_, _, type)`, `Bun.file(path, {type})`, `Bun.file().write(data, {type})`, `s3file.writer({type})`, and the S3 `client.file(path, {type})` paths were canonicalizing an explicit user-supplied `type` through Bun's MIME table and, as a side effect of how the canonicalized value was stored, a typeless `slice()` of such a blob inherited the parent's type instead of being empty.

```js
// before:
new Blob([], { type: "text/plain" }).type                      // "text/plain;charset=utf-8"   node/spec: "text/plain"
new Blob(["x"], { type: "text/plain" }).slice(0, 1).type       // "text/plain;charset=utf-8"   node/spec: ""
new Blob(["x"], { type: "text/plain" }).slice(0, 1, "").type   // "text/plain;charset=utf-8"   node/spec: ""
new Blob(["x"], { type: "a/b"        }).slice(0, 1).type       // ""  (correct, because "a/b" is not in the table)
```

The inheritance was inconsistent: whether `blob.slice(0, 1).type` was empty depended on whether the parent's type string happened to be in Bun's static MIME table.

## Why

When a user's `type` matched a table entry, `vm.mime_type()` returned the canonical `MimeType` (e.g. `text/plain` → `text/plain;charset=utf-8`) and the blob stored it as `BlobContentType::Static`. `get_slice_from()` then copied the parent's `content_type` onto a typeless slice specifically when it was `Static`, so a table-matched parent bled its type into the slice while an unrecognised parent did not.

## Fix

* Every site that accepts an explicit user-supplied `type` now calls `BlobContentType::from_lowercased(slice)` directly instead of going through the MIME table, matching the [File API spec](https://w3c.github.io/FileAPI/#dom-blob-type) and Node.
* `get_slice_from()` no longer inherits the parent's `content_type`; a slice's type is exactly the caller-supplied `contentType` (or `""` if omitted/empty/invalid) per the [slice algorithm](https://w3c.github.io/FileAPI/#slice-method-algo). The `size == 0` early return is dropped so `new Blob([]).slice(0, 0, type)` also honors the caller's type.
* Consumers of the now-empty slice `content_type`: `headers_ref.rs` filters empty so a typeless slice body omits the `Content-Type` header rather than sending an empty value; `RequestContext::get_content_type` falls back to the File/S3 store's extension-sniffed `mime_type` so `new Response(Bun.file(p).slice(a, b))` from a dynamic handler keeps the same `Content-Type` as the unsliced file (no spurious `Content-Disposition`); `S3File::write_format` emits the `offset:` line correctly when the type line is absent.

Bun-inferred defaults are unchanged: `Bun.file("x.txt").type` is still `"text/plain;charset=utf-8"` (extension-sniffed), `new Response("s")` still defaults to `text/plain;charset=utf-8`, and data-URL handling still canonicalizes.

Rebased onto #33599 (the `BlobContentType` enum refactor), which reduced the source change to dropping the `vm.mime_type()` match at eight call sites plus the slice-inheritance block.

## Verification

```sh
bun bd test test/js/web/fetch/blob.test.ts -t "Blob type"            # 17 pass (8 fail on released bun)
bun bd test test/js/web/fetch/blob.test.ts                            # 45 pass
bun bd test test/js/web/structured-clone-blob-file.test.ts            # 36 pass
bun bd test test/js/bun/util/inspect.test.js                          # 73 pass
bun bd test test/js/bun/http/bun-serve-static.test.ts                 # 41 pass
bun bd test test/js/web/html/FormData-multipart-serialization.test.ts # 6 pass
bun bd test test/js/bun/util/file-type.test.ts test/js/bun/globals.test.js  # 22 pass
```

Six existing test files that asserted the canonicalized type are updated to expect the verbatim type; in each case the test's actual invariant (clone preserves type, serve is stable across registrations, multipart round-trips, S3 inspect shows the slice's own type) is preserved. One vendored Elysia test that asserts the old behavior is skipped via `test/vendor.json`.

Fixes #15078

Related: #19603 is the same family but goes through `MimeType::init` / `by_name`, which this PR does not touch. Remaining sites that still canonicalize for a #19603 follow-up:

* `Body.rs` `res.blob()` path (`MimeType::init` copying a response `Content-Type` onto the returned blob), and its `!content_type_was_set && store.is_some()` heuristic at line 2173 that stamps `text/plain;charset=utf-8` onto `.blob()` of an untyped in-memory body (now also reachable from `new Response(typedBlob.slice())`, where it was previously masked by the inherited flag).
* `RequestContext::get_content_type`'s `by_name` call, so a dynamic `fetch` handler returning `new Response(new Blob([...], {type: "text/html"}))` still serves `text/html;charset=utf-8` while the static route and in-process `.headers` now report `text/html` verbatim. The dynamic-serve wire behavior is unchanged from before this PR.
* `fetch.rs::data_url_response` (`MimeType::init` on the data URL's media type).