### PR TITLE
Bun.serve: include disposition-type in auto Content-Disposition header

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3684,7 +3684,9 @@ where
                     {
                         let header_value = {
                             let mut w = &mut filename_buf[..];
-                            if write!(w, "filename=\"{}\"", bstr::BStr::new(truncated)).is_ok() {
+                            if write!(w, "attachment; filename=\"{}\"", bstr::BStr::new(truncated))
+                                .is_ok()
+                            {
                                 let written = 1024 - w.len();
                                 &filename_buf[..written]
                             } else {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { once } from "node:events";
 import * as net from "node:net";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
@@ -158,5 +160,61 @@ describe("response Connection: close closes the socket", () => {
     } finally {
       socket.destroy();
     }
+  });
+});
+
+// RFC 6266 §4.1: content-disposition = disposition-type *( ";" disposition-parm )
+// The disposition-type token is mandatory; a bare `filename="..."` is invalid and
+// UAs / strict parsers handle it inconsistently.
+describe("auto Content-Disposition for Bun.file() responses", () => {
+  test("includes a disposition-type", async () => {
+    using dir = tempDir("cd-serve", {
+      "asset.bin": "0123456789",
+      "report.pdf": "0123456789",
+      "bundle.zip": "0123456789",
+      "page.html": "0123456789",
+      "data.json": "0123456789",
+      "photo.png": "0123456789",
+    });
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        const name = new URL(req.url).pathname.slice(1);
+        return new Response(Bun.file(join(String(dir), name)));
+      },
+    });
+
+    const seen: Record<string, string | null> = {};
+    for (const name of ["asset.bin", "report.pdf", "bundle.zip", "page.html", "data.json", "photo.png"]) {
+      const res = await fetch(new URL(name, server.url));
+      await res.arrayBuffer();
+      seen[name] = res.headers.get("content-disposition");
+    }
+    expect(seen).toEqual({
+      "asset.bin": 'attachment; filename="asset.bin"',
+      "report.pdf": 'attachment; filename="report.pdf"',
+      "bundle.zip": 'attachment; filename="bundle.zip"',
+      // inline-rendered categories must not get the header at all
+      "page.html": null,
+      "data.json": null,
+      "photo.png": null,
+    });
+  });
+
+  test("user-set header is not overridden", async () => {
+    using dir = tempDir("cd-serve-user", { "asset.bin": "x" });
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        return new Response(Bun.file(join(String(dir), "asset.bin")), {
+          headers: { "content-disposition": "inline" },
+        });
+      },
+    });
+    const res = await fetch(server.url);
+    await res.arrayBuffer();
+    expect(res.headers.get("content-disposition")).toBe("inline");
   });
 });


### PR DESCRIPTION
## Reproduction

```js
const srv = Bun.serve({
  port: 0,
  fetch: () => new Response(Bun.file("/tmp/asset.bin")),
});
require("fs").writeFileSync("/tmp/asset.bin", "x");
const res = await fetch(srv.url);
console.log(res.headers.get("content-disposition"));
// before: filename="asset.bin"
// after:  attachment; filename="asset.bin"
```

## Cause

`render_metadata()` writes `filename="{basename}"` with no disposition-type. RFC 6266 4.1 grammar is `content-disposition = disposition-type *( ";" disposition-parm )`: the leading token is mandatory, and `filename=` cannot parse as one (`=` and `"` are not tchar). Strict consumers (the npm `content-disposition` parser used by express/got, RFC-conforming proxies) reject the field outright, and user agents disagree on how to recover from it, so whether a bun-served file downloads or renders inline is UA-dependent.

## Fix

Prefix the value with `attachment; `. The auto-header is skipped for MIME categories browsers render natively without a viewer plugin (html/json/text/css/js/image/audio/video/font/wasm), and Chrome/Firefox/Safari already treated the previous malformed value as a download (tc2231 `attmissingdisposition*`), so `attachment` matches both the code's intent and the observed behavior. Types like `application/pdf` reach this path exactly as before; users who want inline rendering set the header explicitly, which is covered by the second test case. The existing 32-byte slack in the 1024-byte stack buffer already covers the 12 extra bytes.

## Verification

`bun bd test test/js/bun/http/bun-serve-headers.test.ts`: 8 pass / 0 fail. New test asserts the exact header value for `.bin`/`.pdf`/`.zip` and asserts no header for `.html`/`.json`/`.png`; a second case confirms a user-set `Content-Disposition: inline` is still respected.

RFC 5987 `filename*=` for non-ASCII basenames is a reasonable follow-up but is a separate concern from the syntactic bug fixed here.
