### PR TITLE
sql: report verify-full hostname mismatch as ERR_TLS_CERT_ALTNAME_INVALID

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -986,8 +986,24 @@ impl<const SSL: bool> SocketHandler<SSL> {
             }
         };
         if !handshake_was_successful {
-            let Ok(v) = crate::jsc::verify_error_to_js(&ssl_error, &this.global_object) else {
-                return;
+            // `do_handshake` returns false with an all-zero `ssl_error` only when
+            // the chain verified but the VerifyFull identity check failed.
+            let v = if success == 1 && ssl_error.error_no == 0 {
+                let hostname = this.connection_mut().server_name();
+                this.global_object
+                    .err(
+                        crate::jsc::ErrorCode::TLS_CERT_ALTNAME_INVALID,
+                        format_args!(
+                            "Hostname/IP does not match certificate's altnames: Host: {}",
+                            bstr::BStr::new(hostname),
+                        ),
+                    )
+                    .to_js()
+            } else {
+                let Ok(v) = crate::jsc::verify_error_to_js(&ssl_error, &this.global_object) else {
+                    return;
+                };
+                v
             };
             this.fail_with_js_value(v);
         }

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -402,6 +402,16 @@ impl MySQLConnection {
         self.status == ConnectionState::Connected
     }
 
+    pub fn server_name(&self) -> &[u8] {
+        let p = self.tls_config.server_name();
+        if p.is_null() {
+            b""
+        } else {
+            // SAFETY: NUL-terminated C string owned by `tls_config`.
+            unsafe { bun_core::ffi::cstr(p) }.to_bytes()
+        }
+    }
+
     pub fn do_handshake(
         &mut self,
         success: i32,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -443,21 +443,15 @@ impl MySQLConnection {
                         // match the intended host. Absence of a configured server name is
                         // not a license to skip the check — fail closed.
                         if self.ssl_mode == SSLMode::VerifyFull {
-                            let servername = self.tls_config.server_name();
-                            if servername.is_null() {
-                                self.tls_status = TLSStatus::SslFailed;
-                                return Ok(false);
-                            }
+                            let hostname = self.server_name();
                             // SAFETY: native handle of a connected TLS socket is `SSL*`.
                             let ssl_ptr: *mut bun_boringssl_sys::SSL = self
                                 .socket
                                 .get_native_handle()
                                 .map(|h| h.cast())
                                 .unwrap_or(core::ptr::null_mut());
-                            // SAFETY: `server_name` is a NUL-terminated C string owned by
-                            // `tls_config` for the connection lifetime.
-                            let hostname = unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                            if ssl_ptr.is_null()
+                            if hostname.is_empty()
+                                || ssl_ptr.is_null()
                                 || !bun_boringssl::check_server_identity(
                                     // SAFETY: `ssl_ptr` is non-null (checked by the short-circuit above) and live (handshake just succeeded).
                                     unsafe { &mut *ssl_ptr },

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -887,30 +887,39 @@ impl PostgresSQLConnection {
 
                         if self.ssl_mode == SSLMode::VerifyFull {
                             let servername = self.tls_config.server_name();
-                            let ok = if servername.is_null() {
-                                false
+                            // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
+                            let hostname: &[u8] = if servername.is_null() {
+                                b""
                             } else {
-                                // SAFETY: native handle of a connected TLS socket is `SSL*`.
-                                let ssl_ptr: *mut BoringSSL::c::SSL = self
-                                    .socket
-                                    .get()
-                                    .get_native_handle()
-                                    .map_or(core::ptr::null_mut(), |p| p.cast());
-                                // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
-                                let hostname =
-                                    unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                                // SAFETY: `ssl_ptr` is the live SSL* of a connected TLS socket.
-                                !ssl_ptr.is_null()
-                                    && BoringSSL::check_server_identity(
-                                        unsafe { &mut *ssl_ptr },
-                                        hostname,
-                                    )
+                                unsafe { bun_core::ffi::cstr(servername) }.to_bytes()
                             };
+                            // SAFETY: native handle of a connected TLS socket is `SSL*`.
+                            let ssl_ptr: *mut BoringSSL::c::SSL = self
+                                .socket
+                                .get()
+                                .get_native_handle()
+                                .map_or(core::ptr::null_mut(), |p| p.cast());
+                            // SAFETY: `ssl_ptr` is the live SSL* of a connected TLS socket.
+                            let ok = !hostname.is_empty()
+                                && !ssl_ptr.is_null()
+                                && BoringSSL::check_server_identity(
+                                    unsafe { &mut *ssl_ptr },
+                                    hostname,
+                                );
                             if !ok {
-                                let Ok(v) = verify_error_to_js(&ssl_error, self.global()) else {
-                                    return;
-                                };
-                                self.fail_with_js_value(v);
+                                // The chain verified (error_no == 0 above); only the
+                                // identity check failed, so `ssl_error` carries nothing.
+                                let err = self
+                                    .global()
+                                    .err(
+                                        jsc::ErrorCode::TLS_CERT_ALTNAME_INVALID,
+                                        format_args!(
+                                            "Hostname/IP does not match certificate's altnames: Host: {}",
+                                            bstr::BStr::new(hostname),
+                                        ),
+                                    )
+                                    .to_js();
+                                self.fail_with_js_value(err);
                             }
                         }
                     }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -887,10 +887,10 @@ impl PostgresSQLConnection {
 
                         if self.ssl_mode == SSLMode::VerifyFull {
                             let servername = self.tls_config.server_name();
-                            // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
                             let hostname: &[u8] = if servername.is_null() {
                                 b""
                             } else {
+                                // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
                                 unsafe { bun_core::ffi::cstr(servername) }.to_bytes()
                             };
                             // SAFETY: native handle of a connected TLS socket is `SSL*`.

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -1,8 +1,17 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import tls from "node:tls";
 import { describeWithContainer, isDockerEnabled } from "harness";
 import path from "node:path";
-import { listeningServer, pgAuthenticationCleartextPassword, pgSSLRequest, pgSSLResponse } from "./wire-frames";
+import {
+  listeningServer,
+  pgAuthenticationCleartextPassword,
+  pgAuthenticationOk,
+  pgReadyForQuery,
+  pgSSLRequest,
+  pgSSLResponse,
+} from "./wire-frames";
 
 if (!isDockerEnabled()) {
   test.skip("skipping TLS SQL tests - Docker is not available", () => {});
@@ -416,5 +425,79 @@ test("postgres client aborts the connection when the server declines TLS that wa
       for (const socket of sockets) socket.destroy();
       await new Promise<void>(resolve => server.close(() => resolve()));
     }
+  }
+});
+
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+test("postgres sslmode=verify-full reports a hostname mismatch as ERR_TLS_CERT_ALTNAME_INVALID", async () => {
+  // Self-signed certificate with only DNS:localhost in its SANs (no IP SANs).
+  // The client trusts it as its own CA, so the chain verifies; connecting by
+  // 127.0.0.1 under verify-full fails only the identity check.
+  const cert = readFileSync(path.join(import.meta.dir, "..", "..", "regression", "issue", "27890-localhost-only.crt"));
+  const key = readFileSync(path.join(import.meta.dir, "..", "..", "regression", "issue", "27890-localhost-only.key"));
+  const secureContext = tls.createSecureContext({ cert, key });
+
+  const sockets = new Set<import("node:net").Socket>();
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    let preTls = Buffer.alloc(0);
+    const onData = (d: Buffer) => {
+      preTls = Buffer.concat([preTls, d]);
+      if (preTls.length < pgSSLRequest().length) return;
+      socket.removeListener("data", onData);
+      socket.write(pgSSLResponse("S"));
+      const tlsSock = new tls.TLSSocket(socket, { isServer: true, secureContext });
+      sockets.add(tlsSock);
+      tlsSock.on("error", () => {});
+      tlsSock.on("data", () => {
+        tlsSock.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+      });
+    };
+    socket.on("data", onData);
+  });
+
+  try {
+    // verify-ca: the cert is trusted as its own CA, so the chain verifies and
+    // the connection succeeds. This proves the cert and server are sound and
+    // that the verify-full rejection below is the identity check alone.
+    {
+      await using sql = new SQL(`postgres://u:pw@127.0.0.1:${port}/db?sslmode=verify-ca`, {
+        max: 1,
+        connectionTimeout: 5,
+        tls: { ca: cert },
+      });
+      await sql.connect();
+      expect(sql.options.hostname).toBe("127.0.0.1");
+    }
+
+    // verify-full: the chain verifies but 127.0.0.1 is not in the cert's SANs,
+    // so check_server_identity fails. The rejection must carry a code and a
+    // message that names the host; previously the client built the error from
+    // an all-zero verify-error struct, which on assert-enabled builds aborts
+    // the process in JSC::createError(!message.isEmpty()) and on release
+    // surfaces as `Error { message: "", code: undefined }`.
+    {
+      await using sql = new SQL(`postgres://u:pw@127.0.0.1:${port}/db?sslmode=verify-full`, {
+        max: 1,
+        connectionTimeout: 5,
+        tls: { ca: cert },
+      });
+      const outcome = await sql.connect().then(
+        () => ({ connected: true }),
+        e => ({ code: e?.code, message: e?.message }),
+      );
+      expect(outcome).toEqual({
+        code: "ERR_TLS_CERT_ALTNAME_INVALID",
+        message: expect.stringContaining("127.0.0.1"),
+      });
+    }
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
   }
 });

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -1,9 +1,9 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import tls from "node:tls";
 import { describeWithContainer, isDockerEnabled } from "harness";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+import tls from "node:tls";
 import {
   listeningServer,
   pgAuthenticationCleartextPassword,


### PR DESCRIPTION
### Repro

```ts
// self-signed cert with SAN DNS:localhost only; trusted as its own CA
const sql = new Bun.SQL(`postgres://u:pw@127.0.0.1:${port}/db?sslmode=verify-full`,
                        { max: 1, tls: { ca: cert } });
await sql.connect();
```

Release build (1.4.0): `Error { code: undefined, message: "" }`
Assertion-enabled build (origin/main debug): process aborts with

```
ASSERTION FAILED: !message.isEmpty()
vendor/WebKit/Source/JavaScriptCore/runtime/Error.cpp(41) : JSObject *JSC::createError(...)
```

With `sslmode=verify-ca` and the same cert the connection succeeds, proving the chain verifies and only the identity check is at fault.

### Cause

`PostgresSQLConnection::on_handshake()` in the `VerifyFull` arm, when `ssl_error.error_no == 0` (chain verified) and `BoringSSL::check_server_identity()` returns false, called `verify_error_to_js(&ssl_error, ...)`. `ssl_error` is only populated by OpenSSL's chain-verification callback, so on this path it is `{ error_no: 0, code: null, reason: null }`, which `verify_error_to_js` turns into `SystemError { code: "", message: "" }` and then into `createError(global, "")`.

`JSMySQLConnection::on_handshake_()` had the same shape: `do_handshake()` returns `Ok(false)` for an identity-check failure and the caller built the error from the same all-zero struct.

### Fix

Build `ERR_TLS_CERT_ALTNAME_INVALID` with the hostname being checked instead of reusing the empty verify-error struct, matching what `js_valkey.rs` already does for the same case and what Node's `checkServerIdentity` produces.

### Verification

`test/js/sql/tls-sql.test.ts` gains a fault-injection test that runs a scripted postgres wire server which answers `S` to `SSLRequest` and wraps the socket in a `node:tls` server with a `DNS:localhost`-only cert. Connecting to `127.0.0.1` with `sslmode=verify-ca` succeeds (chain verifies); `sslmode=verify-full` rejects with `{ code: "ERR_TLS_CERT_ALTNAME_INVALID", message: /127.0.0.1/ }`.

```
USE_SYSTEM_BUN=1 bun test test/js/sql/tls-sql.test.ts -t ALTNAME   # fails: code=undefined message=""
bun bd test test/js/sql/tls-sql.test.ts -t ALTNAME                 # passes
```

The existing TLS SQL tests (`tls-sql.test.ts`, `postgres-tls-ctx-leak.test.ts`, `sql-mysql-tls-plaintext-injection.test.ts`) still pass.