### PR TITLE
sql(postgres): gate enqueue-time Bind+Execute on queued requests being written

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -110,6 +110,11 @@ pub struct PostgresSQLConnection {
     pub pipelined_requests: Cell<u32>,
     /// number of non-pipelined requests (Simple/Copy)
     pub nonpipelinable_requests: Cell<u32>,
+    /// number of queued requests whose bytes have not been written yet
+    /// (QueryStatus::Pending); gates the enqueue-time pipeline fast path so a
+    /// later prepared-statement execute cannot be emitted ahead of an earlier
+    /// queued request whose Parse/Bind/Execute is still unwritten.
+    pub pending_requests: Cell<u32>,
 
     pub poll_ref: JsCell<KeepAlive>,
     // Read-only back-reference to the JS global; the VM/global strictly outlives
@@ -1192,6 +1197,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
             requests: JsCell::new(PostgresRequest::Queue::init()),
             pipelined_requests: Cell::new(0),
             nonpipelinable_requests: Cell::new(0),
+            pending_requests: Cell::new(0),
             poll_ref: JsCell::new(KeepAlive::default()),
             global_object: BackRef::new(global_object),
             // `vm` is the `&mut VirtualMachine` from `bun_vm().as_mut()` above —
@@ -1485,6 +1491,7 @@ impl PostgresSQLConnection {
             match request.status.get() {
                 // pending we will fail the request and the stmt will be marked as error ConnectionClosed too
                 QueryStatus::Pending => {
+                    self.note_request_written();
                     let Some(stmt) = request.statement_mut() else {
                         // The deref/discard at the bottom of the loop is intentionally skipped here.
                         continue;
@@ -1596,6 +1603,18 @@ impl PostgresSQLConnection {
             .get()
             .contains(ConnectionFlags::IS_READY_FOR_QUERY)
             || self.current().is_some()
+    }
+
+    #[inline]
+    pub fn note_request_pending(&self) {
+        self.pending_requests.set(self.pending_requests.get() + 1);
+    }
+
+    #[inline]
+    pub fn note_request_written(&self) {
+        let n = self.pending_requests.get();
+        debug_assert!(n > 0, "pending_requests underflow");
+        self.pending_requests.set(n.wrapping_sub(1));
     }
 
     pub fn can_pipeline(&self) -> bool {
@@ -1795,7 +1814,12 @@ impl PostgresSQLConnection {
                         .set(self.pipelined_requests.get() - 1);
                 }
             }
-            QueryStatus::Success | QueryStatus::Fail | QueryStatus::Pending => {}
+            QueryStatus::Pending => {
+                // ErrorResponse on a Parse-in-flight request: it never reached
+                // Binding, so account for it leaving the pending set here.
+                self.note_request_written();
+            }
+            QueryStatus::Success | QueryStatus::Fail => {}
         }
     }
 
@@ -1865,6 +1889,11 @@ impl PostgresSQLConnection {
             let req = ParentRef::from(NonNull::new(req_ptr).expect("queue item non-null"));
             match req.status.get() {
                 QueryStatus::Pending => {
+                    // Optimistically account for this request leaving Pending; the
+                    // few paths below that keep it Pending (can't execute yet /
+                    // Parse written but not Bind / statement still Parsing) undo
+                    // this via note_request_pending() before returning/continuing.
+                    self.note_request_written();
                     if req.flags.get().simple {
                         if self.pipelined_requests.get() > 0
                             || !self
@@ -1880,6 +1909,7 @@ impl PostgresSQLConnection {
                                     .contains(ConnectionFlags::IS_READY_FOR_QUERY)
                             );
                             // need to wait for the previous request to finish before starting simple queries
+                            self.note_request_pending();
                             defer_cleanup!(self);
                             return;
                         }
@@ -2063,6 +2093,7 @@ impl PostgresSQLConnection {
                                             "need to wait to finish the pipeline before starting a new query preparation"
                                         );
                                         // need to wait to finish the pipeline before starting a new query preparation
+                                        self.note_request_pending();
                                         defer_cleanup!(self);
                                         return;
                                     }
@@ -2264,17 +2295,22 @@ impl PostgresSQLConnection {
                                         f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                     });
                                     statement.status = StatementStatus::Parsing;
+                                    // Parse+Describe+Sync written; Bind+Execute deferred to the
+                                    // next advance(), so the request is still pending on the wire.
+                                    self.note_request_pending();
                                     self.flush_data_and_reset_timeout();
                                     defer_cleanup!(self);
                                     return;
                                 }
                                 StatementStatus::Parsing => {
                                     // we are still parsing, lets wait for it to be prepared or failed
+                                    self.note_request_pending();
                                     offset += 1;
                                     continue;
                                 }
                             }
                         } else {
+                            self.note_request_pending();
                             offset += 1;
                             continue;
                         }

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -553,6 +553,9 @@ impl PostgresSQLQuery {
                 release_query_ref();
                 return Err(global_object.throw_out_of_memory());
             }
+            if this.status.get() == Status::Pending {
+                connection.note_request_pending();
+            }
 
             // Request is enqueued: keep the event loop alive until the server
             // responds. KeepAlive is a flag (not a count), so taking this any
@@ -641,7 +644,13 @@ impl PostgresSQLQuery {
                             return Err(global_object.throw_value(error_response));
                         }
                         StatementStatus::Prepared => {
-                            if !connection.has_query_running() || connection.can_pipeline() {
+                            // Only write ahead of the FIFO drain when every queued
+                            // request has already emitted its bytes; otherwise this
+                            // Bind+Execute would overtake an earlier unwritten
+                            // request on the wire while reply attribution stays FIFO.
+                            if (!connection.has_query_running() || connection.can_pipeline())
+                                && connection.pending_requests.get() == 0
+                            {
                                 this.update_flags(|f| f.binary = !stmt.fields.is_empty());
                                 bun_core::scoped_log!(Postgres, "bindAndExecute");
 
@@ -824,6 +833,9 @@ impl PostgresSQLQuery {
         {
             release_query_ref();
             return Err(global_object.throw_out_of_memory());
+        }
+        if this.status.get() == Status::Pending {
+            connection.note_request_pending();
         }
         // Request is enqueued: keep the event loop alive until the server
         // responds. See the matching call in the simple-query branch above

--- a/test/js/sql/postgres-prepared-pipeline-reorder.test.ts
+++ b/test/js/sql/postgres-prepared-pipeline-reorder.test.ts
@@ -95,10 +95,6 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const b = sql`SELECT 'B'::text AS v`.simple();
     const c = sql`SELECT ${"C"}::text AS v`;
 
-    expect(await Promise.all([a, b, c])).toEqual([
-      [{ v: "A" }],
-      [{ v: "B" }],
-      [{ v: "C" }],
-    ]);
+    expect(await Promise.all([a, b, c])).toEqual([[{ v: "A" }], [{ v: "B" }], [{ v: "C" }]]);
   });
 });

--- a/test/js/sql/postgres-prepared-pipeline-reorder.test.ts
+++ b/test/js/sql/postgres-prepared-pipeline-reorder.test.ts
@@ -1,0 +1,104 @@
+// The enqueue-time fast path for an already-prepared statement wrote
+// Bind+Execute whenever can_pipeline() was true. can_pipeline() only looked at
+// WAITING_TO_PREPARE / backpressure / nonpipelinable counts, none of which are
+// set for a request that was queued but whose bytes have not been emitted yet
+// (a new statement text enqueued while another query is in flight). A later
+// query reusing a prepared statement would therefore write its Bind+Execute
+// ahead of that queued request, while reply attribution stays FIFO over the
+// request queue: the queued request is silently fulfilled with the next
+// query's rows (decoded under an empty column list), and the next query never
+// settles, wedging the connection.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  // Before the fix: B's Parse is never sent. C's Bind+Execute is written
+  // immediately after A's, so C's row is delivered to B (as [{}]) and C hangs
+  // forever along with every later query on the connection.
+  test("a prepared-statement execute does not jump a queued unwritten prepare", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 30 });
+
+    await sql`SELECT ${"warm"}::text AS v`; // SELECT $1::text AS v is now prepared
+
+    const a = sql`SELECT ${"A"}::text AS v`;
+    const b = sql`SELECT ${"B"}::text AS v, ${1}::int AS w`;
+    const c = sql`SELECT ${"C"}::text AS v`;
+    const after = sql`SELECT ${"after"}::text AS v`;
+
+    expect(await Promise.all([a, b, c, after])).toEqual([
+      [{ v: "A" }],
+      [{ v: "B", w: 1 }],
+      [{ v: "C" }],
+      [{ v: "after" }],
+    ]);
+  });
+
+  // Same shape with two distinct new statement texts queued between two
+  // prepared-statement executes.
+  test("prepared executes do not jump multiple queued unwritten prepares", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 30 });
+
+    await sql`SELECT ${"warm"}::text AS v`;
+
+    const a = sql`SELECT ${"A"}::text AS v`;
+    const b1 = sql`SELECT ${"B1"}::text AS v, ${1}::int AS w`;
+    const b2 = sql`SELECT ${"B2"}::text AS v, ${2}::int AS w, ${3}::int AS x`;
+    const c = sql`SELECT ${"C"}::text AS v`;
+
+    expect(await Promise.all([a, b1, b2, c])).toEqual([
+      [{ v: "A" }],
+      [{ v: "B1", w: 1 }],
+      [{ v: "B2", w: 2, x: 3 }],
+      [{ v: "C" }],
+    ]);
+  });
+
+  // Larger mixed burst: interleave reuses of one prepared statement with many
+  // distinct new statement texts so the enqueue-time gate and advance()'s
+  // pending bookkeeping are exercised across a longer queue.
+  test("mixed burst of prepared and new statements returns every row in order", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 30 });
+
+    await sql`SELECT ${"warm"}::text AS v`;
+
+    const queries: Promise<any>[] = [];
+    const expected: any[] = [];
+    for (let i = 0; i < 20; i++) {
+      if (i % 3 === 1) {
+        queries.push(sql.unsafe(`SELECT $1::text AS v, ${i}::int AS k${i}`, [String(i)]));
+        expected.push([{ v: String(i), [`k${i}`]: i }]);
+      } else {
+        queries.push(sql`SELECT ${String(i)}::text AS v`);
+        expected.push([{ v: String(i) }]);
+      }
+    }
+
+    expect(await Promise.all(queries)).toEqual(expected);
+  });
+
+  // Sibling: a simple-protocol query queued while a prepared execute is in
+  // flight also sits Pending without bumping nonpipelinable_requests, so the
+  // same fast path would jump it.
+  test("a prepared-statement execute does not jump a queued unwritten simple query", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 30 });
+
+    await sql`SELECT ${"warm"}::text AS v`;
+
+    const a = sql`SELECT ${"A"}::text AS v`;
+    const b = sql`SELECT 'B'::text AS v`.simple();
+    const c = sql`SELECT ${"C"}::text AS v`;
+
+    expect(await Promise.all([a, b, c])).toEqual([
+      [{ v: "A" }],
+      [{ v: "B" }],
+      [{ v: "C" }],
+    ]);
+  });
+});

