### PR TITLE
sql(postgres): reject duplicate authentication requests

### DIFF
--- a/src/sql_jsc/postgres/AuthenticationState.rs
+++ b/src/sql_jsc/postgres/AuthenticationState.rs
@@ -6,6 +6,7 @@ pub enum AuthenticationState {
     Ok,
     Sasl(SASL),
     Md5,
+    ClearText,
 }
 
 impl AuthenticationState {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -972,7 +972,13 @@ impl PostgresSQLConnection {
         self.ref_();
         self.update_flags(|f| f.insert(ConnectionFlags::IS_PROCESSING_DATA));
 
-        self.disable_connection_timeout();
+        // connectionTimeout bounds the whole handshake (connect → ReadyForQuery),
+        // so it keeps running across packets until `set_status(Connected)`
+        // switches the timer to the idle interval. Resetting it per packet
+        // would let a server that trickles bytes defeat the bound.
+        if self.status.get() == Status::Connected {
+            self.disable_connection_timeout();
+        }
 
         let event_loop = self.event_loop();
         event_loop.enter();
@@ -1062,7 +1068,9 @@ impl PostgresSQLConnection {
         self.update_flags(|f| f.remove(ConnectionFlags::IS_PROCESSING_DATA));
 
         // reset the connection timeout after we're done processing the data
-        self.reset_connection_timeout();
+        if self.status.get() == Status::Connected {
+            self.reset_connection_timeout();
+        }
         // SAFETY: `self` is a live Box-allocated connection; this releases one ref.
         unsafe { Self::deref(self.as_ctx_ptr()) };
     }
@@ -2598,13 +2606,20 @@ impl PostgresSQLConnection {
 
                 match &auth {
                     protocol::Authentication::SASL => {
+                        // AuthenticationSASL starts a new exchange and is only
+                        // valid before any authentication exchange has begun.
+                        // libpq rejects this as "duplicate SASL authentication
+                        // request"; answering it again loops unboundedly
+                        // against a malicious/MITM server.
                         if !matches!(
                             self.authentication_state.get(),
-                            AuthenticationState::Sasl(_)
+                            AuthenticationState::Pending
                         ) {
-                            self.authentication_state
-                                .set(AuthenticationState::Sasl(Default::default()));
+                            debug!("duplicate AuthenticationSASL");
+                            return Err(AnyPostgresError::UnexpectedMessage);
                         }
+                        self.authentication_state
+                            .set(AuthenticationState::Sasl(Default::default()));
 
                         let mut mechanism_buf = [0u8; 128];
                         // `sasl` borrow ends before `self.writer()`/`self.flush_data()`
@@ -2821,17 +2836,33 @@ impl PostgresSQLConnection {
                     }
 
                     protocol::Authentication::ClearTextPassword => {
+                        if !matches!(
+                            self.authentication_state.get(),
+                            AuthenticationState::Pending
+                        ) {
+                            debug!("duplicate AuthenticationCleartextPassword");
+                            return Err(AnyPostgresError::UnexpectedMessage);
+                        }
                         debug!("ClearTextPassword");
                         let response = protocol::PasswordMessage {
                             // password is a valid slice into options_buf.
                             password: Data::Temporary(self.password),
                         };
 
+                        self.authentication_state
+                            .set(AuthenticationState::ClearText);
                         response.write_internal(&mut self.writer())?;
                         self.flush_data();
                     }
 
                     protocol::Authentication::MD5Password { salt } => {
+                        if !matches!(
+                            self.authentication_state.get(),
+                            AuthenticationState::Pending
+                        ) {
+                            debug!("duplicate AuthenticationMD5Password");
+                            return Err(AnyPostgresError::UnexpectedMessage);
+                        }
                         debug!("MD5Password");
                         // Format is: md5 + md5(md5(password + username) + salt)
                         let mut first_hash_buf: [u8; 16] = Default::default();

--- a/test/js/sql/postgres-duplicate-auth-request.test.ts
+++ b/test/js/sql/postgres-duplicate-auth-request.test.ts
@@ -12,7 +12,6 @@
 // "duplicate SASL authentication request".
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import type net from "node:net";
 import {
   listeningServer,
   pgAuthenticationCleartextPassword,

--- a/test/js/sql/postgres-duplicate-auth-request.test.ts
+++ b/test/js/sql/postgres-duplicate-auth-request.test.ts
@@ -1,0 +1,199 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// A server (or MITM) that answers the client's password / SASLInitialResponse
+// with another Authentication{SASL,CleartextPassword,MD5Password} request
+// drove the client into an unbounded authentication loop at 100% CPU, and
+// connectionTimeout never fired because every arriving packet reset the
+// connect-phase timer. libpq rejects a second AuthenticationSASL with
+// "duplicate SASL authentication request".
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import type net from "node:net";
+import {
+  listeningServer,
+  pgAuthenticationCleartextPassword,
+  pgAuthenticationMD5Password,
+  pgAuthenticationOk,
+  pgAuthenticationSASL,
+  pgReadyForQuery,
+} from "./wire-frames";
+
+/**
+ * Answer the startup packet with `request`, then answer every subsequent
+ * client message (PasswordMessage / SASLInitialResponse, type 'p') with the
+ * same `request` again, up to `limit` times. Resolves to the error the
+ * client surfaced and the number of 'p' responses observed.
+ */
+async function duplicateAuthRequest(request: Buffer, limit: number) {
+  let responses = 0;
+  const { port, server } = await listeningServer(socket => {
+    let buf = Buffer.alloc(0);
+    let sawStartup = false;
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      for (;;) {
+        if (!sawStartup) {
+          // StartupMessage: Int32(len) Int32(protocol) ...; no leading type byte.
+          if (buf.length < 4) return;
+          const len = buf.readInt32BE(0);
+          if (buf.length < len) return;
+          sawStartup = true;
+          buf = buf.subarray(len);
+          socket.write(request);
+          continue;
+        }
+        if (buf.length < 5) return;
+        const len = buf.readInt32BE(1);
+        if (buf.length < 1 + len) return;
+        const type = String.fromCharCode(buf[0]);
+        buf = buf.subarray(1 + len);
+        if (type !== "p") continue;
+        responses++;
+        if (responses >= limit) {
+          socket.destroy();
+          return;
+        }
+        socket.write(request);
+      }
+    });
+  });
+
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 2,
+  });
+  let err: any;
+  try {
+    await db.connect();
+    err = new Error("expected connect() to reject");
+  } catch (e) {
+    err = e;
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  return { err, responses };
+}
+
+const methods = [
+  { name: "AuthenticationSASL", frame: pgAuthenticationSASL() },
+  { name: "AuthenticationCleartextPassword", frame: pgAuthenticationCleartextPassword() },
+  { name: "AuthenticationMD5Password", frame: pgAuthenticationMD5Password() },
+];
+
+test.each(methods)("postgres: duplicate $name is rejected, not answered again", async ({ frame }) => {
+  const limit = 50;
+  const { err, responses } = await duplicateAuthRequest(frame, limit);
+  // The client must answer the first request (responses == 1) and then error
+  // on the duplicate without answering it. Before the fix `responses` hit
+  // `limit` in a few milliseconds.
+  expect({ code: err.code, responses }).toEqual({
+    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
+    responses: 1,
+  });
+});
+
+// Mixed sequences: a second authentication-start message of any kind after
+// a first of a different kind is equally a protocol violation.
+const mixed = [
+  { name: "SASL after CleartextPassword", first: pgAuthenticationCleartextPassword(), second: pgAuthenticationSASL() },
+  { name: "CleartextPassword after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationCleartextPassword() },
+  { name: "MD5Password after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationMD5Password() },
+];
+
+test.each(mixed)("postgres: $name is rejected", async ({ first, second }) => {
+  const limit = 50;
+  let responses = 0;
+  const { port, server } = await listeningServer(socket => {
+    let buf = Buffer.alloc(0);
+    let sawStartup = false;
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      for (;;) {
+        if (!sawStartup) {
+          if (buf.length < 4) return;
+          const len = buf.readInt32BE(0);
+          if (buf.length < len) return;
+          sawStartup = true;
+          buf = buf.subarray(len);
+          socket.write(first);
+          continue;
+        }
+        if (buf.length < 5) return;
+        const len = buf.readInt32BE(1);
+        if (buf.length < 1 + len) return;
+        const type = String.fromCharCode(buf[0]);
+        buf = buf.subarray(1 + len);
+        if (type !== "p") continue;
+        responses++;
+        if (responses >= limit) {
+          socket.destroy();
+          return;
+        }
+        socket.write(second);
+      }
+    });
+  });
+
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 2,
+  });
+  let err: any;
+  try {
+    await db.connect();
+    err = new Error("expected connect() to reject");
+  } catch (e) {
+    err = e;
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  expect({ code: err.code, responses }).toEqual({
+    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
+    responses: 1,
+  });
+});
+
+// Boundary: the normal single-request flow for each method still connects.
+async function singleRequestConnects(request: Buffer) {
+  const { port, server } = await listeningServer(socket => {
+    let sawStartup = false;
+    socket.on("error", () => {});
+    socket.on("data", () => {
+      if (!sawStartup) {
+        sawStartup = true;
+        socket.write(request);
+        return;
+      }
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    });
+  });
+  const db = new SQL({
+    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
+    max: 1,
+    connectionTimeout: 2,
+  });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 });
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test("postgres: a single AuthenticationCleartextPassword still connects", async () => {
+  await singleRequestConnects(pgAuthenticationCleartextPassword());
+});
+
+test("postgres: a single AuthenticationMD5Password still connects", async () => {
+  await singleRequestConnects(pgAuthenticationMD5Password());
+});

--- a/test/js/sql/postgres-duplicate-auth-request.test.ts
+++ b/test/js/sql/postgres-duplicate-auth-request.test.ts
@@ -22,12 +22,12 @@ import {
 } from "./wire-frames";
 
 /**
- * Answer the startup packet with `request`, then answer every subsequent
- * client message (PasswordMessage / SASLInitialResponse, type 'p') with the
- * same `request` again, up to `limit` times. Resolves to the error the
- * client surfaced and the number of 'p' responses observed.
+ * Answer the startup packet with `first`, then answer every subsequent client
+ * message (PasswordMessage / SASLInitialResponse, type 'p') with `second`, up
+ * to `limit` times. Resolves to the error the client surfaced and the number
+ * of 'p' responses observed.
  */
-async function duplicateAuthRequest(request: Buffer, limit: number) {
+async function duplicateAuthRequest(first: Buffer, second: Buffer, limit: number) {
   let responses = 0;
   const { port, server } = await listeningServer(socket => {
     let buf = Buffer.alloc(0);
@@ -38,85 +38,6 @@ async function duplicateAuthRequest(request: Buffer, limit: number) {
       for (;;) {
         if (!sawStartup) {
           // StartupMessage: Int32(len) Int32(protocol) ...; no leading type byte.
-          if (buf.length < 4) return;
-          const len = buf.readInt32BE(0);
-          if (buf.length < len) return;
-          sawStartup = true;
-          buf = buf.subarray(len);
-          socket.write(request);
-          continue;
-        }
-        if (buf.length < 5) return;
-        const len = buf.readInt32BE(1);
-        if (buf.length < 1 + len) return;
-        const type = String.fromCharCode(buf[0]);
-        buf = buf.subarray(1 + len);
-        if (type !== "p") continue;
-        responses++;
-        if (responses >= limit) {
-          socket.destroy();
-          return;
-        }
-        socket.write(request);
-      }
-    });
-  });
-
-  const db = new SQL({
-    url: `postgres://u:pw@127.0.0.1:${port}/db?sslmode=disable`,
-    max: 1,
-    connectionTimeout: 2,
-  });
-  let err: any;
-  try {
-    await db.connect();
-    err = new Error("expected connect() to reject");
-  } catch (e) {
-    err = e;
-  } finally {
-    await db.close({ timeout: 0 });
-    await new Promise<void>(r => server.close(() => r()));
-  }
-  return { err, responses };
-}
-
-const methods = [
-  { name: "AuthenticationSASL", frame: pgAuthenticationSASL() },
-  { name: "AuthenticationCleartextPassword", frame: pgAuthenticationCleartextPassword() },
-  { name: "AuthenticationMD5Password", frame: pgAuthenticationMD5Password() },
-];
-
-test.each(methods)("postgres: duplicate $name is rejected, not answered again", async ({ frame }) => {
-  const limit = 50;
-  const { err, responses } = await duplicateAuthRequest(frame, limit);
-  // The client must answer the first request (responses == 1) and then error
-  // on the duplicate without answering it. Before the fix `responses` hit
-  // `limit` in a few milliseconds.
-  expect({ code: err.code, responses }).toEqual({
-    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
-    responses: 1,
-  });
-});
-
-// Mixed sequences: a second authentication-start message of any kind after
-// a first of a different kind is equally a protocol violation.
-const mixed = [
-  { name: "SASL after CleartextPassword", first: pgAuthenticationCleartextPassword(), second: pgAuthenticationSASL() },
-  { name: "CleartextPassword after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationCleartextPassword() },
-  { name: "MD5Password after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationMD5Password() },
-];
-
-test.each(mixed)("postgres: $name is rejected", async ({ first, second }) => {
-  const limit = 50;
-  let responses = 0;
-  const { port, server } = await listeningServer(socket => {
-    let buf = Buffer.alloc(0);
-    let sawStartup = false;
-    socket.on("error", () => {});
-    socket.on("data", chunk => {
-      buf = Buffer.concat([buf, chunk]);
-      for (;;) {
-        if (!sawStartup) {
           if (buf.length < 4) return;
           const len = buf.readInt32BE(0);
           if (buf.length < len) return;
@@ -156,6 +77,36 @@ test.each(mixed)("postgres: $name is rejected", async ({ first, second }) => {
     await db.close({ timeout: 0 });
     await new Promise<void>(r => server.close(() => r()));
   }
+  return { err, responses };
+}
+
+const methods = [
+  { name: "AuthenticationSASL", frame: pgAuthenticationSASL() },
+  { name: "AuthenticationCleartextPassword", frame: pgAuthenticationCleartextPassword() },
+  { name: "AuthenticationMD5Password", frame: pgAuthenticationMD5Password() },
+];
+
+test.each(methods)("postgres: duplicate $name is rejected, not answered again", async ({ frame }) => {
+  const { err, responses } = await duplicateAuthRequest(frame, frame, 50);
+  // The client must answer the first request (responses == 1) and then error
+  // on the duplicate without answering it. Before the fix `responses` hit the
+  // limit in a few milliseconds.
+  expect({ code: err.code, responses }).toEqual({
+    code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
+    responses: 1,
+  });
+});
+
+// Mixed sequences: a second authentication-start message of any kind after
+// a first of a different kind is equally a protocol violation.
+const mixed = [
+  { name: "SASL after CleartextPassword", first: pgAuthenticationCleartextPassword(), second: pgAuthenticationSASL() },
+  { name: "CleartextPassword after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationCleartextPassword() },
+  { name: "MD5Password after SASL", first: pgAuthenticationSASL(), second: pgAuthenticationMD5Password() },
+];
+
+test.each(mixed)("postgres: $name is rejected", async ({ first, second }) => {
+  const { err, responses } = await duplicateAuthRequest(first, second, 50);
   expect({ code: err.code, responses }).toEqual({
     code: "ERR_POSTGRES_UNEXPECTED_MESSAGE",
     responses: 1,

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -88,6 +88,22 @@ export function pgAuthenticationCleartextPassword(): Buffer {
   return buf;
 }
 
+// PostgreSQL FE/BE protocol §55.7 AuthenticationMD5Password: Byte1('R') Int32(12) Int32(5) Byte4(salt)
+export function pgAuthenticationMD5Password(salt: Buffer = Buffer.alloc(4, 0x61)): Buffer {
+  const buf = Buffer.alloc(13);
+  buf.write("R", 0);
+  buf.writeInt32BE(12, 1);
+  buf.writeInt32BE(5, 5);
+  salt.copy(buf, 9);
+  return buf;
+}
+
+// PostgreSQL FE/BE protocol §55.7 AuthenticationSASL: Byte1('R') Int32(len) Int32(10) (String mechanism)* Byte1(0)
+export function pgAuthenticationSASL(mechanisms: string[] = ["SCRAM-SHA-256"]): Buffer {
+  const body = Buffer.concat([pgInt32(10), ...mechanisms.map(m => pgCString(m)), Buffer.from([0])]);
+  return pgRaw("R", body);
+}
+
 // PostgreSQL FE/BE protocol §55.7 ReadyForQuery: Byte1('Z') Int32(5) Byte1(status)
 export function pgReadyForQuery(status: "I" | "T" | "E" = "I"): Buffer {
   const buf = Buffer.alloc(6);


### PR DESCRIPTION
## Problem

A server (or active MITM in the non-TLS / `sslmode < verify-ca` cases) that answers the client's `SASLInitialResponse` with another `AuthenticationSASL` (`R`, code 10) drives Bun into an unbounded 100% CPU authentication loop, pre-auth, with no application-visible signal. `connectionTimeout` never fires because every arriving packet resets the connect-phase timer. The same holds for repeated `AuthenticationCleartextPassword` and `AuthenticationMD5Password`.

```
client sent 200 SASLInitialResponses to 200 AuthenticationSASL requests on ONE connection in 18ms (connectionTimeout: 2 never fired)
BUG: unbounded authentication loop, 100% CPU, no timeout
```

libpq rejects this as `duplicate SASL authentication request`.

## Cause

The `Authentication::SASL` arm in `PostgresSQLConnection.rs` accepted code 10 in every authentication state (it did `if !matches!(state, Sasl(_)) { set Sasl(default) }` then unconditionally sent a fresh `SASLInitialResponse`). The `ClearTextPassword` and `MD5Password` arms had no state check at all. Separately, `on_data` bracketed processing with `disable_connection_timeout()` / `reset_connection_timeout()`, making the connect deadline per-packet rather than per-connect.

## Fix

`AuthenticationSASL`, `AuthenticationCleartextPassword` and `AuthenticationMD5Password` each start an authentication exchange and are now only accepted while `authentication_state` is `Pending`; any later arrival is rejected with `ERR_POSTGRES_UNEXPECTED_MESSAGE`. A new `AuthenticationState::ClearText` variant records that a cleartext password was sent. `on_data` now leaves the connect-phase timer running until `ReadyForQuery` transitions the connection to `Connected`.

## Verification

- New `test/js/sql/postgres-duplicate-auth-request.test.ts` with a scripted wire server: duplicate and mixed-method auth requests are rejected after exactly one response; the single-request happy paths for cleartext and MD5 still connect.
- Real SCRAM-SHA-256 and MD5 logins against a local PostgreSQL instance still succeed.
- Existing `test/js/sql/` wire-protocol and connection tests pass.