### PR TITLE
Bun.serve: ignore leading empty lines before the request-line

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1116,21 +1116,20 @@ struct HttpResponseData;
              * request-line, like Node/llhttp - e.g. a stray "\r\n" sent on an
              * idle keep-alive connection must not be treated as a bad request.
              * llhttp's s_start state loops on '\r' and '\n' independently, so a
-             * leading bare LF (or bare CR) is also tolerated. Node-compat only:
-             * Bun.serve keeps rejecting a request that does not start with the
-             * request-line, so this leniency is not a Bun-native default. */
-            if constexpr (IsNodeHttp) {
-                if (isNewline((unsigned char) data[0])) [[unlikely]] {
-                    /* The enclosing loop only runs while length is non-zero, so the
-                     * first byte is known to be one; re-test only after advancing. */
-                    do {
-                        data += 1;
-                        length -= 1;
-                        consumedTotal += 1;
-                    } while (length && isNewline((unsigned char) data[0]));
-                    if (length == 0) {
-                        break;
-                    }
+             * leading bare LF (or bare CR) is also tolerated. Applies to Bun.serve
+             * as well: the RFC's own motivating case (a stray CRLF after a POST
+             * body in front of the next keep-alive request) otherwise kills that
+             * request with a 400. */
+            if (isNewline((unsigned char) data[0])) [[unlikely]] {
+                /* The enclosing loop only runs while length is non-zero, so the
+                 * first byte is known to be one; re-test only after advancing. */
+                do {
+                    data += 1;
+                    length -= 1;
+                    consumedTotal += 1;
+                } while (length && isNewline((unsigned char) data[0]));
+                if (length == 0) {
+                    break;
                 }
             }
             auto result = getHeaders(data, data + length, req->headers, reserved, req->ancientHttp, isConnectRequest, useStrictMethodValidation, useInsecureHTTPParser, maxHeaderSize);

--- a/test/js/bun/http/bun-serve-leading-crlf.test.ts
+++ b/test/js/bun/http/bun-serve-leading-crlf.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { connect } from "node:net";
+
+/* RFC 9112 2.2: "a server that is expecting to receive and parse a request-line
+ * SHOULD ignore at least one empty line (CRLF) received prior to the
+ * request-line." The motivating case the RFC gives is a client that sends an
+ * extra CRLF after a POST body, which then sits in front of the next request
+ * on the same keep-alive connection. */
+
+describe("Bun.serve: empty line(s) before the request-line are ignored (RFC 9112 2.2)", () => {
+  async function run(bytes: string) {
+    const events: string[] = [];
+    await using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        events.push(`request ${req.method} ${new URL(req.url).pathname}`);
+        await req.text();
+        return new Response("ok");
+      },
+    });
+
+    const raw = await new Promise<string>(resolve => {
+      const out: Buffer[] = [];
+      const sock = connect(server.port, "127.0.0.1", () => sock.end(Buffer.from(bytes, "latin1")));
+      const done = () => {
+        sock.destroy();
+        resolve(Buffer.concat(out).toString("latin1"));
+      };
+      sock.on("data", d => out.push(d));
+      sock.on("close", done);
+      sock.on("error", done);
+    });
+    const statuses = (raw.match(/HTTP\/1\.[01] (\d{3})/g) ?? []).map(m => m.slice(-3));
+    return { events, statuses };
+  }
+
+  it.each([
+    ["one CRLF", "\r\n"],
+    ["one bare LF", "\n"],
+    ["multiple CRLF", "\r\n\r\n\r\n"],
+  ])("leading %s before a single request", async (_, prefix) => {
+    const { events, statuses } = await run(prefix + "GET /a HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    expect({ events, statuses }).toEqual({ events: ["request GET /a"], statuses: ["200"] });
+  });
+
+  it("stray CRLF after a POST body on a keep-alive connection", async () => {
+    const { events, statuses } = await run(
+      "POST /a HTTP/1.1\r\nHost: x\r\nContent-Length: 2\r\n\r\nhi" +
+        "\r\n" +
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    );
+    expect({ events, statuses }).toEqual({
+      events: ["request POST /a", "request GET /b"],
+      statuses: ["200", "200"],
+    });
+  });
+});

--- a/test/js/bun/http/http-spec.ts
+++ b/test/js/bun/http/http-spec.ts
@@ -121,6 +121,21 @@ const testCases: TestCase[] = [
     expectedStatus: [[200, 299]],
   },
   {
+    request: "\r\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+    description: "Leading empty line before request-line (RFC 9112 2.2)",
+    expectedStatus: [[200, 299]],
+  },
+  {
+    request: "\r\n\r\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+    description: "Multiple leading empty lines before request-line",
+    expectedStatus: [[200, 299]],
+  },
+  {
+    request: "\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+    description: "Leading bare LF before request-line",
+    expectedStatus: [[200, 299]],
+  },
+  {
     request: "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n",
     description: "Valid GET request with HTTP/1.0",
     expectedStatus: [[200, 299]],

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3938,20 +3938,19 @@ describe("a client half-close after the request does not truncate a large respon
   });
 });
 
