### PR TITLE
Bun.serve: keep idleTimeout armed after the request body completes

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -374,8 +374,10 @@ private:
 
                 /* Todo: can this handle timeout for non-post as well? */
                 if (fin) {
-                    /* If we just got the last chunk (or empty chunk), disable timeout */
-                    us_socket_timeout((struct us_socket_t *) user, 0);
+                    /* Last body chunk received. Re-arm (not clear) the idle timeout so a
+                     * stalled handler is still reaped; clearing it here lost any timeout the
+                     * request handler set before the body bytes in the same segment were parsed. */
+                    ((HttpResponse<SSL> *) user)->resetTimeout();
                 } else {
                     /* We still have some more data coming in later, so reset timeout */
                     /* Only reset timeout if we got enough bytes (16kb/sec) since last time we reset here */

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2539,7 +2539,10 @@ it.concurrent(
     const results = await Promise.all([
       raw("get", "GET /get HTTP/1.1\r\nHost: a\r\n\r\n"),
       raw("post-cl", "POST /post-cl HTTP/1.1\r\nHost: a\r\nContent-Length: 1\r\n\r\nx"),
-      raw("post-chunked", "POST /post-chunked HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nx\r\n0\r\n\r\n"),
+      raw(
+        "post-chunked",
+        "POST /post-chunked HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nx\r\n0\r\n\r\n",
+      ),
       raw("post-t6", "POST /t6 HTTP/1.1\r\nHost: a\r\nContent-Length: 1\r\n\r\nx"),
     ]);
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2511,6 +2511,50 @@ it.concurrent(
   20_000,
 );
 
+it.concurrent(
+  "idleTimeout reaps a hung handler after the request body is received",
+  async () => {
+    const aborted: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      idleTimeout: 2,
+      fetch(req, srv) {
+        const p = new URL(req.url).pathname;
+        req.signal.addEventListener("abort", () => aborted.push(p));
+        if (p === "/t6") srv.timeout(req, 6);
+        return new Promise<Response>(() => {});
+      },
+    });
+
+    const raw = (name: string, wire: string) =>
+      new Promise<{ name: string; closed: boolean }>((resolve, reject) => {
+        const s = net.connect(server.port as number, "127.0.0.1");
+        s.on("connect", () => s.write(wire));
+        s.on("error", reject);
+        s.on("close", () => resolve({ name, closed: true }));
+      });
+
+    const results = await Promise.all([
+      raw("get", "GET /get HTTP/1.1\r\nHost: a\r\n\r\n"),
+      raw("post-cl", "POST /post-cl HTTP/1.1\r\nHost: a\r\nContent-Length: 1\r\n\r\nx"),
+      raw("post-chunked", "POST /post-chunked HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nx\r\n0\r\n\r\n"),
+      raw("post-t6", "POST /t6 HTTP/1.1\r\nHost: a\r\nContent-Length: 1\r\n\r\nx"),
+    ]);
+
+    expect(results).toEqual([
+      { name: "get", closed: true },
+      { name: "post-cl", closed: true },
+      { name: "post-chunked", closed: true },
+      { name: "post-t6", closed: true },
+    ]);
+    expect(aborted.sort()).toEqual(["/get", "/post-chunked", "/post-cl", "/t6"]);
+    expect(server.pendingRequests).toBe(0);
+  },
+  20_000,
+);
+
 it.concurrent("#6462", async () => {
   let headers: string[] = [];
   using server = Bun.serve({


### PR DESCRIPTION
## What

`Bun.serve`'s `idleTimeout` was silently not applied to any request that carried a body once the body had fully arrived. A handler that never responded to a POST/PUT was never reaped, and a synchronous `server.timeout(req, N)` inside the handler was a no-op on any request with a body. The identical bodyless GET was reaped normally.

## Repro

```js
using server = Bun.serve({
  port: 0, idleTimeout: 2,
  fetch: () => new Promise(() => {}),
});
// GET /hang                          -> closed after ~4 s
// POST /hang (Content-Length: 1, x)  -> STILL OPEN forever
// POST /hang (chunked, 1 byte)       -> STILL OPEN forever
// POST /hang + server.timeout(req,6) -> STILL OPEN forever
```

A peer sending complete small POST bodies to any slow/stalled route accumulates unreapable connections, live `Request` objects and `server.pendingRequests` without bound.

## Cause

uWS's request-body data callback disabled the socket timeout when the final chunk arrived (`HttpContext.h` onData → `if (fin) us_socket_timeout(user, 0)`) and nothing re-armed it until the response ended. Bun arms the per-request idle timeout inside the request handler (`prepare_js_request_context` → `resp.timeout(idle_timeout)`), which runs before the parser consumes body bytes that arrived in the same TCP segment, so the fin-disarm always won. The same ordering cancelled a synchronous `server.timeout(req, N)`.

## Fix

Re-arm the socket timeout to the stored per-response `idleTimeout` on body fin (`resetTimeout()`) instead of clearing it. A handler that responds inside the inStream callback still calls `resetTimeout` via `end()`/`tryEnd()`, so prompt responses are unchanged, and the stored value already reflects whatever `server.timeout(req, N)` set.

## Verification

New test in `test/js/bun/http/serve.test.ts` opens raw TCP sockets for GET, POST with `Content-Length`, POST with `Transfer-Encoding: chunked`, and POST with a synchronous `server.timeout(req, 6)`, all against a handler that never responds, and asserts every socket is closed by the server and every `req.signal` fires abort.

Before: POST variants hang until the 20 s test timeout.
After: all four close (GET/POST at ~4 s, the `timeout(req, 6)` case at ~8 s).