### PR TITLE
fetch: derive Authorization: Basic from URL credentials

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -122,6 +122,48 @@ fn http_thread_timer_read() -> u64 {
     crate::http_thread().timer.elapsed().as_nanos() as u64
 }
 
+/// Derive a `Basic <base64(user:pass)>` header value from percent-encoded URL
+/// userinfo components. Returns `None` if both are empty. A malformed
+/// %-sequence falls back to the raw bytes (per WHATWG percent-decode).
+pub fn basic_auth_from_url_userinfo(username: &[u8], password: &[u8]) -> Option<Vec<u8>> {
+    if username.is_empty() && password.is_empty() {
+        return None;
+    }
+    let user = PercentEncoding::decode_alloc(username).unwrap_or_else(|_| username.into());
+    let pass = PercentEncoding::decode_alloc(password).unwrap_or_else(|_| password.into());
+    let mut plain = Vec::with_capacity(user.len() + 1 + pass.len());
+    plain.extend_from_slice(&user);
+    plain.push(b':');
+    plain.extend_from_slice(&pass);
+    let size = bun_base64::encode_len_from_size(plain.len());
+    let mut out = vec![0u8; b"Basic ".len() + size];
+    out[..b"Basic ".len()].copy_from_slice(b"Basic ");
+    let n = bun_base64::encode(&mut out[b"Basic ".len()..], &plain);
+    out.truncate(b"Basic ".len() + n);
+    Some(out)
+}
+
+/// Return a copy of a WHATWG-serialized `href` with the userinfo (`user:pass@`)
+/// removed. The input is assumed to be a WHATWG-serialized URL, which never
+/// contains a literal `@` in the userinfo or host.
+pub fn href_without_userinfo(href: &[u8]) -> Vec<u8> {
+    if let Some(scheme_end) = bun_core::strings::index_of(href, b"://") {
+        let authority_start = scheme_end + 3;
+        let rest = &href[authority_start..];
+        let authority_end = rest
+            .iter()
+            .position(|&b| matches!(b, b'/' | b'?' | b'#'))
+            .unwrap_or(rest.len());
+        if let Some(at) = rest[..authority_end].iter().position(|&b| b == b'@') {
+            let mut out = Vec::with_capacity(href.len() - (at + 1));
+            out.extend_from_slice(&href[..authority_start]);
+            out.extend_from_slice(&rest[at + 1..]);
+            return out;
+        }
+    }
+    href.to_vec()
+}
+
 /// Build the `Proxy-Authorization: Basic <b64(user[:pass])>` header value.
 /// Returns `None` (and logs) if percent-decoding fails.
 fn build_proxy_authorization(proxy: &URL<'_>) -> Option<Vec<u8>> {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -50,6 +50,7 @@ pub mod zlib;
 
 // ── crate-root re-exports ──
 pub use async_http::AsyncHTTP;
+pub use async_http::{basic_auth_from_url_userinfo, href_without_userinfo};
 pub use certificate_info::CertificateInfo;
 pub use decompressor::Decompressor;
 pub use header_builder::HeaderBuilder;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5167,6 +5167,13 @@ impl<'a> HTTPClient<'a> {
                             }
                         }
 
+                        // https://fetch.spec.whatwg.org/#http-redirect-fetch step 10-11
+                        if !self.flags.is_node_http_client
+                            && (!self.url.username.is_empty() || !self.url.password.is_empty())
+                        {
+                            return Err(err!(RedirectURLCredentials));
+                        }
+
                         // If one of the following is true
                         // - internalResponse's status is 301 or 302 and request's method is `POST`
                         // - internalResponse's status is 303 and request's method is not `GET` or `HEAD`

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1512,6 +1512,20 @@ impl Request {
             bail!(Err(JsError::Thrown));
         }
 
