### PR TITLE
crypto: match Node's X509Certificate infoAccess/subjectAltName output on BoringSSL

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -901,7 +901,7 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen)
                 BIO_printf(out.get(), (j == 0) ? "%X" : ":%X", pair);
             }
         } else {
-#if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_MAJOR >= 3 || defined(OPENSSL_IS_BORINGSSL)
             BIO_printf(out.get(), "<invalid length=%d>", ip->length);
 #else
             BIO_printf(out.get(), "<invalid>");

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1028,7 +1028,7 @@ bool SafeX509InfoAccessPrint(const BIOPointer& out, X509_EXTENSION* ext)
     }
     sk_ACCESS_DESCRIPTION_pop_free(descs, ACCESS_DESCRIPTION_free);
 
-#if OPENSSL_VERSION_MAJOR < 3
+#if OPENSSL_VERSION_MAJOR < 3 && !defined(OPENSSL_IS_BORINGSSL)
     BIO_write(out.get(), "\n", 1);
 #endif
 

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -86,3 +86,17 @@ describe("X509Certificate.infoAccess", () => {
     expect(cert.infoAccess).toBeUndefined();
   });
 });
+
+describe("X509Certificate.subjectAltName", () => {
+  const escaping = path.join(import.meta.dir, "..", "test", "fixtures", "x509-escaping");
+  const altCert = (i: number) => new X509Certificate(readFileSync(path.join(escaping, `alt-${i}-cert.pem`)));
+
+  // Node on OpenSSL 3 includes the bad length; BoringSSL leaves OPENSSL_VERSION_MAJOR undefined so
+  // the <invalid length=N> branch in PrintGeneralName must be selected explicitly.
+  test.each([
+    [10, "IP Address:<invalid length=5>"],
+    [11, "IP Address:<invalid length=6>"],
+  ])("alt-%i-cert.pem renders a malformed IP SAN with its length", (i, expected) => {
+    expect(altCert(i).subjectAltName).toBe(expected);
+  });
+});

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -72,3 +72,17 @@ describe("X509Certificate.checkHost()", () => {
     expect(cnOnly.checkIP("127.0.0.1")).toBeUndefined();
   });
 });
+
+describe("X509Certificate.infoAccess", () => {
+  // Node on OpenSSL 3 produces no trailing newline; match that so split("\n") does not yield a
+  // trailing empty element and exact string comparisons against Node-persisted values hold.
+  test("has no trailing newline", () => {
+    const cert = new X509Certificate(cnOnlyCertPem);
+    expect(cert.infoAccess).toBe("OCSP - URI:http://ocsp.nodejs.org/\nCA Issuers - URI:http://ca.nodejs.org/ca.cert");
+  });
+
+  test("is undefined when the certificate has no AIA extension", () => {
+    const cert = new X509Certificate(wildcardSanCertPem);
+    expect(cert.infoAccess).toBeUndefined();
+  });
+});

--- a/test/js/node/test/parallel/test-crypto-x509.js
+++ b/test/js/node/test/parallel/test-crypto-x509.js
@@ -52,7 +52,7 @@ emailAddress=ry@tinyclouds.org`;
 
 let infoAccessCheck = `OCSP - URI:http://ocsp.nodejs.org/
 CA Issuers - URI:http://ca.nodejs.org/ca.cert`;
