### PR TITLE
Bun.serve: evaluate If-None-Match on Bun.file routes

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -3,7 +3,9 @@ use core::ffi::c_void;
 use core::mem::size_of;
 
 use bun_core::String as BunString;
+use bun_core::strings;
 use bun_http::{Headers, Method};
+use bun_http_types::ETag;
 use bun_http_types::ETag::StringPointer;
 use bun_io::Closer;
 use bun_io::FileType;
@@ -450,13 +452,26 @@ impl FileRoute {
 
         let status_code: u16 = 'brk: {
             // RFC 9110 §13.2.2: conditional preconditions are evaluated before
-            // Range. If-Modified-Since on an unmodified resource yields 304 even
-            // when a Range header is present (without If-Range).
-            // Unlike If-Unmodified-Since, If-Modified-Since can only be used with a
-            // GET or HEAD. When used in combination with If-None-Match, it is
-            // ignored, unless the server doesn't support If-None-Match.
-            if let Some(requested_if_modified_since) = input_if_modified_since_date {
-                if method == Method::HEAD || method == Method::GET {
+            // Range. If-None-Match is evaluated first; when present it suppresses
+            // If-Modified-Since regardless of outcome (step 3 vs step 4). Both
+            // only apply to GET/HEAD for 304 purposes.
+            if method == Method::HEAD || method == Method::GET {
+                if let Some(inm) = req.header(b"if-none-match").filter(|v| !v.is_empty()) {
+                    if this.status_code == 200 {
+                        let matched = match this.headers.get(b"etag").filter(|v| !v.is_empty()) {
+                            Some(etag) => ETag::if_none_match(etag, inm),
+                            // No stored ETag: only `*` can match (RFC 9110
+                            // §13.1.2 — any current representation).
+                            None => strings::trim(inm, b" \t") == b"*",
+                        };
+                        if matched {
+                            break 'brk 304;
+                        }
+                    }
+                    // If-None-Match present but did not match: condition is
+                    // true, fall through to Range/200 without consulting
+                    // If-Modified-Since.
+                } else if let Some(requested_if_modified_since) = input_if_modified_since_date {
                     let Ok(lmd) = this.last_modified_date() else {
                         return;
                     }; // TODO: properly propagate exception upwards

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -66,6 +66,10 @@ describe("Bun.file in serve routes", () => {
           "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
         },
       }),
+      "/hello-blob.txt": Bun.file(join(tempDir, "hello.txt")),
+      "/with-etag.txt": new Response(Bun.file(join(tempDir, "hello.txt")), {
+        headers: { "ETag": '"custom-etag"' },
+      }),
       "/partial.txt": new Response(Bun.file(join(tempDir, "partial.txt"))),
       "/partial-slice.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10)),
       "/fd-not-supported.txt": (() => {
@@ -392,6 +396,77 @@ describe("Bun.file in serve routes", () => {
 
       // Should not return 304 for POST
       expect(res2.status).not.toBe(304);
+    });
+
+    describe.each(["/hello.txt", "/hello-blob.txt"])("If-None-Match on %s", path => {
+      describe.each(["GET", "HEAD"])("%s", method => {
+        it("returns 304 for If-None-Match: *", async () => {
+          // RFC 9110 §13.1.2: `*` matches any current representation.
+          const res = await fetch(new URL(path, server.url), {
+            method,
+            headers: { "If-None-Match": "*" },
+          });
+          expect(res.status).toBe(304);
+          expect(await res.text()).toBe("");
+        });
+
+        it("ignores If-Modified-Since when If-None-Match is present and does not match", async () => {
+          // RFC 9110 §13.2.2 step 4: If-Modified-Since is only evaluated when
+          // If-None-Match is NOT present. A non-matching If-None-Match means
+          // the condition is true: serve the representation (200), even though
+          // If-Modified-Since alone would have produced 304.
+          const lastModified = (await fetch(new URL(path, server.url))).headers.get("Last-Modified");
+          expect(lastModified).not.toBeEmpty();
+
+          const res = await fetch(new URL(path, server.url), {
+            method,
+            headers: {
+              "If-None-Match": '"does-not-match"',
+              "If-Modified-Since": lastModified!,
+            },
+          });
+          expect(res.status).toBe(200);
+          if (method === "GET") expect(await res.text()).toBe("Hello, World!");
+        });
+
+        it("still 304s for If-None-Match: * when If-Modified-Since is also present", async () => {
+          const res = await fetch(new URL(path, server.url), {
+            method,
+            headers: {
+              "If-None-Match": "*",
+              "If-Modified-Since": "Tue, 01 Jan 1980 00:00:00 GMT",
+            },
+          });
+          expect(res.status).toBe(304);
+          expect(await res.text()).toBe("");
+        });
+      });
+    });
+
+    it("does not apply If-None-Match to POST requests on file routes", async () => {
+      const res = await fetch(new URL(`/hello-blob.txt`, server.url), {
+        method: "POST",
+        headers: { "If-None-Match": "*" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("Hello, World!");
+    });
+
+    it("returns 304 when If-None-Match matches a user-set ETag on a file route", async () => {
+      const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+        headers: { "If-None-Match": '"custom-etag"' },
+      });
+      expect(res.status).toBe(304);
+      expect(res.headers.get("ETag")).toBe('"custom-etag"');
+      expect(await res.text()).toBe("");
+    });
+
+    it("returns 200 when If-None-Match does not match a user-set ETag on a file route", async () => {
+      const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+        headers: { "If-None-Match": '"other"' },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("Hello, World!");
     });
 
     it.todo("handles ETag", async () => {


### PR DESCRIPTION
### Problem

`Bun.serve` file routes (`Bun.file(path)` or `new Response(Bun.file(path))` in the `routes` table) only implemented `If-Modified-Since`; `If-None-Match` was never read. Per RFC 9110 this caused two wrong outcomes:

- `If-None-Match: *` on an existing file returned **200** instead of **304** (section 13.1.2: `*` matches any current representation).
- A request carrying both `If-None-Match` and `If-Modified-Since` was answered based solely on `If-Modified-Since`, so a cache revalidating with a stale entity tag plus the last `Last-Modified` it held got a **304** governed only by the weak, second-resolution date (section 13.2.2 step 4: `If-Modified-Since` must not be evaluated when `If-None-Match` is present).

`StaticRoute` (`new Response("...")`) in the same `routes` table already handled both cases correctly, so the two static-serving route types answered the identical conditional request differently.

### Reproduction

```ts
import { writeFileSync, utimesSync } from "node:fs";
writeFileSync("/tmp/a.txt", "hello");
utimesSync("/tmp/a.txt", new Date("2026-01-02T03:04:05Z"), new Date("2026-01-02T03:04:05Z"));

using s = Bun.serve({ port: 0, development: false, routes: {
  "/file":   Bun.file("/tmp/a.txt"),
  "/static": new Response("hello"),
}});
const get = (p, h) => fetch(`${s.url}${p}`, { headers: h }).then(r => r.status);
const lm = (await fetch(`${s.url}file`)).headers.get("last-modified");

await get("static", { "if-none-match": "*" }); // 304 (correct)
await get("file",   { "if-none-match": "*" }); // 200, should be 304
await get("file",   { "if-none-match": '"x"', "if-modified-since": lm }); // 304, should be 200
```

### Fix

In `FileRoute::on`, evaluate `If-None-Match` ahead of the existing `If-Modified-Since` branch for GET and HEAD on a would-be-200 route:

- If the route carries a user-supplied `ETag` header, compare via the existing `ETag::if_none_match` helper (same code path `StaticRoute` uses).
- Otherwise only `*` can match, since file routes do not synthesize an ETag.
- When `If-None-Match` is present but does not match, fall through to Range/200 **without** consulting `If-Modified-Since`.

### Related

#32914 touches the same block to wire up `If-None-Match` when a manifest-supplied `ETag` is present. That change explicitly leaves routes without a stored ETag unchanged, so it does not cover the `If-None-Match: *` case on a bare `Bun.file(path)` route. This PR handles both, and the `FileRoute.rs` portion here supersedes the one in #32914.

### Tests

New cases in `test/js/bun/http/bun-serve-file.test.ts` under the existing "Conditional requests" block, parameterized over both file-route spellings (`new Response(Bun.file(...))` and bare `Bun.file(...)`) and over GET/HEAD:

- `If-None-Match: *` returns 304
- non-matching `If-None-Match` + matching `If-Modified-Since` returns 200
- `If-None-Match: *` + past `If-Modified-Since` returns 304
- POST with `If-None-Match: *` still returns 200
- a user-set `ETag` on a file route matches and does not match correctly

13 of the 15 new assertions fail on current `main` and all pass with the fix. `serve-if-none-match.test.ts` (StaticRoute) is unchanged at 20/20 pass.