### PR TITLE
Update TinyCC to latest upstream

### DIFF
--- a/scripts/build/deps/tinycc.ts
+++ b/scripts/build/deps/tinycc.ts
@@ -2,7 +2,8 @@
  * TinyCC — small embeddable C compiler. Powers bun:ffi's JIT-compile path,
  * where user-provided C gets compiled and linked at runtime.
  *
- * Disabled on windows-arm64 (tinycc doesn't have an arm64-coff backend).
+ * Disabled on windows-arm64 (upstream tinycc now has an arm64-pe backend,
+ * but bun:ffi has never been enabled there — see cfg.tinycc in config.ts).
  *
  * Built via DirectBuild — no cmake sub-process. The old overlay
  * CMakeLists.txt had two recurring ASAN workarounds for the c2str host
@@ -12,7 +13,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const TINYCC_COMMIT = "12882eee073cfe5c7621bcfadf679e1372d4537b";
+const TINYCC_COMMIT = "c22ca054d270c9e25630590fe0e2c867793ab82d";
 
 export const tinycc: Dependency = {
   name: "tinycc",

--- a/src/runtime/ffi/libtcc1.c
+++ b/src/runtime/ffi/libtcc1.c
@@ -604,3 +604,56 @@ unsigned long long __fixunsxfdi (long double a1)
     else
         return 0;
 }
+
+/* TinyCC's lib/va_list.c: __va_arg is no longer inlined by tccdefs.h, and Bun
+   replaces libtcc1 with this file. Only referenced by x86_64 SysV codegen.
+   Deviation from upstream: no extern abort() — Bun never injects that symbol,
+   so referencing it would make every cc() fail with an unresolved reference. */
+#if defined(__x86_64__) && !defined(_WIN32)
+
+enum __va_arg_type {
+    __va_gen_reg, __va_float_reg, __va_stack
+};
+
+void *__va_arg(__builtin_va_list ap,
+               int arg_type,
+               int size, int align)
+{
+    size = (size + 7) & ~7;
+    align = (align + 7) & ~7;
+    switch ((enum __va_arg_type)arg_type) {
+    case __va_gen_reg:
+        if (ap->gp_offset + size <= 48) {
+            ap->gp_offset += size;
+            return ap->reg_save_area + ap->gp_offset - size;
+        }
+        goto use_overflow_area;
+
+    case __va_float_reg:
+        if (ap->fp_offset < 128 + 48) {
+            ap->fp_offset += 16;
+            if (size == 8)
+                return ap->reg_save_area + ap->fp_offset - 16;
+            if (ap->fp_offset < 128 + 48) {
+                double *p = (double *)(ap->reg_save_area + ap->fp_offset);
+                p[-1] = p[0];
+                ap->fp_offset += 16;
+                return ap->reg_save_area + ap->fp_offset - 32;
+            }
+        }
+        goto use_overflow_area;
+
+    case __va_stack:
+    use_overflow_area:
+        ap->overflow_arg_area += size;
+        ap->overflow_arg_area = (char*)((long long)(ap->overflow_arg_area + align - 1) & -align);
+        return ap->overflow_arg_area - size;
+
+    default:
+        /* unreachable: the compiler only emits the three classes above.
+           Trap with a null write like TinyCC's old inline __va_arg did. */
+        *(volatile char *)0 = 0;
+        return 0;
+    }
+}
+#endif /* __x86_64__ && !_WIN32 */

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -457,6 +457,189 @@ describe.skipIf(isASAN || isFFIUnavailable)("GC liveness of compiled symbols and
   });
 });
 
