### PR TITLE
http: accept up to 1000 request header fields and truncate beyond

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -18,7 +18,10 @@
 #pragma once
 
 #ifndef UWS_HTTP_MAX_HEADERS_COUNT
-#define UWS_HTTP_MAX_HEADERS_COUNT 200
+/* Slot 0 is the request line and the last slot is the terminating sentinel,
+ * so this stores up to UWS_HTTP_MAX_HEADERS_COUNT - 2 header fields. 1002
+ * matches Node.js's default parser.maxHeaderPairs = 2000 (1000 fields). */
+#define UWS_HTTP_MAX_HEADERS_COUNT 1002
 #endif
 
 // todo: HttpParser is in need of a few clean-ups and refactorings
@@ -757,13 +760,22 @@ namespace uWS
                 return HttpParserResult::success((unsigned int) ((postPaddedBuffer + 2) - start));
             }
 
+            /* Last array slot holds the null-key terminator; never store a field there. */
+            HttpRequest::Header * const headersEnd = headers + (UWS_HTTP_MAX_HEADERS_COUNT - 1);
             headers++;
 
-            for (unsigned int i = 1; i < UWS_HTTP_MAX_HEADERS_COUNT - 1; i++) {
+            /* Once the array is full we keep parsing into this scratch slot and drop the
+             * result, matching Node.js (parser.maxHeaderPairs truncates; it never rejects
+             * on count). The header-size byte limit still bounds total work. */
+            HttpRequest::Header discarded;
+
+            while (true) {
+                const bool storing = headers < headersEnd;
+                HttpRequest::Header * const slot = storing ? headers : &discarded;
                 /* Lower case and consume the field name */
                 preliminaryKey = postPaddedBuffer;
                 postPaddedBuffer = consumeFieldName(postPaddedBuffer);
-                headers->key = std::string_view(preliminaryKey, (size_t) (postPaddedBuffer - preliminaryKey));
+                slot->key = std::string_view(preliminaryKey, (size_t) (postPaddedBuffer - preliminaryKey));
                 if(maxHeaderSize && (uintptr_t)(postPaddedBuffer - headerStart) > maxHeaderSize) {
                     return HttpParserResult::error(HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE);
                 }
@@ -779,8 +791,18 @@ namespace uWS
                 /* RFC 9112 5.1: field-name is a non-empty token. An empty name would also
                  * collide with the end-of-headers sentinel and hide later headers from the
                  * Content-Length / Transfer-Encoding request-smuggling checks. */
-                if (headers->key.length() == 0) {
+                if (slot->key.length() == 0) {
                     return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN);
+                }
+                /* Body framing is derived from the stored array after this function returns;
+                 * a Content-Length or Transfer-Encoding we cannot store would be invisible to
+                 * that logic and misframe the body on a pipelined connection (request
+                 * smuggling), so reject rather than silently drop it. */
+                if (!storing) [[unlikely]] {
+                    if ((slot->key.length() == 14 && !strncasecmp(slot->key.data(), "content-length", 14)) ||
+                        (slot->key.length() == 17 && !strncasecmp(slot->key.data(), "transfer-encoding", 17))) {
+                        return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_REQUEST);
+                    }
                 }
                 postPaddedBuffer++;
 
@@ -810,22 +832,24 @@ namespace uWS
                     * This way we can have this one single check to see if we found \r\n WITHIN our allowed search space. */
                 if (postPaddedBuffer[1] == '\n') {
                     /* Store this header, it is valid */
-                    headers->value = std::string_view(preliminaryValue, (size_t) (postPaddedBuffer - preliminaryValue));
+                    slot->value = std::string_view(preliminaryValue, (size_t) (postPaddedBuffer - preliminaryValue));
                     postPaddedBuffer += 2;
                     /* Trim trailing whitespace (SP, HTAB) per RFC 9110 Section 5.5 */
-                    while (headers->value.length() && isHTTPHeaderValueWhitespace(headers->value.back())) {
-                        headers->value.remove_suffix(1);
+                    while (slot->value.length() && isHTTPHeaderValueWhitespace(slot->value.back())) {
+                        slot->value.remove_suffix(1);
                     }
 
                     /* Trim initial whitespace (SP, HTAB) per RFC 9110 Section 5.5 */
-                    while (headers->value.length() && isHTTPHeaderValueWhitespace(headers->value.front())) {
-                        headers->value.remove_prefix(1);
+                    while (slot->value.length() && isHTTPHeaderValueWhitespace(slot->value.front())) {
+                        slot->value.remove_prefix(1);
                     }
 
                     if(maxHeaderSize && (uintptr_t)(postPaddedBuffer - headerStart) > maxHeaderSize) {
                         return HttpParserResult::error(HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE);
                     }
-                    headers++;
+                    if (storing) {
+                        headers++;
+                    }
 
                     /* We definitely have at least one header (or request line), so check if we are done */
                     if (*postPaddedBuffer == '\r') {
@@ -851,8 +875,6 @@ namespace uWS
                     return HttpParserResult::shortRead();
                 }
             }
-            /* We ran out of header space, too large request */
-            return HttpParserResult::error(HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE);
         }
 
     /* This is the only caller of getHeaders and is thus the deepest part of the parser. */

--- a/test/js/node/http/node-http-header-count.test.ts
+++ b/test/js/node/http/node-http-header-count.test.ts
@@ -1,0 +1,152 @@
+import { expect, test, describe } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+
+function buildRequest(extraHeaders: number, trailer = "Connection: close\r\n") {
+  let req = `GET / HTTP/1.1\r\nHost: x\r\n`;
+  for (let i = 0; i < extraHeaders; i++) req += `X-${i}: v\r\n`;
+  req += trailer;
+  req += "\r\n";
+  return req;
+}
+
+function rawRequest(port: number, bytes: string): Promise<string> {
+  return new Promise(resolve => {
+    const chunks: Buffer[] = [];
+    const sock = net.connect(port, "127.0.0.1", () => sock.end(Buffer.from(bytes, "latin1")));
+    const done = () => {
+      sock.destroy();
+      resolve(Buffer.concat(chunks).toString("latin1"));
+    };
+    sock.on("data", d => chunks.push(d));
+    sock.on("close", done);
+    sock.on("error", done);
+  });
+}
+
+function statusLine(response: string): string {
+  return response.slice(0, response.indexOf("\r\n"));
+}
+
+describe("node:http server accepts requests with many header fields", () => {
+  async function probe(extraHeaders: number, trailer?: string) {
+    const events: string[] = [];
+    const server = http.createServer((req, res) => {
+      events.push(`request rawHeaders=${req.rawHeaders.length / 2}`);
+      res.end("ok");
+    });
+    server.on("clientError", (err: NodeJS.ErrnoException) => {
+      events.push(`clientError ${err.code}`);
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await rawRequest(port, buildRequest(extraHeaders, trailer));
+      return { status: statusLine(response), events };
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  }
+
+  // Previously rejected with 431 / HPE_HEADER_OVERFLOW once the total field
+  // count reached 199. Node.js accepts these (default ceiling is 1000 fields,
+  // tunable via server.maxHeadersCount) and only rejects on byte size.
+  for (const n of [150, 197, 300, 900]) {
+    test(`${n} extra header fields are delivered`, async () => {
+      const { status, events } = await probe(n);
+      expect({ status, events }).toEqual({
+        status: "HTTP/1.1 200 OK",
+        events: [`request rawHeaders=${n + 2}`],
+      });
+    });
+  }
+
+  test("fields beyond the stored limit are truncated, not rejected", async () => {
+    // Host + 1100 X-N fields + Connection is ~12 KB, under the 16 KB default
+    // byte limit, so only the count path is exercised.
+    const { status, events } = await probe(1100);
+    expect({ status, events }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      events: ["request rawHeaders=1000"],
+    });
+  });
+
+  test("Content-Length past the stored limit is rejected (request smuggling guard)", async () => {
+    const { status, events } = await probe(1100, "Content-Length: 5\r\nConnection: close\r\n");
+    expect({ status, events }).toEqual({
+      status: "HTTP/1.1 400 Bad Request",
+      events: ["clientError HPE_INTERNAL"],
+    });
+  });
+
+  test("Transfer-Encoding past the stored limit is rejected (request smuggling guard)", async () => {
+    const { status, events } = await probe(1100, "Transfer-Encoding: chunked\r\nConnection: close\r\n");
+    expect({ status, events }).toEqual({
+      status: "HTTP/1.1 400 Bad Request",
+      events: ["clientError HPE_INTERNAL"],
+    });
+  });
+
+  test("byte-size limit still rejects with 431", async () => {
+    const events: string[] = [];
+    const server = http.createServer({ maxHeaderSize: 2048 }, (req, res) => {
+      events.push("request");
+      res.end("ok");
+    });
+    server.on("clientError", (err: NodeJS.ErrnoException) => {
+      events.push(`clientError ${err.code}`);
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const { port } = server.address() as AddressInfo;
+      // 300 tiny fields are ~3 KB of header bytes: the 2 KB byte limit fires
+      // before the count path is ever reached.
+      const response = await rawRequest(port, buildRequest(300));
+      expect({ status: statusLine(response), events }).toEqual({
+        status: "HTTP/1.1 431 Request Header Fields Too Large",
+        events: ["clientError HPE_HEADER_OVERFLOW"],
+      });
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});
+
+describe("Bun.serve accepts requests with many header fields", () => {
+  for (const n of [197, 300, 900]) {
+    test(`${n} extra header fields are delivered`, async () => {
+      let seen: Record<string, string | null> = {};
+      await using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          seen = { first: req.headers.get("x-0"), last: req.headers.get(`x-${n - 1}`) };
+          return new Response("ok");
+        },
+      });
+      const response = await rawRequest(server.port, buildRequest(n));
+      expect({ status: statusLine(response), seen }).toEqual({
+        status: "HTTP/1.1 200 OK",
+        seen: { first: "v", last: "v" },
+      });
+    });
+  }
+
+  test("fields beyond the stored limit are truncated, not rejected", async () => {
+    let seen: Record<string, string | null> = {};
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        seen = { first: req.headers.get("x-0"), dropped: req.headers.get("x-1099") };
+        return new Response("ok");
+      },
+    });
+    const response = await rawRequest(server.port, buildRequest(1100));
+    expect({ status: statusLine(response), seen }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      seen: { first: "v", dropped: null },
+    });
+  });
+});


