### PR TITLE
node:worker_threads: receiveMessageOnPort drains the retained queue after close()

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -207,9 +207,12 @@ void MessagePort::close()
 
     m_isDetached = true;
 
-    // m_pipe is held for the port's whole lifetime (the GC thread reads
-    // it in hasPendingActivity()); marking our side Closed is sufficient.
-    m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
+    // Reject new sends and notify the peer, but leave the inbox intact: node's
+    // close() defers teardown to the uv close callback, so same-tick
+    // receiveMessageOnPort still drains the already-received queue. The
+    // destructive drop happens in the deferred task below (or immediately if
+    // the context is terminating and no task can be queued).
+    m_pipe->markClosed(m_side);
 
     // Release the self-reference taken by jsRef() (set when .onmessage is
     // assigned or .ref() is called from JS). The JS .close() binding calls
@@ -243,10 +246,15 @@ void MessagePort::close()
         context->postTask([protectedThis = Ref { *this }](ScriptExecutionContext&) {
             protectedThis->dispatchCloseEvent();
             protectedThis->removeAllEventListeners();
+            // Matches node's OnClose -> Detach: drop any still-queued messages
+            // (and cascade through transferred ports) now that same-tick
+            // receiveMessageOnPort has had its chance.
+            protectedThis->m_pipe->close(protectedThis->m_side, MessagePortPipe::CloseKind::Explicit);
             protectedThis->m_closeEventPending.store(false, std::memory_order_release);
         });
     } else {
         removeAllEventListeners();
+        m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
     }
 }
 
@@ -368,9 +376,10 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
 
 JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject)
 {
-    if (!isEntangled())
-        return jsUndefined();
-
+    // Deliberately not gated on isEntangled(): node's receiveMessageOnPort keeps
+    // draining the retained inbox after close() until the deferred teardown
+    // drops it. A transferred-away port has no context, so the check below
+    // still returns undefined for that case.
     auto* context = scriptExecutionContext();
     if (!context)
         return jsUndefined();

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -255,6 +255,17 @@ void MessagePortPipe::detach(uint8_t side)
     s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled), std::memory_order_acq_rel);
 }
 
+void MessagePortPipe::markClosed(uint8_t side)
+{
+    ASSERT(side < 2);
+    {
+        auto& s = m_sides[side];
+        Locker locker { s.lock };
+        s.state.fetch_or(Closed | ClosedByRequest, std::memory_order_acq_rel);
+    }
+    notifyPeerClosed(1 - side);
+}
+
 void MessagePortPipe::close(uint8_t side, CloseKind kind)
 {
     ASSERT(side < 2);

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -261,7 +261,12 @@ void MessagePortPipe::markClosed(uint8_t side)
     {
         auto& s = m_sides[side];
         Locker locker { s.lock };
-        s.state.fetch_or(Closed | ClosedByRequest, std::memory_order_acq_rel);
+        // Clear Attached so a drain task already in flight bails at its
+        // per-iteration guard instead of popping the retained inbox and
+        // handing each message to the now-detached port (which would drop
+        // it). The inbox stays; only the terminal close() swaps it out.
+        uint64_t st = s.state.load(std::memory_order_relaxed);
+        s.state.store((st | Closed | ClosedByRequest) & ~Attached, std::memory_order_release);
     }
     notifyPeerClosed(1 - side);
 }

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -75,8 +75,9 @@ public:
     // so reading Closed alone made .ref() GC-dependent). Both notify the peer.
     enum class CloseKind : uint8_t { Explicit,
         Collected };
-    // Set Closed|ClosedByRequest and notify the peer, but KEEP the inbox so
-    // receiveMessageOnPort can still drain it; the terminal close() below drops it.
+    // Set Closed|ClosedByRequest, clear Attached (so any scheduled drain bails),
+    // notify the peer, and KEEP the inbox so receiveMessageOnPort can still
+    // drain it; the terminal close() below drops it.
     void markClosed(uint8_t side);
     void close(uint8_t side, CloseKind = CloseKind::Collected);
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -75,6 +75,9 @@ public:
     // so reading Closed alone made .ref() GC-dependent). Both notify the peer.
     enum class CloseKind : uint8_t { Explicit,
         Collected };
