### PR TITLE
process.memoryUsage: count Buffer/typed-array backing stores in arrayBuffers

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3751,6 +3751,26 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
         return {};
     }
 
+    // Sample all heap statistics before allocating the result object so that
+    // constructEmptyObject() cannot trigger a collection between the caller's
+    // last allocation and the heap walk below.
+    JSC::DeferGC deferGC(vm);
+
+    size_t heapTotal = vm.heap.blockBytesAllocated();
+    size_t heapUsed = vm.heap.sizeAfterLastEdenCollection();
+
+    // heap.arrayBufferSize() misses OversizeTypedArray backing stores and adds
+    // sizeof(ArrayBuffer) overhead per entry, so walk the relevant subspaces
+    // and report exact byteLength like Node.js does.
+    size_t arrayBuffers = computeArrayBuffersBytes(vm);
+
+    // Node documents arrayBuffers as a subset of external. extraMemorySize()
+    // only re-accumulates OversizeTypedArray bytes during GC marking, so clamp
+    // external to be at least arrayBuffers to preserve that relationship.
+    size_t external = vm.heap.extraMemorySize() + vm.heap.externalMemorySize();
+    if (external < arrayBuffers)
+        external = arrayBuffers;
+
     JSC::JSObject* result = JSC::constructEmptyObject(vm, process->memoryUsageStructure());
     if (throwScope.exception()) [[unlikely]] {
         return {};
@@ -3766,24 +3786,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     // }
 
     result->putDirectOffset(vm, 0, JSC::jsNumber(current_rss));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.blockBytesAllocated()));
-
-    // heap.size() loops through every cell...
-    // TODO: add a binding for heap.sizeAfterLastCollection()
-    result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
-
-    // heap.arrayBufferSize() misses OversizeTypedArray backing stores and adds
-    // sizeof(ArrayBuffer) overhead per entry, so walk the relevant subspaces
-    // and report exact byteLength like Node.js does.
-    size_t arrayBuffers = computeArrayBuffersBytes(vm);
-
-    // Node documents arrayBuffers as a subset of external. extraMemorySize()
-    // only re-accumulates OversizeTypedArray bytes during GC marking, so clamp
-    // external to be at least arrayBuffers to preserve that relationship.
-    size_t external = vm.heap.extraMemorySize() + vm.heap.externalMemorySize();
-    if (external < arrayBuffers)
-        external = arrayBuffers;
-
+    result->putDirectOffset(vm, 1, JSC::jsNumber(heapTotal));
+    result->putDirectOffset(vm, 2, JSC::jsNumber(heapUsed));
     result->putDirectOffset(vm, 3, JSC::jsNumber(external));
     result->putDirectOffset(vm, 4, JSC::jsNumber(arrayBuffers));
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -47,9 +47,12 @@
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/HeapIterationScope.h>
+#include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/JSArrayBufferView.h>
+#include <JavaScriptCore/JSDataView.h>
 #include <JavaScriptCore/MarkedBlockInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <wtf/HashSet.h>
 #include "wtf-bindings.h"
 #include "EventLoopTask.h"
 #include <JavaScriptCore/StructureCache.h>
@@ -3675,37 +3678,64 @@ err:
 #endif
 }
 
-// Bytes of live OversizeTypedArray backing stores (Buffer.alloc / new Uint8Array
-// whose .buffer was never materialized). Off-heap but not registered via
-// heap.addReference(), so heap.arrayBufferSize() does not see them.
-static size_t oversizeTypedArrayBytes(JSC::VM& vm)
+// Sum the byteLength of every live ArrayBuffer / SharedArrayBuffer plus every
+// OversizeTypedArray backing store. heap.arrayBufferSize() adds
+// sizeof(ArrayBuffer) overhead per buffer and ignores OversizeTypedArray.
+static size_t computeArrayBuffersBytes(JSC::VM& vm)
 {
     using namespace JSC;
 
     size_t total = 0;
-    auto accumulate = [&](IsoSubspace* space) {
+    UncheckedKeyHashSet<ArrayBuffer*> buffers;
+
+    auto visitViews = [&](IsoSubspace* space) {
         if (!space)
             return;
         space->forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
             auto* view = static_cast<JSArrayBufferView*>(static_cast<JSCell*>(cell));
-            if (view->mode() == OversizeTypedArray)
+            TypedArrayMode mode = view->mode();
+            if (mode == OversizeTypedArray)
                 total += view->byteLengthRaw();
+            else if (isWastefulTypedArray(mode)) {
+                if (ArrayBuffer* buffer = view->butterfly()->indexingHeader()->arrayBuffer())
+                    buffers.add(buffer);
+            }
         });
     };
 
     HeapIterationScope iterationScope(vm.heap);
