### PR TITLE
semver: zero trailing components after wildcard in hyphen-range left endpoint

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1050,6 +1050,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                         second_version.major = second_version.major.saturating_add(1);
                         second_version.minor = 0;
                         second_version.patch = 0;
+                        second_version.tag = Default::default();
 
                         Range {
                             left: Comparator {
@@ -1066,6 +1067,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                         // "1.0.0 - 1.0.x" --> ">=1.0.0 <1.1.0"
                         second_version.minor = second_version.minor.saturating_add(1);
                         second_version.patch = 0;
+                        second_version.tag = Default::default();
 
                         Range {
                             left: Comparator {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1010,6 +1010,22 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
             i += (!hyphenate) as usize;
 
             if hyphenate {
+                // node-semver's hyphenReplace zeroes every component at and after
+                // the first wildcard in the left endpoint ("1.x.256" -> ">=1.0.0").
+                let version = match token.wildcard {
+                    Wildcard::Major => Version::default(),
+                    Wildcard::Minor => Version {
+                        major: version.major,
+                        ..Default::default()
+                    },
+                    Wildcard::Patch => Version {
+                        major: version.major,
+                        minor: version.minor,
+                        ..Default::default()
+                    },
+                    Wildcard::None => version,
+                };
+
                 let second_parsed = Version::parse(sliced.sub(&input[i..]));
                 let mut second_version = second_parsed.version.min();
                 if second_version.tag.has_build() {

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -478,6 +478,40 @@ describe("Bun.semver.satisfies()", () => {
     }
   });
 
+  test("hyphen range left endpoint with wildcard zeroes trailing components", () => {
+    // node-semver's hyphenReplace: once a component is a wildcard, every
+    // component after it is zeroed. "1.x.256 - 1" desugars to ">=1.0.0 <2.0.0-0".
+    testSatisfies("1.x.256 - 1", "1.0.0", true);
+    testSatisfies("1.x.256 - 1", "1.0.20", true);
+    testSatisfies("1.x.256 - 1", "1.0.255", true);
+    testSatisfies("1.x.256 - 1", "1.0.256", true);
+    testSatisfies("1.x.256 - 1", "1.5.0", true);
+    testSatisfies("1.x.256 - 1", "0.9.9", false);
+    testSatisfies("1.x.256 - 1", "2.0.0", false);
+
+    testSatisfies("1.*.256 - 1", "1.0.0", true);
+    testSatisfies("1.*.256 - 1", "1.0.255", true);
+    testSatisfies("1.X.256 - 1", "1.0.0", true);
+
+    // "x.2.3 - 6" desugars to "<7.0.0-0" (no lower bound).
+    testSatisfies("x.2.3 - 6", "0.0.1", true);
+    testSatisfies("x.2.3 - 6", "0.1.0", true);
+    testSatisfies("x.2.3 - 6", "0.2.2", true);
+    testSatisfies("x.2.3 - 6", "0.2.3", true);
+    testSatisfies("x.2.3 - 6", "5.0.0", true);
+    testSatisfies("x.2.3 - 6", "7.0.0", false);
+
+    // "1.x.256-beta - 3" desugars to ">=1.0.0 <4.0.0-0" (prerelease dropped).
+    testSatisfies("1.x.256-beta - 3", "1.0.0", true);
+    testSatisfies("1.x.256-beta - 3", "1.0.0-beta", false);
+    testSatisfies("1.2.x-beta - 3", "1.2.0-beta", false);
+
+    // Right endpoint with trailing numeric after wildcard (already worked).
+    testSatisfies("1.0.0 - 2.x.5", "2.9.9", true);
+    testSatisfies("1.0.0 - 2.x.5", "3.0.0", false);
+    testSatisfies("1.0.0 - x.5.5", "999.0.0", true);
+  });
+
   test("range includes", () => {
     // https://github.com/npm/node-semver/blob/14d263faa156e408a033b9b12a2f87735c2df42c/test/fixtures/range-include.js#L3
     var tests = [

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -510,6 +510,12 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("1.0.0 - 2.x.5", "2.9.9", true);
     testSatisfies("1.0.0 - 2.x.5", "3.0.0", false);
     testSatisfies("1.0.0 - x.5.5", "999.0.0", true);
+
+    // Right endpoint drops any prerelease after a wildcard.
+    testSatisfies("1.0.0 - 2.x.5-beta", "2.9.9", true);
+    testSatisfies("1.0.0 - 2.x.5-beta", "3.0.0-alpha", false);
+    testSatisfies("1.0.0 - 2.0.x-beta", "2.0.9", true);
+    testSatisfies("1.0.0 - 2.0.x-beta", "2.1.0-alpha", false);
   });
 
   test("range includes", () => {


### PR DESCRIPTION
### Problem

`Bun.semver.satisfies` desugars the left endpoint of a hyphen range differently from node-semver when a wildcard component is followed by a numeric component or prerelease tag:

```js
Bun.semver.satisfies("1.0.0", "1.x.256 - 1")   // false   node-semver: true
Bun.semver.satisfies("0.0.1", "x.2.3 - 6")     // false   node-semver: true
Bun.semver.satisfies("1.2.0-beta", "1.2.x-beta - 3")  // true    node-semver: false
```

node-semver's `hyphenReplace` zeroes every component at and after the first wildcard in the FROM endpoint: `1.x.256` becomes `>=1.0.0`, `x.2.3` becomes the empty comparator (no lower bound), and any trailing prerelease is dropped. `validRange("1.x.256 - 1")` is `">=1.0.0 <2.0.0-0"`.

### Cause

In `semver::query::parse` the hyphen branch uses `parse_result.version.min()` directly as the left comparator version. `Partial::min()` replaces each `None` component with `0` independently, so for `1.x.256` (major=1, minor=None, patch=256) it yields `{1, 0, 256}` and the range becomes `>=1.0.256` instead of `>=1.0.0`.

The right-endpoint handling already branches on `second_parsed.wildcard` and zeroes the trailing components explicitly; the left endpoint did not.

### Fix

At the top of the hyphen branch, rebuild the left `version` per `hyphenReplace`: for `Wildcard::Minor` keep only `major`, for `Wildcard::Major` use the zero version, for `Wildcard::Patch` keep `major`/`minor`, and in each wildcard case drop the tag. `Wildcard::None` is unchanged.

### Verification

New test in `test/cli/install/semver.test.ts` covering `1.x.256 - 1` (the reported range, all three wildcard spellings), `x.2.3 - 6` (major-wildcard left endpoint with trailing numerics), the prerelease-after-wildcard case, and the right-endpoint shapes that already worked. Every expected value matches node-semver 7. The test fails on the unfixed build and passes with the fix; all 27 tests in the file pass (1858 expect calls).