### PR TITLE
sql(postgres): sign received server-first-message in SCRAM AuthMessage

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2772,19 +2772,25 @@ impl PostgresSQLConnection {
 
                         let server_signature = sasl.server_signature();
 
-                        // This will usually start with "v="
-                        let comparison_signature = final_data.slice();
+                        // RFC 5802 §7: server-final-message = (server-error / verifier)
+                        // ["," extensions]. Compare only the verifier value up to the
+                        // first ',' and require the "v=" prefix.
+                        let server_final = final_data.slice();
+                        let first_attr = match strings::index_of_char(server_final, b',') {
+                            Some(i) => &server_final[..i as usize],
+                            None => server_final,
+                        };
 
-                        if comparison_signature.len() < 2
+                        if !first_attr.starts_with(b"v=")
                             || !BoringSSL::c::constant_time_eq(
                                 server_signature,
-                                &comparison_signature[2..],
+                                &first_attr[2..],
                             )
                         {
                             debug!(
                                 "SASLFinal - SASL Server signature mismatch\nExpected: {}\nActual: {}",
                                 bstr::BStr::new(server_signature),
-                                bstr::BStr::new(&comparison_signature[2..])
+                                bstr::BStr::new(server_final)
                             );
                             self.fail(
                                 b"The server did not return the correct signature",

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2782,10 +2782,7 @@ impl PostgresSQLConnection {
                         };
 
                         if !first_attr.starts_with(b"v=")
-                            || !BoringSSL::c::constant_time_eq(
-                                server_signature,
-                                &first_attr[2..],
-                            )
+                            || !BoringSSL::c::constant_time_eq(server_signature, &first_attr[2..])
                         {
                             debug!(
                                 "SASLFinal - SASL Server signature mismatch\nExpected: {}\nActual: {}",

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2644,6 +2644,14 @@ impl PostgresSQLConnection {
                         }
                         debug!("SASLContinue");
 
+                        // RFC 5802 §5.1: a reserved-mext ("m=") in a server message
+                        // MUST fail authentication at a client that doesn't implement
+                        // the signalled mandatory extension (libpq rejects this too).
+                        if cont.data.slice().starts_with(b"m=") {
+                            debug!("SASLContinue mandatory extension not supported");
+                            return Err(AnyPostgresError::InvalidMessage);
+                        }
+
                         // RFC 5802 §5.1: the server's combined nonce MUST begin with
                         // the client nonce we sent in the client-first-message.
                         if !cont.r.slice().starts_with(sasl.nonce()) {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2697,16 +2697,17 @@ impl PostgresSQLConnection {
                         )?;
                         drop(server_salt_decoded_base64);
 
+                        // RFC 5802 §3 AuthMessage: sign the server-first-message as received
+                        // (cont.data), not a rebuilt "r=,s=,i=", so any RFC-legal extension
+                        // attributes the server sent are covered by the proof.
                         let mut auth_string: Vec<u8> = Vec::new();
                         {
                             use std::io::Write as _;
                             let _ = write!(
                                 &mut auth_string,
-                                "n=*,r={},r={},s={},i={},c=biws,r={}",
+                                "n=*,r={},{},c=biws,r={}",
                                 bstr::BStr::new(sasl.nonce()),
-                                bstr::BStr::new(cont.r.slice()),
-                                bstr::BStr::new(cont.s.slice()),
-                                bstr::BStr::new(cont.i.slice()),
+                                bstr::BStr::new(cont.data.slice()),
                                 bstr::BStr::new(cont.r.slice()),
                             );
                         }

--- a/test/js/sql/postgres-scram-authmessage.test.ts
+++ b/test/js/sql/postgres-scram-authmessage.test.ts
@@ -1,12 +1,6 @@
-// RFC 5802 §3: AuthMessage = client-first-message-bare + "," + server-first-message
-// + "," + client-final-message-without-proof. The server-first-message grammar permits
-// extension attributes after "i=", and those bytes are part of the signed AuthMessage.
-// A scripted SCRAM server that knows the password derives the RFC proof directly and
-// checks the client's ClientProof against it, then completes the handshake so connect()
-// resolving is the end-to-end assertion.
-//
-// Fault-injection: today's PostgreSQL emits exactly r=,s=,i= so a live container cannot
-// exercise the extension case. Frame builders come from test/js/sql/wire-frames.ts.
+// RFC 5802 §3: AuthMessage signs the server-first/server-final bytes as received,
+// including any extension attributes. A live PostgreSQL never sends extensions, so
+// this scripted SCRAM server injects them and checks ClientProof against the RFC value.
 
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
@@ -26,13 +20,9 @@ const pgAuthenticationSASLContinue = (msg: string) => pgRaw("R", Buffer.concat([
 // AuthenticationSASLFinal: Byte1('R') Int32(len) Int32(12) Byte[n](server-final-message)
 const pgAuthenticationSASLFinal = (msg: string) => pgRaw("R", Buffer.concat([pgInt32(12), Buffer.from(msg)]));
 
-/**
- * Drive a full SCRAM-SHA-256 handshake against Bun.SQL, verifying the ClientProof
- * against the RFC 5802 AuthMessage (computed from the messages as exchanged on the
- * wire), then send a valid server-final so connect() resolves iff both sides agree.
- * @param firstExt appended verbatim to the server-first-message after "i=N"
- * @param finalExt appended verbatim to the server-final-message after "v=<sig>"
- */
+// Drive a full SCRAM-SHA-256 handshake: `firstExt` is appended to server-first after
+// "i=N", `finalExt` to server-final after "v=<sig>". connect() resolving proves the
+// client accepted the RFC-derived v= signature.
 async function runScramHandshake(firstExt: string, finalExt: string): Promise<void> {
   const {
     promise: gotProofs,
@@ -50,7 +40,10 @@ async function runScramHandshake(firstExt: string, finalExt: string): Promise<vo
     let clientFirstBare = "";
     let serverFirst = "";
     let salted = Buffer.alloc(0);
-    socket.on("error", () => {});
+    socket.on("error", reject);
+    socket.on("close", () => {
+      if (saslState < 2) reject(new Error("socket closed before SCRAM handshake completed"));
+    });
     socket.on("data", chunk => {
       buf = Buffer.concat([buf, chunk]);
       try {

--- a/test/js/sql/postgres-scram-authmessage.test.ts
+++ b/test/js/sql/postgres-scram-authmessage.test.ts
@@ -20,10 +20,15 @@ const pgAuthenticationSASLContinue = (msg: string) => pgRaw("R", Buffer.concat([
 // AuthenticationSASLFinal: Byte1('R') Int32(len) Int32(12) Byte[n](server-final-message)
 const pgAuthenticationSASLFinal = (msg: string) => pgRaw("R", Buffer.concat([pgInt32(12), Buffer.from(msg)]));
 
-// Drive a full SCRAM-SHA-256 handshake: `firstExt` is appended to server-first after
-// "i=N", `finalExt` to server-final after "v=<sig>". connect() resolving proves the
-// client accepted the RFC-derived v= signature.
-async function runScramHandshake(firstExt: string, finalExt: string): Promise<void> {
+// Drive a full SCRAM-SHA-256 handshake: `firstPrefix`/`firstExt` wrap server-first
+// ("<prefix>r=...,s=...,i=N<ext>"), `finalExt` is appended to server-final after
+// "v=<sig>". Returns the connect() settlement error, or undefined if it resolved.
+async function runScramHandshake(opts: {
+  firstPrefix?: string;
+  firstExt?: string;
+  finalExt?: string;
+}): Promise<unknown> {
+  const { firstPrefix = "", firstExt = "", finalExt = "" } = opts;
   const {
     promise: gotProofs,
     resolve: resolveProofs,
@@ -77,7 +82,7 @@ async function runScramHandshake(firstExt: string, finalExt: string): Promise<vo
             const salt = randomBytes(18);
             salted = pbkdf2Sync(PASSWORD, salt, ITERS, 32, "sha256");
             serverFirst =
-              `r=${clientNonce}${randomBytes(16).toString("base64")},` +
+              `${firstPrefix}r=${clientNonce}${randomBytes(16).toString("base64")},` +
               `s=${salt.toString("base64")},i=${ITERS}${firstExt}`;
             socket.write(pgAuthenticationSASLContinue(serverFirst));
             saslState = 1;
@@ -120,14 +125,16 @@ async function runScramHandshake(firstExt: string, finalExt: string): Promise<vo
     connectionTimeout: 5,
   });
   try {
-    // Start the handshake first; then await whichever settles: the proof capture
-    // (server saw client-final) or connect() rejecting earlier in the exchange.
-    const connected = db.connect();
-    connected.catch(() => {});
-    const { clientProof, rfcProof } = await Promise.race([gotProofs, connected.then(() => gotProofs)]);
-    expect(clientProof).toBe(rfcProof);
-    // connect() resolving proves the client also accepted the server's RFC v= signature.
-    await connected;
+    gotProofs.catch(() => {});
+    const connectError = await db.connect().then(
+      () => undefined,
+      e => e,
+    );
+    if (connectError === undefined) {
+      const { clientProof, rfcProof } = await gotProofs;
+      expect(clientProof).toBe(rfcProof);
+    }
+    return connectError;
   } finally {
     await db.close({ timeout: 0 });
     await new Promise<void>(r => server.close(() => r()));
@@ -136,18 +143,24 @@ async function runScramHandshake(firstExt: string, finalExt: string): Promise<vo
 
 describe("postgres SCRAM-SHA-256: RFC 5802 extension attributes", () => {
   test("canonical server-first / server-final (no extensions)", async () => {
-    await runScramHandshake("", "");
+    expect(await runScramHandshake({})).toBeUndefined();
   });
 
   test("server-first-message carrying an extension attribute", async () => {
-    await runScramHandshake(",x=future-ext", "");
+    expect(await runScramHandshake({ firstExt: ",x=future-ext" })).toBeUndefined();
   });
 
   test("server-final-message carrying an extension attribute", async () => {
-    await runScramHandshake("", ",x=future-ext");
+    expect(await runScramHandshake({ finalExt: ",x=future-ext" })).toBeUndefined();
   });
 
   test("both server-first and server-final carrying extension attributes", async () => {
-    await runScramHandshake(",x=future-ext", ",x=future-ext");
+    expect(await runScramHandshake({ firstExt: ",x=future-ext", finalExt: ",x=future-ext" })).toBeUndefined();
+  });
+
+  test("server-first-message carrying a reserved-mext ('m=') is rejected", async () => {
+    const err = await runScramHandshake({ firstPrefix: "m=mandatory-ext," });
+    expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe("ERR_POSTGRES_INVALID_MESSAGE");
   });
 });

--- a/test/js/sql/postgres-scram-authmessage.test.ts
+++ b/test/js/sql/postgres-scram-authmessage.test.ts
@@ -30,9 +30,10 @@ const pgAuthenticationSASLFinal = (msg: string) => pgRaw("R", Buffer.concat([pgI
  * Drive a full SCRAM-SHA-256 handshake against Bun.SQL, verifying the ClientProof
  * against the RFC 5802 AuthMessage (computed from the messages as exchanged on the
  * wire), then send a valid server-final so connect() resolves iff both sides agree.
- * @param extension appended verbatim to the server-first-message after "i=N"
+ * @param firstExt appended verbatim to the server-first-message after "i=N"
+ * @param finalExt appended verbatim to the server-final-message after "v=<sig>"
  */
-async function runScramHandshake(extension: string): Promise<void> {
+async function runScramHandshake(firstExt: string, finalExt: string): Promise<void> {
   const {
     promise: gotProofs,
     resolve: resolveProofs,
@@ -84,7 +85,7 @@ async function runScramHandshake(extension: string): Promise<void> {
             salted = pbkdf2Sync(PASSWORD, salt, ITERS, 32, "sha256");
             serverFirst =
               `r=${clientNonce}${randomBytes(16).toString("base64")},` +
-              `s=${salt.toString("base64")},i=${ITERS}${extension}`;
+              `s=${salt.toString("base64")},i=${ITERS}${firstExt}`;
             socket.write(pgAuthenticationSASLContinue(serverFirst));
             saslState = 1;
           } else {
@@ -104,7 +105,11 @@ async function runScramHandshake(extension: string): Promise<void> {
             const serverKey = hmac(salted, "Server Key");
             const serverSig = hmac(serverKey, authMessage).toString("base64");
             socket.write(
-              Buffer.concat([pgAuthenticationSASLFinal(`v=${serverSig}`), pgAuthenticationOk(), pgReadyForQuery()]),
+              Buffer.concat([
+                pgAuthenticationSASLFinal(`v=${serverSig}${finalExt}`),
+                pgAuthenticationOk(),
+                pgReadyForQuery(),
+              ]),
             );
             saslState = 2;
           }
@@ -136,12 +141,20 @@ async function runScramHandshake(extension: string): Promise<void> {
   }
 }
 
-describe("postgres SCRAM-SHA-256 AuthMessage", () => {
-  test("canonical server-first-message (r=,s=,i=)", async () => {
-    await runScramHandshake("");
+describe("postgres SCRAM-SHA-256: RFC 5802 extension attributes", () => {
+  test("canonical server-first / server-final (no extensions)", async () => {
+    await runScramHandshake("", "");
   });
 
-  test("server-first-message carrying an RFC 5802 extension attribute", async () => {
-    await runScramHandshake(",x=future-ext");
+  test("server-first-message carrying an extension attribute", async () => {
+    await runScramHandshake(",x=future-ext", "");
+  });
+
+  test("server-final-message carrying an extension attribute", async () => {
+    await runScramHandshake("", ",x=future-ext");
+  });
+
+  test("both server-first and server-final carrying extension attributes", async () => {
+    await runScramHandshake(",x=future-ext", ",x=future-ext");
   });
 });

--- a/test/js/sql/postgres-scram-authmessage.test.ts
+++ b/test/js/sql/postgres-scram-authmessage.test.ts
@@ -33,7 +33,11 @@ const pgAuthenticationSASLFinal = (msg: string) => pgRaw("R", Buffer.concat([pgI
  * @param extension appended verbatim to the server-first-message after "i=N"
  */
 async function runScramHandshake(extension: string): Promise<void> {
-  const { promise: gotProofs, resolve: resolveProofs, reject } = Promise.withResolvers<{
+  const {
+    promise: gotProofs,
+    resolve: resolveProofs,
+    reject,
+  } = Promise.withResolvers<{
     clientProof: string;
     rfcProof: string;
   }>();
@@ -122,10 +126,7 @@ async function runScramHandshake(extension: string): Promise<void> {
     // (server saw client-final) or connect() rejecting earlier in the exchange.
     const connected = db.connect();
     connected.catch(() => {});
-    const { clientProof, rfcProof } = await Promise.race([
-      gotProofs,
-      connected.then(() => gotProofs),
-    ]);
+    const { clientProof, rfcProof } = await Promise.race([gotProofs, connected.then(() => gotProofs)]);
     expect(clientProof).toBe(rfcProof);
     // connect() resolving proves the client also accepted the server's RFC v= signature.
     await connected;

--- a/test/js/sql/postgres-scram-authmessage.test.ts
+++ b/test/js/sql/postgres-scram-authmessage.test.ts
@@ -1,0 +1,146 @@
+// RFC 5802 §3: AuthMessage = client-first-message-bare + "," + server-first-message
+// + "," + client-final-message-without-proof. The server-first-message grammar permits
+// extension attributes after "i=", and those bytes are part of the signed AuthMessage.
+// A scripted SCRAM server that knows the password derives the RFC proof directly and
+// checks the client's ClientProof against it, then completes the handshake so connect()
+// resolving is the end-to-end assertion.
+//
+// Fault-injection: today's PostgreSQL emits exactly r=,s=,i= so a live container cannot
+// exercise the extension case. Frame builders come from test/js/sql/wire-frames.ts.
+
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { createHash, createHmac, pbkdf2Sync, randomBytes } from "node:crypto";
+import { listeningServer, pgAuthenticationOk, pgInt32, pgRaw, pgReadyForQuery } from "./wire-frames";
+
+const PASSWORD = "pw";
+const ITERS = 4096;
+
+const sha256 = (d: Buffer | string) => createHash("sha256").update(d).digest();
+const hmac = (key: Buffer, data: Buffer | string) => createHmac("sha256", key).update(data).digest();
+
+// PostgreSQL FE/BE §55.7 AuthenticationSASL: Byte1('R') Int32(len) Int32(10) String(mechanism)* Byte1(0)
+const pgAuthenticationSASL = () => pgRaw("R", Buffer.concat([pgInt32(10), Buffer.from("SCRAM-SHA-256\0\0")]));
+// AuthenticationSASLContinue: Byte1('R') Int32(len) Int32(11) Byte[n](server-first-message)
+const pgAuthenticationSASLContinue = (msg: string) => pgRaw("R", Buffer.concat([pgInt32(11), Buffer.from(msg)]));
+// AuthenticationSASLFinal: Byte1('R') Int32(len) Int32(12) Byte[n](server-final-message)
+const pgAuthenticationSASLFinal = (msg: string) => pgRaw("R", Buffer.concat([pgInt32(12), Buffer.from(msg)]));
+
+/**
+ * Drive a full SCRAM-SHA-256 handshake against Bun.SQL, verifying the ClientProof
+ * against the RFC 5802 AuthMessage (computed from the messages as exchanged on the
+ * wire), then send a valid server-final so connect() resolves iff both sides agree.
+ * @param extension appended verbatim to the server-first-message after "i=N"
+ */
+async function runScramHandshake(extension: string): Promise<void> {
+  const { promise: gotProofs, resolve: resolveProofs, reject } = Promise.withResolvers<{
+    clientProof: string;
+    rfcProof: string;
+  }>();
+
+  const { port, server } = await listeningServer(socket => {
+    let buf = Buffer.alloc(0);
+    let sawStartup = false;
+    let saslState = 0;
+    let clientFirstBare = "";
+    let serverFirst = "";
+    let salted = Buffer.alloc(0);
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      try {
+        for (;;) {
+          if (!sawStartup) {
+            // StartupMessage: Int32(len) Int32(protocol) ...; no type byte.
+            if (buf.length < 4) return;
+            const len = buf.readInt32BE(0);
+            if (buf.length < len) return;
+            buf = buf.subarray(len);
+            sawStartup = true;
+            socket.write(pgAuthenticationSASL());
+            continue;
+          }
+          if (buf.length < 5) return;
+          const len = buf.readInt32BE(1);
+          if (buf.length < 1 + len) return;
+          const type = String.fromCharCode(buf[0]);
+          const body = buf.subarray(5, 1 + len);
+          buf = buf.subarray(1 + len);
+          if (type !== "p") continue;
+
+          if (saslState === 0) {
+            // SASLInitialResponse: String(mechanism) Int32(n) Byte[n](client-first-message)
+            const z = body.indexOf(0);
+            const n = body.readInt32BE(z + 1);
+            const clientFirst = body.subarray(z + 5, z + 5 + n).toString();
+            // gs2-header = [pny]["=" saslname],[authzid],
+            clientFirstBare = clientFirst.replace(/^[nyp](=[^,]*)?,[^,]*,/, "");
+            const clientNonce = /(?:^|,)r=([^,]*)/.exec(clientFirstBare)![1];
+            const salt = randomBytes(18);
+            salted = pbkdf2Sync(PASSWORD, salt, ITERS, 32, "sha256");
+            serverFirst =
+              `r=${clientNonce}${randomBytes(16).toString("base64")},` +
+              `s=${salt.toString("base64")},i=${ITERS}${extension}`;
+            socket.write(pgAuthenticationSASLContinue(serverFirst));
+            saslState = 1;
+          } else {
+            // SASLResponse: client-final-message
+            const finalMsg = body.toString();
+            const pIdx = finalMsg.lastIndexOf(",p=");
+            const withoutProof = finalMsg.slice(0, pIdx);
+            const clientProof = finalMsg.slice(pIdx + 3);
+
+            const authMessage = `${clientFirstBare},${serverFirst},${withoutProof}`;
+            const clientKey = hmac(salted, "Client Key");
+            const storedKey = sha256(clientKey);
+            const clientSig = hmac(storedKey, authMessage);
+            const rfcProof = Buffer.from(clientKey.map((b, i) => b ^ clientSig[i])).toString("base64");
+            resolveProofs({ clientProof, rfcProof });
+
+            const serverKey = hmac(salted, "Server Key");
+            const serverSig = hmac(serverKey, authMessage).toString("base64");
+            socket.write(
+              Buffer.concat([pgAuthenticationSASLFinal(`v=${serverSig}`), pgAuthenticationOk(), pgReadyForQuery()]),
+            );
+            saslState = 2;
+          }
+        }
+      } catch (e) {
+        reject(e);
+        socket.destroy();
+      }
+    });
+  });
+
+  const db = new SQL({
+    url: `postgres://u:${PASSWORD}@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 5,
+  });
+  try {
+    // Start the handshake first; then await whichever settles: the proof capture
+    // (server saw client-final) or connect() rejecting earlier in the exchange.
+    const connected = db.connect();
+    connected.catch(() => {});
+    const { clientProof, rfcProof } = await Promise.race([
+      gotProofs,
+      connected.then(() => gotProofs),
+    ]);
+    expect(clientProof).toBe(rfcProof);
+    // connect() resolving proves the client also accepted the server's RFC v= signature.
+    await connected;
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+describe("postgres SCRAM-SHA-256 AuthMessage", () => {
+  test("canonical server-first-message (r=,s=,i=)", async () => {
+    await runScramHandshake("");
+  });
+
+  test("server-first-message carrying an RFC 5802 extension attribute", async () => {
+    await runScramHandshake(",x=future-ext");
+  });
+});


### PR DESCRIPTION
## What

The postgres SCRAM-SHA-256 client computed `AuthMessage` by re-serializing the parsed `r=`, `s=`, `i=` attributes instead of using the `server-first-message` bytes as received. RFC 5802 §3 defines:

```
AuthMessage := client-first-message-bare + "," +
               server-first-message + "," +
               client-final-message-without-proof
```

and the `server-first-message` grammar permits trailing extension attributes (`["," extensions]`). A conforming server that sends `r=...,s=...,i=4096,x=anything` would reject Bun's `ClientProof`, and Bun would reject the server's (correct) `v=` signature with `ERR_POSTGRES_SASL_SIGNATURE_MISMATCH`.

The same gap existed in the `SASLFinal` handler: it compared the computed server signature against everything after `v=`, so a legal `v=<sig>,x=ext` (`server-final-message = (server-error / verifier) ["," extensions]`, §7) failed the compare even when the signature matched.

This is forward-compat only: today's PostgreSQL emits exactly `r=,s=,i=` and `v=<sig>`. libpq and postgres.js both operate on the received bytes.

## Fix

- `SASLContinue`: use the raw received payload (already held in `SASLContinue::data`) in the `AuthMessage` format string instead of rebuilding from `r/s/i`.
- `SASLContinue`: explicitly reject a leading `m=` (reserved-mext) per RFC 5802 §5.1, matching libpq. Signing the received bytes would otherwise let such a message authenticate where the old reconstruction accidentally failed.
- `SASLFinal`: slice the first attribute to the first `,` and require the `v=` prefix before the constant-time compare.

## Testing

`test/js/sql/postgres-scram-authmessage.test.ts` runs a scripted SCRAM server that knows the password, derives the RFC proof from the messages as exchanged on the wire, and completes the full handshake (including `v=`). Five cases: canonical (control), extension on server-first, extension on server-final, both, and `m=` on server-first (expects `ERR_POSTGRES_INVALID_MESSAGE`).

Before the fix, all four non-control cases fail; after the fix, all five pass.