+        // https://fetch.spec.whatwg.org/#dom-request step 6
+        {
+            let href_utf8 = href.to_utf8_without_ref();
+            let parsed = bun_url::URL::parse(href_utf8.slice());
+            if !parsed.username.is_empty() || !parsed.password.is_empty() {
+                let err = global_this.throw_type_error(format_args!(
+                    "Request cannot be constructed from a URL that includes credentials: {}",
+                    href
+                ));
+                href.deref();
+                bail!(Err(err));
+            }
+        }
+
         // hrefFromString increments the reference count if they end up being
         // the same
         //

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1498,7 +1498,7 @@ impl Request {
             ))));
         }
 
-        let href = bun_url::href_from_string(&req.url.get());
+        let mut href = bun_url::href_from_string(&req.url.get());
         if href.is_empty() {
             if !global_this.has_exception() {
                 // globalThis.throw can cause GC, which could cause the above string to be freed.
@@ -1512,19 +1512,23 @@ impl Request {
             bail!(Err(JsError::Thrown));
         }
 
-        // https://fetch.spec.whatwg.org/#dom-request step 6
-        {
+        // Bun diverges from Fetch #dom-request step 6: instead of rejecting a
+        // URL that includes credentials, derive `Authorization: Basic` and
+        // strip the userinfo so it never reaches `request.url`.
+        let url_derived_auth: Option<Vec<u8>> = {
             let href_utf8 = href.to_utf8_without_ref();
             let parsed = bun_url::URL::parse(href_utf8.slice());
-            if !parsed.username.is_empty() || !parsed.password.is_empty() {
-                let err = global_this.throw_type_error(format_args!(
-                    "Request cannot be constructed from a URL that includes credentials: {}",
-                    href
-                ));
-                href.deref();
-                bail!(Err(err));
+            match bun_http::basic_auth_from_url_userinfo(parsed.username, parsed.password) {
+                Some(auth) => {
+                    let stripped = bun_http::href_without_userinfo(href_utf8.slice());
+                    drop(href_utf8);
+                    href.deref();
+                    href = BunString::clone_utf8(&stripped);
+                    Some(auth)
+                }
+                None => None,
             }
-        }
+        };
 
         // hrefFromString increments the reference count if they end up being
         // the same
@@ -1533,6 +1537,23 @@ impl Request {
         // decrement it to be perfectly balanced.
 
         req.url.set(href);
+
+        if let Some(auth) = url_derived_auth {
+            let headers = match req.ensure_fetch_headers(global_this) {
+                Ok(h) => h,
+                Err(e) => bail!(Err(e)),
+            };
+            if !headers.fast_has(HTTPHeaderName::Authorization) {
+                match headers.put(
+                    HTTPHeaderName::Authorization,
+                    &BunString::borrow_utf8(&auth),
+                    global_this,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => bail!(Err(e)),
+                }
+            }
+        }
 
         if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
             if let BodyValue::Blob(blob) = req.body_value() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -614,6 +614,23 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         url_type = URLType::Blob;
     }
 
+    // https://fetch.spec.whatwg.org/#dom-request step 6
+    if !ALLOW_GET_BODY && (!url.username.is_empty() || !url.password.is_empty()) {
+        let err = ctx.to_type_error(
+            jsc::ErrorCode::INVALID_URL,
+            format_args!(
+                "Request cannot be constructed from a URL that includes credentials: {}",
+                bstr::BStr::new(url.href)
+            ),
+        );
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
+    }
+
     // **Start with the harmless ones.**
 
     // "method"

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -614,21 +614,16 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         url_type = URLType::Blob;
     }
 
-    // https://fetch.spec.whatwg.org/#dom-request step 6
-    if !ALLOW_GET_BODY && (!url.username.is_empty() || !url.password.is_empty()) {
-        let err = ctx.to_type_error(
-            jsc::ErrorCode::INVALID_URL,
-            format_args!(
-                "Request cannot be constructed from a URL that includes credentials: {}",
-                bstr::BStr::new(url.href)
-            ),
-        );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+    // Bun diverges from Fetch #dom-request step 6: instead of rejecting a URL
+    // that includes credentials, derive `Authorization: Basic` and strip the
+    // userinfo so it never reaches `response.url` or the wire.
+    let mut url_derived_auth: Option<Vec<u8>> = None;
+    if !ALLOW_GET_BODY && url_type == URLType::Remote {
+        if let Some(auth) = http::basic_auth_from_url_userinfo(url.username, url.password) {
+            url_derived_auth = Some(auth);
+            url_proxy_buffer = http::href_without_userinfo(&url_proxy_buffer);
+            url = parse_url_detached!(&url_proxy_buffer[..]);
+        }
     }
 
     // **Start with the harmless ones.**
@@ -1609,6 +1604,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             None,
             any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
         ));
+    }
+
+    if let Some(auth) = url_derived_auth {
+        let h = headers.get_or_insert_with(Headers::default);
+        if h.get(b"Authorization").is_none() {
+            h.append(b"Authorization", &auth);
+        }
     }
 
     // `body` is mutated in place for the sendfile/readfile paths and then

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1276,6 +1276,12 @@ impl FetchTasklet {
             ));
         }
 
