### PR TITLE
node:http2: handle an oversized request header list as a stream error, not a process crash

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2372,8 +2372,9 @@ class Http2Stream extends Duplex {
     markStreamClosed(this);
     // RST code 8 not emitted as an error as its used by clients to signify
     // abort and is already covered by aborted event, also allows more
-    // seamless compatibility with http1
-    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL)
+    // seamless compatibility with http1. A stream user code never received (rejected before the
+    // 'stream' event) has no possible listener; synthesizing the error there would be uncatchable.
+    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL && !this[kNeverAnnounced])
       err = $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
 
     this[bunHTTP2Session] = null;
@@ -3483,6 +3484,9 @@ class ServerHttp2Session extends Http2Session {
       self.#connections++;
       if (stream_id % 2 === 1) self.#peerInitiatedStreams++;
       const stream = new ServerHttp2Stream(stream_id, self, null);
+      // The stream is not surfaced until streamHeaders fires the 'stream' event; until then an
+      // error on it has no possible listener and must not be synthesized by _destroy.
+      stream[kNeverAnnounced] = true;
       // Returned to the native caller, which stores it as the stream context — no
       // setStreamContext host call needed.
       return stream;
@@ -3589,6 +3593,7 @@ class ServerHttp2Session extends Http2Session {
         // user handler — in particular, losing WantTrailer/FinalCalled breaks
         // any later `sendTrailers()` with ERR_HTTP2_TRAILERS_NOT_READY.
         stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded;
+        stream[kNeverAnnounced] = false;
         if (onServerStreamCreatedChannel.hasSubscribers) {
           onServerStreamCreatedChannel.publish({ stream, headers });
         }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2102,6 +2102,7 @@ class Http2Stream extends Duplex {
   #sentTrailers: any;
   [kAborted]: boolean = false;
   [kHeadRequest]: boolean = false;
+  [kNeverAnnounced]: boolean = false;
   constructor(streamId, session, headers) {
     super({
       decodeStrings: false,

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2807,6 +2807,10 @@ class ServerHttp2Stream extends Http2Stream {
       process.nextTick(callback, err);
       return;
     }
+    // The callback is how user code receives the pushed stream; from here on it can have an
+    // 'error' listener (streamStart marked it never-announced, and streamHeaders never fires for
+    // server-initiated streams).
+    if (pushedStream) pushedStream[kNeverAnnounced] = false;
     process.nextTick(callback, null, pushedStream, headers);
   }
 

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -824,14 +824,13 @@ impl Connection {
     /// RFC 9113 §6.10 CONTINUATION: append the fragment; complete the block on END_HEADERS.
     fn handle_continuation(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         // dispatch() already enforced that we are assembling this exact stream.
-        // Cap the reassembled block at the header-list limit (floored so tiny custom settings
-        // don't reject normal blocks): HPACK output is never smaller than its input, so a
-        // compressed block already past max_header_list_size can only decode past it too —
-        // tearing down here is safe for every legitimate block and bounds memory against
-        // CONTINUATION floods. node itself never errors on this (nghttp2 tolerates far more,
-        // verified on node v26.3.0) — this is deliberate hardening, covered by the
-        // maxHeaderListSize test in node-http2.test.js.
-        let cap = (self.local_settings.max_header_list_size as usize).max(65536);
+        // Buffer past max_header_list_size so finish_header_block can refuse an oversized block
+        // with a per-stream RST_STREAM while keeping the connection-scoped HPACK table in sync
+        // (§4.3, §10.5.1); only past the hard DoS cap is the connection torn down. Node/nghttp2
+        // was observed to GOAWAY at roughly this point (~144 KiB with default settings).
+        let cap = (self.local_settings.max_header_list_size as usize)
+            .max(65536)
+            .saturating_mul(2);
         if self.header_block.len().saturating_add(payload.len()) > cap {
             self.send_go_away(sink, ErrorCode::EnhanceYourCalm, b"header block too large");
             return true;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4539,7 +4539,12 @@ impl H2FrameParser {
             let cap = (self.local_settings.get().max_header_list_size as usize)
                 .max(65536)
                 .saturating_mul(2);
-            if stream.pending_header_block.len().saturating_add(payload.len()) > cap {
+            if stream
+                .pending_header_block
+                .len()
+                .saturating_add(payload.len())
+                > cap
+            {
                 self.send_go_away(
                     frame.stream_identifier,
                     ErrorCode::ENHANCE_YOUR_CALM,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1499,7 +1499,7 @@ pub struct Stream {
     header_block_size: usize,
     header_block_count: usize,
     // Header block fragments buffered across HEADERS + CONTINUATION until
-    // END_HEADERS arrives (RFC 9113 §4.3); capped at `max_header_list_size`.
+    // END_HEADERS arrives (RFC 9113 §4.3).
     pending_header_block: Vec<u8>,
     // Flags from the HEADERS frame that started `pending_header_block`;
     // CONTINUATION frames only carry END_HEADERS.
@@ -4533,12 +4533,13 @@ impl H2FrameParser {
             let payload = content.data();
             let end = content.end;
             self.read_buffer.with_mut(|rb| rb.reset());
-            if stream.pending_header_block.len() + payload.len()
-                > self.local_settings.get().max_header_list_size as usize
-            {
-                // Cap the buffered compressed block at max_header_list_size as a
-                // DoS bound; the decoded list size is checked separately in
-                // decode_header_block.
+            // Hard DoS bound on the compressed buffer only; buffer past the advertised
+            // max_header_list_size so decode_header_block can refuse the oversized block with a
+            // per-stream RST_STREAM while keeping the connection-scoped HPACK table in sync.
+            let cap = (self.local_settings.get().max_header_list_size as usize)
+                .max(65536)
+                .saturating_mul(2);
+            if stream.pending_header_block.len().saturating_add(payload.len()) > cap {
                 self.send_go_away(
                     frame.stream_identifier,
                     ErrorCode::ENHANCE_YOUR_CALM,
@@ -4713,19 +4714,6 @@ impl H2FrameParser {
                 // decoded and END_STREAM finalized in handle_continuation_frame so
                 // the JS event order stays onStreamHeaders -> onStreamEnd.
                 let fragment = &payload[offset..end];
-                if fragment.len() > self.local_settings.get().max_header_list_size as usize {
-                    // Cap the buffered compressed block at max_header_list_size
-                    // as a DoS bound; the decoded list size is checked separately
-                    // in decode_header_block.
-                    self.send_go_away(
-                        frame.stream_identifier,
-                        ErrorCode::ENHANCE_YOUR_CALM,
-                        b"ENHANCE_YOUR_CALM",
-                        self.last_stream_id.get(),
-                        true,
-                    );
-                    return Ok(end_);
-                }
                 stream.pending_header_block.extend_from_slice(fragment);
                 stream.pending_header_flags = frame.flags;
                 self.expecting_continuation.set(frame.stream_identifier);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -420,6 +420,115 @@ describe("frame size limit (checklist §4.2)", () => {
   });
 });
 
+// RFC 9113 §10.5.1: a request whose header list exceeds SETTINGS_MAX_HEADER_LIST_SIZE is a
+// per-stream error, not a connection error, and must not kill the server process. Spawned as a
+// subprocess because the bug was an uncatchable 'error' on a stream user code never received.
+describe.concurrent("header list size limit (RFC 9113 §10.5.1)", () => {
+  for (const [label, headerCount, expectProbe, expectRst1, expectSessionError] of [
+    // ~72 KiB of well-formed headers: over the default 65535 limit, under the hard DoS cap.
+    // Stream 1 is RST_STREAM(ENHANCE_YOUR_CALM); the connection survives and serves stream 3.
+    ["RST_STREAMs an oversized header list and keeps the connection alive", 24, true, true, false],
+    // ~150 KiB: past the hard DoS cap. Connection is torn down (GOAWAY ENHANCE_YOUR_CALM) with a
+    // catchable session error; the process must still survive.
+    ["GOAWAYs a header block past the hard cap without crashing", 50, false, false, true],
+  ] as const) {
+    test(`server ${label}`, async () => {
+      const fixture = `
+        const http2 = require("node:http2");
+        const net = require("node:net");
+        const srv = http2.createServer();
+        const events = [];
+        srv.on("error", e => events.push("server-error:" + e.code));
+        srv.on("sessionError", e => events.push("sessionError:" + e.code));
+        srv.on("session", s => s.on("error", e => events.push("session-error:" + e.code)));
+        srv.on("stream", (st, h) => {
+          st.on("error", e => events.push("stream-error:" + e.code));
+          events.push("REQ:" + h[":path"]);
+          st.respond({ ":status": 200 });
+          st.end("k");
+        });
+        const fr = (t, f, sid, pl) => { const b = Buffer.alloc(9 + pl.length); b.writeUIntBE(pl.length, 0, 3); b[3] = t; b[4] = f; b.writeUInt32BE(sid, 5); pl.copy(b, 9); return b; };
+        const hint = (head, p, v) => { const m = (1 << p) - 1; if (v < m) return Buffer.from([head | v]); const o = [head | m]; v -= m; while (v >= 128) { o.push((v & 0x7f) | 0x80); v >>= 7; } o.push(v); return Buffer.from(o); };
+        const hstr = s => { const b = Buffer.from(s); return Buffer.concat([hint(0, 7, b.length), b]); };
+        const lit = (n, v) => Buffer.concat([Buffer.from([0x00]), hstr(n), hstr(v)]);
+        const block = (path, extra) => Buffer.concat([Buffer.from([0x82, 0x86]), lit(":path", path), lit(":authority", "h"), ...extra.map(([k, v]) => lit(k, v))]);
+        srv.listen(0, "127.0.0.1", () => {
+          const port = srv.address().port;
+          const big = block("/big", Array.from({ length: ${headerCount} }, (_, i) => ["x-" + i, Buffer.alloc(3000, "Q").toString()]));
+          const frames = [];
+          for (let o = 0; o < big.length; o += 16000) {
+            const last = o + 16000 >= big.length;
+            frames.push(fr(o === 0 ? 1 : 9, (last ? 4 : 0) | (o === 0 ? 1 : 0), 1, big.subarray(o, o + 16000)));
+          }
+          const sock = net.connect(port, "127.0.0.1", () => {
+            sock.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\\r\\n\\r\\nSM\\r\\n\\r\\n", "binary"), fr(4, 0, 0, Buffer.alloc(0)), ...frames]));
+          });
+          sock.on("error", () => {});
+          let raw = Buffer.alloc(0);
+          let probed = false;
+          let done = false;
+          const scan = () => {
+            let p = 0, probeOk = false, goaway = -1, rst1 = -1, verdict = false;
+            while (p + 9 <= raw.length) {
+              const l = raw.readUIntBE(p, 3), t = raw[p + 3], sid = raw.readUInt32BE(p + 5) & 0x7fffffff;
+              if (p + 9 + l > raw.length) break;
+              if (t === 1 && sid === 3) probeOk = true;
+              if (t === 7) { goaway = raw.readUInt32BE(p + 13); verdict = true; }
+              if (t === 3 && sid === 1) { rst1 = raw.readUInt32BE(p + 9); verdict = true; }
+              p += 9 + l;
+            }
+            return { probeOk, goaway, rst1, verdict };
+          };
+          const finish = () => {
+            if (done) return;
+            done = true;
+            const { probeOk, goaway, rst1 } = scan();
+            console.log(JSON.stringify({ events, probeOk, goaway, rst1 }));
+            process.exit(0);
+          };
+          sock.on("data", d => {
+            raw = Buffer.concat([raw, d]);
+            const s = scan();
+            // Send the probe only after the server's verdict on stream 1.
+            if (!probed && s.verdict) {
+              probed = true;
+              try { sock.write(fr(1, 5, 3, block("/probe", []))); } catch {}
+            }
+            // Done once the probe is answered, or once a GOAWAY arrived (connection is over).
+            if (probed && (s.probeOk || s.goaway !== -1)) finish();
+          });
+          sock.on("close", finish);
+        });
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("ERR_HTTP2_STREAM_ERROR");
+      const out = JSON.parse(stdout.trim());
+      if (expectRst1) {
+        expect(out.rst1).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
+      }
+      if (expectProbe) {
+        expect(out.events).toContain("REQ:/probe");
+      } else {
+        expect(out.events).not.toContain("REQ:/big");
+      }
+      if (expectSessionError) {
+        expect(out.goaway).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
+        expect(out.events).toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
+      } else {
+        expect(out.goaway).toBe(-1);
+        expect(out.events).not.toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
+      }
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`
 // client and asserts the client's wire behavior (push stream states, SETTINGS ack ordering).
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1498,7 +1498,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
 
-        it("rejects a header block whose compressed size exceeds maxHeaderListSize", async () => {
+        it("rejects a header block whose compressed size exceeds the hard DoS cap", async () => {
           const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
           const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
           const server = net.createServer(async socket => {
@@ -1507,12 +1507,12 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             socket.write(settings.data);
             await waitToWrite;
 
-            // 5 x 16384 = 81920 compressed bytes > the default 65535
-            // maxHeaderListSize; the connection must be torn down before the
-            // block is ever decoded.
+            // 9 x 16384 = 147456 compressed bytes > the 2x max_header_list_size
+            // hard cap (131072 with default settings); the connection is torn
+            // down without decoding the block (RFC 9113 §10.5.1).
             const chunk = Buffer.alloc(16384, 0x41);
             socket.write(Buffer.concat([new http2utils.HeadersFrame(1, chunk, 0, /* EOH */ false, false).data]));
-            for (let i = 0; i < 4; i++) {
+            for (let i = 0; i < 8; i++) {
               // raw CONTINUATION frame without END_HEADERS
               socket.write(Buffer.concat([new http2utils.Frame(chunk.byteLength, 9, 0, 1).data, chunk]));
             }
@@ -1577,6 +1577,109 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
       });
     });
   }
+}
+
+// RFC 9113 §10.5.1: a request whose header list exceeds SETTINGS_MAX_HEADER_LIST_SIZE is a
+// per-stream error, not a connection error, and must not kill the server process. Spawned as a
+// subprocess because the bug was an uncatchable 'error' on a stream user code never received.
+for (const [label, headerCount, expectProbe, expectRst1, expectSessionError] of [
+  // ~72 KiB of well-formed headers: over the default 65535 limit, under the hard DoS cap.
+  // Stream 1 is RST_STREAM(ENHANCE_YOUR_CALM); the connection survives and serves stream 3.
+  ["RST_STREAMs an oversized header list and keeps the connection alive", 24, true, true, false],
+  // ~150 KiB: past the hard DoS cap. Connection is torn down (GOAWAY ENHANCE_YOUR_CALM) with a
+  // catchable session error; the process must still survive.
+  ["GOAWAYs a header block past the hard cap without crashing", 50, false, false, true],
+]) {
+  it(`http2 server ${label}`, async () => {
+    const fixture = `
+      const http2 = require("node:http2");
+      const net = require("node:net");
+      const srv = http2.createServer();
+      const events = [];
+      srv.on("error", e => events.push("server-error:" + e.code));
+      srv.on("sessionError", e => events.push("sessionError:" + e.code));
+      srv.on("session", s => s.on("error", e => events.push("session-error:" + e.code)));
+      srv.on("stream", (st, h) => {
+        st.on("error", e => events.push("stream-error:" + e.code));
+        events.push("REQ:" + h[":path"]);
+        st.respond({ ":status": 200 });
+        st.end("k");
+      });
+      const fr = (t, f, sid, pl) => { const b = Buffer.alloc(9 + pl.length); b.writeUIntBE(pl.length, 0, 3); b[3] = t; b[4] = f; b.writeUInt32BE(sid, 5); pl.copy(b, 9); return b; };
+      const hint = (head, p, v) => { const m = (1 << p) - 1; if (v < m) return Buffer.from([head | v]); const o = [head | m]; v -= m; while (v >= 128) { o.push((v & 0x7f) | 0x80); v >>= 7; } o.push(v); return Buffer.from(o); };
+      const hstr = s => { const b = Buffer.from(s); return Buffer.concat([hint(0, 7, b.length), b]); };
+      const lit = (n, v) => Buffer.concat([Buffer.from([0x00]), hstr(n), hstr(v)]);
+      const block = (path, extra) => Buffer.concat([Buffer.from([0x82, 0x86]), lit(":path", path), lit(":authority", "h"), ...extra.map(([k, v]) => lit(k, v))]);
+      srv.listen(0, "127.0.0.1", () => {
+        const port = srv.address().port;
+        const big = block("/big", Array.from({ length: ${headerCount} }, (_, i) => ["x-" + i, Buffer.alloc(3000, "Q").toString()]));
+        const frames = [];
+        for (let o = 0; o < big.length; o += 16000) {
+          const last = o + 16000 >= big.length;
+          frames.push(fr(o === 0 ? 1 : 9, (last ? 4 : 0) | (o === 0 ? 1 : 0), 1, big.subarray(o, o + 16000)));
+        }
+        const sock = net.connect(port, "127.0.0.1", () => {
+          sock.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\\r\\n\\r\\nSM\\r\\n\\r\\n", "binary"), fr(4, 0, 0, Buffer.alloc(0)), ...frames]));
+        });
+        sock.on("error", () => {});
+        let raw = Buffer.alloc(0);
+        let probed = false;
+        let done = false;
+        const scan = () => {
+          let p = 0, probeOk = false, goaway = -1, rst1 = -1, verdict = false;
+          while (p + 9 <= raw.length) {
+            const l = raw.readUIntBE(p, 3), t = raw[p + 3], sid = raw.readUInt32BE(p + 5) & 0x7fffffff;
+            if (p + 9 + l > raw.length) break;
+            if (t === 1 && sid === 3) probeOk = true;
+            if (t === 7) { goaway = raw.readUInt32BE(p + 13); verdict = true; }
+            if (t === 3 && sid === 1) { rst1 = raw.readUInt32BE(p + 9); verdict = true; }
+            p += 9 + l;
+          }
+          return { probeOk, goaway, rst1, verdict };
+        };
+        const finish = () => {
+          if (done) return;
+          done = true;
+          const { probeOk, goaway, rst1 } = scan();
+          console.log(JSON.stringify({ events, probeOk, goaway, rst1 }));
+          process.exit(0);
+        };
+        sock.on("data", d => {
+          raw = Buffer.concat([raw, d]);
+          const s = scan();
+          // Send the probe only after the server's verdict on stream 1.
+          if (!probed && s.verdict) {
+            probed = true;
+            try { sock.write(fr(1, 5, 3, block("/probe", []))); } catch {}
+          }
+          // Done once the probe is answered, or once a GOAWAY arrived (connection is over).
+          if (probed && (s.probeOk || s.goaway !== -1)) finish();
+        });
+        sock.on("close", finish);
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("ERR_HTTP2_STREAM_ERROR");
+    const out = JSON.parse(stdout.trim());
+    if (expectRst1) {
+      expect(out.rst1).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
+    }
+    if (expectProbe) {
+      expect(out.events).toContain("REQ:/probe");
+    } else {
+      expect(out.events).not.toContain("REQ:/big");
+    }
+    if (expectSessionError) {
+      expect(out.events).toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
+    }
+    expect(exitCode).toBe(0);
+  });
 }
 
 it("sensitive headers should work", async () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1579,112 +1579,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
   }
 }
 
-// RFC 9113 §10.5.1: a request whose header list exceeds SETTINGS_MAX_HEADER_LIST_SIZE is a
-// per-stream error, not a connection error, and must not kill the server process. Spawned as a
-// subprocess because the bug was an uncatchable 'error' on a stream user code never received.
-for (const [label, headerCount, expectProbe, expectRst1, expectSessionError] of [
-  // ~72 KiB of well-formed headers: over the default 65535 limit, under the hard DoS cap.
-  // Stream 1 is RST_STREAM(ENHANCE_YOUR_CALM); the connection survives and serves stream 3.
-  ["RST_STREAMs an oversized header list and keeps the connection alive", 24, true, true, false],
-  // ~150 KiB: past the hard DoS cap. Connection is torn down (GOAWAY ENHANCE_YOUR_CALM) with a
-  // catchable session error; the process must still survive.
-  ["GOAWAYs a header block past the hard cap without crashing", 50, false, false, true],
-]) {
-  it(`http2 server ${label}`, async () => {
-    const fixture = `
-      const http2 = require("node:http2");
-      const net = require("node:net");
-      const srv = http2.createServer();
-      const events = [];
-      srv.on("error", e => events.push("server-error:" + e.code));
-      srv.on("sessionError", e => events.push("sessionError:" + e.code));
-      srv.on("session", s => s.on("error", e => events.push("session-error:" + e.code)));
-      srv.on("stream", (st, h) => {
-        st.on("error", e => events.push("stream-error:" + e.code));
-        events.push("REQ:" + h[":path"]);
-        st.respond({ ":status": 200 });
-        st.end("k");
-      });
-      const fr = (t, f, sid, pl) => { const b = Buffer.alloc(9 + pl.length); b.writeUIntBE(pl.length, 0, 3); b[3] = t; b[4] = f; b.writeUInt32BE(sid, 5); pl.copy(b, 9); return b; };
-      const hint = (head, p, v) => { const m = (1 << p) - 1; if (v < m) return Buffer.from([head | v]); const o = [head | m]; v -= m; while (v >= 128) { o.push((v & 0x7f) | 0x80); v >>= 7; } o.push(v); return Buffer.from(o); };
-      const hstr = s => { const b = Buffer.from(s); return Buffer.concat([hint(0, 7, b.length), b]); };
-      const lit = (n, v) => Buffer.concat([Buffer.from([0x00]), hstr(n), hstr(v)]);
-      const block = (path, extra) => Buffer.concat([Buffer.from([0x82, 0x86]), lit(":path", path), lit(":authority", "h"), ...extra.map(([k, v]) => lit(k, v))]);
-      srv.listen(0, "127.0.0.1", () => {
-        const port = srv.address().port;
-        const big = block("/big", Array.from({ length: ${headerCount} }, (_, i) => ["x-" + i, Buffer.alloc(3000, "Q").toString()]));
-        const frames = [];
-        for (let o = 0; o < big.length; o += 16000) {
-          const last = o + 16000 >= big.length;
-          frames.push(fr(o === 0 ? 1 : 9, (last ? 4 : 0) | (o === 0 ? 1 : 0), 1, big.subarray(o, o + 16000)));
-        }
-        const sock = net.connect(port, "127.0.0.1", () => {
-          sock.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\\r\\n\\r\\nSM\\r\\n\\r\\n", "binary"), fr(4, 0, 0, Buffer.alloc(0)), ...frames]));
-        });
-        sock.on("error", () => {});
-        let raw = Buffer.alloc(0);
-        let probed = false;
-        let done = false;
-        const scan = () => {
-          let p = 0, probeOk = false, goaway = -1, rst1 = -1, verdict = false;
-          while (p + 9 <= raw.length) {
-            const l = raw.readUIntBE(p, 3), t = raw[p + 3], sid = raw.readUInt32BE(p + 5) & 0x7fffffff;
-            if (p + 9 + l > raw.length) break;
-            if (t === 1 && sid === 3) probeOk = true;
-            if (t === 7) { goaway = raw.readUInt32BE(p + 13); verdict = true; }
-            if (t === 3 && sid === 1) { rst1 = raw.readUInt32BE(p + 9); verdict = true; }
-            p += 9 + l;
-          }
-          return { probeOk, goaway, rst1, verdict };
-        };
-        const finish = () => {
-          if (done) return;
-          done = true;
-          const { probeOk, goaway, rst1 } = scan();
-          console.log(JSON.stringify({ events, probeOk, goaway, rst1 }));
-          process.exit(0);
-        };
-        sock.on("data", d => {
-          raw = Buffer.concat([raw, d]);
-          const s = scan();
-          // Send the probe only after the server's verdict on stream 1.
-          if (!probed && s.verdict) {
-            probed = true;
-            try { sock.write(fr(1, 5, 3, block("/probe", []))); } catch {}
-          }
-          // Done once the probe is answered, or once a GOAWAY arrived (connection is over).
-          if (probed && (s.probeOk || s.goaway !== -1)) finish();
-        });
-        sock.on("close", finish);
-      });
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("ERR_HTTP2_STREAM_ERROR");
-    const out = JSON.parse(stdout.trim());
-    if (expectRst1) {
-      expect(out.rst1).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
-    }
-    if (expectProbe) {
-      expect(out.events).toContain("REQ:/probe");
-    } else {
-      expect(out.events).not.toContain("REQ:/big");
-    }
-    if (expectSessionError) {
-      expect(out.goaway).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
-      expect(out.events).toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
-    } else {
-      expect(out.goaway).toBe(-1);
-      expect(out.events).not.toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
-    }
-    expect(exitCode).toBe(0);
-  });
-}
 
 it("sensitive headers should work", async () => {
   const server = http2.createServer();
@@ -2004,7 +1898,7 @@ it(
       });
     });
   },
-  15_000 * ASAN_MULTIPLIER,
+  20_000 * ASAN_MULTIPLIER,
 );
 
 it("http2.createServer validates input options", () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1579,7 +1579,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
   }
 }
 
-
 it("sensitive headers should work", async () => {
   const server = http2.createServer();
   let client;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1676,7 +1676,11 @@ for (const [label, headerCount, expectProbe, expectRst1, expectSessionError] of 
       expect(out.events).not.toContain("REQ:/big");
     }
     if (expectSessionError) {
+      expect(out.goaway).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
       expect(out.events).toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
+    } else {
+      expect(out.goaway).toBe(-1);
+      expect(out.events).not.toContain("sessionError:ERR_HTTP2_SESSION_ERROR");
     }
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### What

A well-formed request whose header list exceeds `SETTINGS_MAX_HEADER_LIST_SIZE` (default 65535) kills the whole `node:http2` server process with an uncatchable `ERR_HTTP2_STREAM_ERROR`. Any peer that can open a TCP connection can trigger it; nothing in the request is malformed. Node serves the same bytes.

```js
// 24 ordinary 3 KiB headers (~72 KiB total, e.g. a client with big cookies)
// node:  REQ /big, PROBE ok, SURVIVED, exit 0
// bun:   uncaught ERR_HTTP2_STREAM_ERROR (NGHTTP2_ENHANCE_YOUR_CALM), exit 1
import http2 from 'node:http2';
import net from 'node:net';
const srv = http2.createServer();
srv.on('sessionError', e => console.log('sessionError', e.code));
srv.on('stream', (st, h) => { st.on('error', () => {}); st.respond({':status':200}); st.end('k'); });
// ... raw h2c client sends HEADERS + CONTINUATION with 24 x 3000-byte values, then a second request
```

```
error: Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM
 code: "ERR_HTTP2_STREAM_ERROR"
      at _destroy (node:http2:1690:31)
      at emitStreamErrorNT (node:http2:2202:21)
```

### Why

Two bugs stacked:

1. **Premature GOAWAY.** `handle_continuation` capped the reassembled compressed block at exactly `max_header_list_size` and answered with a connection-level GOAWAY when exceeded. RFC 9113 10.5.1 makes an oversized header list a stream error (RST_STREAM or 431), and 4.3 requires the block to be decompressed so the connection-scoped HPACK table stays in sync. The existing `maxHeaderListPairs` path in `finish_header_block` already does exactly that; the byte-size limit just never reached it.

2. **Uncatchable stream error.** Bun creates the `ServerHttp2Stream` in `streamStart` before the header block is decoded. When the session then tears down, that stream's `_destroy` re-synthesizes `ERR_HTTP2_STREAM_ERROR` from the rst code, which is emitted on a stream that was never handed to user code: no listener is possible, so it is uncaught. Node cannot hit this because it only constructs the JS stream once a complete header block has been decoded. This is the same sink as #32832 (which addresses it for the malformed-HPACK case); this PR hits it from the well-formed-oversized side.

### Fix

`src/runtime/api/bun/h2/connection.rs`: the CONTINUATION buffer is allowed to grow to twice `max_header_list_size` (floored at 64 KiB), so `finish_header_block` can decode the full block and refuse it with a per-stream `RST_STREAM(ENHANCE_YOUR_CALM)` while the connection and HPACK state survive. Only past that hard DoS cap is the connection torn down; Node/nghttp2 was measured to GOAWAY at roughly the same point (~144 KiB with default settings). The legacy parser in `h2_frame_parser.rs` is kept in sync.

`src/js/node/http2.ts`: server streams are marked `kNeverAnnounced` in `streamStart` and cleared when the `'stream'` event fires in `streamHeaders`. `_destroy` skips the synthesized `ERR_HTTP2_STREAM_ERROR` for never-announced streams. Streams the user does hold are unchanged.

### Verification

Two spawned-subprocess tests in `test/js/node/http2/node-http2.test.js`, so a regression shows up as the child dying:

- ~72 KiB of well-formed headers: stream 1 gets `RST_STREAM(ENHANCE_YOUR_CALM)`, the connection stays alive and serves a second request on stream 3, child exits 0. Fails on main with the uncaught error above.
- ~150 KiB: past the hard cap, connection is torn down with a catchable `sessionError`, child exits 0. Also fails on main.

The existing client-side compressed-block-cap test is updated to exercise the new threshold.

`test/js/node/http2/node-http2.test.js`, `h2-conformance.test.ts`, `node-http2-continuation.test.ts` and the relevant `test/js/node/test/parallel/test-http2-*` tests pass.