### PR TITLE
fetch: preserve a leading UTF-8 BOM in formData()

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -86,8 +86,6 @@ impl FormData {
     ) -> crate::Result<JSValue> {
         match encoding {
             Encoding::URLEncoded => {
-                // The URL Standard parses each name/value with "UTF-8 decode
-                // without BOM", which treats a leading U+FEFF as data.
                 let str = EncodedSlice::utf8(input);
                 // C++ may throw (e.g. string too long) — `create_from_url_query`
                 // wraps the FFI in a validation scope and maps zero → JsError.
@@ -213,7 +211,6 @@ pub(crate) fn to_js_from_multipart_data(
                 // `append_blob` dupes the content type; release this stack-local.
                 blob.detach();
             } else {
-                // "UTF-8 decode without BOM" keeps a leading U+FEFF as data.
                 let value = EncodedSlice::utf8(value_str);
                 wrap.form.append(&key, &value);
             }

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -86,7 +86,9 @@ impl FormData {
     ) -> crate::Result<JSValue> {
         match encoding {
             Encoding::URLEncoded => {
-                let str = EncodedSlice::utf8(strings::without_utf8_bom(input));
+                // The URL Standard parses each name/value with "UTF-8 decode
+                // without BOM", which treats a leading U+FEFF as data.
+                let str = EncodedSlice::utf8(input);
                 // C++ may throw (e.g. string too long) — `create_from_url_query`
                 // wraps the FFI in a validation scope and maps zero → JsError.
                 DOMFormData::create_from_url_query(global, &str).map_err(|_| crate::Error::JSError)
@@ -211,16 +213,8 @@ pub(crate) fn to_js_from_multipart_data(
                 // `append_blob` dupes the content type; release this stack-local.
                 blob.detach();
             } else {
-                let value = EncodedSlice::utf8(
-                    // > Each part whose `Content-Disposition` header does not
-                    // > contain a `filename` parameter must be parsed into an
-                    // > entry whose value is the UTF-8 decoded without BOM
-                    // > content of the part. This is done regardless of the
-                    // > presence or the value of a `Content-Type` header and
-                    // > regardless of the presence or the value of a
-                    // > `charset` parameter.
-                    strings::without_utf8_bom(value_str),
-                );
+                // "UTF-8 decode without BOM" keeps a leading U+FEFF as data.
+                let value = EncodedSlice::utf8(value_str);
                 wrap.form.append(&key, &value);
             }
         }

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -251,7 +251,7 @@ test("text with BOM", async () => {
   expect(text).toBe("test=\uFEFF");
 });
 
-test.todo("formData with BOM", async () => {
+test("formData with BOM", async () => {
   await using server = createServer((req, res) => {
     res.setHeader("content-type", "application/x-www-form-urlencoded");
     res.end("\uFEFFtest=\uFEFF");

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -26,12 +26,6 @@ describe("UTF-8 BOM should be ignored", () => {
         const blob = new Blob(['\uFEFF{"hello":"World 🌎"}'], { type: "application/json" });
         expect(await blob.json()).toStrictEqual({ "hello": "World 🌎" } as any);
       });
-
-      it("in formData()", async () => {
-        const blob = new Blob(["\uFEFFhello=world 🌎"], { type: "application/x-www-form-urlencoded" });
-        const formData = await blob.formData();
-        expect(formData.get("hello")).toBe("world 🌎");
-      });
     });
 
     it("in text()", async () => {
@@ -42,12 +36,6 @@ describe("UTF-8 BOM should be ignored", () => {
     it("in json()", async () => {
       const blob = new Blob(['\uFEFF{"hello":"World"}'], { type: "application/json" });
       expect(await blob.json()).toEqual({ "hello": "World" } as any);
-    });
-
-    it("in formData()", async () => {
-      const blob = new Blob(["\uFEFFhello=world"], { type: "application/x-www-form-urlencoded" });
-      const formData = await blob.formData();
-      expect(formData.get("hello")).toBe("world");
     });
   });
 
@@ -62,14 +50,6 @@ describe("UTF-8 BOM should be ignored", () => {
         headers: { "content-type": "application/json" },
       });
       expect(await response.json()).toEqual({ "hello": "World" } as any);
-    });
-
-    it("in formData()", async () => {
-      const response = new Response(Buffer.from("\uFEFFhello=world"), {
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-      });
-      const formData = await response.formData();
-      expect(formData.get("hello")).toBe("world");
     });
   });
 
@@ -88,15 +68,6 @@ describe("UTF-8 BOM should be ignored", () => {
         headers: { "content-type": "application/json" },
       });
       expect(await request.json()).toEqual({ "hello": "World" } as any);
-    });
-
-    it("in formData()", async () => {
-      const request = new Request("https://example.com", {
-        body: Buffer.from("\uFEFFhello=world"),
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-      });
-      const formData = await request.formData();
-      expect(formData.get("hello")).toBe("world");
     });
   });
 
@@ -141,17 +112,6 @@ describe("UTF-8 BOM should be ignored", () => {
       expect(await stream.json()).toEqual({ "hello": "World" });
     });
 
-    it("in Bun.readableStreamToFormData()", async () => {
-      const stream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(Buffer.from("\uFEFFhello=world"));
-          controller.close();
-        },
-      });
-      const formData = await Bun.readableStreamToFormData(stream);
-      expect(formData.get("hello")).toBe("world");
-    });
-
     it("in Bun.readableStreamToBlob()", async () => {
       const stream = new ReadableStream({
         start(controller) {
@@ -173,5 +133,113 @@ describe("UTF-8 BOM should be ignored", () => {
       const blob = await stream.blob();
       expect(await blob.text()).toBe("Hello, World!");
     });
+  });
+});
+
+// The URL Standard's application/x-www-form-urlencoded parser and the
+// multipart/form-data parser both decode with "UTF-8 decode without BOM",
+// which treats a leading U+FEFF as data (unlike text()/json()).
+describe("UTF-8 BOM should be preserved in formData()", () => {
+  const urlencoded = { "content-type": "application/x-www-form-urlencoded" };
+
+  it("matches URLSearchParams on the same bytes", async () => {
+    const expected = [...new URLSearchParams("\uFEFFa=1")];
+    expect(expected).toEqual([["\uFEFFa", "1"]]);
+
+    const fromString = await new Response("\uFEFFa=1", { headers: urlencoded }).formData();
+    expect([...fromString]).toEqual(expected);
+
+    const fromBytes = await new Response(new Uint8Array([0xef, 0xbb, 0xbf, 0x61, 0x3d, 0x31]), {
+      headers: urlencoded,
+    }).formData();
+    expect([...fromBytes]).toEqual(expected);
+
+    const fromRequest = await new Request("http://h/", {
+      method: "POST",
+      body: "\uFEFFa=1",
+      headers: urlencoded,
+    }).formData();
+    expect([...fromRequest]).toEqual(expected);
+  });
+
+  it("BOM-only body yields a single entry", async () => {
+    const formData = await new Response("\uFEFF", { headers: urlencoded }).formData();
+    expect([...formData]).toEqual([["\uFEFF", ""]]);
+  });
+
+  it("in Blob", async () => {
+    const blob = new Blob(["\uFEFFhello=world"], { type: "application/x-www-form-urlencoded" });
+    const formData = await blob.formData();
+    expect([...formData]).toEqual([["\uFEFFhello", "world"]]);
+    expect(formData.get("\uFEFFhello")).toBe("world");
+    expect(formData.get("hello")).toBe(null);
+  });
+
+  it("in Blob with emoji", async () => {
+    const blob = new Blob(["\uFEFFhello=world 🌎"], { type: "application/x-www-form-urlencoded" });
+    const formData = await blob.formData();
+    expect([...formData]).toEqual([["\uFEFFhello", "world 🌎"]]);
+  });
+
+  it("in Response", async () => {
+    const response = new Response(Buffer.from("\uFEFFhello=world"), { headers: urlencoded });
+    const formData = await response.formData();
+    expect([...formData]).toEqual([["\uFEFFhello", "world"]]);
+    expect(formData.get("\uFEFFhello")).toBe("world");
+    expect(formData.get("hello")).toBe(null);
+  });
+
+  it("in Request", async () => {
+    const request = new Request("https://example.com", {
+      body: Buffer.from("\uFEFFhello=world"),
+      headers: urlencoded,
+    });
+    const formData = await request.formData();
+    expect([...formData]).toEqual([["\uFEFFhello", "world"]]);
+    expect(formData.get("\uFEFFhello")).toBe("world");
+    expect(formData.get("hello")).toBe(null);
+  });
+
+  it("in Bun.readableStreamToFormData()", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from("\uFEFFhello=world"));
+        controller.close();
+      },
+    });
+    const formData = await Bun.readableStreamToFormData(stream);
+    expect([...formData]).toEqual([["\uFEFFhello", "world"]]);
+    expect(formData.get("\uFEFFhello")).toBe("world");
+    expect(formData.get("hello")).toBe(null);
+  });
+
+  it("in multipart/form-data part values", async () => {
+    const boundary = "----x";
+    const body = [`------x`, `Content-Disposition: form-data; name="field"`, ``, `\uFEFFvalue`, `------x--`, ``].join(
+      "\r\n",
+    );
+    const response = new Response(body, {
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    });
+    const formData = await response.formData();
+    expect([...formData]).toEqual([["field", "\uFEFFvalue"]]);
+  });
+
+  it("in multipart/form-data round-tripped through FormData", async () => {
+    const sent = new FormData();
+    sent.append("leading", "\uFEFFbom");
+    sent.append("only", "\uFEFF");
+    sent.append("trailing", "x\uFEFF");
+    sent.append("file", new Blob([new Uint8Array([0xef, 0xbb, 0xbf, 0x41])]), "f.txt");
+    const received = await new Request("http://h/", { method: "POST", body: sent }).formData();
+
+    const strings = [...received].filter(([, v]) => typeof v === "string");
+    expect(strings).toEqual([
+      ["leading", "\uFEFFbom"],
+      ["only", "\uFEFF"],
+      ["trailing", "x\uFEFF"],
+    ]);
+    const file = received.get("file") as Blob;
+    expect([...new Uint8Array(await file.arrayBuffer())]).toEqual([0xef, 0xbb, 0xbf, 0x41]);
   });
 });


