### PR TITLE
child_process: place 'ipc' at the requested stdio index 0/1/2

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -397,6 +397,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut socket_fd_indices: Vec<usize> = Vec::new();
     let mut argv0: Option<*const c_char> = None;
     let mut ipc_channel: i32 = -1;
+    // Index into stdio[0..3] when "ipc" occupies stdin/stdout/stderr.
+    // Node's stdio array index is the child fd, so the channel must be dup2'd
+    // onto that fd rather than appended as an extra fd.
+    #[cfg_attr(windows, allow(unused_mut))]
+    let mut ipc_stdio_index: i32 = -1;
     let mut timeout: Option<i32> = None;
     let mut uid: Option<u32> = None;
     let mut gid: Option<u32> = None;
@@ -633,6 +638,13 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                         let mut i: i32 = 0;
                         while let Some(value) = stdio_iter.next()? {
                             Stdio::extract(&mut stdio[i as usize], global_this, i, value, IS_SYNC)?;
+                            // Windows still routes 'ipc' at 0-2 through an
+                            // extra_fds slot (libuv named pipe); only POSIX
+                            // can dup2 the socketpair onto stdin/out/err.
+                            #[cfg(unix)]
+                            if matches!(stdio[i as usize], Stdio::Ipc) {
+                                ipc_stdio_index = i;
+                            }
                             if i == 2 {
                                 break;
                             }
@@ -982,6 +994,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 return Ok(JSValue::ZERO);
             }
             let ipc_fd: i32 = 'brk: {
+                if ipc_stdio_index != -1 {
+                    // "ipc" is at stdin/stdout/stderr; the channel is that fd
+                    // in the child and no extra_fds slot is appended.
+                    break 'brk ipc_stdio_index;
+                }
                 if ipc_channel == -1 {
                     // If the user didn't specify an IPC channel, we need to add one
                     ipc_channel = i32::try_from(extra_fds.len()).expect("int cast");
@@ -1263,6 +1280,8 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let spawned_stdin = spawned.stdin.take();
     let spawned_stdout = spawned.stdout.take();
     let spawned_stderr = spawned.stderr.take();
+    #[cfg(unix)]
+    let spawned_ipc = spawned.ipc.take();
     let mut spawned_extra_pipes = core::mem::take(&mut spawned.extra_pipes);
     // `to_process` returns a freshly Box-allocated `Process` carrying an
     // intrusive `ThreadSafeRefCount` initialized to 1. `Subprocess.process`
@@ -1273,8 +1292,18 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     #[cfg(unix)]
     let posix_ipc_fd = if !IS_SYNC && maybe_ipc_mode.is_some() {
-        spawned_extra_pipes[usize::try_from(ipc_channel).expect("int cast")].fd()
+        if ipc_stdio_index != -1 {
+            spawned_ipc.unwrap_or(Fd::INVALID)
+        } else {
+            spawned_extra_pipes[usize::try_from(ipc_channel).expect("int cast")].fd()
+        }
     } else {
+        // No ipc callback: spawn_process_posix still created a socketpair for
+        // 'ipc' at stdin/stdout/stderr; close the parent end so it isn't leaked
+        // (the extra_fds path would close it via stdio_pipes/finalize_streams).
+        if let Some(fd) = spawned_ipc {
+            fd.close();
+        }
         Fd::INVALID
     };
 
@@ -1386,6 +1415,9 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 }
                 if let Some(fd) = spawned_stderr {
                     fd.close();
+                }
+                if ipc_stdio_index != -1 && posix_ipc_fd != Fd::INVALID {
+                    posix_ipc_fd.close();
                 }
             }
             #[cfg(not(unix))]
@@ -1524,6 +1556,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                     IPC::SocketUnion::Uninitialized,
                 )));
                 posix_ipc_info = Some(IPC::Socket::from(socket));
+            } else if ipc_stdio_index != -1 && posix_ipc_fd != Fd::INVALID {
+                // Not in stdio_pipes; close it here so it isn't leaked. The
+                // extra_fds path leaves it OwnedFd in stdio_pipes for
+                // finalize_streams to close.
+                posix_ipc_fd.close();
             }
         }
     }
@@ -1543,9 +1580,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 }
             }
             // uws owns the fd now (owns_fd=1); neutralize the slot so finalizeStreams doesn't double-close.
