### PR TITLE
child_process: preserve Buffer in advanced IPC serialization

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -110,6 +110,7 @@
 #include "ZigGlobalObject.h"
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
+#include "JSBuffer.h"
 #include "JSX509Certificate.h"
 #include "ncrypto.h"
 #include "JSKeyObject.h"
@@ -276,6 +277,10 @@ enum ArrayBufferViewSubtag {
     BigInt64ArrayTag = 10,
     BigUint64ArrayTag = 11,
     Float16ArrayTag = 12,
+
+    // Bun subtags start at 254 and decrease with each addition, so they can't
+    // collide with future WebKit subtags. A Uint8Array that is a Node.js Buffer.
+    Bun__NodeBufferTag = 254,
 };
 
 // static bool isTypeExposedToGlobalObject(JSC::JSGlobalObject& globalObject, SerializationTag tag)
@@ -374,6 +379,7 @@ static unsigned typedArrayElementSize(ArrayBufferViewSubtag tag)
     case Int8ArrayTag:
     case Uint8ArrayTag:
     case Uint8ClampedArrayTag:
+    case Bun__NodeBufferTag:
         return 1;
     case Int16ArrayTag:
     case Uint16ArrayTag:
@@ -1350,9 +1356,15 @@ private:
             write(Uint8ClampedArrayTag);
         else if (obj->inherits<JSInt8Array>())
             write(Int8ArrayTag);
-        else if (obj->inherits<JSUint8Array>())
-            write(Uint8ArrayTag);
-        else if (obj->inherits<JSInt16Array>())
+        else if (obj->inherits<JSUint8Array>()) {
+            // child_process advanced IPC preserves Buffer (Node writes it as a host
+            // object); structuredClone()/postMessage() deliver Uint8Array in Node too,
+            // so only the cross-process transfer path emits the Buffer subtag.
+            if (m_forTransfer == SerializationForCrossProcessTransfer::Yes && JSBuffer__isBuffer(m_lexicalGlobalObject, JSValue::encode(JSValue(obj))))
+                write(Bun__NodeBufferTag);
+            else
+                write(Uint8ArrayTag);
+        } else if (obj->inherits<JSInt16Array>())
             write(Int16ArrayTag);
         else if (obj->inherits<JSUint16Array>())
             write(Uint16ArrayTag);
@@ -3812,6 +3824,19 @@ private:
         case BigUint64ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, BigUint64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
             return true;