-    accumulate(vm.heap.int8ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.int16ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.int32ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.uint8ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.uint8ClampedArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.uint16ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.uint32ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.float16ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.float32ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.float64ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.bigInt64ArraySpace<SubspaceAccess::Concurrently>());
-    accumulate(vm.heap.bigUint64ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.int8ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.int16ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.int32ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.uint8ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.uint8ClampedArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.uint16ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.uint32ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.float16ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.float32ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.float64ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.bigInt64ArraySpace<SubspaceAccess::Concurrently>());
+    visitViews(vm.heap.bigUint64ArraySpace<SubspaceAccess::Concurrently>());
+
+    if (auto* space = vm.heap.dataViewSpace<SubspaceAccess::Concurrently>()) {
+        space->forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
+            auto* view = static_cast<JSDataView*>(static_cast<JSCell*>(cell));
+            if (ArrayBuffer* buffer = view->possiblySharedBuffer())
+                buffers.add(buffer);
+        });
+    }
+
+    if (auto* space = vm.heap.arrayBufferSpace<SubspaceAccess::Concurrently>()) {
+        space->forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
+            auto* wrapper = static_cast<JSArrayBuffer*>(static_cast<JSCell*>(cell));
+            if (ArrayBuffer* buffer = wrapper->impl())
+                buffers.add(buffer);
+        });
+    }
+
+    for (ArrayBuffer* buffer : buffers)
+        total += buffer->byteLength();
+
     return total;
 }
 
@@ -3742,10 +3772,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     // TODO: add a binding for heap.sizeAfterLastCollection()
     result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
 
-    // arrayBufferSize() only counts buffers registered via addReference();
-    // add OversizeTypedArray backing stores so Buffer.alloc / new Uint8Array
-    // are reflected like Node.js documents.
-    size_t arrayBuffers = vm.heap.arrayBufferSize() + oversizeTypedArrayBytes(vm);
+    // heap.arrayBufferSize() misses OversizeTypedArray backing stores and adds
+    // sizeof(ArrayBuffer) overhead per entry, so walk the relevant subspaces
+    // and report exact byteLength like Node.js does.
+    size_t arrayBuffers = computeArrayBuffersBytes(vm);
 
     // Node documents arrayBuffers as a subset of external. extraMemorySize()
     // only re-accumulates OversizeTypedArray bytes during GC marking, so clamp

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -46,6 +46,10 @@
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <JavaScriptCore/HeapIterationScope.h>
+#include <JavaScriptCore/JSArrayBufferView.h>
+#include <JavaScriptCore/MarkedBlockInlines.h>
+#include <JavaScriptCore/SubspaceInlines.h>
 #include "wtf-bindings.h"
 #include "EventLoopTask.h"
 #include <JavaScriptCore/StructureCache.h>
@@ -3671,6 +3675,40 @@ err:
 #endif
 }
 
