### PR TITLE
udp: stop dispatching recvmmsg batch after close() from inside data handler

### DIFF
--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -143,6 +143,13 @@ extern "C" fn on_data(
 
     let mut i: c_int = 0;
     while i < packets {
+        // A prior iteration's callback (or its error handler) may have closed
+        // this socket; stop dispatching the rest of the recvmmsg batch so no
+        // 'data' fires after 'close'. Matches libuv's per-datagram recheck.
+        if udp_socket.closed.get() {
+            break;
+        }
+
         let peer = buf.get_peer(i);
 
         let mut addr_buf = [0u8; INET6_ADDRSTRLEN + 1];

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -409,6 +409,55 @@ describe("udpSocket()", () => {
     }
   });
 
+  // The on_data callback receives a recvmmsg batch and iterates it. If the
+  // user's data handler closes the socket, the remaining packets in that
+  // batch must not be dispatched — matches libuv's per-datagram handle
+  // recheck (node:dgram relies on this for close() semantics).
+  test("close() from inside the data handler stops the rest of the recvmmsg batch", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const trace = [];
+        const server = await Bun.udpSocket({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            data(socket, buf) {
+              trace.push("data:" + socket.closed);
+              if (trace.length === 1) socket.close();
+            },
+          },
+        });
+        const client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1" });
+        const payload = [];
+        for (let i = 0; i < 32; i++) payload.push("x", server.port, "127.0.0.1");
+        // One sendmmsg syscall: on loopback the whole burst lands in the
+        // kernel recv queue before the event loop polls, so recvmmsg yields a
+        // multi-packet batch and on_data iterates more than once.
+        client.sendMany(payload);
+        // Let the event loop drain any additional recvmmsg rounds.
+        for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r));
+        client.close();
+        console.log(JSON.stringify(trace));
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderr = rawStderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderr).toBe("");
+    // Exactly one data event, observed while the socket was still open.
+    expect(stdout.trim()).toBe('["data:false"]');
+    expect(exitCode).toBe(0);
+  });
+
   // sendMany() iterates the input array and may run user JS (array index
   // getters, port `valueOf()`, address `toString()`). That user JS can
   // connect or disconnect the socket; sendMany must snapshot the connection

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -1,6 +1,56 @@
-import { describe, expect, it } from "bun:test";
-import { isIPv6, isMacOS, isWindows } from "harness";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, isIPv6, isMacOS, isWindows } from "harness";
 import * as dgram from "node:dgram";
+
+// close() from inside a 'message' handler must stop delivery of the remaining
+// datagrams in the current recvmmsg batch. Node guarantees no 'message' fires
+// after 'close'; previously bun replayed the rest of the batch into a handle
+// whose 'close' event and close() callback had already fired.
+test("node:dgram close() inside 'message' handler stops remaining batch datagrams", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import dgram from "node:dgram";
+      const trace = [];
+      const rx = dgram.createSocket("udp4");
+      await new Promise(r => rx.bind(0, "127.0.0.1", r));
+      const port = rx.address().port;
+      rx.on("message", d => {
+        trace.push("message:" + d.toString());
+        if (d.toString() === "0") rx.close(() => trace.push("closeCallback"));
+      });
+      rx.on("close", () => trace.push("closeEvent"));
+      const tx = dgram.createSocket("udp4");
+      tx.on("error", () => {});
+      // Queue a burst on the kernel rx buffer before the loop dispatches
+      // 'message'. Each send is awaited so its syscall has completed before
+      // the next one starts; on loopback this deterministically yields a
+      // multi-packet recvmmsg batch.
+      for (let i = 0; i < 16; i++) {
+        await new Promise(r => tx.send(String(i), port, "127.0.0.1", r));
+      }
+      // Let any queued 'message' / 'close' events drain.
+      for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r));
+      tx.close();
+      console.log(JSON.stringify(trace));
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const trace = JSON.parse(stdout.trim());
+  // The socket closes on the first datagram. Node ordering: 'close' event
+  // first, then the close() callback (both via queueMicrotask in dgram.ts).
+  expect({ stderr, trace }).toEqual({
+    stderr: "",
+    trace: ["message:0", "closeEvent", "closeCallback"],
+  });
+  expect(exitCode).toBe(0);
+});
 
 describe.skipIf(!isIPv6())("node:dgram", () => {
   it("adds membership successfully (IPv6)", () => {

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -41,7 +41,11 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = rawStderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
   const trace = JSON.parse(stdout.trim());
   // The socket closes on the first datagram. Node ordering: 'close' event
   // first, then the close() callback (both via queueMicrotask in dgram.ts).


### PR DESCRIPTION
## Problem

When a `Bun.udpSocket` `data` handler (and by extension a `node:dgram` `'message'` listener) calls `close()` on its own socket, the remaining packets of the current recvmmsg batch are still dispatched into the now-closed handle, after the `'close'` event and the `close()` callback have both already fired.

```js
import dgram from "node:dgram";
const trace = [];
const rx = dgram.createSocket("udp4");
await new Promise(r => rx.bind(0, "127.0.0.1", r));
rx.on("message", d => {
  trace.push("message:" + d);
  if (d.toString() === "1") rx.close(() => trace.push("closeCallback"));
});
rx.on("close", () => trace.push("closeEvent"));
const tx = dgram.createSocket("udp4");
for (const m of ["1", "2", "3"]) await new Promise(r => tx.send(m, rx.address().port, "127.0.0.1", r));
setTimeout(() => { tx.close(); console.log(JSON.stringify(trace)); }, 300);
// node v26:  ["message:1","closeEvent","closeCallback"]
// bun:       ["message:1","closeEvent","closeCallback","message:2","message:3"]
```

"Receive one, then close" is the shape of every one-shot UDP request/response and shutdown path; the post-close callbacks run against destroyed state (`this.address()` inside them throws `ERR_SOCKET_DGRAM_NOT_RUNNING`), and a burst of N datagrams yields up to N-1 post-close events controllable by any peer that can send a burst.

## Cause

`on_data()` in `src/runtime/socket/udp_socket.rs` iterates the uSockets recvmmsg packet buffer with `while i < packets { ... callback.call(...); i += 1 }` and never re-checks `udp_socket.closed` after a JS callback returns. `close()` called from inside such a callback sets `closed = true` and puts the underlying `us_udp_socket` on the loop's deferred-close list synchronously, so the flag is observable on the very next iteration. Node's libuv re-checks the handle between each datagram of a batch, so a socket closed from inside its own handler never sees another event.

## Fix

Re-check `udp_socket.closed` at the top of each packet iteration and break out of the batch once the socket has been closed. The outer uSockets `do { recvmmsg; on_data } while (!u->closed)` loop in `loop.c` already guards subsequent recv rounds; this change brings the inner per-packet loop in line.

## Verification

Both new tests fail on bun 1.4.0 (extra `data`/`message` events delivered on a closed socket) and pass with this change:

- `test/js/bun/udp/udp_socket.test.ts`: sends a 32-packet `sendMany` burst, closes from the first `data` callback, asserts exactly one `data` event fired while `socket.closed === false`.
- `test/js/node/dgram/node-dgram.test.js`: reproduces the node:dgram scenario above with a 16-packet burst, asserts the trace is exactly `["message:0","closeEvent","closeCallback"]`.