+        case Bun__NodeBufferTag: {
+            auto* globalObject = defaultGlobalObject(m_globalObject);
+            JSC::Structure* structure = arrayBuffer->isResizableOrGrowableShared()
+                ? globalObject->JSResizableOrGrowableSharedBufferSubclassStructure()
+                : globalObject->JSBufferSubclassStructure();
+            RefPtr<Uint8Array> impl = Uint8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length);
+            if (!impl) [[unlikely]] {
+                arrayBufferView = jsNull();
+                return true;
+            }
+            arrayBufferView = JSC::JSUint8Array::create(structure, m_lexicalGlobalObject, WTF::move(impl));
+            return true;
+        }
         default:
             return false;
         }

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick, isWindows } from "harness";
+import { bunEnv, bunExe, gcTick, isWindows, tempDir } from "harness";
+import * as cp from "node:child_process";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -88,6 +89,82 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
 });
 
 describe("ipc mode advanced", () => {
+  it("Buffer round-trips as Buffer (not Uint8Array) at every depth", async () => {
+    // Node's advanced IPC serializer registers Buffer as a host object so the subclass
+    // survives; structuredClone and Worker postMessage deliberately do not, and those
+    // paths are asserted here to keep that distinction covered.
+    const childSource = `
+      process.on("message", m => {
+        process.send({
+          top:    { isBuf: Buffer.isBuffer(m.top),      ctor: m.top.constructor.name,      hex: m.top.toString("hex") },
+          nested: { isBuf: Buffer.isBuffer(m.o.inner),  ctor: m.o.inner.constructor.name,  hex: m.o.inner.toString("hex") },
+          inArr:  { isBuf: Buffer.isBuffer(m.arr[0]),   ctor: m.arr[0].constructor.name,   hex: m.arr[0].toString("hex") },
+          u8:     { isBuf: Buffer.isBuffer(m.u8),       ctor: m.u8.constructor.name },
+          empty:  { isBuf: Buffer.isBuffer(m.empty),    ctor: m.empty.constructor.name,    len: m.empty.length },
+          sc:     structuredClone(Buffer.from([1])).constructor.name,
+        });
+        process.disconnect();
+      });
+    `;
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    await using child = spawn([bunExe(), "-e", childSource], {
+      env: bunEnv,
+      stdio: ["ignore", "inherit", "inherit"],
+      serialization: "advanced",
+      ipc: message => resolve(message),
+      onExit: (_p, exitCode, signalCode) => reject(new Error(`child exited (${exitCode}, ${signalCode}) before reply`)),
+    });
+    child.send({
+      top: Buffer.from([0x01, 0x02, 0x03]),
+      o: { inner: Buffer.from([0x09]) },
+      arr: [Buffer.from([0xab, 0xcd])],
+      u8: new Uint8Array([7, 8]),
+      empty: Buffer.alloc(0),
+    });
+    const m = await promise;
+    expect(m).toEqual({
+      top: { isBuf: true, ctor: "Buffer", hex: "010203" },
+      nested: { isBuf: true, ctor: "Buffer", hex: "09" },
+      inArr: { isBuf: true, ctor: "Buffer", hex: "abcd" },
+      u8: { isBuf: false, ctor: "Uint8Array" },
+      empty: { isBuf: true, ctor: "Buffer", len: 0 },
+      sc: "Uint8Array",
+    });
+  });
+
+  it("Buffer round-trips as Buffer via child_process.fork with serialization: advanced", async () => {
+    using dir = tempDir("ipc-advanced-buffer", {
+      "child.js": `
+        process.on("message", m => {
+          process.send({
+            isBuf: Buffer.isBuffer(m.b),
+            ctor: m.b.constructor.name,
+            nestedIsBuf: Buffer.isBuffer(m.o.inner),
+            bytes: Array.from(m.b),
+          });
+          process.disconnect();
+        });
+      `,
+    });
+    const child = cp.fork(path.join(String(dir), "child.js"), [], {
+      execPath: bunExe(),
+      env: bunEnv,
+      serialization: "advanced",
+      stdio: ["ignore", "ignore", "inherit", "ipc"],
+    });
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<any>();
+      child.once("message", resolve);
+      child.once("error", reject);
+      child.once("exit", (code, sig) => reject(new Error(`child exited (${code}, ${sig}) before reply`)));
+      child.send({ b: Buffer.from([1, 2, 3]), o: { inner: Buffer.from([9]) } });
+      const m = await promise;
+      expect(m).toEqual({ isBuf: true, ctor: "Buffer", nestedIsBuf: true, bytes: [1, 2, 3] });
+    } finally {
+      child.kill("SIGKILL");
+    }
+  });
+
   it("a message_len that overflows header_length + message_len does not crash the receiver", async () => {
     // The advanced IPC framing is [u8 type][u32-le length][payload]. Decoding previously
     // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child


### PR DESCRIPTION
### Problem

A `Buffer` sent over child_process IPC with `serialization: "advanced"` (bun parent, bun child) arrives as a plain `Uint8Array`: `Buffer.isBuffer(msg)` is `false` and Buffer methods (`.toString("hex")`, `.readUInt32BE`, ...) are missing. The bytes are intact, only the subclass is lost, so the failure is deferred and silent.

```js
import * as cp from "node:child_process";
import { fileURLToPath } from "node:url";
const SELF = fileURLToPath(import.meta.url);
if (process.argv[2] === "child") {
  process.on("message", m => {
    process.send({ isBuf: Buffer.isBuffer(m.b), ctor: m.b.constructor.name,
                   nestedIsBuf: Buffer.isBuffer(m.o.inner), bytes: Array.from(m.b) });
    process.disconnect();
  });
} else {
  const c = cp.fork(SELF, ["child"], { serialization: "advanced", stdio: ["ignore", "ignore", "inherit", "ipc"] });
  c.send({ b: Buffer.from([1, 2, 3]), o: { inner: Buffer.from([9]) } });
  c.once("message", m => console.log(JSON.stringify(m)));
}
// node:   {"isBuf":true, "ctor":"Buffer",    "nestedIsBuf":true, "bytes":[1,2,3]}
// bun:    {"isBuf":false,"ctor":"Uint8Array","nestedIsBuf":false,"bytes":[1,2,3]}
```

Node's advanced IPC serializer registers `Buffer` as a host object on its v8.Serializer so it round-trips at every depth. (`structuredClone(Buffer)` and `worker.postMessage(Buffer)` deliver `Uint8Array` in Node too; the preservation is specific to this path.)

### Cause

Bun's advanced IPC uses the JSC structured-clone serializer (`SerializedScriptValue`), which encodes every `JSUint8Array` view, including `Buffer`, as `Uint8ArrayTag`. The deserializer always rebuilds a plain `Uint8Array`.

### Fix

Add a Bun-specific `ArrayBufferViewSubtag` (`Bun__NodeBufferTag = 254`, counting down so it can't collide with future WebKit subtags). `dumpArrayBufferView` writes it instead of `Uint8ArrayTag` only when `m_forTransfer == SerializationForCrossProcessTransfer::Yes`, which is set exclusively by the advanced IPC entry point (`Bun__serializeJSValue` from `src/jsc/ipc.rs`). `readArrayBufferViewImpl` reconstructs the view with `JSBufferSubclassStructure` (or the resizable variant for resizable/growable backing buffers).

`structuredClone()`, `Worker`/`MessagePort`/`BroadcastChannel` `postMessage()`, and `bun:jsc` serialize all pass `forTransfer = No` and are unchanged; they keep delivering `Uint8Array`, matching Node. The subtag value and decode path match #33039 (which covers `v8.serialize`) so the two land cleanly together.

### Verification

New tests in `test/js/bun/spawn/spawn.ipc.test.ts` cover top-level, nested, and array-nested Buffers, empty Buffers, plain `Uint8Array` staying `Uint8Array`, `structuredClone` staying `Uint8Array` inside the child, and the same over `child_process.fork`.

```
bun bd test test/js/bun/spawn/spawn.ipc.test.ts                                            # 13 pass
USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn.ipc.test.ts -t "Buffer round-trips"    # 2 fail
bun bd test test/js/web/workers/structured-clone.test.ts structuredClone-classes.test.ts   # 267 pass
```