### PR DESCRIPTION
### Problem
- `formData()` on `Request`, `Response`, `Blob` and `Bun.serve` request bodies strips a leading UTF-8 BOM (`EF BB BF`) from `application/x-www-form-urlencoded` bodies and from `multipart/form-data` string part values. A multipart part that is exactly U+FEFF becomes `""`. File parts keep their bytes.
- The cause is two `strings::without_utf8_bom()` calls in `FormData::to_js` and `to_js_from_multipart_data` (`src/runtime/webcore/FormData.rs:89`, `:222` on main). The spec step they quote, "UTF-8 decode without BOM", is the Encoding Standard variant that skips BOM removal and keeps U+FEFF as data. The helper does the opposite.

### Fix
- Drop both `without_utf8_bom()` calls. `text()` and `json()` still strip the BOM ("UTF-8 decode"), unchanged.
- Correct because Node (undici), Chromium (`CreateUTF8DecodeWithoutBOM()` for both arms), WebKit and WPT `url/urlencoded-parser.any.js` (`"\uFEFFtest=\uFEFF"` through `response.formData()` expects `[["\uFEFFtest","\uFEFF"]]`) all keep it.
- Verified: `test/js/web/fetch/utf8-bom.test.ts` (9 cases fail on 1.4.3, pass with the fix) and the un-skipped `test.todo("formData with BOM")` in `client-fetch.test.ts`. Also ran `FormData.test.ts`, `body.test.ts`, `URLSearchParams.test.ts`.

