### PR TITLE
node:stream: make addAbortSignal error web streams through their controller

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -114,6 +114,12 @@ declare function $pokePromiseAsHandled(promise: Promise<any>): void;
  * Does not lock the stream. Throws when given anything else.
  */
 declare function $webStreamClosedPromise(stream: ReadableStream | WritableStream): Promise<void>;
+/**
+ * Node's controller.error(e) for a WHATWG stream: errors the stream through its controller,
+ * no-op once past readable/writable. Used by node:stream's addAbortSignal in place of Node's
+ * Symbol.for("nodejs.webstream.controllerErrorFunction") own property.
+ */
+declare function $webStreamControllerError(stream: ReadableStream | WritableStream | TransformStream, error: any): void;
 declare function $getInternalField<Fields extends any[], N extends keyof Fields>(
   base: InternalFieldObject<Fields>,
   number: N,

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -198,6 +198,7 @@ using namespace JSC;
     macro(vmErrorDecorated) \
     macro(warning) \
     macro(webStreamClosedPromise) \
+    macro(webStreamControllerError) \
     macro(writable) \
     macro(writableType) \
     macro(write) \

--- a/src/js/internal/streams/add-abort-signal.ts
+++ b/src/js/internal/streams/add-abort-signal.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isNodeStream, isWebStream, kControllerErrorFunction } = require("internal/streams/utils");
+const { isNodeStream, isWebStream } = require("internal/streams/utils");
 const eos = require("internal/streams/end-of-stream");
 
 const SymbolDispose = Symbol.dispose;
@@ -33,7 +33,9 @@ function addAbortSignalNoValidate(signal, stream) {
         stream.destroy($makeAbortError(undefined, { cause: signal.reason }));
       }
     : () => {
-        stream[kControllerErrorFunction]($makeAbortError(undefined, { cause: signal.reason }));
+        // Bun's native web streams don't carry Node's kControllerErrorFunction own property;
+        // error through the real controller-error op (a no-op once past readable/writable).
+        $webStreamControllerError(stream, $makeAbortError(undefined, { cause: signal.reason }));
       };
   if (signal.aborted) {
     onAbort();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1661,6 +1661,7 @@ JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseStatus);
 JSC_DECLARE_HOST_FUNCTION(jsBunPeekPromiseSettledValue);
 JSC_DECLARE_HOST_FUNCTION(jsBunPokePromiseAsHandled);
 JSC_DECLARE_HOST_FUNCTION(jsWebStreamClosedPromise);
+JSC_DECLARE_HOST_FUNCTION(jsWebStreamControllerError);
 
 JSC_DEFINE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
@@ -1790,6 +1791,26 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamClosedPromise, (JSGlobalObject * globalObjec
 
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
     return JSValue::encode(throwTypeError(globalObject, scope, "Expected a ReadableStream or WritableStream"_s));
+}
+
+// node:stream's addAbortSignal on a web stream errors it via controller.error(e). Callers in
+// internal/streams/add-abort-signal.ts gate on isWebStream() first, so the argument is always
+// one of the three; anything else is a no-op (Node's kControllerErrorFunction defaults to one).
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamControllerError, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue streamValue = callFrame->argument(0);
+    JSValue error = callFrame->argument(1);
+    if (auto* readable = dynamicDowncast<WebCore::JSReadableStream>(streamValue)) {
+        Bun::WebStreams::webStreamControllerError(globalObject, readable, error);
+    } else if (auto* writable = dynamicDowncast<WebCore::JSWritableStream>(streamValue)) {
+        Bun::WebStreams::webStreamControllerError(globalObject, writable, error);
+    } else if (auto* transform = dynamicDowncast<WebCore::JSTransformStream>(streamValue)) {
+        Bun::WebStreams::webStreamControllerError(globalObject, transform, error);
+    }
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
 }
 
 extern "C" JSC::EncodedJSValue Bun__Jest__createTestModuleObject(JSC::JSGlobalObject*);