--- a/test/js/sql/postgres-split-prepare-reorder-fixture.ts
+++ b/test/js/sql/postgres-split-prepare-reorder-fixture.ts
@@ -1,0 +1,149 @@
+// Mock postgres server that replies to a named-statement prepare with its four
+// backend messages in separate socket writes, so ParameterDescription arrives
+// in an earlier on_data() than ReadyForQuery. That is ordinary inbound TCP
+// segmentation; the bytes and their order are identical to a coalesced reply.
+//
+// Queries issued during that gap must not overtake earlier-enqueued queries on
+// the wire: responses are attributed by enqueue order (requests.peek_item(0)),
+// so a Bind written out of order delivers another query's rows.
+
+import net from "node:net";
+import {
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const SPLIT = process.env.SPLIT !== "0";
+const tick = () => new Promise<void>(r => setImmediate(r));
+
+// Parse a Bind body far enough to return the first parameter value as text.
+function bindFirstParam(body: Buffer): string {
+  let o = body.indexOf(0) + 1; // skip portal name
+  o = body.indexOf(0, o) + 1; // skip statement name
+  const nFmt = body.readInt16BE(o);
+  o += 2 + 2 * nFmt;
+  o += 2; // nParams
+  const len = body.readInt32BE(o);
+  o += 4;
+  return body.subarray(o, o + len).toString("utf-8");
+}
+
+let bindsServed = 0;
+const server = net.createServer(socket => {
+  socket.on("error", () => {});
+  let pending = Buffer.alloc(0);
+  let sawStartup = false;
+  // Replies go out in the order they were enqueued even though each reply is
+  // written message-by-message across event-loop turns.
+  let replyChain: Promise<void> = Promise.resolve();
+  const reply = (msgs: Buffer[]) => {
+    replyChain = replyChain.then(async () => {
+      if (!SPLIT) return void socket.write(Buffer.concat(msgs));
+      for (const m of msgs) {
+        socket.write(m);
+        await tick();
+        await tick();
+      }
+    });
+  };
+  socket.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    if (!sawStartup) {
+      if (pending.length < 4) return;
+      const len = pending.readInt32BE(0);
+      if (pending.length < len) return;
+      pending = pending.subarray(len);
+      sawStartup = true;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    }
+    pending = pgReadFrontendMessages(pending, (type, body) => {
+      if (type === 0x50 /* 'P' Parse */) {
+        // Followed by Describe('S') + Sync; reply with the four-message prepare
+        // response, one write per message so the client sees them across reads.
+        reply([
+          pgParseComplete(),
+          pgParameterDescription([25]),
+          pgRowDescription([{ name: "v", typeOid: 25 }]),
+          pgReadyForQuery(),
+        ]);
+      } else if (type === 0x42 /* 'B' Bind */) {
+        const v = bindFirstParam(body);
+        // Followed by Execute + Sync; echo the bound parameter back as one row.
+        reply([pgBindComplete(), pgDataRow([Buffer.from(v)]), pgCommandComplete("SELECT 1"), pgReadyForQuery()]);
+        bindsServed++;
+      }
+    });
+  });
+});
+
+await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+const port = (server.address() as net.AddressInfo).port;
+
+const sql = new Bun.SQL({
+  adapter: "postgres",
+  hostname: "127.0.0.1",
+  port,
+  username: "u",
+  password: "",
+  database: "db",
+  tls: false,
+  max: 1,
+  prepare: true,
+  connectionTimeout: 20,
+});
+
+// q0 triggers Parse+Describe+Sync; q1..q3 share the statement and sit Pending
+// behind it. Then one query per event-loop turn so several land between the
+// split ParameterDescription and ReadyForQuery reads.
+const expected: string[] = [];
+const got: (string | undefined)[] = [];
+const settled: boolean[] = [];
+const errors: string[] = [];
+const issue = (tag: string) => {
+  const i = expected.length;
+  expected.push(tag);
+  got.push(undefined);
+  settled.push(false);
+  sql`SELECT ${tag} AS v`.then(
+    rows => {
+      got[i] = rows[0]?.v;
+      settled[i] = true;
+    },
+    err => {
+      errors.push(`${tag}: ${err?.message ?? err}`);
+      settled[i] = true;
+    },
+  );
+};
+for (let i = 0; i < 4; i++) issue(`q${i}`);
+for (let i = 4; i < 16; i++) {
+  await tick();
+  issue(`q${i}`);
+}
+
+// Await settlement by condition: the server first has to answer as many Binds
+// as were issued, then every query has to have settled. Both polls are bounded
+// so the never-settle face surfaces as a reported failure instead of a hang.
+for (let t = 0; t < 10000 && bindsServed < expected.length; t++) await tick();
+for (let t = 0; t < 10000 && settled.some(s => !s); t++) await tick();
+
+await sql.close({ timeout: 0 }).catch(() => {});
+server.close();
+
+const unsettled = expected.filter((_, i) => !settled[i]);
+const mismatches = expected.map((e, i) => [e, got[i]] as const).filter(([e, g], i) => settled[i] && e !== g);
+if (unsettled.length > 0 || mismatches.length > 0 || errors.length > 0) {
+  console.error(
+    JSON.stringify({ unsettled: unsettled.length, mismatches, errors, got, total: expected.length }),
+  );
+  process.exit(1);
+}
+console.log(`ok ${expected.length}/${expected.length}`);
+process.exit(0);