### PR DESCRIPTION
### Repro

```js
import http from "node:http";
import net from "node:net";

const ev = [];
const srv = http.createServer((req, res) => { ev.push(`nh=${req.rawHeaders.length / 2}`); res.end("ok"); });
srv.on("clientError", e => ev.push(`clientError ${e.code}`));
await new Promise(ok => srv.listen(0, "127.0.0.1", ok));
const port = srv.address().port;

const play = bytes => new Promise(done => {
  const out = []; const s = net.connect(port, "127.0.0.1", () => s.end(Buffer.from(bytes, "latin1")));
  s.on("data", d => out.push(d)); s.on("close", () => done(Buffer.concat(out).toString("latin1")));
});
const REQ = n => `GET / HTTP/1.1\r\nHost: x\r\n` +
  Array.from({ length: n }, (_, i) => `X-${i}: v\r\n`).join("") + "Connection: close\r\n\r\n";

for (const n of [150, 197, 300, 1100])
  console.log(n, (await play(REQ(n))).split("\r\n")[0], ev.splice(0).join("+"));
srv.close();
```

```
node 26.3: 150 HTTP/1.1 200 OK nh=152 / 197 ... nh=199 / 300 ... nh=302 / 1100 ... nh=1000
bun 1.4.0: 150 HTTP/1.1 200 OK nh=152 / 197 HTTP/1.1 431 ... clientError HPE_HEADER_OVERFLOW (same for 300, 1100)
```

