### PR TITLE
fetch(): reject instead of throwing synchronously when option conversion throws

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -355,13 +355,37 @@ impl StringOrURL {
 /// Public entry point for `Bun.fetch` - validates body on GET/HEAD/OPTIONS
 #[bun_jsc::host_fn(export = "Bun__fetch")]
 pub(crate) fn bun_fetch(ctx: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-    fetch_impl::<false>(ctx, callframe)
+    reject_on_exception(ctx, fetch_impl::<false>(ctx, callframe))
 }
 
 /// Internal entry point for Node.js HTTP client - allows body on GET/HEAD/OPTIONS
 #[bun_jsc::host_fn]
 pub(crate) fn node_http_client(ctx: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-    fetch_impl::<true>(ctx, callframe)
+    reject_on_exception(ctx, fetch_impl::<true>(ctx, callframe))
+}
+
+/// WHATWG fetch step 3: an exception thrown while processing `input`/`init`
+/// rejects the returned promise; `fetch()` never throws synchronously.
+fn reject_on_exception(
+    global_this: &JSGlobalObject,
+    result: JsResult<JSValue>,
+) -> JsResult<JSValue> {
+    let err = match result {
+        Ok(v) if !v.is_empty() => return Ok(v),
+        Err(jsc::JsError::Terminated) => return Err(jsc::JsError::Terminated),
+        Err(jsc::JsError::OutOfMemory) => global_this.create_out_of_memory_error(),
+        Ok(_) | Err(jsc::JsError::Thrown) => match global_this.try_take_exception() {
+            Some(exc) if exc.is_termination_exception() => return Err(jsc::JsError::Terminated),
+            Some(exc) => exc.to_error().unwrap_or(exc),
+            None => return result,
+        },
+    };
+    Ok(
+        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+            global_this,
+            err,
+        ),
+    )
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -377,7 +377,12 @@ fn reject_on_exception(
         Ok(_) | Err(jsc::JsError::Thrown) => match global_this.try_take_exception() {
             Some(exc) if exc.is_termination_exception() => return Err(jsc::JsError::Terminated),
             Some(exc) => exc.to_error().unwrap_or(exc),
-            None => return result,
+            None => {
+                // `fetch_impl` only returns Ok(ZERO)/Err(Thrown) with an exception
+                // pending; reaching here means it was cleared, which is a bug.
+                debug_assert!(false, "fetch_impl signaled a thrown exception but none is pending");
+                global_this.create_error_instance(format_args!("fetch() failed"))
+            }
         },
     };
     Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -380,7 +380,10 @@ fn reject_on_exception(
             None => {
                 // `fetch_impl` only returns Ok(ZERO)/Err(Thrown) with an exception
                 // pending; reaching here means it was cleared, which is a bug.
-                debug_assert!(false, "fetch_impl signaled a thrown exception but none is pending");
+                debug_assert!(
+                    false,
+                    "fetch_impl signaled a thrown exception but none is pending"
+                );
                 global_this.create_error_instance(format_args!("fetch() failed"))
             }
         },

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -380,12 +380,7 @@ fn reject_on_exception(
             None => return result,
         },
     };
-    Ok(
-        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-            global_this,
-            err,
-        ),
-    )
+    Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -73,6 +73,72 @@ test("fetch({toString throwing}, {headers} isn't accessed)", async () => {
   expect(str.toString).toHaveBeenCalledTimes(1);
 });
 
