### PR TITLE
Bun.serve: close the connection when a handler sets Connection: close

### DIFF
--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -595,6 +595,23 @@ static void writeResponseHeader(uWS::HttpResponse<isSSL>* res, const WTF::String
     res->writeHeader(nameView, valueView);
 }
 
+// Connection is `1#connection-option` (RFC 9112 §9.3): look for the "close"
+// token anywhere in a comma-separated list. Mirrors the /(?:^|\W)close(?:$|\W)/i
+// check used by Bun's node:http layer.
+static bool connectionValueHasClose(const WTF::String& value)
+{
+    size_t pos = 0;
+    while ((pos = value.findIgnoringASCIICase("close"_s, pos)) != WTF::notFound) {
+        bool leftOk = pos == 0 || !isASCIIAlphanumeric(value[pos - 1]);
+        size_t end = pos + 5;
+        bool rightOk = end >= value.length() || !isASCIIAlphanumeric(value[end]);
+        if (leftOk && rightOk)
+            return true;
+        pos = end;
+    }
+    return false;
+}
+
 template<bool isSSL>
 static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL>* res)
 {
@@ -653,10 +670,11 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
         }
 
-        // RFC 9112 §9.6: a server that sends "Connection: close" MUST close the
-        // connection after the response. Mark the uWS state so end()/tryEnd()
-        // shut the socket down instead of returning it to the keep-alive pool.
-        if (header.key == WebCore::HTTPHeaderName::Connection && equalLettersIgnoringASCIICase(value, "close"_s)) {
+        // RFC 9112 §9.6: a server that sends the "close" connection option MUST
+        // close the connection after the response. Mark the uWS state so
+        // end()/tryEnd() shut the socket down instead of returning it to the
+        // keep-alive pool.
+        if (header.key == WebCore::HTTPHeaderName::Connection && connectionValueHasClose(value)) {
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
         }
         writeResponseHeader<isSSL>(res, name, value);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -652,6 +652,13 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         if (header.key == WebCore::HTTPHeaderName::TransferEncoding) {
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
         }
+
+        // RFC 9112 §9.6: a server that sends "Connection: close" MUST close the
+        // connection after the response. Mark the uWS state so end()/tryEnd()
+        // shut the socket down instead of returning it to the keep-alive pool.
+        if (header.key == WebCore::HTTPHeaderName::Connection && equalLettersIgnoringASCIICase(value, "close"_s)) {
+            data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
+        }
         writeResponseHeader<isSSL>(res, name, value);
     }
 

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import * as net from "node:net";
+import { once } from "node:events";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
@@ -33,4 +35,122 @@ test("weird headers", async () => {
       expect(res.headers.get(name)).toBe("1");
     }
   }