`Bun.serve` answers the same bytes with its own 431 + connection close.

### Cause

`UWS_HTTP_MAX_HEADERS_COUNT` is a compile-time 200-slot array in `HttpRequest`. Slot 0 is the request line and the last slot is the null-key sentinel, so 198 header fields fill it and `getHeaders` returns `HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE`. The byte total is nowhere near `maxHeaderSize` (a few KB of tiny headers trips this while a single 8 KB header does not), and no server option can raise it. Node.js's parser has no count-based rejection: `parser.maxHeaderPairs` (default 2000 = 1000 fields) truncates the delivered `rawHeaders` but the request is still served.

### Fix

- Raise `UWS_HTTP_MAX_HEADERS_COUNT` to 1002 so the stored capacity matches Node.js's default 1000-field ceiling. `HttpRequest` grows from ~6 KB to ~32 KB; it is a stack local in `consumePostPadded` on the JS event-loop thread (12-18 MB main / 4 MB worker stack), so the footprint is fine.
- When the array fills, keep parsing into a scratch `Header` slot and drop the result instead of returning 431, so requests with more than 1000 fields are served with the first 1000 (Node.js parity). Header syntax is still validated and `maxHeaderSize` still bounds total bytes.
- If a discarded field is `Content-Length` or `Transfer-Encoding`, reject with 400: body framing is derived from the stored array after parsing, so a framing header past the stored range would be invisible to the RFC 9112 checks and misframe the body on a pipelined connection.

### Verification

`test/js/node/http/node-http-header-count.test.ts` covers 150/197/300/900 fields on both `node:http` and `Bun.serve`, truncation at 1100 fields, the CL/TE guard, and that the 431 byte-size path is unchanged. Fails 10/12 on released Bun, 12/12 pass on this branch; the repro above now matches Node.js exactly.