+        if fail == err!("RedirectURLCredentials") {
+            return BodyValueError::TypeError(BunString::static_(
+                "Redirect was rejected because the Location header URL includes credentials",
+            ));
+        }
+
         // some times we don't have metadata so we also check http.url
         let path = if let Some(metadata) = &self.metadata {
             BunString::clone_utf8(metadata.url.slice())

--- a/test/js/web/fetch/fetch-url-credentials.test.ts
+++ b/test/js/web/fetch/fetch-url-credentials.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import * as http from "node:http";
+import { once } from "node:events";
+
+// https://fetch.spec.whatwg.org/#dom-request step 6:
+//   "If parsedURL includes credentials, then throw a TypeError."
+// https://fetch.spec.whatwg.org/#http-redirect-fetch steps 10-11:
+//   "If locationURL includes credentials, then return a network error."
+
+describe("URL credentials", () => {
+  test.each([
+    "http://user:pass@example.com/",
+    "http://user@example.com/",
+    "http://:pass@example.com/",
+    "https://user:pass@example.com/path?query#hash",
+  ])("new Request(%j) throws a TypeError", url => {
+    expect(() => new Request(url)).toThrow(TypeError);
+    expect(() => new Request(url)).toThrow("includes credentials");
+    expect(() => new Request(new URL(url))).toThrow(TypeError);
+  });
+
+  test("new Request() with a URL that has no credentials does not throw", () => {
+    expect(() => new Request("http://example.com/")).not.toThrow();
+    // serialized credentials get percent-encoded into the path, which is fine
+    expect(() => new Request("http://example.com/user:pass@x")).not.toThrow();
+    // '@' in the query string is fine
+    expect(() => new Request("http://example.com/?x=@y")).not.toThrow();
+    // empty user+password is serialized without the '@'
+    expect(new Request("http://@example.com/").url).toBe("http://example.com/");
+  });
+
+  test("fetch() with a URL that includes credentials rejects with a TypeError and never connects", async () => {
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        hits++;
+        return new Response("OK");
+      },
+    });
+    const url = `http://user:pass@${server.hostname}:${server.port}/`;
+
+    const err = await fetch(url).then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.message).toContain("includes credentials");
+    // the server must not have been contacted
+    expect(hits).toBe(0);
+
+    // same thing via a URL object
+    const err2 = await fetch(new URL(url)).then(
+      () => null,
+      e => e,
+    );
+    expect(err2).toBeInstanceOf(TypeError);
+    expect(hits).toBe(0);
+  });
+
+  async function withRedirectServers(fn: (portA: number, portB: number, seen: string[]) => Promise<void>) {
+    const seen: string[] = [];
+    const mk = () =>
+      http.createServer((req, res) => {
+        seen.push(req.url!);
+        const u = new URL(req.url!, "http://x");
+        if (u.pathname === "/r") {
+          res.writeHead(302, { location: u.searchParams.get("to")!, "content-length": 0 });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "content-length": 2 });
+        res.end("OK");
+      });
+    const A = mk();
+    const B = mk();
+    try {
+      A.listen(0, "127.0.0.1");
+      B.listen(0, "127.0.0.1");
+      await once(A, "listening");
+      await once(B, "listening");
+      await fn((A.address() as any).port, (B.address() as any).port, seen);
+    } finally {
+      A.close();
+      B.close();
+    }
+  }
+
+  test("fetch() rejects a cross-origin redirect to a URL that includes credentials", async () => {
+    await withRedirectServers(async (PA, PB, seen) => {
+      const target = `http://user:pass@127.0.0.1:${PA}/redirected`;
+      const err = await fetch(`http://127.0.0.1:${PB}/r?to=${encodeURIComponent(target)}`, {
+        headers: { authorization: "Bearer ORIG" },
+      }).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toContain("includes credentials");
+      // only the redirect endpoint on B was contacted, never the credentialed target on A
+      expect(seen.some(u => u.startsWith("/redirected"))).toBe(false);
+    });
+  });
+
+  test("fetch() rejects a same-origin redirect to a URL that includes credentials", async () => {
+    await withRedirectServers(async (PA, _PB, seen) => {
+      const target = `http://user:pass@127.0.0.1:${PA}/redirected`;
+      const err = await fetch(`http://127.0.0.1:${PA}/r?to=${encodeURIComponent(target)}`).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(seen.some(u => u.startsWith("/redirected"))).toBe(false);
+    });
+  });
+
+  test("fetch() rejects a protocol-relative redirect to a URL that includes credentials", async () => {
+    await withRedirectServers(async (PA, PB, seen) => {
+      const target = `//user:pass@127.0.0.1:${PA}/redirected`;
+      const err = await fetch(`http://127.0.0.1:${PB}/r?to=${encodeURIComponent(target)}`).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(seen.some(u => u.startsWith("/redirected"))).toBe(false);
+    });
+  });
+
+  test("fetch() follows a redirect to a URL with no credentials", async () => {
+    await withRedirectServers(async (PA, PB, seen) => {
+      const target = `http://127.0.0.1:${PA}/redirected`;
+      const res = await fetch(`http://127.0.0.1:${PB}/r?to=${encodeURIComponent(target)}`);
+      expect(res.status).toBe(200);
+      expect(res.redirected).toBe(true);
+      expect(res.url).toBe(target);
+      expect(seen.some(u => u.startsWith("/redirected"))).toBe(true);
+    });
+  });
+});