-// The node:http compat parser tolerates empty lines (and a bare CR/LF) before the
-// request-line like llhttp's s_start state. That leniency must stay behind the
-// node-http flag: Bun.serve still rejects a request that does not begin with the
-// request-line.
+// RFC 9112 2.2: a server SHOULD ignore at least one empty line (CRLF) received
+// prior to the request-line. llhttp's s_start state loops on '\r' and '\n'
+// independently, so a leading bare LF or bare CR is tolerated the same way.
 it.each([
   ["CRLF", "\r\n"],
   ["bare LF", "\n"],
   ["bare CR", "\r"],
-])("Bun.serve rejects a leading %s before the request-line", async (_label, prefix) => {
+])("Bun.serve ignores a leading %s before the request-line", async (_label, prefix) => {
   using server = serve({ port: 0, fetch: () => new Response("ok") });
 
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   const socket = connect(server.port, "127.0.0.1", () => {
-    socket.write(`${prefix}GET / HTTP/1.1\r\nHost: localhost\r\n\r\n`);
+    socket.write(`${prefix}GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
   });
   let received = "";
   socket.on("data", chunk => {
@@ -3962,5 +3961,5 @@ it.each([
   const statusLine = (await promise).split("\r\n")[0];
   socket.destroy();
 
-  expect(statusLine).toBe("HTTP/1.1 400 Bad Request");
+  expect(statusLine).toBe("HTTP/1.1 200 OK");
 });


### PR DESCRIPTION
### Repro

```js
import net from "node:net";
const CRLF = "\r\n";
const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: req => new Response("ok") });
const play = bytes => new Promise(res => {
  const out = []; const s = net.connect({ port: server.port, host: "127.0.0.1" });
  const fin = () => { s.destroy(); res(Buffer.concat(out).toString("latin1")); };
  s.on("connect", () => s.write(Buffer.from(bytes, "latin1")));
  s.on("data", d => out.push(d)); s.on("close", fin); s.on("error", fin);
});
const st = r => (r.match(/HTTP\/1\.[01] (\d{3})/g) || []).map(x => x.slice(-3)).join(",");
const A = st(await play(CRLF + `GET /a HTTP/1.1${CRLF}Host: x${CRLF}${CRLF}`));
const B = st(await play(`POST /a HTTP/1.1${CRLF}Host: x${CRLF}Content-Length: 2${CRLF}${CRLF}hi` + CRLF +
                        `GET /b HTTP/1.1${CRLF}Host: x${CRLF}Connection: close${CRLF}${CRLF}`));
console.log(JSON.stringify({ A, B })); server.stop(true);
```

```
bun (main):  {"A":"400","B":"200,400"}
node 26.3:   {"A":"200","B":"200,200"}
```

A `node:http` server on the same build already answers 200/200,200.

### Cause

RFC 9112 2.2: "a server that is expecting to receive and parse a request-line SHOULD ignore at least one empty line (CRLF) received prior to the request-line." The RFC's motivating case is exactly case B: some clients emit an extra CRLF after a POST body, which then sits in front of the next request on the same keep-alive connection.

The leading-CR/LF skip in `fenceAndConsumePostPadded` (`packages/bun-uws/src/HttpParser.h`) is gated behind `if constexpr (IsNodeHttp)`, so the `node:http` compat server tolerates a leading empty line but `Bun.serve` still answers `400 Bad Request` + close.

### Fix

Remove the `IsNodeHttp` gate so the existing skip applies to both server stacks. The skip consumes the CR/LF bytes into `consumedTotal`, so they are never buffered and the `MAX_FALLBACK_SIZE` accounting is unchanged. `node:http` behavior is identical (the skip was already running there).

### Verification

- `test/js/bun/http/bun-serve-leading-crlf.test.ts` covers a single request with a leading CRLF / bare LF / multiple CRLFs and the pipelined POST+CRLF+GET case against `Bun.serve`. All four fail on an unfixed build (`400`) and pass with the fix.
- `test/js/bun/http/http-spec.ts` (h1spec against `Bun.serve`) gains three leading-empty-line cases.
- The existing `serve.test.ts` cases that asserted `Bun.serve` rejects a leading CRLF/LF/CR are inverted to assert `200 OK`.
- `test-http-blank-header.js`, `test-http-upgrade-server2.js`, `test-http-server-destroy-socket-on-client-error.js` and the rest of the `node:http` compat suites are unaffected (the skip was already active for that path).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->