### PR TITLE
Make Bun.CookieMap iteration order Map-like

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -54,14 +54,11 @@ CookieMap::CookieMap()
 {
 }
 
-CookieMap::CookieMap(Vector<Ref<Cookie>>&& cookies)
-    : m_modifiedCookies(WTF::move(cookies))
-{
-}
-
 CookieMap::CookieMap(Vector<KeyValuePair<String, String>>&& cookies)
-    : m_originalCookies(WTF::move(cookies))
 {
+    m_entries.reserveInitialCapacity(cookies.size());
+    for (auto& pair : cookies)
+        m_entries.append(Entry { WTF::move(pair) });
 }
 
 ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& variant, bool throwOnInvalidCookieString)
@@ -132,36 +129,16 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
 
 std::optional<String> CookieMap::get(const String& name) const
 {
-    auto modifiedCookieIndex = m_modifiedCookies.findIf([&](auto& cookie) {
-        return cookie->name() == name;
-    });
-    if (modifiedCookieIndex != notFound) {
-        // a set cookie with an empty value is treated as not existing, because that is what delete() sets
-        if (m_modifiedCookies[modifiedCookieIndex]->value().isEmpty()) {
-            return std::nullopt;
-        }
-        return std::optional<String>(m_modifiedCookies[modifiedCookieIndex]->value());
-    }
-    auto originalCookieIndex = m_originalCookies.findIf([&](auto& cookie) {
-        return cookie.key == name;
-    });
-    if (originalCookieIndex != notFound) {
-        return std::optional<String>(m_originalCookies[originalCookieIndex].value);
-    }
-    return std::nullopt;
-}
-
-Vector<KeyValuePair<String, String>> CookieMap::getAll() const
-{
-    Vector<KeyValuePair<String, String>> all;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
-        all.append(KeyValuePair<String, String>(cookie->name(), cookie->value()));
-    }
-    for (const auto& cookie : m_originalCookies) {
-        all.append(KeyValuePair<String, String>(cookie.key, cookie.value));
-    }
-    return all;
+    auto index = m_entries.findIf([&](auto& entry) { return entry.name() == name; });
+    if (index == notFound)
+        return std::nullopt;
+    const auto& entry = m_entries[index];
+    // A cookie set via set() whose value is empty is treated as absent, because that is how
+    // delete() marks its Set-Cookie tombstone. Original (parsed) entries with an empty value
+    // are still visible.
+    if (entry.cookie && entry.cookie->value().isEmpty())
+        return std::nullopt;
+    return entry.value();
 }
 
 bool CookieMap::has(const String& name) const
@@ -169,34 +146,43 @@ bool CookieMap::has(const String& name) const
     return get(name).has_value();
 }
 