+// va_arg on x86_64 SysV lowers to a call to __va_arg, which TinyCC expects
+// libtcc1 to provide; Bun replaces libtcc1 with src/runtime/ffi/libtcc1.c.
+// TinyCC's setjmp/longjmp error handling conflicts with ASan.
+describe.skipIf(isASAN || isFFIUnavailable)("variadic functions inside cc()-compiled C", () => {
+  it("va_arg over ints, doubles, and the stack overflow area", async () => {
+    using dir = tempDir("bun-ffi-cc-varargs", {
+      "varargs.c": /* c */ `
+        #include <stdarg.h>
+
+        static long long sum_ints(int count, ...) {
+          va_list ap;
+          va_start(ap, count);
+          long long total = 0;
+          for (int i = 0; i < count; i++) total += va_arg(ap, int);
+          va_end(ap);
+          return total;
+        }
+
+        static double sum_doubles(int count, ...) {
+          va_list ap;
+          va_start(ap, count);
+          double total = 0;
+          for (int i = 0; i < count; i++) total += va_arg(ap, double);
+          va_end(ap);
+          return total;
+        }
+
+        /* alternating int/double reads from one va_list: gp_offset and
+           fp_offset must advance independently */
+        static double sum_pairs(int count, ...) {
+          va_list ap;
+          va_start(ap, count);
+          double total = 0;
+          for (int i = 0; i < count; i++) {
+            total += va_arg(ap, int);
+            total += va_arg(ap, double);
+          }
+          va_end(ap);
+          return total;
+        }
+
+        /* a 16-byte all-double struct occupies two SSE register save slots */
+        struct dd { double a, b; };
+        static double sum_dd(int count, ...) {
+          va_list ap;
+          va_start(ap, count);
+          double total = 0;
+          for (int i = 0; i < count; i++) {
+            struct dd v = va_arg(ap, struct dd);
+            total += v.a + v.b;
+          }
+          va_end(ap);
+          return total;
+        }
+
+        /* 10 ints: exhausts the 6 integer registers and spills to the stack. */
+        long long ten_ints(void) { return sum_ints(10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10); }
+        /* 10 doubles: exhausts the 8 SSE registers and spills to the stack. */
+        double ten_doubles(void) { return sum_doubles(10, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5); }
+        double interleaved(void) { return sum_pairs(9, 1,0.5, 2,0.5, 3,0.5, 4,0.5, 5,0.5, 6,0.5, 7,0.5, 8,0.5, 9,0.5); }
+        double double_pairs(void) {
+          struct dd x = { 1.5, 2.5 }, y = { 3.0, 4.0 };
+          return sum_dd(2, x, y);
+        }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "varargs.c"),
+          symbols: {
+            ten_ints: { args: [], returns: "i64" },
+            ten_doubles: { args: [], returns: "f64" },
+            interleaved: { args: [], returns: "f64" },
+            double_pairs: { args: [], returns: "f64" },
+          },
+        });
+        console.log(
+          JSON.stringify({
+            ten_ints: Number(symbols.ten_ints()),
+            ten_doubles: symbols.ten_doubles(),
+            interleaved: symbols.interleaved(),
+            double_pairs: symbols.double_pairs(),
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is included in the received object so failures show it, but is not
+    // asserted empty: debug builds emit benign startup warnings.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        ten_ints: 55,
+        ten_doubles: 50,
+        interleaved: 49.5,
+        double_pairs: 11,
+      },
+      exitCode: 0,
+    });
+  });
+});
+
+// long double is 16 bytes on x86_64 and always va_arg'd through the stack; on
+// aarch64 it is binary128 and its arithmetic needs soft-float helpers
+// (__addtf3, ...) that Bun's TCC states do not provide, so x64 only.
+describe.skipIf(isASAN || isFFIUnavailable || process.arch !== "x64")(
+  "long double varargs inside cc()-compiled C",
+  () => {
+    it("va_arg over long double", async () => {
+      using dir = tempDir("bun-ffi-cc-varargs-ld", {
+        "ld.c": /* c */ `
+        #include <stdarg.h>
+
+        static double sum_long_doubles(int count, ...) {
+          va_list ap;
+          va_start(ap, count);
+          long double total = 0;
+          for (int i = 0; i < count; i++) total += va_arg(ap, long double);
+          va_end(ap);
+          return (double)total;
+        }
+
+        double long_doubles(void) { return sum_long_doubles(3, 1.5L, 2.25L, 3.25L); }
+      `,
+        "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "ld.c"),
+          symbols: { long_doubles: { args: [], returns: "f64" } },
+        });
+        console.log(JSON.stringify({ long_doubles: symbols.long_doubles() }));
+      `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+      expect({ results, stderr, exitCode }).toMatchObject({
+        results: { long_doubles: 7 },
+        exitCode: 0,
+      });
+    });
+  },
+);
+
+// TinyCC compiles thread-local variables to Local-Exec TLS, which has no
+// meaning inside an in-memory relocation (there is no PT_TLS segment): the
+// generated loads/stores alias the host process's own thread block. TinyCC
+// must reject it instead of silently corrupting Bun's thread-locals.
+describe.skipIf(isASAN || isFFIUnavailable)("thread-local storage inside cc()-compiled C", () => {
+  it.each(["_Thread_local", "__thread"])("%s is a compile error", keyword => {
+    const dir = tempDirWithFiles(`bun-ffi-cc-tls`, {
+      "tls.c": `${keyword} int bun_test_tls_counter = 0;\nint bump(void) { return ++bun_test_tls_counter; }\n`,
+    });
+    expect(() => {
+      cc({
+        source: path.join(dir, "tls.c"),
+        symbols: { bump: { args: [], returns: "int" } },
+      });
+    }).toThrow(/thread-local storage is not supported/);
+  });
+});
+
 describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
   // JSC NaN-boxes doubles, so a NaN whose payload collides with the tag space
   // ("impure NaN", see JSC's PureNaN.h) must never be encoded as-is: it would

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -336,7 +336,7 @@ it("process.versions", () => {
     mimalloc: "afb41757285694f832e7a2f164d35f5717457f96",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
-    tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",
+    tinycc: "c22ca054d270c9e25630590fe0e2c867793ab82d",
     lolhtml: "77127cd2b8545998756e8d64e36ee2313c4bb312",
     ares: "3ac47ee46edd8ea40370222f91613fc16c434853",
     libdeflate: "c8c56a20f8f621e6a966b716b31f1dedab6a41e3",


### PR DESCRIPTION
## Summary

Updates the vendored TinyCC (the C compiler behind `bun:ffi`'s `cc()` / JIT trampolines) to the tip of upstream TinyCC, merged into [oven-sh/tinycc `mob` @ `c22ca054`](https://github.com/oven-sh/tinycc/commit/c22ca054d270c9e25630590fe0e2c867793ab82d). The previous pin was from January 2026; this brings in ~82 upstream commits.

Fork maintenance (already pushed to `oven-sh/tinycc` `mob`):
- Merged upstream `mob` @ `a338258d` (2026-06-13). Fork patches upstream has since implemented itself were dropped in favor of the upstream version (all of the Windows-ARM64/PE backend work, `configure` host_cc, CI job, test skips, libtcc1 aarch64 guard).
- Fork patches that remain on top of upstream are exactly the macOS ones (`-framework`, framework header/library search, `dlsym(RTLD_SELF)` fallback, cached xcode-select SDK lookup) plus the enum-attribute / `__attribute__((deprecated))` parser patches. Fixed three latent bugs in them while there (uninitialized `pstrcat` buffer, `bool` without `<stdbool.h>`, `parse_attribute` on an uninitialized `AttributeDef`).
- Added two fork guards: `tcc_relocate` now rejects thread-local variables (upstream newly accepts `_Thread_local`/`__thread` and emits Local-Exec TLS, which has no meaning for an in-memory image — the generated thread-pointer-relative accesses land inside the host process's own TLS block, i.e. they would silently corrupt Bun's thread-locals; previously this was a compile error, and it is again), and `tcc_relocate` flushes the instruction cache after `VirtualProtect` on arm64 Windows (groundwork for enabling bun:ffi there).

Notable upstream fixes we pick up: an x86_64 miscompile (missing REX prefix when materializing 0 into r8–r15, which are the 5th/6th integer argument registers), an out-of-bounds read in `tccrun` after relocate with `-g`, arm64 long-double comparison fixes, an arm64 inline assembler, Win32 compile-lock init made thread-safe, and Win32 JIT run memory moved from the CRT heap to a dedicated `VirtualAlloc` region with `RtlAddFunctionTable` failure now surfaced as an error ([`6728a64f`](https://github.com/TinyCC/tinycc/commit/6728a64f1b) + [`601a0882`](https://github.com/TinyCC/tinycc/commit/601a088214)). The last one is the root cause of the Windows x64 `bun:ffi` segfaults inside `RtlAddFunctionTable` / `JSFFIFunction::trampoline` tracked as Sentry BUN-2V2K and BUN-3K30; see #32013 for the full analysis. Supersedes #32013. Should address #31941 (not auto-closing; the link is causal, not an observed before/after).

Bun-side changes needed by the bump:
- `src/runtime/ffi/libtcc1.c`: upstream moved `__va_arg` out of the preprocessor predefs into libtcc1, which Bun replaces with this file — so ship `__va_arg` here. Without it, any `va_arg` in `cc()`-compiled C on x86_64 fails to relocate (`unresolved reference to '__va_arg'`). The function is upstream's, minus the `extern abort()` (Bun's trampoline TCC states are `-nostdlib`, so an extern there breaks every `cc()` call).
- `process.versions.tinycc` pin updated in `process.test.js`.
- Tests: a varargs suite covering register/stack/interleaved/16-byte-struct/`long double` `va_arg` paths, and a test that `_Thread_local`/`__thread` produce a compile error.

Not changed here: bun:ffi is still disabled on Windows ARM64. Upstream now has an arm64-PE backend, but running Bun's FFI suites on real windows-arm64 hardware (see the follow-up PR) shows it still miscompiles variadic doubles and crashes when JIT code calls back into the host, so enabling stays split out until those are fixed in the fork.

## Test plan

- [x] `bun bd --asan=off test test/js/bun/ffi/cc.test.ts test/js/bun/ffi/ffi.test.js test/js/bun/ffi/ffi-error-messages.test.ts` — all pass (the `dlopen` matrix runs against `/tmp/bun-ffi-test.so`)
- [x] New varargs test fails against the new TinyCC without the `libtcc1.c` change (`unresolved reference to '__va_arg'`) and passes with it; also passes on the previous TinyCC
- [x] New TLS test fails without the fork's `tcc_relocate` guard (TinyCC silently accepts TLS) and passes with it
- [x] TinyCC's own `./configure && make && make test` passes on the merged fork tree (linux-x64)
- [x] Fresh `vendor/tinycc` fetch of the pinned commit → full debug build → the above suites
- [ ] CI: macOS x64/arm64 and Windows x64 lanes build TinyCC from the new commit and run the ffi suites
