### PR TITLE
crypto: render UPN/XmppAddr/SRVName otherName SAN entries in X509Certificate

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -920,29 +920,22 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen)
         // awkward, especially when passed to translatePeerCertificate.
         bool unicode = true;
         const char* prefix = nullptr;
-        // OpenSSL 1.1.1 does not support othername in GENERAL_NAME_print and may
-        // not define these NIDs.
-#if OPENSSL_VERSION_MAJOR >= 3
-        int nid = OBJ_obj2nid(gen->d.otherName->type_id);
-        switch (nid) {
-        case NID_id_on_SmtpUTF8Mailbox:
+        // BoringSSL does not register NIDs for most of these otherName types, so
+        // match on the numeric OID text instead of relying on OBJ_obj2nid.
+        char oid[128];
+        OBJ_obj2txt(oid, sizeof(oid), gen->d.otherName->type_id, true);
+        if (strcmp(oid, "1.3.6.1.5.5.7.8.9") == 0) {
             prefix = "SmtpUTF8Mailbox";
-            break;
-        case NID_XmppAddr:
+        } else if (strcmp(oid, "1.3.6.1.5.5.7.8.5") == 0) {
             prefix = "XmppAddr";
-            break;
-        case NID_SRVName:
+        } else if (strcmp(oid, "1.3.6.1.5.5.7.8.7") == 0) {
             prefix = "SRVName";
             unicode = false;
-            break;
-        case NID_ms_upn:
+        } else if (strcmp(oid, "1.3.6.1.4.1.311.20.2.3") == 0) {
             prefix = "UPN";
-            break;
-        case NID_NAIRealm:
+        } else if (strcmp(oid, "1.3.6.1.5.5.7.8.8") == 0) {
             prefix = "NAIRealm";
-            break;
         }
-#endif // OPENSSL_VERSION_MAJOR >= 3
         int val_type = gen->d.otherName->value->type;
         if (prefix == nullptr || (unicode && val_type != V_ASN1_UTF8STRING) || (!unicode && val_type != V_ASN1_IA5STRING)) {
             BIO_printf(out.get(), "othername:<unsupported>");

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -901,11 +901,7 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen)
                 BIO_printf(out.get(), (j == 0) ? "%X" : ":%X", pair);
             }
         } else {
-#if OPENSSL_VERSION_MAJOR >= 3
             BIO_printf(out.get(), "<invalid length=%d>", ip->length);
-#else
-            BIO_printf(out.get(), "<invalid>");
-#endif
         }
     } else if (gen->type == GEN_RID) {
         // Unlike OpenSSL's default implementation, never print the OID as text and

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -72,3 +72,85 @@ describe("X509Certificate.checkHost()", () => {
     expect(cnOnly.checkIP("127.0.0.1")).toBeUndefined();
   });
 });
