### PR TITLE
Bun.serve: flush the response header section before the first stream chunk

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2141,6 +2141,12 @@ where
                             response_stream.sink.ctx = None;
                             this.render_metadata();
                         }
+                        // Terminate the header section now so clients observe the
+                        // response before the stream's first chunk (SSE streams may
+                        // be idle indefinitely). Idempotent if assign_to_stream
+                        // already wrote a chunk; `false` leaves uncork to the
+                        // enclosing cork scope.
+                        resp.flush_headers(false);
 
                         // The sink only tracks `has_backpressure`; the
                         // on_writable registration lives here so it is armed

--- a/test/js/bun/http/serve-stream-reject-flush-leak-fixture.ts
+++ b/test/js/bun/http/serve-stream-reject-flush-leak-fixture.ts
@@ -8,12 +8,10 @@
 //   1. Go async first (setImmediate) so RequestContext.toAsync() has already
 //      registered the uWS abort handler and doRenderStream is parked on the
 //      pending pull() promise (onResolveStream/onRejectStream wired up).
-//   2. Bump the sink's highWaterMark so write() buffers instead of draining
-//      straight to res.write() — this keeps isHttpWriteCalled() false so
-//      end() takes the tryEnd() path.
-//   3. Write a chunk large enough that tryEnd() hits socket backpressure on
-//      a non-reading client → pending_flush is created + protected.
-//   4. Throw, rejecting the pull() promise → onRejectStream →
+//   2. Write a chunk large enough that res.write() hits socket backpressure
+//      on a non-reading client, then call flush(true) → pending_flush is
+//      created + protected.
+//   3. Throw, rejecting the pull() promise → onRejectStream →
 //      handleRejectStream() with pending_flush still set.
 //
 // Without the fix, protected Promise count grows by ~1 per iteration.