-            subprocess.stdio_pipes.with_mut(|v| {
-                v[usize::try_from(ipc_channel).expect("int cast")] = ExtraPipe::Unavailable;
-            });
+            if ipc_channel != -1 {
+                subprocess.stdio_pipes.with_mut(|v| {
+                    v[usize::try_from(ipc_channel).expect("int cast")] = ExtraPipe::Unavailable;
+                });
+            }
         }
         #[cfg(not(unix))]
         {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -397,11 +397,6 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut socket_fd_indices: Vec<usize> = Vec::new();
     let mut argv0: Option<*const c_char> = None;
     let mut ipc_channel: i32 = -1;
-    // Index into stdio[0..3] when "ipc" occupies stdin/stdout/stderr.
-    // Node's stdio array index is the child fd, so the channel must be dup2'd
-    // onto that fd rather than appended as an extra fd.
-    #[cfg_attr(windows, allow(unused_mut))]
-    let mut ipc_stdio_index: i32 = -1;
     let mut timeout: Option<i32> = None;
     let mut uid: Option<u32> = None;
     let mut gid: Option<u32> = None;
@@ -638,13 +633,6 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                         let mut i: i32 = 0;
                         while let Some(value) = stdio_iter.next()? {
                             Stdio::extract(&mut stdio[i as usize], global_this, i, value, IS_SYNC)?;
-                            // Windows still routes 'ipc' at 0-2 through an
-                            // extra_fds slot (libuv named pipe); only POSIX
-                            // can dup2 the socketpair onto stdin/out/err.
-                            #[cfg(unix)]
-                            if matches!(stdio[i as usize], Stdio::Ipc) {
-                                ipc_stdio_index = i;
-                            }
                             if i == 2 {
                                 break;
                             }
@@ -974,6 +962,23 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     // Note: reshaped for borrowck — re-borrow through the guard tuple so the guard
     // stays armed (runs on every early return) until disarmed by `**should_close_memfd = false` below.
     let (should_close_memfd, stdio) = &mut *memfd_guard;
+
+    // Index into stdio[0..3] when "ipc" occupies stdin/stdout/stderr. Node's
+    // stdio array index is the child fd, so the channel must be dup2'd onto
+    // that fd rather than appended as an extra fd. Computed here (after the
+    // stdio array / shortcut-option parsing and the terminal override have all
+    // finished mutating stdio[0..3]) so it reflects what spawn_process will
+    // actually see. Windows still routes 'ipc' at 0-2 through an extra_fds
+    // slot (libuv named pipe); only POSIX can dup2 the socketpair onto
+    // stdin/out/err.
+    #[cfg(unix)]
+    let ipc_stdio_index: i32 = stdio
+        .iter()
+        .position(|s| matches!(s, Stdio::Ipc))
+        .map(|i| i as i32)
+        .unwrap_or(-1);
+    #[cfg(not(unix))]
+    let ipc_stdio_index: i32 = -1;
 
     // "NODE_CHANNEL_FD=" is 16 bytes long, 15 bytes for the number, and 1 byte for the null terminator should be enough/safe
     let mut ipc_env_buf: [u8; 32] = [0; 32];
@@ -1580,7 +1585,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 }
             }
             // uws owns the fd now (owns_fd=1); neutralize the slot so finalizeStreams doesn't double-close.
