### PR TITLE
node:tls: abort handshake with fatal alert when server rejects client cert

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -592,6 +592,7 @@ extern void us_internal_socket_raw_shutdown(struct us_socket_t *s);
 static void ssl_update_handshake(struct us_socket_t *s);
 static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s);
 static int us_ssl_inline_reject_tripped(struct us_socket_t *s);
+static void ssl_discard_parked_reason(struct us_socket_t *s);
 static inline int ssl_gone(struct us_socket_t *s);
 
 /* ── BIO plumbing ─────────────────────────────────────────────────────────
@@ -1191,10 +1192,18 @@ end:
 }
 
 static int us_verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
-  /* Always continue; the user inspects via us_socket_verify_error after
-   * on_handshake. Returning 1 defers the decision to JS without aborting
-   * mid-handshake - the same model as Node (crypto_tls.cc VerifyCallback). */
-  return 1;
+  /* Clients and non-rejectUnauthorized servers defer the decision to JS so
+   * authorized / authorizationError stay inspectable after the handshake. */
+  if (preverify_ok) return 1;
+  SSL *ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+  if (!ssl || !SSL_is_server(ssl) ||
+      !(SSL_get_verify_mode(ssl) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
+    return 1;
+  }
+  /* requestCert + rejectUnauthorized must fail inside the handshake so the
+   * peer receives a fatal alert instead of a clean post-handshake close.
+   * SSL_get_verify_result keeps the X509 reason for tlsClientError. */
+  return 0;
 }
 
 /* Rejecting client: keep walking (so the final verdict matches node's
@@ -1839,11 +1848,7 @@ void us_internal_ssl_detach(struct us_socket_t *s) {
     s->ssl = NULL;
     /* Same for a parked handshake reason: no dispatch can claim it now, and a
      * socket reusing this address would report it as its own failure. */
-    struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
-    if (loop_ssl_data && loop_ssl_data->ssl_last_fatal_error_owner == (void *)s) {
-      loop_ssl_data->ssl_last_fatal_error[0] = 0;
-      loop_ssl_data->ssl_last_fatal_error_owner = NULL;
-    }
+    ssl_discard_parked_reason(s);
   }
 }
 
@@ -1968,6 +1973,15 @@ static int ssl_dispatch_parked_reason(struct us_socket_t *s) {
   return 1;
 }
 
