### PR TITLE
require(esm): throw ERR_REQUIRE_CYCLE_MODULE for an ESM already on the evaluation stack

### DIFF
--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -345,5 +345,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_TRACE_EVENTS_CATEGORY_REQUIRED", TypeError],
   ["ERR_TRACE_EVENTS_UNAVAILABLE", Error],
+  ["ERR_REQUIRE_CYCLE_MODULE", Error],
 ];
 export default errors;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -785,11 +785,9 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
-        // The entry exists but is currently on the link/evaluate stack
-        // (an ancestor in the import graph, or a self-require). Re-entering
-        // loadModuleSync would call CyclicModuleRecord::link() on a record
-        // whose status is Linking/Evaluating, which the spec forbids and
-        // JSC asserts against. Surface Node's ERR_REQUIRE_CYCLE_MODULE.
+        // The entry is on the link/evaluate stack (ancestor or self-require).
+        // loadModuleSync would re-enter link() on a Linking/Evaluating record,
+        // which the spec forbids and JSC asserts; throw Node's cycle error.
         if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record())) {
             auto status = cyclic->status();
             if (status == JSC::CyclicModuleRecord::Status::Linking || status == JSC::CyclicModuleRecord::Status::Evaluating) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -785,6 +785,19 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
+        // The entry exists but is currently on the link/evaluate stack
+        // (an ancestor in the import graph, or a self-require). Re-entering
+        // loadModuleSync would call CyclicModuleRecord::link() on a record
+        // whose status is Linking/Evaluating, which the spec forbids and
+        // JSC asserts against. Surface Node's ERR_REQUIRE_CYCLE_MODULE.
+        if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record())) {
+            auto status = cyclic->status();
+            if (status == JSC::CyclicModuleRecord::Status::Linking || status == JSC::CyclicModuleRecord::Status::Evaluating) {
+                auto message = makeString("Cannot require() ES Module "_s, keyString, " in a cycle. A cycle involving require(esm) is not allowed to maintain invariants mandated by the ECMAScript specification. Try making at least part of the dependency in the graph lazily loaded."_s);
+                scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_REQUIRE_CYCLE_MODULE, message));
+                return {};
+            }
+        }
     }
 
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);