-            if ipc_channel != -1 {
+            // Only when the channel actually came from extra_fds: if
+            // ipc_stdio_index is set, uws took spawned.ipc and the extra_fds
+            // slot (if any) is a separate OwnedFd that finalize_streams should
+            // still close.
+            if ipc_channel != -1 && ipc_stdio_index == -1 {
                 subprocess.stdio_pipes.with_mut(|v| {
                     v[usize::try_from(ipc_channel).expect("int cast")] = ExtraPipe::Unavailable;
                 });

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1526,6 +1526,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         // Ensure we kill the process so we don't leave things in an unexpected state.
         let _ = subprocess.try_kill(subprocess.kill_signal);
 
+        #[cfg(unix)]
+        if ipc_stdio_index != -1 && posix_ipc_fd != Fd::INVALID {
+            posix_ipc_fd.close();
+        }
+
         if global_this.has_exception() {
             return Err(JsError::Thrown);
         }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -972,11 +972,27 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     // slot (libuv named pipe); only POSIX can dup2 the socketpair onto
     // stdin/out/err.
     #[cfg(unix)]
-    let ipc_stdio_index: i32 = stdio
-        .iter()
-        .position(|s| matches!(s, Stdio::Ipc))
-        .map(|i| i as i32)
-        .unwrap_or(-1);
+    let ipc_stdio_index: i32 = {
+        let idx = stdio
+            .iter()
+            .position(|s| matches!(s, Stdio::Ipc))
+            .map(|i| i as i32)
+            .unwrap_or(-1);
+        if idx != -1 && (IS_SYNC || maybe_ipc_mode.is_none()) {
+            // spawnSync / Bun.spawn without an ipc callback: nothing will read
+            // spawned.ipc, so creating a socketpair would leave the child with
+            // a broken-peer socket and its first write() raises SIGPIPE. Fall
+            // back to /dev/null (the pre-existing behaviour for this slot).
+            for s in stdio.iter_mut() {
+                if matches!(s, Stdio::Ipc) {
+                    *s = Stdio::Ignore;
+                }
+            }
+            -1
+        } else {
+            idx
+        }
+    };
     #[cfg(not(unix))]
     let ipc_stdio_index: i32 = -1;
 
@@ -1303,12 +1319,10 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             spawned_extra_pipes[usize::try_from(ipc_channel).expect("int cast")].fd()
         }
     } else {
-        // No ipc callback: spawn_process_posix still created a socketpair for
-        // 'ipc' at stdin/stdout/stderr; close the parent end so it isn't leaked
-        // (the extra_fds path would close it via stdio_pipes/finalize_streams).
-        if let Some(fd) = spawned_ipc {
-            fd.close();
-        }
+        // The ipc_stdio_index scan above rewrote Stdio::Ipc at 0-2 to Ignore
+        // when there is no IPC consumer, so spawn_process_posix never populated
+        // spawned.ipc on this branch.
+        debug_assert!(spawned_ipc.is_none());
         Fd::INVALID
     };
 

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -773,8 +773,26 @@ pub unsafe fn spawn_process_posix(
             PosixStdio::Inherit => {
                 actions.inherit(fileno)?;
             }
-            PosixStdio::Ipc | PosixStdio::Ignore => {
+            PosixStdio::Ignore => {
                 actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
+            }
+            PosixStdio::Ipc => {
+                // Node's stdio array index IS the child fd, including 'ipc':
+                // `['ipc','pipe','pipe']` means the channel is the child's fd 0.
+                // Mirror the extra_fds IPC handling (socketpair + dup2) so the
+                // requested slot is the channel instead of /dev/null.
+                let fds: [Fd; 2] =
+                    match bun_sys::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, true) {
+                        Ok(p) => p,
+                        Err(e) => return Ok(Err(e)),
+                    };
+                cleanup.to_close_at_end.push(fds[1]);
+                cleanup.to_close_on_error.push(fds[0]);
+                actions.dup2(fds[1], fileno)?;
+                if fds[1] != fileno {
+                    actions.close(fds[1])?;
+                }
+                spawned.ipc = Some(fds[0]);
             }
             PosixStdio::Path(path) => {
                 actions.open(fileno, path, flag | bun_sys::O::CREAT as u32, 0o664)?;

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -787,10 +787,6 @@ pub unsafe fn spawn_process_posix(
                         Err(e) => return Ok(Err(e)),
                     };
                 cleanup.to_close_at_end.push(fds[1]);
-                actions.dup2(fds[1], fileno)?;
-                if fds[1] != fileno {
-                    actions.close(fds[1])?;
-                }
                 if spawned.ipc.is_none() {
                     cleanup.to_close_on_error.push(fds[0]);
                     spawned.ipc = Some(fds[0]);
@@ -801,6 +797,10 @@ pub unsafe fn spawn_process_posix(
                     // unconditionally so it isn't leaked (to_close_on_error is
                     // disarmed on success).
                     cleanup.to_close_at_end.push(fds[0]);
+                }
+                actions.dup2(fds[1], fileno)?;
+                if fds[1] != fileno {
+                    actions.close(fds[1])?;
                 }
             }
             PosixStdio::Path(path) => {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -787,12 +787,21 @@ pub unsafe fn spawn_process_posix(
                         Err(e) => return Ok(Err(e)),
                     };
                 cleanup.to_close_at_end.push(fds[1]);
-                cleanup.to_close_on_error.push(fds[0]);
                 actions.dup2(fds[1], fileno)?;
                 if fds[1] != fileno {
                     actions.close(fds[1])?;
                 }
-                spawned.ipc = Some(fds[0]);
+                if spawned.ipc.is_none() {
+                    cleanup.to_close_on_error.push(fds[0]);
+                    spawned.ipc = Some(fds[0]);
+                } else {
+                    // node:child_process rejects multiple 'ipc' entries; for a
+                    // direct Bun.spawn caller the first slot is the channel and
+                    // later slots are dead sockets. Close the parent end
+                    // unconditionally so it isn't leaked (to_close_on_error is
+                    // disarmed on success).
+                    cleanup.to_close_at_end.push(fds[0]);
+                }
             }
             PosixStdio::Path(path) => {
                 actions.open(fileno, path, flag | bun_sys::O::CREAT as u32, 0o664)?;

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { execSync, spawn } from "node:child_process";
 import { once } from "node:events";
 
@@ -164,5 +164,43 @@ describe("child.stdin", () => {
       ret: false,
       cbCode: "ERR_STREAM_DESTROYED",
     });
+  });
+});
+
+// Node's stdio array index is the child fd number, including for 'ipc'.
+// Placing 'ipc' at index 0/1/2 must wire the channel to that fd, not fd 3.
+describe.skipIf(isWindows).each([
+  [0, ["ipc", "pipe", "pipe"]],
+  [1, ["pipe", "ipc", "pipe"]],
+  [2, ["pipe", "pipe", "ipc"]],
+])("stdio 'ipc' at index %d", (index, stdio) => {
+  it("places the channel at the requested fd", async () => {
+    // The child must not touch stdout/stderr directly (those may be the
+    // channel itself); it reports back via process.send.
+    const CHILD = `
+      const fs = require("node:fs");
+      process.once("message", ping => {
+        process.send({
+          ping,
+          fdIsSocket: fs.fstatSync(${index}).isSocket(),
+        });
+        process.exit(0);
+      });
+    `;
+    const child = spawn(bunExe(), ["-e", CHILD], { env: bunEnv, stdio });
+    const { promise, resolve, reject } = Promise.withResolvers();
+    child.once("message", resolve);
+    child.once("error", reject);
+    child.once("exit", (code, signal) =>
+      reject(new Error(`child exited before message (code=${code} signal=${signal})`)),
+    );
+    child.send("ping");
+    const msg = await promise;
+    expect(msg).toEqual({
+      ping: "ping",
+      // Requested slot must be the socketpair end, not /dev/null.
+      fdIsSocket: true,
+    });
+    expect(child.stdio[index]).toBe(null);
   });
 });