--- a/test/js/web/fetch/fetch-url-credentials.test.ts
+++ b/test/js/web/fetch/fetch-url-credentials.test.ts
@@ -2,60 +2,107 @@ import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import * as http from "node:http";
 
-// https://fetch.spec.whatwg.org/#dom-request step 6:
-//   "If parsedURL includes credentials, then throw a TypeError."
-// https://fetch.spec.whatwg.org/#http-redirect-fetch steps 10-11:
-//   "If locationURL includes credentials, then return a network error."
+// Bun-specific divergence from https://fetch.spec.whatwg.org/#dom-request step 6:
+// instead of rejecting a URL that includes credentials, derive an
+// `Authorization: Basic` header and strip the userinfo from the stored URL.
+// Redirects to a Location that includes credentials are still rejected per
+// https://fetch.spec.whatwg.org/#http-redirect-fetch steps 10-11.
+
+const basic = (userpass: string) => "Basic " + Buffer.from(userpass).toString("base64");
 
 describe("URL credentials", () => {
   test.each([
-    "http://user:pass@example.com/",
-    "http://user@example.com/",
-    "http://:pass@example.com/",
-    "https://user:pass@example.com/path?query#hash",
-  ])("new Request(%j) throws a TypeError", url => {
-    expect(() => new Request(url)).toThrow(TypeError);
-    expect(() => new Request(url)).toThrow("includes credentials");
-    expect(() => new Request(new URL(url))).toThrow(TypeError);
+    ["http://user:pass@example.com/", "http://example.com/", basic("user:pass")],
+    ["http://user@example.com/", "http://example.com/", basic("user:")],
+    ["http://:pass@example.com/", "http://example.com/", basic(":pass")],
+    ["http://user%40x:p%40ss@example.com/", "http://example.com/", basic("user@x:p@ss")],
+    ["https://user:pass@example.com/path?q=1#h", "https://example.com/path?q=1#h", basic("user:pass")],
+  ])("new Request(%j) derives Authorization and strips userinfo", (input, expectedUrl, expectedAuth) => {
+    const req = new Request(input);
+    expect({ url: req.url, auth: req.headers.get("authorization") }).toEqual({
+      url: expectedUrl,
+      auth: expectedAuth,
+    });
+
+    // same behaviour when the input is a URL object
+    const req2 = new Request(new URL(input));
+    expect({ url: req2.url, auth: req2.headers.get("authorization") }).toEqual({
+      url: expectedUrl,
+      auth: expectedAuth,
+    });
   });
 
-  test("new Request() with a URL that has no credentials does not throw", () => {
-    expect(() => new Request("http://example.com/")).not.toThrow();
-    // serialized credentials get percent-encoded into the path, which is fine
-    expect(() => new Request("http://example.com/user:pass@x")).not.toThrow();
-    // '@' in the query string is fine
-    expect(() => new Request("http://example.com/?x=@y")).not.toThrow();
+  test("new Request() does not derive Authorization when the caller supplied one", () => {
+    const req = new Request("http://user:pass@example.com/", {
+      headers: { authorization: "Bearer TOKEN" },
+    });
+    expect({ url: req.url, auth: req.headers.get("authorization") }).toEqual({
+      url: "http://example.com/",
+      auth: "Bearer TOKEN",
+    });
+  });
+
+  test("new Request() with a URL that has no credentials is unchanged", () => {
+    const cases = ["http://example.com/", "http://example.com/user:pass@x", "http://example.com/?x=@y"];
+    for (const url of cases) {
+      const req = new Request(url);
+      expect({ url: req.url, auth: req.headers.get("authorization") }).toEqual({
+        url,
+        auth: null,
+      });
+    }
     // empty user+password is serialized without the '@'
     expect(new Request("http://@example.com/").url).toBe("http://example.com/");
   });
 
-  test("fetch() with a URL that includes credentials rejects with a TypeError and never connects", async () => {
-    let hits = 0;
+  test("fetch() with a URL that includes credentials sends Authorization: Basic and strips userinfo", async () => {
+    const seen: (string | undefined)[] = [];
     await using server = Bun.serve({
       port: 0,
-      fetch() {
-        hits++;
+      fetch(req) {
+        seen.push(req.headers.get("authorization") ?? undefined);
         return new Response("OK");
       },
     });
-    const url = `http://user:pass@${server.hostname}:${server.port}/`;
+    const base = `${server.hostname}:${server.port}`;
+    const res = await fetch(`http://user:pass@${base}/x`);
+    expect({
+      status: res.status,
+      url: res.url,
+      seen,
+    }).toEqual({
+      status: 200,
+      url: `http://${base}/x`,
+      seen: [basic("user:pass")],
+    });
+  });
 
-    const err = await fetch(url).then(
-      () => null,
-      e => e,
-    );
-    expect(err).toBeInstanceOf(TypeError);
-    expect(err.message).toContain("includes credentials");
-    // the server must not have been contacted
-    expect(hits).toBe(0);
+  test("fetch() does not derive Authorization when the caller supplied one", async () => {
+    const seen: (string | undefined)[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        seen.push(req.headers.get("authorization") ?? undefined);
+        return new Response("OK");
+      },
+    });
+    const res = await fetch(`http://user:pass@${server.hostname}:${server.port}/`, {
+      headers: { authorization: "Bearer TOKEN" },
+    });
+    expect({ status: res.status, seen }).toEqual({ status: 200, seen: ["Bearer TOKEN"] });
+  });
 
-    // same thing via a URL object
-    const err2 = await fetch(new URL(url)).then(
-      () => null,
-      e => e,
-    );
-    expect(err2).toBeInstanceOf(TypeError);
-    expect(hits).toBe(0);
+  test("fetch(new Request(url)) sends the Request's derived Authorization", async () => {
+    const seen: (string | undefined)[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        seen.push(req.headers.get("authorization") ?? undefined);
+        return new Response("OK");
+      },
+    });
+    const res = await fetch(new Request(`http://user:pass@${server.hostname}:${server.port}/`));
+    expect({ status: res.status, seen }).toEqual({ status: 200, seen: [basic("user:pass")] });
   });
 
   async function withRedirectServers(fn: (portA: number, portB: number, seen: string[]) => Promise<void>) {
@@ -97,7 +144,6 @@ describe("URL credentials", () => {
       );
       expect(err).toBeInstanceOf(TypeError);
       expect(err.message).toContain("includes credentials");
-      // only the redirect endpoint on B was contacted, never the credentialed target on A
       expect(seen.some(u => u.startsWith("/redirected"))).toBe(false);
     });
   });

--- a/test/js/web/fetch/fetch-url-credentials.test.ts
+++ b/test/js/web/fetch/fetch-url-credentials.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import * as http from "node:http";
 import { once } from "node:events";
+import * as http from "node:http";
 
 // https://fetch.spec.whatwg.org/#dom-request step 6:
 //   "If parsedURL includes credentials, then throw a TypeError."


### PR DESCRIPTION
## What

`fetch("http://user:pass@host/")` currently resolves successfully without sending any `Authorization` header: the URL userinfo is parsed and then ignored. The credentials are also echoed back in `response.url`. Separately, a redirect to a `Location` that includes credentials is followed and the userinfo surfaces in `response.url`.

This change makes `fetch()` and `new Request()` derive an `Authorization: Basic <base64(user:pass)>` header from URL userinfo (percent-decoded), strip the userinfo from the stored URL so it never reaches `request.url` / `response.url`, and reject redirects to a `Location` that includes credentials.

## Repro

```js
import * as http from "node:http";
const server = http.createServer((req, res) => {
  res.writeHead(200);
  res.end(req.headers.authorization ?? "none");
});
await new Promise(r => server.listen(0, "127.0.0.1", r));
const port = server.address().port;

const res = await fetch(`http://user:pass@127.0.0.1:${port}/`);
// before: "none", response.url includes "user:pass@"
// after:  "Basic dXNlcjpwYXNz", response.url has no userinfo
console.log(await res.text(), res.url);
```

## Behaviour

- `new Request("http://user:pass@host/")` sets `request.url` to `http://host/` and `request.headers.get("authorization")` to `Basic <base64(user:pass)>`
- `fetch("http://user:pass@host/")` sends `Authorization: Basic ...`; `response.url` has no userinfo
- A caller-supplied `Authorization` header takes precedence over the URL-derived one
- The internal `node:http` client entry point is unchanged (it handles `auth` at the JS layer)
- A redirect whose `Location` includes credentials rejects with a `TypeError` (the Fetch spec's security barrier; following it would let any redirecting server plant userinfo in `response.url`)

This diverges from the Fetch spec and Node's `fetch()`, which both throw a `TypeError` on a credentialed URL. It matches curl / axios / got / `http.get()`.

## Verification

```
$ bun bd test test/js/web/fetch/fetch-url-credentials.test.ts
 14 pass
 0 fail

$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-url-credentials.test.ts
 3 pass
 11 fail
```

Related: #924
