### PR TITLE
Reject json() on an empty body with the JSON.parse SyntaxError

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2723,15 +2723,6 @@ impl BlobExt for Blob {
         // SAFETY: `raw_bytes` is valid for reads for the duration of this call
         // (either a leaked Box for `Temporary` or a store-backed view otherwise).
         let (bom, buf) = strings::BOM::detect_and_split(unsafe { &*raw_bytes });
-        if buf.is_empty() {
-            if LIFETIME == Lifetime::Temporary {
-                // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
-                unsafe { drop(bun_core::heap::take(raw_bytes)) };
-            }
-            return Err(global.throw_value(
-                global.create_syntax_error_instance(format_args!("Unexpected end of JSON input")),
-            ));
-        }
 
         if bom == Some(strings::BOM::Utf16Le) {
             // Reinterpret as u16: drop a trailing odd byte.
@@ -6342,9 +6333,6 @@ impl Any {
         match self {
             Any::Blob(b) => b.to_json(global, lifetime),
             Any::InternalBlob(ib) => {
-                if ib.bytes.is_empty() {
-                    return Ok(JSValue::NULL);
-                }
                 let str = ib.to_json(global);
                 // the GC will collect the string
                 *self = Any::Blob(Blob::default());
@@ -6354,9 +6342,6 @@ impl Any {
                 let str =
                     BunString::adopt_wtf_impl(core::mem::replace(impl_, core::ptr::null_mut()));
                 *self = Any::Blob(Blob::default());
-                if str.length() == 0 {
-                    return Ok(JSValue::NULL);
-                }
                 str.to_js_by_parse_json(global)
             }
         }

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -151,7 +151,7 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   expect(JSON.parse(stdout)).toEqual({
     ascii: { a: 1, b: "two" },
     utf8: { s: "wörld" },
-    emptyErr: "Unexpected end of JSON input",
+    emptyErr: "JSON Parse error: Unexpected EOF",
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -929,13 +929,10 @@ for (const { body, fn } of bodyTypes) {
       for (const actual of invalidTests) {
         test(actual || "<empty>", async () => {
           expect(async () => await fn(actual).json()).toThrow(SyntaxError);
-          // An empty body is rejected before the parser runs, with its own message.
-          if (actual !== "") {
-            const error = await fn(actual)
-              .json()
-              .catch(error => error);
-            expect(error.message).toBe(jsonParseError(actual).message);
-          }
+          const error = await fn(actual)
+            .json()
+            .catch(error => error);
+          expect(error.message).toBe(jsonParseError(actual).message);
         });
       }
     });
@@ -1532,5 +1529,65 @@ describe.concurrent("a fetch() Response that cannot have a body", () => {
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ status: 205, body: null, text: "" });
     expect(exitCode).toBe(0);
+  });
+});
+
+// #24955: an empty body must reject .json() the way JSON.parse("") throws, on
+// every path that holds the body. A fetch() Response resolved null.
+describe.concurrent("an empty body rejects .json() with the JSON.parse error", () => {
+  const expected = { name: "SyntaxError", message: jsonParseError("").message };
+  const settle = (promise: Promise<unknown>) =>
+    promise.then(
+      value => ({ resolved: value }),
+      (error: Error) => ({ name: error.name, message: error.message }),
+    );
+
+  test("fetch() Response", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("") });
+    const response = await fetch(server.url);
+    expect(await settle(response.json())).toEqual(expected);
+  });
+
+  test("fetch() Response with a Content-Type", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("", { headers: { "Content-Type": "application/json" } }),
+    });
+    const response = await fetch(server.url);
+    expect(await settle(response.json())).toEqual(expected);
+  });
+
+  test("fetch() Response with no body (204)", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(null, { status: 204 }) });
+    const response = await fetch(server.url);
+    expect(await settle(response.json())).toEqual(expected);
+  });
+
+  test("Request received by Bun.serve()", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: async request => Response.json(await settle(request.json())),
+    });
+    const response = await fetch(server.url, { method: "POST", body: "" });
+    expect(await response.json()).toEqual(expected);
+  });
+
+  test.each([
+    ["Response('')", () => new Response("")],
+    ["Response(null)", () => new Response(null)],
+    ["Response(new Uint8Array(0))", () => new Response(new Uint8Array(0))],
+    ["Request('')", () => new Request("http://example.com/", { method: "POST", body: "" })],
+    ["Blob([])", () => new Blob([])],
+    ["Blob(['\\uFEFF'])", () => new Blob(["\uFEFF"])],
+    ["Blob([]).stream()", () => new Blob([]).stream()],
+    ["Response(ReadableStream)", () => new Response(new ReadableStream({ start: controller => controller.close() }))],
+  ])("%s", async (_, make) => {
+    expect(await settle(make().json())).toEqual(expected);
+  });
+
+  test("Bun.file()", async () => {
+    using dir = tempDir("empty-json", { "empty.json": "", "bom.json": "\uFEFF" });
+    expect(await settle(file(`${dir}/empty.json`).json())).toEqual(expected);
+    expect(await settle(file(`${dir}/bom.json`).json())).toEqual(expected);
   });
 });


