### PR TITLE
css: fix @counter-style and @scope printer round-trip

### DIFF
--- a/src/css/rules/counter_style.rs
+++ b/src/css/rules/counter_style.rs
@@ -19,7 +19,7 @@ impl CounterStyleRule {
         // #[cfg(feature = "sourcemap")]
         // dest.add_mapping(self.loc);
 
-        dest.write_str("@counter-style")?;
+        dest.write_str("@counter-style ")?;
         super::custom_ident_to_css(&self.name, dest)?;
         super::decl_block_to_css(&self.declarations, dest)
     }

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -60,7 +60,7 @@ impl<R> ScopeRule<R> {
                 )?;
             } else {
                 let ctx = dest.ctx;
-                return serialize_selector_list(scope_end.v.slice(), dest, ctx, false);
+                serialize_selector_list(scope_end.v.slice(), dest, ctx, false)?;
             }
             dest.write_char(b')')?;
             dest.whitespace()?;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7632,6 +7632,16 @@ describe("css tests", () => {
     );
   });
 
+  describe("scope", () => {
+    minify_test("@scope(.a) to (.b){.foo{color:red}}", "@scope(.a) to (.b){.foo{color:red}}");
+    minify_test("@scope to (.limit){.a{color:red}}", "@scope to (.limit){.a{color:red}}");
+    minify_test(
+      "@scope to (.limit){.a{color:red}}.after{color:#00f}",
+      "@scope to (.limit){.a{color:red}}.after{color:#00f}",
+    );
+    minify_test("@scope{.a{color:red}}", "@scope{.a{color:red}}");
+  });
+
   describe("grid-template-areas", () => {
     // Not in the typed property table yet; `.` null-cell tokens (including
     // multi-dot runs) must survive the unparsed-token round-trip unchanged.

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7621,6 +7621,17 @@ describe("css tests", () => {
     minify_test("@font-palette-values --{base-palette:99999", "@font-palette-values --{base-palette:99999}");
   });
 
+  describe("counter-style", () => {
+    minify_test(
+      '@counter-style thumbs{system:cyclic;symbols:X;suffix:" "}',
+      '@counter-style thumbs{system:cyclic;symbols:X;suffix:" "}',
+    );
+    minify_test(
+      "@counter-style circled{system:fixed;symbols:A B C}.l{list-style:circled}",
+      "@counter-style circled{system:fixed;symbols:A B C}.l{list-style:circled}",
+    );
+  });
+
   describe("grid-template-areas", () => {
     // Not in the typed property table yet; `.` null-cell tokens (including
     // multi-dot runs) must survive the unparsed-token round-trip unchanged.


### PR DESCRIPTION
### What does this PR do?

Fixes two at-rule printers that emit CSS browsers reject.

#### `@counter-style`

The printer emits `@counter-style<name>` with no space between the at-keyword and the counter style name, so `@counter-style thumbs { ... }` round-trips as `@counter-stylethumbs { ... }`. Browsers treat that as an unknown at-rule and drop the entire block, so any `@counter-style` a user ships silently disappears from the built output.

```js
const css = `@counter-style thumbs { system: cyclic; symbols: X; suffix: " "; }`;
await Bun.write("/tmp/e.css", css);
const b = await Bun.build({ entrypoints: ["/tmp/e.css"], minify: true });
console.log(await b.outputs[0].text());
// @counter-stylethumbs{system:cyclic;symbols:X;suffix:" "}
```

`CounterStyleRule::to_css` writes `"@counter-style"` and then the identifier via `custom_ident_to_css`, which writes the name with no leading whitespace. The sibling printers for `@property` and `@font-palette-values` write a trailing space in the literal; `@counter-style` was missing it. Fix: `dest.write_str("@counter-style ")?;`.

#### `@scope to (...)` without a scope-start

`ScopeRule::to_css` has an early `return` in the `scope_start = None, scope_end = Some` branch that exits before writing the closing `)`, `{`, the nested rules, and `}`. So `@scope to (.limit) { .a { color: red } }` round-trips as `@scope to (.limit` with the body dropped and the following rule corrupted:

```js
await Bun.write("/tmp/e.css", `@scope to (.limit) { .a { color: red } } .after { color: blue }`);
const b = await Bun.build({ entrypoints: ["/tmp/e.css"], minify: true });
console.log(await b.outputs[0].text());
// @scope to (.limit.after{color:#00f}
```

The sibling `scope_start.is_some()` branch correctly uses `?` and falls through. Fix: drop the `return` and `?` the call so it falls through to the closing paren and block emission like the other branch.

#### Verification

New `minify_test` cases in `test/js/bun/css/css.test.ts`.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css.test.ts -t counter-style`: 2 fail with `Received: "@counter-stylethumbs{...}"`.
- `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css.test.ts -t @scope`: 2 fail with `Received: "@scope to (.limit"` and `"@scope to (.limit.after{...}"`; the `@scope(.a) to (.b)` and bare `@scope{...}` variants pass on both builds.
- `bun bd test test/js/bun/css/css.test.ts`: 1126 pass, 67 skip, 0 fail.
- `bun bd test test/js/bun/css/nested-selector-list-expansion.test.ts`: 24 pass.