### Background
- The Encoding Standard has two entry points. "UTF-8 decode" peeks three bytes and drops `EF BB BF`. "UTF-8 decode without BOM" runs the decoder with no BOM step, so the bytes decode to U+FEFF.
- Fetch's body mixin uses "UTF-8 decode" for `text()` and `json()`, and "UTF-8 decode without BOM" for multipart string parts. The URL Standard's urlencoded parser also uses "UTF-8 decode without BOM" on each name and value.
- #7391 added the strip to fix `res.json()` on a BOM-prefixed response (#4876). It changed the `formData()` arms too, and `utf8-bom.test.ts` asserted that. Those assertions are rewritten here.

<details><summary>Notes</summary>

Repro (output is codepoints in hex):

```js
const fd = new FormData();
fd.append("a", "\uFEFFbom"); fd.append("b", "\uFEFF"); fd.append("c", "x\uFEFF");
fd.append("f", new Blob([new Uint8Array([0xEF,0xBB,0xBF,0x41])]), "f.txt");
const out = await new Request("http://x/", { method: "POST", body: fd }).formData();
// bun 1.4.3:   a=[62,6f,6d]      b=[]      c=[78,feff] f=file:4
// node 26.3.0: a=[feff,62,6f,6d] b=[feff]  c=[78,feff] f=file:4
// this PR:     identical to node

const body = new Uint8Array([0xEF,0xBB,0xBF,0x61,0x3D,0xEF,0xBB,0xBF,0x62,0x26,0x63,0x3D,0x64]); // BOM a= BOM b&c=d
await new Response(body, { headers: { "content-type": "application/x-www-form-urlencoded" } }).formData();
// bun 1.4.3:   [["a","\uFEFFb"],["c","d"]]   (leading BOM dropped, inner one kept)
// node, PR:    [["\uFEFFa","\uFEFFb"],["c","d"]]
```

