### PR TITLE
install: don't re-apply a patch per peer variant in isolated installs

### DIFF
--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -303,6 +303,16 @@ impl<'a> Installer<'a> {
         let _guard = PatchTaskGuard(patch_task_ptr);
         // SAFETY: exclusive owner — see above.
         let patch_task = unsafe { &mut *patch_task_ptr };
+        // Every peer variant shares one patched cache dir (named by the patch
+        // contents hash, not the peer set). Once it exists, reuse it: rebuilding
+        // it replaces the directory under earlier entries' running hardlink tasks.
+        if let crate::patch_install::Callback::Apply(apply) = &patch_task.callback {
+            if sys::directory_exists_at(apply.cache_dir, apply.cache_dir_subpath.as_zstr())
+                .unwrap_or(false)
+            {
+                return;
+            }
+        }
         bun_core::handle_oom(patch_task.apply());
 
         if let crate::patch_install::Callback::Apply(apply) = &mut patch_task.callback {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -665,13 +665,17 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
     );
   }
 
+  // CI exports BUN_INSTALL_CACHE_DIR, which overrides bunfig's `cache`. Pin it
+  // so the patched cache directory is created where the assertions look.
+  const cacheDir = join(packageDir, ".bun-cache");
+
   // Force the hardlink backend so the inode assertions below hold on every
   // platform (macOS defaults to clonefile, which copies).
   async function install() {
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install", "--backend", "hardlink"],
       cwd: packageDir,
-      env: bunEnv,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -688,11 +692,11 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
     expect(storeDirs.length).toBe(noDepsVersions.length);
 
     // Exactly one patched cache directory exists for the package.
-    const cacheDirs = (await readdirSorted(join(packageDir, ".bun-cache"))).filter(
+    const cacheDirs = (await readdirSorted(cacheDir)).filter(
       dir => dir.startsWith("peer-deps@1.0.0") && dir.includes("_patch_hash="),
     );
     expect(cacheDirs.length).toBe(1);
-    const cacheFile = join(packageDir, ".bun-cache", cacheDirs[0], "index.js");
+    const cacheFile = join(cacheDir, cacheDirs[0], "index.js");
 
     // The patch is applied in every variant, and every variant is hardlinked
     // from the single patched cache materialization. Before the fix each

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, readlinkSync } from "fs";
+import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
 import { dirname, join } from "path";
@@ -620,6 +620,103 @@ describe("optional peers", () => {
     await checkInstall();
     await checkInstall();
   });
+});
+
+// https://github.com/oven-sh/bun/issues/28147
+test("patched package shared by multiple peer variants is materialized into the cache once", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  // `peer-deps@1.0.0` has `peerDependencies: { "no-deps": "*" }`. Giving each
+  // workspace a different `no-deps` version forces one isolated store variant
+  // of `peer-deps` per workspace, all sharing one patched cache directory.
+  const noDepsVersions = ["1.0.0", "1.0.1", "1.1.0", "2.0.0"];
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "patched-peer-variants",
+      workspaces: ["packages/*"],
+      patchedDependencies: {
+        "peer-deps@1.0.0": "patches/peer-deps@1.0.0.patch",
+      },
+    }),
+  );
+  await write(
+    join(packageDir, "patches", "peer-deps@1.0.0.patch"),
+    `diff --git a/patched.txt b/patched.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e728b8dad
+--- /dev/null
++++ b/patched.txt
+@@ -0,0 +1 @@
++hello world
+`,
+  );
+  for (const version of noDepsVersions) {
+    await write(
+      join(packageDir, "packages", `pkg-${version}`, "package.json"),
+      JSON.stringify({
+        name: `pkg-${version}`,
+        version: "1.0.0",
+        dependencies: {
+          "peer-deps": "1.0.0",
+          "no-deps": version,
+        },
+      }),
+    );
+  }
+
+  // Force the hardlink backend so the inode assertions below hold on every
+  // platform (macOS defaults to clonefile, which copies).
+  async function install() {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--backend", "hardlink"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("packages installed");
+    expect(exitCode).toBe(0);
+  }
+
+  async function checkInstall() {
+    const storeDirs = (await readdirSorted(join(packageDir, "node_modules", ".bun"))).filter(dir =>
+      dir.startsWith("peer-deps@1.0.0"),
+    );
+    expect(storeDirs.length).toBe(noDepsVersions.length);
+
+    // Exactly one patched cache directory exists for the package.
+    const cacheDirs = (await readdirSorted(join(packageDir, ".bun-cache"))).filter(
+      dir => dir.startsWith("peer-deps@1.0.0") && dir.includes("_patch_hash="),
+    );
+    expect(cacheDirs.length).toBe(1);
+    const cacheFile = join(packageDir, ".bun-cache", cacheDirs[0], "index.js");
+
+    // The patch is applied in every variant, and every variant is hardlinked
+    // from the single patched cache materialization. Before the fix each
+    // variant re-applied the patch, replacing the shared cache directory the
+    // previous variant was concurrently hardlinking from (EPERM on Windows,
+    // divergent inodes on POSIX).
+    const inodes = new Set<number>();
+    for (const storeDir of storeDirs) {
+      const pkgDir = join(packageDir, "node_modules", ".bun", storeDir, "node_modules", "peer-deps");
+      expect(await file(join(pkgDir, "patched.txt")).text()).toBe("hello world\n");
+      inodes.add(statSync(join(pkgDir, "index.js")).ino);
+    }
+    inodes.add(statSync(cacheFile).ino);
+    expect(inodes.size).toBe(1);
+  }
+
+  await install();
+  await checkInstall();
+
+  // Reinstall with a warm cache and no node_modules: the patched cache
+  // directory already exists and must not be rebuilt per variant.
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await install();
+  await checkInstall();
 });
 
 for (const backend of ["clonefile", "hardlink", "copyfile"]) {


### PR DESCRIPTION
### What does this PR do?

Fixes an isolated-linker (`--linker=isolated`) bug where a patched dependency that resolves into multiple peer-variant store entries had its patch re-applied once **per store entry**.

All peer variants of a package share a single patched cache directory — its name is keyed by `name@version` + the patch **contents hash**, not the peer set — but `Installer::apply_package_patch` ran once per entry. Each re-application rebuilds the patched tree in a temp dir and renames it over the shared cache directory while earlier variants' hardlink tasks are already walking that directory:

- On Windows, `renameat_concurrently` has no atomic-exchange fallback, so it falls back to `delete_tree(dest)` + `rename`, deleting the tree out from under the in-flight `CreateHardLinkW` calls → `EPERM: Operation not permitted: failed to link package` (the intermittent CI failure in the issue; OpenCode works around it by forcing the hoisted linker).
- On POSIX, `renameat2(RENAME_EXCHANGE)` hides the race, but each store variant ends up hardlinked to a different, orphaned generation of the package instead of the single cache materialization.

The fix: skip the patch application when the content-addressed patched cache directory already exists. This is the same invariant the hoisted installer already relies on (`determine_preinstall_state` treats an existing patched cache folder as `done`), and it covers both isolated call sites (`on_package_extracted`'s per-entry loop and the warm-cache path in `isolated_install.rs`). A changed patch produces a different contents hash → a different directory name → is never skipped.

Fixes #28147

### How did you verify your code works?

Added a test in `test/cli/install/isolated-install.test.ts`: a workspace with 4 packages, each resolving a different `no-deps` version, all depending on `peer-deps@1.0.0` (peer on `no-deps: *`) with a `patchedDependencies` entry — producing 4 isolated store variants sharing one patched cache dir. It asserts (with `--backend=hardlink`) that exactly one patched cache directory exists, the patch is applied in every variant, and every variant's files share the cache file's inode, on both a cold-cache install and a warm-cache reinstall.

- With the fix: passes (all variants + cache = 1 inode).
- With only the `src/` hunk reverted: fails — the 4 variants hold 3–4 distinct inode generations, i.e. each later variant rebuilt the cache dir the earlier ones had already linked from.
- Full `isolated-install.test.ts` (56 tests), `bun-patch.test.ts`, and `bun-install-patch.test.ts` pass.
- Also exercised manually against the local registry: repeat installs, warm-cache reinstall after `rm -rf node_modules`, changing the patch contents (new hash → new cache dir picked up by all variants), and removing the patch.