+});
+
+// RFC 9112 §9.6: a server that sends "Connection: close" MUST close the
+// connection after that response. Bun was emitting the header but leaving the
+// socket in the keep-alive pool, servicing further requests on the "closed"
+// connection.
+describe("response Connection: close closes the socket", () => {
+  async function check(makeResponse: () => Response) {
+    let handled = 0;
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      idleTimeout: 0,
+      fetch() {
+        handled++;
+        return makeResponse();
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+
+      // Collect everything the server sends until it closes the connection, or
+      // until it services a second request on the same socket (the bug). Either
+      // event resolves the promise, so this never relies on a wall-clock wait.
+      const result = await new Promise<{ raw: string; closedByServer: boolean }>(resolve => {
+        let raw = "";
+        let sentSecond = false;
+        socket.on("data", chunk => {
+          raw += chunk.toString("latin1");
+          // Once the first response body has fully arrived, send a follow-up
+          // request. A correct server has already closed (or is about to) and
+          // will never answer it; a buggy server answers and we resolve below.
+          if (!sentSecond && raw.includes("\r\n\r\n") && raw.includes("bye")) {
+            sentSecond = true;
+            socket.write("GET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+          }
+          if ((raw.match(/HTTP\/1\.1 200/g) ?? []).length > 1) {
+            resolve({ raw, closedByServer: false });
+          }
+        });
+        socket.on("close", () => resolve({ raw, closedByServer: true }));
+      });
+
+      const responses = (result.raw.match(/HTTP\/1\.1 200/g) ?? []).length;
+      const head = result.raw.split("\r\n\r\n")[0];
+      expect(head.toLowerCase()).toContain("connection: close");
+      expect({ responses, handled, closedByServer: result.closedByServer }).toEqual({
+        responses: 1,
+        handled: 1,
+        closedByServer: true,
+      });
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  test("string body", async () => {
+    await check(() => new Response("bye", { headers: { Connection: "close" } }));
+  });
+
+  test("case-insensitive value", async () => {
+    await check(() => new Response("bye", { headers: { connection: "Close" } }));
+  });
+
+  test("streaming body", async () => {
+    await check(
+      () =>
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("bye"));
+              c.close();
+            },
+          }),
+          { headers: { Connection: "close" } },
+        ),
+    );
+  });
+
+  test("keep-alive still the default", async () => {
+    // Negative: without Connection: close, a second request on the same socket
+    // must be serviced.
+    let handled = 0;
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      idleTimeout: 0,
+      fetch() {
+        handled++;
+        return new Response("bye");
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\nGET / HTTP/1.1\r\nHost: x\r\n\r\n");
+
+      let raw = "";
+      await new Promise<void>((resolve, reject) => {
+        socket.on("data", chunk => {
+          raw += chunk.toString("latin1");
+          if ((raw.match(/HTTP\/1\.1 200/g) ?? []).length >= 2) resolve();
+        });
+        socket.on("close", () => reject(new Error("server closed a keep-alive connection")));
+      });
+
+      expect(handled).toBe(2);
+      expect(raw.toLowerCase()).not.toContain("connection: close");
+    } finally {
+      socket.destroy();
+    }
+  });
 });

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -84,7 +84,7 @@ describe("response Connection: close closes the socket", () => {
 
       const responses = (result.raw.match(/HTTP\/1\.1 200/g) ?? []).length;
       const head = result.raw.split("\r\n\r\n")[0];
-      expect(head.toLowerCase()).toContain("connection: close");
+      expect(head).toMatch(/\r\nconnection:[^\r\n]*\bclose\b/i);
       expect({ responses, handled, closedByServer: result.closedByServer }).toEqual({
         responses: 1,
         handled: 1,
@@ -101,6 +101,12 @@ describe("response Connection: close closes the socket", () => {
 
   test("case-insensitive value", async () => {
     await check(() => new Response("bye", { headers: { connection: "Close" } }));
+  });
+
+  test("token list", async () => {
+    // Connection is 1#connection-option: "close" as one of several tokens must
+    // still trigger closure.
+    await check(() => new Response("bye", { headers: { Connection: "TE, close" } }));
   });
 
   test("streaming body", async () => {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import * as net from "node:net";
 import { once } from "node:events";
+import * as net from "node:net";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {


### PR DESCRIPTION
## What

When a `Bun.serve` handler returns `new Response(body, { headers: { connection: "close" } })`, the server now actually closes the TCP connection after sending the response.

## Repro

```js
import * as net from "node:net";
const server = Bun.serve({
  port: 0, idleTimeout: 0,
  fetch: () => new Response("bye", { headers: { connection: "close" } }),
});
const s = net.connect(server.port, "127.0.0.1");
s.on("connect", () => s.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
// before: "Connection: close" is on the wire but the socket stays open forever
//         and a second request on the same socket is answered
// after:  the socket closes right after the response body
```

Before this change the header was written to the wire but the socket stayed in the keep-alive pool until `idleTimeout` fired (indefinitely with `idleTimeout: 0`), and further requests on that socket were serviced. RFC 9112 section 9.6 says a server that sends the `close` connection option MUST initiate closure after that response. Node's `http` module closes in roughly 15 ms in the same scenario.

## Cause

The keep-alive versus close decision for a uWS response is carried by the `HTTP_CONNECTION_CLOSE` bit on `HttpResponseData::state`. Every `end()` / `tryEnd()` / `endWithoutBody()` / `endStream()` call in `RequestContext` already passes `should_close_connection()`, which reads that bit. The bit is only ever seeded from the incoming request (HTTP/1.0 or a request `Connection: close` header), never from the handler's response headers, so a response-side `Connection: close` was written but never acted on.

## Fix

`writeFetchHeadersToUWSResponse` already inspects each common header and sets `HttpResponseData` state bits for `Content-Length`, `Date`, and `Transfer-Encoding`. Add the same for `Connection` with a case-insensitive value of `close`, setting `HTTP_CONNECTION_CLOSE`. The existing `should_close_connection()` plumbing then makes `end()` shut the socket down instead of resetting the idle timer. The flag also prevents uWS from writing a duplicate `Connection: close` header in `internalEnd`.

## Verification

New tests in `test/js/bun/http/bun-serve-headers.test.ts` drive a raw TCP client against `Bun.serve` with `idleTimeout: 0`:

- `string body`, `case-insensitive value`, `streaming body`: send one request, then a second on the same socket once the first response body arrives. Assert exactly one response, one handler invocation, and that the server closed the socket.
- `keep-alive still the default`: negative control, two pipelined requests on the same socket are both answered when no `Connection: close` is set.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-serve-headers.test.ts
(fail) response Connection: close closes the socket > string body
(fail) response Connection: close closes the socket > case-insensitive value
(fail) response Connection: close closes the socket > streaming body
  { closedByServer: false, handled: 2, responses: 2 }

$ bun bd test test/js/bun/http/bun-serve-headers.test.ts
 5 pass
 0 fail
```