### PR TITLE
semver: classify prerelease identifiers by character class, not u64 parse

### DIFF
--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -30,9 +30,7 @@ impl VersionInt for u64 {
     type TagPadding = [u8; 0];
     #[inline]
     fn parse_ascii(s: &[u8]) -> Option<Self> {
-        // None for empty, any non-[0-9] byte, or overflow. Callers rely on
-        // the non-digit None case for pre-release identifier ordering
-        // (semver identifiers are `[0-9A-Za-z-]+`, so `_` never appears).
+        // None for empty, any non-[0-9] byte, or overflow.
         bun_core::parse_unsigned::<u64>(s, 10).ok()
     }
 }
@@ -974,6 +972,26 @@ impl<T: VersionInt> Partial<T> {
 // Tag
 // ──────────────────────────────────────────────────────────────────────────
 
+#[inline]
+fn is_numeric_identifier(part: &[u8]) -> bool {
+    !part.is_empty() && part.iter().all(u8::is_ascii_digit)
+}
+
+/// Compare two all-digit identifiers numerically without bounding their
+/// magnitude: strip leading zeros, then compare by length, then lexically.
+fn order_numeric_identifiers(lhs: &[u8], rhs: &[u8]) -> Ordering {
+    fn strip_leading_zeros(s: &[u8]) -> &[u8] {
+        let i = s.iter().position(|&b| b != b'0').unwrap_or(s.len() - 1);
+        &s[i..]
+    }
+    let lhs = strip_leading_zeros(lhs);
+    let rhs = strip_leading_zeros(rhs);
+    match lhs.len().cmp(&rhs.len()) {
+        Ordering::Equal => strings::order(lhs, rhs),
+        not_equal => not_equal,
+    }
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Tag {
@@ -1018,31 +1036,25 @@ impl Tag {
             let lhs_part = lhs_part.unwrap();
             let rhs_part = rhs_part.unwrap();
 
-            let lhs_uint: Option<u64> = u64::parse_ascii(lhs_part);
-            let rhs_uint: Option<u64> = u64::parse_ascii(rhs_part);
-
-            // a part that doesn't parse as an integer is greater than a part that does
+            // SemVer 2.0 §11.4: an identifier is numeric iff it consists only of
+            // digits. Classify by character class, not by whether the value fits
+            // in a u64 — an all-digit identifier that overflows u64 is still numeric.
             // https://github.com/npm/node-semver/blob/816c7b2cbfcb1986958a290f941eddfd0441139e/internal/identifiers.js#L12
-            if lhs_uint.is_some() && rhs_uint.is_none() {
-                return Ordering::Less;
-            }
-            if lhs_uint.is_none() && rhs_uint.is_some() {
-                return Ordering::Greater;
-            }
+            let lhs_numeric = is_numeric_identifier(lhs_part);
+            let rhs_numeric = is_numeric_identifier(rhs_part);
 
-            if lhs_uint.is_none() && rhs_uint.is_none() {
-                match strings::order(lhs_part, rhs_part) {
-                    Ordering::Equal => {
-                        // continue to the next part
-                        continue;
-                    }
+            match (lhs_numeric, rhs_numeric) {
+                // numeric identifiers always have lower precedence than non-numeric
+                (true, false) => return Ordering::Less,
+                (false, true) => return Ordering::Greater,
+                (false, false) => match strings::order(lhs_part, rhs_part) {
+                    Ordering::Equal => continue,
                     not_equal => return not_equal,
-                }
-            }
-
-            match lhs_uint.unwrap().cmp(&rhs_uint.unwrap()) {
-                Ordering::Equal => continue,
-                not_equal => return not_equal,
+                },
+                (true, true) => match order_numeric_identifiers(lhs_part, rhs_part) {
+                    Ordering::Equal => continue,
+                    not_equal => return not_equal,
+                },
             }
         }
     }

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -106,6 +106,55 @@ describe("Bun.semver.order()", () => {
     }
   });
 
+  // SemVer 2.0 §11.4: numeric identifiers have no size limit, and always have
+  // lower precedence than alphanumeric identifiers. An all-digit identifier
+  // that overflows u64 must still be classified as numeric.
+  test("prerelease: numeric identifiers larger than u64::MAX", () => {
+    const u64max = "18446744073709551615";
+    const u64maxPlus1 = "18446744073709551616";
+    // [greater, lesser]
+    const tests = [
+      // numeric < alphanumeric, regardless of magnitude
+      ["1.0.0--", "1.0.0-99999999999999999999999"],
+      ["1.0.0--", `1.0.0-${u64maxPlus1}`],
+      ["1.0.0--", `1.0.0-${u64max}`],
+      ["1.0.0-a", "1.0.0-99999999999999999999999"],
+      ["1.0.0-alpha", `1.0.0-${u64maxPlus1}`],
+      ["1.0.0-0a", `1.0.0-${u64maxPlus1}`],
+      // two overflowing numerics: compare numerically (by length, then lex)
+      ["1.0.0-100000000000000000000", "1.0.0-20000000000000000000"],
+      ["1.0.0-99999999999999999999999", `1.0.0-${u64maxPlus1}`],
+      [`1.0.0-${u64maxPlus1}`, `1.0.0-${u64max}`],
+      // one side overflows, other fits u64
+      [`1.0.0-${u64maxPlus1}`, "1.0.0-1"],
+      ["1.0.0-99999999999999999999999", "1.0.0-0"],
+      [`1.0.0-${u64max}`, "1.0.0-1"],
+      // same length, both overflow
+      ["1.0.0-99999999999999999999", "1.0.0-20000000000000000000"],
+      // nested in a dotted identifier
+      ["1.0.0-alpha.100000000000000000000", "1.0.0-alpha.20000000000000000000"],
+      ["1.0.0-alpha.beta", "1.0.0-alpha.99999999999999999999999"],
+    ];
+    for (const [greater, lesser] of tests) {
+      expect({ greater, lesser, result: order(greater, lesser) }).toEqual({ greater, lesser, result: 1 });
+      expect({ greater, lesser, result: order(lesser, greater) }).toEqual({ greater, lesser, result: -1 });
+      expect(order(greater, greater)).toBe(0);
+      expect(order(lesser, lesser)).toBe(0);
+    }
+
+    // equality across the u64 boundary
+    for (const n of [u64max, u64maxPlus1, "99999999999999999999999"]) {
+      expect(order(`1.0.0-${n}`, `1.0.0-${n}`)).toBe(0);
+      expect(order(`1.0.0-a.${n}`, `1.0.0-a.${n}`)).toBe(0);
+    }
+
+    // satisfies() uses the same ordering
+    expect(satisfies("1.0.0--", ">1.0.0-99999999999999999999999")).toBe(true);
+    expect(satisfies("1.0.0-99999999999999999999999", "<1.0.0--")).toBe(true);
+    expect(satisfies("1.0.0-100000000000000000000", ">1.0.0-20000000000000000000")).toBe(true);
+    expect(satisfies(`1.0.0-${u64maxPlus1}`, `>1.0.0-${u64max}`)).toBe(true);
+  });
+
   // not supported by semver, but supported by Bun
   test.each([
     ["0", "0.0"],


### PR DESCRIPTION
### Problem

`Bun.semver.order()` and `Bun.semver.satisfies()` invert SemVer 2.0 precedence when a prerelease identifier is all digits but exceeds `u64::MAX`:

```js
Bun.semver.order("1.0.0-99999999999999999999999", "1.0.0--")
//   bun: 1   node-semver: -1   (numeric should sort BELOW alphanumeric)

Bun.semver.order("1.0.0-20000000000000000000", "1.0.0-100000000000000000000")
//   bun: 1   node-semver: -1   (2e19 should be < 1e20, not byte-string compared)

Bun.semver.order("1.0.0-18446744073709551615", "1.0.0--")  // u64::MAX exactly
//   bun: -1  (correct)
Bun.semver.order("1.0.0-18446744073709551616", "1.0.0--")  // u64::MAX + 1
//   bun: 1   node-semver: -1   (inverted)

Bun.semver.satisfies("1.0.0--", ">1.0.0-99999999999999999999999")
//   bun: false   node-semver: true
```

SemVer 2.0 section 11.4 places no size limit on numeric identifiers: "Identifiers consisting of only digits are compared numerically", and "Numeric identifiers always have lower precedence than non-numeric identifiers."

### Cause

`Tag::order_pre` in `src/semver/Version.rs` classified each dotted prerelease identifier as numeric vs alphanumeric by whether `u64::parse_ascii(part)` returned `Some`. That helper returns `None` on overflow, not just on non-digit input, so an all-digit identifier with 20+ digits fell into the "doesn't parse as an integer, therefore alphanumeric, therefore greater" branch and was then compared as a byte string.

### Fix

Classify numeric vs alphanumeric by character class (non-empty and every byte is an ASCII digit), matching node-semver's `/^[0-9]+$/`. Compare two numeric identifiers by stripping leading zeros, then by length, then lexically. That is equivalent to an arbitrary-precision numeric compare and preserves the existing loose-mode behavior for identifiers with leading zeros (`order("1.0.0-01", "1.0.0-2") === -1`).

### Verification

New test in `test/cli/install/semver.test.ts` covering numeric vs alphanumeric across the u64 boundary, two overflowing numerics of different lengths, same-length overflowing numerics, mixed overflow/non-overflow, dotted identifiers, equality, and the `satisfies()` path. The test fails on an unfixed build and passes with the fix; the file's 26 existing tests still pass (27 total, 1840 expect calls).

Differential against node-semver 7.6.2 over 676 identifier pairs: 50 mismatches before, 12 after. The 12 remaining are all adjacent values near 2^53 where node-semver returns 0 because its `compareIdentifiers()` coerces via `Number()` and loses precision; Bun now follows the spec and distinguishes them.