### PR TITLE
stdio: reset writable state after end() on file-backed process.stdout/stderr

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -65,11 +65,6 @@ export function getStdioWriteStream(
           // stdout/stderr don't produce readable data, so yield nothing
         })();
       };
-    } else {
-      // File-backed stdio: Node's SyncWriteStream runs end() -> finish ->
-      // destroy -> the _destroy override below -> _undestroy(), which resets
-      // writable state so later writes succeed. autoClose:false disabled that.
-      stream._writableState.autoDestroy = true;
     }
   }
 

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -65,6 +65,11 @@ export function getStdioWriteStream(
           // stdout/stderr don't produce readable data, so yield nothing
         })();
       };
+    } else {
+      // File-backed stdio: Node's SyncWriteStream runs end() -> finish ->
+      // destroy -> the _destroy override below -> _undestroy(), which resets
+      // writable state so later writes succeed. autoClose:false disabled that.
+      stream._writableState.autoDestroy = true;
     }
   }
 

--- a/test/js/node/process/process-stdout-write-after-end-file-fixture.mjs
+++ b/test/js/node/process/process-stdout-write-after-end-file-fixture.mjs
@@ -1,0 +1,41 @@
+const code = e => (e == null ? null : String(e.code || e.name || e));
+
+// Which stream to exercise. The JSON report goes to the other stream.
+const which = process.argv[2] === "stderr" ? "stderr" : "stdout";
+const so = process[which];
+const reportStream = which === "stderr" ? process.stdout : process.stderr;
+
+const ev = [];
+so.on("error", e => ev.push("err:" + code(e)));
+
+const finished = new Promise(resolve => so.once("finish", resolve));
+so.write("A");
+so.end("B");
+
+// Let end() run to completion before the post-end write. This is the
+// pipeline(src, process.stdout) shape: pipeline resolves after the destination
+// finishes, then the program keeps logging. 'finish' always fires; one
+// setImmediate then lets any finish -> destroy -> _undestroy nextTicks drain.
+await finished;
+await new Promise(resolve => setImmediate(resolve));
+
+const { promise, resolve } = Promise.withResolvers();
+let cbErr = "no-callback";
+const ret = so.write("C", e => {
+  cbErr = code(e);
+  resolve();
+});
+// console goes to the same fd; its bytes must land alongside the write().
+console[which === "stderr" ? "error" : "log"]("D");
+await promise;
+await new Promise(r => process.nextTick(r));
+
+reportStream.write(
+  JSON.stringify({
+    writableEnded: so.writableEnded,
+    writable: so.writable,
+    ret,
+    cbErr,
+    ev,
+  }) + "\n",
+);

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import fs from "node:fs";
 import path from "path";
 
