### PR TITLE
fetch: normalize string bodies so text() matches the UTF-8 decode of arrayBuffer()

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6716,6 +6716,11 @@ impl Any {
                 if str.length() == 0 {
                     return Ok(JSValue::NULL);
                 }
+                // Fetch "parse JSON from bytes" runs "UTF-8 decode", which
+                // strips a leading BOM. `substring` borrows `str`'s storage.
+                if str.char_at(0) == 0xFEFF {
+                    return str.substring(1).to_js_by_parse_json(global);
+                }
                 str.to_js_by_parse_json(global)
             }
         }
@@ -6781,6 +6786,11 @@ impl Any {
                     core::ptr::null_mut(),
                 )));
                 *self = Any::Blob(Blob::default());
+                // Fetch body mixin `text()` is "UTF-8 decode", which strips a
+                // leading BOM. `substring` borrows `str`'s storage.
+                if str.length() > 0 && str.char_at(0) == 0xFEFF {
+                    return str.substring(1).to_js(global);
+                }
                 str.to_js(global)
             }
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6716,11 +6716,6 @@ impl Any {
                 if str.length() == 0 {
                     return Ok(JSValue::NULL);
                 }
-                // Fetch "parse JSON from bytes" runs "UTF-8 decode", which
-                // strips a leading BOM. `substring` borrows `str`'s storage.
-                if str.char_at(0) == 0xFEFF {
-                    return str.substring(1).to_js_by_parse_json(global);
-                }
                 str.to_js_by_parse_json(global)
             }
         }
@@ -6786,11 +6781,6 @@ impl Any {
                     core::ptr::null_mut(),
                 )));
                 *self = Any::Blob(Blob::default());