+// Bytes of live OversizeTypedArray backing stores (Buffer.alloc / new Uint8Array
+// whose .buffer was never materialized). Off-heap but not registered via
+// heap.addReference(), so heap.arrayBufferSize() does not see them.
+static size_t oversizeTypedArrayBytes(JSC::VM& vm)
+{
+    using namespace JSC;
+
+    size_t total = 0;
+    auto accumulate = [&](IsoSubspace* space) {
+        if (!space)
+            return;
+        space->forEachLiveCell([&](HeapCell* cell, HeapCell::Kind) {
+            auto* view = static_cast<JSArrayBufferView*>(static_cast<JSCell*>(cell));
+            if (view->mode() == OversizeTypedArray)
+                total += view->byteLengthRaw();
+        });
+    };
+
+    HeapIterationScope iterationScope(vm.heap);
+    accumulate(vm.heap.int8ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.int16ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.int32ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.uint8ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.uint8ClampedArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.uint16ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.uint32ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.float16ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.float32ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.float64ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.bigInt64ArraySpace<SubspaceAccess::Concurrently>());
+    accumulate(vm.heap.bigUint64ArraySpace<SubspaceAccess::Concurrently>());
+    return total;
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3704,20 +3742,20 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     // TODO: add a binding for heap.sizeAfterLastCollection()
     result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
 
-    result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
+    // arrayBufferSize() only counts buffers registered via addReference();
+    // add OversizeTypedArray backing stores so Buffer.alloc / new Uint8Array
+    // are reflected like Node.js documents.
+    size_t arrayBuffers = vm.heap.arrayBufferSize() + oversizeTypedArrayBytes(vm);
 
-    // JSC won't count this number until vm.heap.addReference() is called.
-    // That will only happen in cases like:
-    // - new ArrayBuffer()
-    // - new Uint8Array(42).buffer
-    // - fs.readFile(path, "utf-8") (sometimes)
-    // - ...
-    //
-    // But it won't happen in cases like:
-    // - new Uint8Array(42)
-    // - Buffer.alloc(42)
-    // - new Uint8Array(42).slice()
-    result->putDirectOffset(vm, 4, JSC::jsNumber(vm.heap.arrayBufferSize()));
+    // Node documents arrayBuffers as a subset of external. extraMemorySize()
+    // only re-accumulates OversizeTypedArray bytes during GC marking, so clamp
+    // external to be at least arrayBuffers to preserve that relationship.
+    size_t external = vm.heap.extraMemorySize() + vm.heap.externalMemorySize();
+    if (external < arrayBuffers)
+        external = arrayBuffers;
+
+    result->putDirectOffset(vm, 3, JSC::jsNumber(external));
+    result->putDirectOffset(vm, 4, JSC::jsNumber(arrayBuffers));
 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(result));
 }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1464,13 +1464,6 @@ it("process._exiting", () => {
   expect(process._exiting).toBe(false);
 });
 