### PR DESCRIPTION
### Repro

```js
import { spawn } from "node:child_process";
const c = spawn(process.execPath, ["-e", `
  const fs = require("node:fs");
  process.send({ fd1: fs.readlinkSync("/proc/self/fd/1") });
`], { stdio: ["pipe", "ipc", "pipe"] });
c.once("message", m => console.log(m));
```

Node: `{ fd1: 'socket:[...]' }` (the channel is fd 1).
Bun: `{ fd1: '/dev/null' }` (the requested slot is discarded; the channel was moved to fd 3).

Because a Bun/Node child locates the channel via `NODE_CHANNEL_FD`, `process.send` still works at fd 3, so the substitution is silent: the program appears fine while a whole stdio stream is being thrown away into `/dev/null`. Any non-JS child that implements the fd-numbered protocol ("the channel is my fd 0/1") is broken. `'ipc'` at index >= 3 is already honoured; this is specifically the 0/1/2 remap.

### Cause

`spawn_process_posix` handled `PosixStdio::Ipc` at indices 0-2 identically to `Ignore` (open `/dev/null`), and the JS spawn bindings only scanned indices >= 3 for `'ipc'` when picking `NODE_CHANNEL_FD`, so a fresh channel was always appended at the first free extra-fd slot.

### Fix

* `spawn_process.rs`: for `PosixStdio::Ipc` at stdin/stdout/stderr, create the socketpair and dup2 it onto the requested fd (mirroring the extra_fds IPC path) and return the parent end via `PosixSpawnResult::ipc`.
* `js_bun_spawn_bindings.rs`: detect `'ipc'` at indices 0-2, use that index for `NODE_CHANNEL_FD`, read the parent fd from `spawned.ipc`, and skip the extra_fds append/neutralization for this case. Parent-end fds are closed on every error path that previously relied on `stdio_pipes`/`finalize_streams`.

Windows keeps its existing behaviour (IPC via a libuv named pipe appended after the three standard streams).

### Verification

New parameterized tests in `test/js/node/child_process/child-process-stdio.test.js` spawn with `'ipc'` at each of indices 0, 1, 2; the child round-trips a message and asserts `fs.fstatSync(index).isSocket()`. Fails on 1.4.0 (`fdIsSocket: false`), passes with this change. Existing child_process and spawn IPC suites pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child-process-stdio.test.js

<!-- robobun:evidence:end -->