-                // Fetch body mixin `text()` is "UTF-8 decode", which strips a
-                // leading BOM. `substring` borrows `str`'s storage.
-                if str.length() > 0 && str.char_at(0) == 0xFEFF {
-                    return str.substring(1).to_js(global);
-                }
                 str.to_js(global)
             }
         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -953,14 +953,9 @@ impl Value {
 
             debug_assert!(str.tag() == bun_core::Tag::WTFStringImpl);
 
-            // A string body's bytes are its UTF-8 encoding (fetch "extract a
-            // body", USVString), and text()/json() are "UTF-8 decode" of those
-            // bytes, which strips a leading BOM and cannot yield lone
-            // surrogates. Only keep the zero-copy WTFStringImpl fast path when
-            // the string already equals that round trip; otherwise store the
-            // encoded bytes so text()/json()/arrayBuffer()/bytes() all agree.
-            // 8-bit Latin-1 cannot hold U+FEFF or surrogates, so only 16-bit
-            // storage needs checking.
+            // Keep the zero-copy WTFStringImpl only when text()'s "UTF-8
+            // decode" of the encoded bytes would return it unchanged: no
+            // leading BOM, no lone surrogates (neither fits in 8-bit Latin-1).
             if str.is_utf16() {
                 let utf16 = str.utf16();
                 if utf16[0] == 0xFEFF || !simdutf::validate::utf16le(utf16) {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -24,6 +24,7 @@ use bun_core::{MutableString, String as BunString, ZigString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::{JsCell, StringJsc as _};
+use bun_simdutf_sys::simdutf;
 
 /// Deref the `Value::WTFStringImpl` / `AnyBlob::WTFStringImpl` payload.
 /// Centralises the per-site `(**s)` raw deref at the dozen `match` arms below
@@ -951,6 +952,26 @@ impl Value {
             }
 
             debug_assert!(str.tag() == bun_core::Tag::WTFStringImpl);
+
+            // A string body's bytes are its UTF-8 encoding (fetch "extract a
+            // body", USVString), and text()/json() are "UTF-8 decode" of those
+            // bytes, which strips a leading BOM and cannot yield lone
+            // surrogates. Only keep the zero-copy WTFStringImpl fast path when
+            // the string already equals that round trip; otherwise store the
+            // encoded bytes so text()/json()/arrayBuffer()/bytes() all agree.
+            // 8-bit Latin-1 cannot hold U+FEFF or surrogates, so only 16-bit
+            // storage needs checking.
+            if str.is_utf16() {
+                let utf16 = str.utf16();
+                if utf16[0] == 0xFEFF || !simdutf::validate::utf16le(utf16) {
+                    let bytes = bun_core::strings::to_utf8_alloc(utf16);
+                    str.deref();
+                    return Ok(Value::InternalBlob(InternalBlob {
+                        bytes,
+                        was_string: true,
+                    }));
+                }
+            }
 
             // `leak_wtf_impl()` transfers the +1 ref out of the bun_core::String wrapper.
             return Ok(Value::WTFStringImpl(str.leak_wtf_impl()));

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -953,9 +953,7 @@ impl Value {
 
             debug_assert!(str.tag() == bun_core::Tag::WTFStringImpl);
 
-            // Keep the zero-copy WTFStringImpl only when text()'s "UTF-8
-            // decode" of the encoded bytes would return it unchanged: no
-            // leading BOM, no lone surrogates (neither fits in 8-bit Latin-1).
+            // text() is "UTF-8 decode" of the encoded bytes: no leading BOM, no lone surrogates.
             if str.is_utf16() {
                 let utf16 = str.utf16();
                 if utf16[0] == 0xFEFF || !simdutf::validate::utf16le(utf16) {

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -51,64 +51,42 @@ describe("UTF-8 BOM should be ignored", () => {
     });
   });
 
-  describe("Response (string body)", () => {
+  describe.each([
+    ["Response", (body: string, type: string) => new Response(body, { headers: { "content-type": type } })],
+    [
+      "Request",
+      (body: string, type: string) =>
+        new Request("https://example.com", { method: "POST", body, headers: { "content-type": type } }),
+    ],
+  ] as const)("%s (string body)", (_, make) => {
     it("in text()", async () => {
-      const response = new Response("\uFEFFHello, World!", { headers: { "content-type": "text/plain" } });
-      expect(await response.text()).toBe("Hello, World!");
+      expect(await make("\uFEFFHello, World!", "text/plain").text()).toBe("Hello, World!");
     });
 
     it("in text() with emoji", async () => {
-      const response = new Response("\uFEFFHello, World! 🌎", { headers: { "content-type": "text/plain" } });
-      expect(await response.text()).toBe("Hello, World! 🌎");
+      expect(await make("\uFEFFHello, World! 🌎", "text/plain").text()).toBe("Hello, World! 🌎");
     });
 
     it("in text() with only a BOM", async () => {
-      const response = new Response("\uFEFF");
-      expect(await response.text()).toBe("");
+      expect(await make("\uFEFF", "text/plain").text()).toBe("");
     });
 
     it("in text() only strips one leading BOM", async () => {
-      const response = new Response("\uFEFF\uFEFFHello");
-      expect(await response.text()).toBe("\uFEFFHello");
+      expect(await make("\uFEFF\uFEFFHello", "text/plain").text()).toBe("\uFEFFHello");
     });
 
     it("in text() leaves an interior BOM", async () => {
-      const response = new Response("Hello\uFEFFWorld");
-      expect(await response.text()).toBe("Hello\uFEFFWorld");
+      expect(await make("Hello\uFEFFWorld", "text/plain").text()).toBe("Hello\uFEFFWorld");
     });
 
     it("in json()", async () => {
-      const response = new Response('\uFEFF{"hello":"World"}', {
-        headers: { "content-type": "application/json" },
-      });
-      expect(await response.json()).toEqual({ "hello": "World" } as any);
+      expect(await make('\uFEFF{"hello":"World"}', "application/json").json()).toEqual({ "hello": "World" } as any);
     });
 
     it("in json() with emoji", async () => {
-      const response = new Response('\uFEFF{"hello":"World 🌎"}', {
-        headers: { "content-type": "application/json" },
-      });
-      expect(await response.json()).toEqual({ "hello": "World 🌎" } as any);
-    });
-  });
-
-  describe("Request (string body)", () => {
-    it("in text()", async () => {
-      const request = new Request("https://example.com", {
-        method: "POST",
-        body: "\uFEFFHello, World!",
-        headers: { "content-type": "text/plain" },
-      });
-      expect(await request.text()).toBe("Hello, World!");
-    });
-
-    it("in json()", async () => {
-      const request = new Request("https://example.com", {
-        method: "POST",
-        body: '\uFEFF{"hello":"World"}',
-        headers: { "content-type": "application/json" },
-      });
-      expect(await request.json()).toEqual({ "hello": "World" } as any);
+      expect(await make('\uFEFF{"hello":"World 🌎"}', "application/json").json()).toEqual({
+        "hello": "World 🌎",
+      } as any);
     });
   });
 

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -51,6 +51,67 @@ describe("UTF-8 BOM should be ignored", () => {
     });
   });
 
+  describe("Response (string body)", () => {
+    it("in text()", async () => {
+      const response = new Response("\uFEFFHello, World!", { headers: { "content-type": "text/plain" } });
+      expect(await response.text()).toBe("Hello, World!");
+    });
+
+    it("in text() with emoji", async () => {
+      const response = new Response("\uFEFFHello, World! 🌎", { headers: { "content-type": "text/plain" } });
+      expect(await response.text()).toBe("Hello, World! 🌎");
+    });
+
+    it("in text() with only a BOM", async () => {
+      const response = new Response("\uFEFF");
+      expect(await response.text()).toBe("");
+    });
+
+    it("in text() only strips one leading BOM", async () => {
+      const response = new Response("\uFEFF\uFEFFHello");
+      expect(await response.text()).toBe("\uFEFFHello");
+    });
+
+    it("in text() leaves an interior BOM", async () => {
+      const response = new Response("Hello\uFEFFWorld");
+      expect(await response.text()).toBe("Hello\uFEFFWorld");
+    });
+
+    it("in json()", async () => {
+      const response = new Response('\uFEFF{"hello":"World"}', {
+        headers: { "content-type": "application/json" },
+      });
+      expect(await response.json()).toEqual({ "hello": "World" } as any);
+    });
+
+    it("in json() with emoji", async () => {
+      const response = new Response('\uFEFF{"hello":"World 🌎"}', {
+        headers: { "content-type": "application/json" },
+      });
+      expect(await response.json()).toEqual({ "hello": "World 🌎" } as any);
+    });
+  });
+
+  describe("Request (string body)", () => {
+    it("in text()", async () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        body: "\uFEFFHello, World!",
+        headers: { "content-type": "text/plain" },
+      });
+      expect(await request.text()).toBe("Hello, World!");
+    });
+
+    it("in json()", async () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        body: '\uFEFF{"hello":"World"}',
+        headers: { "content-type": "application/json" },
+      });
+      expect(await request.json()).toEqual({ "hello": "World" } as any);
+    });
+  });
+
   describe("Response", () => {
     it("in text()", async () => {
       const response = new Response(Buffer.from("\uFEFFHello, World!"), { headers: { "content-type": "text/plain" } });

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -88,6 +88,37 @@ describe("UTF-8 BOM should be ignored", () => {
         "hello": "World 🌎",
       } as any);
     });
+
+    it("replaces lone surrogates with U+FFFD in text()", async () => {
+      expect(await make("a\uD800b", "text/plain").text()).toBe("a\uFFFDb");
+      expect(await make("a\uDC00b", "text/plain").text()).toBe("a\uFFFDb");
+    });
+
+    it("replaces lone surrogates with U+FFFD in json()", async () => {
+      expect(await make('{"a":"\uD800"}', "application/json").json()).toEqual({ a: "\uFFFD" } as any);
+    });
+
+    // Fetch body mixin: text() is "UTF-8 decode" of the body's bytes, and a
+    // string body's bytes are its UTF-8 encoding, so text() must equal
+    // TextDecoder().decode(arrayBuffer()) for every string body.
+    it.each([
+      "hello",
+      "Hello, World! 🌎",
+      "\uFEFF",
+      "\uFEFFHello",
+      "\uFEFF\uFEFF",
+      "a\uFEFFb",
+      "\uD800",
+      "a\uD800b",
+      "\uDC00abc",
+      "\uD83C\uDF0E",
+      "日本語",
+      "\uFEFF\uD800🌎",
+    ])("text() matches TextDecoder().decode(arrayBuffer()) for %j", async body => {
+      const text = await make(body, "text/plain").text();
+      const bytes = await make(body, "text/plain").arrayBuffer();
+      expect(text).toBe(new TextDecoder().decode(bytes));
+    });
   });
 
   describe("Response", () => {


### PR DESCRIPTION
## What

`new Response(str).text()` / `.json()` now match `new TextDecoder().decode(await new Response(str).arrayBuffer())` for every string body: a leading U+FEFF BOM is stripped and lone surrogates become U+FFFD, matching Node, browsers, and Bun's own byte-backed body paths.

## Repro

```js
const doc = "\ufeff" + '{"a":1}';
await new Response(doc).json();                            // before: SyntaxError: Failed to parse JSON
await new Response(new TextEncoder().encode(doc)).json();  // always: {a: 1}

await new Response("a\uD800b").text();                     // before: "a\uD800b" (lone surrogate kept)
new TextDecoder().decode(await new Response("a\uD800b").arrayBuffer());  // always: "a\uFFFDb"
```

Node v26 and browsers return `{a: 1}` / `"a\uFFFDb"` on every row.

## Cause

A string `BodyInit` is its UTF-8 encoding (fetch "extract a body", USVString), and the Body mixin `text()` / `json()` are "UTF-8 decode" of those bytes. UTF-8 decode strips a leading `EF BB BF` and cannot produce a lone surrogate.

Bun's string-body fast path stores the raw `WTFStringImpl` (`body::Value::from_js`, `src/runtime/webcore/Body.rs`) and `.text()` hands it straight back (`Any::to_string`, `Any::WTFStringImpl` arm) with no encode/decode round trip, so a leading BOM and any lone surrogate survived. `.arrayBuffer()`/`.bytes()` of the same body transcode via `to_utf8_alloc` and do normalize, so the two disagreed.

## Fix

In `body::Value::from_js`, when the incoming JS string is 16-bit and either starts with `0xFEFF` or fails `simdutf::validate::utf16le` (i.e. contains a lone surrogate), encode it to UTF-8 and store as `InternalBlob` so every consumer agrees. 8-bit Latin-1 strings cannot hold U+FEFF or surrogates, and well-formed 16-bit strings pass the SIMD validator, so both keep the zero-copy `WTFStringImpl` path.

## Verification

`test/js/web/fetch/utf8-bom.test.ts` gains a `describe.each` over `Response` / `Request` string bodies covering BOM-only, double-BOM, interior BOM preserved, emoji, lone high/low surrogates, and a `text() === new TextDecoder().decode(arrayBuffer())` invariant over a dozen string shapes.

```
bun bd test test/js/web/fetch/utf8-bom.test.ts   # 63 pass / 0 fail
USE_SYSTEM_BUN=1 bun test ...                    # 33 pass / 30 fail
```

Also ran `body.test.ts`, `response.test.ts`, `body-mixin-errors.test.ts`, `body-clone.test.ts` (all green) and `BUN_JSC_validateExceptionChecks=1`.