+// https://github.com/oven-sh/bun/issues/33644
+describe("fetch() rejects instead of throwing synchronously when option conversion throws", () => {
+  function expectRejects(factory: () => Promise<Response>, message: string) {
+    let promise: Promise<Response>;
+    try {
+      promise = factory();
+    } catch (e) {
+      throw new Error(`fetch() threw synchronously (expected a rejected promise): ${(e as Error).message}`);
+    }
+    expect(promise).toBeInstanceOf(Promise);
+    return expect(promise).rejects.toThrow(message);
+  }
+
+  test("url toString() throws", async () => {
+    await expectRejects(
+      () =>
+        fetch({
+          toString() {
+            throw new Error("UBOOM");
+          },
+        } as any),
+      "UBOOM",
+    );
+  });
+
+  test("init.headers iterable throws", async () => {
+    await expectRejects(
+      () =>
+        fetch("http://127.0.0.1:1/", {
+          headers: {
+            *[Symbol.iterator]() {
+              throw new Error("HBOOM");
+            },
+          } as any,
+        }),
+      "HBOOM",
+    );
+  });
+
+  const propertyNames = [
+    "body",
+    "decompress",
+    "headers",
+    "keepalive",
+    "method",
+    "proxy",
+    "redirect",
+    "signal",
+    "timeout",
+    "tls",
+    "unix",
+    "verbose",
+  ];
+  test.each(propertyNames)("init.%s getter throws", async name => {
+    await expectRejects(
+      () =>
+        fetch("http://127.0.0.1:1/", {
+          get [name]() {
+            throw new Error(`${name}-BOOM`);
+          },
+        } as any),
+      `${name}-BOOM`,
+    );
+  });
+});
+
 test("fetch(RequestSubclass, undefined)", async () => {
   class MyRequest extends Request {
     constructor(input: RequestInfo, init?: RequestInit) {

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -164,11 +164,10 @@ describe.concurrent("fetch() with streaming", () => {
       },
     });
     // A locked (or disturbed) body init is rejected at Request construction with a
-    // TypeError (fetch spec; Node agrees on the error). Like Bun's other fetch
-    // argument errors, it surfaces synchronously.
+    // TypeError (fetch spec; Node agrees on the error), surfaced as a rejected promise.
     stream.getReader();
 
-    expect(() => fetch(server.url, { method: "POST", body: stream })).toThrow(
+    await expect(fetch(server.url, { method: "POST", body: stream })).rejects.toThrow(
       expect.objectContaining({ name: "TypeError", message: "Body object should not be disturbed or locked" }),
     );
   });

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -71,14 +71,12 @@ test("fetch() with subclass containing invalid HTTP headers throws without crash
 
   const request = new MyRequest("https://example.com", {}, "https://example.com");
   expect(request.method).toBe("POST");
-  expect(() => fetch(request)).toThrow("Invalid header name");
+  await expect(fetch(request)).rejects.toThrow("Invalid header name");
 
   // quick gc test
-  for (let i = 0; i < 1e4; i++) {
-    try {
-      fetch(request);
-    } catch (e) {}
+  for (let i = 0; i < 1e3; i++) {
+    fetch(request).catch(() => {});
   }
 
-  expect(() => fetch(request)).toThrow("Invalid header name");
+  await expect(fetch(request)).rejects.toThrow("Invalid header name");
 });

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -73,7 +73,8 @@ test("fetch() with subclass containing invalid HTTP headers throws without crash
   expect(request.method).toBe("POST");
   await expect(fetch(request)).rejects.toThrow("Invalid header name");
 
-  // quick gc test
+  // quick gc test; 1e3 iterations since each now allocates a rejected Promise
+  // (previously 1e4 sync throws, which allocated nothing).
   for (let i = 0; i < 1e3; i++) {
     fetch(request).catch(() => {});
   }


### PR DESCRIPTION
Closes #33644.

### Repro

```js
try {
  fetch("http://127.0.0.1:1/", {
    headers: { *[Symbol.iterator]() { throw new Error("HBOOM") } },
  }).catch(e => console.log("REJECTED", e.message));
} catch (e) { console.log("SYNC THROW:", e.message); }
```

```
bun:  SYNC THROW: HBOOM
node: REJECTED HBOOM
```

Per WHATWG `fetch()` step 3: *"Let requestObject be the result of invoking the initial value of Request as constructor with input and init. If this throws an exception, reject p with it and return p."* `fetch()` never throws synchronously.

### Cause

`fetch_impl` in `src/runtime/webcore/fetch.rs` uses `?` propagation throughout option extraction (`fast_get`, `get`, `FetchHeaders::create_from_js`, `to_slice_or_null`, ...). Any of these can run user JS (getters, iterators, `toString`/`Symbol.toPrimitive`), and a thrown exception propagates as `Err(JsError::Thrown)` to the `#[bun_jsc::host_fn]` wrapper, which surfaces it as a synchronous throw. Several spots also return `Ok(JSValue::ZERO)` with a pending exception, which has the same effect.

Every *validation* failure in the same function already returns a rejected promise; only genuine user-JS exceptions escaped synchronously.

### Fix

At the `bun_fetch` / `node_http_client` entry-point boundary, convert any `Err` / `Ok(ZERO)`-with-pending-exception from `fetch_impl` into a rejected promise. Termination exceptions are propagated unchanged. This matches how `JSPromise::reject` handles `JsResult<JSValue>`.

### Tests

New `describe` in `test/js/web/fetch/fetch-args.test.ts` covers:
- url `toString()` throws
- `init.headers` iterable throws
- throwing getter on each of `body`, `decompress`, `headers`, `keepalive`, `method`, `proxy`, `redirect`, `signal`, `timeout`, `tls`, `unix`, `verbose`

Each asserts `fetch()` returns a `Promise` (no sync throw) that rejects with the thrown error. All 14 fail on the unfixed build with "fetch() threw synchronously" and pass with the fix.

Two existing tests updated for the new (spec-correct) behavior:
- `test/js/web/request/request-subclass.test.ts`: the GC-stress loop now attaches `.catch(() => {})` instead of `try/catch`, with fewer iterations since each iteration now allocates a Promise.
- `test/js/web/fetch/fetch.stream.test.ts`: a comment stating the error "surfaces synchronously" is updated and the assertion changed to `rejects.toThrow`.