### PR TITLE
fetch: accept a URL object for proxy.url

### DIFF
--- a/docs/guides/http/proxy.mdx
+++ b/docs/guides/http/proxy.mdx
@@ -15,7 +15,7 @@ await fetch("https://example.com", {
 
 ---
 
-The `proxy` option can be a URL string or an object with `url` and optional `headers`. The URL can include the username and password if the proxy requires authentication. It can be `http://` or `https://`.
+The `proxy` option can be a URL string, or an object with `url` (a string or a `URL`) and optional `headers`. The URL can include the username and password if the proxy requires authentication. It can be `http://` or `https://`.
 
 ---
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -51,7 +51,7 @@ const response = await fetch("http://example.com", {
 
 ### Proxying requests
 
-To proxy a request, pass an object with the `proxy` property set to a URL string:
+To proxy a request, pass an object with the `proxy` property set to a URL string, or to an object whose `url` is a string or a `URL`:
 
 ```ts
 const response = await fetch("http://example.com", {

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4277,9 +4277,9 @@ declare module "bun" {
       | string
       | {
           /**
-           * The proxy URL (http:// or https://)
+           * The proxy URL (http:// or https://), as a string or a `URL`.
            */
-          url: string;
+          url: string | URL;
           /**
            * Custom headers to send to the proxy server.
            * Supports plain objects or Headers class instances.

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1967,9 +1967,9 @@ interface BunFetchRequestInit extends RequestInit {
     | string
     | {
         /**
-         * The proxy URL
+         * The proxy URL, as a string or a `URL`.
          */
-        url: string;
+        url: string | URL;
         /**
          * Custom headers to send to the proxy server.
          * These headers are sent in the CONNECT request (for HTTPS targets)

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1025,77 +1025,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         // Get the URL from the proxy object
                         if let Some(proxy_url_arg) = proxy_arg.get(global_this, "url")? {
                             if !proxy_url_arg.is_undefined_or_null() {
-                                if proxy_url_arg.is_string() && proxy_url_arg.get_length(ctx)? > 0 {
-                                    // +1 ref; see the string-format branch above.
-                                    let href = bun_core::OwnedString::new(jsc::URL::href_from_js(
-                                        proxy_url_arg,
-                                        global_this,
-                                    )?);
-                                    if href.tag() == BunStringTag::Dead {
-                                        let err = ctx.to_type_error(
-                                            jsc::ErrorCode::INVALID_ARG_VALUE,
-                                            format_args!("fetch() proxy URL is invalid"),
-                                        );
-                                        return Ok(
-                                            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                                global_this, err,
-                                            ),
-                                        );
-                                    }
-                                    let mut buffer: Vec<u8> =
-                                        Vec::with_capacity(url_proxy_buffer.len());
-                                    buffer.extend_from_slice(&url_proxy_buffer);
-                                    write!(&mut buffer, "{}", href)
-                                        .expect("write to Vec cannot fail");
-                                    let url_len = url.href.len();
-                                    url = parse_url_detached!(&buffer[0..url_len]);
-                                    if url.is_file() {
-                                        url_type = URLType::File;
-                                    } else if url.is_blob() {
-                                        url_type = URLType::Blob;
-                                    }
-
-                                    proxy = Some(parse_url_detached!(&buffer[url_len..]));
-                                    // allocator.free(url_proxy_buffer) — old Vec dropped on reassign.
-                                    url_proxy_buffer = buffer;
-
-                                    // Get the headers from the proxy object (optional)
-                                    if let Some(headers_value) =
-                                        proxy_arg.get(global_this, "headers")?
-                                    {
-                                        if !headers_value.is_undefined_or_null() {
-                                            if let Some(fetch_hdrs) =
-                                                FetchHeaders::cast(headers_value)
-                                            {
-                                                // `cast` returns a live JS-owned FetchHeaders*;
-                                                // BackRef invariant holds for this read.
-                                                let fetch_hdrs = bun_ptr::BackRef::from(fetch_hdrs);
-                                                proxy_headers = Some(from_fetch_headers(
-                                                    Some(&*fetch_hdrs),
-                                                    None,
-                                                ));
-                                            } else if let Some(fetch_hdrs) =
-                                                FetchHeaders::create_from_js(ctx, headers_value)?
-                                            {
-                                                // `create_from_js` returns a +1-ref NonNull<FetchHeaders>;
-                                                // RAII guard releases it on scope exit.
-                                                let _guard = FetchHeadersRef(Some(fetch_hdrs));
-                                                let fetch_hdrs = bun_ptr::BackRef::from(fetch_hdrs);
-                                                proxy_headers = Some(from_fetch_headers(
-                                                    Some(&*fetch_hdrs),
-                                                    None,
-                                                ));
-                                            }
-                                        }
-                                    }
-
-                                    break 'extract_proxy url_proxy_buffer;
-                                } else {
+                                // Deliberately no type gate: `href_from_js` accepts a string
+                                // or a `URL` object and is the sole validator (Dead = invalid).
+                                // +1 ref; see the string-format branch above.
+                                let href = bun_core::OwnedString::new(jsc::URL::href_from_js(
+                                    proxy_url_arg,
+                                    global_this,
+                                )?);
+                                if href.tag() == BunStringTag::Dead {
                                     let err = ctx.to_type_error(
                                         jsc::ErrorCode::INVALID_ARG_VALUE,
-                                        format_args!(
-                                            "fetch() proxy.url must be a non-empty string"
-                                        ),
+                                        format_args!("fetch() proxy URL is invalid"),
                                     );
                                     return Ok(
                                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -1103,6 +1043,48 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                         ),
                                     );
                                 }
+                                let mut buffer: Vec<u8> =
+                                    Vec::with_capacity(url_proxy_buffer.len());
+                                buffer.extend_from_slice(&url_proxy_buffer);
+                                write!(&mut buffer, "{}", href).expect("write to Vec cannot fail");
+                                let url_len = url.href.len();
+                                url = parse_url_detached!(&buffer[0..url_len]);
+                                if url.is_file() {
+                                    url_type = URLType::File;
+                                } else if url.is_blob() {
+                                    url_type = URLType::Blob;
+                                }
+
+                                proxy = Some(parse_url_detached!(&buffer[url_len..]));
+                                // allocator.free(url_proxy_buffer) — old Vec dropped on reassign.
+                                url_proxy_buffer = buffer;
+
+                                // Get the headers from the proxy object (optional)
+                                if let Some(headers_value) =
+                                    proxy_arg.get(global_this, "headers")?
+                                {
+                                    if !headers_value.is_undefined_or_null() {
+                                        if let Some(fetch_hdrs) = FetchHeaders::cast(headers_value)
+                                        {
+                                            // `cast` returns a live JS-owned FetchHeaders*;
+                                            // BackRef invariant holds for this read.
+                                            let fetch_hdrs = bun_ptr::BackRef::from(fetch_hdrs);
+                                            proxy_headers =
+                                                Some(from_fetch_headers(Some(&*fetch_hdrs), None));
+                                        } else if let Some(fetch_hdrs) =
+                                            FetchHeaders::create_from_js(ctx, headers_value)?
+                                        {
+                                            // `create_from_js` returns a +1-ref NonNull<FetchHeaders>;
+                                            // RAII guard releases it on scope exit.
+                                            let _guard = FetchHeadersRef(Some(fetch_hdrs));
+                                            let fetch_hdrs = bun_ptr::BackRef::from(fetch_hdrs);
+                                            proxy_headers =
+                                                Some(from_fetch_headers(Some(&*fetch_hdrs), None));
+                                        }
+                                    }
+                                }
+
+                                break 'extract_proxy url_proxy_buffer;
                             }
                         }
                     }

--- a/test/integration/bun-types/fixture/fetch.ts
+++ b/test/integration/bun-types/fixture/fetch.ts
@@ -264,6 +264,15 @@ if (typeof process !== "undefined") {
 }
 
 {
+  // Object proxy with url as a URL object is valid
+  fetch("https://example.com", {
+    proxy: {
+      url: new URL("http://proxy.example.com:8080"),
+    },
+  });
+}
+
+{
   // Object proxy with url and headers (plain object) is valid
   fetch("https://example.com", {
     proxy: {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1203,6 +1203,29 @@ describe.concurrent("proxy object format with headers", () => {
     expect(response.status).toBe(200);
   });
 
+  // https://github.com/oven-sh/bun/issues/29103
+  test("proxy object with url as a URL object works same as a string url", async () => {
+    const response = await fetch(httpServer.url, {
+      method: "GET",
+      proxy: {
+        url: new URL(httpProxyServer.url),
+      },
+      keepalive: false,
+    });
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+  });
+
+  test("proxy object with a non-URL object url throws error", async () => {
+    await expect(
+      fetch(httpServer.url, {
+        method: "GET",
+        proxy: { url: {} },
+        keepalive: false,
+      }),
+    ).rejects.toThrow("fetch() proxy URL is invalid");
+  });
+
   test("proxy object with url and headers sends headers to proxy (HTTP proxy)", async () => {
     // Create a proxy server that captures headers
     const capturedHeaders: string[] = [];
@@ -1390,7 +1413,7 @@ describe.concurrent("proxy object format with headers", () => {
         } as any,
         keepalive: false,
       }),
-    ).rejects.toThrow("fetch() proxy.url must be a non-empty string");
+    ).rejects.toThrow("fetch() proxy URL is invalid");
   });
 
   test("proxy object with empty headers object works", async () => {


### PR DESCRIPTION
`fetch(url, { proxy: { url: <URL object> } })` rejected with `TypeError: fetch() proxy.url must be a non-empty string`. `@npmcli/agent` passes a WHATWG `URL` there, and `Bun.serve().url` is itself a `URL`, so `proxy: { url: server.url }` — the most natural spelling — was broken too. OpenCode carries a patch to stringify it (#29103).

**Root cause / fix.** The object-form branch gated `proxy.url` on `is_string()` before handing it to `jsc::URL::href_from_js` — but `href_from_js` (`URL__getHrefFromJS`) already does everything: it stringifies any value, parses it, and returns `Dead` for empty or unparseable input, with the exception check. The gate was pure over-restriction in front of a complete validator. The fix **deletes the gate and its now-dead `else` arm** and lets `href_from_js` be the single source of truth (net **−16 lines** in `fetch.rs`). The top-level string-form gate is deliberately untouched: it is load-bearing (it routes strings away from the object branch).

**Verified end-to-end**, not just via the test file: drove the debug binary from a plain script against two real servers where the "proxy" answers with its own body, so a fetch to `origin` returning `FROM_PROXY` has provably routed through the proxy.
```
{url: <string>}                    => FROM_PROXY /hello
{url: new URL(...)}                => FROM_PROXY /hello   <-- the fix
{url: server.url} (a URL obj)      => FROM_PROXY /hello
probe {url: {}} (junk object)      => TypeError: fetch() proxy URL is invalid
probe {url: ""} (empty)            => TypeError: fetch() proxy URL is invalid
probe {url: null}                  => FROM_ORIGIN (still ignored, per contract)
probe {url: "not a url"}           => TypeError: fetch() proxy URL is invalid
```
The regression test is proven load-bearing: with only the src hunk reverted it fails with exactly the reported `TypeError: fetch() proxy.url must be a non-empty string`.

Also widens `proxy.url` to `string | URL` in `bun-types` (plus the WebSocket sibling, whose runtime already stringifies a `URL` via `IDLUSVString`) with a fixture, and updates the two docs pages — so the tests need no `as any`. The types suite passes 12/12.

**Deliberate calls a reviewer will notice, made explicit:**
- `{ url: "" }` now reports the pre-existing sibling message `"fetch() proxy URL is invalid"` instead of `"must be a non-empty string"`. The old message was richer but was also emitted, misleadingly, for non-string values; there is now exactly one validator and one message for one condition. The single test asserting the old text is updated.
- A throwing user `toString()`/`Symbol` in `proxy.url` now surfaces the way it already does for `headers` in the same block on both `main` and 1.3.14 (a synchronous throw). That is a long-standing, spec-divergent property of the whole option-conversion path, not something introduced here — filed as #33644 with a `headers`-only repro.
- Deliberately **not** in scope: `proxy: new URL(p)` as the *whole* option value is still silently ignored (a silent proxy bypass, with an identical WebSocket sibling). Fixing it naively would break the intentional, tested #25413 "object without `url` is ignored" contract, so it needs a real `URL`-instance check — filed as #33645 with the analysis.
- The string branch and the object branch share a ~28-line body. That duplication predates this change (the diff only re-indents it); extracting it fights an early return, a labelled break, a local macro, and four outer locals, and would be more complex than what it removes.

Fixes #29103