### PR TITLE
Bun.serve: make idleTimeout a floor so it never fires early

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -60,7 +60,8 @@
 
 /* Small 16KB shared send buffer for UDP packet metadata */
 #define LIBUS_SEND_BUFFER_LENGTH (1 << 14)
-/* A timeout granularity of 4 seconds means give or take 4 seconds from set timeout */
+/* Timeout sweep period. A timeout of N seconds fires within
+ * (ceil(N/4)*4, ceil(N/4)*4 + 4] seconds of arming, never before N. */
 #define LIBUS_TIMEOUT_GRANULARITY 4
 /* 32 byte padding of receive buffer ends */
 #define LIBUS_RECV_BUFFER_PADDING 32

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -101,9 +101,17 @@ unsigned char us_connecting_socket_kind(struct us_connecting_socket_t *c) {
     return c->kind;
 }
 
+/* The sweep advances timestamp on an absolute 4 s grid, so the first tick
+ * after arming lands in (0, 4] s. +1 makes the timeout a floor (never fires
+ * before `units`); clamp so values near the wheel max don't wrap to tick 1. */
+static inline unsigned int us_internal_timeout_ticks(unsigned int units, unsigned int shift) {
+    unsigned int ticks = ((units + ((1u << shift) - 1)) >> shift) + 1;
+    return ticks > 240 ? 240 : ticks;
+}
+
 __attribute__((always_inline)) void us_socket_timeout(struct us_socket_t *s, unsigned int seconds) {
     if (seconds) {
-        s->timeout = ((unsigned int)s->group->timestamp + ((seconds + 3) >> 2)) % 240;
+        s->timeout = ((unsigned int)s->group->timestamp + us_internal_timeout_ticks(seconds, 2)) % 240;
     } else {
         s->timeout = 255;
     }
@@ -111,7 +119,7 @@ __attribute__((always_inline)) void us_socket_timeout(struct us_socket_t *s, uns
 
 void us_connecting_socket_timeout(struct us_connecting_socket_t *c, unsigned int seconds) {
     if (seconds) {
-        c->timeout = ((unsigned int)c->group->timestamp + ((seconds + 3) >> 2)) % 240;
+        c->timeout = ((unsigned int)c->group->timestamp + us_internal_timeout_ticks(seconds, 2)) % 240;
     } else {
         c->timeout = 255;
     }
@@ -119,7 +127,7 @@ void us_connecting_socket_timeout(struct us_connecting_socket_t *c, unsigned int
 
 __attribute__((always_inline)) void us_socket_long_timeout(struct us_socket_t *s, unsigned int minutes) {
     if (minutes) {
-        s->long_timeout = ((unsigned int)s->group->long_timestamp + minutes) % 240;
+        s->long_timeout = ((unsigned int)s->group->long_timestamp + us_internal_timeout_ticks(minutes, 0)) % 240;
     } else {
         s->long_timeout = 255;
     }
@@ -127,7 +135,7 @@ __attribute__((always_inline)) void us_socket_long_timeout(struct us_socket_t *s
 
 void us_connecting_socket_long_timeout(struct us_connecting_socket_t *c, unsigned int minutes) {
     if (minutes) {
-        c->long_timeout = ((unsigned int)c->group->long_timestamp + minutes) % 240;
+        c->long_timeout = ((unsigned int)c->group->long_timestamp + us_internal_timeout_ticks(minutes, 0)) % 240;
     } else {
         c->long_timeout = 255;
     }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -103,10 +103,11 @@ unsigned char us_connecting_socket_kind(struct us_connecting_socket_t *c) {
 
 /* The sweep advances timestamp on an absolute 4 s grid, so the first tick
  * after arming lands in (0, 4] s. +1 makes the timeout a floor (never fires
- * before `units`); clamp so values near the wheel max don't wrap to tick 1. */
+ * before `units`); cap below the 240-slot wheel so the stored slot can never
+ * equal the arm-time slot (the long wheel re-checks that slot next sweep). */
 static inline unsigned int us_internal_timeout_ticks(unsigned int units, unsigned int shift) {
     unsigned int ticks = ((units + ((1u << shift) - 1)) >> shift) + 1;
-    return ticks > 240 ? 240 : ticks;
+    return ticks > 239 ? 239 : ticks;
 }
 
 __attribute__((always_inline)) void us_socket_timeout(struct us_socket_t *s, unsigned int seconds) {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2506,7 +2506,7 @@ it.concurrent(
     expect(server.timeout).toBeFunction();
     const res = await fetch(new URL("/long-timeout", server.url.origin));
     expect(res.status).toBe(200);
-    expect(res.text()).resolves.toBe("Hello, World!");
+    await expect(res.text()).resolves.toBe("Hello, World!");
   },
   20_000,
 );

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2383,7 +2383,7 @@ it.concurrent(
   async () => {
     using server = Bun.serve({
       port: 0,
-      idleTimeout: 8, // uws precision is in seconds, and lower than 4 seconds is not reliable its timer is not that accurate
+      idleTimeout: 8, // uws precision is 4 seconds, so this fires in (8, 12] s
       async fetch(req) {
         const url = new URL(req.url);
         return new Response(
@@ -2391,7 +2391,7 @@ it.concurrent(
             async pull(controller) {
               controller.enqueue("Hello,");
               if (url.pathname === "/timeout") {
-                await Bun.sleep(10000);
+                await Bun.sleep(14000);
               } else {
                 await Bun.sleep(10);
               }
@@ -2408,14 +2408,14 @@ it.concurrent(
       const res = await fetch(new URL(pathname, server.url.origin));
       expect(res.status).toBe(200);
       if (success) {
-        expect(res.text()).resolves.toBe("Hello, World!");
+        await expect(res.text()).resolves.toBe("Hello, World!");
       } else {
-        expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
+        await expect(res.text()).rejects.toThrow(/The socket connection was closed unexpectedly./);
       }
     }
     await Promise.all([testTimeout("/ok", true), testTimeout("/timeout", false)]);
   },
-  15_000,
+  20_000,
 );
 
 it.concurrent(
@@ -2507,6 +2507,65 @@ it.concurrent(
     const res = await fetch(new URL("/long-timeout", server.url.origin));
     expect(res.status).toBe(200);
     expect(res.text()).resolves.toBe("Hello, World!");
+  },
+  20_000,
+);
+
+it.concurrent(
+  "idleTimeout never fires before the configured number of seconds",
+  async () => {
+    // uSockets sweeps timeouts on an absolute 4 s grid; a socket armed t ms
+    // before a grid boundary used to get its first tick after only t ms, so
+    // idleTimeout: 4 could close a socket ~0 ms after the request arrived.
+    // Space requests across one full 4 s period so at least one lands in the
+    // window just before a tick regardless of the sweep timer's phase. The
+    // sleeps below construct that input pattern, they are not a wait.
+    const HANDLER_MS = 150;
+    let earliestAbort = Infinity;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      idleTimeout: 4,
+      async fetch(req) {
+        const start = performance.now();
+        let responded = false;
+        req.signal.addEventListener("abort", () => {
+          if (!responded) earliestAbort = Math.min(earliestAbort, performance.now() - start);
+        });
+        await Bun.sleep(HANDLER_MS);
+        responded = true;
+        return new Response("done");
+      },
+    });
+
+    const one = () =>
+      new Promise<number>(resolve => {
+        const s = net.connect(server.port!, "127.0.0.1");
+        let got = 0;
+        s.on("connect", () => s.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
+        s.on("data", c => {
+          got += c.length;
+          s.destroy();
+        });
+        s.on("error", () => {});
+        s.on("close", () => resolve(got));
+      });
+
+    const pending: Promise<number>[] = [];
+    for (let i = 0; i < 32; i++) {
+      pending.push(one());
+      await Bun.sleep(130);
+    }
+    const bytes = await Promise.all(pending);
+    const killed = bytes.filter(b => b === 0).length;
+
+    // A 150 ms handler is never idle for 4 s, so no request may be reaped and
+    // req.signal must not abort before the configured timeout elapsed.
+    expect({ killed, earliestAbort: earliestAbort < 3900 ? earliestAbort : "never" }).toEqual({
+      killed: 0,
+      earliestAbort: "never",
+    });
   },
   20_000,
 );


### PR DESCRIPTION
## Reproduction

```js
// idleTimeout: 4, handler sleeps 150 ms, 32 requests spaced 130 ms so
// their arrival phase sweeps one full 4 s wheel period.
const server = Bun.serve({
  port: 0, idleTimeout: 4,
  async fetch(req) { await Bun.sleep(150); return new Response("done"); },
});
```

On 1.4.0 one of those requests is closed with zero response bytes and `req.signal` aborts ~80 ms after the request arrived, even though nothing was idle for anywhere near 4 s:

```
requests killed with NO response: 1/32
earliest req.signal abort after request arrival: 83 ms (configured idleTimeout: 4000 ms)
```

## Cause

`us_socket_timeout` stores `s->timeout = (group->timestamp + ceil(seconds/4)) % 240` and the sweep in `loop.c` fires when `timestamp == s->timeout`. But `timestamp` advances on an absolute `LIBUS_TIMEOUT_GRANULARITY` (4 s) grid that is unrelated to when the socket was armed, so a socket armed t ms before a grid boundary gets its first tick after only t ms. For `idleTimeout: N` the actual fire window was `(4*(k-1), 4*k]` with `k = ceil(N/4)`, i.e. `idleTimeout: 4` could fire after ~0 ms and every value N could fire up to 4 s early. `server.timeout(req, N)`, `Bun.connect` socket timeouts and the WebSocket `maxLifetime` (minute wheel) arm through the same helpers.

## Fix

Arm with one extra tick, clamped to the 240-slot wheel, so a timeout of N seconds fires in `(ceil(N/4)*4, ceil(N/4)*4 + 4]` s and never before N (packages/bun-usockets/src/socket.c). The same adjustment is applied to `us_connecting_socket_timeout` and the minute-granularity `us_socket_long_timeout` / `us_connecting_socket_long_timeout`.

The existing `should allow use of custom timeout` test stalled for 10 s under an 8 s `idleTimeout`; that now fires in (8, 12] s so the stall is bumped to 14 s, and the `.resolves` / `.rejects` assertions in that helper are now awaited.

## Verification

```
# without packages/ change
(fail) idleTimeout never fires before the configured number of seconds
  { earliestAbort: 31.72, killed: 1 }

# with packages/ change
(pass) idleTimeout never fires before the configured number of seconds [4848ms]
```

`test/js/bun/http/serve.test.ts`: 239 pass / 4 pre-existing container-env failures (localhost/IPv6/proxy) that reproduce on main.