### PR TITLE
fake timers: honor setSystemTime across advanceTimersByTime; make Bun.cron mockable

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1176,7 +1176,8 @@ pub mod time {
     // Defined in `util::time`; re-exported so `bun_core::time::*` resolves uniformly.
     pub use crate::util::time::{
         MS_PER_DAY, MS_PER_S, NS_PER_DAY, NS_PER_HOUR, NS_PER_MIN, NS_PER_MS, NS_PER_S, NS_PER_US,
-        NS_PER_WEEK, S_PER_DAY, US_PER_MS, US_PER_S, milli_timestamp, nano_timestamp, timestamp,
+        NS_PER_WEEK, S_PER_DAY, US_PER_MS, US_PER_S, milli_timestamp,
+        milli_timestamp_allow_mocked_time, nano_timestamp, timestamp,
     };
 
     #[derive(Clone, Copy)]

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3042,6 +3042,12 @@ pub mod time {
     pub fn milli_timestamp() -> i64 {
         (nano_timestamp() / NS_PER_MS as i128) as i64
     }
+    /// Wall-clock milliseconds since the Unix epoch, or the fake-timers mocked
+    /// wall clock when active. See [`super::mock_time`].
+    #[inline]
+    pub fn milli_timestamp_allow_mocked_time() -> f64 {
+        super::mock_time::wall_ms().unwrap_or_else(|| milli_timestamp() as f64)
+    }
     /// Wall-clock seconds since the Unix epoch.
     #[inline]
     pub fn timestamp() -> i64 {
@@ -5338,11 +5344,13 @@ pub mod timespec_mode {
 /// Mocked-time storage. The data lives at T0 so `Timespec::now` reads it
 /// directly; the test-runner (`useFakeTimers`) writes via `set`/`clear`
 /// from `bun_runtime::test_runner::timers::FakeTimers::CurrentTime`.
-/// Sentinel `i64::MIN` ⇒ not mocked.
+/// Sentinel `i64::MIN` / `NaN` ⇒ not mocked.
 pub mod mock_time {
-    use core::sync::atomic::{AtomicI64, Ordering};
+    use core::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
     static MOCKED_TIME_NS: AtomicI64 = AtomicI64::new(i64::MIN);
+    // Mocked wall-clock `Date.now()` in ms, stored as f64 bits; NaN = unset.
+    static MOCKED_WALL_MS: AtomicU64 = AtomicU64::new(f64::NAN.to_bits());
 
     /// Set the mocked monotonic time (nanoseconds). Called by fake-timers.
     #[inline]
@@ -5360,6 +5368,24 @@ pub mod mock_time {
     pub fn get() -> Option<i64> {
         let v = MOCKED_TIME_NS.load(Ordering::Relaxed);
         if v == i64::MIN { None } else { Some(v) }
+    }
+    /// Set the mocked wall-clock time (`Date.now()` in ms). Called by
+    /// fake-timers alongside `set` so calendar-based consumers and the
+    /// monotonic timer heap move through the same mock.
+    #[inline]
+    pub fn set_wall_ms(ms: f64) {
+        MOCKED_WALL_MS.store(ms.to_bits(), Ordering::Relaxed);
+    }
+    /// Clear the mocked wall-clock time.
+    #[inline]
+    pub fn clear_wall() {
+        MOCKED_WALL_MS.store(f64::NAN.to_bits(), Ordering::Relaxed);
+    }
+    /// Current mocked wall-clock time in ms, or `None` if not mocked.
+    #[inline]
+    pub fn wall_ms() -> Option<f64> {
+        let v = f64::from_bits(MOCKED_WALL_MS.load(Ordering::Relaxed));
+        if v.is_nan() { None } else { Some(v) }
     }
 }
 

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -212,7 +212,6 @@ impl Tag {
             | Tag::BunTest // for test timeouts
             | Tag::EventLoopDelayMonitor // probably important
             | Tag::StatWatcherScheduler
-            | Tag::CronJob // calendar-anchored to real wall clock
             => false,
             _ => true,
         }

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1436,6 +1436,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsNow, (JSC::JSGlobalObject * globalObject, JSC
 {
     return JSValue::encode(jsNumber(globalObject->jsDateNow()));
 }
+
+extern "C" void Bun__FakeTimers__setSystemTime(double ms);
+
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     JSValue argument0 = callframe->argument(0);
@@ -1443,11 +1446,16 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
     // JSGlobalObject::overridenDateNow's "no override" sentinel is NaN (see
     // JSGlobalObject::jsDateNow()), so every real timestamp, including 0 and
     // pre-epoch negatives, overrides; an omitted arg, NaN, or invalid Date resets.
+    double ms;
     if (auto* dateInstance = dynamicDowncast<DateInstance>(argument0)) {
-        globalObject->overridenDateNow = dateInstance->internalNumber();
-        return JSValue::encode(callframe->thisValue());
+        ms = dateInstance->internalNumber();
+    } else {
+        ms = argument0.isNumber() ? argument0.asNumber() : PNaN;
     }
-    globalObject->overridenDateNow = argument0.isNumber() ? argument0.asNumber() : PNaN;
+    globalObject->overridenDateNow = ms;
+    // Rebase the Rust-side fake-timers offset so advanceTimersByTime ticks
+    // from this value instead of the activation-time clock.
+    Bun__FakeTimers__setSystemTime(ms);
 
     return JSValue::encode(callframe->thisValue());
 }

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1632,9 +1632,10 @@ impl CronJob {
     }
 
     fn compute_next_timespec(&self) -> Option<bun_core::Timespec> {
-        // Cron occurrences are calendar-based (real epoch); the timer heap is
-        // monotonic. Anchor both to real time so fake timers don't half-apply.
-        let now_ms: f64 = bun_core::time::milli_timestamp() as f64;
+        // Cron occurrences are calendar-based (epoch); the timer heap is
+        // monotonic. Anchor both to the same clock (mocked when fake timers
+        // are active) so they can never half-apply.
+        let now_ms: f64 = bun_core::time::milli_timestamp_allow_mocked_time();
         // The monotonic timer can fire fractionally before the wall-clock target
         // (clock skew / NTP step); floor next() at the prior target so it can't
         // recompute the same minute and double-fire.
@@ -1646,7 +1647,7 @@ impl CronJob {
         self.last_next_ms.set(next_ms);
         let delta: i64 = (next_ms - now_ms).max(1.0) as i64;
         Some(bun_core::Timespec::ms_from_now(
-            bun_core::TimespecMockMode::ForceRealTime,
+            bun_core::TimespecMockMode::AllowMockedTime,
             delta,
         ))
     }

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -64,8 +64,10 @@ impl CurrentTime {
             date_now_offset = js.floor() - timespec_ms;
             self.date_now_offset.store(date_now_offset.to_bits(), Ordering::Relaxed);
         }
+        let date_now = date_now_offset + timespec_ms;
         // SAFETY: FFI call into C++ JSMock; global is a valid &JSGlobalObject
-        JSMock__setOverridenDateNow(global, date_now_offset + timespec_ms);
+        JSMock__setOverridenDateNow(global, date_now);
+        bun_core::mock_time::set_wall_ms(date_now);
 
         vm.overridden_performance_now = Some(offset.ns());
     }
@@ -76,12 +78,33 @@ impl CurrentTime {
             *self.offset_raw.write() = MIN_TIMESPEC;
         }
         bun_core::mock_time::clear();
+        bun_core::mock_time::clear_wall();
         // NaN is JSGlobalObject::overridenDateNow's "no override" sentinel; a
         // real -1 would pin Date.now() at 1969-12-31T23:59:59.999Z.
         // SAFETY: FFI call into C++ JSMock; global is a valid &JSGlobalObject
         JSMock__setOverridenDateNow(global, f64::NAN);
         vm.overridden_performance_now = None;
     }
+}
+
+/// `jest.setSystemTime` (C++ `JSMock__jsSetSystemTime`) writes
+/// `globalObject->overridenDateNow` directly; rebase `date_now_offset` here so
+/// the next `advanceTimersByTime` recomputes `Date.now` from the set time
+/// instead of the stale activation-time offset. No-op when fake timers are
+/// inactive or `ms` is NaN (the "clear override" sentinel).
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn Bun__FakeTimers__setSystemTime(ms: f64) {
+    if ms.is_nan() {
+        return;
+    }
+    let Some(current) = CURRENT_TIME.get_timespec_now() else {
+        return;
+    };
+    let date_now_offset = ms - current.ms() as f64;
+    CURRENT_TIME
+        .date_now_offset
+        .store(date_now_offset.to_bits(), Ordering::Relaxed);
+    bun_core::mock_time::set_wall_ms(ms);
 }
 
 use crate::jsc_hooks::timer_all;

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -121,15 +121,43 @@ describe("Bun.cron (in-process)", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("ignores jest fake timers (calendar-anchored to real time)", () => {
+  test("honors jest fake timers", () => {
     jest.useFakeTimers();
     try {
+      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+      const firedAt: number[] = [];
+      using job = Bun.cron("* * * * *", () => void firedAt.push(Date.now()));
+
+      jest.advanceTimersByTime(59_999);
+      expect(firedAt).toEqual([]);
+
+      jest.advanceTimersByTime(1);
+      expect(firedAt).toEqual([new Date("2026-01-01T12:01:00.000Z").getTime()]);
+
+      // Re-arms for the next minute; never double-fires at the same boundary
+      jest.advanceTimersByTime(60_000);
+      expect(firedAt).toEqual([
+        new Date("2026-01-01T12:01:00.000Z").getTime(),
+        new Date("2026-01-01T12:02:00.000Z").getTime(),
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("stop() under fake timers prevents further fires", () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
       let fires = 0;
-      using job = Bun.cron("* * * * *", () => void fires++);
-      jest.runAllTimers();
+      const job = Bun.cron("* * * * *", () => void fires++);
+
+      jest.advanceTimersByTime(60_000);
+      expect(fires).toBe(1);
+
+      job.stop();
       jest.advanceTimersByTime(120_000);
-      jest.runAllTimers();
-      expect(fires).toBe(0);
+      expect(fires).toBe(1);
     } finally {
       jest.useRealTimers();
     }

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -29,6 +29,29 @@ test("we can go back in time", () => {
   expect(now.toISOString()).toBe(orig.toISOString());
 });
 
+test("advanceTimersByTime ticks from the setSystemTime value", () => {
+  jest.useFakeTimers();
+  try {
+    const base = new Date("2026-01-01T12:00:00.000Z").getTime();
+    jest.setSystemTime(new Date(base));
+    expect(Date.now()).toBe(base);
+
+    jest.advanceTimersByTime(1000);
+    expect(Date.now()).toBe(base + 1000);
+    expect(new Date().toISOString()).toBe("2026-01-01T12:00:01.000Z");
+
+    jest.advanceTimersByTime(500);
+    expect(Date.now()).toBe(base + 1500);
+
+    // setSystemTime with a number argument rebases again
+    jest.setSystemTime(base);
+    jest.advanceTimersByTime(2000);
+    expect(Date.now()).toBe(base + 2000);
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
 test("setSystemTime accepts pre-epoch and epoch times and resets with no argument", () => {
   const realBefore = Date.now();
   jest.useFakeTimers();


### PR DESCRIPTION
Two changes, the second dependent on the first.

## Part 1: `advanceTimersByTime` discards `setSystemTime`

```js
jest.useFakeTimers();
jest.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
Date.now();                      // 2026-01-01T12:00:00.000Z
jest.advanceTimersByTime(1000);
Date.now();                      // snaps back to real wall-clock + 1s
```

`JSMock__jsSetSystemTime` wrote `globalObject->overridenDateNow` directly and never updated the Rust-side `CurrentTime.date_now_offset`. `advanceTimersByTime` then recomputed `Date.now` from that stale offset and pushed it back into JSC. Fix: `JSMock__jsSetSystemTime` now calls `Bun__FakeTimers__setSystemTime` to rebase `date_now_offset` (no-op when fake timers are inactive or the argument is NaN).

## Part 2: `Bun.cron` honors fake timers

`compute_next_timespec` was anchored to `ForceRealTime` to avoid the calendar target and the monotonic deadline moving on different clocks. The fix is to make both mockable instead of neither:

- `bun_core::mock_time` gains a mocked wall clock (`set_wall_ms` / `wall_ms`) alongside the existing monotonic one, plus `time::milli_timestamp_allow_mocked_time()`. `CurrentTime::set`/`clear` in FakeTimers mirror the same `Date.now` value they already push into JSC. Cron reads it via `bun_core`, never reaching into the test_runner crate.
- `compute_next_timespec` reads the mocked wall clock and returns an `AllowMockedTime` deadline, so both clocks move through the same mock.
- `Tag::CronJob` is removed from the `allow_fake_timers` exclusion list so the cron timer lands in the fake heap that `advanceTimersByTime` drains.

## Verification

```
bun bd test test/js/bun/test/test-timers.test.ts                # 3 pass
bun bd test test/js/bun/cron/in-process-cron.test.ts            # 27 pass
bun bd test test/js/bun/test/fake-timers/fake-timers.test.ts    # 30 pass
```

The flipped cron test asserts: `setSystemTime(12:00:00)` → `advanceTimersByTime(59_999)` no fire → `+1` ms fires at exactly `12:01:00` → `+60_000` re-arms to `12:02:00` and never double-fires.