### PR TITLE
install: fail --frozen-lockfile on manifest drift and fix the spurious lockfile re-saves behind it

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1,6 +1,7 @@
 use core::sync::atomic::Ordering;
 
-use bun_collections::DynamicBitSet;
+use bun_collections::array_hash_map::MapEntry;
+use bun_collections::{ArrayHashMap, DynamicBitSet};
 use bun_core::UnwrapOrOom as _;
 use bun_core::time::nano_timestamp;
 use bun_core::{Global, Output};
@@ -18,8 +19,8 @@ use crate::update_transitive::{
     plannable_peer_rows, print_kept_patched, redirect_moved_edges,
 };
 use crate::{
-    Dependency, DependencyID, Features, PackageID, PackageNameHash, PatchTask, Resolution,
-    invalid_package_id,
+    Dependency, DependencyID, Features, PackageID, PackageNameAndVersionHash, PackageNameHash,
+    PatchTask, Resolution, invalid_package_id,
 };
 // Bring the typed `items_<field>()` column accessors into scope for
 // `MultiArrayList<Package>` / `Slice<Package>`.
@@ -280,15 +281,37 @@ pub fn install_with_manager(
                 let (mut builder_, lf) = manager.lockfile.string_builder_split();
                 let builder = &mut builder_;
 
+                // Like the root scripts below, trusted and patched dependencies
+                // are taken from package.json whether or not the differ counted
+                // a change: it leaves out the entries a save would drop, and
+                // those still have to apply to whatever this install resolves.
+                //
+                // `ArrayHashMap::clone()` is an inherent fallible method,
+                // not the `Clone` trait, so
+                // `Option::clone` won't see it — map by hand.
+                *lf.trusted_dependencies = match &lockfile.trusted_dependencies {
+                    Some(td) => Some(td.clone()?),
+                    None => None,
+                };
+
                 if !had_any_diffs {
                     // always grab latest scripts for root package
                     maybe_root
                         .scripts
                         .count(&lockfile.buffers.string_bytes, builder);
+                    for patch_dep in lockfile.patched_dependencies.values() {
+                        builder.count(patch_dep.path.slice(&lockfile.buffers.string_bytes));
+                    }
                     builder.allocate()?;
                     lf.packages.items_scripts_mut()[0] = maybe_root
                         .scripts
                         .clone_into(&lockfile.buffers.string_bytes, builder);
+                    copy_patched_dependencies(
+                        lf.patched_dependencies,
+                        &lockfile,
+                        builder,
+                        patched_dependencies_to_remove,
+                    );
                     builder.clamp();
                     if bare_update {
                         transitive = TransitiveUpdate::plan(manager, &direct_deps_before)?;
@@ -370,14 +393,6 @@ pub fn install_with_manager(
                         builder,
                     )?;
 
-                    // `ArrayHashMap::clone()` is an inherent fallible method,
-                    // not the `Clone` trait, so
-                    // `Option::clone` won't see it — map by hand.
-                    *lf.trusted_dependencies = match &lockfile.trusted_dependencies {
-                        Some(td) => Some(td.clone()?),
-                        None => None,
-                    };
-
                     lf.dependencies.reserve(len as usize);
                     lf.resolutions.reserve(len as usize);
 
@@ -446,60 +461,12 @@ pub fn install_with_manager(
                         }
                     }
 
-                    // Update patched dependencies
-                    {
-                        for (key, value) in lockfile.patched_dependencies.iter() {
-                            let pkg_name_and_version_hash = *key;
-                            debug_assert!(value.patchfile_hash_is_null);
-                            let gop = lf.patched_dependencies.entry(pkg_name_and_version_hash);
-                            // ArrayHashMap getOrPut semantics → entry API approximation
-                            match gop {
-                                bun_collections::array_hash_map::MapEntry::Vacant(v) => {
-                                    // `PatchedDep` has private padding/hash fields,
-                                    // so the `..Default::default()` struct-update form is rejected
-                                    // outside its module. Build via `default()` + field stores.
-                                    let mut new = crate::lockfile_real::PatchedDep::default();
-                                    new.path = builder.append::<SemverString>(
-                                        value.path.slice(&lockfile.buffers.string_bytes),
-                                    );
-                                    new.set_patchfile_hash(None);
-                                    v.insert(new);
-                                    // gop.value_ptr.path = gop.value_ptr.path;
-                                }
-                                bun_collections::array_hash_map::MapEntry::Occupied(mut o) => {
-                                    if !strings::eql(
-                                        o.get().path.slice(builder.string_bytes.as_slice()),
-                                        value.path.slice(&lockfile.buffers.string_bytes),
-                                    ) {
-                                        o.get_mut().path = builder.append::<SemverString>(
-                                            value.path.slice(&lockfile.buffers.string_bytes),
-                                        );
-                                        o.get_mut().set_patchfile_hash(None);
-                                    }
-                                }
-                            }
-                        }
-
-                        let mut count: usize = 0;
-                        for (key, _) in lf.patched_dependencies.iter() {
-                            if !lockfile.patched_dependencies.contains_key(key) {
-                                count += 1;
-                            }
-                        }
-                        if count > 0 {
-                            patched_dependencies_to_remove.reserve(count);
-                            for (key, _) in lf.patched_dependencies.iter() {
-                                if !lockfile.patched_dependencies.contains_key(key) {
-                                    patched_dependencies_to_remove.insert(*key, ());
-                                }
-                            }
-                            let to_remove: Vec<u64> =
-                                patched_dependencies_to_remove.keys().to_vec();
-                            for hash in to_remove {
-                                let _ = lf.patched_dependencies.ordered_remove(&hash);
-                            }
-                        }
-                    }
+                    copy_patched_dependencies(
+                        lf.patched_dependencies,
+                        &lockfile,
+                        builder,
+                        patched_dependencies_to_remove,
+                    );
 
                     builder.clamp();
 
@@ -510,6 +477,36 @@ pub fn install_with_manager(
                     if bare_update {
                         transitive = TransitiveUpdate::plan(manager, &direct_deps_before)?;
                         pinned_rows = enqueue_transitive(manager, &transitive, invalidates_rows)?;
+                    }
+
+                    // Workspace members whose package.json changed are re-read by
+                    // resolving one dependency on each of them again.
+                    let changed_workspace_ids: Vec<PackageID> = manager
+                        .summary
+                        .changed_workspaces
+                        .iter()
+                        .map(|workspace| workspace.package_id)
+                        .collect();
+                    for package_id in changed_workspace_ids {
+                        let Some(dependency_id) = manager
+                            .lockfile
+                            .dependency_to_reresolve_workspace(package_id)
+                        else {
+                            continue;
+                        };
+                        let dependency =
+                            manager.lockfile.buffers.dependencies[dependency_id as usize].clone();
+                        manager.lockfile.buffers.resolutions[dependency_id as usize] =
+                            invalid_package_id;
+                        if let Err(err) = enqueue_dependency_with_main(
+                            manager,
+                            dependency_id,
+                            &dependency,
+                            invalid_package_id,
+                            false,
+                        ) {
+                            add_dependency_error(manager, &dependency, err);
+                        }
                     }
 
                     // `enqueueDependencyWithMain` can reach `Lockfile.Package.fromNPM`,
@@ -1436,6 +1433,57 @@ fn frozen_changed_section(
         Some("the catalog")
     } else {
         None
+    }
+}
+
+/// Brings the loaded lockfile's `patchedDependencies` in line with the ones
+/// just parsed from package.json (`lockfile`); `builder` must already have
+/// room for their paths. The entries only the loaded lockfile has are queued
+/// in `patched_dependencies_to_remove` so the install un-patches them.
+fn copy_patched_dependencies(
+    loaded: &mut lockfile::PatchedDependenciesMap,
+    lockfile: &Lockfile,
+    builder: &mut lockfile::StringBuilder<'_>,
+    patched_dependencies_to_remove: &mut ArrayHashMap<PackageNameAndVersionHash, ()>,
+) {
+    for (key, value) in lockfile.patched_dependencies.iter() {
+        debug_assert!(value.patchfile_hash_is_null);
+        let path = value.path.slice(&lockfile.buffers.string_bytes);
+        match loaded.entry(*key) {
+            MapEntry::Vacant(v) => {
+                // `PatchedDep` has private padding/hash fields,
+                // so the `..Default::default()` struct-update form is rejected
+                // outside its module. Build via `default()` + field stores.
+                let mut new = lockfile::PatchedDep::default();
+                new.path = builder.append::<SemverString>(path);
+                new.set_patchfile_hash(None);
+                v.insert(new);
+            }
+            MapEntry::Occupied(mut o) => {
+                if !strings::eql(o.get().path.slice(builder.string_bytes.as_slice()), path) {
+                    o.get_mut().path = builder.append::<SemverString>(path);
+                    o.get_mut().set_patchfile_hash(None);
+                }
+            }
+        }
+    }
+
+    let count = loaded
+        .iter()
+        .filter(|(key, _)| !lockfile.patched_dependencies.contains_key(key))
+        .count();
+    if count > 0 {
+        patched_dependencies_to_remove.reserve(count);
+        for (key, _) in loaded.iter() {
+            if !lockfile.patched_dependencies.contains_key(key) {
+                patched_dependencies_to_remove.insert(*key, ());
+            }
+        }
+        let to_remove: Vec<PackageNameAndVersionHash> =
+            patched_dependencies_to_remove.keys().to_vec();
+        for hash in to_remove {
+            let _ = loaded.ordered_remove(&hash);
+        }
     }
 }
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -801,38 +801,44 @@ pub fn install_with_manager(
     if manager.options.enable.frozen_lockfile()
         && !matches!(load_result, lockfile::LoadResult::NotFound)
     {
-        'frozen_lockfile: {
-            let changed_section = frozen_changed_section(manager, root_package_json_path);
-            if changed_section.is_none() {
-                if load_result.loaded_from_text_lockfile() {
-                    if bun_core::handle_oom(Lockfile::eql(
-                        &manager.lockfile,
-                        &lockfile_before_clean,
-                        lockfile_before_clean.loaded_package_count as usize,
-                    )) {
-                        break 'frozen_lockfile;
-                    }
-                } else if !(manager
-                    .lockfile
-                    .has_meta_hash_changed(
-                        PackageManager::verbose_install()
-                            || manager.options.do_.print_meta_hash_string(),
-                        packages_len_before_install,
-                    )
-                    .unwrap_or(false))
-                {
-                    break 'frozen_lockfile;
-                }
-            }
+        // `eql`/`has_meta_hash_changed` compare resolved packages only; a
+        // manifest change that resolves to packages already in the lockfile
+        // only shows up in the differ. trustedDependencies and
+        // patchedDependencies are applied from package.json either way and are
+        // dropped from bun.lock by tools like `turbo prune`, so they are not
+        // part of the comparison.
+        let manifests_changed = manager.summary.changes_dependencies();
+        let resolutions_changed = if load_result.loaded_from_text_lockfile() {
+            !bun_core::handle_oom(Lockfile::eql(
+                &manager.lockfile,
+                &lockfile_before_clean,
+                lockfile_before_clean.loaded_package_count as usize,
+            ))
+        } else {
+            manager
+                .lockfile
+                .has_meta_hash_changed(
+                    PackageManager::verbose_install()
+                        || manager.options.do_.print_meta_hash_string(),
+                    packages_len_before_install,
+                )
+                .unwrap_or(false)
+        };
 
+        if manifests_changed || resolutions_changed {
             if log_level != Options::LogLevel::Silent {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
                 );
-                if let Some(section) = changed_section {
+                if manifests_changed {
+                    print_frozen_lockfile_manifest_changes(
+                        manager,
+                        root_package_json_path,
+                        loaded_lockfile_name(&load_result),
+                    );
+                } else {
                     bun_core::note!(
-                        "{} in package.json changed since {} was saved",
-                        section,
+                        "the packages resolved from the manifests differ from {}",
                         loaded_lockfile_name(&load_result)
                     );
                 }
@@ -1423,19 +1429,6 @@ pub(crate) fn get_workspace_filters(
     Ok((filters, install_root_dependencies))
 }
 
-fn frozen_changed_section(
-    manager: &mut PackageManager,
-    root_package_json_path: &ZStr,
-) -> Option<&'static str> {
-    if manager.summary.overrides_changed {
-        Some(overrides_field_name(manager, root_package_json_path))
-    } else if manager.summary.catalogs_changed {
-        Some("the catalog")
-    } else {
-        None
-    }
-}
-
 /// Brings the loaded lockfile's `patchedDependencies` in line with the ones
 /// just parsed from package.json (`lockfile`); `builder` must already have
 /// room for their paths. The entries only the loaded lockfile has are queued
@@ -1563,6 +1556,53 @@ fn add_dependency_error(manager: &mut PackageManager, dependency: &Dependency, e
 // hot verify-and-exit path during fat-LTO emission, so a no-op
 // `bun install` / `bun install --frozen-lockfile` (node_modules already up to
 // date) faults in far fewer distinct `.text` pages.
+
+#[cold]
+#[inline(never)]
+fn print_frozen_lockfile_manifest_changes(
+    manager: &mut PackageManager,
+    root_package_json_path: &ZStr,
+    lockfile_name: &str,
+) {
+    let summary = &manager.summary;
+    if summary.add > 0 || summary.root_remove > 0 || summary.update > 0 {
+        bun_core::note!(
+            "dependencies in package.json changed since {} was saved (<green>{}<r> added, <red>{}<r> removed, <cyan>{}<r> updated)",
+            lockfile_name,
+            summary.add,
+            summary.root_remove,
+            summary.update,
+        );
+    }
+    for workspace in summary
+        .changed_workspaces
+        .iter()
+        .filter(|workspace| workspace.dependencies_changed)
+    {
+        bun_core::note!(
+            "dependencies in {}/package.json changed since {} was saved (<green>{}<r> added, <red>{}<r> removed, <cyan>{}<r> updated)",
+            bstr::BStr::new(&workspace.path),
+            lockfile_name,
+            workspace.add,
+            workspace.remove,
+            workspace.update,
+        );
+    }
+    let catalogs_changed = summary.catalogs_changed;
+    if summary.overrides_changed {
+        bun_core::note!(
+            "{} in package.json changed since {} was saved",
+            overrides_field_name(manager, root_package_json_path),
+            lockfile_name
+        );
+    }
+    if catalogs_changed {
+        bun_core::note!(
+            "the catalog in package.json changed since {} was saved",
+            lockfile_name
+        );
+    }
+}
 
 #[cold]
 #[inline(never)]

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3221,6 +3221,130 @@ impl Lockfile {
 
         false
     }
+
+    /// The dependency to re-resolve so that workspace member `package_id` is
+    /// read from disk again: resolving a `workspace:` dependency declared by the
+    /// root or a member re-parses the member into the same package id, so one
+    /// such edge is enough. Members reached some other way (an override on an
+    /// npm range, for instance) fall back to whichever dependency resolved to
+    /// them, which re-applies that route.
+    pub(crate) fn dependency_to_reresolve_workspace(
+        &self,
+        package_id: PackageID,
+    ) -> Option<DependencyID> {
+        let packages = self.packages.slice();
+        let resolutions = self.buffers.resolutions.as_slice();
+        let dependencies = self.buffers.dependencies.as_slice();
+        let resolves_to_member = |dep_id: usize| {
+            resolutions[dep_id] == package_id && !dependencies[dep_id].behavior.is_optional_peer()
+        };
+
+        let pick = |candidates: &mut dyn Iterator<Item = usize>| {
+            let mut fallback = None;
+            for dep_id in candidates.filter(|&dep_id| resolves_to_member(dep_id)) {
+                if dependencies[dep_id].version.tag == dependency::Tag::Workspace {
+                    return Some(dep_id);
+                }
+                fallback.get_or_insert(dep_id);
+            }
+            fallback
+        };
+
+        let mut declared = packages
+            .items_resolution()
+            .iter()
+            .zip(packages.items_dependencies())
+            .filter(|(resolution, _)| {
+                matches!(
+                    resolution.tag,
+                    ResolutionTag::Root | ResolutionTag::Workspace
+                )
+            })
+            .flat_map(|(_, list)| list.begin() as usize..list.end() as usize);
+        let dep_id = pick(&mut declared).or_else(|| pick(&mut (0..dependencies.len())))?;
+        Some(dep_id as DependencyID)
+    }
+
+    /// Whether bun.lock would keep this `trustedDependencies` entry: the
+    /// writer only emits the names that some dependency in the tree, or the
+    /// npm package one resolved to, has (the two names `has_trusted_dependency`
+    /// checks). The differ uses this for entries that are new in package.json,
+    /// so the ones a save would drop anyway are not reported on every install.
+    pub(crate) fn stores_trusted_dependency(&self, name: &[u8]) -> bool {
+        let name_hash = SemverStringBuilder::string_hash(name);
+        let buf = self.buffers.string_bytes.as_slice();
+        let packages = self.packages.slice();
+        let pkg_names = packages.items_name();
+        let pkg_name_hashes = packages.items_name_hash();
+        let pkg_resolutions = packages.items_resolution();
+
+        self.buffers
+            .dependencies
+            .iter()
+            .zip(self.buffers.resolutions.iter())
+            .any(|(dep, &package_id)| {
+                let Some(&pkg_name_hash) = pkg_name_hashes.get(package_id as usize) else {
+                    return false;
+                };
+                (dep.name_hash == name_hash && dep.name.slice(buf) == name)
+                    || (pkg_name_hash == name_hash
+                        && pkg_resolutions[package_id as usize].tag == ResolutionTag::Npm
+                        && pkg_names[package_id as usize].slice(buf) == name)
+            })
+    }
+
+    /// Whether bun.lock would keep any of the entries of `patched` (a
+    /// `patchedDependencies` map from another lockfile) that `f` accepts: the
+    /// writer only emits the entries whose `name@version` (built the way its
+    /// tree walk builds it) names a package in the lockfile. The differ uses
+    /// this for entries that are new in package.json.
+    pub(crate) fn stores_any_patched_dependency(
+        &self,
+        patched: &PatchedDependenciesMap,
+        mut f: impl FnMut(PackageNameAndVersionHash) -> bool,
+    ) -> bool {
+        if patched.count() == 0 {
+            return false;
+        }
+        let buf = self.buffers.string_bytes.as_slice();
+        let packages = self.packages.slice();
+        let mut name_and_version: Vec<u8> = Vec::new();
+        for ((&name, &name_hash), resolution) in packages
+            .items_name()
+            .iter()
+            .zip(packages.items_name_hash())
+            .zip(packages.items_resolution())
+        {
+            if resolution.tag == ResolutionTag::Root {
+                continue;
+            }
+            name_and_version.clear();
+            let _ = write!(
+                &mut name_and_version,
+                "{}@",
+                bstr::BStr::new(name.slice(buf))
+            );
+            match resolution.tag {
+                ResolutionTag::Workspace => {
+                    if let Some(workspace_version) = self.workspace_versions.get(&name_hash) {
+                        let _ = write!(&mut name_and_version, "{}", workspace_version.fmt(buf));
+                    }
+                }
+                _ => {
+                    let _ = write!(
+                        &mut name_and_version,
+                        "{}",
+                        resolution.fmt(buf, PathSep::Posix)
+                    );
+                }
+            }
+            let key = SemverStringBuilder::string_hash(&name_and_version);
+            if patched.contains(&key) && f(key) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -907,10 +907,25 @@ pub struct AddedTrustedDependency {
     pub(crate) name: Box<[u8]>,
 }
 
+/// A workspace member whose package.json no longer matches its lockfile package.
+pub struct WorkspaceDiff {
+    /// The member's package in the lockfile the diff was generated from.
+    pub(crate) package_id: PackageID,
+    pub(crate) path: Box<[u8]>,
+    pub(crate) add: u32,
+    pub(crate) remove: u32,
+    pub(crate) update: u32,
+    /// False when only its lifecycle scripts changed.
+    pub(crate) dependencies_changed: bool,
+}
+
 #[derive(Default)]
 pub struct DiffSummary {
     pub(crate) add: u32,
+    /// On the root summary: distinct names removed across the root and every member.
     pub(crate) remove: u32,
+    /// Removed from the root package.json itself.
+    pub(crate) root_remove: u32,
     pub(crate) update: u32,
     pub(crate) script_only_updates: u32,
     pub(crate) overrides_changed: bool,
@@ -919,10 +934,16 @@ pub struct DiffSummary {
     pub(crate) added_trusted_dependencies:
         ArrayHashMap<TruncatedPackageNameHash, AddedTrustedDependency, ArrayIdentityContext>,
     pub(crate) removed_trusted_dependencies: TrustedDependenciesSet,
+    /// package.json declares `trustedDependencies`, which by itself turns the
+    /// default list off, but the lockfile does not record the field.
+    pub(crate) trusted_dependencies_declared: bool,
 
     pub(crate) patched_dependencies_changed: bool,
 
     pub(crate) pruned_workspaces: Vec<PackageNameHash>,
+
+    /// Only populated on the root summary.
+    pub(crate) changed_workspaces: Vec<WorkspaceDiff>,
 }
 
 impl DiffSummary {
@@ -933,13 +954,13 @@ impl DiffSummary {
             || self.update > 0
             || self.overrides_changed
             || self.catalogs_changed
+            || !self.changed_workspaces.is_empty()
     }
 
     #[inline]
     pub(crate) fn has_diffs(&self) -> bool {
         self.changes_resolutions()
-            || self.added_trusted_dependencies.count() > 0
-            || self.removed_trusted_dependencies.count() > 0
+            || self.trusted_dependencies_changed()
             || self.patched_dependencies_changed
     }
 
@@ -950,6 +971,16 @@ impl DiffSummary {
             || self.overrides_changed
             || self.catalogs_changed
             || self.update > self.script_only_updates
+            || self
+                .changed_workspaces
+                .iter()
+                .any(|workspace| workspace.dependencies_changed)
+    }
+
+    pub(crate) fn trusted_dependencies_changed(&self) -> bool {
+        self.added_trusted_dependencies.count() > 0
+            || self.removed_trusted_dependencies.count() > 0
+            || self.trusted_dependencies_declared
     }
 }
 
@@ -1006,14 +1037,12 @@ impl Diff {
                 ),
             _ => true,
         };
-        // `parseWithJSON` may grow `to_lockfile.buffers.dependencies` and
-        // invalidate the old slice, so `to_deps` is re-derived after it. Held as raw fat
-        // pointers so the `&mut to_lockfile`/`&mut from_lockfile` reborrows below
-        // (sort, recursive `generate`) don't conflict with these read views; the
-        // recursive call only sorts `overrides`/`catalogs` and never reallocates
-        // either lockfile's `buffers.dependencies`/`resolutions`, so the raw
-        // pointers remain valid for the loop body.
-        let mut to_deps: bun_ptr::RawSlice<Dependency> = to
+        // Held as raw fat pointers so the `&mut to_lockfile`/`&mut from_lockfile`
+        // reborrows below (sort, `diff_workspace_members`) don't conflict with
+        // these read views. `to_deps` is not used once the members have been
+        // parsed into `to_lockfile`, and nothing below reallocates
+        // `from_lockfile.buffers`, so the views stay valid where they are used.
+        let to_deps: bun_ptr::RawSlice<Dependency> = to
             .dependencies
             .get(to_lockfile.buffers.dependencies.as_slice())
             .into();
@@ -1035,21 +1064,24 @@ impl Diff {
         let (from_deps, from_resolutions) = (from_deps.slice(), from_resolutions.slice());
         let mut to_i: usize = 0;
 
-        if lockfile::OverrideMap::changed(
-            &mut from_lockfile.overrides,
-            from_lockfile.buffers.string_bytes.as_slice(),
-            &mut to_lockfile.overrides,
-            to_lockfile.buffers.string_bytes.as_slice(),
-        ) {
-            summary.overrides_changed = true;
-
-            if PackageManager::verbose_install() {
-                bun_core::pretty_errorln!("Overrides changed since last install");
-            }
-        }
-
+        // Lockfile-wide sections are compared once, at the root; the caller
+        // applies changes to them across every package, so the per-member
+        // diffs in `diff_workspace_members` only compare dependency edges.
         let mut catalog_entries_skipped: Vec<Box<[u8]>> = Vec::new();
         if is_root {
+            if lockfile::OverrideMap::changed(
+                &mut from_lockfile.overrides,
+                from_lockfile.buffers.string_bytes.as_slice(),
+                &mut to_lockfile.overrides,
+                to_lockfile.buffers.string_bytes.as_slice(),
+            ) {
+                summary.overrides_changed = true;
+
+                if PackageManager::verbose_install() {
+                    bun_core::pretty_errorln!("Overrides changed since last install");
+                }
+            }
+
             let tolerate_catalog_subset = pm.options.enable.frozen_lockfile();
             'catalogs: {
                 // don't sort if lengths are different
@@ -1186,167 +1218,6 @@ impl Diff {
             }
         }
 
-        'trusted_dependencies: {
-            // trusted dependency diff
-            //
-            // situations:
-            // 1 - Both old lockfile and new lockfile use default trusted dependencies, no diffs
-            // 2 - Both exist, only diffs are from additions and removals
-            //
-            // 3 - Old lockfile has trusted dependencies, new lockfile does not. Added are dependencies
-            //     from default list that didn't exist previously. We need to be careful not to add these
-            //     to the new lockfile. Removed are dependencies from old list that
-            //     don't exist in the default list.
-            //
-            // 4 - Old lockfile used the default list, new lockfile has trusted dependencies. Added
-            //     are dependencies are all from the new lockfile. Removed is empty because the default
-            //     list isn't appended to the lockfile.
-
-            // 1
-            if from_lockfile.trusted_dependencies.is_none()
-                && to_lockfile.trusted_dependencies.is_none()
-            {
-                break 'trusted_dependencies;
-            }
-
-            // 2
-            if let (Some(from_trusted_dependencies), Some(to_trusted_dependencies)) = (
-                from_lockfile.trusted_dependencies.as_mut(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // added
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    // Empty name = legacy bun.lockb hash-only sentinel.
-                    let already_trusted = from_trusted_dependencies
-                        .get_mut(&to_trusted)
-                        .is_some_and(|from_name| {
-                            if from_name.is_empty() && !to_name.is_empty() {
-                                from_name.clone_from(to_name);
-                            }
-                            from_name.is_empty() || to_name.is_empty() || **from_name == **to_name
-                        });
-                    if !already_trusted {
-                        summary.added_trusted_dependencies.put(
-                            to_trusted,
-                            AddedTrustedDependency {
-                                add_to_lockfile: true,
-                                name: to_name.clone(),
-                            },
-                        )?;
-                    }
-                }
-
-                // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    let still_trusted =
-                        to_trusted_dependencies
-                            .get(&from_trusted)
-                            .is_some_and(|to_name| {
-                                from_name.is_empty()
-                                    || to_name.is_empty()
-                                    || **to_name == **from_name
-                            });
-                    if !still_trusted {
-                        summary
-                            .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
-                    }
-                }
-
-                break 'trusted_dependencies;
-            }
-
-            // 3
-            if let (Some(from_trusted_dependencies), None) = (
-                from_lockfile.trusted_dependencies.as_ref(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // added
-                for entry in default_trusted_dependencies::entries() {
-                    if !from_trusted_dependencies
-                        .contains(&(entry.hash as TruncatedPackageNameHash))
-                    {
-                        // although this is a new trusted dependency, it is from the default
-                        // list so it shouldn't be added to the lockfile
-                        summary.added_trusted_dependencies.put(
-                            entry.hash as TruncatedPackageNameHash,
-                            AddedTrustedDependency {
-                                add_to_lockfile: false,
-                                name: Box::from(entry.key),
-                            },
-                        )?;
-                    }
-                }
-
-                // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
-                        summary
-                            .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
-                    }
-                }
-
-                break 'trusted_dependencies;
-            }
-
-            // 4
-            if let (None, Some(to_trusted_dependencies)) = (
-                from_lockfile.trusted_dependencies.as_ref(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // add all to trusted dependencies, even if they exist in default because they weren't in the
-                // lockfile originally
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    summary.added_trusted_dependencies.put(
-                        to_trusted,
-                        AddedTrustedDependency {
-                            add_to_lockfile: true,
-                            name: to_name.clone(),
-                        },
-                    )?;
-                }
-
-                {
-                    // removed
-                    // none
-                }
-
-                break 'trusted_dependencies;
-            }
-        }
-
-        summary.patched_dependencies_changed = 'patched_dependencies_changed: {
-            if from_lockfile.patched_dependencies.count()
-                != to_lockfile.patched_dependencies.count()
-            {
-                break 'patched_dependencies_changed true;
-            }
-            let iter = to_lockfile.patched_dependencies.iterator();
-            for entry in iter {
-                if let Some(val) = from_lockfile.patched_dependencies.get(&*entry.key_ptr) {
-                    if val
-                        .path
-                        .slice(from_lockfile.buffers.string_bytes.as_slice())
-                        != entry
-                            .value_ptr
-                            .path
-                            .slice(to_lockfile.buffers.string_bytes.as_slice())
-                    {
-                        break 'patched_dependencies_changed true;
-                    }
-                } else {
-                    break 'patched_dependencies_changed true;
-                }
-            }
-            for key in from_lockfile.patched_dependencies.keys() {
-                if !to_lockfile.patched_dependencies.contains(key) {
-                    break 'patched_dependencies_changed true;
-                }
-            }
-            false
-        };
-
         let mut missing_workspaces: Vec<PackageID> = Vec::new();
         let mut survivors: Vec<(String, DependencySlice)> = Vec::new();
         for (i, from_dep) in from_deps.iter().enumerate() {
@@ -1442,118 +1313,13 @@ impl Diff {
                     }
                 }
 
+                // Edges onto workspace members stay mapped even when the member
+                // changed: `diff_workspace_members` below reports it, and the
+                // install re-reads the member into the same package id.
                 if let Some(mapping) = id_mapping.as_deref_mut() {
-                    let mut workspace_hooks_only = false;
-                    let update_mapping = 'update_mapping: {
-                        if !is_root || !from_dep.behavior.is_workspace() {
-                            break 'update_mapping true;
-                        }
-
-                        let Some(workspace_path) = to_lockfile
-                            .workspace_paths
-                            .get(&from_dep.name_hash)
-                            .copied()
-                        else {
-                            break 'update_mapping false;
-                        };
-
-                        let mut package_json_path: AutoAbsPath = AutoAbsPath::init_top_level_dir();
-                        // defer package_json_path.deinit(); — Drop handles it
-
-                        let _ = package_json_path.append(
-                            workspace_path.slice(to_lockfile.buffers.string_bytes.as_slice()),
-                        );
-                        let _ = package_json_path.append(b"package.json");
-
-                        // `bun.sys.File.toSource` was removed from
-                        // T1 (`bun_sys`) because `bun_ast::Source` lives in T2.
-                        // Route through the workspace cache's path-based getter
-                        // instead, which both reads and parses.
-                        let mut workspace_pkg = Package::default();
-
-                        // The cache entry borrows `pm.workspace_package_json_cache`;
-                        // capture a stable BACKREF to its `source` so the
-                        // `&mut pm` reborrow below doesn't conflict. The entry
-                        // lives in a `StringHashMap` whose backing storage is
-                        // not touched by `parse_with_json`.
-                        let (source_ref, json_root): (bun_ptr::ParentRef<bun_ast::Source>, Expr) =
-                            match pm
-                                .workspace_package_json_cache
-                                .get_with_path(
-                                    &mut *log,
-                                    package_json_path.slice(),
-                                    Default::default(),
-                                )
-                                .unwrap()
-                            {
-                                Ok(entry) => (bun_ptr::ParentRef::new(&entry.source), entry.root),
-                                Err(_) => break 'update_mapping false,
-                            };
-                        // BACKREF — entry storage is stable for the remainder
-                        // of this block (see note above).
-                        let source = source_ref.get();
-
-                        let mut resolver: () = ();
-                        workspace_pkg.parse_with_json::<()>(
-                            to_lockfile,
-                            pm,
-                            log,
-                            source,
-                            json_root,
-                            &mut resolver,
-                            Features::WORKSPACE,
-                        )?;
-
-                        // `parse_with_json` may have grown `to_lockfile.buffers
-                        // .dependencies` — re-derive the slice.
-                        to_deps = to
-                            .dependencies
-                            .get(to_lockfile.buffers.dependencies.as_slice())
-                            .into();
-                        survivors.push((workspace_pkg.name, workspace_pkg.dependencies));
-
-                        let from_pkg = from_lockfile.packages.get(from_resolutions[i] as usize);
-                        let diff = Self::generate_inner(
-                            pm,
-                            log,
-                            from_lockfile,
-                            to_lockfile,
-                            &from_pkg,
-                            &workspace_pkg,
-                            update_requests,
-                            None,
-                            removed_names,
-                        )?;
-
-                        if pm.options.log_level.is_verbose()
-                            && (diff.add + diff.remove + diff.update) > 0
-                        {
-                            bun_core::pretty_errorln!(
-                                "Workspace package \"{}\" has added <green>{}<r> dependencies, removed <red>{}<r> dependencies, and updated <cyan>{}<r> dependencies",
-                                bstr::BStr::new(
-                                    workspace_path
-                                        .slice(to_lockfile.buffers.string_bytes.as_slice())
-                                ),
-                                diff.add,
-                                diff.remove,
-                                diff.update,
-                            );
-                        }
-
-                        workspace_hooks_only = !diff.changes_dependencies();
-                        !diff.changes_resolutions()
-                    };
-
-                    if update_mapping {
-                        mapping[cur_to_i] = i as PackageID;
-                        continue;
-                    }
-                    if workspace_hooks_only {
-                        summary.script_only_updates += 1;
-                    }
-                } else {
-                    continue;
+                    mapping[cur_to_i] = i as PackageID;
                 }
+                continue;
             }
 
             // Changed literal: keep the locked resolution while it still satisfies the new range (npm's sticky rule), unless this row is being updated.
@@ -1599,6 +1365,17 @@ impl Diff {
                 .saturating_sub(summary.remove as usize + summary.pruned_workspaces.len()),
         )) as u32;
         if is_root {
+            summary.root_remove = summary.remove;
+            Self::diff_workspace_members(
+                pm,
+                log,
+                from_lockfile,
+                to_lockfile,
+                update_requests,
+                removed_names,
+                &mut survivors,
+                &mut summary,
+            )?;
             summary.remove = removed_names.len() as u32;
         }
 
@@ -1644,7 +1421,9 @@ impl Diff {
             );
         }
 
-        if from.resolution.tag != ResolutionTag::Root {
+        // Only bun.lockb stores scripts (`filled`); bun.lock reads them from
+        // package.json at install time, so there is nothing to refresh.
+        if from.resolution.tag != ResolutionTag::Root && from.scripts.filled {
             for (to_hook, from_hook) in to.scripts.hooks().iter().zip(from.scripts.hooks().iter()) {
                 if !String::eql(
                     **to_hook,
@@ -1659,7 +1438,287 @@ impl Diff {
             }
         }
 
+        if is_root {
+            Self::compare_trusted_and_patched(from_lockfile, to_lockfile, &mut summary)?;
+        }
+
         Ok(summary)
+    }
+
+    /// The lockfile-wide sections that depend on the members having been
+    /// parsed: `to_lockfile` only holds every workspace's trusted dependencies
+    /// after `diff_workspace_members`.
+    fn compare_trusted_and_patched(
+        from_lockfile: &mut Lockfile,
+        to_lockfile: &Lockfile,
+        summary: &mut DiffSummary,
+    ) -> crate::Result<()> {
+        'trusted_dependencies: {
+            // trusted dependency diff
+            //
+            // situations:
+            // 1 - Both old lockfile and new lockfile use default trusted dependencies, no diffs
+            // 2 - Both exist, only diffs are from additions and removals
+            //
+            // 3 - Old lockfile has trusted dependencies, new lockfile does not. Added are dependencies
+            //     from default list that didn't exist previously. We need to be careful not to add these
+            //     to the new lockfile. Removed are dependencies from old list that
+            //     don't exist in the default list.
+            //
+            // 4 - Old lockfile used the default list, new lockfile has trusted dependencies. Added
+            //     are dependencies are all from the new lockfile. Removed is empty because the default
+            //     list isn't appended to the lockfile.
+
+            // 1
+            if from_lockfile.trusted_dependencies.is_none()
+                && to_lockfile.trusted_dependencies.is_none()
+            {
+                break 'trusted_dependencies;
+            }
+
+            // 2
+            if let (Some(from_trusted_dependencies), Some(to_trusted_dependencies)) = (
+                from_lockfile.trusted_dependencies.as_mut(),
+                to_lockfile.trusted_dependencies.as_ref(),
+            ) {
+                let mut added: Vec<(TruncatedPackageNameHash, &[u8])> = Vec::new();
+                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
+                    // Empty name = legacy bun.lockb hash-only sentinel.
+                    let already_trusted = from_trusted_dependencies
+                        .get_mut(&to_trusted)
+                        .is_some_and(|from_name| {
+                            if from_name.is_empty() && !to_name.is_empty() {
+                                from_name.clone_from(to_name);
+                            }
+                            from_name.is_empty() || to_name.is_empty() || **from_name == **to_name
+                        });
+                    if !already_trusted {
+                        added.push((to_trusted, &**to_name));
+                    }
+                }
+
+                // removed
+                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
+                    let still_trusted =
+                        to_trusted_dependencies
+                            .get(&from_trusted)
+                            .is_some_and(|to_name| {
+                                from_name.is_empty()
+                                    || to_name.is_empty()
+                                    || **to_name == **from_name
+                            });
+                    if !still_trusted {
+                        summary
+                            .removed_trusted_dependencies
+                            .put(from_trusted, from_name.clone())?;
+                    }
+                }
+
+                Self::add_stored_trusted_dependencies(from_lockfile, summary, &added)?;
+
+                break 'trusted_dependencies;
+            }
+
+            // 3
+            if let (Some(from_trusted_dependencies), None) = (
+                from_lockfile.trusted_dependencies.as_ref(),
+                to_lockfile.trusted_dependencies.as_ref(),
+            ) {
+                // added
+                for entry in default_trusted_dependencies::entries() {
+                    if !from_trusted_dependencies
+                        .contains(&(entry.hash as TruncatedPackageNameHash))
+                    {
+                        // although this is a new trusted dependency, it is from the default
+                        // list so it shouldn't be added to the lockfile
+                        summary.added_trusted_dependencies.put(
+                            entry.hash as TruncatedPackageNameHash,
+                            AddedTrustedDependency {
+                                add_to_lockfile: false,
+                                name: Box::from(entry.key),
+                            },
+                        )?;
+                    }
+                }
+
+                // removed
+                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
+                    if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
+                        summary
+                            .removed_trusted_dependencies
+                            .put(from_trusted, from_name.clone())?;
+                    }
+                }
+
+                break 'trusted_dependencies;
+            }
+
+            // 4
+            if let (None, Some(to_trusted_dependencies)) = (
+                from_lockfile.trusted_dependencies.as_ref(),
+                to_lockfile.trusted_dependencies.as_ref(),
+            ) {
+                // add all to trusted dependencies, even if they exist in default because they weren't in the
+                // lockfile originally
+                let added: Vec<(TruncatedPackageNameHash, &[u8])> = to_trusted_dependencies
+                    .iter()
+                    .map(|(&to_trusted, to_name)| (to_trusted, &**to_name))
+                    .collect();
+                Self::add_stored_trusted_dependencies(from_lockfile, summary, &added)?;
+                summary.trusted_dependencies_declared = true;
+
+                break 'trusted_dependencies;
+            }
+        }
+
+        summary.patched_dependencies_changed = 'patched_dependencies_changed: {
+            for (key, from_patch) in from_lockfile.patched_dependencies.iter() {
+                let Some(to_patch) = to_lockfile.patched_dependencies.get(key) else {
+                    break 'patched_dependencies_changed true;
+                };
+                if from_patch
+                    .path
+                    .slice(from_lockfile.buffers.string_bytes.as_slice())
+                    != to_patch
+                        .path
+                        .slice(to_lockfile.buffers.string_bytes.as_slice())
+                {
+                    break 'patched_dependencies_changed true;
+                }
+            }
+            // Additions only count if bun.lock would store them.
+            from_lockfile.stores_any_patched_dependency(&to_lockfile.patched_dependencies, |key| {
+                !from_lockfile.patched_dependencies.contains(&key)
+            })
+        };
+
+        Ok(())
+    }
+
+    /// bun.lock only stores the trusted dependencies that name something in
+    /// the lockfile, so only those count as added; the rest would be reported
+    /// on every install. Names already in the lockfile are stored either way.
+    fn add_stored_trusted_dependencies(
+        from_lockfile: &Lockfile,
+        summary: &mut DiffSummary,
+        added: &[(TruncatedPackageNameHash, &[u8])],
+    ) -> crate::Result<()> {
+        for &(name_hash, name) in added {
+            if !from_lockfile.stores_trusted_dependency(name) {
+                continue;
+            }
+            summary.added_trusted_dependencies.put(
+                name_hash,
+                AddedTrustedDependency {
+                    add_to_lockfile: true,
+                    name: Box::from(name),
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Compares every workspace member in the lockfile against its current
+    /// package.json, however the root ends up depending on it (its `workspaces`
+    /// entry, an override, or only through another member).
+    fn diff_workspace_members(
+        pm: &mut PackageManager,
+        log: &mut bun_ast::Log,
+        from_lockfile: &mut Lockfile,
+        to_lockfile: &mut Lockfile,
+        update_requests: Option<&[UpdateRequest]>,
+        removed_names: &mut Vec<PackageNameHash>,
+        survivors: &mut Vec<(String, DependencySlice)>,
+        summary: &mut DiffSummary,
+    ) -> crate::Result<()> {
+        for package_id in 0..from_lockfile.packages.len() {
+            let from_pkg = from_lockfile.packages.get(package_id);
+            if from_pkg.resolution.tag != ResolutionTag::Workspace {
+                continue;
+            }
+            // Not declared by the current manifests (removed, or not on disk):
+            // the root loop has already dealt with its edge.
+            let Some(workspace_path) = to_lockfile
+                .workspace_paths
+                .get(&from_pkg.name_hash)
+                .copied()
+            else {
+                continue;
+            };
+
+            let mut package_json_path: AutoAbsPath = AutoAbsPath::init_top_level_dir();
+            let _ = package_json_path
+                .append(workspace_path.slice(to_lockfile.buffers.string_bytes.as_slice()));
+            let _ = package_json_path.append(b"package.json");
+
+            // The cache entry borrows `pm.workspace_package_json_cache`;
+            // capture a stable BACKREF to its `source` so the `&mut pm`
+            // reborrow below doesn't conflict. The entry lives in a
+            // `StringHashMap` whose backing storage is not touched by
+            // `parse_with_json`.
+            let parsed: Option<(bun_ptr::ParentRef<bun_ast::Source>, Expr)> = pm
+                .workspace_package_json_cache
+                .get_with_path(&mut *log, package_json_path.slice(), Default::default())
+                .unwrap()
+                .ok()
+                .map(|entry| (bun_ptr::ParentRef::new(&entry.source), entry.root));
+
+            let diff = match parsed {
+                Some((source_ref, json_root)) => {
+                    let mut workspace_pkg = Package::default();
+                    let mut resolver: () = ();
+                    workspace_pkg.parse_with_json::<()>(
+                        to_lockfile,
+                        pm,
+                        log,
+                        source_ref.get(),
+                        json_root,
+                        &mut resolver,
+                        Features::WORKSPACE,
+                    )?;
+                    survivors.push((workspace_pkg.name, workspace_pkg.dependencies));
+                    Self::generate_inner(
+                        pm,
+                        log,
+                        from_lockfile,
+                        to_lockfile,
+                        &from_pkg,
+                        &workspace_pkg,
+                        update_requests,
+                        None,
+                        removed_names,
+                    )?
+                }
+                // Unreadable package.json: re-resolving the member reports the error.
+                None => DiffSummary {
+                    update: 1,
+                    ..Default::default()
+                },
+            };
+            if !diff.changes_resolutions() {
+                continue;
+            }
+
+            let path = workspace_path.slice(to_lockfile.buffers.string_bytes.as_slice());
+            if pm.options.log_level.is_verbose() {
+                bun_core::pretty_errorln!(
+                    "Workspace package \"{}\" has added <green>{}<r> dependencies, removed <red>{}<r> dependencies, and updated <cyan>{}<r> dependencies",
+                    bstr::BStr::new(path),
+                    diff.add,
+                    diff.remove,
+                    diff.update,
+                );
+            }
+            summary.changed_workspaces.push(WorkspaceDiff {
+                package_id: package_id as PackageID,
+                path: Box::from(path),
+                add: diff.add,
+                remove: diff.remove,
+                update: diff.update,
+                dependencies_changed: diff.changes_dependencies(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -525,6 +525,17 @@ impl Stringifier {
                                 found_trusted_dependencies.insert(dep.name_hash, dep.name);
                             }
                         }
+                        // `has_trusted_dependency` checks an npm package under its
+                        // own name, which differs from `dep.name` behind an `npm:` alias.
+                        if res.tag == ResolutionTag::Npm {
+                            if let Some(trusted_name) = trusted_dependencies
+                                .get(&(pkg_name_hash as TruncatedPackageNameHash))
+                            {
+                                if **trusted_name == *pkg_name.slice(buf) {
+                                    found_trusted_dependencies.insert(pkg_name_hash, pkg_name);
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -533,17 +544,24 @@ impl Stringifier {
 
             tree_sort_buf.sort_by(tree_sort_is_less_than);
 
-            if found_trusted_dependencies.len() > 0 {
+            // The field being present is what turns the default trusted list
+            // off, so it is written even when none of its names made it into
+            // the tree (bun.lockb has HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG for this).
+            if lockfile.trusted_dependencies.is_some() {
                 Self::write_indent(writer, *indent)?;
-                writer.write_all(b"\"trustedDependencies\": [\n")?;
-                *indent += 1;
-                for dep_name in found_trusted_dependencies.values() {
-                    Self::write_indent(writer, *indent)?;
-                    writeln!(writer, "\"{}\",", bstr::BStr::new(dep_name.slice(buf)))?;
-                }
+                if found_trusted_dependencies.len() == 0 {
+                    writer.write_all(b"\"trustedDependencies\": [],\n")?;
+                } else {
+                    writer.write_all(b"\"trustedDependencies\": [\n")?;
+                    *indent += 1;
+                    for dep_name in found_trusted_dependencies.values() {
+                        Self::write_indent(writer, *indent)?;
+                        writeln!(writer, "\"{}\",", bstr::BStr::new(dep_name.slice(buf)))?;
+                    }
 
-                Self::dec_indent(writer, indent)?;
-                writer.write_all(b"],\n")?;
+                    Self::dec_indent(writer, indent)?;
+                    writer.write_all(b"],\n")?;
+                }
             }
 
             if found_patched_dependencies.len() > 0 {
@@ -1849,6 +1867,9 @@ pub(crate) fn parse_into_binary_lockfile(
     mut manager: Option<&mut PackageManager>,
 ) -> Result<(), ParseError> {
     lockfile.init_empty();
+    let link_workspace_packages = manager
+        .as_deref()
+        .is_none_or(|manager| manager.options.link_workspace_packages);
 
     let Some(lockfile_version_expr) = root.get(b"lockfileVersion") else {
         log.add_error(Some(source), root.loc, b"Missing lockfile version");
@@ -2388,7 +2409,10 @@ pub(crate) fn parse_into_binary_lockfile(
             &mut optional_peers_buf,
             None,
             None,
-            Some(&workspaces_obj),
+            Some(RootWorkspaces {
+                workspaces_obj: &workspaces_obj,
+                link_workspace_packages,
+            }),
             true,
         )?;
 
@@ -3051,10 +3075,6 @@ pub(crate) fn parse_into_binary_lockfile(
             .resize(lockfile.buffers.dependencies.len(), invalid_package_id);
         lockfile.buffers.resolutions.fill(invalid_package_id);
 
-        // a package can list the same dependency in each dependnecy group, but only the first
-        // is chosen (dev -> optional -> prod -> peer)
-        let mut seen_deps: bun_collections::StringArrayHashMap<()> = Default::default();
-
         // The two `[0]` writes are done first via
         // sequential `&mut` accessors so the loops can take all column views
         // immutably without overlapping exclusive borrows or `unsafe`.
@@ -3073,6 +3093,7 @@ pub(crate) fn parse_into_binary_lockfile(
         let package_index = &lockfile.package_index;
         let overrides = &lockfile.overrides;
         let catalogs: &CatalogMap = &lockfile.catalogs;
+        let workspace_versions = &lockfile.workspace_versions;
 
         // Disjoint-field split of `lockfile.buffers` so each loop body can hold
         // `&mut dependencies[i]` and `&mut resolutions[i]` together with a shared
@@ -3113,22 +3134,17 @@ pub(crate) fn parse_into_binary_lockfile(
                     return Err(ParseError::InvalidPackageInfo);
                 };
 
-                if !dep.behavior.is_workspace()
-                    && seen_deps
-                        .get_or_put(dep.name.slice(string_buf))?
-                        .found_existing
-                {
-                    resolutions[dep_id as usize] = res_id;
-                    continue;
-                }
-
-                map_dep_to_pkg(
+                map_manifest_dep_to_pkg(
                     dep,
                     dep_id,
                     res_id,
                     resolutions,
                     lockfile_version,
                     pkg_resolutions,
+                    overrides,
+                    workspace_versions,
+                    link_workspace_packages,
+                    string_buf,
                 );
             }
         }
@@ -3140,8 +3156,6 @@ pub(crate) fn parse_into_binary_lockfile(
             for _pkg_id in workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len {
                 let pkg_id: PackageID = _pkg_id;
                 let workspace_name = pkg_names[pkg_id as usize].slice(string_buf);
-
-                seen_deps.clear_retaining_capacity();
 
                 let deps = pkg_deps[pkg_id as usize];
                 for _dep_id in deps.begin()..deps.end() {
@@ -3198,18 +3212,17 @@ pub(crate) fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    if seen_deps.get_or_put(dep_name)?.found_existing {
-                        resolutions[dep_id as usize] = res_id;
-                        continue;
-                    }
-
-                    map_dep_to_pkg(
+                    map_manifest_dep_to_pkg(
                         dep,
                         dep_id,
                         res_id,
                         resolutions,
                         lockfile_version,
                         pkg_resolutions,
+                        overrides,
+                        workspace_versions,
+                        link_workspace_packages,
+                        string_buf,
                     );
                 }
             }
@@ -3432,6 +3445,64 @@ pub(crate) fn resolve_peer_dep_version_based(
     None
 }
 
+/// Root and workspace edges are diffed against a fresh parse of their
+/// package.json, so an edge resolved to a workspace package is tagged as a
+/// workspace dependency only where `Package::parse_dependency` tags it too:
+/// `workspace:` specifiers, and npm ranges satisfied by the workspace version
+/// the lockfile recorded (peers, overridden edges and `*` on a versionless
+/// workspace reach a workspace without that and stay npm-tagged). With linking
+/// disabled the parser links nothing, so a plain range that still points at a
+/// workspace is stale; tagging it makes the differ re-resolve it.
+///
+/// Edges of npm packages are not diffed and go through `map_dep_to_pkg`.
+fn map_manifest_dep_to_pkg(
+    dep: &mut Dependency,
+    dep_id: DependencyID,
+    pkg_id: PackageID,
+    resolutions: &mut [PackageID],
+    text_lockfile_version: Version,
+    pkg_resolutions: &[Resolution],
+    overrides: &OverrideMap,
+    workspace_versions: &VersionHashMap,
+    link_workspace_packages: bool,
+    string_buf: &[u8],
+) {
+    let tag_as_workspace = match dep.version.tag {
+        DependencyVersionTag::Workspace => true,
+        DependencyVersionTag::Npm => {
+            let npm = dep.version.npm();
+            if link_workspace_packages {
+                // Like the parser, an `npm:` alias is matched against the
+                // workspace it points at, not the alias name.
+                let name_hash = if npm.is_alias {
+                    StringBuilder::string_hash(npm.name.slice(string_buf))
+                } else {
+                    dep.name_hash
+                };
+                workspace_versions
+                    .get(&name_hash)
+                    .is_some_and(|version| npm.version.satisfies(*version, string_buf, string_buf))
+            } else {
+                !dep.behavior.is_peer() && (npm.is_alias || !overrides.map.contains(&dep.name_hash))
+            }
+        }
+        _ => false,
+    };
+
+    if tag_as_workspace {
+        map_dep_to_pkg(
+            dep,
+            dep_id,
+            pkg_id,
+            resolutions,
+            text_lockfile_version,
+            pkg_resolutions,
+        );
+    } else {
+        resolutions[dep_id as usize] = pkg_id;
+    }
+}
+
 // Taking `&mut BinaryLockfile` plus a `&mut Dependency` that
 // points into `lockfile.buffers.dependencies` would be illegal aliasing.
 // The function only touches `buffers.resolutions[dep_id]` and reads
@@ -3514,6 +3585,13 @@ fn dependency_resolution_failure(
     Ok(())
 }
 
+/// What `parse_append_dependencies::<_, true>` needs to give the root its
+/// edges to the workspace members.
+struct RootWorkspaces<'a> {
+    workspaces_obj: &'a Expr,
+    link_workspace_packages: bool,
+}
+
 // A separate `string_buf` parameter would borrow the same
 // `lockfile.buffers.string_bytes` / `string_pool` fields and alias `lockfile`.
 // Instead each append constructs a fresh `sbuf!(lockfile)` so the borrow
@@ -3528,7 +3606,8 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     // Only meaningful when `CHECK_FOR_BUNDLED`; carried as Option.
     pkg_path: Option<&[u8]>,
     bundled_pkgs: Option<&PkgPathSet>,
-    workspaces_obj: Option<&Expr>,
+    // Only meaningful when `IS_ROOT`.
+    root_workspaces: Option<RootWorkspaces<'_>>,
     catalogs_apply: bool,
 ) -> Result<(u32, u32), ParseError> {
     // Clearing on entry is equivalent to clearing on every exit path for all
@@ -3663,7 +3742,10 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     }
 
     if IS_ROOT {
-        let workspaces_obj = workspaces_obj.expect("workspaces_obj required when IS_ROOT");
+        let RootWorkspaces {
+            workspaces_obj,
+            link_workspace_packages,
+        } = root_workspaces.expect("root_workspaces required when IS_ROOT");
         'workspaces: for workspace_path in lockfile.workspace_paths.values() {
             for row in object_rows(workspaces_obj) {
                 let path = row.key.slice();
@@ -3681,6 +3763,27 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .as_utf8_string_literal()
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
+
+                // `Package::parse_dependency` replaces this edge with the root's own
+                // entry for the member when that entry is an npm range it does not link.
+                if let Some(&workspace_version) = lockfile.workspace_versions.get(&name_hash) {
+                    let string_buf = lockfile.buffers.string_bytes.as_slice();
+                    let replaced = lockfile.buffers.dependencies[off..].iter().any(|dep| {
+                        dep.version.tag == DependencyVersionTag::Npm && {
+                            let npm = dep.version.npm();
+                            StringBuilder::string_hash(npm.name.slice(string_buf)) == name_hash
+                                && !(link_workspace_packages
+                                    && npm.version.satisfies(
+                                        workspace_version,
+                                        string_buf,
+                                        string_buf,
+                                    ))
+                        }
+                    });
+                    if replaced {
+                        continue 'workspaces;
+                    }
+                }
 
                 let dep = Dependency {
                     name: sbuf!(lockfile).append_with_hash(name, name_hash)?,

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -863,5 +863,44 @@ pub(crate) fn load(
 
     debug_assert!(stream.pos as u64 == total_buffer_size);
 
+    restore_workspace_dependency_paths(lockfile);
+
     Ok(res)
+}
+
+/// bun.lockb stores an edge as tag plus literal, so a workspace edge reloads holding
+/// the literal's value (`*`), while a fresh parse of the manifest holds the member's
+/// path, which is what `Version::eql` compares. Point the edges of the root and
+/// workspace packages back at the path of the member they resolved to.
+fn restore_workspace_dependency_paths(lockfile: &mut Lockfile) {
+    let packages = lockfile.packages.slice();
+    let package_resolutions = packages.items_resolution();
+    let package_dependencies = packages.items_dependencies();
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+    let dependencies = lockfile.buffers.dependencies.as_mut_slice();
+
+    for (dependency_slice, resolution) in package_dependencies.iter().zip(package_resolutions) {
+        if !matches!(
+            resolution.tag,
+            ResolutionTag::Root | ResolutionTag::Workspace
+        ) {
+            continue;
+        }
+        for dep_id in dependency_slice.begin() as usize..dependency_slice.end() as usize {
+            let dep = &mut dependencies[dep_id];
+            if dep.version.tag != dependency::Tag::Workspace {
+                continue;
+            }
+            let Some(target) = resolutions
+                .get(dep_id)
+                .and_then(|&package_id| package_resolutions.get(package_id as usize))
+            else {
+                continue;
+            };
+            if target.tag != ResolutionTag::Workspace {
+                continue;
+            }
+            dep.version.value.workspace = *target.workspace();
+        }
+    }
 }

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -69,7 +69,7 @@ where
             w.write(info.name.slice(sb))?;
 
             w.object_field(b"tag")?;
-            w.write(info.name.slice(sb))?;
+            w.write(info.tag.slice(sb))?;
 
             let _ = w.end_object();
         }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -776,20 +776,16 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             let path_str = sbuf!(lockfile).append(importer_path)?;
             lockfile.workspace_paths.put(name_hash, path_str)?;
 
-            if let Some(version_expr) = value.get(b"version") {
-                let Some(version_raw) = as_string(&version_expr) else {
-                    return Err(invalid_pnpm_lockfile());
-                };
+            // pnpm-lock.yaml does not record importer versions; bun.lock does,
+            // and the loader needs them to tell linked ranges apart.
+            if let Some((version_raw, _)) = get_string(workspace_root, b"version") {
                 let version_str = sbuf!(lockfile).append(version_raw)?;
-
                 let parsed = semver::Version::parse(version_str.sliced(string_bytes!(lockfile)));
-                if !parsed.valid {
-                    return Err(invalid_pnpm_lockfile());
+                if parsed.valid && parsed.wildcard == semver::query::token::Wildcard::None {
+                    lockfile
+                        .workspace_versions
+                        .put(name_hash, parsed.version.min())?;
                 }
-
-                lockfile
-                    .workspace_versions
-                    .put(name_hash, parsed.version.min())?;
             }
         }
 

--- a/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
@@ -352,3 +352,24 @@ what-bin@1.0.0:
   integrity sha512-sa99On1k5aDqCvpni/TQ6rLzYprUWBlb8fNwWOzbjDlM24fRr7FKDOuaBO/Y9WEIcZuzoPkCW5EkBCpflj8REQ==
 "
 `;
+
+exports[`text lockfile --frozen-lockfile fails when package.json gains a direct dependency that is already resolved transitively 1`] = `
+"{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "foo",
+      "dependencies": {
+        "one-dep": "1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "no-deps": ["no-deps@1.0.1", "http://localhost:1234/no-deps/-/no-deps-1.0.1.tgz", {}, "sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A=="],
+
+    "one-dep": ["one-dep@1.0.0", "http://localhost:1234/one-dep/-/one-dep-1.0.0.tgz", { "dependencies": { "no-deps": "1.0.1" } }, "sha512-qG6lZjwM1vFmRCHwP+XpOKu6FkrBmwr20+54+qaHGdjZlw/wz8aJrhFqX4dZksqmBLZtj2mzL77Yf04WKs1+Kg=="],
+  }
+}
+"
+`;

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -50,7 +50,10 @@ exports[`dependency on workspace without version in package.json: version: * 1`]
     {
       "name": "no-deps",
       "literal": "*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -173,7 +176,10 @@ exports[`dependency on workspace without version in package.json: version: *.*.*
     {
       "name": "no-deps",
       "literal": "*.*.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -296,7 +302,10 @@ exports[`dependency on workspace without version in package.json: version: =* 1`
     {
       "name": "no-deps",
       "literal": "=*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -419,7 +428,10 @@ exports[`dependency on workspace without version in package.json: version: kjwoe
     {
       "name": "no-deps",
       "literal": "kjwoehcojrgjoj",
-      "workspace": "packages/mono",
+      "dist_tag": {
+        "name": "no-deps",
+        "tag": "no-deps"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -542,7 +554,10 @@ exports[`dependency on workspace without version in package.json: version: *.1.*
     {
       "name": "no-deps",
       "literal": "*.1.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -665,7 +680,10 @@ exports[`dependency on workspace without version in package.json: version: *-pre
     {
       "name": "no-deps",
       "literal": "*-pre",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -430,7 +430,7 @@ exports[`dependency on workspace without version in package.json: version: kjwoe
       "literal": "kjwoehcojrgjoj",
       "dist_tag": {
         "name": "no-deps",
-        "tag": "no-deps"
+        "tag": "kjwoehcojrgjoj"
       },
       "package_id": 2,
       "behavior": {
@@ -1758,7 +1758,7 @@ exports[`dependency on workspace without version in package.json: version: lates
       "literal": "latest",
       "dist_tag": {
         "name": "no-deps",
-        "tag": "no-deps"
+        "tag": "latest"
       },
       "package_id": 3,
       "behavior": {
@@ -1914,7 +1914,7 @@ exports[`dependency on workspace without version in package.json: version:  1`] 
       "literal": "",
       "dist_tag": {
         "name": "no-deps",
-        "tag": "no-deps"
+        "tag": "latest"
       },
       "package_id": 3,
       "behavior": {
@@ -2070,7 +2070,7 @@ exports[`dependency on same name as workspace and dist-tag: with version 1`] = `
       "literal": "latest",
       "dist_tag": {
         "name": "no-deps",
-        "tag": "no-deps"
+        "tag": "latest"
       },
       "package_id": 3,
       "behavior": {

--- a/test/cli/install/__snapshots__/migrate-bun-lockb-v2.test.ts.snap
+++ b/test/cli/install/__snapshots__/migrate-bun-lockb-v2.test.ts.snap
@@ -860,7 +860,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "literal": "workspace:",
       "name": "pkg-wat-2",
       "package_id": 42,
-      "workspace": "",
+      "workspace": "packages/pkg2",
     },
   ],
   "format": "v3",

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -1356,6 +1356,46 @@ describe("`bun audit fix`", () => {
     await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
   });
 
+  // bun.lock only records the patchedDependencies entries that match an
+  // installed version, so this one is in package.json alone until the fix
+  // installs the version it is for. package.json has not changed since the
+  // last install, which is also the case where it has to be applied.
+  test.concurrent("applies the patchedDependencies entry written for the version it installs", async () => {
+    await using server = startRegistry({ "no-deps": [adv("<1.0.1")] });
+    const patchedDependencies = { "no-deps@1.0.1": "patches/no-deps@1.0.1.patch" };
+    using dir = await setup(
+      server,
+      { name: "foo", dependencies: { "one-range-dep": "1.0.0", "no-deps": "1.0.0" }, patchedDependencies },
+      {
+        "patches/no-deps@1.0.1.patch": `diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@ -1,4 +1,5 @@
+ {
+     "name": "no-deps",
++    "patched": true,
+     "version": "1.0.1"
+ }
+`,
+      },
+    );
+    await reinstall(dir, { name: "foo", dependencies: { "one-range-dep": "1.0.0" }, patchedDependencies });
+    let lockfile = await lock(dir);
+    expect(lockfile).toContain('"no-deps@1.0.0"');
+    expect(lockfile).not.toContain("patchedDependencies");
+
+    const { stdout, stderr, exitCode } = await auditFix(dir);
+    expect(stdout).toContain("  ^ no-deps 1.0.0 -> 1.0.1");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(await pkgJson(dir, "node_modules", "no-deps")).toEqual({ name: "no-deps", patched: true, version: "1.0.1" });
+
+    lockfile = await lock(dir);
+    expect(lockfile).toContain('"no-deps@1.0.1": "patches/no-deps@1.0.1.patch"');
+
+    await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
+  });
+
   test.concurrent("reports a fix that would violate a dependent's range and changes nothing", async () => {
     const bulkHits = { count: 0 };
     await using server = startRegistry({ "no-deps": [adv("<1.1.0")] }, { bulkHits });

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -751,6 +751,699 @@ describe("text lockfile", () => {
     expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
   });
 
+  test("--frozen-lockfile fails when package.json gains a direct dependency that is already resolved transitively", async () => {
+    // one-dep@1.0.0 depends on no-deps@1.0.1, so no-deps is in the lock as a
+    // transitive. Adding no-deps as a direct dependency must fail under
+    // --frozen-lockfile even though the hoisted tree is unchanged.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "one-dep": "1.0.0" },
+      }),
+    );
+
+    let { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    let err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    const firstLockfile = await Bun.file(join(packageDir, "bun.lock")).text();
+    expect(firstLockfile).toContain('"no-deps":');
+    expect(firstLockfile.replace(/localhost:\d+/g, "localhost:1234")).toMatchSnapshot();
+
+    // Add no-deps as a direct dependency: the name is already in bun.lock's
+    // packages map but NOT in workspaces."".dependencies.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "one-dep": "1.0.0", "no-deps": "1.0.1" },
+      }),
+    );
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(err).toContain(
+      "note: dependencies in package.json changed since bun.lock was saved (1 added, 0 removed, 0 updated)",
+    );
+    // bun.lock must not be rewritten on a failed frozen install
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
+    expect(await exited).toBe(1);
+
+    // A plain install would rewrite the lock (proves the lock really was stale).
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).not.toBe(firstLockfile);
+    expect(await exited).toBe(0);
+
+    // And once bun.lock is in sync, --frozen-lockfile succeeds again.
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  });
+
+  test("--frozen-lockfile fails when a direct dependency present transitively is removed", async () => {
+    // The inverse: removing a direct dep whose package stays in the tree via a
+    // transitive edge must also fail frozen.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "one-dep": "1.0.0", "no-deps": "1.0.1" },
+      }),
+    );
+
+    let { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    let err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    const firstLockfile = await Bun.file(join(packageDir, "bun.lock")).text();
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "one-dep": "1.0.0" },
+      }),
+    );
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
+    expect(await exited).toBe(1);
+  });
+
+  // https://github.com/oven-sh/bun/issues/24223
+  test("--frozen-lockfile fails when a dependency's version literal changes but the locked resolution still satisfies it", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "no-deps": "^1.0.0" },
+      }),
+    );
+
+    let { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    let err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    const firstLockfile = await Bun.file(join(packageDir, "bun.lock")).text();
+    expect(await Bun.file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.1.0",
+    });
+
+    // ^1.1.0 is still satisfied by the locked 1.1.0, so the hoisted tree is
+    // unchanged, but the lockfile's stored spec no longer matches.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "no-deps": "^1.1.0" },
+      }),
+    );
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
+    expect(await exited).toBe(1);
+  });
+
+  // https://github.com/oven-sh/bun/issues/22689
+  test("--frozen-lockfile fails when a workspace package.json gains a dependency already resolved by another workspace", async () => {
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["packages/*"],
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg2", "package.json"),
+        JSON.stringify({
+          name: "pkg2",
+        }),
+      ),
+    ]);
+
+    let { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    let err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    const firstLockfile = await Bun.file(join(packageDir, "bun.lock")).text();
+
+    // pkg2 now also depends on no-deps@1.0.0, which is already in the lock via pkg1.
+    await write(
+      join(packageDir, "packages", "pkg2", "package.json"),
+      JSON.stringify({
+        name: "pkg2",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(err).toContain(
+      "note: dependencies in packages/pkg2/package.json changed since bun.lock was saved (1 added, 0 removed, 0 updated)",
+    );
+    expect(err).not.toContain("dependencies in package.json");
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
+    expect(await exited).toBe(1);
+  });
+
+  async function install(...args: string[]) {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    return { err, exitCode };
+  }
+
+  // Patches the package.json of no-deps@1.0.0.
+  const noDepsPatch = `diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@ -1,4 +1,5 @@
+ {
+     "name": "no-deps",
++    "patched": true,
+     "version": "1.0.0"
+ }
+`;
+
+  /** The dependency literals of the workspace package at `memberDir`, from whichever lockfile is on disk. */
+  function lockedWorkspaceDependencies(memberDir: string): Record<string, string> {
+    const lockfile = parseLockfile(packageDir) as any;
+    const member = lockfile.packages.find((pkg: any) => pkg.resolution.value === `workspace:${memberDir}`);
+    expect(member).toBeDefined();
+    return Object.fromEntries(
+      member.dependencies.map((id: number) => {
+        const dep = lockfile.dependencies.find((dep: any) => dep.id === id);
+        return [dep.name, dep.literal];
+      }),
+    );
+  }
+
+  // Members the root does not depend on through its "workspaces" entry (the
+  // root's own entry for the member wins in the first shape, only a sibling
+  // depends on it in the second) still have to be compared against their
+  // package.json. The dependency each member gains is already in the lockfile
+  // through the root, so nothing but that comparison can notice the change.
+  // The second shape cannot be written as bun.lock yet (the member and the
+  // registry package compete for the same key), so it runs with bun.lockb.
+  for (const [label, files, memberDir, gained, lockfileName, installArgs] of [
+    [
+      "a member kept only by an override on the root's entry for it",
+      {
+        "package.json": {
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0", pkg1: "^9.0.0" },
+          overrides: { pkg1: "workspace:*" },
+        },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0" },
+      },
+      "packages/pkg1",
+      { "no-deps": "1.0.0" },
+      "bun.lock",
+      ["--save-text-lockfile"],
+    ],
+    [
+      "a member only a sibling depends on, while the root depends on its published version",
+      {
+        "package.json": {
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "2.0.0", "a-dep": "1.0.1" },
+        },
+        "packages/a-dep/package.json": { name: "a-dep", version: "9.9.9" },
+        "packages/pkg1/package.json": { name: "pkg1", dependencies: { "a-dep": "workspace:*" } },
+      },
+      "packages/a-dep",
+      { "no-deps": "2.0.0" },
+      "bun.lockb",
+      [],
+    ],
+  ] as const) {
+    test(`--frozen-lockfile fails when ${label} gains a dependency (${lockfileName})`, async () => {
+      await Promise.all(
+        Object.entries(files).map(([path, json]) => write(join(packageDir, path), JSON.stringify(json))),
+      );
+      const memberPackageJson = join(packageDir, memberDir, "package.json");
+
+      let { err, exitCode } = await install(...installArgs);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      const firstLockfile = await file(join(packageDir, lockfileName)).bytes();
+      expect(lockedWorkspaceDependencies(memberDir)).toEqual({});
+
+      ({ err, exitCode } = await install());
+      expect(err).not.toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+
+      await write(
+        memberPackageJson,
+        JSON.stringify({ ...(await file(memberPackageJson).json()), dependencies: gained }),
+      );
+
+      ({ err, exitCode } = await install("--frozen-lockfile"));
+      expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+      expect(err).toContain(
+        `note: dependencies in ${memberDir}/package.json changed since ${lockfileName} was saved (1 added, 0 removed, 0 updated)`,
+      );
+      expect(err).not.toContain("dependencies in package.json");
+      expect(await file(join(packageDir, lockfileName)).bytes()).toEqual(firstLockfile);
+      expect(exitCode).toBe(1);
+
+      ({ err, exitCode } = await install());
+      expect(err).toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+      expect(lockedWorkspaceDependencies(memberDir)).toEqual(gained);
+
+      ({ err, exitCode } = await install("--frozen-lockfile"));
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // trustedDependencies and patchedDependencies are applied from package.json
+  // and are not part of the frozen comparison (turbo prune drops them from
+  // bun.lock), so changing them passes --frozen-lockfile; a plain install then
+  // stores them. `stored` is what bun.lock contains afterwards: declaring
+  // trustedDependencies at all turns the default trusted list off, so the
+  // field is stored even when none of its names are.
+  const patched = { patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" } };
+  for (const [label, change, stored, installedPackageJson] of [
+    [
+      "an installed package added to trustedDependencies",
+      { trustedDependencies: ["no-deps"] },
+      { trustedDependencies: ["no-deps"] },
+      { version: "1.0.0" },
+    ],
+    ["an empty trustedDependencies", { trustedDependencies: [] }, { trustedDependencies: [] }, { version: "1.0.0" }],
+    [
+      "a trustedDependencies naming nothing installed",
+      { trustedDependencies: ["not-a-dependency"] },
+      { trustedDependencies: [] },
+      { version: "1.0.0" },
+    ],
+    ["an installed package added to patchedDependencies", patched, patched, { version: "1.0.0", patched: true }],
+  ] as const) {
+    test(`${label} passes --frozen-lockfile and is stored by the next install`, async () => {
+      const manifest = { name: "foo", dependencies: { "no-deps": "1.0.0" } };
+      await Promise.all([
+        write(packageJson, JSON.stringify(manifest)),
+        write(join(packageDir, "patches", "no-deps@1.0.0.patch"), noDepsPatch),
+      ]);
+
+      let { err, exitCode } = await install("--save-text-lockfile");
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      const firstLockfile = await file(join(packageDir, "bun.lock")).text();
+      expect(firstLockfile).not.toContain(Object.keys(change)[0]);
+
+      await write(packageJson, JSON.stringify({ ...manifest, ...change }));
+
+      ({ err, exitCode } = await install("--frozen-lockfile"));
+      expect(err).not.toContain("error:");
+      expect(await file(join(packageDir, "bun.lock")).text()).toBe(firstLockfile);
+      expect(exitCode).toBe(0);
+
+      ({ err, exitCode } = await install());
+      expect(err).toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+      expect(Bun.JSONC.parse(await file(join(packageDir, "bun.lock")).text())).toMatchObject(stored);
+      expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject(
+        installedPackageJson,
+      );
+
+      ({ err, exitCode } = await install("--frozen-lockfile"));
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // `electron` is on the default trusted list; declaring trustedDependencies
+  // without it must keep its scripts blocked on installs from the lockfile too,
+  // which is only the case if bun.lock records the (effectively empty) field.
+  for (const trustedDependencies of [[], ["not-a-dependency"]]) {
+    test(`trustedDependencies ${JSON.stringify(trustedDependencies)} still disables the default trusted list when installing from bun.lock`, async () => {
+      await write(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies: { electron: "1.0.0" }, trustedDependencies }),
+      );
+      const preinstallMarker = join(packageDir, "node_modules", "electron", "preinstall.txt");
+
+      let { err, exitCode } = await install("--save-text-lockfile");
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await exists(preinstallMarker)).toBeFalse();
+      expect(Bun.JSONC.parse(await file(join(packageDir, "bun.lock")).text())).toMatchObject({
+        trustedDependencies: [],
+      });
+
+      for (const args of [[], ["--frozen-lockfile"]]) {
+        await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+        ({ err, exitCode } = await install(...args));
+        expect(err).not.toContain("error:");
+        expect(err).not.toContain("Saved lockfile");
+        expect(exitCode).toBe(0);
+        expect(await exists(join(packageDir, "node_modules", "electron", "package.json"))).toBeTrue();
+        expect(await exists(preinstallMarker)).toBeFalse();
+      }
+    });
+  }
+
+  // An npm package is trusted under its own name, not under the alias it is
+  // installed as, so that is the name bun.lock has to record: installs from
+  // the lockfile trust what it lists.
+  test("trustedDependencies naming the package behind an npm: alias is stored and stays trusted when installing from bun.lock", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: { "postinstall-alias": "npm:lifecycle-postinstall@1.0.0" },
+        trustedDependencies: ["lifecycle-postinstall"],
+      }),
+    );
+    const postinstallMarker = join(packageDir, "node_modules", "postinstall-alias", "postinstall.txt");
+
+    let { err, exitCode } = await install("--save-text-lockfile");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(await exists(postinstallMarker)).toBeTrue();
+    expect(Bun.JSONC.parse(await file(join(packageDir, "bun.lock")).text())).toMatchObject({
+      trustedDependencies: ["lifecycle-postinstall"],
+    });
+
+    for (const args of [[], ["--frozen-lockfile"]]) {
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      ({ err, exitCode } = await install(...args));
+      expect(err).not.toContain("error:");
+      expect(err).not.toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+      expect(await exists(postinstallMarker)).toBeTrue();
+    }
+  });
+
+  // Stable repos whose lockfile is already up to date: a second install must
+  // not re-save it and --frozen-lockfile must pass. Each of these used to
+  // report a spurious manifest diff on every install with bun.lock, bun.lockb
+  // or both.
+  const upToDateShapes: [string, Record<string, object | string>][] = [
+    [
+      "workspace member depending on a sibling",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", dependencies: { pkg2: "workspace:*" } },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "root depending on workspace members",
+      {
+        "package.json": {
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: { pkg1: "workspace:*" },
+          devDependencies: { pkg2: "^1.0.0" },
+        },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0" },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "root entry for a member that is not linked, kept by an override",
+      {
+        "package.json": {
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: { pkg1: "^9.0.0" },
+          overrides: { pkg1: "workspace:*" },
+        },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0" },
+      },
+    ],
+    [
+      "workspace member with a lifecycle script",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", scripts: { postinstall: "exit 0" } },
+      },
+    ],
+    [
+      "trustedDependencies declared in a workspace member",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": {
+          name: "pkg1",
+          version: "1.0.0",
+          dependencies: { "no-deps": "1.0.0" },
+          trustedDependencies: ["no-deps"],
+        },
+      },
+    ],
+    [
+      "sibling workspace in devDependencies and peerDependencies",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": {
+          name: "pkg1",
+          version: "1.0.0",
+          devDependencies: { pkg2: "workspace:*" },
+          peerDependencies: { pkg2: "*" },
+        },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "sibling workspace linked through npm ranges in two dependency groups",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": {
+          name: "pkg1",
+          version: "1.0.0",
+          devDependencies: { pkg2: "^1.0.0" },
+          peerDependencies: { pkg2: "^1.0.0" },
+        },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "star range on a sibling workspace without a version",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", dependencies: { pkg2: "*" } },
+        "packages/pkg2/package.json": { name: "pkg2" },
+      },
+    ],
+    [
+      "npm: alias of a sibling workspace",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"] },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", dependencies: { renamed: "npm:pkg2@*" } },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "catalog entry pointing at a workspace",
+      {
+        "package.json": { name: "foo", workspaces: { packages: ["packages/*"], catalog: { pkg2: "workspace:*" } } },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", dependencies: { pkg2: "catalog:" } },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "override sending an unsatisfied range to a workspace",
+      {
+        "package.json": { name: "foo", workspaces: ["packages/*"], overrides: { pkg2: "workspace:*" } },
+        "packages/pkg1/package.json": { name: "pkg1", version: "1.0.0", dependencies: { pkg2: "^5.0.0" } },
+        "packages/pkg2/package.json": { name: "pkg2", version: "1.0.0" },
+      },
+    ],
+    [
+      "$reference override",
+      {
+        "package.json": {
+          name: "foo",
+          dependencies: { "no-deps": "^1.0.0", "a-dep": "1.0.1" },
+          overrides: { "a-dep": "$no-deps" },
+        },
+      },
+    ],
+    // bun.lock only stores the entries of these two sections that match a
+    // package in the lockfile.
+    [
+      "trustedDependencies naming a package that is not installed",
+      {
+        "package.json": {
+          name: "foo",
+          dependencies: { "no-deps": "1.0.0" },
+          trustedDependencies: ["no-deps", "not-a-dependency"],
+        },
+      },
+    ],
+    [
+      "trustedDependencies naming only packages that are not installed",
+      {
+        "package.json": {
+          name: "foo",
+          dependencies: { "no-deps": "1.0.0" },
+          trustedDependencies: ["not-a-dependency"],
+        },
+      },
+    ],
+    [
+      "empty trustedDependencies",
+      { "package.json": { name: "foo", dependencies: { "no-deps": "1.0.0" }, trustedDependencies: [] } },
+    ],
+    [
+      "patchedDependencies entry for a version that is not installed",
+      {
+        "package.json": {
+          name: "foo",
+          dependencies: { "no-deps": "1.1.0" },
+          patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" },
+        },
+        "patches/no-deps@1.0.0.patch": noDepsPatch,
+      },
+    ],
+  ];
+
+  // The bunfig written by createTestDir has saveTextLockfile = false, so a
+  // plain install writes bun.lockb.
+  for (const [lockfileName, installArgs] of [
+    ["bun.lock", ["--save-text-lockfile"]],
+    ["bun.lockb", []],
+  ] as const) {
+    for (const [label, files] of upToDateShapes) {
+      test(`--frozen-lockfile passes and nothing is re-saved (${lockfileName}): ${label}`, async () => {
+        await Promise.all(
+          Object.entries(files).map(([path, content]) =>
+            write(join(packageDir, path), typeof content === "string" ? content : JSON.stringify(content)),
+          ),
+        );
+
+        let { stderr, exited } = spawn({
+          cmd: [bunExe(), "install", ...installArgs],
+          cwd: packageDir,
+          stdout: "ignore",
+          stderr: "pipe",
+          env,
+        });
+        let err = await stderr.text();
+        expect(err).not.toContain("error:");
+        expect(await exited).toBe(0);
+        const firstLockfile = await Bun.file(join(packageDir, lockfileName)).bytes();
+
+        ({ stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "ignore",
+          stderr: "pipe",
+          env,
+        }));
+        err = await stderr.text();
+        expect(err).not.toContain("error:");
+        expect(err).not.toContain("Saved lockfile");
+        expect(await Bun.file(join(packageDir, lockfileName)).bytes()).toEqual(firstLockfile);
+        expect(await exited).toBe(0);
+
+        ({ stderr, exited } = spawn({
+          cmd: [bunExe(), "install", "--frozen-lockfile"],
+          cwd: packageDir,
+          stdout: "ignore",
+          stderr: "pipe",
+          env,
+        }));
+        err = await stderr.text();
+        expect(err).not.toContain("error:");
+        expect(await exited).toBe(0);
+      });
+    }
+  }
+
   for (const omit of ["dev", "peer", "optional"]) {
     test(`resolvable lockfile with ${omit} dependencies disabled`, async () => {
       await Promise.all([
@@ -869,6 +1562,51 @@ describe("text lockfile", () => {
       firstLockfile,
     );
   });
+});
+
+// https://github.com/oven-sh/bun/issues/13823
+test("--frozen-lockfile fails when package.json gains a direct dependency already resolved transitively (bun.lockb)", async () => {
+  // bunfig has saveTextLockfile = false, so a plain install writes bun.lockb and
+  // the frozen check takes the has_meta_hash_changed branch.
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      dependencies: { "one-dep": "1.0.0" },
+    }),
+  );
+
+  let { stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exists(join(packageDir, "bun.lockb"))).toBe(true);
+  expect(await exists(join(packageDir, "bun.lock"))).toBe(false);
+  expect(await exited).toBe(0);
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      dependencies: { "one-dep": "1.0.0", "no-deps": "1.0.1" },
+    }),
+  );
+
+  ({ stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  err = await stderr.text();
+  expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+  expect(await exited).toBe(1);
 });
 
 test("--lockfile-only", async () => {
@@ -1037,6 +1775,7 @@ describe("frozen lockfile", () => {
       "Resolving dependencies
       Resolved, downloaded and extracted [4]
       error: lockfile had changes, but lockfile is frozen
+      note: dependencies in package.json changed since bun.lock was saved (1 added, 0 removed, 0 updated)
       note: try re-running without --frozen-lockfile and commit the updated lockfile"
     `);
     expect(exitCode).toBe(1);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -7616,6 +7616,9 @@ describe.concurrent("bun-install", () => {
         env,
       });
       const err2 = await new Response(stderr2).text();
+      // the lockfile already matches package.json, so nothing is re-resolved
+      // (which is what used to create node_modules/.cache here) or re-saved
+      expect(err2).not.toContain("Saved lockfile");
       const out2 = await new Response(stdout2).text();
       expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
@@ -7626,7 +7629,7 @@ describe.concurrent("bun-install", () => {
       ]);
       expect(await exited2).toBe(0);
       expect(ctx.requested).toBe(0);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "bar"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual(["bar"]);
       expect(await readlink(join(ctx.package_dir, "node_modules", "bar"))).toBeWorkspaceLink(join("..", "bar"));
       expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).text()).toEqual(bar_package);
       await access(join(ctx.package_dir, "bun.lockb"));
@@ -9109,6 +9112,10 @@ describe.concurrent("bun-install", () => {
       });
       const err2 = await new Response(stderr2).text();
       expect(err2).not.toContain("error:");
+      // the lockfile already matches the package.jsons, so nothing is
+      // re-resolved (which is what used to create node_modules/.cache here)
+      // or re-saved
+      expect(err2).not.toContain("Saved lockfile");
       const out2 = await new Response(stdout2).text();
       expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
@@ -9120,7 +9127,7 @@ describe.concurrent("bun-install", () => {
       expect(await exited2).toBe(0);
       expect(urls.sort()).toBeEmpty();
       expect(ctx.requested).toBe(0);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "bar", "baz"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual(["bar", "baz"]);
       expect(await readlink(join(ctx.package_dir, "node_modules", "bar"))).toBeWorkspaceLink(
         join("..", "packages", "bar"),
       );

--- a/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/migrate.test.ts.snap
@@ -3571,7 +3571,7 @@ bun install --frozen-lockfile exit code: 0
 exports[`package-lock.json migration fixes arborist fixtures edit-package-json--changed 1`] = `
 "migrated lockfile from package-lock.json
 bun pm migrate exit code: 0
-bun install --frozen-lockfile exit code: 0
+bun install --frozen-lockfile exit code: 1
 
 {
   "lockfileVersion": 2,

--- a/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
@@ -32,6 +32,7 @@ exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-p
     },
     "apps/web": {
       "name": "@repo/web",
+      "version": "1.0.0",
       "dependencies": {
         "@repo/ui": "workspace:*",
         "@repo/utils": "workspace:*",
@@ -40,12 +41,14 @@ exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-p
     },
     "packages/ui": {
       "name": "@repo/ui",
+      "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",
       },
     },
     "packages/utils": {
       "name": "@repo/utils",
+      "version": "1.0.0",
       "dependencies": {
         "lodash": "^4.17.21",
       },

--- a/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
@@ -363,6 +363,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
     },
     "packages/pkg1": {
       "name": "@workspace/pkg1",
+      "version": "1.0.0",
       "dependencies": {
         "@workspace/pkg2": "workspace:*",
         "lodash": "^4.17.21",
@@ -370,12 +371,14 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
     },
     "packages/pkg2": {
       "name": "@workspace/pkg2",
+      "version": "1.0.0",
       "dependencies": {
         "@workspace/pkg3": "workspace:*",
       },
     },
     "packages/pkg3": {
       "name": "@workspace/pkg3",
+      "version": "1.0.0",
       "dependencies": {
         "@workspace/pkg1": "workspace:*",
       },


### PR DESCRIPTION
Fixes #22689
Fixes #24223
Fixes #13823

### Problem

- `bun install --frozen-lockfile` (and `bun ci`, `--production`) exits 0 on a stale lockfile whenever the manifest change resolves to packages the lockfile already has: a dependency added to one workspace that another workspace (or a transitive) already pulls in, a removed direct dependency that stays in the tree transitively, a range change the locked version still satisfies. npm/pnpm/yarn all refuse these.
- Cause: the frozen check in `install_with_manager.rs` compares the resolved package set (`Lockfile::eql` for `bun.lock`, the meta hash for `bun.lockb`) and, since #38333, the overrides and catalog flags of the differ; the differ's dependency comparison itself (`Diff::generate`, root and workspace members) is not consulted.
- Consulting it is only possible once it is quiet on stable repos. On main it reports a diff on every install for a number of shapes (since #38333 the byte-identical re-save is suppressed, so this is invisible, but every one of them would become a permanent frozen failure): a workspace member with a lifecycle script, `trustedDependencies` declared in a member, a sibling workspace listed in two dependency sections, a `catalog:` entry or an override pointing at a workspace, `*` on a versionless workspace, a root entry for a member that the parser does not link (`{a: "^9.0.0"}` plus an override), every `bun.lockb` monorepo whose members depend on each other, stale `trustedDependencies` / `patchedDependencies` entries, a `trustedDependencies` entry for a package installed under an `npm:` alias (which `bun.lock` also never records, so installing from the lockfile relied on that perpetual diff to trust it), and monorepos migrated from pnpm-lock.yaml whose members depend on each other by version range.

### Fix

Five commits:

1. `install: stop reporting manifest diffs for repos whose lockfile is already up to date` (`Package.rs`, `lockfile.rs`, `bun.lock.rs`, `bun.lockb.rs`, a hook in `install_with_manager.rs`)
   - lifecycle scripts are only compared when the loaded package recorded them (`scripts.filled`, i.e. `bun.lockb`); `bun.lock` stores none and reads them from package.json at install time.
   - overrides, catalogs, `trustedDependencies` and `patchedDependencies` are compared once, at the root, and the last two only after the members have been parsed (the lockfile holds the union over all workspaces; before, a list declared in a member was reported removed on every install). The caller already applies changes to these sections across every package's edges.
   - workspace members: `Diff::generate` used to compare a member only by recursing through the root's workspace-behavior edge onto it. `diff_workspace_members` now compares every workspace package in the lockfile with its package.json regardless of how the root reaches it (its `workspaces` entry, an override on its own entry, only through a sibling), records the changed ones in `changed_workspaces` (which `changes_resolutions` / `changes_dependencies` / `has_diffs` include, so the existing consumers keep their meaning), and `install_with_manager` re-resolves one dependency onto each changed member (`Lockfile::dependency_to_reresolve_workspace`, preferring a `workspace:` edge declared by the root or a member), which re-reads it into the same package id through the folder resolver, exactly what re-resolving the synthetic edge used to do. Root edges onto members always stay mapped. The pass also feeds #38333's `survivors` / `removed_names` bookkeeping, so pruned checkouts behave as before.
   - the `bun.lock` loader tagged every root/workspace edge that resolved to a workspace package as a workspace dependency, except the second entry of a duplicated name, and always synthesized the root's edge to each member. The parser tags only `workspace:` specifiers and npm ranges satisfied by the member's version, tags every entry, and replaces the synthetic edge with the root's own entry when that entry is an npm range it does not link; `map_manifest_dep_to_pkg` and the synthesis loop now follow those rules (using the versions recorded in the lockfile, so a member that moved out of range still produces a diff). This is the `bun-workspaces.test.ts.snap` change: loaded `*`/dist-tag edges onto a versionless member keep their own tag.
   - `bun.lockb` stores an edge as tag plus literal, so a member's `workspace:*` edge reloaded holding `*` while a fresh parse holds the member's path, which is what `Version::eql` compares. `restore_workspace_dependency_paths` points the root's and members' workspace edges back at the path of the package they resolved to after loading, as the `bun.lock` loader already did (the `migrate-bun-lockb-v2` snapshot shows the path now; the bytes written are unchanged).
   - `bun.lock` only writes the `trustedDependencies` names and `patchedDependencies` keys that match something in the tree, while the differ compared the full package.json sets. Entries that are only in package.json now count as additions when the lockfile has something for them to apply to (`stores_trusted_dependency`, `stores_any_patched_dependency`); what the loaded lockfile holds is compared as before. `has_trusted_dependency` checks an npm package under the package's own name, so `{"x": "npm:real@1"}` is trusted by listing `real`; the writer only looked at edge names and never stored such an entry, and `stores_trusted_dependency` has to agree with `has_trusted_dependency`, otherwise the entry is filtered out of the diff and an install from the lockfile stops trusting it. Both now also match the name of the npm package an edge resolved to (one extra insert in the writer's collection loop; for a non-aliased edge it re-inserts the key just inserted, so #38736's byte order is unaffected). And since the differ now leaves some package.json entries out on purpose, `install_with_manager` copies `trustedDependencies` and `patchedDependencies` from the fresh parse whether or not it reported a diff, as it already did for the root scripts (the patched block is the else branch's existing code moved into `copy_patched_dependencies`, called from both branches). Otherwise a run without a manifest diff kept the loaded subsets, which shows on the one such run that still changes resolutions: `bun audit fix` moving a package to the version a patch is written for installed it unpatched. Declaring `trustedDependencies` at all is what turns the default trusted list off, so the writer now emits `"trustedDependencies": []` when the field is declared but none of its names are in the tree (`bun.lockb` already has a tag for this), and a package.json that declares the field while the lockfile does not record it is a diff (`trusted_dependencies_declared`). On main a `bun.lock` written for `"trustedDependencies": []` drops the field and the default list is back in effect from the second install on, `bun ci` included (verified with the `electron` fixture); such lockfiles now get re-saved once.
2. `install: record workspace versions when migrating pnpm-lock.yaml` (`pnpm.rs`): the migration read the version off the pnpm importer entry, which never has one, so migrated lockfiles listed members without versions and the loader rule above could not tell a linked range apart; it now reads the member's package.json, like the package-lock.json migration. Two migration snapshots gain the `"version"` lines bun's own writer produces.
3. `install: fail --frozen-lockfile when a manifest diverges from bun.lock, and say which one` (`install_with_manager.rs`): the check becomes `summary.changes_dependencies() || <eql / meta hash>`. `changes_dependencies` is #38333's notion of "the dependency declarations changed" (root and members, overrides, catalog; not lifecycle scripts), so `trustedDependencies` and `patchedDependencies` stay out of the comparison, as the pruned-checkout tests require (`turbo prune` strips them; they are applied from package.json either way). The notes reuse #38333's wording:
   ```
   error: lockfile had changes, but lockfile is frozen
   note: dependencies in packages/pkg2/package.json changed since bun.lock was saved (1 added, 0 removed, 0 updated)
   note: try re-running without --frozen-lockfile and commit the updated lockfile
   ```
   (`dependencies in package.json ...` for the root; `overrides` / `resolutions` / `the catalog in package.json changed since ...` exactly as before, so #38333's assertions still hold; `the packages resolved from the manifests differ from bun.lock` when only the resolution comparison fires.) `frozen_changed_section` is folded into this.
4. tests.
5. `install: debug lockfile JSON wrote the package name as a dist-tag dependency's tag`: the `bun:internal-for-testing` dump wrote `info.name` for a dist-tag's `tag`; it surfaced because a loaded dist-tag edge now stays a dist-tag.

Dropped while rebasing onto current main: the `bun update` lockfile-specifier commit and the `$ref` override storage fix, both of which #38333 implemented independently (`package_json_write_back::sync_lockfile`, `bun-update-lockfile-sync.test.ts`), together with their tests.

### Verification

`test/cli/install/bun-install-registry.test.ts` (the file fails on main, passes here):
- failing direction: direct dep added that is already transitive (asserts the note and that `bun.lock` is left untouched), direct dep removed but still transitive, range literal changed (#24223), dep added to a second workspace (#22689, asserts the member note and no root note), a `bun.lockb` variant (#13823); and `--frozen-lockfile fails when <member> gains a dependency`: a member kept only by an override on the root's entry (`bun.lock`) and a member only a sibling depends on while the root depends on its published version (`bun.lockb`; `bun.lock` cannot load that shape today, #37248). The latter two add a dependency the root already has, so only the member comparison can notice; they check no diff on the second install, the frozen failure naming the member, the member actually being re-read by a plain install (lockfile dump), and frozen passing afterwards. All fail on main.
- passing direction, `--frozen-lockfile passes and nothing is re-saved (<format>): <shape>`, 16 shapes under both formats (member depending on a sibling, root depending on members, override-kept unlinked entry, lifecycle script, member `trustedDependencies`, sibling in dev+peer, sibling linked in two groups, `*` on a versionless sibling, `npm:` alias of a sibling, `catalog:` -> workspace, override -> workspace, `$ref` override, stale / all-stale / empty `trustedDependencies`, stale `patchedDependencies` key). With the gate in place these rows are what proves the differ is quiet; on main's byte-compare save they pass trivially, so they act as guards there.
- `trustedDependencies [] / ["not-a-dependency"] still disables the default trusted list when installing from bun.lock` (`electron` stays blocked on the first install, a plain install from the lockfile and a frozen one; `bun.lock` contains the empty field), and `<change> passes --frozen-lockfile and is stored by the next install` for an installed name, `[]`, an all-stale list and a patch (stores `["no-deps"]`, `[]`, `[]`, the patch entry; frozen passes before and after). The electron tests and the `[]`-storing rows fail on main.
- `trustedDependencies naming the package behind an npm: alias is stored and stays trusted when installing from bun.lock`: `lifecycle-postinstall` installed as `postinstall-alias` and trusted under its real name; the postinstall runs on the first install, `bun.lock` records the name, and it runs again on a plain and on a frozen install from the lockfile. Fails on main on the `bun.lock` content (the name is not stored); failed on the previous revision of this PR at the second install (entry filtered out, `bun.lock` held `[]`, script blocked).
- the existing `production = true` test's inline snapshot gains the new note.

`bun-audit.test.ts`, `applies the patchedDependencies entry written for the version it installs`: `no-deps@1.0.0` locked as a transitive, a `patchedDependencies` entry for `1.0.1` (so `bun.lock` stores nothing for it), and `bun audit fix` moving it to `1.0.1` has to install it patched and store the entry; frozen passes afterwards. Passes on main, fails on this branch with the unconditional copy removed (checked by building without it), passes here.

`migration/migrate.test.ts`: the arborist fixture `edit-package-json--changed` (package.json says `abbrev: ^1.1.0`, its lockfile was written from `^1.1.1`) now records a frozen exit code of 1; #38853 had just recorded 0 for it and deferred this to this PR. It is the range-literal shape from #24223.

`bun-install.test.ts`: two existing `bun.lockb` workspace tests now assert the second install neither re-saves nor creates a `.cache` entry (they re-resolve on every install on main). `pnpm-lock-v9.test.ts` "link: version with a semver specifier" is the test that exposed commit 2.

Also run locally with the debug build: all of `test/cli/install/` (the only failures are the tests that need network access or git clones), which includes #38333's `frozen-lockfile-pruned`, `frozen-lockfile-missing-workspace`, `nested-overrides`, `bun-update-lockfile-sync`, `bun-lock` (incl. #38736's byte-order test), `bun-workspaces`, the migration suites, `isolated-install`; source lints; `cargo clippy -p bun_install`. Plus registry-free ad-hoc shapes under both formats: a member reached through a catalog entry and then edited, two members edited at once (one removing a dependency) producing one note each and no root note, and `linkWorkspacePackages` flipped either way after the lockfile exists.

CI on this head (13f2595): every GitHub check passes (clippy, mordant, miri, format, source lints) and Buildkite build 97980 has all 177 Linux and Windows jobs green, with the only test failures being retried flakes in files this PR does not touch; its two darwin jobs expired because no darwin agent has been connected today, which affects every build, so the build shows as failed until the fleet is back.

### Background

- `Diff::generate` (`Package.rs`) compares the root package as loaded from the lockfile against a fresh parse of package.json; its `DiffSummary` drives the rebuild of the root's edges, `should_save_lockfile`, and (since #38333) `changes_resolutions` / `changes_dependencies` consumers such as dedupe, prune and the transitive update planner. `had_any_diffs` true on an unchanged repo means a full re-resolve every install; before #38333 it also meant a visible re-save, which is how these shapes were found.
- `bun.lock` stores each workspace's dependency sections as literal specifiers plus a resolved `packages` map; the loader re-parses the literals, synthesizes the root's edge to each member, and fixes up edges that resolved to workspace packages. `bun.lockb` stores the parsed edges as tag plus literal. Both loaders have to land on exactly what the parser produces for the differ to stay quiet.
- When the install re-resolves a `workspace:` dependency declared by the root or a member, the folder resolver re-parses that member's package.json and replaces its package in place (same id), so every other edge onto it sees the new dependency list; the re-read hook relies on that.
- `bun.lock` writes `trustedDependencies` / `patchedDependencies` filtered to what is in the tree, `bun.lockb` writes the full sets; a stable repo therefore reloads a subset of what package.json declares under `bun.lock`, which is why the differ asks "would a save store this" for new entries instead of comparing the sets.

<details>
<summary>Earlier versions</summary>

- v1 only gated on <code>had_any_diffs</code>; review listed the stable shapes for which it is spuriously true.
- v2 fixed the <code>bun.lock</code> loader and the argument-less <code>bun update</code> flows; review found <code>bun.lockb</code> monorepos, the synthetic root edge, and <code>bun update &lt;name&gt;</code>.
- v3 compared members only through root edges and the trusted/patched sets in full; review found members reached via an override going unnoticed and stale trusted/patched entries failing forever, then the all-stale <code>trustedDependencies</code> case re-enabling the default list.
- v4 was the rebase onto main after #38333 / #38736: the update-specifier and <code>$ref</code> work is dropped as already landed, the member pass is rebuilt on the new <code>generate_inner</code>, the gate uses <code>changes_dependencies</code> so trusted/patched changes no longer fail frozen, the notes use #38333's wording, and the pnpm migration gap it exposed is fixed. Review of v4 found that its <code>stores_trusted_dependency</code> only looked at edge names, so a trusted name for an <code>npm:</code>-aliased package was filtered out and, with the loaded list kept, no longer trusted from the second install on.
- v5 (this one): the writer and <code>stores_trusted_dependency</code> also match the resolved npm package's name, both sections are copied from package.json regardless of the diff result, the loader's root-only flag became a small struct, and a second rebase picks up #38870 (the frozen comparison passes the loaded package count) and #38853 (the arborist snapshot above).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->