@@ -2902,6 +2923,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         GlobalPropertyInfo(builtinNames.peekPromiseSettledValuePrivateName(), JSFunction::create(vm, this, 1, String(), jsBunPeekPromiseSettledValue, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.pokePromiseAsHandledPrivateName(), JSFunction::create(vm, this, 1, String(), jsBunPokePromiseAsHandled, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.webStreamClosedPromisePrivateName(), JSFunction::create(vm, this, 1, String(), jsWebStreamClosedPromise, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
+        GlobalPropertyInfo(builtinNames.webStreamControllerErrorPrivateName(), JSFunction::create(vm, this, 2, String(), jsWebStreamControllerError, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.fulfillModuleSyncPrivateName(), JSFunction::create(vm, this, 1, String(), functionFulfillModuleSync, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.esmNamespaceForCjsPrivateName(), JSFunction::create(vm, this, 1, String(), functionEsmNamespaceForCjs, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         GlobalPropertyInfo(builtinNames.esmRegistryDeletePrivateName(), JSFunction::create(vm, this, 1, String(), functionEsmRegistryDelete, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -176,6 +176,11 @@ void markPromiseAsHandled(JSC::VM&, JSC::JSPromise*); // userJS: no — WebStrea
 // settles with a primitive / the stored error, so none of these can run user JS or throw.
 JSC::JSPromise* webStreamClosedPromise(JSC::JSGlobalObject*, JSReadableStream*); // userJS: no — WebStreamsMisc.cpp
 JSC::JSPromise* webStreamClosedPromise(JSC::JSGlobalObject*, JSWritableStream*); // userJS: no — WebStreamsMisc.cpp
+// node:stream's addAbortSignal on a web stream: the controller.error(e) op, without needing
+// Node's kControllerErrorFunction own property. No-op once past readable/writable.
+void webStreamControllerError(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue error); // userJS: yes — WebStreamsMisc.cpp
+void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSValue error); // userJS: yes — WebStreamsMisc.cpp
+void webStreamControllerError(JSC::JSGlobalObject*, JSTransformStream*, JSC::JSValue error); // userJS: yes — WebStreamsMisc.cpp
 void resolveStreamClosedPromise(JSC::VM&, JSReadableStream*); // userJS: no — WebStreamsMisc.cpp
 void resolveStreamClosedPromise(JSC::VM&, JSWritableStream*); // userJS: no — WebStreamsMisc.cpp
 void rejectStreamClosedPromise(JSC::VM&, JSReadableStream*, JSC::JSValue error); // userJS: no — WebStreamsMisc.cpp

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -3,8 +3,13 @@
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include "WebStreamsInternals.h"
 
+#include "JSDirectStreamController.h"
+#include "JSReadableByteStreamController.h"
 #include "JSReadableStream.h"
+#include "JSReadableStreamDefaultController.h"
+#include "JSTransformStream.h"
 #include "JSWritableStream.h"
+#include "JSWritableStreamDefaultController.h"
 
 #include "BunClientData.h"
 #include "JSDOMConvertNumbers.h"
@@ -442,6 +447,43 @@ JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream
     }
     stream->m_closedPromise.set(vm, stream, promise);
     return promise;
+}
+
+// node:stream's addAbortSignal errors a web stream via Node's kControllerErrorFunction own
+// property, which is controller.error bound to the stream's controller. Bun's web streams are
+// native and never carry that property, so route through the real controller-error op instead.
+void webStreamControllerError(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue error)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    switch (stream->m_controllerKind) {
+    case ControllerKind::Default:
+        RELEASE_AND_RETURN(scope, readableStreamDefaultControllerError(globalObject, uncheckedDowncast<WebCore::JSReadableStreamDefaultController>(stream->m_controller.get()), error));
+    case ControllerKind::Byte:
+        RELEASE_AND_RETURN(scope, readableByteStreamControllerError(globalObject, uncheckedDowncast<WebCore::JSReadableByteStreamController>(stream->m_controller.get()), error));
+    case ControllerKind::Direct:
+        RELEASE_AND_RETURN(scope, uncheckedDowncast<WebCore::JSDirectStreamController>(stream->m_controller.get())->handleError(globalObject, error));
+    case ControllerKind::None:
+    case ControllerKind::NativeSink:
+        if (stream->m_state == ReadableStreamState::Readable)
+            RELEASE_AND_RETURN(scope, readableStreamError(globalObject, stream, error));
+        return;
+    }
+}
+
+void webStreamControllerError(JSGlobalObject* globalObject, JSWritableStream* stream, JSValue error)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (auto* controller = stream->m_controller.get())
+        RELEASE_AND_RETURN(scope, writableStreamDefaultControllerErrorIfNeeded(globalObject, controller, error));
+}
+
+void webStreamControllerError(JSGlobalObject* globalObject, JSTransformStream* stream, JSValue error)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(scope, transformStreamError(globalObject, stream, error));
 }
 
 // The ONE sanctioned completion-record catch: the spec's "interpreting X as a completion

--- a/test/js/node/stream/add-abort-signal-webstream.test.ts
+++ b/test/js/node/stream/add-abort-signal-webstream.test.ts
@@ -1,0 +1,165 @@
+import { test, expect, describe } from "bun:test";
+import { addAbortSignal } from "node:stream";
+
+// node:stream's addAbortSignal is documented to accept WHATWG web streams since Node 19 and
+// to error them through their controller on abort. Bun's web streams are native and do not
+// carry Node's Symbol.for("nodejs.webstream.controllerErrorFunction") own property, so the
+// abort handler must route through the real controller-error path instead.
+
+describe("addAbortSignal on web streams", () => {
+  test("ReadableStream: already-aborted signal errors the stream", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const rs = new ReadableStream({
+      pull(c) {
+        c.enqueue(new Uint8Array([1]));
+      },
+    });
+    expect(addAbortSignal(ac.signal, rs)).toBe(rs);
+    const err = await rs
+      .getReader()
+      .read()
+      .then(
+        () => null,
+        e => e,
+      );
+    expect(err).not.toBeNull();
+    expect(err.name).toBe("AbortError");
+    expect(err.code).toBe("ABORT_ERR");
+  });
+
+  test("ReadableStream: aborting after registration rejects a pending read", async () => {
+    const ac = new AbortController();
+    const reason = new Error("stop");
+    const rs = new ReadableStream({
+      pull(c) {
+        queueMicrotask(() => c.enqueue(new Uint8Array([2])));
+      },
+    });
+    addAbortSignal(ac.signal, rs);
+    const reader = rs.getReader();
+    const pending = reader.read().then(
+      v => ({ ok: true, v }),
+      e => ({ ok: false, e }),
+    );
+    let uncaught: unknown = null;
+    const onUncaught = (e: unknown) => (uncaught = e);
+    process.on("uncaughtException", onUncaught);
+    try {
+      ac.abort(reason);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+    const result = (await pending) as any;
+    expect(uncaught).toBeNull();
+    expect(result.ok).toBe(false);
+    expect(result.e.name).toBe("AbortError");
+    expect(result.e.cause).toBe(reason);
+    const closed = await reader.closed.then(
+      () => null,
+      e => e,
+    );
+    expect(closed?.name).toBe("AbortError");
+  });
+
+  test("ReadableStream (bytes): abort errors a byte stream", async () => {
+    const ac = new AbortController();
+    const rs = new ReadableStream({
+      type: "bytes",
+      pull(c) {
+        c.enqueue(new Uint8Array([3]));
+      },
+    });
+    addAbortSignal(ac.signal, rs);
+    ac.abort();
+    const err = await rs
+      .getReader()
+      .read()
+      .then(
+        () => null,
+        e => e,
+      );
+    expect(err?.name).toBe("AbortError");
+  });
+
+  test("WritableStream: abort rejects a pending write and closed", async () => {
+    const ac = new AbortController();
+    const ws = new WritableStream({
+      write() {
+        return new Promise(() => {});
+      },
+    });
+    addAbortSignal(ac.signal, ws);
+    const writer = ws.getWriter();
+    const pending = writer.write("hello").then(
+      () => null,
+      e => e,
+    );
+    ac.abort();
+    const err = await pending;
+    expect(err?.name).toBe("AbortError");
+    const closed = await writer.closed.then(
+      () => null,
+      e => e,
+    );
+    expect(closed?.name).toBe("AbortError");
+  });
+
+  test("WritableStream: already-aborted signal errors the stream", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const ws = new WritableStream();
+    addAbortSignal(ac.signal, ws);
+    const writer = ws.getWriter();
+    const err = await writer.write("x").then(
+      () => null,
+      e => e,
+    );
+    expect(err?.name).toBe("AbortError");
+  });
+
+  test("TransformStream: already-aborted signal errors both readable and writable sides", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const ts = new TransformStream();
+    addAbortSignal(ac.signal, ts);
+    const readErr = await ts.readable
+      .getReader()
+      .read()
+      .then(
+        () => null,
+        e => e,
+      );
+    const writeErr = await ts.writable
+      .getWriter()
+      .write("x")
+      .then(
+        () => null,
+        e => e,
+      );
+    expect(readErr?.name).toBe("AbortError");
+    expect(writeErr?.name).toBe("AbortError");
+  });
+
+  test("no-op once the stream is already errored", async () => {
+    const ac = new AbortController();
+    let controller!: ReadableStreamDefaultController;
+    const rs = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const first = new Error("first");
+    controller.error(first);
+    addAbortSignal(ac.signal, rs);
+    ac.abort();
+    const err = await rs
+      .getReader()
+      .read()
+      .then(
+        () => null,
+        e => e,
+      );
+    expect(err).toBe(first);
+  });
+});

--- a/test/js/node/stream/add-abort-signal-webstream.test.ts
+++ b/test/js/node/stream/add-abort-signal-webstream.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { addAbortSignal } from "node:stream";
 
 // node:stream's addAbortSignal is documented to accept WHATWG web streams since Node 19 and

--- a/test/js/node/test/parallel/test-webstreams-abort-controller.js
+++ b/test/js/node/test/parallel/test-webstreams-abort-controller.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const common = require('../common');
+const { finished, addAbortSignal } = require('stream');
+const { ReadableStream, WritableStream } = require('stream/web');
+const assert = require('assert');
+
+function createTestReadableStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.enqueue('b');
+      controller.enqueue('c');
+      controller.close();
+    }
+  });
+}
+
+function createTestWritableStream(values) {
+  return new WritableStream({
+    write(chunk) {
+      values.push(chunk);
+    }
+  });
+}
+
+{
+  const rs = createTestReadableStream();
+
+  const reader = rs.getReader();
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, rs);
+
+  finished(rs, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(reader.read(), /AbortError/).then(common.mustCall());
+    assert.rejects(reader.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  reader.read().then(common.mustCall((result) => {
+    assert.strictEqual(result.value, 'a');
+    ac.abort();
+  }));
+}
+
+{
+  const rs = createTestReadableStream();
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, rs);
+
+  assert.rejects((async () => {
+    for await (const chunk of rs) {
+      if (chunk === 'b') {
+        ac.abort();
+      }
+    }
+  })(), /AbortError/).then(common.mustCall());
+}
+
+{
+  const rs1 = createTestReadableStream();
+
+  const rs2 = createTestReadableStream();
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, rs1);
+  addAbortSignal(ac.signal, rs2);
+
+  const reader1 = rs1.getReader();
+  const reader2 = rs2.getReader();
+
+  finished(rs1, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(reader1.read(), /AbortError/).then(common.mustCall());
+    assert.rejects(reader1.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  finished(rs2, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(reader2.read(), /AbortError/).then(common.mustCall());
+    assert.rejects(reader2.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  ac.abort();
+}
+
+{
+  const rs = createTestReadableStream();
+
+  const { 0: rs1, 1: rs2 } = rs.tee();
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, rs);
+
+  const reader1 = rs1.getReader();
+  const reader2 = rs2.getReader();
+
+  finished(rs1, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(reader1.read(), /AbortError/).then(common.mustCall());
+    assert.rejects(reader1.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  finished(rs2, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(reader2.read(), /AbortError/).then(common.mustCall());
+    assert.rejects(reader2.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  ac.abort();
+}
+
+{
+  const values = [];
+  const ws = createTestWritableStream(values);
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, ws);
+
+  const writer = ws.getWriter();
+
+  finished(ws, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.deepStrictEqual(values, ['a']);
+    assert.rejects(writer.write('b'), /AbortError/).then(common.mustCall());
+    assert.rejects(writer.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  writer.write('a').then(() => {
+    ac.abort();
+  }).then(common.mustCall());
+}
+
+{
+  const values = [];
+
+  const ws1 = createTestWritableStream(values);
+  const ws2 = createTestWritableStream(values);
+
+  const ac = new AbortController();
+
+  addAbortSignal(ac.signal, ws1);
+  addAbortSignal(ac.signal, ws2);
+
+  const writer1 = ws1.getWriter();
+  const writer2 = ws2.getWriter();
+
+  finished(ws1, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(writer1.write('a'), /AbortError/).then(common.mustCall());
+    assert.rejects(writer1.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  finished(ws2, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.rejects(writer2.write('a'), /AbortError/).then(common.mustCall());
+    assert.rejects(writer2.closed, /AbortError/).then(common.mustCall());
+  }));
+
+  ac.abort();
+}


### PR DESCRIPTION
## Reproduction

```js
import { addAbortSignal } from "node:stream";

const ac = new AbortController();
const rs = new ReadableStream({ pull(c) { c.enqueue(new Uint8Array([1])); } });
addAbortSignal(ac.signal, rs);
ac.abort();
console.log(await rs.getReader().read());
// bun : uncaught TypeError: stream[kControllerErrorFunction] is not a function
//       then { value: Uint8Array [1], done: false }  (the "aborted" stream keeps flowing)
// node: read() rejects AbortError (ABORT_ERR)
```

For a pre-aborted signal the `TypeError` is thrown synchronously from `addAbortSignal`; for an abort after registration it is thrown from inside the signal's `abort` listener as an uncaught exception. In both cases the stream is never errored.

## Cause

`internal/streams/add-abort-signal` is Node's `addAbortSignalNoValidate` verbatim: for a non-Node stream the abort handler calls `stream[kControllerErrorFunction](new AbortError(...))`, where `kControllerErrorFunction = Symbol.for("nodejs.webstream.controllerErrorFunction")`. Node installs that symbol as `controller.error.bind(controller)` on every ReadableStream/WritableStream/TransformStream it constructs. Bun's web streams are native C++ and never define it, so the property is `undefined` and the call throws.

## Fix

Add a `$webStreamControllerError(stream, error)` private global, following the existing `$webStreamClosedPromise` precedent, that dispatches to the real controller-error operation for the native stream:

- `ReadableStream`: `readableStreamDefaultControllerError` / `readableByteStreamControllerError` (and the direct/native-sink kinds Bun adds)
- `WritableStream`: `writableStreamDefaultControllerErrorIfNeeded`
- `TransformStream`: `transformStreamError` (errors both sides)

and call it from the abort handler in place of the symbol property. Semantics match Node's `controller.error(e)`: no-op once the stream is past `readable`/`writable`.

## Verification

`test/js/node/stream/add-abort-signal-webstream.test.ts` covers the default, byte, writable and transform controller kinds plus the already-aborted and already-errored paths. 7/7 fail on `main` with `stream[kControllerErrorFunction] is not a function`, 7/7 pass with the fix.

Node's `test/parallel/test-webstreams-abort-controller.js` (vendored unmodified from v26.3.0) passes.

#32627 (draft) previously approached this from the JS builtins that the C++ webstreams rewrite removed.