### PR TITLE
Bun.serve: serve the fresh file, not a 206, when Bun.file's cached size is stale

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1746,6 +1746,7 @@ where
         let crate::webcore::blob::store::Data::File(file) = &self.blob.store().unwrap().data else {
             unreachable!("do_sendfile called with non-file blob");
         };
+        let store_max_size = file.max_size;
         let mut file_buf = PathBuffer::uninit();
         let auto_close = !matches!(
             file.pathlike,
@@ -1826,7 +1827,22 @@ where
             AnyBlob::Blob(b) => b.size.get(),
             _ => unreachable!(),
         };
+        let blob_offset = match &self.blob {
+            AnyBlob::Blob(b) => b.offset.get(),
+            _ => unreachable!(),
+        };
         let stat_size: BlobSizeType = BlobSizeType::try_from(stat.st_size.max(0)).unwrap();
+        // An unsliced blob has offset 0 and either the unset-size sentinel or,
+        // if JS touched `.size`, the value `resolve_size` cached on the store
+        // (`file.max_size`). Comparing against the fresh `stat_size` here is
+        // wrong: when the file grew after `.size` was read, a stale cached
+        // size would be mistaken for a slice bound and the response truncated
+        // with an unsolicited 206. `.slice(0, store_max_size)` is
+        // indistinguishable from an unsliced blob (same store, same size) and
+        // is served as the whole file; any other `.slice()` differs in offset
+        // or size.
+        let is_whole_file = blob_offset == 0
+            && (original_size == crate::webcore::blob::MAX_SIZE || original_size == store_max_size);
         if let AnyBlob::Blob(b) = &mut self.blob {
             b.size.set(if is_regular {
                 stat_size
@@ -1836,16 +1852,16 @@ where
         }
 
         self.flags.set_needs_content_length(true);
-        let blob_offset = match &self.blob {
-            AnyBlob::Blob(b) => b.offset.get(),
-            _ => unreachable!(),
-        };
         self.sendfile = SendfileContext {
-            remain: blob_offset + original_size,
+            remain: if is_regular && is_whole_file {
+                stat_size
+            } else {
+                blob_offset + original_size
+            },
             offset: blob_offset,
             total: 0,
         };
-        if is_regular && auto_close {
+        if is_regular && auto_close && !is_whole_file {
             self.flags.set_needs_content_range(
                 self.sendfile.remain.saturating_sub(self.sendfile.offset) != stat_size,
             );
@@ -1863,13 +1879,9 @@ where
         // Honor an incoming Range: header for whole-file responses. We
         // don't compose Range with a user-supplied .slice() because the
         // Content-Range arithmetic gets ambiguous; the slice path keeps
-        // its existing slice-as-range behavior. `offset == 0` alone is
-        // insufficient — `Bun.file(p).slice(0, n)` has offset 0 — so we
-        // also check the size: an unsliced blob has either the unset-size
-        // sentinel or, if JS already read `.size`, the stat'd size; a
-        // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
-        // already set Content-Range or a non-200 status — they're
-        // managing partial responses themselves.
+        // its existing slice-as-range behavior. Skip if the user already
+        // set Content-Range or a non-200 status — they're managing
+        // partial responses themselves.
         let user_handles_range = if let Some(r) = self.response_weakref.get() {
             r.status_code() != 200
                 || r.get_init_headers_mut()
@@ -1878,8 +1890,6 @@ where
         } else {
             false
         };
-        let is_whole_file = blob_offset == 0
-            && (original_size == crate::webcore::blob::MAX_SIZE || original_size == stat_size);
         // RFC 9110 §14.2: Range is only defined for GET (HEAD mirrors GET's headers).
         let method_allows_range = self.method == Method::GET || self.method == Method::HEAD;
         if is_regular

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -2,7 +2,7 @@ import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, rmScope, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
-import { unlinkSync } from "node:fs";
+import { appendFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
@@ -1138,3 +1138,85 @@ console.log("OK");
   },
   60_000,
 );
+
+describe.concurrent("Bun.file response after the file grew on disk", () => {
+  // Touching `.size`/`.exists()` caches the stat result on the BunFile. If the
+  // file then grows before the Response is sent, the stale cached size must not
+  // be mistaken for a `.slice()` bound: the fresh stat taken at send time wins,
+  // and the whole file is served as a plain 200.
+  async function run(mode: string, init?: ResponseInit, reqInit?: RequestInit) {
+    using dir = tempDir("serve-file-grow", {});
+    const p = join(String(dir), "asset.bin");
+    await using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        writeFileSync(p, Buffer.alloc(1000, 65));
+        const f = Bun.file(p);
+        if (mode === "size") void f.size;
+        if (mode === "exists") await f.exists();
+        appendFileSync(p, Buffer.alloc(4000, 66));
+        return new Response(f, init);
+      },
+    });
+    const res = await fetch(server.url, reqInit);
+    const body = new Uint8Array(await res.arrayBuffer());
+    return {
+      status: res.status,
+      contentRange: res.headers.get("content-range"),
+      contentLength: res.headers.get("content-length"),
+      bodyLength: body.byteLength,
+      body,
+    };
+  }
+
+  it.each(["none", "size", "exists"])(
+    "serves the fresh file as 200 after %s was touched (no init headers)",
+    async mode => {
+      const r = await run(mode);
+      expect({
+        status: r.status,
+        contentRange: r.contentRange,
+        contentLength: r.contentLength,
+        bodyLength: r.bodyLength,
+      }).toEqual({ status: 200, contentRange: null, contentLength: "5000", bodyLength: 5000 });
+      expect(r.body.subarray(0, 1000)).toEqual(Buffer.alloc(1000, 65));
+      expect(r.body.subarray(1000)).toEqual(Buffer.alloc(4000, 66));
+    },
+  );
+
+  it.each(["none", "size", "exists"])(
+    "serves the fresh file as 200 after %s was touched (with init headers)",
+    async mode => {
+      const r = await run(mode, { headers: { "x-a": "b" } });
+      expect({
+        status: r.status,
+        contentRange: r.contentRange,
+        contentLength: r.contentLength,
+        bodyLength: r.bodyLength,
+      }).toEqual({ status: 200, contentRange: null, contentLength: "5000", bodyLength: 5000 });
+    },
+  );
+
+  it("still resolves an incoming Range header against the fresh size", async () => {
+    const r = await run("size", undefined, { headers: { Range: "bytes=0-1999" } });
+    expect({
+      status: r.status,
+      contentRange: r.contentRange,
+      contentLength: r.contentLength,
+      bodyLength: r.bodyLength,
+    }).toEqual({ status: 206, contentRange: "bytes 0-1999/5000", contentLength: "2000", bodyLength: 2000 });
+    expect(r.body.subarray(0, 1000)).toEqual(Buffer.alloc(1000, 65));
+    expect(r.body.subarray(1000)).toEqual(Buffer.alloc(1000, 66));
+  });
+
+  it("a Range past the stale cached size is satisfiable against the fresh size", async () => {
+    const r = await run("size", undefined, { headers: { Range: "bytes=2000-2999" } });
+    expect({
+      status: r.status,
+      contentRange: r.contentRange,
+      contentLength: r.contentLength,
+      bodyLength: r.bodyLength,
+    }).toEqual({ status: 206, contentRange: "bytes 2000-2999/5000", contentLength: "1000", bodyLength: 1000 });
+    expect(r.body).toEqual(Buffer.alloc(1000, 66));
+  });
+});


