### PR TITLE
Bun.serve: make stop(true) force-close after a prior graceful stop

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1525,15 +1525,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             // A previous graceful stop already took the listener. An abrupt stop
             // still needs to close the app so in-flight connections are torn down.
-            if abrupt && !self.flags.contains(ServerFlags::TERMINATED) {
-                if let Some(ws) = self.config.websocket.as_mut() {
-                    ws.handler.app = None;
-                }
-                self.flags.insert(ServerFlags::TERMINATED);
-                if let Some(app) = self.app {
-                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).close();
-                }
+            if abrupt {
+                self.terminate_app();
             }
             return;
         };
@@ -1561,13 +1554,24 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if !abrupt {
             // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
             bun_opaque::opaque_deref_mut(listener).close();
-        } else if !self.flags.contains(ServerFlags::TERMINATED) {
-            if let Some(ws) = self.config.websocket.as_mut() {
-                ws.handler.app = None;
-            }
-            self.flags.insert(ServerFlags::TERMINATED);
+        } else {
+            self.terminate_app();
+        }
+    }
+
+    /// Force-close every connection on the uws app and mark the server
+    /// terminated. Guarded by `TERMINATED` so repeated abrupt stops are no-ops.
+    fn terminate_app(&mut self) {
+        if self.flags.contains(ServerFlags::TERMINATED) {
+            return;
+        }
+        if let Some(ws) = self.config.websocket.as_mut() {
+            ws.handler.app = None;
+        }
+        self.flags.insert(ServerFlags::TERMINATED);
+        if let Some(app) = self.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(self.app.unwrap()).close();
+            bun_opaque::opaque_deref_mut(app).close();
         }
     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1522,8 +1522,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             if Self::HAS_H3 && self.h3_app.is_some() {
                 self.unref();
                 self.notify_inspector_server_stopped();
-                if abrupt {
-                    self.flags.insert(ServerFlags::TERMINATED);
+            }
+            // A previous graceful stop already took the listener. An abrupt stop
+            // still needs to close the app so in-flight connections are torn down.
+            if abrupt && !self.flags.contains(ServerFlags::TERMINATED) {
+                if let Some(ws) = self.config.websocket.as_mut() {
+                    ws.handler.app = None;
+                }
+                self.flags.insert(ServerFlags::TERMINATED);
+                if let Some(app) = self.app {
+                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                    bun_opaque::opaque_deref_mut(app).close();
                 }
             }
             return;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2502,15 +2502,15 @@ where
     pub fn stop_from_js(&mut self, abruptly: Option<JSValue>) -> JSValue {
         let rc = self.get_all_closed_promise(&self.global());
 
-        if self.has_listener() {
-            let abrupt = 'brk: {
-                if let Some(val) = abruptly {
-                    if val.is_boolean() && val.to_boolean() {
-                        break 'brk true;
-                    }
+        let abrupt = 'brk: {
+            if let Some(val) = abruptly {
+                if val.is_boolean() && val.to_boolean() {
+                    break 'brk true;
                 }
-                false
-            };
+            }
+            false
+        };
+        if self.has_listener() || (abrupt && !self.flags.contains(ServerFlags::TERMINATED)) {
             self.stop(abrupt);
         }
 
@@ -2518,7 +2518,7 @@ where
     }
 
     pub fn dispose_from_js(&mut self) -> JSValue {
-        if self.has_listener() {
+        if self.has_listener() || !self.flags.contains(ServerFlags::TERMINATED) {
             self.stop(true);
         }
         JSValue::UNDEFINED

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2196,6 +2196,92 @@ it("should be able to abrupt stop the server", async () => {
   }
 });
 
+describe("server.stop(true) after a prior graceful stop", () => {
+  async function setup(stopper: (server: Server) => void) {
+    const enc = new TextEncoder();
+    const firstChunk = Promise.withResolvers<void>();
+    const aborted = mock(() => {});
+    const cancelled = mock(() => {});
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch(req) {
+        req.signal.addEventListener("abort", aborted);
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(enc.encode("data: x\n\n"));
+              await Bun.sleep(20);
+            },
+            cancel: cancelled,
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      },
+    });
+    const closed = Promise.withResolvers<void>();
+    const sock = net.connect(server.port, "127.0.0.1", () => {
+      sock.write(`GET /sse HTTP/1.1\r\nHost: x\r\n\r\n`);
+    });
+    sock.once("data", () => firstChunk.resolve());
+    sock.on("error", () => {});
+    sock.on("close", () => closed.resolve());
+    try {
+      await firstChunk.promise;
+
+      server.stop(false);
+      expect(server.pendingRequests).toBe(1);
+
+      stopper(server);
+      await closed.promise;
+
+      expect({
+        pendingRequests: server.pendingRequests,
+        cancelled: cancelled.mock.calls.length,
+        aborted: aborted.mock.calls.length,
+      }).toEqual({ pendingRequests: 0, cancelled: 1, aborted: 1 });
+    } finally {
+      sock.destroy();
+      server.stop(true);
+    }
+  }
+
+  it("force-closes in-flight connections", async () => {
+    await setup(server => server.stop(true));
+  });
+
+  it("force-closes in-flight connections via [Symbol.dispose]", async () => {
+    await setup(server => server[Symbol.dispose]());
+  });
+
+  it("resolves the stop() promise once connections are gone", async () => {
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch() {
+        return new Response(new ReadableStream({ pull: () => Bun.sleep(1000) }));
+      },
+    });
+    const gotData = Promise.withResolvers<void>();
+    const sock = net.connect(server.port, "127.0.0.1", () => {
+      sock.write(`GET / HTTP/1.1\r\nHost: x\r\n\r\n`);
+    });
+    sock.once("data", () => gotData.resolve());
+    sock.on("error", () => {});
+    try {
+      await gotData.promise;
+      const gracefulPromise = server.stop(false);
+      expect(server.pendingRequests).toBe(1);
+      const forcePromise = server.stop(true);
+      await Promise.all([gracefulPromise, forcePromise]);
+      expect(server.pendingRequests).toBe(0);
+    } finally {
+      sock.destroy();
+      server.stop(true);
+    }
+  });
+});
+
 it.concurrent("should not instanciate error instances in each request", async () => {
   const startErrorCount = heapStats().objectTypeCounts.Error || 0;
   using server = Bun.serve({


### PR DESCRIPTION
## Problem

`server.stop(true)` is a silent no-op if `server.stop(false)` was called first. The standard graceful-shutdown-with-a-deadline pattern (`stop(false)` to stop accepting and drain, then `stop(true)` when the deadline hits) could never force-close anything: SSE/streaming responses kept flowing, `cancel()` and `req.signal` never fired, `pendingRequests` never drained.

```js
const server = Bun.serve({
  port: 0, idleTimeout: 0,
  fetch(req) {
    return new Response(new ReadableStream({
      async pull(c) { c.enqueue(enc.encode("data: x\n\n")); await Bun.sleep(20); },
      cancel() { /* never fires */ },
    }), { headers: { "Content-Type": "text/event-stream" } });
  },
});
// ... open a raw TCP client, wait for data ...
server.stop(false);                 // graceful: stop accepting, let in-flight drain
await Bun.sleep(500);
server.stop(true);                  // deadline hit: force-terminate everything
// socket stays open, events keep arriving, pendingRequests stays 1
```

Before:
```
{"graceFirst":false,"closedByForce":true, "streamCancelled":true, "pendingRequests":0}
{"graceFirst":true, "closedByForce":false,"streamCancelled":false,"pendingRequests":1}
```

After:
```
{"graceFirst":false,"closedByForce":true,"streamCancelled":true,"pendingRequests":0}
{"graceFirst":true, "closedByForce":true,"streamCancelled":true,"pendingRequests":0}
```

## Cause

Two layers, both gated on the listener still being present:

- `stop_from_js` (`src/runtime/server/server_body.rs`) wrapped the whole `stop()` call in `if self.has_listener()`. After a graceful stop, `stop_listening` has already done `self.listener.take()`, so the second call returned the all-closed promise and did nothing else. `dispose_from_js` (`[Symbol.dispose]`) had the same guard.
- `stop_listening` (`src/runtime/server/mod.rs`) itself early-returned when `self.listener` was `None`, so even reaching `stop(true)` would not close the app.

## Fix

- `stop_from_js` / `dispose_from_js` also call `stop()` when the listener is gone but the app has not been terminated yet.
- `stop_listening` closes the uws app on an abrupt stop even if the listener was taken by an earlier graceful stop, guarded by `!TERMINATED` so repeated `stop(true)` stays idempotent.

`stop()`'s other effects (`js_value.downgrade()`, hot-map removal, `unref()`, `notify_inspector_server_stopped()`) are all idempotent.

## Verification

New `server.stop(true) after a prior graceful stop` block in `test/js/bun/http/serve.test.ts` opens a raw TCP client against a streaming SSE response, calls `stop(false)` then `stop(true)` (and separately `[Symbol.dispose]()`), and asserts the socket closes, `cancel()` and the abort signal fire, `pendingRequests` reaches 0, and both the graceful and force `stop()` promises resolve.

```
bun bd test test/js/bun/http/serve.test.ts -t "after a prior graceful stop"   # 3 pass
USE_SYSTEM_BUN=1 bun test <same>                                              # 3 time out
```

Full `serve.test.ts` and `websocket-server.test.ts` have the same failure set as `main` (environment-only: IPv6, root-port, egress proxy, debug-build benchmark timeouts).