+
+describe("X509Certificate GeneralName otherName rendering", () => {
+  const escaping = path.join(import.meta.dir, "..", "test", "fixtures", "x509-escaping");
+  const altCert = (i: number) => new X509Certificate(readFileSync(path.join(escaping, `alt-${i}-cert.pem`)));
+  const infoCert = (i: number) => new X509Certificate(readFileSync(path.join(escaping, `info-${i}-cert.pem`)));
+
+  // SAN containing a Microsoft UPN otherName (OID 1.3.6.1.4.1.311.20.2.3) alongside
+  // an otherName with an unrecognised OID. Node renders the UPN value; the unknown
+  // OID stays <unsupported>.
+  const upnCertPem = `-----BEGIN CERTIFICATE-----
+MIIE/jCCBKOgAwIBAgIUZnRcX//etu5qC/QAboNi6sr28JEwCgYIKoZIzj0EAwIw
+NzESMBAGA1UECgwJeDUwOSBmdXp6MQ4wDAYDVQQLDAVpbnRlcjERMA8GA1UEAwwI
+eDUwOS1pY2EwIBcNMjYwNzA3MTQxMzU3WhgPMjA1NjA1MTAxNDEzNTdaMIGcMQsw
+CQYDVQQGEwJVUzEXMBUGA1UECAwOQ2EsIGxpZitvciBuaWExFzAVBgNVBAcMDlNh
+biBGcmFuO2NvXHN0MRgwFgYDVQQKDA94NTA5IGZ1enosIEluYy4xDzANBgNVBAsM
+BnVuaXQgQTEPMA0GA1UECwwGdW5pdCBCMR8wHQYDVQQDDBZsZWFmLng1MDkuc3lz
+ZnV6ei50ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMq0JETQojnNa5naE
+h0omNA2Lw0xyCFhwmNpY72Ovg7jNyeSPFG76CEAwZwfMkuOUYvQjoXas8TOXCCzU
+BwlzWKOCAyMwggMfMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgSwMD4GA1Ud
+JQQ3MDUGCCsGAQUFBwMBBggrBgEFBQcDAgYIKwYBBQUHAwQGCCsGAQUFBwMIBgsr
+BgEEAYaNHwcDATAdBgNVHQ4EFgQU3v/4cOhnMu5PCkw1xeuT16dGCD0wHwYDVR0j
+BBgwFoAU3rjGCTihf9dxHN2t2GOE676f/NowggG0BgNVHREEggGrMIIBp4IWbGVh
+Zi54NTA5LnN5c2Z1enoudGVzdIIXKi5hbHQueDUwOS5zeXNmdXp6LnRlc3SCH3hu
+LS1iY2hlci1rdmEueDUwOS5zeXNmdXp6LnRlc3SCBnNpbmdsZYcEfwAAAYcEChQe
+KIcQAAAAAAAAAAAAAAAAAAAAAYcQIAENuIWjAAAAAIouA3BzNIEWbGVhZkB4NTA5
+LnN5c2Z1enoudGVzdIEcc2Vjb25kQGFsdC54NTA5LnN5c2Z1enoudGVzdIYiaHR0
+cHM6Ly94NTA5LnN5c2Z1enoudGVzdC9wYXRoP3E9MYYnbGRhcDovL2RzLng1MDku
+c3lzZnV6ei50ZXN0OjM4OS9kYz14NTA5iAkrBgEEAYaNHyqgJQYKKwYBBAGCNxQC
+A6AXDBV1cG5AeDUwOS5zeXNmdXp6LnRlc3SgIAYJKwYBBAGGjR8FoBMMEWN1c3Rv
+bS1vdGhlci1uYW1lpEQwQjELMAkGA1UEBhMCVVMxEDAOBgNVBAoMB2RpciBvcmcx
+ITAfBgNVBAMMGGRpci1jbi54NTA5LnN5c2Z1enoudGVzdDBrBggrBgEFBQcBAQRf
+MF0wKgYIKwYBBQUHMAGGHmh0dHA6Ly9vY3NwLng1MDkuc3lzZnV6ei50ZXN0LzAv
+BggrBgEFBQcwAoYjaHR0cDovL2NhLng1MDkuc3lzZnV6ei50ZXN0L2ljYS5kZXIw
+NgYDVR0fBC8wLTAroCmgJ4YlaHR0cDovL2NybC54NTA5LnN5c2Z1enoudGVzdC9y
+b290LmNybDAiBgNVHSAEGzAZMA0GCysGAQQBho0fAQIDMAgGBmeBDAECATAKBggq
+hkjOPQQDAgNJADBGAiEAwo0YOYGn/dGePEVGONfRAstkLEmoD7MCx9nC4VfJivgC
+IQCsfIM9dwu37dJvDDswGG+tckzIv5nLd7qdrspvBrl0nQ==
+-----END CERTIFICATE-----`;
+
+  test("subjectAltName renders the Microsoft UPN otherName", () => {
+    const san = new X509Certificate(upnCertPem).subjectAltName;
+    expect(san).toBe(
+      "DNS:leaf.x509.sysfuzz.test, " +
+        "DNS:*.alt.x509.sysfuzz.test, " +
+        "DNS:xn--bcher-kva.x509.sysfuzz.test, " +
+        "DNS:single, " +
+        "IP Address:127.0.0.1, " +
+        "IP Address:10.20.30.40, " +
+        "IP Address:0:0:0:0:0:0:0:1, " +
+        "IP Address:2001:DB8:85A3:0:0:8A2E:370:7334, " +
+        "email:leaf@x509.sysfuzz.test, " +
+        "email:second@alt.x509.sysfuzz.test, " +
+        "URI:https://x509.sysfuzz.test/path?q=1, " +
+        "URI:ldap://ds.x509.sysfuzz.test:389/dc=x509, " +
+        "Registered ID:1.3.6.1.4.1.99999.42, " +
+        "othername:UPN:upn@x509.sysfuzz.test, " +
+        "othername:<unsupported>, " +
+        'DirName:"CN=dir-cn.x509.sysfuzz.test\\u002cO=dir org\\u002cC=US"',
+    );
+  });
+
+  test.each([
+    [24, "othername:XmppAddr:abc123"],
+    [25, 'othername:"XmppAddr:abc123\\u002c DNS:good.example.com"'],
+    [26, 'othername:"XmppAddr:good.example.com\\u0000abc123"'],
+    [27, "othername:<unsupported>"],
+    [28, "othername:SRVName:abc123"],
+    [29, "othername:<unsupported>"],
+    [30, 'othername:"SRVName:abc\\u0000def"'],
+  ])("subjectAltName renders otherName in alt-%i-cert.pem", (i, expected) => {
+    expect(altCert(i).subjectAltName).toBe(expected);
+  });
+
+  test("infoAccess renders otherName entries", () => {
+    expect(infoCert(3).infoAccess).toBe(
+      "OCSP - othername:XmppAddr:good.example.com\n" +
+        "OCSP - othername:<unsupported>\n" +
+        "OCSP - othername:SRVName:abc123\n",
+    );
+    expect(infoCert(4).infoAccess).toBe('OCSP - othername:"XmppAddr:good.example.com\\u0000abc123"\n');
+  });
+});

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -73,7 +73,7 @@ describe("X509Certificate.checkHost()", () => {
   });
 });
 
