### PR TITLE
fix(BunFile): lastModified returns 0 for missing files instead of 2^52-1 sentinel

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2252,7 +2252,13 @@ impl BlobExt for Blob {
                     resolve_file_stat(store);
                 }
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
-                return JSValue::js_number(store.data_mut().as_file().last_modified as f64);
+                let last_modified = store.data_mut().as_file().last_modified;
+                // If stat failed (file does not exist) the sentinel is still
+                // here; expose 0 to JS, mirroring `.size` == 0 for a missing file.
+                if last_modified == jsc::INIT_TIMESTAMP {
+                    return JSValue::js_number(0.0);
+                }
+                return JSValue::js_number(last_modified as f64);
             }
         }
 
@@ -2260,7 +2266,7 @@ impl BlobExt for Blob {
             return JSValue::js_number(self.last_modified.get());
         }
 
-        JSValue::js_number(jsc::INIT_TIMESTAMP as f64)
+        JSValue::js_number(0.0)
     }
 
     fn get_size_for_bindings(&self) -> u64 {

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -23,6 +23,42 @@ test("delete() and stat() should work with unicode paths", async () => {
   expect(await Bun.file(filename).delete()).toBe(undefined);
 
   expect(await Bun.file(filename).exists()).toBe(false);
+});
+
+describe("Bun.file().lastModified", () => {
+  // 2**52 - 1: the internal "not yet statted" sentinel that must never reach JS.
+  const SENTINEL = 4503599627370495;
+
+  test("returns 0 for a path that does not exist", async () => {
+    using dir = tempDir("lastmodified-missing", {});
+    const missing = Bun.file(join(String(dir), "does-not-exist.txt"));
+    expect(await missing.exists()).toBe(false);
+    expect(missing.lastModified).toBe(0);
+    expect(missing.lastModified).not.toBe(SENTINEL);
+  });
+
+  test("a missing file is not newer than a real one", async () => {
+    using dir = tempDir("lastmodified-compare", { "real.txt": "x" });
+    const real = Bun.file(join(String(dir), "real.txt"));
+    const missing = Bun.file(join(String(dir), "nope.txt"));
+    expect(real.lastModified).toBeGreaterThan(0);
+    expect(real.lastModified).toBeLessThan(SENTINEL);
+    expect(missing.lastModified).toBe(0);
+    expect(missing.lastModified < real.lastModified).toBe(true);
+  });
+
+  test("returns 0 after the file is deleted", async () => {
+    using dir = tempDir("lastmodified-deleted", { "gone.txt": "x" });
+    const path = join(String(dir), "gone.txt");
+    expect(Bun.file(path).lastModified).toBeGreaterThan(0);
+    await Bun.file(path).delete();
+    expect(Bun.file(path).lastModified).toBe(0);
+  });
+
+  test("in-memory Blob.lastModified is 0, not the internal sentinel", () => {
+    expect(new Blob(["x"]).lastModified).toBe(0);
+    expect(new Blob().lastModified).toBe(0);
+  });
 });
 
 test("writer.end() should not close the fd if it does not own the fd", async () => {


### PR DESCRIPTION
## Repro

```js
const m = Bun.file("/definitely/not/a/real/path");
console.log(m.lastModified);                 // 4503599627370495  (2**52 - 1)
console.log(new Date(m.lastModified).toISOString()); // +144683-05-23T16:29:30.495Z
console.log(m.size, await m.exists());       // 0 false  (these two are already normalized)

await Bun.write("/tmp/real", "x");
console.log(m.lastModified > Bun.file("/tmp/real").lastModified); // true: missing is "newer"
```

## Cause

`get_last_modified` reads the file store's `last_modified` field, which is initialized to `jsc::INIT_TIMESTAMP` (`(1u64 << 52) - 1`). When the field is still the sentinel it calls `resolve_file_stat`, but that function silently does nothing on stat failure (ENOENT etc.), so the sentinel is returned to JS unchanged. The fallthrough for in-memory `Blob`s also returned the raw sentinel.

`.size` already normalizes this case to `0` via `resolve_size`; `.lastModified` was the one getter that leaked the lazy marker.

## Fix

After the resolve attempt, if the field is still `INIT_TIMESTAMP`, return `0` instead of the sentinel. Same for the in-memory `Blob` fallthrough. `new File([...], name)` is unchanged and still returns `Date.now()` when no `lastModified` option is passed, per the File API.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/util/bun-file.test.ts -t lastModified   # 4 fail, all show 4503599627370495
bun bd test test/js/bun/util/bun-file.test.ts                                 # 10 pass
```