A real Chromium `<textarea>` whose value is `"\uFEFFbom"` puts `EF BB BF 62 6F 6D` on the wire in a multipart form, so a server that strips it returns different text than the browser sent. 1.3, 1.4.2 and canary behave the same, so this is not a regression.

Rebased onto main on 2026-09-08 (the original July diff conflicted after `ZigString` became `EncodedSlice`), and added a multipart round-trip case covering the BOM-only part and a file part starting with `EF BB BF`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/client-fetch.test.ts "test/js/web/fetch/utf8-bom.test.ts"
bun test v1.4.3 (f42e98025)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-8 BOM should be ignored > handles empty strings [16.60ms]
(pass) UTF-8 BOM should be ignored > handles UTF8 BOM + emoji [9.87ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in text() [4.97ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in json() [7.06ms]
(pass) UTF-8 BOM should be ignored > Blob > in text() [4.46ms]
(pass) UTF-8 BOM should be ignored > Blob > in json() [4.42ms]
(pass) UTF-8 BOM should be ignored > Response > in text() [4.78ms]
(pass) UTF-8 BOM should be ignored > Response > in json() [4.90ms]
(pass) UTF-8 BOM should be ignored > Request > in text() [5.83ms]
(pass) UTF-8 BOM should be ignored > Request > in json() [5.43ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToText() [8.57ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToJSON() [6.38ms]
(pass) UTF-8 BOM should be ignored > re
... (truncated)

release without fix: 10 failed, 1 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-8 BOM should be ignored > handles empty strings [0.30ms]
(pass) UTF-8 BOM should be ignored > handles UTF8 BOM + emoji [0.14ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in text() [0.08ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in json() [0.11ms]
(pass) UTF-8 BOM should be ignored > Blob > in text() [0.05ms]
(pass) UTF-8 BOM should be ignored > Blob > in json() [0.08ms]
(pass) UTF-8 BOM should be ignored > Response > in text() [0.08ms]
(pass) UTF-8 BOM should be ignored > Response > in json() [0.06ms]
(pass) UTF-8 BOM should be ignored > Request > in text() [0.09ms]
(pass) UTF-8 BOM should be ignored > Request > in json() [0.08ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToText() [0.13ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToJSON() [0.08ms]
(pass) UTF-8 BOM should be ignored > readable stream > in ReadableStream.prototype.text() [0.07ms]
(pass) UTF-8 BOM should be ignored > readable stream > in ReadableStream.prototype.json() [0.07ms]
(pass) UTF-8 BOM should be ignored > read
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/client-fetch.test.ts "test/js/web/fetch/utf8-bom.test.ts"
bun test v1.4.3 (f42e98025)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-8 BOM should be ignored > handles empty strings [15.83ms]
(pass) UTF-8 BOM should be ignored > handles UTF8 BOM + emoji [10.38ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in text() [4.88ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in json() [5.20ms]
(pass) UTF-8 BOM should be ignored > Blob > in text() [4.51ms]
(pass) UTF-8 BOM should be ignored > Blob > in json() [4.96ms]
(pass) UTF-8 BOM should be ignored > Response > in text() [4.99ms]
(pass) UTF-8 BOM should be ignored > Response > in json() [5.19ms]
(pass) UTF-8 BOM should be ignored > Request > in text() [6.30ms]
(pass) UTF-8 BOM should be ignored > Request > in json() [6.45ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToText() [8.38ms]
(pass) UTF-8 BOM should be ignored > readable stream > in Bun.readableStreamToJSON() [6.69ms]
(pass) UTF-8 BOM should be ignored > r
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 739ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 02s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+83f9367bb
[build] done
bun test v1.4.3-canary.1 (83f9367bb)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-8 BOM should be ignored > handles empty strings [0.29ms]
(pass) UTF-8 BOM should be ignored > handles UTF8 BOM + emoji [0.14ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in text() [0.07ms]
(pass) UTF-8 BOM should be ignored > Blob > with emoji > in json() [0.11ms]
(pass) UTF-8 BOM should be ignored > Blob > in text() [0.07ms]
(pass) UTF-8 BOM should be ignored > Blob > in json() [0.08ms]
(pass) UTF-8 BOM should be ignored > Response > in text() [0.07ms]
(pass) 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs        |  13 +--
 test/js/web/fetch/client-fetch.test.ts |   2 +-
 test/js/web/fetch/utf8-bom.test.ts     | 148 ++++++++++++++++++++++++---------
 3 files changed, 111 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/webcore/FormData.rs             3      3     13
test/js/web/fetch/client-fetch.test.ts      1      1      6
test/js/web/fetch/utf8-bom.test.ts          1      1      7
```

</details>

<!-- robobun:evidence:end -->