--- a/test/js/bun/resolve/require-esm-cycle.test.ts
+++ b/test/js/bun/resolve/require-esm-cycle.test.ts
@@ -1,0 +1,117 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// require() of an ES module that is currently on the import evaluation stack
+// (ESM → ESM → createRequire back to an ancestor) must throw
+// ERR_REQUIRE_CYCLE_MODULE like Node, not abort in CyclicModuleRecord::link
+// and not silently return an empty namespace.
+describe.concurrent("require(esm) while the target is mid-evaluation", () => {
+  test("ESM→ESM→createRequire(ancestor) throws ERR_REQUIRE_CYCLE_MODULE", async () => {
+    using dir = tempDir("require-esm-cycle", {
+      "a.mjs": `import './b.mjs';
+export const A = 1;
+console.log("a done");
+`,
+      "b.mjs": `import { createRequire } from "node:module";
+let got;
+try { got = createRequire(import.meta.url)("./a.mjs"); }
+catch (e) { got = "!" + (e.code || e.name); }
+console.log("b required a:", typeof got === "object" ? JSON.stringify(got) : got);
+`,
+      "entry.mjs": `import { pathToFileURL } from "node:url";
+await import(pathToFileURL("./a.mjs").href);
+console.log("alive");
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "b required a: !ERR_REQUIRE_CYCLE_MODULE\na done\nalive\n",
+      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+      exitCode: 0,
+    });
+  });
+
+  test("self-require from an ESM throws ERR_REQUIRE_CYCLE_MODULE", async () => {
+    using dir = tempDir("require-esm-self-cycle", {
+      "self.mjs": `import { createRequire } from "node:module";
+let got;
+try { got = createRequire(import.meta.url)("./self.mjs"); }
+catch (e) { got = "!" + (e.code || e.name); }
+console.log("self required:", typeof got === "object" ? JSON.stringify(got) : got);
+export const S = 1;
+`,
+      "entry.mjs": `import { pathToFileURL } from "node:url";
+await import(pathToFileURL("./self.mjs").href);
+console.log("alive");
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "self required: !ERR_REQUIRE_CYCLE_MODULE\nalive\n",
+      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+      exitCode: 0,
+    });
+  });
+
+  test("uncaught cycle error rejects the dynamic import and does not abort", async () => {
+    using dir = tempDir("require-esm-cycle-uncaught", {
+      "a.mjs": `import './b.mjs';
+export const A = 1;
+`,
+      "b.mjs": `import { createRequire } from "node:module";
+createRequire(import.meta.url)("./a.mjs");
+`,
+      "entry.mjs": `import { pathToFileURL } from "node:url";
+try {
+  await import(pathToFileURL("./a.mjs").href);
+  console.log("should not reach");
+} catch (e) {
+  console.log("caught:", e.code || e.name);
+}
+console.log("alive");
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "caught: ERR_REQUIRE_CYCLE_MODULE\nalive\n",
+      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/bun/resolve/require-esm-cycle.test.ts
+++ b/test/js/bun/resolve/require-esm-cycle.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// require() of an ES module that is currently on the import evaluation stack
-// (ESM → ESM → createRequire back to an ancestor) must throw
+// require() of an ESM that is mid-evaluation (ancestor or self) must throw
 // ERR_REQUIRE_CYCLE_MODULE like Node, not abort in CyclicModuleRecord::link
 // and not silently return an empty namespace.
 describe.concurrent("require(esm) while the target is mid-evaluation", () => {
@@ -15,8 +14,8 @@ console.log("a done");
       "b.mjs": `import { createRequire } from "node:module";
 let got;
 try { got = createRequire(import.meta.url)("./a.mjs"); }
-catch (e) { got = "!" + (e.code || e.name); }
-console.log("b required a:", typeof got === "object" ? JSON.stringify(got) : got);
+catch (e) { got = { code: e.code, name: e.name, message: e.message }; }
+console.log("b required a:", JSON.stringify(got));
 `,
       "entry.mjs": `import { pathToFileURL } from "node:url";
 await import(pathToFileURL("./a.mjs").href);
@@ -32,11 +31,20 @@ console.log("alive");
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "b required a: !ERR_REQUIRE_CYCLE_MODULE\na done\nalive\n",
-      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+    const lines = stdout.split("\n");
+    expect({ lines, stderr, exitCode }).toEqual({
+      lines: [expect.stringMatching(/^b required a: /), "a done", "alive", ""],
+      stderr: "",
       exitCode: 0,
     });
+    const got = JSON.parse(lines[0].slice("b required a: ".length));
+    expect(got).toEqual({
+      code: "ERR_REQUIRE_CYCLE_MODULE",
+      name: "Error",
+      message: expect.stringContaining("Cannot require() ES Module"),
+    });
+    expect(got.message).toContain("a.mjs");
+    expect(got.message).toContain("in a cycle");
   });
 
   test("self-require from an ESM throws ERR_REQUIRE_CYCLE_MODULE", async () => {
@@ -64,7 +72,7 @@ console.log("alive");
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "self required: !ERR_REQUIRE_CYCLE_MODULE\nalive\n",
-      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+      stderr: "",
       exitCode: 0,
     });
   });
@@ -98,7 +106,7 @@ console.log("alive");
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "caught: ERR_REQUIRE_CYCLE_MODULE\nalive\n",
-      stderr: expect.not.stringContaining("ASSERTION FAILED"),
+      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/js/bun/resolve/require-esm-cycle.test.ts
+++ b/test/js/bun/resolve/require-esm-cycle.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // require() of an ES module that is currently on the import evaluation stack
@@ -30,11 +30,7 @@ console.log("alive");
       cwd: String(dir),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "b required a: !ERR_REQUIRE_CYCLE_MODULE\na done\nalive\n",
@@ -64,11 +60,7 @@ console.log("alive");
       cwd: String(dir),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "self required: !ERR_REQUIRE_CYCLE_MODULE\nalive\n",
@@ -102,11 +94,7 @@ console.log("alive");
       cwd: String(dir),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "caught: ERR_REQUIRE_CYCLE_MODULE\nalive\n",


### PR DESCRIPTION
## Repro

```js
// a.mjs
import './b.mjs';
export const A = 1;

// b.mjs
import { createRequire } from "node:module";
try { createRequire(import.meta.url)("./a.mjs"); }
catch (e) { console.log(e.code); }
```

| runtime | result |
| --- | --- |
| Node v26 | `ERR_REQUIRE_CYCLE_MODULE`, then `a` finishes |
| Bun 1.4.0 release | prints nothing (require returns an empty `{}` namespace, nothing to catch) |
| Bun assert-enabled build | `ASSERTION FAILED: status() == Status::Unlinked \|\| status() == Status::Linked \|\| status() == Status::EvaluatingAsync \|\| status() == Status::Evaluated` in `CyclicModuleRecord::link`, exit 134 |

This is the ordinary dual-package / ESM-helper cycle written with an ESM intermediary: an ESM whose body (directly or via an imported helper) `createRequire()`'s something that is already on the import evaluation stack, including itself.

## Cause

`functionEsmLoadSync` in `ZigGlobalObject.cpp` is the `require(esm)` fast path. When the registry already has an entry for the key it short-circuits only if `isModuleEvaluated(record)` (status `Evaluated` with no error). For an entry that exists but is `Evaluating` or `Linking`, it fell through into `loadModuleSync`, which calls `CyclicModuleRecord::link()` on the live record. ecma-262 `Link()` asserts `module.[[Status]]` is not `linking` or `evaluating`, and JSC enforces that with a debug assertion; release builds proceed through a spec-violating re-link of a half-evaluated record and hand back an empty namespace.

## Fix

Before re-entering the loader, check the existing entry's `CyclicModuleRecord` status. If it is `Linking` or `Evaluating`, throw `ERR_REQUIRE_CYCLE_MODULE` with Node's message. `link()` is never called on the live record.

`ERR_REQUIRE_CYCLE_MODULE` is appended at the end of `ErrorCode.ts` (and mirrored into `src/jsc/ErrorCode.rs`) to keep discriminants index-aligned.

## Verification

`test/js/bun/resolve/require-esm-cycle.test.ts` covers three cases:

- ESM imports ESM which `createRequire()`'s the ancestor: caught error has `code === "ERR_REQUIRE_CYCLE_MODULE"`, ancestor finishes evaluating, process exits 0
- ESM self-require via `createRequire`: same
- uncaught cycle error: the outer `await import()` rejects with the cycle error and the process does not abort

```
$ bun bd test test/js/bun/resolve/require-esm-cycle.test.ts
 3 pass, 0 fail
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/require-esm-cycle.test.ts
 0 pass, 3 fail
```

The neighboring `require-esm-*` suites (gc-roots, microtask-order, transitive-tla, esModule) and `require.test.ts` remain green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/require-esm-cycle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (59d5d28e8)

test/js/bun/resolve/require-esm-cycle.test.ts:
30 |       stdio: ["ignore", "pipe", "pipe"],
31 |     });
32 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 | 
34 |     const lines = stdout.split("\n");
35 |     expect({ lines, stderr, exitCode }).toEqual({
                                             ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 134,
    "lines": [
-     StringMatching /^b required a: /,
-     "a done",
-     "alive",
      "",
    ],
-   "stderr": "",
+   "stderr": 
+ "ASSERTION FAILED: status() == Status::Unlinked || status() == Status::Linked || status() == Status::EvaluatingAsync |
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/resolve/require-esm-cycle.test.ts:
36 |       lines: [expect.stringMatching(/^b required a: /), "a done", "alive", ""],
37 |       stderr: "",
38 |       exitCode: 0,
39 |     });
40 |     const got = JSON.parse(lines[0].slice("b required a: ".length));
41 |     expect(got).toEqual({
                     ^
error: expect(received).toEqual(expected)

- {
-   "code": "ERR_REQUIRE_CYCLE_MODULE",
-   "message": StringContaining "Cannot require() ES Module",
-   "name": "Error",
- }
+ {}

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/resolve/require-esm-cycle.test.ts:41:17)
(fail) require(esm) while the target is mid-evaluation > ESM→ESM→createRequire(ancestor) throws ERR_REQUIRE_CYCLE_MODULE [20.64ms]
102 |       cwd: String(dir),
103 |       stdio: ["ignore", "pipe", "pipe"],
104 |     });
105 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
106 | 
107 |     expect({ stdout, stderr, exitCode }).toEqual({
                                               ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/require-esm-cycle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (59d5d28e8)

test/js/bun/resolve/require-esm-cycle.test.ts:
(pass) require(esm) while the target is mid-evaluation > ESM→ESM→createRequire(ancestor) throws ERR_REQUIRE_CYCLE_MODULE [654.15ms]
(pass) require(esm) while the target is mid-evaluation > self-require from an ESM throws ERR_REQUIRE_CYCLE_MODULE [625.31ms]
(pass) require(esm) while the target is mid-evaluation > uncaught cycle error rejects the dynamic import and does not abort [722.40ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [2.79s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     59d5d28e8d
  features     (none)

22 deps, 106 codegen, 1168 objects in 836ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1231] gen ErrorCode+*.h
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1230] fetch pi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.ts                 |   1 +
 src/jsc/bindings/ZigGlobalObject.cpp          |  11 +++
 test/js/bun/resolve/require-esm-cycle.test.ts | 113 ++++++++++++++++++++++++++
 3 files changed, 125 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/jsc/bindings/ErrorCode.ts                      3      3      0
src/jsc/bindings/ZigGlobalObject.cpp               2      3      0
test/js/bun/resolve/require-esm-cycle.test.ts      1      7      0
```

</details>

<!-- robobun:evidence:end -->