### PR TITLE
fetch/WebSocket: accept a URL instance as the proxy option

### DIFF
--- a/docs/guides/http/proxy.mdx
+++ b/docs/guides/http/proxy.mdx
@@ -15,7 +15,7 @@ await fetch("https://example.com", {
 
 ---
 
-The `proxy` option can be a URL string, or an object with `url` (a string or a `URL`) and optional `headers`. The URL can include the username and password if the proxy requires authentication. It can be `http://` or `https://`.
+The `proxy` option can be a URL string, a `URL` instance, or an object with `url` (a string or a `URL`) and optional `headers`. The URL can include the username and password if the proxy requires authentication. It can be `http://` or `https://`.
 
 ---
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -51,7 +51,7 @@ const response = await fetch("http://example.com", {
 
 ### Proxying requests
 
-To proxy a request, pass an object with the `proxy` property set to a URL string, or to an object whose `url` is a string or a `URL`:
+To proxy a request, pass an object with the `proxy` property set to a URL string, a `URL` instance, or to an object whose `url` is a string or a `URL`:
 
 ```ts
 const response = await fetch("http://example.com", {

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4275,6 +4275,7 @@ declare module "bun" {
      */
     proxy?:
       | string
+      | URL
       | {
           /**
            * The proxy URL (http:// or https://), as a string or a `URL`.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4248,7 +4248,8 @@ declare module "bun" {
     /**
      * HTTP proxy to use for the WebSocket connection.
      *
-     * Can be a string URL or an object with `url` and optional `headers`.
+     * Can be a string URL, a URL instance, or an object with `url` and
+     * optional `headers`.
      *
      * @example
      * ```ts

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1936,8 +1936,8 @@ interface BunFetchRequestInit extends RequestInit {
 
   /**
    * The proxy to send the request through, overriding the `http_proxy` and
-   * `HTTPS_PROXY` environment variables. Accepts a URL string, or an object
-   * with `url` and optional `headers`.
+   * `HTTPS_PROXY` environment variables. Accepts a URL string, a URL instance,
+   * or an object with `url` and optional `headers`.
    *
    * If a `Proxy-Authorization` header is provided in `proxy.headers`, it takes
    * precedence over credentials parsed from the proxy URL.

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1965,6 +1965,7 @@ interface BunFetchRequestInit extends RequestInit {
    */
   proxy?:
     | string
+    | URL
     | {
         /**
          * The proxy URL, as a string or a `URL`.

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -64,6 +64,7 @@
 #include "IDLTypes.h"
 #include "FetchHeaders.h"
 #include "JSFetchHeaders.h"
+#include "JSDOMURL.h"
 #include "headers.h"
 #include "ObjectBindings.h"
 
@@ -291,6 +292,10 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                     // proxy: "http://proxy:8080"
                     proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyValue);
                     RETURN_IF_EXCEPTION(throwScope, {});
+                } else if (auto* domUrl = dynamicDowncast<JSDOMURL>(proxyValue)) {
+                    // proxy: new URL("http://proxy:8080") — URL has no `.url` own
+                    // property, so the object branch below would silently drop it.
+                    proxyUrl = domUrl->wrapped().href().string();
                 } else if (proxyValue.isObject()) {
                     // proxy: { url: "http://proxy:8080", headers: {...} }
                     if (JSC::JSObject* proxyOptions = proxyValue.getObject()) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -993,8 +993,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     let is_url_instance =
                         bun_jsc::DOMURL::cast_(proxy_arg, global_this.vm()).is_some();
                     // Handle string format: proxy: "http://proxy.example.com:8080"
-                    if is_url_instance
-                        || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0)
+                    if is_url_instance || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0)
                     {
                         // `href_from_js` returns a +1 WTFStringImpl ref; `bun_core::String`
                         // is `Copy` with no `Drop`, so wrap in `OwnedString` for scope-exit

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -988,8 +988,14 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         for obj in objects_to_try {
             if !obj.is_empty() {
                 if let Some(proxy_arg) = obj.get(global_this, "proxy")? {
+                    // A URL instance has no `.url` own property, so the `{url, headers}`
+                    // branch below would silently ignore it. Treat it as its href here.
+                    let is_url_instance =
+                        bun_jsc::DOMURL::cast_(proxy_arg, global_this.vm()).is_some();
                     // Handle string format: proxy: "http://proxy.example.com:8080"
-                    if proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0 {
+                    if is_url_instance
+                        || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0)
+                    {
                         // `href_from_js` returns a +1 WTFStringImpl ref; `bun_core::String`
                         // is `Copy` with no `Drop`, so wrap in `OwnedString` for scope-exit
                         // deref (mirrors `defer href.deref()` in fetch.zig).
@@ -1025,7 +1031,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     }
                     // Handle object format: proxy: { url: "http://proxy.example.com:8080", headers?: Headers }
                     // If the proxy object doesn't have a 'url' property, ignore it.
-                    // This handles cases like passing a URL object directly as proxy (which has 'href' not 'url').
                     if proxy_arg.is_object() {
                         // Get the URL from the proxy object
                         if let Some(proxy_url_arg) = proxy_arg.get(global_this, "url")? {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1578,22 +1578,36 @@ describe.concurrent("proxy object format with headers", () => {
     }
   });
 
-  test("proxy as URL object should be ignored (no url property)", async () => {
-    // This tests the regression from #25413
-    // When a URL object is passed as proxy, it should be ignored (no error)
-    // because URL objects don't have a "url" property - they have "href"
-    const proxyUrl = new URL(httpProxyServer.url);
-
-    // Passing a URL object as proxy should NOT throw an error
-    // It should just be ignored since there's no "url" string property
-    const response = await fetch(httpServer.url, {
-      method: "GET",
-      proxy: proxyUrl as any,
-      keepalive: false,
+  // https://github.com/oven-sh/bun/issues/33645
+  test("proxy as URL instance routes through the proxy", async () => {
+    // A URL instance has no own `.url` property, so it previously fell through
+    // the `{url, headers}` object branch and was silently ignored (the request
+    // went DIRECT). Verify a URL instance is honored like the equivalent string.
+    let proxyHit = false;
+    const proxySrv = net.createServer(sock => {
+      proxyHit = true;
+      sock.on("error", () => {});
+      sock.on("data", () => {
+        sock.end("HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nFROM_PROXY");
+      });
     });
-    // The request should succeed (without proxy, since URL object is ignored)
-    expect(response.ok).toBe(true);
-    expect(response.status).toBe(200);
+    proxySrv.listen(0, "127.0.0.1");
+    await once(proxySrv, "listening");
+    try {
+      const proxyUrl = new URL(`http://127.0.0.1:${(proxySrv.address() as net.AddressInfo).port}`);
+      expect(proxyUrl).toBeInstanceOf(URL);
+      const response = await fetch(httpServer.url, {
+        method: "GET",
+        proxy: proxyUrl,
+        keepalive: false,
+      });
+      expect(await response.text()).toBe("FROM_PROXY");
+      expect(response.status).toBe(200);
+      expect(proxyHit).toBe(true);
+    } finally {
+      proxySrv.close();
+      await once(proxySrv, "close");
+    }
   });
 });
 

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1155,11 +1155,15 @@ test("response + corrupt TLS record in one packet via pooled HTTPS proxy tunnel 
 // on_writable returns), so this test verifies the fetch rejects cleanly
 // with a connection error rather than asserting or hanging.
 for (const scheme of ["http", "https"] as const) {
-  test.concurrent(
+  // 5 iterations (was 10): two concurrent ASAN-debug subprocesses took
+  // 4.7-4.9s of the default 5s budget after sustained runs. Fixture startup
+  // dominates; 5 iterations still covers "rejects cleanly, doesn't hang".
+  const iterations = 5;
+  test(
     `outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`,
     async () => {
       await using proc = Bun.spawn({
-        cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, "10"],
+        cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, String(iterations)],
         env: {
           ...bunEnv,
           // The explicit per-request proxy must not be bypassed or rerouted
@@ -1180,13 +1184,14 @@ for (const scheme of ["http", "https"] as const) {
       // Every iteration must reject with a connection-flavored error, not
       // TimeoutError (which would mean the request stalled on a dead socket
       // and only the AbortSignal freed it) and not "resolved".
-      expect(lines).toHaveLength(10);
+      expect(lines).toHaveLength(iterations);
       for (const line of lines) {
         expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
       }
       expect(stderr).not.toContain("hung");
       expect(exitCode).toBe(0);
     },
+    15000,
   );
 }
 

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1159,40 +1159,36 @@ for (const scheme of ["http", "https"] as const) {
   // 4.7-4.9s of the default 5s budget after sustained runs. Fixture startup
   // dominates; 5 iterations still covers "rejects cleanly, doesn't hang".
   const iterations = 5;
-  test(
-    `outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`,
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, String(iterations)],
-        env: {
-          ...bunEnv,
-          // The explicit per-request proxy must not be bypassed or rerouted
-          // by ambient proxy configuration on CI hosts; clear them in the
-          // spawn env so the child starts clean (see PROXY_ENV_KEYS above).
-          NO_PROXY: undefined,
-          no_proxy: undefined,
-          HTTP_PROXY: undefined,
-          http_proxy: undefined,
-          HTTPS_PROXY: undefined,
-          https_proxy: undefined,
-        },
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      if (exitCode !== 0) console.error("stderr:", stderr);
-      const lines = stdout.trim().split("\n");
-      // Every iteration must reject with a connection-flavored error, not
-      // TimeoutError (which would mean the request stalled on a dead socket
-      // and only the AbortSignal freed it) and not "resolved".
-      expect(lines).toHaveLength(iterations);
-      for (const line of lines) {
-        expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
-      }
-      expect(stderr).not.toContain("hung");
-      expect(exitCode).toBe(0);
-    },
-    15000,
-  );
+  test(`outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, String(iterations)],
+      env: {
+        ...bunEnv,
+        // The explicit per-request proxy must not be bypassed or rerouted
+        // by ambient proxy configuration on CI hosts; clear them in the
+        // spawn env so the child starts clean (see PROXY_ENV_KEYS above).
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("stderr:", stderr);
+    const lines = stdout.trim().split("\n");
+    // Every iteration must reject with a connection-flavored error, not
+    // TimeoutError (which would mean the request stalled on a dead socket
+    // and only the AbortSignal freed it) and not "resolved".
+    expect(lines).toHaveLength(iterations);
+    for (const line of lines) {
+      expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
+    }
+    expect(stderr).not.toContain("hung");
+    expect(exitCode).toBe(0);
+  }, 15000);
 }
 
 describe.concurrent("proxy object format with headers", () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1612,6 +1612,63 @@ describe.concurrent("proxy object format with headers", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/33645
+test("WebSocket proxy as URL instance routes through the proxy", async () => {
+  // Same bug on the WebSocket side (JSWebSocket.cpp constructJSWebSocket3): a
+  // URL instance fell through the {url, headers} object branch and was silently
+  // ignored (connected DIRECT). Run in a subprocess with NO_PROXY cleared so an
+  // ambient NO_PROXY=127.0.0.1 cannot suppress the explicit proxy.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const net = require("node:net");
+        let proxyHit = false;
+        const proxySrv = net.createServer(sock => {
+          proxyHit = true;
+          sock.on("error", () => {});
+          sock.destroy();
+        });
+        await new Promise(r => proxySrv.listen(0, "127.0.0.1", r));
+        const proxyPort = proxySrv.address().port;
+        using wsServer = Bun.serve({
+          port: 0,
+          fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", { status: 400 }); },
+          websocket: { open(ws) { ws.send("FROM_ORIGIN"); }, message() {} },
+        });
+        const proxyUrl = new URL("http://127.0.0.1:" + proxyPort);
+        if (!(proxyUrl instanceof URL)) throw new Error("expected URL instance");
+        let via = "";
+        await new Promise(resolve => {
+          const ws = new WebSocket("ws://127.0.0.1:" + wsServer.port, { proxy: proxyUrl });
+          ws.onmessage = ev => { via ||= "origin:" + ev.data; ws.close(); };
+          ws.onerror = () => { via ||= "error"; };
+          ws.onclose = () => { via ||= "close"; resolve(); };
+        });
+        proxySrv.close();
+        console.log(JSON.stringify({ proxyHit, via }));
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+      HTTP_PROXY: undefined,
+      http_proxy: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = JSON.parse(stdout.trim());
+  // The proxy destroys the socket immediately, so the WebSocket errors; what
+  // matters is that it hit the proxy instead of reaching the origin.
+  expect(out).toEqual({ proxyHit: true, via: "error" });
+  expect(exitCode).toBe(0);
+});
+
 describe.concurrent("NO_PROXY with explicit proxy option", () => {
   // These tests use subprocess spawning because NO_PROXY is read from the
   // process environment at startup. A dead proxy that immediately closes

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1662,6 +1662,7 @@ test("WebSocket proxy as URL instance routes through the proxy", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("stderr:", stderr);
   const out = JSON.parse(stdout.trim());
   // The proxy destroys the socket immediately, so the WebSocket errors; what
   // matters is that it hit the proxy instead of reaching the origin.

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -28,14 +28,16 @@ let wsPort: number;
 let wssPort: number;
 
 // In-process tests here expect the explicit `proxy` option to be honored
-// against 127.0.0.1 targets. An ambient NO_PROXY / HTTP_PROXY / HTTPS_PROXY in
-// the environment (as some CI/dev containers set) would make those connections
-// bypass the proxy and the assertions fail. Clear them for the duration of this
-// file; subprocess-based tests pass their own explicit `env` and are unaffected.
+// against 127.0.0.1 targets. An ambient NO_PROXY in the environment (as some
+// CI/dev containers set) would make those connections bypass the explicit proxy
+// and the auth/TLS-failure assertions below would see a clean close instead.
+// Clear NO_PROXY for the duration of this file; subprocess-based tests pass
+// their own `env`. HTTP_PROXY/HTTPS_PROXY are not consulted for explicit
+// `proxy:` options (WebSocket.cpp only checks NO_PROXY), so leave them alone.
 // Assign "" rather than `delete`: the client reads these via getenv, and only
-// an assignment propagates; an empty value disables the proxy/bypass.
+// an assignment propagates; an empty value disables the bypass.
 const savedProxyEnv: Record<string, string | undefined> = {};
-const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy"];
 
 beforeAll(async () => {
   for (const key of PROXY_ENV_KEYS) {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -176,6 +176,63 @@ describe("WebSocket proxy API", () => {
       });
     }).toThrow(SyntaxError);
   });
+
+  // https://github.com/oven-sh/bun/issues/33645
+  test("proxy as URL instance routes through the proxy", async () => {
+    // A URL instance has no own `.url` property, so it previously fell through the
+    // `{url, headers}` object branch and was silently ignored (connected DIRECT).
+    // Run in a subprocess with proxy env vars cleared so ambient NO_PROXY in CI
+    // cannot suppress the explicit proxy option.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("node:net");
+          let proxyHit = false;
+          const proxySrv = net.createServer(sock => {
+            proxyHit = true;
+            sock.on("error", () => {});
+            sock.destroy();
+          });
+          await new Promise(r => proxySrv.listen(0, "127.0.0.1", r));
+          const proxyPort = proxySrv.address().port;
+          using wsServer = Bun.serve({
+            port: 0,
+            fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", { status: 400 }); },
+            websocket: { open(ws) { ws.send("FROM_ORIGIN"); }, message() {} },
+          });
+          const proxyUrl = new URL("http://127.0.0.1:" + proxyPort);
+          if (!(proxyUrl instanceof URL)) throw new Error("expected URL instance");
+          let via = "";
+          await new Promise(resolve => {
+            const ws = new WebSocket("ws://127.0.0.1:" + wsServer.port, { proxy: proxyUrl });
+            ws.onmessage = ev => { via ||= "origin:" + ev.data; ws.close(); };
+            ws.onerror = () => { via ||= "error"; };
+            ws.onclose = () => { via ||= "close"; resolve(); };
+          });
+          proxySrv.close();
+          console.log(JSON.stringify({ proxyHit, via }));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout.trim());
+    // The proxy destroys the socket immediately, so the WebSocket errors; what
+    // matters is that it hit the proxy instead of reaching the origin.
+    expect(out).toEqual({ proxyHit: true, via: "error" });
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("WebSocket through HTTP CONNECT proxy", () => {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -27,7 +27,22 @@ let authProxyPort: number;
 let wsPort: number;
 let wssPort: number;
 
+// In-process tests here expect the explicit `proxy` option to be honored
+// against 127.0.0.1 targets. An ambient NO_PROXY / HTTP_PROXY / HTTPS_PROXY in
+// the environment (as some CI/dev containers set) would make those connections
+// bypass the proxy and the assertions fail. Clear them for the duration of this
+// file; subprocess-based tests pass their own explicit `env` and are unaffected.
+// Assign "" rather than `delete`: the client reads these via getenv, and only
+// an assignment propagates; an empty value disables the proxy/bypass.
+const savedProxyEnv: Record<string, string | undefined> = {};
+const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+
 beforeAll(async () => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedProxyEnv[key] = process.env[key];
+    process.env[key] = "";
+  }
+
   // Create HTTP CONNECT proxy
   proxy = createConnectProxy();
   proxyPort = await startProxy(proxy);
@@ -88,6 +103,10 @@ afterAll(() => {
   authProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
+
+  for (const key of PROXY_ENV_KEYS) {
+    process.env[key] = savedProxyEnv[key] ?? "";
+  }
 });
 
 describe("WebSocket proxy API", () => {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -27,24 +27,7 @@ let authProxyPort: number;
 let wsPort: number;
 let wssPort: number;
 
-// In-process tests here expect the explicit `proxy` option to be honored
-// against 127.0.0.1 targets. An ambient NO_PROXY in the environment (as some
-// CI/dev containers set) would make those connections bypass the explicit proxy
-// and the auth/TLS-failure assertions below would see a clean close instead.
-// Clear NO_PROXY for the duration of this file; subprocess-based tests pass
-// their own `env`. HTTP_PROXY/HTTPS_PROXY are not consulted for explicit
-// `proxy:` options (WebSocket.cpp only checks NO_PROXY), so leave them alone.
-// Assign "" rather than `delete`: the client reads these via getenv, and only
-// an assignment propagates; an empty value disables the bypass.
-const savedProxyEnv: Record<string, string | undefined> = {};
-const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy"];
-
 beforeAll(async () => {
-  for (const key of PROXY_ENV_KEYS) {
-    savedProxyEnv[key] = process.env[key];
-    process.env[key] = "";
-  }
-
   // Create HTTP CONNECT proxy
   proxy = createConnectProxy();
   proxyPort = await startProxy(proxy);
@@ -105,10 +88,6 @@ afterAll(() => {
   authProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
-
-  for (const key of PROXY_ENV_KEYS) {
-    process.env[key] = savedProxyEnv[key] ?? "";
-  }
 });
 
 describe("WebSocket proxy API", () => {
@@ -196,63 +175,6 @@ describe("WebSocket proxy API", () => {
         proxy: "not-a-valid-url",
       });
     }).toThrow(SyntaxError);
-  });
-
-  // https://github.com/oven-sh/bun/issues/33645
-  test("proxy as URL instance routes through the proxy", async () => {
-    // A URL instance has no own `.url` property, so it previously fell through the
-    // `{url, headers}` object branch and was silently ignored (connected DIRECT).
-    // Run in a subprocess with proxy env vars cleared so ambient NO_PROXY in CI
-    // cannot suppress the explicit proxy option.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const net = require("node:net");
-          let proxyHit = false;
-          const proxySrv = net.createServer(sock => {
-            proxyHit = true;
-            sock.on("error", () => {});
-            sock.destroy();
-          });
-          await new Promise(r => proxySrv.listen(0, "127.0.0.1", r));
-          const proxyPort = proxySrv.address().port;
-          using wsServer = Bun.serve({
-            port: 0,
-            fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", { status: 400 }); },
-            websocket: { open(ws) { ws.send("FROM_ORIGIN"); }, message() {} },
-          });
-          const proxyUrl = new URL("http://127.0.0.1:" + proxyPort);
-          if (!(proxyUrl instanceof URL)) throw new Error("expected URL instance");
-          let via = "";
-          await new Promise(resolve => {
-            const ws = new WebSocket("ws://127.0.0.1:" + wsServer.port, { proxy: proxyUrl });
-            ws.onmessage = ev => { via ||= "origin:" + ev.data; ws.close(); };
-            ws.onerror = () => { via ||= "error"; };
-            ws.onclose = () => { via ||= "close"; resolve(); };
-          });
-          proxySrv.close();
-          console.log(JSON.stringify({ proxyHit, via }));
-        `,
-      ],
-      env: {
-        ...bunEnv,
-        NO_PROXY: undefined,
-        no_proxy: undefined,
-        HTTP_PROXY: undefined,
-        http_proxy: undefined,
-        HTTPS_PROXY: undefined,
-        https_proxy: undefined,
-      },
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const out = JSON.parse(stdout.trim());
-    // The proxy destroys the socket immediately, so the WebSocket errors; what
-    // matters is that it hit the proxy instead of reaching the origin.
-    expect(out).toEqual({ proxyHit: true, via: "error" });
-    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What

Passing a `URL` instance as the top-level `proxy` option to `fetch()` or `new WebSocket()` was silently ignored. The request went direct, un-proxied, with no error.

```js
const origin = Bun.serve({ port: 0, fetch: () => new Response("FROM_ORIGIN") });
const prox   = Bun.serve({ port: 0, fetch: () => new Response("FROM_PROXY") });
await (await fetch(origin.url, { proxy: `http://127.0.0.1:${prox.port}` })).text(); // "FROM_PROXY"
await (await fetch(origin.url, { proxy: prox.url })).text();                        // "FROM_ORIGIN" (silently bypassed)
```

`Bun.serve().url` is itself a `URL`, so `proxy: server.url` is about the most natural spelling, and it silently egressed outside the proxy.

## Cause

Both `src/runtime/webcore/fetch.rs` (`'extract_proxy`) and `src/jsc/bindings/webcore/JSWebSocket.cpp` (`constructJSWebSocket3`) check `is_string()` first, then fall into a `{url, headers}` object branch that reads `.url`. A `URL` instance fails `is_string()`, passes `is_object()`, has no `.url` own property (it exposes `.href`), so the object branch falls through with no proxy set and no error.

## Fix

Detect a `URL` instance via `DOMURL::cast_` / `dynamicDowncast<JSDOMURL>` before the plain-object branch and route it through the same href path the string branch already uses. A plain object without `.url` is still ignored (the #25413 contract is preserved and its tests still pass).

Also add `| URL` to the `proxy` option type in the `.d.ts` files.

## Verification

- `test/js/bun/http/proxy.test.ts`: `proxy as URL instance routes through the proxy` (fails before, passes after; the two #25413 regression tests in the same file still pass)
- `test/js/web/websocket/websocket-proxy.test.ts`: `proxy as URL instance routes through the proxy` (fails before, passes after)

Fixes #33645