--- a/test/js/sql/postgres-split-prepare-reorder.test.ts
+++ b/test/js/sql/postgres-split-prepare-reorder.test.ts
@@ -1,0 +1,45 @@
+// Result attribution in the postgres client must not depend on how the inbound
+// byte stream happens to be segmented. When a named statement's preparation
+// reply (ParseComplete / ParameterDescription / RowDescription / ReadyForQuery)
+// arrives split across multiple reads, the statement becomes Prepared in the
+// ParameterDescription handler while the earlier-enqueued queries are still
+// Pending and unwritten. A query enqueued in that gap used to pass the
+// enqueue-time pipeline gate and write its Bind immediately, ahead of the
+// held-back cohort, while responses are still attributed to
+// requests.peek_item(0) in enqueue order: the first query receives the jumper's
+// rows, or a subset of queries never settle. This is the recv-side form of the
+// reorder covered by postgres-prepared-pipeline-reorder.test.ts: one statement
+// text, default configuration, only the inbound segmentation differs.
+//
+// Fault-injection test: requires a server that deliberately splits the prepare
+// reply across writes, which a healthy container on loopback will not reliably
+// do. All wire-protocol bytes come from test/js/sql/wire-frames.ts.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+const fixture = path.join(import.meta.dir, "postgres-split-prepare-reorder-fixture.ts");
+
+test("postgres: queries issued during a split prepare reply are not reordered", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({ stdout: "ok 16/16", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
+test("postgres: the same bytes coalesced into single writes deliver correct results (control)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...bunEnv, SPLIT: "0" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({ stdout: "ok 16/16", stderr: "" });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -182,6 +182,39 @@ export function pgCopyDone(): Buffer {
   return pgRaw("c", Buffer.alloc(0));
 }
 
+// PostgreSQL FE/BE protocol §55.7 ParseComplete: Byte1('1') Int32(4)
+export function pgParseComplete(): Buffer {
+  return pgRaw("1", Buffer.alloc(0));
+}
+
+// PostgreSQL FE/BE protocol §55.7 BindComplete: Byte1('2') Int32(4)
+export function pgBindComplete(): Buffer {
+  return pgRaw("2", Buffer.alloc(0));
+}
+
+// PostgreSQL FE/BE protocol §55.7 ParameterDescription: Byte1('t') Int32(len) Int16(nparams) Int32[nparams](typeOid)
+export function pgParameterDescription(typeOids: number[]): Buffer {
+  const body = Buffer.alloc(2 + 4 * typeOids.length);
+  body.writeInt16BE(typeOids.length, 0);
+  for (let i = 0; i < typeOids.length; i++) body.writeInt32BE(typeOids[i], 2 + 4 * i);
+  return pgRaw("t", body);
+}
+
+/**
+ * Drain complete PostgreSQL frontend messages from `buffered`, calling
+ * onMessage(type, body) for each; returns the leftover bytes. The very first
+ * frontend message (StartupMessage) has no type byte: feed it separately.
+ */
+export function pgReadFrontendMessages(buffered: Buffer, onMessage: (type: number, body: Buffer) => void): Buffer {
+  while (buffered.length >= 5) {
+    const len = buffered.readInt32BE(1);
+    if (buffered.length < 1 + len) break;
+    onMessage(buffered[0], buffered.subarray(5, 1 + len));
+    buffered = buffered.subarray(1 + len);
+  }
+  return buffered;
+}
+
 // PostgreSQL FE/BE protocol §55.7 DataRow: Byte1('D') Int32(len) Int16(ncols) per col: Int32(byteLen | -1) Byte[len]
 export function pgDataRow(cols: (Buffer | null)[]): Buffer {
   const parts: Buffer[] = [Buffer.alloc(2)];


### PR DESCRIPTION
## What

A burst of three ordinary parameterized tagged-template queries on one connection can silently fulfil the middle query with the next query's rows and permanently wedge every later query on the connection.

## Reproduction

```js
const sql = new Bun.SQL(process.env.DATABASE_URL, { max: 1 }); // prepare:true is the default

await sql`SELECT ${"warm"} AS v`;              // T1 = SELECT $1 AS v is now prepared
const A = sql`SELECT ${"A"} AS v`;             // T1 (prepared)  -> Bind+Execute written
const B = sql`SELECT ${"B"} AS v, ${1} AS w`;  // T2 (new text)  -> nothing written (A in flight)
const C = sql`SELECT ${"C"} AS v`;             // T1 (prepared)  -> Bind+Execute written now, ahead of B

await Promise.all([A, B, C]);
// A = [{v:"A"}], B = [{}] (C's row decoded under B's empty column list), C = <never settles>
```

The wire trace for the A/B/C burst is `Bind["A"] Execute Sync  Bind["C"] Execute Sync`: zero Parse messages and only two Bind/Execute groups for three queries. `BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING=1` makes the same program pass.

## Cause

`PostgresSQLQuery::do_run` has an enqueue-time fast path for an already-prepared statement that writes Bind+Execute directly to the write buffer when `!has_query_running() || can_pipeline()`. `can_pipeline()` checks `WAITING_TO_PREPARE`, backpressure, `nonpipelinable_requests`, and buffer size. None of those are set for a request that was enqueued with `QueryStatus::Pending` and nothing written: a new statement text queued while another query is in flight falls through `can_execute = false` without touching any flag or counter.

So C's Bind+Execute is emitted from the enqueue path, out of order, while reply attribution stays strictly FIFO over the request queue. B is fulfilled with C's DataRow (decoded under B's empty column list) and C never settles; neither does any later query. The same applies when B is a simple-protocol query queued behind a pipelined execute, since `nonpipelinable_requests` is only bumped when the simple query is actually written.

## Fix

Track the number of queued requests whose bytes have not been emitted yet (`pending_requests`) and refuse the enqueue-time fast path while it is nonzero. `do_run` increments it when a request is enqueued with `QueryStatus::Pending`; `advance()` decrements it as each pending request transitions to Running/Binding/Fail or is discarded, and re-increments on the few paths that leave the request pending (cannot execute yet, statement still Parsing, Parse written but Bind deferred). `finish_request` and `clean_up_requests` account for the remaining exit paths. In release builds an underflow fails closed (fast path disabled) rather than open; debug builds assert.

## Verification

```
bun bd test test/js/sql/postgres-prepared-pipeline-reorder.test.ts
  4 pass  0 fail
USE_SYSTEM_BUN=1 bun test test/js/sql/postgres-prepared-pipeline-reorder.test.ts
  0 pass  4 fail (all hang)
```

The existing pipeline/prepare tests (`postgres-simple-query-pipeline.test.ts`, `sql-prepare-false.test.ts`, `postgres-multi-statement-fields.test.ts`, `postgres-binary-numeric.test.ts`) also pass with the debug build and no `pending_requests` underflow assert fires.


Fixes #33665.


## Recv-side trigger (same invariant, one statement text)

The same reorder happens with a single statement text when the backend's preparation reply arrives split across more than one read: `ParameterDescription` marks the statement `Prepared` and clears `WAITING_TO_PREPARE` before `ReadyForQuery` arrives, so a query enqueued in that gap passed `can_pipeline()` and wrote its Bind ahead of the earlier Pending queries that `advance()` had not yet reached. Loopback usually coalesces the four prepare-reply messages into one read, so this surfaces on real networks, TLS record boundaries, or a loaded backend rather than against a local container.

`test/js/sql/postgres-split-prepare-reorder.test.ts` pins this form with a mock server that writes one backend message per socket write (plus a `SPLIT=0` control that coalesces the identical bytes). Without the `pending_requests` gate, 14/16 queries receive another query's rows:

```
{"mismatches":[["q0","q10"],["q1","q11"],...],"got":["q10","q11","q12","q13","q0","q1",...]}
```