+    // Set Closed|ClosedByRequest and notify the peer, but KEEP the inbox so
+    // receiveMessageOnPort can still drain it; the terminal close() below drops it.
+    void markClosed(uint8_t side);
     void close(uint8_t side, CloseKind = CloseKind::Collected);
 
     // Lockless snapshot for the GC visitor / hasPendingActivity.

--- a/test/js/node/worker_threads/messageport-close-queue.test.ts
+++ b/test/js/node/worker_threads/messageport-close-queue.test.ts
@@ -33,6 +33,43 @@ describe("MessagePort.close() retains already-queued messages", () => {
     port2.close();
   });
 
+  test.concurrent("a drain scheduled before close() does not consume the retained inbox", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { MessageChannel, receiveMessageOnPort } = require("node:worker_threads");
+          const { port1, port2 } = new MessageChannel();
+          const got = [];
+          port1.on("message", m => got.push(m));   // started: a drain is scheduled on send()
+          port2.postMessage("a");
+          port2.postMessage("b");
+          port1.close();
+          const sync = receiveMessageOnPort(port1);
+          setImmediate(() => {
+            // The stale drain must have bailed (node's uv_close cancels the
+            // pending uv_async); the inbox is still here for rmo and nothing
+            // was delivered to the listener.
+            console.log(JSON.stringify({ got, sync, after: receiveMessageOnPort(port1) }));
+            port2.close();
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    // Node still returns "b" at the first setImmediate (uv close callbacks fire
+    // after the check phase); bun drops it one phase earlier. Either way the
+    // listener was never called and same-tick rmo returned "a".
+    expect({ got: out.got, sync: out.sync }).toEqual({ got: [], sync: { message: "a" } });
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("the retained queue is dropped once the deferred close runs", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -45,11 +82,13 @@ describe("MessagePort.close() retains already-queued messages", () => {
           port2.postMessage("b");
           port1.close();
           const sync = receiveMessageOnPort(port1);
-          setImmediate(() => {
-            // Deferred close has dropped the remaining inbox (node's OnClose -> Detach).
+          // Node drops the inbox in the uv close-callbacks phase, which runs
+          // after setImmediate; two nested setImmediates land past that in
+          // both runtimes.
+          setImmediate(() => setImmediate(() => {
             console.log(JSON.stringify({ sync, after: receiveMessageOnPort(port1) }));
             port2.close();
-          });
+          }));
         `,
       ],
       env: bunEnv,

--- a/test/js/node/worker_threads/messageport-close-queue.test.ts
+++ b/test/js/node/worker_threads/messageport-close-queue.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { MessageChannel, MessagePort, receiveMessageOnPort } from "node:worker_threads";
+
+// Node's MessagePort.close() retains the already-received queue until the
+// deferred uv close callback fires, so same-tick receiveMessageOnPort can
+// still drain it.
+describe("MessagePort.close() retains already-queued messages", () => {
+  test("receiveMessageOnPort drains the queue after close()", () => {
+    const { port1, port2 } = new MessageChannel();
+    port2.postMessage("q1");
+    port2.postMessage("q2");
+    port2.postMessage("q3");
+    expect(receiveMessageOnPort(port1)).toStrictEqual({ message: "q1" });
+    port1.close();
+    expect(receiveMessageOnPort(port1)).toStrictEqual({ message: "q2" });
+    expect(receiveMessageOnPort(port1)).toStrictEqual({ message: "q3" });
+    expect(receiveMessageOnPort(port1)).toBe(undefined);
+    port2.close();
+  });
+
+  test("transferred port queued at close() time is usable via receiveMessageOnPort", () => {
+    const { port1, port2 } = new MessageChannel();
+    const { port1: ip1, port2: ip2 } = new MessageChannel();
+    port2.postMessage({ inner: ip1 }, [ip1]);
+    port1.close();
+    const r = receiveMessageOnPort(port1) as { message: { inner: MessagePort } };
+    expect(r).toBeDefined();
+    r.message.inner.postMessage("via-inner");
+    expect(receiveMessageOnPort(ip2)).toStrictEqual({ message: "via-inner" });
+    r.message.inner.close();
+    ip2.close();
+    port2.close();
+  });
+
+  test.concurrent("the retained queue is dropped once the deferred close runs", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { MessageChannel, receiveMessageOnPort } = require("node:worker_threads");
+          const { port1, port2 } = new MessageChannel();
+          port2.postMessage("a");
+          port2.postMessage("b");
+          port1.close();
+          const sync = receiveMessageOnPort(port1);
+          setImmediate(() => {
+            // Deferred close has dropped the remaining inbox (node's OnClose -> Detach).
+            console.log(JSON.stringify({ sync, after: receiveMessageOnPort(port1) }));
+            port2.close();
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ sync: { message: "a" } });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -68,7 +68,7 @@ describe("MessagePortChannel closed port", () => {
             const ITERATIONS = 1000;
             const PAYLOAD_SIZE = 128 * 1024;
 
-            function round() {
+            async function round() {
               for (let i = 0; i < ITERATIONS; i++) {
                 const carrier = new MessageChannel();
                 const inner = new MessageChannel();
@@ -84,7 +84,7 @@ describe("MessagePortChannel closed port", () => {
                   carrier.port2.close();
                   carrier.port1.postMessage(null, [inner.port1]);
                 } else {
-                  // Drop path: MessagePortPipe::close() swaps out the inbox; the dropped
+                  // Drop path: the deferred close task swaps out the inbox; the dropped
                   // message's TransferredMessagePort is harvested into the close worklist.
                   carrier.port1.postMessage(null, [inner.port1]);
                   carrier.port2.close();
@@ -93,15 +93,18 @@ describe("MessagePortChannel closed port", () => {
                 inner.port2.close();
                 carrier.port1.close();
               }
+              // close() defers the inbox drop to a task (node compat); let those
+              // run so the freed memory is reusable before RSS is measured.
+              await Bun.sleep(0);
               Bun.gc(true);
               Bun.gc(true);
             }
 
             // Warm up to establish allocator high-water mark.
-            round();
+            await round();
 
             const rssBefore = process.memoryUsage().rss;
-            round();
+            await round();
             const rssAfter = process.memoryUsage().rss;
             const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
 


### PR DESCRIPTION
## Repro

```js
import { MessageChannel, receiveMessageOnPort } from "node:worker_threads";

const { port1, port2 } = new MessageChannel();
port2.postMessage("q1");
port2.postMessage("q2");
receiveMessageOnPort(port1);           // { message: "q1" } everywhere
port1.close();
receiveMessageOnPort(port1);
// node:  { message: "q2" }   (queue survives until the async close cb)
// bun:   undefined           (queue destroyed on the spot)
```

Silent data loss in a documented `node:worker_threads` pattern (drain-after-close via `receiveMessageOnPort`). Node defers `MessagePort` teardown to the uv close callback, so same-tick `receiveMessageOnPort` can still drain the already-received queue; a tick later the queue is gone.

Originally this PR also fixed the close-inside-handler case (close called from a `'message'` listener drops the queued tail). #31216 landed with its own fix for that via `m_isDispatching` + `flushQueuedMessagesBeforeClose()`, so this PR has been rebased to cover only the remaining `receiveMessageOnPort`-after-close gap.

## Cause

`MessagePort::close()` called the destructive `m_pipe->close()` synchronously, which swaps out the inbox and nulls the side's `port`/`ctxId`; and `tryTakeMessage()` was gated on `isEntangled()` (false after `close()` sets `m_isDetached`). So both the pipe state and the port guard prevented post-close reads.

## Fix

- Add `MessagePortPipe::markClosed()`: sets `Closed | ClosedByRequest` (so `send()` drops new messages and `isOtherSideClosedByRequest()` reads true) and notifies the peer, but leaves the inbox, `port`, and `ctxId` in place.
- `MessagePort::close()` calls `markClosed()` at the point where it previously called the destructive `close()`. The destructive `m_pipe->close()` moves into the existing deferred close task (the one that fires `'close'` and removes listeners), matching node's OnClose -> Detach timing. On the context-terminating path, where no task can be queued, the destructive close still runs synchronously.
- `tryTakeMessage()` drops its `isEntangled()` guard: it now relies on the `scriptExecutionContext()` check (a transferred-away port has no context) and on `takeOne()` returning `nullopt` once the deferred drop has emptied the inbox.

## Verification

New `test/js/node/worker_threads/messageport-close-queue.test.ts` (all fail on the unfixed build, pass with the fix):

- `receiveMessageOnPort` drains the retained queue after `close()`
- a transferred port queued at `close()` time is usable via `receiveMessageOnPort`
- the retained queue is dropped once the deferred close runs (same-tick read returns the message, post-`setImmediate` read returns `undefined`)

Existing `message-port-pipe`, `message-port-closed-leak`, `message-port-context-destroy-leak`, `message-channel`, and node's `test-worker-message-port-close*` / `test-worker-message-port-receive-message` / `test-worker-message-port-transfer-closed` parallel tests pass.

The tests live in a standalone file rather than `worker_threads.test.ts` because several of #31216's new tests in that file exceed the 5s default under debug/ASAN; keeping this suite separate avoids compounding those timeouts.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/messageport-close-queue.test.ts test/js/web/workers/message-port-closed-leak.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eb57f4fc4)

test/js/web/workers/message-port-closed-leak.test.ts:
(pass) MessagePortChannel closed port > postMessage to closed port does not accumulate in pending queue [6715.84ms]
(pass) MessagePortChannel closed port > transferred port dropped before receiver closed does not leak channel [4510.79ms]
(pass) MessagePortChannel closed port > transferred port dropped after receiver closed does not leak channel [4499.49ms]
(pass) MessagePortChannel closed port > deep chain of nested transferred ports does not overflow on close [8875.11ms]

test/js/node/worker_threads/messageport-close-queue.test.ts:
11 |     port2.postMessage("q1");
12 |     port2.postMessa
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (eb95a6e5d)

test/js/web/workers/message-port-closed-leak.test.ts:
(pass) MessagePortChannel closed port > postMessage to closed port does not accumulate in pending queue [149.86ms]
(pass) MessagePortChannel closed port > transferred port dropped before receiver closed does not leak channel [148.62ms]
(pass) MessagePortChannel closed port > transferred port dropped after receiver closed does not leak channel [96.59ms]
(pass) MessagePortChannel closed port > deep chain of nested transferred ports does not overflow on close [73.46ms]

test/js/node/worker_threads/messageport-close-queue.test.ts:
(pass) MessagePort.close() retains already-queued messages > receiveMessageOnPort drains the queue after close() [0.15ms]
(pass) MessagePort.close() retains already-queued messages > transferred port queued at close() time is usable via receiveMessageOnPort [0.19ms]
(pass) MessagePort.close() retains already-queued messages > the retained queue is dropped once the deferred close runs [20.16ms]
(pass) MessagePort.close() retains already-queued messages > a drain scheduled before close() does not consume the retained inbox [21.01ms]

 8 pass
 0 fail
 22 e
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/messageport-close-queue.test.ts test/js/web/workers/message-port-closed-leak.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eb57f4fc4)

test/js/web/workers/message-port-closed-leak.test.ts:
(pass) MessagePortChannel closed port > postMessage to closed port does not accumulate in pending queue [6690.88ms]
(pass) MessagePortChannel closed port > transferred port dropped before receiver closed does not leak channel [4519.94ms]
(pass) MessagePortChannel closed port > transferred port dropped after receiver closed does not leak channel [4490.40ms]
(pass) MessagePortChannel closed port > deep chain of nested transferred ports does not overflow on close [8699.93ms]

test/js/node/worker_threads/messageport-close-queue.test.ts:
(pass) MessagePort.close() retains already-queued messages
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/17] gen cpp.rs (cppbind)
[1/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp           |  21 +++--
 src/jsc/bindings/webcore/MessagePortPipe.cpp       |  16 ++++
 src/jsc/bindings/webcore/MessagePortPipe.h         |   4 +
 .../worker_threads/messageport-close-queue.test.ts | 103 +++++++++++++++++++++
 .../web/workers/message-port-closed-leak.test.ts   |  11 ++-
 5 files changed, 145 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp                      3      6      0
src/jsc/bindings/webcore/MessagePortPipe.cpp                  5      6      0
src/jsc/bindings/webcore/MessagePortPipe.h                    4      4      0
…/js/node/worker_threads/messageport-close-queue.test.ts      1      2      0
test/js/web/workers/message-port-closed-leak.test.ts          2      2      0
```

</details>

<!-- robobun:evidence:end -->