### PR TITLE
child_process: wait for extra stdio pipes before emitting 'close'

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1264,14 +1264,18 @@ class ChildProcess extends EventEmitter {
       default:
         switch (io) {
           case "pipe":
-          case "socket-fd":
+          case "socket-fd": {
             if (!NetModule) NetModule = require("node:net");
             // #spawn mapped "pipe" at i>=3 to "socket-fd", so the parent-end
             // fd in handle.stdio[i] is UnownedFd: we own it and
             // net.connect({fd}) -> usockets will close it on socket close.
             const fd = handle && handle.stdio[i];
             if (fd == null) return null;
-            return NetModule.connect({ fd });
+            const socket = NetModule.connect({ fd });
+            this.#closesNeeded++;
+            socket.once("close", () => this.#maybeClose());
+            return socket;
+          }
         }
         return null;
     }

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -729,6 +729,44 @@ done
   expect(asyncOut.trim().split("\n")).toEqual(expected);
 });
 
+// Node documents 'close' as firing only after the process has exited AND every
+// stdio stream has closed. Extra pipe fds (index >= 3) must participate in that
+// accounting so data written to them is observable at 'close'.
+it.skipIf(isWindows)("'close' waits for extra stdio pipes (index >= 3) to end", async () => {
+  const child = spawn("/bin/sh", ["-c", "printf A; printf B >&2; printf CCC >&3; printf DDD >&4"], {
+    stdio: ["ignore", "pipe", "pipe", "pipe", "pipe"],
+    env: bunEnv,
+  });
+
+  const got = ["", "", "", "", ""];
+  const order: string[] = [];
+  const ended: Promise<void>[] = [];
+  for (const i of [1, 2, 3, 4]) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    ended.push(promise);
+    child.stdio[i]!.on("data", d => (got[i] += d));
+    child.stdio[i]!.on("end", () => {
+      order.push(`end${i}`);
+      resolve();
+    });
+  }
+
+  const closed = Promise.withResolvers<{ got: string[]; order: string[] }>();
+  child.on("error", closed.reject);
+  child.on("close", () => {
+    order.push("close");
+    closed.resolve({ got: [...got], order: [...order] });
+  });
+
+  const [atClose] = await Promise.all([closed.promise, ...ended]);
+
+  expect(atClose.got).toEqual(["", "A", "B", "CCC", "DDD"]);
+  for (const i of [1, 2, 3, 4]) {
+    expect(atClose.order.indexOf(`end${i}`)).toBeGreaterThanOrEqual(0);
+    expect(atClose.order.indexOf(`end${i}`)).toBeLessThan(atClose.order.indexOf("close"));
+  }
+});
+
 describe("uid/gid options", () => {
   const isRoot = process.getuid?.() === 0;
   // 65534 is "nobody" on every Linux distro and on macOS.


### PR DESCRIPTION
## Problem

`child_process.spawn()` with more than three `"pipe"` stdio entries emits `'close'` before the extra-fd (index >= 3) streams have delivered their data or ended. Node documents `'close'` as "emitted after a process has ended and the stdio streams of a child process have been closed", and the common pattern of accumulating on `'data'` and acting on `'close'` silently loses everything written to an extra stdio pipe.

```js
import * as cp from "node:child_process";
const c = cp.spawn("/bin/sh", ["-c", "printf A; printf B >&2; printf CCC >&3; printf DDD >&4"],
                   { stdio: ["ignore", "pipe", "pipe", "pipe", "pipe"] });
const got = ["", "", "", "", ""], order = [];
for (const i of [1, 2, 3, 4]) {
  c.stdio[i].on("data", d => (got[i] += d));
  c.stdio[i].on("end", () => order.push(`end${i}`));
}
c.on("close", () => { order.push("close"); console.log(JSON.stringify({ order, got })); });
```

Node v26.3.0:
```
{"order":["end1","end2","end3","end4","close"],"got":["","A","B","CCC","DDD"]}
```

Bun (before):
```
{"order":["end1","end2","close"],"got":["","A","B","",""]}
```
(fd 3 and fd 4 are empty at `'close'`; `end3`/`end4` arrive on a later tick)

## Cause

In `ChildProcess.#getBunSpawnIo`, only the `case 1`/`case 2` branch for stdout and stderr increments `#closesNeeded` and hooks `#maybeClose` on the stream's `'close'` event. The `default:` branch that materializes index >= 3 pipes as `net.Socket` never joins the `#closesGot === #closesNeeded` accounting, so the child's `'close'` is computed from stdout + stderr + exit alone.

## Fix

Increment `#closesNeeded` and register the `'close'` listener on the extra-fd socket, same as stdout/stderr.

## Verification

New test in `test/js/node/child_process/child_process.test.ts` asserts that at `'close'` time all extra-fd data is present and every `end<i>` fired before `'close'`. Fails on the released binary, passes with this change.