### PR DESCRIPTION
### Problem
- `fetch()` of a response with an empty body: `response.json()` resolves `null`. Node rejects with the `JSON.parse` SyntaxError. Fixes #24955. A `Request` body in `Bun.serve()` resolves `null` the same way.
- An empty `Blob`, `Response("")` or `Bun.file()` body rejects with a hardcoded `Unexpected end of JSON input`. A streamed empty body rejects with `JSON Parse error: Unexpected EOF`, the `JSON.parse("")` message.
- The cause is three empty-body checks in `src/runtime/webcore/Blob.rs` that run before the JSON helpers: `to_json_with_bytes` (line 2726) throws the hardcoded message, `Any::to_json` (lines 6336 and 6348) returns `null` for an `InternalBlob` or a `WTFStringImpl` body.

### Fix
- Remove the three checks. The body text goes to `EncodedSlice__toJSONObject` or `BunString__toJSON` as any other text does. Since #41387, both helpers parse an empty input as `""` and throw the `JSON.parse` SyntaxError.
- Every path now gives one result for an empty body: a rejected promise with the `JSON.parse("")` SyntaxError. This is what the fetch spec says (`json()` runs `JSON.parse` on the text and rethrows) and what Node does.
- Verified: `test/js/web/fetch/body.test.ts` (new `describe` block, 11 of its 13 cases fail on bun 1.4.1, and the `<empty>` cases of the `json()` table now check the message). Also `test/js/bun/util/bun-file.test.ts`, `test/js/bun/spawn/readablestream-helpers.test.ts` and `test/js/bun/http/serve.test.ts` on the debug build.

### Background
- A `Body` holds its bytes in one of several forms: a `Blob` (a store with bytes or a file), an `InternalBlob` (an owned byte vector, what a `fetch()` or `Bun.serve()` body arrives as), or a `WTFStringImpl` (a JS string body). `Any::to_json` dispatches on the form.
- `EncodedSlice__toJSONObject` (`src/jsc/bindings/bindings.cpp`) and `BunString__toJSON` (`src/jsc/bindings/BunString.cpp`) are the two C++ helpers that run `JSONParseWithException` on the text.
- This PR first changed those helpers too. #41387 landed that half on 2026-09-04. This PR now holds only the `Blob.rs` change.

<details><summary>Notes</summary>

- Probe on bun 1.4.1, `await (await fetch(url)).json()` where the server answers `new Response("")`: resolves `null`. With a `204`: rejects `Unexpected end of JSON input`. `new Response("").json()`, `new Blob([]).json()`, `Bun.file(empty).json()`: `Unexpected end of JSON input`. `new Blob([]).stream().json()` and a `Response` over an empty `ReadableStream`: `JSON Parse error: Unexpected EOF`.
- Node 26: `new Response("").json()` rejects with `SyntaxError: Unexpected end of JSON input`, the V8 message of `JSON.parse("")`. JSC's message for the same input is `JSON Parse error: Unexpected EOF`. The tests compare against `JSON.parse("")` of the running engine, not against a literal.
- The BOM-only case (`Blob(["\uFEFF"])`, a file that holds only a byte order mark) ran through the removed check too. `BOM::detect_and_split` strips the mark, the helpers see an empty slice and throw the same error.
- The `Temporary` lifetime branch in `to_json_with_bytes` is still freed: the `_free` guard below the removed check covers the empty slice.
- A BOM-only `Blob` now reaches `set_is_ascii_flag(true)` from `json()`, as a BOM-prefixed `Blob` with ASCII content already does from `text()` and `json()`. The flag is wrong for the store in both cases, and a later `slice(1).text()` decodes the BOM bytes as Latin-1. That is the helper bug #38503 fixes in `set_is_ascii_flag`. This PR does not add a guard at the call site.
- Self-review: 3 concerns raised. Addressed: the PR body names the issue and #41387, and this is the rebase of #33658, not a new PR. Not addressed: the `set_is_ascii_flag` stamp above (owned by #38503).
- `bun-file.test.ts` pins the message for a BOM-only file. It changes from the hardcoded text to the `JSON.parse("")` message.
- Ran with `BUN_JSC_validateExceptionChecks=1` on the `json()` tests of `body.test.ts`: 81 pass.
- `serve.test.ts`: 295 pass, 2 fail (`root range port(#7187)`, `/bun:info to loopback clients`). Both fail the same way on the released build in this environment, which runs as root.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->