@@ -39,17 +37,16 @@ const server = Bun.serve({
         type: "direct",
         async pull(controller: any) {
           await new Promise<void>(r => setImmediate(() => r()));
-          controller.start({ highWaterMark: CHUNK.length + 1 });
           controller.write(CHUNK);
-          const p = controller.end();
+          const p = controller.flush(true);
           if (p instanceof Promise && Bun.peek.status(p) === "pending") {
             flushPending++;
           }
           // Tear down the client after handleRejectStream has run. The throw
           // below rejects pull()'s promise; onRejectStream → handleRejectStream
           // fires on the microtask queue, then this setImmediate fires on the
-          // next macrotask. Without it the parked tryEnd() write never drains
-          // (client is paused) and uWS won't close the connection.
+          // next macrotask. Without it the parked write never drains (client
+          // is paused) and uWS won't close the connection.
           setImmediate(() => currentSocket?.destroy());
           throw new Error("boom");
         },
@@ -65,10 +62,10 @@ function protectedPromiseCount() {
 
 function oneRequest(): Promise<void> {
   // Raw TCP client that sends the request line and then never reads, so the
-  // server's first body write (tryEnd of 8 MiB) hits backpressure. Windows'
-  // loopback fast-path will absorb the full 8 MiB into the kernel if the
-  // client is draining, so explicitly pause(); the server side destroys the
-  // socket once handleRejectStream has run.
+  // server's 8 MiB body write hits backpressure. Windows' loopback fast-path
+  // will absorb the full 8 MiB into the kernel if the client is draining, so
+  // explicitly pause(); the server side destroys the socket once
+  // handleRejectStream has run.
   return new Promise(resolve => {
     const socket = connect({ port: server.port, host: "127.0.0.1" }, () => {
       socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
@@ -116,7 +113,7 @@ console.log(
 
 // The test must actually exercise the backpressure → pending_flush path.
 if (flushPending < ITERATIONS / 2) {
-  console.error(`insufficient backpressure: only ${flushPending}/${ITERATIONS} end() calls returned a pending promise`);
+  console.error(`insufficient backpressure: only ${flushPending}/${ITERATIONS} flush(true) calls returned a pending promise`);
   process.exit(2);
 }
 // Before the fix: delta ≈ ITERATIONS (every pending_flush stays protected).

--- a/test/js/bun/http/serve-stream-reject-flush-leak.test.ts
+++ b/test/js/bun/http/serve-stream-reject-flush-leak.test.ts
@@ -2,15 +2,15 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import { join } from "node:path";
 
-// The fixture needs tryEnd() to park under socket backpressure so
+// The fixture needs the body write to park under socket backpressure so
 // pending_flush is set when the stream rejects. On Windows that can't happen:
 // Winsock's non-blocking send() never returns a partial write — it either
 // copies the entire buffer into the AFD queue (which grows to fit) or returns
 // WSAEWOULDBLOCK only when the queue is already full from a *previous* send.
-// tryEnd() is the first write on a fresh socket, so it always reports full
-// success regardless of payload size, and pending_flush is never created.
-// The leak being guarded (handleRejectStream not unprotecting pending_flush)
-// is therefore POSIX-only by construction.
+// The 8 MiB write is effectively the first body send on a fresh socket, so it
+// always reports full success and pending_flush is never created. The leak
+// being guarded (handleRejectStream not unprotecting pending_flush) is
+// therefore POSIX-only by construction.
 test.skipIf(isWindows)(
   "handleRejectStream unprotects pending_flush (no Promise GC-root leak)",
   async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2474,6 +2474,106 @@ it.concurrent(
   20_000,
 );
 
+describe.each(["default", "direct"] as const)(
+  "streaming Response headers are flushed before the first body chunk (%s stream)",
+  streamType => {
+    function makeServer(controllerBox: { enqueue: (s: string) => void; close: () => void }) {
+      return Bun.serve({
+        port: 0,
+        idleTimeout: 0,
+        fetch() {
+          const body =
+            streamType === "direct"
+              ? new ReadableStream({
+                  type: "direct",
+                  async pull(ctrl) {
+                    const { promise, resolve } = Promise.withResolvers<void>();
+                    controllerBox.enqueue = (s: string) => {
+                      ctrl.write(s);
+                      ctrl.flush();
+                    };
+                    controllerBox.close = resolve;
+                    await promise;
+                  },
+                })
+              : new ReadableStream({
+                  start(ctrl) {
+                    controllerBox.enqueue = (s: string) => ctrl.enqueue(new TextEncoder().encode(s));
+                    controllerBox.close = () => ctrl.close();
+                  },
+                });
+          return new Response(body, {
+            headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+          });
+        },
+      });
+    }
+
+    it.concurrent("raw socket sees the complete header section immediately", async () => {
+      const controllerBox = { enqueue: (_: string) => {}, close: () => {} };
+      await using server = makeServer(controllerBox);
+
+      let buffered = Buffer.alloc(0);
+      let headResolvers = Promise.withResolvers<string>();
+      let bodyResolvers = Promise.withResolvers<string>();
+      const socket = net.connect(server.port, "127.0.0.1", () => {
+        socket.write("GET /sse HTTP/1.1\r\nHost: x\r\nAccept: text/event-stream\r\n\r\n");
+      });
+      socket.on("error", e => {
+        headResolvers.reject(e);
+        bodyResolvers.reject(e);
+      });
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        const sep = buffered.indexOf("\r\n\r\n");
+        if (sep !== -1) headResolvers.resolve(buffered.subarray(0, sep).toString());
+        if (buffered.includes("data: hello")) bodyResolvers.resolve(buffered.toString());
+      });
+      try {
+        // The header section must complete before any body chunk has been produced.
+        const head = await headResolvers.promise;
+        expect(head.split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
+        expect(head.toLowerCase()).toContain("content-type: text/event-stream");
+        expect(head.toLowerCase()).toContain("transfer-encoding: chunked");
+        expect(head.toLowerCase()).toContain("date: ");
+        // At this point the body must still be empty (no chunk was ever enqueued).
+        expect(buffered.subarray(buffered.indexOf("\r\n\r\n") + 4).toString()).toBe("");
+
+        // Now produce the first chunk and verify the body is framed correctly.
+        controllerBox.enqueue("data: hello\n\n");
+        const full = await bodyResolvers.promise;
+        const body = full.slice(full.indexOf("\r\n\r\n") + 4);
+        expect(body).toBe("d\r\ndata: hello\n\n\r\n");
+        controllerBox.close();
+      } finally {
+        socket.destroy();
+      }
+    });
+
+    it.concurrent("fetch() resolves before the first body chunk", async () => {
+      const controllerBox = { enqueue: (_: string) => {}, close: () => {} };
+      await using server = makeServer(controllerBox);
+
+      // fetch() must resolve on the completed head, before any body byte exists.
+      const res = await fetch(server.url);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/event-stream");
+      expect(res.headers.get("transfer-encoding")).toBe("chunked");
+
+      const reader = res.body!.getReader();
+      controllerBox.enqueue("data: hello\n\n");
+      controllerBox.close();
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (value) text += new TextDecoder().decode(value);
+        if (done) break;
+      }
+      expect(text).toBe("data: hello\n\n");
+    });
+  },
+);
+
 it.concurrent("allow requestIP after async operation", async () => {
   using server = Bun.serve({
     port: 0,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -171,12 +171,13 @@ it("should call cancel() on ReadableStream when the Request is aborted", async (
     async server => {
       const controller = new AbortController();
       const signal = controller.signal;
-      const request = fetch(server.url, { signal });
+      // Headers are flushed before the first body chunk, so fetch() resolves
+      // here; the abort surfaces on the body reader.
+      const res = await fetch(server.url, { signal });
       await onIncomingRequest.promise;
       controller.abort();
-      expect(async () => await request).toThrow();
-      // Delay for one run of the event loop.
-      await Bun.sleep(1);
+      expect(async () => await res.blob()).toThrow();
+      await waitForCancel.promise;
 
       expect(abortedFn).toHaveBeenCalled();
       expect(cancelledFn).toHaveBeenCalled();


### PR DESCRIPTION
## What does this PR do?

When `Bun.serve` returns a `Response` whose body is a `ReadableStream` that does not produce a chunk right away, the client sees only a partial header block: the status line and user-set headers arrive immediately, but the `Date` header, `Transfer-Encoding: chunked`, and the terminating `\r\n\r\n` are withheld until the stream's first body chunk. SSE streams are idle until their first event by design, so until that event arrives:

- `fetch()` of the endpoint does not resolve
- `EventSource.onopen` never fires (so reconnect / `Last-Event-ID` logic can't run)
- proxies sit on a half-written header block
- the request can be reaped by `idleTimeout` before its head was ever sent

Node, Deno and SSE libraries all commit the head when the response is returned; there is no `flushHeaders()` equivalent on `Response`, so the only workaround in Bun was pushing a padding comment as a fake first event.

### Reproduction

```js
import * as net from "node:net";
const server = Bun.serve({
  port: 0, idleTimeout: 0,
  fetch() {
    return new Response(new ReadableStream({
      start(c) { setTimeout(() => c.enqueue(new TextEncoder().encode("data: first\n\n")), 1500); },
    }), { headers: { "Content-Type": "text/event-stream" } });
  },
});
let buf = Buffer.alloc(0), t0 = performance.now(), head = -1;
const s = net.connect(server.port, "127.0.0.1", () =>
  s.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
s.on("data", d => {
  buf = Buffer.concat([buf, d]);
  if (head < 0 && buf.includes("\r\n\r\n")) head = Math.round(performance.now() - t0);
});
await Bun.sleep(2000);
console.log({ head }); // before: { head: 1506 }, after: { head: 5 }
```

### Cause

`do_render_stream()` renders the response metadata (`render_metadata()`) into the corked uWS response, but uWS only writes `Date`, the framing header, and the terminating CRLF inside its first `write()`/`end()`. For a pending stream that first `write()` is the first body chunk, so the uncork after `do_render_stream` sends only a partial header block.

### Fix

In the `PromiseResult::Pending` branch of `do_render_stream`, call `resp.flush_headers(false)` after the metadata is rendered. uWS's `flushHeaders()` writes the `Date` header, `Transfer-Encoding: chunked` and the terminating `\r\n\r\n`, and sets `HTTP_WRITE_CALLED`; it is a no-op when `assign_to_stream` already wrote a chunk, so synchronously-ready streams are unchanged. `false` leaves the uncork to the enclosing cork scope so the complete head goes out in one packet.

## How did you verify your code works?

New tests in `test/js/bun/http/serve.test.ts` (both default and `type: "direct"` streams):

- Raw TCP socket receives the complete header section (including `Date` and `Transfer-Encoding: chunked`) before any chunk has been produced, and the first chunk that follows is framed correctly.
- `fetch()` resolves with the full headers before the first chunk, and the body reads through to completion.

All four time out on 1.4.0 (headers never complete) and pass with this change. All existing streaming tests in `serve.test.ts`, `serve-direct-readable-stream.test.ts`, `async-iterator-stream.test.ts`, `serve-stream-body-error.test.ts`, and `serve-async-stream-client-abort.test.ts` still pass.