-it("process.memoryUsage.arrayBuffers", () => {
-  const initial = process.memoryUsage().arrayBuffers;
-  const array = new ArrayBuffer(1024 * 1024 * 16);
-  array.buffer;
-  expect(process.memoryUsage().arrayBuffers).toBeGreaterThanOrEqual(initial + 16 * 1024 * 1024);
-});
-
 it("process.memoryUsage.arrayBuffers counts Buffer and typed array allocations", async () => {
   // Run in a subprocess so GC activity in the test runner cannot disturb the
   // before/after deltas.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1468,7 +1468,7 @@ it("process.memoryUsage.arrayBuffers counts Buffer and typed array allocations",
   // Run in a subprocess so GC activity in the test runner cannot disturb the
   // before/after deltas.
   const script = `
-    const MB = 1 << 20, N = 8, SZ = 8 * MB, TOTAL = N * SZ;
+    const MB = 1 << 20, N = 8, SZ = 8 * MB;
     const held = [];
 
     const a0 = process.memoryUsage().arrayBuffers;

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1494,15 +1494,17 @@ it("process.memoryUsage.arrayBuffers counts Buffer and typed array allocations",
     for (let i = 0; i < N; i++) held[i].buffer;
     const a4after = process.memoryUsage().arrayBuffers;
 
-    const e = process.memoryUsage().external;
+    // Sample external and arrayBuffers from the same call; the clamp only
+    // guarantees external >= arrayBuffers within a single memoryUsage() call.
+    const m = process.memoryUsage();
 
     process.stdout.write(JSON.stringify({
       bufferAlloc: a1 - a0,
       uint8Array: a2 - a1,
       arrayBuffer: a3 - a2,
       promoteDelta: a4after - a4before,
-      external: e,
-      arrayBuffers: process.memoryUsage().arrayBuffers,
+      external: m.external,
+      arrayBuffers: m.arrayBuffers,
     }));
   `;
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1471,6 +1471,93 @@ it("process.memoryUsage.arrayBuffers", () => {
   expect(process.memoryUsage().arrayBuffers).toBeGreaterThanOrEqual(initial + 16 * 1024 * 1024);
 });
 
+it("process.memoryUsage.arrayBuffers counts Buffer and typed array allocations", async () => {
+  // Run in a subprocess so GC activity in the test runner cannot disturb the
+  // before/after deltas.
+  const script = `
+    const MB = 1 << 20, N = 8, SZ = 8 * MB, TOTAL = N * SZ;
+    const held = [];
+
+    const a0 = process.memoryUsage().arrayBuffers;
+    for (let i = 0; i < N; i++) held.push(Buffer.alloc(SZ));
+    const a1 = process.memoryUsage().arrayBuffers;
+
+    for (let i = 0; i < N; i++) held.push(new Uint8Array(SZ));
+    const a2 = process.memoryUsage().arrayBuffers;
+
+    for (let i = 0; i < N; i++) held.push(new ArrayBuffer(SZ));
+    const a3 = process.memoryUsage().arrayBuffers;
+
+    // Touching .buffer promotes the backing store to a real ArrayBuffer;
+    // the reported total must not move by more than the promoted bytes.
+    const a4before = process.memoryUsage().arrayBuffers;
+    for (let i = 0; i < N; i++) held[i].buffer;
+    const a4after = process.memoryUsage().arrayBuffers;
+
+    const e = process.memoryUsage().external;
+
+    process.stdout.write(JSON.stringify({
+      bufferAlloc: a1 - a0,
+      uint8Array: a2 - a1,
+      arrayBuffer: a3 - a2,
+      promoteDelta: a4after - a4before,
+      external: e,
+      arrayBuffers: process.memoryUsage().arrayBuffers,
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = JSON.parse(stdout);
+
+  const TOTAL = 8 * 8 * (1 << 20);
+  // Every allocation path should move the counter by at least the bytes
+  // allocated (allowing a small amount of bookkeeping overhead on top).
+  expect(result.bufferAlloc).toBeGreaterThanOrEqual(TOTAL);
+  expect(result.bufferAlloc).toBeLessThan(TOTAL * 1.5);
+  expect(result.uint8Array).toBeGreaterThanOrEqual(TOTAL);
+  expect(result.uint8Array).toBeLessThan(TOTAL * 1.5);
+  expect(result.arrayBuffer).toBeGreaterThanOrEqual(TOTAL);
+  expect(result.arrayBuffer).toBeLessThan(TOTAL * 1.5);
+  // Promoting an already-counted backing store to an ArrayBuffer must not
+  // double-count it (allow some slack for JSArrayBuffer cell overhead).
+  expect(Math.abs(result.promoteDelta)).toBeLessThan(TOTAL * 0.25);
+  // Node documents arrayBuffers as a subset of external.
+  expect(result.external).toBeGreaterThanOrEqual(result.arrayBuffers);
+  expect(exitCode).toBe(0);
+});
+
+it("process.memoryUsage.arrayBuffers drops after Buffers are collected", async () => {
+  const script = `
+    const SZ = 8 << 20, N = 8;
+    let held = [];
+    for (let i = 0; i < N; i++) held.push(Buffer.alloc(SZ));
+    process.stdout.write(process.memoryUsage().arrayBuffers + " ");
+    held = null;
+    Bun.gc(true);
+    Bun.gc(true);
+    process.stdout.write(String(process.memoryUsage().arrayBuffers));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [during, after] = stdout.trim().split(" ").map(Number);
+  const TOTAL = 8 * (8 << 20);
+  expect(during).toBeGreaterThanOrEqual(TOTAL);
+  expect(after).toBeLessThan(TOTAL * 0.5);
+  expect(exitCode).toBe(0);
+});
+
 it("should handle user assigned `default` properties", async () => {
   process.default = 1;
   process.hello = 2;


### PR DESCRIPTION
### What does this PR do?

Makes `process.memoryUsage().arrayBuffers` count `Buffer` and typed-array allocations that never materialize a backing `ArrayBuffer`, and report exact `byteLength` totals, matching Node.js which documents the field as "memory allocated for ArrayBuffers and SharedArrayBuffers, including all Node.js Buffers".

```js
const MB = 1 << 20, N = 8, SZ = 8 * MB;
const held = [];
const a0 = process.memoryUsage().arrayBuffers;
for (let i = 0; i < N; i++) held.push(Buffer.alloc(SZ, i));
const a1 = process.memoryUsage().arrayBuffers;
for (let i = 0; i < N; i++) held.push(new Uint8Array(new ArrayBuffer(SZ)).fill(i));
const a2 = process.memoryUsage().arrayBuffers;
console.log("Buffer.alloc     64 MiB -> arrayBuffers delta =", a1 - a0);
console.log("new ArrayBuffer  64 MiB -> arrayBuffers delta =", a2 - a1);
```

Before: `Buffer.alloc` delta = 0, `new ArrayBuffer` delta = 67109632 (64 MiB + 8 x sizeof(ArrayBuffer) overhead).
After: both deltas = 67108864 (exactly 64 MiB), matching Node.js v26.3.0.

`Process_functionMemoryUsage` previously reported `vm.heap.arrayBufferSize()`, which only counts backing stores registered via `Heap::addReference()` and charges `gcSizeEstimateInBytes()` (byteLength + sizeof(ArrayBuffer)) per entry. `Buffer.alloc(n)` / `new Uint8Array(n)` for `n > JSArrayBufferView::fastSizeLimit` construct an `OversizeTypedArray` whose Gigacage-malloc'd storage is never registered unless `.buffer` is later materialized via `slowDownAndWasteMemory()`.

The fix replaces `arrayBufferSize()` with a heap walk under a `HeapIterationScope`: iterate the twelve typed-array `IsoSubspace`s plus `dataViewSpace` and `arrayBufferSpace`, collect every referenced `ArrayBuffer*` into a set so buffers shared by multiple views are counted once, sum `byteLength()`, and add `byteLengthRaw()` for every `OversizeTypedArray` view that has no `ArrayBuffer` yet. `FastTypedArray` storage (<= 1000 elements) lives in the GC auxiliary space and is left to `heapTotal`/`heapUsed`. `external` is clamped to be at least `arrayBuffers` so the Node-documented subset relationship holds before JSC re-accumulates `m_extraMemorySize` during the next marking pass.

This makes `process.memoryUsage()` O(live typed arrays + ArrayBuffers) rather than O(1); acceptable for a diagnostic API and avoids needing a WebKit fork change.

### How did you verify your code works?

Added two subprocess-based tests in `test/js/node/process/process.test.js`:
- `arrayBuffers counts Buffer and typed array allocations`: verifies `Buffer.alloc`, `new Uint8Array(n)` and `new ArrayBuffer(n)` each move the counter by at least the allocated bytes, that promoting via `.buffer` does not double-count, and that `external >= arrayBuffers`.
- `arrayBuffers drops after Buffers are collected`: verifies the counter falls after the Buffers become unreachable and `Bun.gc(true)` runs.

Also verified the upstream Node.js `test/js/node/test/parallel/test-memory-usage.js` `strictEqual` delta check now passes (it was previously skipped because `r.arrayBuffers` was 0 at startup).

```
bun bd test test/js/node/process/process.test.js -t memoryUsage
  (pass) process.memoryUsage
  (pass) process.memoryUsage.rss
  (pass) process.memoryUsage.arrayBuffers
  (pass) process.memoryUsage.arrayBuffers counts Buffer and typed array allocations
  (pass) process.memoryUsage.arrayBuffers drops after Buffers are collected

bun bd test/js/node/test/parallel/test-memory-usage.js
  exit 0
```

Both new tests fail on the current release (`Received: 0`) and pass with this change.
