### PR TITLE
Bun.SQL(postgres): send plaintext startup when sslmode=prefer and server declines TLS

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -493,7 +493,11 @@ pub(crate) fn on_data<Context: ReaderContext>(
                         );
                         return Ok(());
                     }
-                    continue;
+                    // sslmode=prefer: fall back to a plaintext startup. Return
+                    // Ok(()) to drop any trailing bytes in this read: nothing
+                    // sent before our StartupMessage is legitimate (CVE-2021-23222).
+                    connection.start();
+                    return Ok(());
                 }
 
                 connection.on(M::NoticeResponse, reader.reborrow())?;

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -577,7 +577,7 @@ impl PostgresSQLConnection {
         );
     }
 
-    fn start(&self) {
+    pub(crate) fn start(&self) {
         self.setup_max_lifetime_timer_if_necessary();
         self.reset_connection_timeout();
         self.send_startup_message();

--- a/test/js/sql/postgres-tls-ctx-leak.test.ts
+++ b/test/js/sql/postgres-tls-ctx-leak.test.ts
@@ -20,9 +20,9 @@ import { listeningServer, pgAuthenticationOk, pgReadyForQuery, pgSSLResponse } f
 //
 // This test doesn't need a real Postgres server: the tls_ctx is allocated up
 // front in PostgresSQLConnection.call() as soon as sslmode != disable, before
-// any TLS handshake. A minimal mock server refuses SSL ('N') but then
-// immediately sends AuthenticationOk + ReadyForQuery so the client reaches
-// `.connected`, letting close() -> disconnect() -> GC -> finalize() ->
+// any TLS handshake. A minimal mock server refuses SSL ('N'), then answers the
+// plaintext StartupMessage with AuthenticationOk + ReadyForQuery so the client
+// reaches `.connected`, letting close() -> disconnect() -> GC -> finalize() ->
 // deinit() exercise the teardown path.
 
 async function countPostgresConnectionsAfterGC(maxWait = 3000): Promise<number> {
@@ -40,11 +40,16 @@ async function countPostgresConnectionsAfterGC(maxWait = 3000): Promise<number> 
 }
 
 test("Postgres connections with sslmode != disable are finalized after close", async () => {
-  // 'N' (SSL refused) + AuthenticationOk + ReadyForQuery('I')
-  const handshake = Buffer.concat([pgSSLResponse("N"), pgAuthenticationOk(), pgReadyForQuery("I")]);
-
   const { server, port } = await listeningServer(socket => {
-    socket.once("data", () => socket.write(handshake));
+    let sawSSLRequest = false;
+    socket.on("data", () => {
+      if (!sawSSLRequest) {
+        sawSSLRequest = true;
+        socket.write(pgSSLResponse("N"));
+        return;
+      }
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery("I")]));
+    });
     socket.on("error", () => {});
   });
 

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -2,7 +2,18 @@ import { SQL, randomUUIDv7 } from "bun";
 import { describe, expect, test } from "bun:test";
 import { describeWithContainer, isDockerEnabled } from "harness";
 import path from "node:path";
-import { listeningServer, pgAuthenticationCleartextPassword, pgSSLRequest, pgSSLResponse } from "./wire-frames";
+import {
+  listeningServer,
+  pgAuthenticationCleartextPassword,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgErrorResponse,
+  pgReadyForQuery,
+  pgRowDescription,
+  pgSSLRequest,
+  pgSSLResponse,
+} from "./wire-frames";
 
 if (!isDockerEnabled()) {
   test.skip("skipping TLS SQL tests - Docker is not available", () => {});
@@ -416,5 +427,171 @@ test("postgres client aborts the connection when the server declines TLS that wa
       for (const socket of sockets) socket.destroy();
       await new Promise<void>(resolve => server.close(() => resolve()));
     }
+  }
+});
+
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+test("postgres sslmode=prefer falls back to a plaintext startup when the server declines TLS", async () => {
+  // libpq docs for sslmode=prefer: "first try an SSL connection; if that fails,
+  // try a non-SSL connection". When the server answers the SSLRequest with 'N',
+  // the client must send a plaintext StartupMessage on the same socket and
+  // continue in plaintext — not idle until connectionTimeout.
+  const wire: string[] = [];
+  const sockets = new Set<import("node:net").Socket>();
+
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    let buf = Buffer.alloc(0);
+    let started = false;
+    socket.on("data", data => {
+      buf = Buffer.concat([buf, data]);
+      for (;;) {
+        if (!started) {
+          if (buf.length < 8) return;
+          const len = buf.readInt32BE(0);
+          if (buf.length < len) return;
+          if (len === 8 && buf.readInt32BE(4) === 80877103) {
+            wire.push("SSLRequest");
+            buf = buf.subarray(8);
+            socket.write(pgSSLResponse("N"));
+            continue;
+          }
+          wire.push("StartupMessage");
+          started = true;
+          buf = buf.subarray(len);
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+          continue;
+        }
+        if (buf.length < 5) return;
+        const len = buf.readInt32BE(1);
+        if (buf.length < 1 + len) return;
+        const type = String.fromCharCode(buf[0]);
+        buf = buf.subarray(1 + len);
+        if (type === "Q") {
+          wire.push("Query");
+          socket.write(
+            Buffer.concat([
+              pgRowDescription([{ name: "x", typeOid: 25 /* text */ }]),
+              pgDataRow([Buffer.from("1")]),
+              pgCommandComplete("SELECT 1"),
+              pgReadyForQuery(),
+            ]),
+          );
+        }
+      }
+    });
+  });
+
+  try {
+    await using sql = new SQL({
+      url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=prefer`,
+      adapter: "postgres",
+      max: 1,
+      connectionTimeout: 3,
+    });
+    const result = await sql`select 1`.simple().then(
+      rows => ({ kind: "ok" as const, rows }),
+      e => ({ kind: "error" as const, code: e?.code ?? String(e) }),
+    );
+    expect({ wire, result }).toEqual({
+      wire: ["SSLRequest", "StartupMessage", "Query"],
+      result: { kind: "ok", rows: [{ x: "1" }] },
+    });
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+test("postgres sslmode=prefer discards bytes that arrive alongside the 'N' SSLRequest answer", async () => {
+  // The server may only answer an SSLRequest with a single byte; any further
+  // bytes in the same read precede our StartupMessage and so cannot be a
+  // legitimate backend response. They must be discarded rather than dispatched
+  // (libpq CVE-2021-23222). The fallback plaintext startup then proceeds
+  // normally.
+  const wire: string[] = [];
+  const sockets = new Set<import("node:net").Socket>();
+
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    let buf = Buffer.alloc(0);
+    let started = false;
+    socket.on("data", data => {
+      buf = Buffer.concat([buf, data]);
+      for (;;) {
+        if (!started) {
+          if (buf.length < 8) return;
+          const len = buf.readInt32BE(0);
+          if (buf.length < len) return;
+          if (len === 8 && buf.readInt32BE(4) === 80877103) {
+            wire.push("SSLRequest");
+            buf = buf.subarray(8);
+            // 'N' plus an ErrorResponse in the same write: the ErrorResponse
+            // precedes any StartupMessage and must not reach the dispatch loop.
+            socket.write(
+              Buffer.concat([
+                pgSSLResponse("N"),
+                pgErrorResponse({ S: "FATAL", C: "XX000", M: "injected before startup" }),
+              ]),
+            );
+            continue;
+          }
+          wire.push("StartupMessage");
+          started = true;
+          buf = buf.subarray(len);
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+          continue;
+        }
+        if (buf.length < 5) return;
+        const len = buf.readInt32BE(1);
+        if (buf.length < 1 + len) return;
+        const type = String.fromCharCode(buf[0]);
+        buf = buf.subarray(1 + len);
+        if (type === "Q") {
+          wire.push("Query");
+          socket.write(
+            Buffer.concat([
+              pgRowDescription([{ name: "x", typeOid: 25 /* text */ }]),
+              pgDataRow([Buffer.from("1")]),
+              pgCommandComplete("SELECT 1"),
+              pgReadyForQuery(),
+            ]),
+          );
+        }
+      }
+    });
+  });
+
+  try {
+    await using sql = new SQL({
+      url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=prefer`,
+      adapter: "postgres",
+      max: 1,
+      connectionTimeout: 3,
+    });
+    const result = await sql`select 1`.simple().then(
+      rows => ({ kind: "ok" as const, rows }),
+      e => ({ kind: "error" as const, code: e?.code ?? String(e), message: String(e?.message ?? e) }),
+    );
+    // The injected ErrorResponse must not surface; the plaintext startup
+    // must have been sent and the query must succeed.
+    expect({ wire, result }).toEqual({
+      wire: ["SSLRequest", "StartupMessage", "Query"],
+      result: { kind: "ok", rows: [{ x: "1" }] },
+    });
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
   }
 });

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -435,11 +435,15 @@ test("postgres client aborts the connection when the server declines TLS that wa
 // PATTERN — anything a real server can produce belongs in describeWithContainer.
 // All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
 // Buffer.alloc frame construction here.
-test("postgres sslmode=prefer falls back to a plaintext startup when the server declines TLS", async () => {
-  // libpq docs for sslmode=prefer: "first try an SSL connection; if that fails,
-  // try a non-SSL connection". When the server answers the SSLRequest with 'N',
-  // the client must send a plaintext StartupMessage on the same socket and
-  // continue in plaintext — not idle until connectionTimeout.
+//
+// Connect with ?sslmode=prefer to a plain-TCP Postgres mock that answers the
+// SSLRequest with `sslRequestResponse`, then completes a plaintext startup and
+// one simple Query. Returns the client-side outcome and the frames the server
+// observed.
+async function runSslmodePreferAgainstNonSslServer(sslRequestResponse: Buffer): Promise<{
+  wire: string[];
+  result: { kind: "ok"; rows: unknown } | { kind: "error"; code: unknown; message: string };
+}> {
   const wire: string[] = [];
   const sockets = new Set<import("node:net").Socket>();
 
@@ -458,93 +462,7 @@ test("postgres sslmode=prefer falls back to a plaintext startup when the server 
           if (len === 8 && buf.readInt32BE(4) === 80877103) {
             wire.push("SSLRequest");
             buf = buf.subarray(8);
-            socket.write(pgSSLResponse("N"));
-            continue;
-          }
-          wire.push("StartupMessage");
-          started = true;
-          buf = buf.subarray(len);
-          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
-          continue;
-        }
-        if (buf.length < 5) return;
-        const len = buf.readInt32BE(1);
-        if (buf.length < 1 + len) return;
-        const type = String.fromCharCode(buf[0]);
-        buf = buf.subarray(1 + len);
-        if (type === "Q") {
-          wire.push("Query");
-          socket.write(
-            Buffer.concat([
-              pgRowDescription([{ name: "x", typeOid: 25 /* text */ }]),
-              pgDataRow([Buffer.from("1")]),
-              pgCommandComplete("SELECT 1"),
-              pgReadyForQuery(),
-            ]),
-          );
-        }
-      }
-    });
-  });
-
-  try {
-    await using sql = new SQL({
-      url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=prefer`,
-      adapter: "postgres",
-      max: 1,
-      connectionTimeout: 3,
-    });
-    const result = await sql`select 1`.simple().then(
-      rows => ({ kind: "ok" as const, rows }),
-      e => ({ kind: "error" as const, code: e?.code ?? String(e) }),
-    );
-    expect({ wire, result }).toEqual({
-      wire: ["SSLRequest", "StartupMessage", "Query"],
-      result: { kind: "ok", rows: [{ x: "1" }] },
-    });
-  } finally {
-    for (const socket of sockets) socket.destroy();
-    await new Promise<void>(resolve => server.close(() => resolve()));
-  }
-});
-
-// Fault-injection test: requires a server that refuses / drops / sends malformed
-// frames, which a healthy container will not do on demand. DO NOT COPY THIS
-// PATTERN — anything a real server can produce belongs in describeWithContainer.
-// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
-// Buffer.alloc frame construction here.
-test("postgres sslmode=prefer discards bytes that arrive alongside the 'N' SSLRequest answer", async () => {
-  // The server may only answer an SSLRequest with a single byte; any further
-  // bytes in the same read precede our StartupMessage and so cannot be a
-  // legitimate backend response. They must be discarded rather than dispatched
-  // (libpq CVE-2021-23222). The fallback plaintext startup then proceeds
-  // normally.
-  const wire: string[] = [];
-  const sockets = new Set<import("node:net").Socket>();
-
-  const { server, port } = await listeningServer(socket => {
-    sockets.add(socket);
-    socket.on("error", () => {});
-    let buf = Buffer.alloc(0);
-    let started = false;
-    socket.on("data", data => {
-      buf = Buffer.concat([buf, data]);
-      for (;;) {
-        if (!started) {
-          if (buf.length < 8) return;
-          const len = buf.readInt32BE(0);
-          if (buf.length < len) return;
-          if (len === 8 && buf.readInt32BE(4) === 80877103) {
-            wire.push("SSLRequest");
-            buf = buf.subarray(8);
-            // 'N' plus an ErrorResponse in the same write: the ErrorResponse
-            // precedes any StartupMessage and must not reach the dispatch loop.
-            socket.write(
-              Buffer.concat([
-                pgSSLResponse("N"),
-                pgErrorResponse({ S: "FATAL", C: "XX000", M: "injected before startup" }),
-              ]),
-            );
+            socket.write(sslRequestResponse);
             continue;
           }
           wire.push("StartupMessage");
@@ -584,14 +502,36 @@ test("postgres sslmode=prefer discards bytes that arrive alongside the 'N' SSLRe
       rows => ({ kind: "ok" as const, rows }),
       e => ({ kind: "error" as const, code: e?.code ?? String(e), message: String(e?.message ?? e) }),
     );
-    // The injected ErrorResponse must not surface; the plaintext startup
-    // must have been sent and the query must succeed.
-    expect({ wire, result }).toEqual({
-      wire: ["SSLRequest", "StartupMessage", "Query"],
-      result: { kind: "ok", rows: [{ x: "1" }] },
-    });
+    return { wire, result };
   } finally {
     for (const socket of sockets) socket.destroy();
     await new Promise<void>(resolve => server.close(() => resolve()));
   }
+}
+
+test("postgres sslmode=prefer falls back to a plaintext startup when the server declines TLS", async () => {
+  // libpq docs for sslmode=prefer: "first try an SSL connection; if that fails,
+  // try a non-SSL connection". When the server answers the SSLRequest with 'N',
+  // the client must send a plaintext StartupMessage on the same socket and
+  // continue in plaintext — not idle until connectionTimeout.
+  expect(await runSslmodePreferAgainstNonSslServer(pgSSLResponse("N"))).toEqual({
+    wire: ["SSLRequest", "StartupMessage", "Query"],
+    result: { kind: "ok", rows: [{ x: "1" }] },
+  });
+});
+
+test("postgres sslmode=prefer discards bytes that arrive alongside the 'N' SSLRequest answer", async () => {
+  // The server may only answer an SSLRequest with a single byte; any further
+  // bytes in the same read precede our StartupMessage and so cannot be a
+  // legitimate backend response. They must be discarded rather than dispatched
+  // (libpq CVE-2021-23222). The fallback plaintext startup then proceeds
+  // normally, so the injected ErrorResponse below must not surface.
+  expect(
+    await runSslmodePreferAgainstNonSslServer(
+      Buffer.concat([pgSSLResponse("N"), pgErrorResponse({ S: "FATAL", C: "XX000", M: "injected before startup" })]),
+    ),
+  ).toEqual({
+    wire: ["SSLRequest", "StartupMessage", "Query"],
+    result: { kind: "ok", rows: [{ x: "1" }] },
+  });
 });


### PR DESCRIPTION
## Problem

`sslmode=prefer` is libpq's documented default: "first try an SSL connection; if that fails, try a non-SSL connection". Postgres ships with `ssl=off`, so a stock `docker run postgres` answers the 8-byte SSLRequest with `N`. Bun then never writes anything else on the socket and the connection idles until `connectionTimeout`:

```
$ bun -e 'await new Bun.SQL("postgres://postgres@127.0.0.1:5432/postgres?sslmode=prefer",{max:1,connectionTimeout:3})`SELECT 1`'
PostgresError: Connection timeout after 3s
 code: "ERR_POSTGRES_CONNECTION_TIMEOUT"
```

A wire capture shows the client sends the SSLRequest, the server replies `N`, and the client goes quiet.

## Cause

In `PostgresRequest::on_data`, the `b'N'` arm with `TlsStatus::MessageSent` correctly fails for `require`/`verify-*`, but for `prefer` it only did `connection.tls_status.set(TlsStatus::SslNotAvailable)` and `continue`d the read loop. Nothing ever called `start()` (the StartupMessage writer) again: `start()` is only reached from `on_open` (already past) and from `setup_tls()` (the `S` arm).

The `continue` also kept dispatching any bytes that arrived in the same read as the `N`, so a server that wrote `N` + ErrorResponse in one segment had that ErrorResponse surfaced as the connection error even though no StartupMessage had been sent. That is the message-injection shape libpq hardened against in CVE-2021-23222.

## Fix

`src/sql_jsc/postgres/PostgresRequest.rs`: in the `N`+`prefer` arm, call `connection.start()` to write the plaintext StartupMessage and `return Ok(())` so any trailing bytes in the same read are discarded (mirrors the `S` arm, which also `return Ok(())`s after `setup_tls()`).

`src/sql_jsc/postgres/PostgresSQLConnection.rs`: widen `start()` to `pub(crate)`.

`test/js/sql/postgres-tls-ctx-leak.test.ts`: the mock server was packing `N` + AuthenticationOk + ReadyForQuery in a single write and relying on the old `continue` to dispatch them; switch it to the real two-round-trip exchange.

## Verification

Against a real local Postgres with `ssl=off`:

```
prefer:  [{"x":1}]                         # was ERR_POSTGRES_CONNECTION_TIMEOUT
disable: [{"x":1}]
require: ERR_POSTGRES_TLS_NOT_AVAILABLE
```

New tests in `test/js/sql/tls-sql.test.ts`:
- `sslmode=prefer falls back to a plaintext startup when the server declines TLS`: mock server answers `N`, asserts `wire == [SSLRequest, StartupMessage, Query]` and the query returns a row.
- `sslmode=prefer discards bytes that arrive alongside the 'N' SSLRequest answer`: mock server writes `N` + ErrorResponse in one segment, asserts the injected error does not surface and the plaintext startup proceeds.

Both fail on `main` (first with `ERR_POSTGRES_CONNECTION_TIMEOUT` and `wire == [SSLRequest]`, second with `ERR_POSTGRES_SERVER_ERROR: injected before startup`) and pass with this change.

Fixes #36887
