### PR TITLE
http: reject DEL (0x7F) in request header field values

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -668,16 +668,17 @@ namespace uWS
             return ConsumeRequestLineResult::error(HTTP_HEADER_PARSER_ERROR_INVALID_HTTP_VERSION);
         }
 
-        /* RFC 9110: 5.5 Field Values (TLDR; anything above 31 is allowed; htab (9) is also allowed)
+        /* RFC 9110: 5.5 Field Values (field-vchar = VCHAR / obs-text = %x21-7E / %x80-FF; SP/HTAB allowed inside)
         * Field values are usually constrained to the range of US-ASCII characters [...]
         * Field values containing CR, LF, or NUL characters are invalid and dangerous [...]
-        * Field values containing other CTL characters are also invalid. */
+        * Field values containing other CTL characters are also invalid.
+        * That "other CTL" set includes DEL (0x7F), so stop on bytes < 0x20 as well as 0x7F. */
         static inline char * tryConsumeFieldValue(char *p) {
             for (; true; p += 8) {
                 uint64_t word;
                 memcpy(&word, p, sizeof(uint64_t));
-                if (hasLess(word, 32)) {
-                    while (*(unsigned char *)p > 31) p++;
+                if (hasLess(word, 32) | hasLess(word ^ (~0ULL/255*0x7F), 1)) {
+                    while (*(unsigned char *)p > 31 && *(unsigned char *)p != 0x7F) p++;
                     return p;
                 }
             }

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1421,9 +1421,12 @@ test("header field value byte validation per RFC 9110 5.5", async () => {
     return { byte, status: match ? match[1] : "none" };
   }
 
-  const bytes = Array.from({ length: 256 }, (_, i) => i).filter(b => b !== 0x0d && b !== 0x0a);
+  // Every CTL (0x00-0x1F, 0x7F) except CR/LF which would end the header line,
+  // plus the accept/reject boundaries around SP, VCHAR and obs-text.
+  const ctls = Array.from({ length: 0x20 }, (_, i) => i).filter(b => b !== 0x0d && b !== 0x0a);
+  const bytes = [...ctls, 0x20, 0x21, 0x7e, 0x7f, 0x80, 0xff];
   const results: Awaited<ReturnType<typeof probe>>[] = [];
-  // Small batches so the listen backlog never overflows on Windows.
+  // Batches keep the listen backlog from overflowing on Windows.
   const batchSize = 8;
   for (let i = 0; i < bytes.length; i += batchSize) {
     results.push(...(await Promise.all(bytes.slice(i, i + batchSize).map(probe))));
@@ -1438,6 +1441,36 @@ test("header field value byte validation per RFC 9110 5.5", async () => {
   );
   // No rejected byte ever reaches the application.
   expect(seen.every(value => !/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(value))).toBe(true);
+});
+
+test("node:http emits clientError HPE_INVALID_HEADER_TOKEN for DEL (0x7F) in a header value", async () => {
+  const events: string[] = [];
+  const server = createServer((req, res) => {
+    events.push(`served ${req.headers["x-a"]}`);
+    res.end("ok");
+  });
+  server.on("clientError", (err: NodeJS.ErrnoException) => {
+    events.push(`clientError ${err.code}`);
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address() as { port: number };
+    const response = await new Promise<string>((resolve, reject) => {
+      const client = net.connect(port, "127.0.0.1");
+      const chunks: Buffer[] = [];
+      client.on("error", reject);
+      client.on("data", chunk => chunks.push(chunk));
+      client.on("close", () => resolve(Buffer.concat(chunks).toString("latin1")));
+      client.write(Buffer.from("GET / HTTP/1.1\r\nHost: x\r\nX-A: a\x7Fb\r\nConnection: close\r\n\r\n", "latin1"));
+    });
+    expect({ events, status: response.split("\r\n", 1)[0] }).toEqual({
+      events: ["clientError HPE_INVALID_HEADER_TOKEN"],
+      status: "HTTP/1.1 400 Bad Request",
+    });
+  } finally {
+    server.closeAllConnections?.();
+    server.close();
+  }
 });
 
 describe("Host header field values in request.url", () => {

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1392,6 +1392,54 @@ test("rejects Transfer-Encoding header with empty value", async () => {
   expect(seen).not.toContain("GET /admin");
 });
 
+test("header field value byte validation per RFC 9110 5.5", async () => {
+  // field-content = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
+  // field-vchar   = VCHAR / obs-text = %x21-7E / %x80-FF
+  // Every CTL (0x00-0x1F and 0x7F) is invalid inside a field value. SP and HTAB are the
+  // only sub-VCHAR bytes permitted. obs-text (0x80-0xFF) is accepted.
+  const seen: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      seen.push(req.headers.get("x-a") ?? "");
+      return new Response("ok");
+    },
+  });
+
+  async function probe(byte: number) {
+    const header = `X-A: a${String.fromCharCode(byte)}b`;
+    const raw = `GET / HTTP/1.1\r\nHost: x\r\n${header}\r\nConnection: close\r\n\r\n`;
+    const response = await new Promise<string>((resolve, reject) => {
+      const client = net.connect(server.port, "127.0.0.1");
+      const chunks: Buffer[] = [];
+      client.on("error", reject);
+      client.on("data", chunk => chunks.push(chunk));
+      client.on("close", () => resolve(Buffer.concat(chunks).toString("latin1")));
+      client.write(Buffer.from(raw, "latin1"));
+    });
+    const match = response.match(/^HTTP\/1\.[01] (\d{3})/);
+    return { byte, status: match ? match[1] : "none" };
+  }
+
+  const bytes = Array.from({ length: 256 }, (_, i) => i).filter(b => b !== 0x0d && b !== 0x0a);
+  const results: Awaited<ReturnType<typeof probe>>[] = [];
+  // Small batches so the listen backlog never overflows on Windows.
+  const batchSize = 8;
+  for (let i = 0; i < bytes.length; i += batchSize) {
+    results.push(...(await Promise.all(bytes.slice(i, i + batchSize).map(probe))));
+  }
+
+  const isValidFieldValueByte = (b: number) => b === 0x09 || b === 0x20 || (b >= 0x21 && b <= 0x7e) || b >= 0x80;
+  expect(results).toEqual(
+    bytes.map(byte => ({
+      byte,
+      status: isValidFieldValueByte(byte) ? "200" : "400",
+    })),
+  );
+  // No rejected byte ever reaches the application.
+  expect(seen.every(value => !/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(value))).toBe(true);
+});
+
 describe("Host header field values in request.url", () => {
   // Windows refuses connections under accept-backlog/TIME_WAIT churn even while the
   // server is listening, so a refused connect (before anything was read) is retried.
@@ -1504,7 +1552,7 @@ describe("Host header field values in request.url", () => {
     [0x21, 0x40],
     [0x41, 0x60],
     [0x61, 0x7e],
-    [0x7f, 0xff],
+    [0x80, 0xff],
   ])(
     "HTTP/1.1 and HTTP/1.0 requests synthesize request.url from the same Host bytes (%i-%i)",
     async (firstByte, lastByte) => {
@@ -1516,7 +1564,8 @@ describe("Host header field values in request.url", () => {
       });
 
       // RFC 3986 `uri-host [ ":" port ]`: unreserved / sub-delims / "%" / ":" / "[" / "]".
-      // Every byte in [0x7f, 0xff] is outside that set, so neither URL uses any of them.
+      // Every byte in [0x80, 0xff] is outside that set, so neither URL uses any of them.
+      // 0x7F (DEL) is rejected at parse time, so it is not part of any batch.
       const isHostByte = (char: string) => /^[A-Za-z0-9._~%!$&'()*+,;=:\[\]-]$/.test(char);
 
       async function checkByte(byte: number) {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1620,6 +1620,28 @@ describe("HTTP Server Security Tests - Advanced", () => {
       await promise;
       expect(mockHandler).not.toHaveBeenCalled();
     });
+
+    test("rejects requests with DEL (0x7F) in header field value", async () => {
+      const mockHandler = createMockHandler();
+      server.on("request", mockHandler);
+      const { promise, resolve, reject } = Promise.withResolvers();
+      server.on("clientError", (err: any) => {
+        try {
+          expect(err.code).toBe("HPE_INVALID_HEADER_TOKEN");
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      // RFC 9110 5.5: field-vchar is VCHAR / obs-text (0x21-0x7E / 0x80-0xFF); DEL (0x7F) is a CTL.
+      const msg = ["GET / HTTP/1.1", "Host: localhost", "X-Custom: a\x7Fb", "", ""].join("\r\n");
+
+      const response = await sendRequest(msg);
+      expect(response).toInclude("400 Bad Request");
+      await promise;
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
   });
 
   describe("Transfer-Encoding Attacks", () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1620,28 +1620,6 @@ describe("HTTP Server Security Tests - Advanced", () => {
       await promise;
       expect(mockHandler).not.toHaveBeenCalled();
     });
-
-    test("rejects requests with DEL (0x7F) in header field value", async () => {
-      const mockHandler = createMockHandler();
-      server.on("request", mockHandler);
-      const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
-        try {
-          expect(err.code).toBe("HPE_INVALID_HEADER_TOKEN");
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      });
-
-      // RFC 9110 5.5: field-vchar is VCHAR / obs-text (0x21-0x7E / 0x80-0xFF); DEL (0x7F) is a CTL.
-      const msg = ["GET / HTTP/1.1", "Host: localhost", "X-Custom: a\x7Fb", "", ""].join("\r\n");
-
-      const response = await sendRequest(msg);
-      expect(response).toInclude("400 Bad Request");
-      await promise;
-      expect(mockHandler).not.toHaveBeenCalled();
-    });
   });
 
   describe("Transfer-Encoding Attacks", () => {


### PR DESCRIPTION
## What

Bun's HTTP server (`Bun.serve` and `node:http`) accepts a DEL byte (`0x7F`) inside a request header field value and delivers it verbatim to the application. Node/llhttp reject the same request with `HPE_INVALID_HEADER_TOKEN`; RFC 9110 §5.5 excludes `0x7F` from `field-vchar` (it is a CTL).

```js
import http from "node:http";
import net from "node:net";
const srv = http.createServer((req, res) => {
  console.log("x-a =", encodeURIComponent(req.headers["x-a"])); // bun: a%7Fb
  res.end("ok");
});
srv.on("clientError", e => console.log("clientError", e.code)); // node: HPE_INVALID_HEADER_TOKEN
srv.listen(0, () => {
  net.connect(srv.address().port).write(
    Buffer.from("GET / HTTP/1.1\r\nHost: x\r\nX-A: a\x7fb\r\nConnection: close\r\n\r\n", "latin1"),
  );
});
```

Every other CTL byte (`0x00`-`0x1F`) is already rejected by both runtimes; `0x7F` is the one exception. A bun origin can therefore accept and forward a header value that a conforming downstream parser rejects, so two hops in a chain disagree on whether the request is valid. No CR/LF/NUL is involved, so this is a parser differential rather than an injection.

## Cause

`tryConsumeFieldValue` in `packages/bun-uws/src/HttpParser.h` scans 8 bytes at a time and stops only when a byte is `< 0x20`. Its own comment quotes the RFC sentence it violates ("Field values containing other CTL characters are also invalid"): `0x7F` is the one CTL that predicate admits.

## Fix

Extend the SWAR fast path and the byte loop to also stop on `0x7F`:

```cpp
if (hasLess(word, 32) | hasLess(word ^ (~0ULL/255*0x7F), 1)) {
    while (*(unsigned char *)p > 31 && *(unsigned char *)p != 0x7F) p++;
    return p;
}
```

The caller already treats any non-CR/non-HTAB stop byte as `HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN`, so no other change is needed. `node:http` surfaces this as `clientError` with `HPE_INVALID_HEADER_TOKEN`, matching Node.

## Verification

New tests in `test/js/bun/http/request-smuggling.test.ts`:

- `header field value byte validation per RFC 9110 5.5` probes every CTL byte (`0x00`-`0x1F` minus CR/LF, and `0x7F`) plus the accept/reject boundaries (`SP`, `0x21`, `0x7E`, `0x80`, `0xFF`) inside a field value against `Bun.serve` and asserts `400` for every CTL and `200` for SP/HTAB/VCHAR/obs-text. On main, byte 127 returns `200`.
- `node:http emits clientError HPE_INVALID_HEADER_TOKEN for DEL (0x7F)` verifies the `node:http` compat server fires `clientError` with the right code and never invokes the handler. On main, the handler is invoked with the DEL byte delivered.
- The existing `Host bytes (0x7f-0xff)` batch is re-ranged to start at `0x80` since `0x7F` is now rejected at parse time.

```
bun bd test test/js/bun/http/request-smuggling.test.ts   # 77 pass, 0 fail
# without the HttpParser.h change: 2 fail (the two new tests)
```
