### PR TITLE
node:http: emit 'close' on server connection socket when the peer disconnects

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1018,7 +1018,6 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
 
 const kBytesWritten = Symbol("kBytesWritten");
 const kEnableStreaming = Symbol("kEnableStreaming");
-const kIsTunnel = Symbol("kIsTunnel");
 function onServerSocketError(this: any, _err) {
   // Default 'error' listener so socket-level errors (e.g. res.destroy(err)
   // forwarding the error to the socket) do not crash the process as
@@ -1036,7 +1035,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   connecting = false;
   timeout = 0;
   [kBytesWritten] = 0;
-  [kIsTunnel] = false;
   [kHandle];
   server: Server;
   _httpMessage;
@@ -1070,10 +1068,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   [kEnableStreaming](enable: boolean) {
-    // kIsTunnel latches: once a socket is detached into CONNECT/upgrade tunnel
-    // mode it never returns to normal request handling, and #onClose relies on
-    // it to emit 'close' on native close.
-    if (enable) this[kIsTunnel] = true;
     const handle = this[kHandle];
     if (handle) {
       if (enable) {
@@ -1162,10 +1156,10 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       process.nextTick(emitCloseNT, message);
     }
 
-    // A tunneled/upgraded connection (CONNECT or WebSocket upgrade) is detached
-    // from the request/response lifecycle, so end the Duplex on native close to
-    // emit 'close' for the upgrade handler and user listeners, like Node.js.
-    if (this[kIsTunnel] && !this.destroyed) {
+    // The native connection is gone: end the Duplex so the socket emits
+    // 'close'. kHandle is already null (no-handle _destroy branch) and the
+    // user-initiated path (#onCloseForDestroy) arrives with destroyed set.
+    if (!this.destroyed) {
       this.destroy();
     }
   }

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,12 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2969,8 +2969,8 @@ it("server connection socket emits 'close' when the peer disconnects after a com
     await socketClosed;
     expect(closeCount).toBe(1);
   } finally {
-    server.close();
     server.closeAllConnections();
+    server.close();
   }
 });
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2939,6 +2939,41 @@ it("removing transfer-encoding on a HEAD response keeps the connection alive", a
   }
 });
 
+it("server connection socket emits 'close' when the peer disconnects after a completed keep-alive response", async () => {
+  // https://github.com/oven-sh/bun/issues/33639
+  const server = createServer((req, res) => res.end("ok"));
+  const { promise: socketClosed, resolve: onSocketClosed } = Promise.withResolvers<void>();
+  let closeCount = 0;
+  server.on("connection", s => {
+    s.on("close", () => {
+      closeCount++;
+      onSocketClosed();
+    });
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const client = connect(port, "127.0.0.1");
+    await once(client, "connect");
+    client.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: keep-alive\r\n\r\n");
+    let body = "";
+    while (!body.includes("\r\n\r\nok")) {
+      const [chunk] = await once(client, "data");
+      body += chunk;
+    }
+    client.end();
+    await once(client, "close");
+
+    await socketClosed;
+    expect(closeCount).toBe(1);
+  } finally {
+    server.close();
+    server.closeAllConnections();
+  }
+});
+
 it("clientError after a kept-alive request reuses the connection's socket and untracks it on close", async () => {
   // The native side returns the existing handle for parser errors on a
   // connection that already served a request; wrapping it again stranded the


### PR DESCRIPTION
Fixes #33639.

## Repro

```js
import http from "node:http"; import net from "node:net";
const server = http.createServer((_q, r) => r.end("ok"));
let closed = false;
server.on("connection", s => s.on("close", () => { closed = true; }));
server.listen(0, "127.0.0.1", () => {
  const p = server.address().port;
  const c = net.connect(p, "127.0.0.1", () => c.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: keep-alive\r\n\r\n"));
  c.on("data", () => c.end());
  c.on("close", () => setTimeout(() => { console.log("server socket close emitted:", closed); process.exit(0); }, 400));
});
```

Node.js prints `true`; Bun printed `false`.

## Cause

`NodeHTTPServerSocket.#onClose` (the native socket close callback) nulls the handle, untracks the connection, and destroys the in-flight request if one is still attached, but it never destroyed the Duplex itself for non-tunnel sockets. The only paths that did were `socket.destroy()` (user-initiated), the per-request abort handler, and (since #32737 landed) the `kIsTunnel`-scoped branch for CONNECT/upgrade sockets. An idle keep-alive socket has no request in flight and is not a tunnel, so when the peer disconnects the Duplex never emits `'close'`.

## Fix

Destroy the Duplex at the end of `#onClose` whenever it is not already destroyed, dropping the `kIsTunnel` gate. `this[kHandle]` is nulled at the top of `#onClose`, so `_destroy` takes its no-handle branch and just completes the destroy. The user-initiated destroy path (`#onCloseForDestroy`) reaches `#onClose` with `destroyed` already set, so the new call is a no-op there. The `kIsTunnel` symbol/field/setter are removed as dead code.

Also makes `test/js/node/http/node-http-proxy.js` hermetic by binding/connecting on `127.0.0.1` instead of `localhost` (on hosts where `localhost` resolves only to `::1` the client connects to IPv4 while the server binds IPv6, failing with ECONNREFUSED even on Node.js).

## Verification

```
# before (test times out at 5000ms because 'close' never fires):
(fail) server connection socket emits 'close' when the peer disconnects after a completed keep-alive response [5000ms]

# after:
(pass) server connection socket emits 'close' when the peer disconnects after a completed keep-alive response [92ms]
```

Also re-ran `node-http.test.ts` (129 pass, 0 fail), `test/regression/issue/32734.test.ts` (the tunnel/upgrade cases #32737 covers, 2 pass), `node-http-with-ws.test.ts`, `res.sendFile.test.ts`, and the vendored `test-http-{abort*,aborted,keep-alive*,response-close,server-stale-close,server-keep-alive-defaults,server-close-all,server-destroy-socket-on-client-error,upgrade-*,1.0-keep-alive,keep-alive-pipeline-max-requests,server-keepalive-req-gc}` node:test files.