### PR DESCRIPTION
### Repro

```js
import * as fs from "node:fs";
const p = "/tmp/asset.bin";
using srv = Bun.serve({
  port: 0,
  async fetch() {
    fs.writeFileSync(p, Buffer.alloc(1000, 65));
    const f = Bun.file(p);
    void f.size;                                   // caches st_size=1000 on the blob and its store
    fs.appendFileSync(p, Buffer.alloc(4000, 66));  // file is now 5000 bytes
    return new Response(f);
  },
});
const res = await fetch(srv.url);                  // client sends NO Range header
console.log(res.status, res.headers.get("content-range"), (await res.arrayBuffer()).byteLength);
```

On 1.4.0 and `main`:

```
206 "bytes 0-999/*" 1000        // unsolicited 206, body truncated to the stale length
```

Adding any init header (`new Response(f, { headers: { "x-a": "b" } })`) flips the status to 200 but the body is still truncated to 1000.

RFC 9110 §15.3.7: a 206 is only ever the answer to a Range request. An unsolicited 206 poisons caches, and the silent truncation is data loss.

### Cause

`do_sendfile` reopens the file and takes a fresh fstat, then decides whether the blob is a sub-range by comparing the blob's cached `size` against that fresh `stat_size`. When `.size`/`.exists()` cached the size at 1000 and the file has since grown to 5000, `size != stat_size` and the blob is treated as a slice: `needs_content_range` is set, `sendfile.remain` is capped at the stale 1000, and `render_metadata` promotes the headerless path to 206.

The `is_whole_file` check for native Range handling had the same defect: it compared against `stat_size`, so a stale-cached whole-file blob was excluded and an incoming Range header was ignored.

### Fix

A whole-file blob's `size` is either the unset sentinel or the value `resolve_size` cached on the store (`file.max_size`); a `.slice()` writes `size` directly and does not touch the store cache. `is_whole_file` now compares against `file.max_size` (captured before the store borrow ends) instead of the fresh `stat_size`, and is computed once up front. A whole-file blob then sends `stat_size` bytes (never the stale cache), never sets `needs_content_range`, and is eligible for native Range handling, which resolves the client's Range against the fresh size.

Shrink (file smaller than the cached size) already behaved correctly and is unchanged.

`.slice()` behavior is unchanged except for one state that is bit-identical to an unsliced blob: `f.slice(0, f.size)` after `.size` was read (offset 0, `size == store.max_size`). That is served as the whole fresh file instead of an unsolicited 206 at the stale length; the Blob struct has no field that distinguishes it from an unsliced blob.

Not addressed here (pre-existing, same bug class): when the path did not exist at `.size`/`.exists()` time and is created afterward, `resolve_size` falls through to `size = 0` with `store.max_size` still `MAX_SIZE`, and that state is indistinguishable from `.slice(0, 0)` on a never-stat'd file. Fixing it without regressing the explicit empty slice needs a dedicated sliced bit on `Blob`, which touches the `#[repr(C)]` layout shared with C++ and the structured-clone format. Follow-up.

### Verification

New `describe("Bun.file response after the file grew on disk")` in `test/js/bun/http/bun-serve-file.test.ts`:

- after `.size` / `await .exists()` / nothing, with and without init headers: 200, `Content-Length: 5000`, no `Content-Range`, full body
- `Range: bytes=0-1999` resolves against the fresh size: 206, `bytes 0-1999/5000`
- `Range: bytes=2000-2999` (past the stale cached size) is satisfiable against the fresh size

6 of the 8 fail without the fix, all pass with it. The rest of `bun-serve-file.test.ts` and the `serve.test.ts` Content-Range/Bun.file suites are unchanged.

### Related

#32794 removes the `needs_content_range` setter entirely for the unsolicited-206 side of this, but still caps `sendfile.remain` at the stale `original_size` so the body remains truncated. This PR is narrower and fixes both the 206 and the truncation without changing the documented slice behavior #32794 is pending a maintainer call on.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->