-void CookieMap::removeInternal(const String& name)
-{
-    // Remove any existing matching cookies
-    m_originalCookies.removeAllMatching([&](auto& cookie) {
-        return cookie.key == name;
-    });
-    m_modifiedCookies.removeAllMatching([&](auto& cookie) {
-        return cookie->name() == name;
-    });
-}
-
 void CookieMap::set(Ref<Cookie> cookie)
 {
-    removeInternal(cookie->name());
-    // Add the new cookie
+    const auto& name = cookie->name();
+
+    m_modifiedCookies.removeAllMatching([&](auto& c) { return c->name() == name; });
+
+    if (cookie->value().isEmpty()) {
+        m_entries.removeAllMatching([&](auto& entry) { return entry.name() == name; });
+        m_modifiedCookies.append(WTF::move(cookie));
+        return;
+    }
+
+    // Map-like insertion order: update the existing entry in place, or append a new one.
+    auto index = m_entries.findIf([&](auto& entry) { return entry.name() == name; });
+    if (index == notFound) {
+        m_entries.append(Entry { cookie.copyRef() });
+    } else {
+        m_entries[index].cookie = cookie.copyRef();
+        for (size_t i = m_entries.size(); i-- > index + 1;) {
+            if (m_entries[i].name() == name)
+                m_entries.removeAt(i);
+        }
+    }
+
     m_modifiedCookies.append(WTF::move(cookie));
 }
 
 ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 {
-    removeInternal(options.name);
-
     String name = options.name;
     String domain = options.domain;
     String path = options.path;
     bool secure = name.startsWithIgnoringASCIICase("__Secure-"_s) || name.startsWithIgnoringASCIICase("__Host-"_s);
 
-    // Add the new cookie
+    m_entries.removeAllMatching([&](auto& entry) { return entry.name() == name; });
+    m_modifiedCookies.removeAllMatching([&](auto& c) { return c->name() == name; });
+
     auto cookie_exception = Cookie::create(name, ""_s, domain, path, 1, secure, CookieSameSite::Lax, false, std::numeric_limits<double>::quiet_NaN(), false);
     if (cookie_exception.hasException()) {
         return cookie_exception.releaseException();
@@ -209,7 +195,7 @@ ExceptionOr<void> CookieMap::remove(const CookieStoreDeleteOptions& options)
 Ref<CookieMap> CookieMap::clone()
 {
     auto clone = adoptRef(*new CookieMap());
-    clone->m_originalCookies = m_originalCookies;
+    clone->m_entries = m_entries;
     clone->m_modifiedCookies = m_modifiedCookies;
     return clone;
 }
@@ -217,13 +203,13 @@ Ref<CookieMap> CookieMap::clone()
 size_t
 CookieMap::size() const
 {
-    size_t size = 0;
-    for (const auto& cookie : m_modifiedCookies) {
-        if (cookie->value().isEmpty()) continue;
-        size += 1;
+    size_t count = 0;
+    for (const auto& entry : m_entries) {
+        if (entry.cookie && entry.cookie->value().isEmpty())
+            continue;
+        count++;
     }
-    size += m_originalCookies.size();
-    return size;
+    return count;
 }
 
 JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
@@ -231,28 +217,17 @@ JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Create an object to hold cookie key-value pairs
     auto* object = JSC::constructEmptyObject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     HashSet<String> seenKeys;
-
-    // Add modified cookies to the object
-    for (const auto& cookie : m_modifiedCookies) {
-        if (!cookie->value().isEmpty()) {
-            seenKeys.add(cookie->name());
-            object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie->name()), JSC::jsString(vm, cookie->value()));
-            RETURN_IF_EXCEPTION(scope, {});
-        }
-    }
-
-    // Add original cookies to the object
-    for (const auto& cookie : m_originalCookies) {
-        // Skip if this cookie name was already added from modified cookies
-        if (seenKeys.add(cookie.key).isNewEntry) {
-            object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie.key), JSC::jsString(vm, cookie.value));
-            RETURN_IF_EXCEPTION(scope, {});
-        }
+    for (const auto& entry : m_entries) {
+        if (entry.cookie && entry.cookie->value().isEmpty())
+            continue;
+        if (!seenKeys.add(entry.name()).isNewEntry)
+            continue;
+        object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, entry.name()), JSC::jsString(vm, entry.value()));
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return object;
@@ -261,9 +236,9 @@ JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
 size_t CookieMap::memoryCost() const
 {
     size_t cost = sizeof(CookieMap);
-    for (auto& cookie : m_originalCookies) {
-        cost += cookie.key.sizeInBytes();
-        cost += cookie.value.sizeInBytes();
+    for (auto& entry : m_entries) {
+        cost += entry.pair.key.sizeInBytes();
+        cost += entry.pair.value.sizeInBytes();
     }
     for (auto& cookie : m_modifiedCookies) {
         cost += cookie->name().sizeInBytes();
@@ -274,17 +249,11 @@ size_t CookieMap::memoryCost() const
 
 std::optional<KeyValuePair<String, String>> CookieMap::Iterator::next()
 {
-    while (m_index < m_target->m_modifiedCookies.size() + m_target->m_originalCookies.size()) {
-        if (m_index >= m_target->m_modifiedCookies.size()) {
-            return m_target->m_originalCookies[(m_index++) - m_target->m_modifiedCookies.size()];
-        }
-
-        auto result = m_target->m_modifiedCookies[m_index++];
-        if (result->value().isEmpty()) {
-            continue; // deleted; skip
-        }
-
-        return KeyValuePair<String, String>(result->name(), result->value());
+    while (m_index < m_target->m_entries.size()) {
+        const auto& entry = m_target->m_entries[m_index++];
+        if (entry.cookie && entry.cookie->value().isEmpty())
+            continue;
+        return KeyValuePair<String, String>(entry.name(), entry.value());
     }
     return std::nullopt;
 }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -152,13 +152,9 @@ void CookieMap::set(Ref<Cookie> cookie)
 
     m_modifiedCookies.removeAllMatching([&](auto& c) { return c->name() == name; });
 
-    if (cookie->value().isEmpty()) {
-        m_entries.removeAllMatching([&](auto& entry) { return entry.name() == name; });
-        m_modifiedCookies.append(WTF::move(cookie));
-        return;
-    }
-
     // Map-like insertion order: update the existing entry in place, or append a new one.
+    // An empty value is stored like any other; the empty-value skip in get()/size()/iteration
+    // hides it, and a later mutation of the Cookie object surfaces it on every path.
     auto index = m_entries.findIf([&](auto& entry) { return entry.name() == name; });
     if (index == notFound) {
         m_entries.append(Entry { cookie.copyRef() });

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -159,6 +159,7 @@ void CookieMap::set(Ref<Cookie> cookie)
     if (index == notFound) {
         m_entries.append(Entry { cookie.copyRef() });
     } else {
+        m_entries[index].pair = {};
         m_entries[index].cookie = cookie.copyRef();
         for (size_t i = m_entries.size(); i-- > index + 1;) {
             if (m_entries[i].name() == name)

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -31,7 +31,6 @@ public:
     static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& init, bool throwOnInvalidCookieString = true);
 
     std::optional<String> get(const String& name) const;
-    Vector<KeyValuePair<String, String>> getAll() const;
     Vector<Ref<Cookie>> getAllChanges() const { return m_modifiedCookies; }
 
     bool has(const String& name) const;
@@ -62,12 +61,30 @@ public:
 
 private:
     CookieMap();
-    CookieMap(Vector<Ref<Cookie>>&& cookies);
     CookieMap(Vector<KeyValuePair<String, String>>&& cookies);
 
-    void removeInternal(const String& name);
+    // An entry is either an original cookie from construction (name/value pair) or one backed
+    // by a Cookie object from set(). For the latter, value() reads through the Cookie so that
+    // mutating the Cookie after set() is observable.
+    struct Entry {
+        KeyValuePair<String, String> pair;
+        RefPtr<Cookie> cookie;
 
-    Vector<KeyValuePair<String, String>> m_originalCookies;
+        Entry(KeyValuePair<String, String>&& p)
+            : pair(WTF::move(p))
+        {
+        }
+        Entry(Ref<Cookie>&& c)
+            : cookie(WTF::move(c))
+        {
+        }
+        const String& name() const { return cookie ? cookie->name() : pair.key; }
+        const String& value() const { return cookie ? cookie->value() : pair.value; }
+    };
+
+    // Live entries in insertion order; drives iteration, get()/has()/size()/toJSON().
+    Vector<Entry> m_entries;
+    // Cookies to emit as Set-Cookie headers (from set() and delete()).
     Vector<Ref<Cookie>> m_modifiedCookies;
 };
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -364,53 +364,155 @@ describe("Cookie name field is immutable", () => {
 });
 
 describe("iterator", () => {
-  test("delete in a loop", () => {
-    const map = new Bun.CookieMap();
-    for (let i = 0; i < 1000; i++) {
-      map.set(`name${i}`, `value${i}`);
-    }
-    for (const key of map.keys()) {
-      map.delete(key);
-    }
-    // expect(map.size).toBe(0);
-    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
-  });
-  test("delete in a loop with predefined entries", () => {
-    const entries: [string, string][] = [];
-    for (let i = 0; i < 1000; i++) {
-      entries.push([`name${i}`, `value${i}`]);
-    }
-    const map = new Bun.CookieMap(entries);
-    for (const key of map.keys()) {
-      map.delete(key);
-    }
-    expect(map.size).toBe(0);
-  });
-  test("delete in a loop with both", () => {
-    const entries: [string, string][] = [];
-    for (let i = 0; i < 500; i++) {
-      entries.push([`pre${i}`, `pre${i}`]);
-    }
-    const map = new Bun.CookieMap(entries);
-    for (let i = 0; i < 1000; i++) {
-      map.set(`post${i}`, `post${i}`);
-    }
-    for (const key of map.keys()) {
-      map.delete(key);
-    }
-    // expect(map.size).toBe(0);
-    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+  // Deleting during iteration skips every other entry (FormData-style), regardless of whether
+  // the entries came from the constructor or from set().
+  test.each([
+    ["set()", () => {
+      const map = new Bun.CookieMap();
+      for (let i = 0; i < 1000; i++) map.set(`name${i}`, `value${i}`);
+      return map;
+    }],
+    ["constructor", () => {
+      const entries: [string, string][] = [];
+      for (let i = 0; i < 1000; i++) entries.push([`name${i}`, `value${i}`]);
+      return new Bun.CookieMap(entries);
+    }],
+    ["both", () => {
+      const entries: [string, string][] = [];
+      for (let i = 0; i < 500; i++) entries.push([`pre${i}`, `pre${i}`]);
+      const map = new Bun.CookieMap(entries);
+      for (let i = 0; i < 500; i++) map.set(`post${i}`, `post${i}`);
+      return map;
+    }],
+  ] as const)("delete in a loop (entries via %s)", (_, build) => {
+    const map = build();
+    for (const key of map.keys()) map.delete(key);
+    // FormData works this way, but not Map/Set. maybe we should work like Map.
+    expect(map.size).toBe(500);
   });
   test("basic iterator", () => {
     const cookies = new Bun.CookieMap({ a: "b", c: "d" });
     cookies.set("e", "f");
     cookies.set("g", "h");
     expect([...cookies.entries()].map(([key, value]) => `${key}=${value}`).join("\n")).toMatchInlineSnapshot(`
-    "e=f
-    g=h
-    a=b
-    c=d"
+    "a=b
+    c=d
+    e=f
+    g=h"
   `);
+  });
+});
+
+describe("iteration order is Map-like", () => {
+  const keysVia = (map: Bun.CookieMap) => ({
+    spread: [...map].map(([k]) => k),
+    entries: [...map.entries()].map(([k]) => k),
+    keys: [...map.keys()],
+    forEach: (() => {
+      const out: string[] = [];
+      map.forEach((_v, k) => out.push(k));
+      return out;
+    })(),
+    toJSON: Object.keys(map.toJSON()),
+  });
+
+  test("set() on an existing name keeps its position", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    map.set("b", "B");
+    expect(keysVia(map)).toEqual({
+      spread: ["a", "b", "c"],
+      entries: ["a", "b", "c"],
+      keys: ["a", "b", "c"],
+      forEach: ["a", "b", "c"],
+      toJSON: ["a", "b", "c"],
+    });
+    expect([...map.values()]).toEqual(["1", "B", "3"]);
+    expect(map.get("b")).toBe("B");
+    expect(map.toSetCookieHeaders()).toEqual(["b=B; Path=/; SameSite=Lax"]);
+  });
+
+  test("set() on a new name appends", () => {
+    const map = new Bun.CookieMap("a=1; b=2");
+    map.set("z", "9");
+    expect(keysVia(map)).toEqual({
+      spread: ["a", "b", "z"],
+      entries: ["a", "b", "z"],
+      keys: ["a", "b", "z"],
+      forEach: ["a", "b", "z"],
+      toJSON: ["a", "b", "z"],
+    });
+  });
+
+  test("matches Map for a mixed sequence of set() and delete()", () => {
+    const ops: Array<["set", string, string] | ["delete", string]> = [
+      ["set", "b", "B"],
+      ["set", "z", "9"],
+      ["delete", "a"],
+      ["set", "c", "C"],
+      ["set", "a", "A"],
+      ["set", "z", "Z"],
+    ];
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    const ref = new Map<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
+    for (const op of ops) {
+      if (op[0] === "set") {
+        map.set(op[1], op[2]);
+        ref.set(op[1], op[2]);
+      } else {
+        map.delete(op[1]);
+        ref.delete(op[1]);
+      }
+      expect([...map]).toEqual([...ref]);
+    }
+    expect([...map]).toEqual([["b", "B"], ["c", "C"], ["z", "Z"], ["a", "A"]]);
+  });
+
+  test.each([
+    ["string", () => new Bun.CookieMap("a=1; b=2; c=3")],
+    ["array", () => new Bun.CookieMap([["a", "1"], ["b", "2"], ["c", "3"]])],
+    ["object", () => new Bun.CookieMap({ a: "1", b: "2", c: "3" })],
+    ["set() on empty", () => {
+      const m = new Bun.CookieMap();
+      m.set("a", "1");
+      m.set("b", "2");
+      m.set("c", "3");
+      return m;
+    }],
+  ] as const)("set() on an existing name keeps its position (built via %s)", (_, build) => {
+    const map = build();
+    map.set("b", "B");
+    map.set("a", "A");
+    expect([...map]).toEqual([["a", "A"], ["b", "B"], ["c", "3"]]);
+  });
+
+  test("delete() then set() appends at the end", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    map.delete("a");
+    map.set("a", "A");
+    expect([...map.keys()]).toEqual(["b", "c", "a"]);
+  });
+
+  test("set() with a Cookie object keeps position and reflects later mutation", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    const cookie = new Bun.Cookie("b", "B");
+    map.set(cookie);
+    expect([...map]).toEqual([["a", "1"], ["b", "B"], ["c", "3"]]);
+    cookie.value = "BB";
+    expect([...map]).toEqual([["a", "1"], ["b", "BB"], ["c", "3"]]);
+    expect(map.get("b")).toBe("BB");
+  });
+
+  test("toSetCookieHeaders() still tracks every set()/delete()", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    map.set("b", "B");
+    map.set("z", "9");
+    map.delete("c");
+    expect([...map.keys()]).toEqual(["a", "b", "z"]);
+    expect(map.toSetCookieHeaders()).toEqual([
+      "b=B; Path=/; SameSite=Lax",
+      "z=9; Path=/; SameSite=Lax",
+      "c=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+    ]);
   });
 });
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -367,23 +367,32 @@ describe("iterator", () => {
   // Deleting during iteration skips every other entry (FormData-style), regardless of whether
   // the entries came from the constructor or from set().
   test.each([
-    ["set()", () => {
-      const map = new Bun.CookieMap();
-      for (let i = 0; i < 1000; i++) map.set(`name${i}`, `value${i}`);
-      return map;
-    }],
-    ["constructor", () => {
-      const entries: [string, string][] = [];
-      for (let i = 0; i < 1000; i++) entries.push([`name${i}`, `value${i}`]);
-      return new Bun.CookieMap(entries);
-    }],
-    ["both", () => {
-      const entries: [string, string][] = [];
-      for (let i = 0; i < 500; i++) entries.push([`pre${i}`, `pre${i}`]);
-      const map = new Bun.CookieMap(entries);
-      for (let i = 0; i < 500; i++) map.set(`post${i}`, `post${i}`);
-      return map;
-    }],
+    [
+      "set()",
+      () => {
+        const map = new Bun.CookieMap();
+        for (let i = 0; i < 1000; i++) map.set(`name${i}`, `value${i}`);
+        return map;
+      },
+    ],
+    [
+      "constructor",
+      () => {
+        const entries: [string, string][] = [];
+        for (let i = 0; i < 1000; i++) entries.push([`name${i}`, `value${i}`]);
+        return new Bun.CookieMap(entries);
+      },
+    ],
+    [
+      "both",
+      () => {
+        const entries: [string, string][] = [];
+        for (let i = 0; i < 500; i++) entries.push([`pre${i}`, `pre${i}`]);
+        const map = new Bun.CookieMap(entries);
+        for (let i = 0; i < 500; i++) map.set(`post${i}`, `post${i}`);
+        return map;
+      },
+    ],
   ] as const)("delete in a loop (entries via %s)", (_, build) => {
     const map = build();
     for (const key of map.keys()) map.delete(key);
@@ -453,7 +462,11 @@ describe("iteration order is Map-like", () => {
       ["set", "z", "Z"],
     ];
     const map = new Bun.CookieMap("a=1; b=2; c=3");
-    const ref = new Map<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
+    const ref = new Map<string, string>([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
     for (const op of ops) {
       if (op[0] === "set") {
         map.set(op[1], op[2]);
@@ -464,25 +477,45 @@ describe("iteration order is Map-like", () => {
       }
       expect([...map]).toEqual([...ref]);
     }
-    expect([...map]).toEqual([["b", "B"], ["c", "C"], ["z", "Z"], ["a", "A"]]);
+    expect([...map]).toEqual([
+      ["b", "B"],
+      ["c", "C"],
+      ["z", "Z"],
+      ["a", "A"],
+    ]);
   });
 
   test.each([
     ["string", () => new Bun.CookieMap("a=1; b=2; c=3")],
-    ["array", () => new Bun.CookieMap([["a", "1"], ["b", "2"], ["c", "3"]])],
+    [
+      "array",
+      () =>
+        new Bun.CookieMap([
+          ["a", "1"],
+          ["b", "2"],
+          ["c", "3"],
+        ]),
+    ],
     ["object", () => new Bun.CookieMap({ a: "1", b: "2", c: "3" })],
-    ["set() on empty", () => {
-      const m = new Bun.CookieMap();
-      m.set("a", "1");
-      m.set("b", "2");
-      m.set("c", "3");
-      return m;
-    }],
+    [
+      "set() on empty",
+      () => {
+        const m = new Bun.CookieMap();
+        m.set("a", "1");
+        m.set("b", "2");
+        m.set("c", "3");
+        return m;
+      },
+    ],
   ] as const)("set() on an existing name keeps its position (built via %s)", (_, build) => {
     const map = build();
     map.set("b", "B");
     map.set("a", "A");
-    expect([...map]).toEqual([["a", "A"], ["b", "B"], ["c", "3"]]);
+    expect([...map]).toEqual([
+      ["a", "A"],
+      ["b", "B"],
+      ["c", "3"],
+    ]);
   });
 
   test("delete() then set() appends at the end", () => {
@@ -496,9 +529,17 @@ describe("iteration order is Map-like", () => {
     const map = new Bun.CookieMap("a=1; b=2; c=3");
     const cookie = new Bun.Cookie("b", "B");
     map.set(cookie);
-    expect([...map]).toEqual([["a", "1"], ["b", "B"], ["c", "3"]]);
+    expect([...map]).toEqual([
+      ["a", "1"],
+      ["b", "B"],
+      ["c", "3"],
+    ]);
     cookie.value = "BB";
-    expect([...map]).toEqual([["a", "1"], ["b", "BB"], ["c", "3"]]);
+    expect([...map]).toEqual([
+      ["a", "1"],
+      ["b", "BB"],
+      ["c", "3"],
+    ]);
     expect(map.get("b")).toBe("BB");
   });
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -543,6 +543,32 @@ describe("iteration order is Map-like", () => {
     expect(map.get("b")).toBe("BB");
   });
 
+  test("mutating a Cookie's value after set() is reflected consistently in iteration and Set-Cookie", () => {
+    const map = new Bun.CookieMap("a=1; b=2; c=3");
+    const cookie = new Bun.Cookie("b", "");
+    map.set(cookie);
+    expect({ keys: [...map.keys()], get: map.get("b"), has: map.has("b"), size: map.size }).toEqual({
+      keys: ["a", "c"],
+      get: null,
+      has: false,
+      size: 2,
+    });
+    cookie.value = "B";
+    expect({
+      keys: [...map.keys()],
+      get: map.get("b"),
+      has: map.has("b"),
+      size: map.size,
+      headers: map.toSetCookieHeaders(),
+    }).toEqual({
+      keys: ["a", "b", "c"],
+      get: "B",
+      has: true,
+      size: 3,
+      headers: ["b=B; Path=/; SameSite=Lax"],
+    });
+  });
+
   test("toSetCookieHeaders() still tracks every set()/delete()", () => {
     const map = new Bun.CookieMap("a=1; b=2; c=3");
     map.set("b", "B");


### PR DESCRIPTION
## Repro

```js
const m1 = new Bun.CookieMap("a=1; b=2; c=3");
m1.set("b", "B");
[...m1.keys()];            // ["b", "a", "c"]   expected ["a", "b", "c"]
Object.keys(m1.toJSON());  // ["b", "a", "c"]

const m2 = new Bun.CookieMap("a=1; b=2");
m2.set("z", "9");
[...m2.keys()];            // ["z", "a", "b"]   expected ["a", "b", "z"]

const ref = new Map([["a","1"],["b","2"],["c","3"]]);
ref.set("b","B"); ref.set("z","9");
[...ref.keys()];           // ["a", "b", "c", "z"]
```

`Bun.CookieMap` is documented as "a Map-like collection of cookies", and its surface (`get`/`set`/`delete`/`has`/`size`/`entries`/`keys`/`values`/`forEach`/`@@iterator`/`toJSON`) mirrors JS `Map` / WebIDL maplike, whose contract is insertion order: `set()` of an existing key updates in place, `set()` of a new key appends. In `Bun.serve` this object is `request.cookies`, so updating one cookie silently reordered every enumeration of the request's cookies (serialization, `toJSON()` snapshots/diffs, logging).

## Cause

`CookieMap` kept two vectors: `m_originalCookies` (from construction) and `m_modifiedCookies` (from `set()`/`delete()`). `Iterator::next()`, `getAll()`, `toJSON()` and `size()` all walked `m_modifiedCookies` first, then `m_originalCookies`. `set()` removed the name from `m_originalCookies` and appended to `m_modifiedCookies`, so any `set()` moved its entry to the modified-first block: an existing key jumped to the front, and a new key was inserted ahead of every original.

## Fix

`m_entries` is now the single insertion-ordered vector that drives iteration, `get`/`has`/`size`/`toJSON`. Each entry is either an original name/value pair or a `RefPtr<Cookie>` from `set()`; for the latter, `value()` reads through the `Cookie`, so mutating the `Cookie` object after `set()` is still observable (existing tested behavior). `m_modifiedCookies` is kept only as the side channel for `toSetCookieHeaders()` and the `Bun.serve` response writer.

`set()` updates the existing entry in place (keeping its position) or appends a new one, collapsing any duplicate names from the original header to one slot, and records the `Cookie` in `m_modifiedCookies` for the `Set-Cookie` delta. `delete()` removes the entry and appends its expiring tombstone to `m_modifiedCookies` as before. `toSetCookieHeaders()` output is unchanged.

Two zero-caller declarations that would otherwise have had to be rewritten are removed: `CookieMap::getAll()` and the `CookieMap(Vector<Ref<Cookie>>&&)` constructor. `removeInternal` is inlined since the two callers now differ.

### Side effect: delete-during-iteration is now consistent

Previously, `for (const k of map.keys()) map.delete(k)` left half the entries behind when they came from `set()` (FormData-style index-vs-shifting-vector), but cleared the map when they came from the constructor, because the modified-first/original-second split happened to keep the effective index into `m_originalCookies` at zero. With a single vector that distinction goes away: it is now consistently FormData-style (half remain) regardless of how entries were added. The three `delete in a loop` tests, whose comments already noted "maybe we should work like Set", are folded into a `test.each` asserting the uniform behavior.

## Verification

New `iteration order is Map-like` describe in `test/js/bun/cookie/cookie-map.test.ts`:

- `set()` on an existing name keeps its position, checked across `[...map]`/`entries()`/`keys()`/`forEach`/`toJSON()`, and across all four construction paths (string, array, object, repeated `set()`)
- `set()` on a new name appends
- a mixed sequence of `set()`/`delete()` produces the same `[...map]` as a real `Map` at every step
- `delete()` then `set()` appends at the end
- `set(cookie)` keeps position and later `cookie.value = ...` is reflected in iteration
- `toSetCookieHeaders()` is unchanged after a reordering `set()`

The existing `basic iterator` snapshot is updated to the Map-like order. 13 tests fail without the `src/` change and all 43 pass with it. The rest of `test/js/bun/cookie/`, `test/js/bun/util/cookie.test.js`, `bun-serve-cookies.test.ts`, `test/bake/dev/request-cookies.test.ts` and `test/js/web/fetch/cookies.test.ts` are green (299 pass).

Overlaps with #33431, which changes the empty-value-as-deletion rule and also removes the same two dead declarations; whichever merges second needs a straightforward rebase on `CookieMap.cpp`.