-if (!common.hasOpenSSL3)
+if (!common.hasOpenSSL3 && !process.features.openssl_is_boringssl)
   infoAccessCheck += '\n';
 
 const der = Buffer.from(

--- a/test/regression/issue/21274.test.ts
+++ b/test/regression/issue/21274.test.ts
@@ -11,9 +11,7 @@ test("#21274", () => {
     "DNS:*.lifecycle-prober-prod-89308e4e-9927-4280-9e14-3330f6900396.asia-northeast1.managedkafka.gmk-lifecycle-prober-prod-1.cloud.goog",
   );
   expect(cert.issuer).toEqual("C=US\nO=Google Trust Services\nCN=WR1");
-  expect(cert.infoAccess).toEqual(
-    "OCSP - URI:http://o.pki.goog/s/wr1/Ui4\nCA Issuers - URI:http://i.pki.goog/wr1.crt",
-  );
+  expect(cert.infoAccess).toEqual("OCSP - URI:http://o.pki.goog/s/wr1/Ui4\nCA Issuers - URI:http://i.pki.goog/wr1.crt");
   expect(cert.validFrom).toEqual("Nov 20 07:24:46 2024 GMT");
   expect(cert.validTo).toEqual("Feb 18 07:24:45 2025 GMT");
   expect(cert.validFromDate).toEqual(new Date("2024-11-20T07:24:46.000Z"));

--- a/test/regression/issue/21274.test.ts
+++ b/test/regression/issue/21274.test.ts
@@ -12,7 +12,7 @@ test("#21274", () => {
   );
   expect(cert.issuer).toEqual("C=US\nO=Google Trust Services\nCN=WR1");
   expect(cert.infoAccess).toEqual(
-    "OCSP - URI:http://o.pki.goog/s/wr1/Ui4\nCA Issuers - URI:http://i.pki.goog/wr1.crt\n",
+    "OCSP - URI:http://o.pki.goog/s/wr1/Ui4\nCA Issuers - URI:http://i.pki.goog/wr1.crt",
   );
   expect(cert.validFrom).toEqual("Nov 20 07:24:46 2024 GMT");
   expect(cert.validTo).toEqual("Feb 18 07:24:45 2025 GMT");


### PR DESCRIPTION
`PrintGeneralName` and `SafeX509InfoAccessPrint` in `src/jsc/bindings/ncrypto.cpp` are ported from Node's ncrypto and carry `#if OPENSSL_VERSION_MAJOR` guards. BoringSSL does not define `OPENSSL_VERSION_MAJOR`, so the preprocessor substitutes `0` and the OpenSSL-1.x branch is always taken. Two user-visible mismatches fall out of this.

## `X509Certificate.infoAccess` has a trailing newline

```js
import { X509Certificate } from "node:crypto";
import { readFileSync } from "node:fs";
const cert = new X509Certificate(readFileSync("test/js/node/test/fixtures/keys/agent1-cert.pem"));
console.log(JSON.stringify(cert.infoAccess));
```

Node v26.3.0: `"OCSP - URI:http://ocsp.nodejs.org/\nCA Issuers - URI:http://ca.nodejs.org/ca.cert"`
Bun (before): `"OCSP - URI:http://ocsp.nodejs.org/\nCA Issuers - URI:http://ca.nodejs.org/ca.cert\n"`

`SafeX509InfoAccessPrint` appends `"\n"` under `#if OPENSSL_VERSION_MAJOR < 3`. This breaks exact string comparisons against Node-persisted values and makes `infoAccess.split("\n")` yield a trailing empty element.

## `X509Certificate.subjectAltName` drops the length of a malformed IP SAN

```js
new X509Certificate(readFileSync("test/js/node/test/fixtures/x509-escaping/alt-10-cert.pem")).subjectAltName
```

Node v26.3.0: `"IP Address:<invalid length=5>"`
Bun (before): `"IP Address:<invalid>"`

`PrintGeneralName` selects `"<invalid length=%d>"` only under `#if OPENSSL_VERSION_MAJOR >= 3`.

## Fix

Add `OPENSSL_IS_BORINGSSL` to both guards so Bun takes the OpenSSL-3 branch that Node's release builds use. Updated the two existing tests that encoded the old trailing-newline behaviour and added coverage for both cases in `test/js/node/crypto/x509.test.ts`.

The remaining `OPENSSL_VERSION_MAJOR` guard in `PrintGeneralName` (the `GEN_OTHERNAME` NID switch at lines 925-945) cannot be unguarded the same way because BoringSSL does not register those NIDs; #33674 fixes it by matching on numeric OID text instead.

## Verification

```
$ bun bd test test/js/node/crypto/x509.test.ts test/regression/issue/21274.test.ts
 19 pass, 0 fail
$ bun bd test/js/node/test/parallel/test-crypto-x509.js
(exit 0)
```