-test.each(["stdout", "stderr"] as const)(
+test.concurrent.each(["stdout", "stderr"] as const)(
   "process.%s - write after end() errors and is not delivered (piped)",
   async which => {
     await using proc = Bun.spawn({
@@ -44,7 +44,7 @@ test.each(["stdout", "stderr"] as const)(
   },
 );
 
-test.each(["stdout", "stderr"] as const)(
+test.concurrent.each(["stdout", "stderr"] as const)(
   "process.%s - write after end() succeeds and is delivered (file)",
   async which => {
     using dir = tempDir("stdio-write-after-end-file", {});

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import fs from "node:fs";
 import path from "path";
 
 test.each(["stdout", "stderr"] as const)(
@@ -40,5 +41,52 @@ test.each(["stdout", "stderr"] as const)(
       expect(dataPipe).not.toContain("POST_END_MARKER");
     }
     expect(exitCode).toBe(0);
+  },
+);
+
+test.each(["stdout", "stderr"] as const)(
+  "process.%s - write after end() succeeds and is delivered (file)",
+  async which => {
+    using dir = tempDir("stdio-write-after-end-file", {});
+    const outPath = path.join(String(dir), "out.txt");
+    const fd = fs.openSync(outPath, "w");
+    try {
+      // Redirect the fixture's target stream to a regular file; the report
+      // stream stays piped so we can read the JSON facts.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "process-stdout-write-after-end-file-fixture.mjs"), which],
+        stdout: which === "stdout" ? fd : "pipe",
+        stderr: which === "stderr" ? fd : "pipe",
+        stdin: "ignore",
+        env: bunEnv,
+      });
+
+      const reportStream = which === "stderr" ? proc.stdout : proc.stderr;
+      const [reportText, exitCode] = await Promise.all([reportStream.text(), proc.exited]);
+      const lines = reportText.trim().split("\n");
+      const report = JSON.parse(lines[lines.length - 1]);
+
+      // Node's file-backed stdio is never-closing: end() runs the finish ->
+      // destroy -> _undestroy cycle, which resets writable state, so a later
+      // write() succeeds with no error and writableEnded is false again.
+      expect(report).toEqual({
+        writableEnded: false,
+        writable: true,
+        ret: true,
+        cbErr: null,
+        ev: [],
+      });
+
+      const fileContents = fs.readFileSync(outPath, "latin1");
+      // stderr may carry benign ASAN/debug noise on fd 2; stdout is clean.
+      if (which === "stdout") {
+        expect(fileContents).toBe("ABCD\n");
+      } else {
+        expect(fileContents).toContain("ABCD\n");
+      }
+      expect(exitCode).toBe(0);
+    } finally {
+      fs.closeSync(fd);
+    }
   },
 );


### PR DESCRIPTION
## What

Regression from b280ca3fbc93 (#33557). When `process.stdout` / `process.stderr` is a regular file (`bun app.js > out.txt`, cron/CI logs, `spawn(..., { stdio: [.., fileFd, ..] })`) and the program calls `process.stdout.end()`, either directly or via `stream.pipeline(src, process.stdout)` which always ends its destination, every later `process.stdout.write()` is now rejected with `ERR_STREAM_WRITE_AFTER_END`, an `'error'` event fires (a fatal uncaught exception when there is no `'error'` listener on stdout), and the bytes never reach the file. Node delivers them; so did Bun 1.4.0 and every earlier main.

## Repro

```js
// parent spawns this with stdout redirected to a file fd
const so = process.stdout;
so.on("error", e => {});
so.write("A");
so.end("B");
setTimeout(() => {
  so.write("C");      // node + bun 1.4.0: succeeds, "C" lands in the file
  console.log("D");   // main: write("C") -> ERR_STREAM_WRITE_AFTER_END, file gets "ABD\n"
}, 50);
```

| runtime | `writableEnded` after cycle | later `write("C")` | file contents |
|---|---|---|---|
| node v26 | `false` | succeeds | `"ABCD\n"` |
| bun 1.4.0 | `true` | succeeds (fast path bypassed state) | `"ABCD\n"` |
| bun main | `true` | `ERR_STREAM_WRITE_AFTER_END` | `"ABD\n"` |
| this PR | `false` | succeeds | `"ABCD\n"` |

## Cause

#33557 correctly made the fast-path `write()` delegate to `Writable.prototype.write` when `state.ending` is set, so piped stdio honors the write-after-end contract. File-backed stdio goes through the same `WriteStream` fast path, and its `state.ending` also latches: the stream is created with `autoClose: false`, which `fs.WriteStream` maps to `autoDestroy: false`, so `end()` reaches `'finish'` but never runs `destroy()`. Node's file-backed stdio is a `SyncWriteStream` with `autoDestroy: true`; `end()` there runs `finish -> destroy -> dummyDestroy -> _undestroy()`, which resets `ending`/`ended`/`finished` so the stream is writable again.

## Fix

Set `_writableState.autoDestroy = true` on file-backed stdio (`fdType === file`) in `getStdioWriteStream`. The existing stdio `_destroy` override (`cb(err); this._undestroy()`) then runs after `'finish'` and resets writable state, matching Node's `SyncWriteStream`. Pipe/socket stdio keeps `autoDestroy: false`, so the write-after-end rejection from #33557 is preserved there (Node's piped stdout also rejects, via EPIPE after `net.Socket` half-close).

This also fixes the long-standing divergence where `process.stdout.writableEnded` stayed `true` on file-backed stdio after `end()` (Node reports `false`), and makes `'close'` fire like it does in Node.

## Verification

`test/js/node/process/process-stdout-write-after-end.test.ts` gains file-backed cases for both `stdout` and `stderr` that redirect the fixture's target stream to a temp-file fd, assert the post-end write succeeds with `{writableEnded: false, ret: true, cbErr: null, ev: []}`, and assert the file received `"ABCD\n"`. Both new cases fail on the released binary and on current main without this change; all four cases (piped + file) pass with it. The fixture also produces identical output under Node.