### PR TITLE
fetch: follow redirects on the response head instead of awaiting the 3xx body

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5273,6 +5273,13 @@ impl<'a> HTTPClient<'a> {
                 || self.state.transfer_encoding == Encoding::Chunked
                 || is_server_sent_events)
         {
+            if self.state.flags.is_redirect_pending {
+                // WHATWG HTTP-redirect fetch runs on the response head; the 3xx
+                // body is discarded, not awaited. The socket still carries
+                // undrained body bytes so it must be closed, not pooled.
+                self.state.flags.allow_keepalive = false;
+                return Ok(ShouldContinue::Finished);
+            }
             Ok(ShouldContinue::ContinueStreaming)
         } else {
             Ok(ShouldContinue::Finished)

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
-import net from "node:net";
 import { once } from "node:events";
+import net from "node:net";
 
 // WHATWG HTTP-redirect fetch runs on the response head (status line + Location);
 // the 3xx body is discarded, not awaited. A redirecting server that never finishes

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -1,6 +1,89 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import net from "node:net";
+import { once } from "node:events";
+
+// WHATWG HTTP-redirect fetch runs on the response head (status line + Location);
+// the 3xx body is discarded, not awaited. A redirecting server that never finishes
+// its own body must not be able to stall the follow-up request.
+describe("fetch() follows a redirect on headers without waiting for the 3xx body", () => {
+  async function run(responseHead: (location: string) => string) {
+    let finalRequests = 0;
+    await using final = Bun.serve({
+      port: 0,
+      fetch() {
+        finalRequests++;
+        return new Response("FINAL");
+      },
+    });
+    const location = `${final.url.origin}/final`;
+
+    const sockets: net.Socket[] = [];
+    const server = net.createServer(socket => {
+      sockets.push(socket);
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        // Write the 302 head (and part of its body) immediately; never send the
+        // rest. The socket stays open until the test tears it down.
+        socket.write(responseHead(location));
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/start`);
+      expect({
+        status: res.status,
+        redirected: res.redirected,
+        url: res.url,
+        body: await res.text(),
+        finalRequests,
+      }).toEqual({
+        status: 200,
+        redirected: true,
+        url: location,
+        body: "FINAL",
+        finalRequests: 1,
+      });
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+    }
+  }
+
+  it("chunked body with no terminating chunk", async () => {
+    await run(loc => `HTTP/1.1 302 Found\r\nLocation: ${loc}\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n`);
+  });
+
+  it("Content-Length body that is never completed", async () => {
+    await run(loc => `HTTP/1.1 302 Found\r\nLocation: ${loc}\r\nContent-Length: 50\r\n\r\n0123456789`);
+  });
+
+  it("close-delimited body on a connection that stays open", async () => {
+    await run(loc => `HTTP/1.1 302 Found\r\nLocation: ${loc}\r\nConnection: close\r\n\r\npartial`);
+  });
+});
+
+it("fetch() with redirect: 'manual' still exposes the 3xx response body", async () => {
+  const server = net.createServer(socket => {
+    socket.on("error", () => {});
+    socket.once("data", () => {
+      socket.end("HTTP/1.1 302 Found\r\nLocation: /elsewhere\r\nContent-Length: 7\r\n\r\nignored");
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+    expect({ status: res.status, redirected: res.redirected, body: await res.text() }).toEqual({
+      status: 302,
+      redirected: false,
+      body: "ignored",
+    });
+  } finally {
+    server.close();
+  }
+});
 
 // https://github.com/oven-sh/bun/issues/12701
 it("fetch() preserves body on redirect", async () => {


### PR DESCRIPTION
## Problem

`fetch()` did not follow a redirect until the 3xx response's own body was fully framed. A `302` whose declared body never finished (short `Content-Length`, unterminated chunked, or a close-delimited body on a socket the server keeps open) left the fetch pending forever with no error and no default timeout. A chunked 302 whose terminator arrived `T` ms late delayed every follow by `T`.

WHATWG [HTTP-redirect fetch](https://fetch.spec.whatwg.org/#http-redirect-fetch) runs on the response head; the 3xx body is content the client must ignore. Node/undici, curl, and browsers all follow immediately on headers.

## Reproduction

```js
import * as net from "node:net";
await using final = Bun.serve({ port: 0, fetch: () => new Response("FINAL") });
const server = net.createServer(s => {
  s.once("data", () => {
    // 302 head arrives immediately; the promised 50-byte body never completes
    s.write(`HTTP/1.1 302 Found\r\nLocation: ${final.url}\r\nContent-Length: 50\r\n\r\n0123456789`);
  });
});
await new Promise(r => server.listen(0, "127.0.0.1", r));
console.log(await fetch(`http://127.0.0.1:${server.address().port}/`).then(r => r.status));
// before: hangs forever
// after:  200
```

## Cause

`handle_response_metadata` in `src/http/lib.rs` sets `is_redirect_pending` when a `Location` header is parsed on a followable 3xx, but then returns `ShouldContinue::ContinueStreaming` whenever the response declares a body (non-zero `Content-Length`, `Transfer-Encoding: chunked`, or close-delimited). `progress_update` only calls `do_redirect` once `state.is_done()` reports the body fully received, so the follow-up request was gated on bytes that were going to be discarded.

## Fix

When `is_redirect_pending` is set and the response declares a body, return `ShouldContinue::Finished` so the caller invokes `do_redirect` immediately. `allow_keepalive` is cleared for this case because the socket still carries undrained 3xx body bytes and must be closed rather than pooled. Redirects with no body (`Content-Length: 0`) keep the existing pooling behaviour.

`redirect: "manual"` is unaffected (`is_redirect_pending` is only set for `redirect: "follow"`), so callers that opt out of following can still read the 3xx body. The HTTP/2 client already followed at headers-complete; HTTP/3 now does too via the shared `apply_multiplexed_headers` path.

## Verification

```
bun bd test test/js/web/fetch/fetch-redirect.test.ts
```

New tests cover a chunked 302 with no terminator, a `Content-Length` 302 whose body never completes, and a close-delimited 302 on an open socket. All three hang under `USE_SYSTEM_BUN=1` and pass with the fix. An additional test confirms `redirect: "manual"` still exposes the 3xx body.