### PR TITLE
Bun.serve: don't treat segment-budget exhaustion as end-of-URL in uWS router

### DIFF
--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -170,6 +170,10 @@ private:
 
         /* If we are on STOP, return where we may stand */
         if (isStop) {
+            /* STOP with unconsumed URL means the segment budget ran out, not end-of-URL: no match here */
+            if (currentUrl.length()) {
+                return false;
+            }
             /* We have reached accross the entire URL with no stoppage, execute */
             for (uint32_t handler : parent->handlers) {
                 if (handlers[handler & HANDLER_MASK](this)) {

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -28,9 +28,12 @@ describe("deep path routing at MAX_URL_SEGMENTS boundary", () => {
     expect(await hit(seg(n, `d${n}x`))).toBe(`exact-${n}`);
   });
 
-  it.each([99, 100])("does not match a %i-segment exact route when the request has extra trailing segments", async n => {
-    expect(await hit(seg(n, `d${n}x`) + "/EXTRA/SEGMENTS")).toBe("catchall");
-  });
+  it.each([99, 100])(
+    "does not match a %i-segment exact route when the request has extra trailing segments",
+    async n => {
+      expect(await hit(seg(n, `d${n}x`) + "/EXTRA/SEGMENTS")).toBe("catchall");
+    },
+  );
 
   it("matches a 100-segment :param route on its exact URL", async () => {
     expect(await hit(`${seg(99, "p")}/VALUE`)).toBe(`param {"last":"VALUE"}`);

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -2,6 +2,49 @@ import type { BunRequest, ServeOptions, Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import net from "node:net";
 
+describe("deep path routing at MAX_URL_SEGMENTS boundary", () => {
+  const seg = (n: number, prefix: string) => "/" + Array.from({ length: n }, (_, i) => `${prefix}${i}`).join("/");
+
+  let server: Server;
+  beforeAll(() => {
+    const routes: Record<string, (req: BunRequest) => Response> = {
+      "/*": () => new Response("catchall"),
+    };
+    for (const n of [99, 100]) {
+      routes[seg(n, `d${n}x`)] = () => new Response(`exact-${n}`);
+    }
+    routes[`${seg(99, "p")}/:last`] = req => new Response(`param ${JSON.stringify(req.params)}`);
+    server = Bun.serve({ port: 0, development: false, routes, fetch: () => new Response("fallback") });
+    server.unref();
+  });
+  afterAll(() => server.stop(true));
+
+  const hit = async (path: string) => {
+    const res = await fetch(new URL(path, server.url));
+    return res.text();
+  };
+
+  it.each([99, 100])("matches a %i-segment exact route on its exact URL", async n => {
+    expect(await hit(seg(n, `d${n}x`))).toBe(`exact-${n}`);
+  });
+
+  it.each([99, 100])("does not match a %i-segment exact route when the request has extra trailing segments", async n => {
+    expect(await hit(seg(n, `d${n}x`) + "/EXTRA/SEGMENTS")).toBe("catchall");
+  });
+
+  it("matches a 100-segment :param route on its exact URL", async () => {
+    expect(await hit(`${seg(99, "p")}/VALUE`)).toBe(`param {"last":"VALUE"}`);
+  });
+
+  it("does not match a 100-segment :param route when the request has extra trailing segments", async () => {
+    expect(await hit(`${seg(99, "p")}/VALUE/AND/MORE/SEGMENTS`)).toBe("catchall");
+  });
+
+  it("catchall still matches requests far deeper than the segment limit", async () => {
+    expect(await hit(seg(200, "z"))).toBe("catchall");
+  });
+});
+
 describe("path parameters", () => {
   let server: Server;
 


### PR DESCRIPTION
## What

The uWS `HttpRouter` caps URL parsing at `MAX_URL_SEGMENTS = 100`. `getUrlSegment()` returns the same STOP sentinel for both genuine end-of-URL and for hitting that cap, and `executeHandlers()` treats STOP as "entire URL consumed, run this node's handlers". So an exact route with 100 path segments silently became a prefix match: it fired for any longer request sharing its first 100 segments. A 100-segment `:param`-terminated route did the same and reported `req.params` for a request-target it never received. Routes with 99 or fewer segments were unaffected.

```js
const seg = n => "/" + Array.from({ length: n }, (_, i) => `s${i}`).join("/");
Bun.serve({
  port: 0,
  routes: {
    [seg(100)]: () => new Response("exact"),
    "/*": () => new Response("catchall"),
  },
});
// GET seg(100) + "/EXTRA/SEGMENTS"  ->  "exact"   (should be "catchall")
```

## Why

```cpp
/* Signal as STOP when we have no more URL or stack space */
if (!currentUrl.length() || urlSegment > int(MAX_URL_SEGMENTS - 1)) {
    return {{}, true};
}
```

Both conditions return `true` in `.second`, and the caller cannot tell them apart. When the budget is exhausted, `currentUrl` still holds the unparsed tail (e.g. `/EXTRA/SEGMENTS`); when the URL genuinely ended, `currentUrl` is empty.

## Fix

At the STOP branch in `executeHandlers`, check `currentUrl.length()`: if non-empty, the segment budget ran out with URL left over, so return `false` (no match at this node) instead of running the node's handlers. The request then falls through to a shallower wildcard (`/*`) or the `fetch()` fallback, matching the behaviour at every other depth.

Routes with exactly 100 segments now match only their exact URL. Patterns registered with more than 100 segments remain truncated at registration (unchanged), but with this fix they no longer mis-route; they simply fail to match and fall through.

## Verification

`bun-serve-routes.test.ts` gains a `MAX_URL_SEGMENTS boundary` describe block covering: exact match at 99 and 100 segments still works; extra trailing segments at 99 and 100 now both fall through to catchall; 100-segment `:param` route matches exactly and no longer fires with extra segments; `/*` still catches a 200-segment request.

Before the fix, the two "extra trailing segments" cases at depth 100 fail with `Received: "exact-100"` and `Received: "param {\"last\":\"VALUE\"}"`. After, all 59 tests in the file pass.