### PR TITLE
node:dgram: reject cross-family send/connect with EINVAL

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -826,10 +826,17 @@ function doConnect(ex, self, ip, address, port, callback) {
   }
 
   if (!ex) {
-    try {
-      connectFn.$call(state.handle.socket, ip, port);
-    } catch (e) {
-      ex = e;
+    // Node resolves the destination with uv_ip4_addr/uv_ip6_addr according to
+    // the socket type, so an address of the other family yields EINVAL before
+    // the kernel is ever reached.
+    if (isIP(ip) !== (self.type === "udp4" ? 4 : 6)) {
+      ex = new ExceptionWithHostPort(UV_EINVAL, "connect", address, port);
+    } else {
+      try {
+        connectFn.$call(state.handle.socket, ip, port);
+      } catch (e) {
+        ex = e;
+      }
     }
   }
 
@@ -1043,6 +1050,17 @@ function doSend(ex, self, ip, list, address, port, callback) {
   if (ip && state.sendBlockList?.check(ip, `ipv${isIP(ip)}`)) {
     if (callback) {
       process.nextTick(callback, $ERR_IP_BLOCKED(ip));
+    }
+    return;
+  }
+
+  // Node resolves the destination with uv_ip4_addr/uv_ip6_addr according to
+  // the socket type; a literal of the other family fails EINVAL and nothing is
+  // sent. Without this guard a udp6 socket would deliver to an IPv4 literal via
+  // the dual-stack kernel path.
+  if (ip !== null && isIP(ip) !== (self.type === "udp4" ? 4 : 6)) {
+    if (callback) {
+      process.nextTick(callback, new ExceptionWithHostPort(UV_EINVAL, "send", address, port));
     }
     return;
   }

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, jest, test } from "bun:test";
-import { createSocket } from "dgram";
+import { createSocket, Socket } from "dgram";
 import { Worker } from "node:worker_threads";
 
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isIPv6, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -332,6 +332,101 @@ describe("after close()", () => {
   test("Symbol.asyncDispose resolves when the socket is already closed", async () => {
     const { socket } = await boundThenClosed();
     expect(await socket[Symbol.asyncDispose]()).toBeUndefined();
+  });
+});
+
+describe.skipIf(!isIPv6())("cross-family destination", () => {
+  // Node resolves send/connect destinations with uv_ip4_addr or uv_ip6_addr
+  // according to the socket type; a literal of the other family yields EINVAL
+  // and no datagram is emitted.
+  async function bound(type: "udp4" | "udp6", address: string) {
+    const socket = createSocket(type);
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    socket.once("error", reject);
+    socket.bind(0, address, resolve);
+    await promise;
+    return socket;
+  }
+
+  function sendOnce(socket: Socket, payload: string, port: number, address: string) {
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    socket.send(payload, port, address, resolve);
+    return promise;
+  }
+
+  test.each([
+    ["udp6", "127.0.0.1", "::1"],
+    ["udp4", "::1", "127.0.0.1"],
+  ] as const)("%s socket send() to %s fails with EINVAL", async (type, dest, bindAddr) => {
+    const receiver = await bound("udp4", "127.0.0.1");
+    const received: string[] = [];
+    receiver.on("message", msg => received.push(String(msg)));
+    const sender = await bound(type, bindAddr);
+    sender.on("error", () => {});
+    try {
+      const err: any = await sendOnce(sender, "x", receiver.address().port, dest);
+      expect({
+        code: err?.code,
+        syscall: err?.syscall,
+        address: err?.address,
+        port: err?.port,
+      }).toEqual({
+        code: "EINVAL",
+        syscall: "send",
+        address: dest,
+        port: receiver.address().port,
+      });
+      // A matching-family send afterwards must still work and nothing from the
+      // rejected cross-family attempt may have been delivered.
+      if (type === "udp4") {
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        receiver.once("message", msg => (String(msg) === "ok" ? resolve() : reject(new Error(String(msg)))));
+        await sendOnce(sender, "ok", receiver.address().port, "127.0.0.1");
+        await promise;
+      }
+      expect(received).toEqual(type === "udp4" ? ["ok"] : []);
+    } finally {
+      sender.close();
+      receiver.close();
+    }
+  });
+
+  test("udp6 socket send() to ::ffff:127.0.0.1 succeeds", async () => {
+    const receiver = await bound("udp4", "127.0.0.1");
+    const sender = await bound("udp6", "::");
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      sender.on("error", reject);
+      receiver.once("message", msg => (String(msg) === "x" ? resolve() : reject(new Error(String(msg)))));
+      const err = await sendOnce(sender, "x", receiver.address().port, "::ffff:127.0.0.1");
+      expect(err).toBeNull();
+      await promise;
+    } finally {
+      sender.close();
+      receiver.close();
+    }
+  });
+
+  test.each([
+    ["udp6", "127.0.0.1"],
+    ["udp4", "::1"],
+  ] as const)("%s socket connect() to %s fails with EINVAL", async (type, dest) => {
+    const receiver = await bound("udp4", "127.0.0.1");
+    const client = createSocket(type);
+    client.on("error", () => {});
+    try {
+      const err: any = await new Promise(resolve => client.connect(receiver.address().port, dest, resolve));
+      expect({ code: err?.code, syscall: err?.syscall, address: err?.address }).toEqual({
+        code: "EINVAL",
+        syscall: "connect",
+        address: dest,
+      });
+    } finally {
+      try {
+        client.close();
+      } catch {}
+      receiver.close();
+    }
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Makes `node:dgram` match Node when a socket's address family does not match the destination literal: the send/connect callback receives `EINVAL` and nothing is put on the wire.

### Repro

```js
import dgram from "node:dgram";
const B4 = dgram.createSocket("udp4");
await new Promise(r => B4.bind(0, "127.0.0.1", r));

const S6 = dgram.createSocket("udp6"); S6.on("error", () => {});
S6.send("x", B4.address().port, "127.0.0.1", e => console.log(e?.code ?? null));
// node: EINVAL (and nothing is delivered)
// bun before: null (and the datagram is delivered to the IPv4 receiver)
// bun after: EINVAL (and nothing is delivered)
```

The mirror case (`udp4` socket sending to `"::1"`) also changes from `EAFNOSUPPORT` to `EINVAL` to match Node, and `connect()` gets the same treatment.

### Cause

Node's `udp6` handle wires `handle.send` to `Send6`, which builds the destination sockaddr with `uv_ip6_addr()`. Passing an IPv4 literal makes `inet_pton(AF_INET6, "127.0.0.1", ...)` fail and `UV_EINVAL` is returned before any syscall. Bun's native send path parsed the address family from the literal itself (AF_INET for `"127.0.0.1"`) and passed that sockaddr to the AF_INET6 socket. With `IPV6_V6ONLY=0` the Linux kernel accepts an AF_INET destination on an AF_INET6 socket, so the datagram was delivered instead of rejected.

### Fix

In `doSend` / `doConnect`, compare `isIP(ip)` against the socket's type and surface `ExceptionWithHostPort(UV_EINVAL, "send"|"connect", address, port)` on mismatch, matching Node's error shape (`code`, `errno`, `syscall`, `address`, `port`). The Bun-native `Bun.udpSocket` send path is unchanged; only the `node:dgram` compat layer is affected. Sending to `::ffff:127.0.0.1` from a `udp6` socket continues to work.

Rebased onto #32625, which already introduced a platform-correct `UV_EINVAL` constant and `ExceptionWithHostPort` in this file, so the fix reuses those directly.

## How did you verify your code works?

```
bun bd test test/js/bun/udp/dgram.test.ts   # 66 pass (5 new)
```

All 75 ported `test/js/node/test/parallel/test-dgram-*.js` files still pass, and the repro above now produces identical output under Bun and Node.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/dgram.test.ts

<!-- robobun:evidence:end -->