### PR TITLE
structuredClone: emit back-reference for an ArrayBuffer detached after first visit

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1832,8 +1832,12 @@ private:
                 return true;
             }
             if (auto* arrayBuffer = toPossiblySharedArrayBuffer(vm, obj)) {
+                // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+                // Step 2: "If memory[value] exists, then return memory[value]" must run before the
+                // IsDetachedBuffer check; a buffer detached after its first visit stays a back-reference.
+                if (checkForDuplicate(obj))
+                    return true;
                 if (arrayBuffer->isDetached()) {
-                    // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
                     // IsDetachedBuffer(value) => throw a "DataCloneError" DOMException (not a TypeError).
                     code = SerializationReturnCode::DataCloneError;
                     return true;
@@ -1844,8 +1848,7 @@ private:
                     write(index->value);
                     return true;
                 }
-                if (!startObjectInternal(obj)) // handle duplicates
-                    return true;
+                recordObject(obj);
 
                 if (arrayBuffer->isShared() && m_context == SerializationContext::WorkerPostMessage) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -3,6 +3,7 @@ import { openSync } from "fs";
 import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
+import { deserialize as v8deserialize, serialize as v8serialize } from "node:v8";
 import { join } from "path";
 
 // Terminal object types that were never entered into the structured clone object
@@ -976,5 +977,98 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
   test("valid Set and Map payloads still round-trip", () => {
     expect(deserialize(serialize(new Set([1, 0])))).toEqual(new Set([1, 0]));
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
+  });
+});
+
+// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+// The memory-table lookup ("If memory[value] exists, then return memory[value]") is the first
+// step for every value, so an ArrayBuffer that was already serialized must resolve as a back-
+// reference even if user code detached it between the first visit and the second.
+describe("structuredClone back-reference to an ArrayBuffer detached after its first visit", () => {
+  const detach = (ab: ArrayBuffer) => structuredClone(ab, { transfer: [ab] });
+
+  const roundTrips: [string, (value: unknown) => any][] = [
+    ["structuredClone", structuredClone],
+    ["v8.deserialize(v8.serialize())", (value: unknown) => v8deserialize(v8serialize(value))],
+    ["bun:jsc deserialize(serialize())", (value: unknown) => deserialize(serialize(value))],
+  ];
+
+  describe.each(roundTrips)("%s", (_, roundTrip) => {
+    test("object properties: {ab, get g(){detach(ab)}, ab2: ab}", () => {
+      const ab = new ArrayBuffer(8);
+      new Uint8Array(ab).fill(7);
+      const input = {
+        ab,
+        get g() {
+          detach(ab);
+          return 1;
+        },
+        ab2: ab,
+      };
+      const cloned = roundTrip(input);
+      expect(ab.byteLength).toBe(0);
+      expect(cloned.ab2).toBe(cloned.ab);
+      expect(cloned.g).toBe(1);
+      expect(cloned.ab.byteLength).toBe(8);
+      expect([...new Uint8Array(cloned.ab)]).toEqual([7, 7, 7, 7, 7, 7, 7, 7]);
+    });
+
+    test("array elements: [ab, {get g(){detach(ab)}}, ab]", () => {
+      const ab = new ArrayBuffer(4);
+      new Uint8Array(ab).set([1, 2, 3, 4]);
+      const input = [
+        ab,
+        {
+          get g() {
+            detach(ab);
+            return 1;
+          },
+        },
+        ab,
+      ];
+      const cloned = roundTrip(input);
+      expect(ab.byteLength).toBe(0);
+      expect(cloned[2]).toBe(cloned[0]);
+      expect(cloned[0].byteLength).toBe(4);
+      expect([...new Uint8Array(cloned[0])]).toEqual([1, 2, 3, 4]);
+    });
+
+    test("resizable ArrayBuffer back-reference after mid-clone detach", () => {
+      const ab = new ArrayBuffer(4, { maxByteLength: 16 });
+      new Uint8Array(ab).set([9, 8, 7, 6]);
+      const input = {
+        ab,
+        get g() {
+          detach(ab);
+          return 1;
+        },
+        ab2: ab,
+      };
+      const cloned = roundTrip(input);
+      expect(cloned.ab2).toBe(cloned.ab);
+      expect(cloned.ab.byteLength).toBe(4);
+      expect(cloned.ab.maxByteLength).toBe(16);
+      expect(cloned.ab.resizable).toBe(true);
+      expect([...new Uint8Array(cloned.ab)]).toEqual([9, 8, 7, 6]);
+    });
+
+    test("control: first visit of a detached ArrayBuffer still throws DataCloneError", () => {
+      const ab = new ArrayBuffer(4);
+      const input = {
+        get g() {
+          detach(ab);
+          return 1;
+        },
+        ab,
+      };
+      let error: unknown;
+      try {
+        roundTrip(input);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(DOMException);
+      expect((error as DOMException).name).toBe("DataCloneError");
+    });
   });
 });


### PR DESCRIPTION
## Reproduction

```js
const detach = ab => structuredClone(ab, { transfer: [ab] });
const ab = new ArrayBuffer(8);
new Uint8Array(ab).fill(7);
// visit order: ab (bytes copied) -> g (detaches ab) -> ab2 (back-reference to ab)
const y = structuredClone({ ab, get g() { detach(ab); return 1; }, ab2: ab });
// bun: DataCloneError: The object can not be cloned.
// node / HTML spec: y.ab2 === y.ab, y.ab.byteLength === 8, bytes = 77777777
```

## Cause

HTML's [StructuredSerializeInternal](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) step 2 is the memory-table lookup: "If memory[value] exists, then return memory[value]", which runs before any type-specific handling. `CloneSerializer::dumpIfTerminal` was checking `arrayBuffer->isDetached()` before `startObjectInternal(obj)` (the object-pool duplicate lookup), so a second reference to an already-serialized `ArrayBuffer` re-examined its detach state and aborted the entire clone with `DataCloneError`, even though the first visit had already copied all 8 bytes into the output.

The same serializer backs `structuredClone`, `postMessage`, `bun:jsc` `serialize`, and `node:v8` `serialize`, so all of them were affected.

## Fix

Split `startObjectInternal` into its two halves in the `JSArrayBuffer` branch: `checkForDuplicate(obj)` now runs first (matching the spec's memory-table step), and `recordObject(obj)` stays exactly where `startObjectInternal` was, after the `m_transferredArrayBuffers` lookup. Transferred buffers are still not entered into the object pool, so serializer and deserializer pool indices remain in lockstep (`ArrayBufferTransferTag` on the read side does not call `addToObjectPool`). The first-visit `IsDetachedBuffer` rejection is unchanged.

## Verification

`bun bd test test/js/web/workers/structured-clone.test.ts` passes all 222 tests. The new describe block covers `structuredClone`, `node:v8`, and `bun:jsc` for object properties, array elements, and resizable `ArrayBuffer`, plus a control case confirming a buffer detached before its first visit still throws `DataCloneError`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d594cf3df)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.27ms]
(pass) structuredClone > primitive null [0.65ms]
(pass) structuredClone > primitive true [0.51ms]
(pass) structuredClone > primitive false [0.49ms]
(pass) structuredClone > primitive string, empty string [0.36ms]
(pass) structuredClone > primitive string, lone high surrogate [0.44ms]
(pass) structuredClone > primitive string, lone low surrogate [0.37ms]
(pass) structuredClone > primitive string, NUL [0.43ms]
(pass) structuredClone > primitive string, astral character [0.56ms]
(pass) structuredClone > primitive number, 0.2 [0.45ms]
(pass) structuredClone > primitive number, 0 [0.39ms]
(pass) structuredClone > pri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2fed45632)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [0.09ms]
(pass) structuredClone > primitive null
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.01ms]
(pass) structuredClone > primitive number, 9007199254740994
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primitive BigInt, -0n
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d594cf3df)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.44ms]
(pass) structuredClone > primitive null [0.61ms]
(pass) structuredClone > primitive true [0.81ms]
(pass) structuredClone > primitive false [0.44ms]
(pass) structuredClone > primitive string, empty string [0.36ms]
(pass) structuredClone > primitive string, lone high surrogate [0.39ms]
(pass) structuredClone > primitive string, lone low surrogate [0.37ms]
(pass) structuredClone > primitive string, NUL [0.41ms]
(pass) structuredClone > primitive string, astral character [0.56ms]
(pass) structuredClone > primitive number, 0.2 [0.40ms]
(pass) structuredClone > primitive number, 0 [0.39ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp |  9 ++-
 test/js/web/workers/structured-clone.test.ts       | 94 ++++++++++++++++++++++
 2 files changed, 100 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp      4      1      0
test/js/web/workers/structured-clone.test.ts            7      7      0
```

</details>

<!-- robobun:evidence:end -->