+static void ssl_discard_parked_reason(struct us_socket_t *s) {
+  struct loop_ssl_data *loop_ssl_data =
+      (struct loop_ssl_data *) s->group->loop->data.ssl_data;
+  if (loop_ssl_data && loop_ssl_data->ssl_last_fatal_error_owner == (void *)s) {
+    loop_ssl_data->ssl_last_fatal_error[0] = 0;
+    loop_ssl_data->ssl_last_fatal_error_owner = NULL;
+  }
+}
+
 static void ssl_trigger_handshake(struct us_socket_t *s, int success) {
   /* Read before the state flip below turns tripped() off. */
   int inline_rejected = us_ssl_inline_reject_tripped(s);
@@ -1981,13 +1995,7 @@ static void ssl_trigger_handshake(struct us_socket_t *s, int success) {
    * through ssl.verifyError() (UNABLE_TO_VERIFY_LEAF_SIGNATURE, ...), not
    * the SSL protocol reason that may wrap it. */
   if (!success && inline_rejected && s->ssl && s_ssl(s)) {
-    struct loop_ssl_data *loop_ssl_data =
-        (struct loop_ssl_data *)s->group->loop->data.ssl_data;
-    if (loop_ssl_data &&
-        loop_ssl_data->ssl_last_fatal_error_owner == (void *)s) {
-      loop_ssl_data->ssl_last_fatal_error[0] = 0;
-      loop_ssl_data->ssl_last_fatal_error_owner = NULL;
-    }
+    ssl_discard_parked_reason(s);
     us_dispatch_handshake(s, 0, us_ssl_socket_verify_error_from_ssl(s_ssl(s)));
     /* Nothing else will tear this connection down (the peer is still waiting
      * for a Finished that will never come) - close unless JS already did. */
@@ -1996,12 +2004,32 @@ static void ssl_trigger_handshake(struct us_socket_t *s, int success) {
     }
     return;
   }
-  /* A fatal SSL protocol error (wrong version number, bad record, ...) was
-   * recorded just before this failure: report it instead of the X509 verify
-   * result so Node's tlsClientError / client error carries the OpenSSL
-   * reason string. */
-  if (!success && ssl_dispatch_parked_reason(s)) {
-    return;
+  if (!success) {
+    /* Server cert-reject failures report SSL_get_verify_result directly. Gate
+     * on a presented peer cert so pre-verify failures (plain HTTP, no cert,
+     * bad record) keep their parked reason instead of INVALID_CALL. */
+    if (s_ssl(s) && SSL_is_server(s_ssl(s)) &&
+        (SSL_get_verify_mode(s_ssl(s)) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
+      X509 *peer_cert = SSL_get_peer_certificate(s_ssl(s));
+      if (peer_cert) {
+        X509_free(peer_cert);
+        long x509_err = SSL_get_verify_result(s_ssl(s));
+        if (x509_err != X509_V_OK) {
+          ssl_discard_parked_reason(s);
+          struct us_bun_verify_error_t verify_error = {
+              .error = x509_err,
+              .code = us_X509_error_code(x509_err),
+              .reason = X509_verify_cert_error_string(x509_err)};
+          us_dispatch_handshake(s, 0, verify_error);
+          return;
+        }
+      }
+    }
+    /* Fatal protocol errors (wrong version number, bad record, ...) parked
+     * above carry the OpenSSL reason string for tlsClientError. */
+    if (ssl_dispatch_parked_reason(s)) {
+      return;
+    }
   }
   struct us_bun_verify_error_t verify_error = us_internal_ssl_verify_error(s);
   us_dispatch_handshake(s, success, verify_error);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2586,6 +2586,10 @@ Reo=
 -----END CERTIFICATE-----`;
 
   const UNTRUSTED_MESSAGE = "unable to verify the first certificate";
+  // Under requestCert + rejectUnauthorized the server aborts the handshake at
+  // the first X509 failure so the peer gets a fatal alert, so that is the
+  // reason reported here (vs the follow-on UNTRUSTED_MESSAGE seen otherwise).
+  const REJECTED_CLIENT_CERT_MESSAGE = "unable to get local issuer certificate";
 
   // https://github.com/oven-sh/bun/issues/33846
   describe.concurrent("Bun.connect (server certificate)", () => {
@@ -3436,10 +3440,10 @@ Reo=
     it("closes a connection whose client certificate is not trusted", async () => {
       using t = await acceptFrom({ ca: CA_CRT, requestCert: true }, { key: ROGUE_KEY, cert: ROGUE_CRT });
       expect(await t.handshake.promise).toEqual({
-        successArg: true,
+        successArg: false,
         authorizedGetter: false,
-        callbackError: UNTRUSTED_MESSAGE,
-        getterError: UNTRUSTED_MESSAGE,
+        callbackError: REJECTED_CLIENT_CERT_MESSAGE,
+        getterError: REJECTED_CLIENT_CERT_MESSAGE,
         writeResult: -1,
       });
       await t.serverClosed.promise;
@@ -3548,7 +3552,11 @@ Reo=
         },
       });
       void client;
-      expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE, writeResult: -1 });
+      expect(await handshake.promise).toEqual({
+        authorized: false,
+        error: REJECTED_CLIENT_CERT_MESSAGE,
+        writeResult: -1,
+      });
       await serverClosed.promise;
       expect(serverReceived).toEqual([]);
       await clientClosed.promise;
@@ -3617,7 +3625,11 @@ Reo=
           },
         },
       });
-      expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE, writeResult: -1 });
+      expect(await handshake.promise).toEqual({
+        authorized: false,
+        error: REJECTED_CLIENT_CERT_MESSAGE,
+        writeResult: -1,
+      });
       await serverClosed.promise;
       expect(serverReceived).toEqual([]);
       await clientClosed.promise;

--- a/test/js/node/tls/fetch-tls-cert.test.ts
+++ b/test/js/node/tls/fetch-tls-cert.test.ts
@@ -223,9 +223,9 @@ it("Fail to complete client's chain.", async () => {
     });
     expect.unreachable();
   } catch (err: any) {
-    // The X.509 verify result (UNABLE_TO_GET_ISSUER_CERT) is the server's.
-    // Node's server signals it with a TLS alert (its client sees an SSL alert
-    // error); Bun's server aborts the connection, so the client sees a reset.
+    // The server aborts the handshake with a fatal TLS alert; over TLS 1.3 the
+    // alert arrives after the client has sent its request, and fetch currently
+    // folds that post-handshake close into ECONNRESET (see #33294).
     expect(err.code).toBe("ECONNRESET");
   }
 });

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { once } from "events";
 import { readFileSync } from "fs";
 import { bunEnv, bunExe, invalidTls, tmpdirSync } from "harness";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 import type { Server, TLSSocket } from "node:tls";
 import { join } from "path";
 import tls from "tls";
@@ -246,7 +246,9 @@ it("Fail to complete client's chain.", async () => {
     });
     expect.unreachable();
   } catch (err: any) {
-    expect(err.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+    // Server aborts the handshake at the first X509 failure (fatal alert to the
+    // client); for a missing intermediate that is UNABLE_TO_GET_ISSUER_CERT_LOCALLY.
+    expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
   }
 });
 
@@ -295,7 +297,7 @@ it("rejects an unverifiable client certificate by default when requestCert is tr
     ]);
     expect(outcome).toBe("closed");
 
-    expect(clientError?.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+    expect(clientError?.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
     expect(secureConnections).toHaveLength(0);
     expect(handled).toHaveLength(0);
 
@@ -318,6 +320,97 @@ it("rejects an unverifiable client certificate by default when requestCert is tr
 
     expect(handled).toHaveLength(1);
     expect(secureConnections).toHaveLength(1);
+  } finally {
+    server.close();
+  }
+});
+
+it("client sees a fatal TLS alert when the server rejects its certificate under rejectUnauthorized", async () => {
+  // The server must reject an unverifiable client cert inside the handshake
+  // (fatal alert), not after: a post-handshake clean close is invisible to the
+  // peer. Pinned to TLS 1.2; over TLS 1.3 the alert lands post-secureConnect.
+  const untrustedClient = {
+    key: readFileSync(join(import.meta.dir, "fixtures", "agent2-key.pem"), "utf8"),
+    cert: readFileSync(join(import.meta.dir, "fixtures", "agent2-cert.pem"), "utf8"),
+  };
+  let serverClientError: any;
+  const server = tls.createServer(
+    {
+      key: serverTls.key,
+      cert: serverTls.cert,
+      ca: clientTls.ca,
+      requestCert: true,
+      rejectUnauthorized: true,
+      maxVersion: "TLSv1.2",
+    },
+    socket => socket.end("SECRET"),
+  );
+  server.on("tlsClientError", err => {
+    serverClientError ??= err;
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    const outcome = await new Promise<{ error: any; secureConnect: boolean; hadError: boolean; data: string }>(
+      resolve => {
+        let error: any = null;
+        let secureConnect = false;
+        let data = "";
+        const c = tls.connect({
+          host: "127.0.0.1",
+          port,
+          ca: serverTls.ca,
+          key: untrustedClient.key,
+          cert: untrustedClient.cert,
+          checkServerIdentity,
+          maxVersion: "TLSv1.2",
+        });
+        c.on("secureConnect", () => (secureConnect = true));
+        c.on("data", d => (data += d));
+        c.on("error", e => (error = e?.code ?? String(e)));
+        c.on("close", hadError => resolve({ error, secureConnect, hadError, data }));
+      },
+    );
+
+    // The client's handshake never completes (fatal alert from the server),
+    // and the server reports the specific X509 verification failure.
+    expect({ ...outcome, serverClientError: serverClientError?.code }).toEqual({
+      data: "",
+      secureConnect: false,
+      error: "ERR_SSL_TLSV1_ALERT_UNKNOWN_CA",
+      hadError: true,
+      serverClientError: "DEPTH_ZERO_SELF_SIGNED_CERT",
+    });
+  } finally {
+    server.close();
+  }
+});
+
+it("tlsClientError keeps the specific reason for non-verification handshake failures under requestCert + rejectUnauthorized", async () => {
+  // SSL_get_verify_result is X509_V_ERR_INVALID_CALL before verification runs,
+  // so the X509-reason dispatch must only fire when a peer cert was actually
+  // presented; plain-HTTP and no-cert clients keep their parked reason.
+  const errors: (string | undefined)[] = [];
+  const server = tls.createServer(
+    { key: serverTls.key, cert: serverTls.cert, ca: clientTls.ca, requestCert: true, rejectUnauthorized: true },
+    s => s.end(),
+  );
+  server.on("tlsClientError", e => errors.push(e?.code));
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+  try {
+    await new Promise<void>(resolve => {
+      const sock = net.connect(port, "127.0.0.1", () => sock.write("GET / HTTP/1.1\r\n\r\n"));
+      sock.on("error", () => {});
+      sock.on("close", () => resolve());
+    });
+    await new Promise<void>(resolve => {
+      const c = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false });
+      c.on("error", () => {});
+      c.on("close", () => resolve());
+    });
+    expect(errors).toEqual(["ERR_SSL_HTTP_REQUEST", "ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE"]);
   } finally {
     server.close();
   }
@@ -629,7 +722,7 @@ it("tls.connect should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
 
   const results = await Promise.all(
     ["not-exist.pem", "", " "].map(async invalid => {
-      const proc = Bun.spawn({
+      await using proc = Bun.spawn({
         env: {
           ...bunEnv,
           SERVER_PORT: server.address.port.toString(),
@@ -666,7 +759,7 @@ it("tls.connect should ignore NODE_EXTRA_CA_CERTS if it contains invalid cert", 
 
   const results = await Promise.all(
     [mixedValidAndInvalidCertsBundlePath, mixedInvalidAndValidCertsBundlePath].map(async invalid => {
-      const proc = Bun.spawn({
+      await using proc = Bun.spawn({
         env: {
           ...bunEnv,
           SERVER_PORT: server.address.port.toString(),

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -11,10 +11,14 @@ const clientTls = {
   cert: readFileSync(join(import.meta.dir, "fixtures", "ec10-cert.pem"), "utf8"),
   ca: readFileSync(join(import.meta.dir, "fixtures", "ca5-cert.pem"), "utf8"),
 };
+// agent10/ca2 come from the upstream-synced keys: the older copy under
+// ./fixtures has a 1024-bit ca2, which Node >= 26 rejects as CA_KEY_TOO_SMALL
+// before any of the chain assertions below can be reached.
+const upstreamKeys = join(import.meta.dir, "..", "test", "fixtures", "keys");
 const serverTls = {
-  key: readFileSync(join(import.meta.dir, "fixtures", "agent10-key.pem"), "utf8"),
-  cert: readFileSync(join(import.meta.dir, "fixtures", "agent10-cert.pem"), "utf8"),
-  ca: readFileSync(join(import.meta.dir, "fixtures", "ca2-cert.pem"), "utf8"),
+  key: readFileSync(join(upstreamKeys, "agent10-key.pem"), "utf8"),
+  cert: readFileSync(join(upstreamKeys, "agent10-cert.pem"), "utf8"),
+  ca: readFileSync(join(upstreamKeys, "ca2-cert.pem"), "utf8"),
 };
 
 function split(file: any, into: any) {
@@ -32,6 +36,11 @@ function checkServerIdentity(hostname: string, cert: any) {
   expect(hostname).toBe("127.0.0.1");
   expect(cert.subject.CN).toBe("agent10.example.com");
 }
+
+// tlsClientError code when a requestCert + rejectUnauthorized server rejects an
+// incomplete client chain: Node emits ConnResetException('socket hang up'); Bun
+// emits the X509 verify error it aborted the handshake on.
+const REJECTED_CLIENT_CHAIN_CODES = ["ECONNRESET", "UNABLE_TO_GET_ISSUER_CERT_LOCALLY"];
 
 function connect(options: any) {
   let { promise, resolve, reject } = Promise.withResolvers();
@@ -246,9 +255,10 @@ it("Fail to complete client's chain.", async () => {
     });
     expect.unreachable();
   } catch (err: any) {
-    // Server aborts the handshake at the first X509 failure (fatal alert to the
-    // client); for a missing intermediate that is UNABLE_TO_GET_ISSUER_CERT_LOCALLY.
-    expect(err.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
+    // Node's server finishes the handshake then destroys the socket, so both peers
+    // see ECONNRESET (lib/internal/tls/wrap.js onServerSocketSecure/onSocketClose).
+    // Bun aborts inside the handshake and reports the X509 reason instead.
+    expect(REJECTED_CLIENT_CHAIN_CODES).toContain(err.code);
   }
 });
 
@@ -297,7 +307,7 @@ it("rejects an unverifiable client certificate by default when requestCert is tr
     ]);
     expect(outcome).toBe("closed");
 
-    expect(clientError?.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
+    expect(REJECTED_CLIENT_CHAIN_CODES).toContain(clientError?.code);
     expect(secureConnections).toHaveLength(0);
     expect(handled).toHaveLength(0);
 
@@ -325,10 +335,10 @@ it("rejects an unverifiable client certificate by default when requestCert is tr
   }
 });
 
-it("client sees a fatal TLS alert when the server rejects its certificate under rejectUnauthorized", async () => {
-  // The server must reject an unverifiable client cert inside the handshake
-  // (fatal alert), not after: a post-handshake clean close is invisible to the
-  // peer. Pinned to TLS 1.2; over TLS 1.3 the alert lands post-secureConnect.
+it("client sees a hard error, not a clean close, when the server rejects its certificate under rejectUnauthorized", async () => {
+  // A post-handshake close_notify would be indistinguishable from an empty reply.
+  // Pinned to TLS 1.2 so the rejection lands before the client's secureConnect
+  // on both runtimes; over TLS 1.3 the client finishes its handshake first.
   const untrustedClient = {
     key: readFileSync(join(import.meta.dir, "fixtures", "agent2-key.pem"), "utf8"),
     cert: readFileSync(join(import.meta.dir, "fixtures", "agent2-cert.pem"), "utf8"),
@@ -373,15 +383,18 @@ it("client sees a fatal TLS alert when the server rejects its certificate under 
       },
     );
 
-    // The client's handshake never completes (fatal alert from the server),
-    // and the server reports the specific X509 verification failure.
-    expect({ ...outcome, serverClientError: serverClientError?.code }).toEqual({
+    // The handler never runs, the client's handshake never completes, and the
+    // client is told the connection failed.
+    expect({ data: outcome.data, secureConnect: outcome.secureConnect, hadError: outcome.hadError }).toEqual({
       data: "",
       secureConnect: false,
-      error: "ERR_SSL_TLSV1_ALERT_UNKNOWN_CA",
       hadError: true,
-      serverClientError: "DEPTH_ZERO_SELF_SIGNED_CERT",
     });
+    // Node destroys the socket without close_notify after verifying, so the
+    // client reads ECONNRESET and tlsClientError is ConnResetException('socket
+    // hang up'); Bun sends a fatal unknown_ca alert and reports the X509 reason.
+    expect(["ECONNRESET", "ERR_SSL_TLSV1_ALERT_UNKNOWN_CA"]).toContain(outcome.error);
+    expect(["ECONNRESET", "DEPTH_ZERO_SELF_SIGNED_CERT"]).toContain(serverClientError?.code);
   } finally {
     server.close();
   }


### PR DESCRIPTION
## What this fixes

A `node:tls` server configured with `requestCert: true, rejectUnauthorized: true` that receives a presented-but-unverifiable client certificate would let the TLS handshake run to completion, then tear the connection down with a clean `close_notify`. From the client's point of view that is indistinguishable from an empty reply:

- `openssl s_client` prints `CONNECTION ESTABLISHED` and exits 0
- a `tls.connect` client gets `secureConnect` followed by a clean `'close'` with `hadError=false` and no `'error'` event

The missing-certificate case was already correct (BoringSSL sends `certificate_required` because `SSL_VERIFY_FAIL_IF_NO_PEER_CERT` is set); this is specifically the presented-and-failed path (self-signed, untrusted CA, expired, revoked).

## Reproduction

<details>
<summary>Self-contained repro (needs <code>openssl</code> on PATH)</summary>

```js
import tls from "node:tls";
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { execFileSync, execFile } from "node:child_process";
const d = fs.mkdtempSync(path.join(os.tmpdir(), "mtls-"));
const ssl = (...a) => execFileSync("openssl", a, { cwd: d, stdio: ["ignore","ignore","pipe"] });
const rd = n => fs.readFileSync(path.join(d, n));
ssl("req","-x509","-newkey","ec","-pkeyopt","ec_paramgen_curve:P-256","-keyout","ca.key","-out","ca.crt","-days","2","-nodes","-subj","/CN=mtls-ca");
ssl("req","-newkey","ec","-pkeyopt","ec_paramgen_curve:P-256","-keyout","srv.key","-out","srv.csr","-nodes","-subj","/CN=localhost","-addext","subjectAltName=DNS:localhost,IP:127.0.0.1");
ssl("x509","-req","-in","srv.csr","-CA","ca.crt","-CAkey","ca.key","-CAcreateserial","-out","srv.crt","-days","2","-copy_extensions","copy");
ssl("req","-x509","-newkey","ec","-pkeyopt","ec_paramgen_curve:P-256","-keyout","bad.key","-out","bad.crt","-days","2","-nodes","-subj","/CN=untrusted-client");

const srv = tls.createServer({ key: rd("srv.key"), cert: rd("srv.crt"), ca: rd("ca.crt"),
  requestCert: true, rejectUnauthorized: true, maxVersion: "TLSv1.2" },
  s => { console.log("handler ran (unexpected)"); s.end("SECRET"); });
srv.on("tlsClientError", e => console.log("SRV tlsClientError", e.code ?? e.message));
srv.listen(0, "127.0.0.1", async () => {
  const port = srv.address().port;
  const sc = await new Promise(res => execFile("openssl",
    ["s_client","-brief","-connect",`127.0.0.1:${port}`,"-servername","localhost",
     "-CAfile",path.join(d,"ca.crt"),"-cert",path.join(d,"bad.crt"),"-key",path.join(d,"bad.key")],
    { timeout: 8000 }, (err, so, se) => res({ code: err ? err.code ?? 1 : 0, se: String(se) })));
  console.log(`s_client exit=${sc.code} established=${/CONNECTION ESTABLISHED/.test(sc.se)} sawSSLError=${/:error:|SSL alert number/.test(sc.se)}`);
  const cli = await new Promise(res => { const r = { sc:false, err:"", he:null };
    const c = tls.connect({ host:"127.0.0.1", port, servername:"localhost", ca: rd("ca.crt"), cert: rd("bad.crt"), key: rd("bad.key") }, () => r.sc = true);
    c.on("error", e => r.err = e.code ?? e.message); c.on("close", he => { r.he = he; res(r); }); c.setTimeout(4000, () => c.destroy()); });
  console.log(`tls.connect: secureConnect=${cli.sc} error=${JSON.stringify(cli.err)} hadError=${cli.he}`);
  srv.close(() => process.exit(sc.code === 0 || cli.err === "" ? 1 : 0));
});
```

Before:
```
SRV tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT
s_client exit=0 established=true sawSSLError=false
tls.connect: secureConnect=true error="" hadError=false
```

After:
```
SRV tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT
s_client exit=1 established=false sawSSLError=true
tls.connect: secureConnect=false error="ERR_SSL_TLSV1_ALERT_UNKNOWN_CA" hadError=true
```
</details>

## Cause

`us_verify_callback` (the BoringSSL per-certificate verify callback) always returned 1, which tells BoringSSL to accept the certificate regardless of the chain-verification outcome and let the handshake complete. The `rejectUnauthorized` decision was then applied in the JS `handshake` handler, which called `destroy()`; that path sends `close_notify` before the TCP close.

Node's `VerifyCallback` also always returns 1, but Node's `destroy()` performs `SSL_free` + `uv_close` without `SSL_shutdown`, so the peer sees an unexpected EOF instead of a clean close.

## Fix

`us_verify_callback` now returns 0 when `preverify_ok` is 0 and the `SSL` is a server with `SSL_VERIFY_FAIL_IF_NO_PEER_CERT` set (the bit that `requestCert + rejectUnauthorized` enables). BoringSSL then aborts the handshake and sends the matching fatal alert (`unknown_ca` / `bad_certificate` / `certificate_expired`), which every TLS client stack surfaces as an error. Clients and servers with `rejectUnauthorized: false` are unchanged: verification is still deferred to JS so the user can inspect `authorized` / `authorizationError`.

`ssl_trigger_handshake` now reports the X509 verification result for a server-side handshake failure so `tlsClientError` continues to carry a specific reason (`DEPTH_ZERO_SELF_SIGNED_CERT`, `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`) rather than the generic SSL-layer `CERTIFICATE_VERIFY_FAILED`.

Two existing assertions in `node-tls-cert.test.ts` that checked `tlsClientError` for an incomplete client chain now see `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` (the first X509 failure) rather than `UNABLE_TO_VERIFY_LEAF_SIGNATURE` (the follow-on failure); both describe the same condition, and aborting at the first failure is what produces the specific alert code on the wire.

Over TLS 1.3 the server's alert arrives after the client has already sent its `Finished` and fired `secureConnect` (one-RTT handshake). Surfacing a post-handshake fatal alert on the client is #33294; the server's on-wire behaviour is correct in both TLS versions with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 14 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->