-describe("X509Certificate GeneralName otherName rendering", () => {
+describe("X509Certificate subjectAltName/infoAccess GeneralName rendering", () => {
   const escaping = path.join(import.meta.dir, "..", "test", "fixtures", "x509-escaping");
   const altCert = (i: number) => new X509Certificate(readFileSync(path.join(escaping, `alt-${i}-cert.pem`)));
   const infoCert = (i: number) => new X509Certificate(readFileSync(path.join(escaping, `info-${i}-cert.pem`)));
@@ -134,6 +134,8 @@ IQCsfIM9dwu37dJvDDswGG+tckzIv5nLd7qdrspvBrl0nQ==
   });
 
   test.each([
+    [10, "IP Address:<invalid length=5>"],
+    [11, "IP Address:<invalid length=6>"],
     [24, "othername:XmppAddr:abc123"],
     [25, 'othername:"XmppAddr:abc123\\u002c DNS:good.example.com"'],
     [26, 'othername:"XmppAddr:good.example.com\\u0000abc123"'],
@@ -141,7 +143,7 @@ IQCsfIM9dwu37dJvDDswGG+tckzIv5nLd7qdrspvBrl0nQ==
     [28, "othername:SRVName:abc123"],
     [29, "othername:<unsupported>"],
     [30, 'othername:"SRVName:abc\\u0000def"'],
-  ])("subjectAltName renders otherName in alt-%i-cert.pem", (i, expected) => {
+  ])("subjectAltName matches Node for alt-%i-cert.pem", (i, expected) => {
     expect(altCert(i).subjectAltName).toBe(expected);
   });
 


### PR DESCRIPTION
## What

`X509Certificate.prototype.subjectAltName` (and `infoAccess`) render every `otherName` SAN entry as `othername:<unsupported>`, including the Microsoft UPN (`1.3.6.1.4.1.311.20.2.3`) that smartcard/AD/Azure client-cert auth carries the user identity in. Node.js renders these as `othername:UPN:<value>`, `othername:XmppAddr:<value>`, `othername:SRVName:<value>`, etc.

```js
import { X509Certificate } from "node:crypto";
const san = new X509Certificate(pem).subjectAltName;
// node: ..., othername:UPN:upn@x509.sysfuzz.test, othername:<unsupported>, ...
// bun:  ..., othername:<unsupported>,             othername:<unsupported>, ...
```

## Cause

The `GEN_OTHERNAME` arm of `PrintGeneralName` (`src/jsc/bindings/ncrypto.cpp`, copied from Node's ncrypto) matches the type OID against NID constants inside `#if OPENSSL_VERSION_MAJOR >= 3`. BoringSSL reports itself as OpenSSL 1.1.1 and never defines `OPENSSL_VERSION_MAJOR`, so the entire switch compiles out, `prefix` stays `nullptr`, and every otherName falls through to `othername:<unsupported>`.

BoringSSL also does not register NIDs for `XmppAddr`, `SRVName`, `NAIRealm`, or `SmtpUTF8Mailbox` (only `NID_ms_upn` exists), so simply dropping the guard would not compile.

## Fix

Match on the numeric OID text via `OBJ_obj2txt(..., /*always_return_oid=*/true)` instead of relying on NID constants. This works under any SSL library regardless of which NIDs happen to be registered, and brings `subjectAltName`/`infoAccess` output byte-for-byte in line with Node for all five otherName types Node special-cases (UPN, XmppAddr, SRVName, NAIRealm, SmtpUTF8Mailbox). Unknown OIDs continue to print `othername:<unsupported>`.

## Verification

New tests in `test/js/node/crypto/x509.test.ts` cover the UPN case plus Node's `x509-escaping` fixtures `alt-24` through `alt-30` (XmppAddr/SRVName with escaping and type-mismatch negative cases) and `info-3`/`info-4` (same path via `infoAccess`). All 23 tests pass on the debug build; 7 of the 9 new tests fail without the `src/` change.