### PR TITLE
Request/fetch: detach from input's signal when init.signal is null

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1372,17 +1372,22 @@ impl Request {
             }
 
             if !fields.contains(Fields::Signal) {
-                match value.fast_get_truthy(global_this, bun_jsc::BuiltinName::signal) {
+                // WebIDL `AbortSignal?`: present iff the member is not undefined.
+                // `fast_get` maps absent/undefined → None; `null` is Some(null) and
+                // means "present, detach" (no fallback to the input Request's signal).
+                match value.fast_get(global_this, bun_jsc::BuiltinName::signal) {
                     Ok(Some(signal_)) => {
                         fields.insert(Fields::Signal);
-                        if let Some(signal) = AbortSignal::ref_from_js(signal_) {
+                        if signal_.is_null() {
+                            // explicit detach; leave `req.signal` as None
+                        } else if let Some(signal) = AbortSignal::ref_from_js(signal_) {
                             // Keep it alive
                             signal_.ensure_still_alive();
                             // `ref_from_js` already ref'd.
                             req.signal.set(Some(signal));
                         } else {
                             if !global_this.has_exception() {
-                                bail!(Err(global_this.throw(format_args!(
+                                bail!(Err(global_this.throw_type_error(format_args!(
                                     "Failed to construct 'Request': signal is not of type AbortSignal."
                                 ))));
                             }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1121,19 +1121,33 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
-    // signal: AbortSignal | undefined;
+    // signal: AbortSignal | null | undefined;
+    // WebIDL `AbortSignal?` member: present iff not undefined. A present `null`
+    // detaches (no fallback to the input Request's signal); a present non-null
+    // non-AbortSignal is a TypeError.
     signal.0 = 'extract_signal: {
         if let Some(options) = options_object {
             if let Some(signal_) = options.get(global_this, "signal")? {
-                if !signal_.is_undefined() {
-                    if let Some(signal__) = AbortSignal::from_js(signal_) {
-                        // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
-                        // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
-                        break 'extract_signal NonNull::new(
-                            bun_opaque::opaque_deref(signal__).ref_(),
-                        );
-                    }
+                if signal_.is_null() {
+                    break 'extract_signal None;
                 }
+                if let Some(signal__) = AbortSignal::from_js(signal_) {
+                    // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
+                    // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
+                    break 'extract_signal NonNull::new(
+                        bun_opaque::opaque_deref(signal__).ref_(),
+                    );
+                }
+                let err = ctx.to_type_error(
+                    jsc::ErrorCode::INVALID_ARG_TYPE,
+                    format_args!("signal is not of type AbortSignal."),
+                );
+                return Ok(
+                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        global_this,
+                        err,
+                    ),
+                );
             }
 
             if global_this.has_exception() {
@@ -1150,15 +1164,24 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
         if let Some(options) = request_init_object {
             if let Some(signal_) = options.get(global_this, "signal")? {
-                if signal_.is_undefined() {
+                if signal_.is_null() {
                     break 'extract_signal None;
                 }
-
                 if let Some(signal__) = AbortSignal::from_js(signal_) {
                     // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
                     // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
                     break 'extract_signal NonNull::new(bun_opaque::opaque_deref(signal__).ref_());
                 }
+                let err = ctx.to_type_error(
+                    jsc::ErrorCode::INVALID_ARG_TYPE,
+                    format_args!("signal is not of type AbortSignal."),
+                );
+                return Ok(
+                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        global_this,
+                        err,
+                    ),
+                );
             }
         }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1134,9 +1134,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if let Some(signal__) = AbortSignal::from_js(signal_) {
                     // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
                     // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
-                    break 'extract_signal NonNull::new(
-                        bun_opaque::opaque_deref(signal__).ref_(),
-                    );
+                    break 'extract_signal NonNull::new(bun_opaque::opaque_deref(signal__).ref_());
                 }
                 let err = ctx.to_type_error(
                     jsc::ErrorCode::INVALID_ARG_TYPE,

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import net from "node:net";
 
 test("undefined args don't throw", () => {
   const request = new Request("https://example.com/", {
@@ -73,4 +74,104 @@ test("clone() does not lock original body when body was accessed before clone", 
 
   expect(originalText).toBe("Hello, world!");
   expect(clonedText).toBe("Hello, world!");
+});
+
+describe("RequestInit signal presence", () => {
+  // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
+  // A present `signal: null` must replace (detach from) the input Request's signal.
+  test("new Request(request, { signal: null }) detaches from input's signal", () => {
+    const ctl = new AbortController();
+    const orig = new Request("http://example.com/", { signal: ctl.signal });
+    const bare = new Request(orig, { signal: null });
+    expect(bare.signal).not.toBe(ctl.signal);
+    ctl.abort(new Error("orig aborted"));
+    expect(bare.signal.aborted).toBe(false);
+  });
+
+  test("new Request(request, { signal: undefined }) inherits input's signal", () => {
+    const ctl = new AbortController();
+    const orig = new Request("http://example.com/", { signal: ctl.signal });
+    const derived = new Request(orig, { signal: undefined });
+    ctl.abort(new Error("orig aborted"));
+    expect(derived.signal.aborted).toBe(true);
+  });
+
+  test("new Request(request, {}) inherits input's signal", () => {
+    const ctl = new AbortController();
+    const orig = new Request("http://example.com/", { signal: ctl.signal });
+    const derived = new Request(orig, {});
+    ctl.abort(new Error("orig aborted"));
+    expect(derived.signal.aborted).toBe(true);
+  });
+
+  test.each(["", {}, 0, false, true])("signal: %p throws TypeError", signal => {
+    expect(() => new Request("http://example.com/", { signal } as any)).toThrow(TypeError);
+  });
+
+  test.each([null, undefined])("signal: %p does not throw", signal => {
+    expect(() => new Request("http://example.com/", { signal } as any)).not.toThrow();
+  });
+
+  async function withServer(fn: (url: string) => Promise<void>) {
+    const srv = net.createServer(s => {
+      s.on("error", () => {});
+      s.on("data", () => s.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"));
+    });
+    try {
+      await new Promise<void>(r => srv.listen(0, "127.0.0.1", () => r()));
+      await fn(`http://127.0.0.1:${(srv.address() as net.AddressInfo).port}/`);
+    } finally {
+      srv.close();
+    }
+  }
+
+  test("fetch(new Request(request, { signal: null })) is not aborted by input's controller", async () => {
+    await withServer(async url => {
+      const ctl = new AbortController();
+      const orig = new Request(url, { signal: ctl.signal });
+      const bare = new Request(orig, { signal: null });
+      ctl.abort(new Error("orig aborted"));
+      const res = await fetch(bare);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("ok");
+    });
+  });
+
+  test("fetch(request, { signal: null }) detaches from request's pre-aborted signal", async () => {
+    await withServer(async url => {
+      const pre = new Request(url, { signal: AbortSignal.abort(new Error("pre")) });
+      const res = await fetch(pre, { signal: null });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("ok");
+    });
+  });
+
+  test("fetch(request, { signal: undefined }) inherits request's signal", async () => {
+    await withServer(async url => {
+      const pre = new Request(url, { signal: AbortSignal.abort(new Error("pre")) });
+      const result = await fetch(pre, { signal: undefined }).then(
+        r => ({ ok: true, status: r.status }),
+        e => ({ ok: false, message: String(e) }),
+      );
+      expect(result).toEqual({ ok: false, message: "Error: pre" });
+    });
+  });
+
+  test("fetch(request, { signal: other }) overrides request's signal", async () => {
+    await withServer(async url => {
+      const pre = new Request(url, { signal: AbortSignal.abort(new Error("pre")) });
+      const other = new AbortController();
+      const res = await fetch(pre, { signal: other.signal });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("ok");
+    });
+  });
+
+  test("fetch(request, { signal: <invalid> }) rejects with TypeError", async () => {
+    await withServer(async url => {
+      const pre = new Request(url, { signal: AbortSignal.abort(new Error("pre")) });
+      await expect(fetch(pre, { signal: {} as any })).rejects.toThrow(TypeError);
+      await expect(fetch(url, { signal: "" as any })).rejects.toThrow(TypeError);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`new Request(input, { signal: null })` and `fetch(input, { signal: null })` never detached the derived request from `input`'s AbortSignal. An explicit `signal: null` was silently ignored whenever `input` was a Request, so aborting the original controller aborted a fetch the caller had explicitly detached.

```js
const ctl = new AbortController();
const orig = new Request(url, { signal: ctl.signal });
const bare = new Request(orig, { signal: null });   // spec: detached
bare.signal === ctl.signal;   // node/deno: false   bun: true
ctl.abort(new Error('orig aborted'));
bare.signal.aborted;          // node/deno: false   bun: true
await fetch(bare);            // node/deno: 200     bun: rejected 'orig aborted'

const pre = new Request(url, { signal: AbortSignal.abort(new Error('pre')) });
await fetch(pre, { signal: null });  // node/deno: 200   bun: rejected 'pre'

new Request(url, { signal: '' });    // node/deno: TypeError   bun: no throw
new Request(url, { signal: {} });    // node/deno: TypeError   bun: plain Error
```

## Cause

`Request::construct_into` read `init.signal` via `fast_get_truthy`, which filters `null` (and `''`, `0`, `false`) to "absent", so the loop fell through and picked up the input Request's signal on the next iteration. `fetch`'s `extract_signal` block similarly fell through to the input Request's signal when `options.signal` was `null` or any non-AbortSignal.

Per the Fetch spec Request constructor step 27, "If init['signal'] *exists*, then set signal to it." WebIDL dictionary members are "present" iff their value is not undefined; a present `null` (the member is `AbortSignal?`) replaces the input's signal with nothing.

## Fix

Read `signal` via `fast_get`/`get` (present iff not undefined). When present:
- `null` marks the field as set and leaves no signal (detach)
- a non-null non-AbortSignal throws/rejects `TypeError` (was plain `Error` in Request, silently ignored in `fetch`)
- an `AbortSignal` is used as before

Only an absent/undefined member falls back to the input Request's signal.

This is orthogonal to #32860 (dependent-signal identity): even with a following signal, `signal: null` must detach.

## Verification

```sh
bun bd test test/js/web/request/request.test.ts
```

9 of the new tests fail on `USE_SYSTEM_BUN=1` and pass with this change.