### PR TITLE
Bun.serve: cancel ReadableStream body for HEAD requests

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2599,6 +2599,17 @@ where
                     // SAFETY: FFI handle
                     resp.write_header(b"transfer-encoding", b"chunked");
                 }
+                // HEAD never transmits the body: cancel the stream so the
+                // source's cancel() runs and its resources are released.
+                // SAFETY: sole `&mut Response`; render_metadata's reborrow ended.
+                let response = unsafe { &mut *response_ptr };
+                if let Some(stream) = response.get_body_readable_stream(global_this) {
+                    let _keep = jsc::EnsureStillAlive(stream.value);
+                    response.detach_readable_stream(global_this);
+                    // Unread stream has no reader; `cancel()` would no-op.
+                    stream.cancel_with_reason(global_this, JSValue::UNDEFINED);
+                }
+                *response.get_body_value() = Body::Value::Used;
                 this.end_without_body(this.should_close_connection());
             }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -183,6 +183,71 @@ it("should call cancel() on ReadableStream when the Request is aborted", async (
     },
   );
 });
+describe("HEAD request with a ReadableStream body", () => {
+  for (const isAsync of [false, true]) {
+    it(`calls cancel() and releases the stream (${isAsync ? "async" : "sync"} handler)`, async () => {
+      let starts = 0;
+      let cancels = 0;
+      let live = 0;
+      const cancelled = Promise.withResolvers<void>();
+      const enc = new TextEncoder();
+      const makeResponse = () => {
+        let t: ReturnType<typeof setInterval>;
+        return new Response(
+          new ReadableStream({
+            start(c) {
+              starts++;
+              live++;
+              t = setInterval(() => {
+                try {
+                  c.enqueue(enc.encode("data: tick\n\n"));
+                } catch {
+                  clearInterval(t);
+                  live--;
+                }
+              }, 20);
+            },
+            cancel() {
+              cancels++;
+              clearInterval(t);
+              live--;
+              if (cancels === starts) cancelled.resolve();
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      };
+      await using server = Bun.serve({
+        port: 0,
+        idleTimeout: 0,
+        fetch: isAsync
+          ? async () => {
+              await 1;
+              return makeResponse();
+            }
+          : () => makeResponse(),
+      });
+      Bun.gc(true);
+      const before = heapStats().objectTypeCounts.ReadableStream || 0;
+
+      for (let i = 0; i < 8; i++) {
+        const res = await fetch(server.url, { method: "HEAD" });
+        expect(res.status).toBe(200);
+        expect(res.headers.get("transfer-encoding")).toBe("chunked");
+        expect(await res.text()).toBe("");
+      }
+      await cancelled.promise;
+
+      expect({ starts, cancels, live }).toEqual({ starts: 8, cancels: 8, live: 0 });
+
+      Bun.gc(true);
+      const after = heapStats().objectTypeCounts.ReadableStream || 0;
+      // Before the fix this leaked one ReadableStream per HEAD (before -> before+8).
+      expect(after).toBeLessThanOrEqual(before + 2);
+    });
+  }
+
+});
 for (let withDelay of [true, false]) {
   for (let connectionHeader of ["keepalive", "not keepalive"] as const) {
     it(`should NOT call cancel() on ReadableStream that finished normally for ${connectionHeader} request and ${withDelay ? "with" : "without"} delay`, async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -246,7 +246,6 @@ describe("HEAD request with a ReadableStream body", () => {
       expect(after).toBeLessThanOrEqual(before + 2);
     });
   }
-
 });
 for (let withDelay of [true, false]) {
   for (let connectionHeader of ["keepalive", "not keepalive"] as const) {


### PR DESCRIPTION
## Problem

A `HEAD` request to a route that returns `new Response(readableStream)` writes the head and ends the response without ever releasing the stream. The underlying source's `cancel()` never runs, so anything acquired in `start()` (SSE intervals, DB cursors, subscriptions) leaks for the life of the process, and the abandoned controller's queue grows unbounded. Every `curl -I` or health-check probe against an SSE/streaming route leaks one full handler's worth of resources.

```js
Bun.serve({
  fetch() {
    let t;
    return new Response(new ReadableStream({
      start(c) { t = setInterval(() => c.enqueue(enc.encode("data: tick\n\n")), 20); },
      cancel() { clearInterval(t); },   // never called for HEAD
    }), { headers: { "Content-Type": "text/event-stream" } });
  },
});
```

After 8 `HEAD /` requests with every socket closed: `{ starts: 8, cancels: 0, live: 8 }`, 8 intervals still firing, 8 `ReadableStream` objects retained. The `GET`-then-disconnect path on the same route does fire `cancel()` correctly.

## Cause

`do_render_head_response()` in `src/runtime/server/RequestContext.rs` handles `Body::Value::Locked(_)` by writing `transfer-encoding: chunked` and calling `end_without_body()`, but never cancels or detaches the locked stream. The other unsent-body paths (client abort, stream error) do release it.

## Fix

In the `Locked` arm, after writing the head, fetch the body's `ReadableStream`, detach it from the `Response`, cancel it, and mark the body `Used`. This uses `cancel_with_reason` rather than `cancel` because the stream was never read and has no reader attached; `ReadableStream__cancel` early-returns when `m_reader` is null. The wire output is unchanged (still `200` with `transfer-encoding: chunked`, no body).

## Verification

```
# before
{ starts: 9, cancels: 1, live: 8, readableStreams: "2 -> 10" }   exit 86
# after
{ starts: 9, cancels: 9, live: 0, readableStreams: "2 -> 2" }    exit 0
```

Added tests in `test/js/bun/http/serve.test.ts` covering both sync and async handlers; each sends 8 HEAD requests and asserts `cancel()` fired for every one, `live === 0`, and no `ReadableStream` heap growth.