### PR TITLE
css: merge adjacent @supports rules with the same condition instead of dropping the later one

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -540,7 +540,8 @@ impl<R> CssRuleList<R> {
                         if let Some(CssRule::Supports(last_rule)) = rules.last_mut()
                             && last_rule.condition.eql(&supp.condition)
                         {
-                            // Drop the duplicate-condition rule outright.
+                            last_rule.rules.v.append(&mut supp.rules.v);
+                            last_rule.minify(context, parent_is_unused)?;
                             break 'arm;
                         }
                         supp.minify(context, parent_is_unused)?;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6447,6 +6447,11 @@ describe("css tests", () => {
       "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
       "@supports (display: grid){.a{color:red}}@supports (display: flex){.b{color:#00f}}",
     );
+    // https://github.com/oven-sh/bun/issues/24770
+    minify_test(
+      ".test { border-top: 1px solid red; @supports (color: blue) { border-top: 1px solid blue } @supports (color: blue) { border-left: 1px solid blue } @supports (color: blue) { border-bottom: 1px solid blue } }",
+      ".test{border-top:1px solid red;@supports (color: blue){&{border-top:1px solid #00f;border-bottom:1px solid #00f;border-left:1px solid #00f}}}",
+    );
   });
 
   describe("transition", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6420,6 +6420,35 @@ describe("css tests", () => {
     error_test("@media (prefers-color-scheme = dark) { .foo { color: chartreuse }}", "ParserError::InvalidMediaQuery");
   });
 
+  describe("supports", () => {
+    cssTest(
+      `@supports (display: grid) { .a { color: red } }
+@supports (display: grid) { .b { color: blue } }`,
+      indoc`@supports (display: grid) {
+  .a {
+    color: red;
+  }
+
+  .b {
+    color: #00f;
+  }
+}
+`,
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } }",
+      "@supports (display: grid){.a{color:red}.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } } @supports (display: grid) { .c { color: green } }",
+      "@supports (display: grid){.a{color:red}.b{color:#00f}.c{color:green}}",
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
+      "@supports (display: grid){.a{color:red}}@supports (display: flex){.b{color:#00f}}",
+    );
+  });
+
   describe("transition", () => {
     minify_test(".foo { transition-duration: 500ms }", ".foo{transition-duration:.5s}");
     minify_test(".foo { transition-duration: .5s }", ".foo{transition-duration:.5s}");


### PR DESCRIPTION
Fixes #24770

### What

`bun build` / `Bun.build` on CSS silently deletes the contents of the second of two adjacent `@supports` rules with the same condition. This happens on the default path (no `--minify`) because the rule-merge pass runs unconditionally.

### Reproduction

```js
const b = await Bun.build({ entrypoints: ["e.css"] });
console.log(await b.outputs[0].text());
```

```css
/* e.css */
@supports (display: grid) { .a { color: red } }
@supports (display: grid) { .b { color: blue } }
@media screen { .c { color: red } }
@media screen { .d { color: blue } }
```

Output before:

```css
@supports (display: grid) {
  .a { color: red; }       /* .b { color: blue } is gone */
}
@media screen {
  .c { color: red; }
  .d { color: #00f; }      /* @media merged correctly */
}
```

Adjacent same-condition `@supports` blocks are exactly what autoprefixer, utility layers, and the bundler's own `@import supports(...)` handling emit, so this is silent style loss on real stylesheets. The same happens for `@supports` nested inside a style rule (#24770's Tailwind case).

### Cause

`CssRuleList::minify` (src/css/rules/mod.rs) merges adjacent at-rules with identical conditions. The `CssRule::Media` arm appends the later rule's children into the earlier rule before discarding the shell:

```rust
last_rule.rules.v.append(&mut med.rules.v);
let _ = last_rule.minify(context, parent_is_unused)?;
break 'arm;
```

The `CssRule::Supports` arm ten lines below lost the append during the lightningcss port and just `break 'arm`s, discarding the later rule with all its contents.

### Fix

Append the later `@supports` rule's children into the earlier one and re-minify the merged block, matching the `@media` arm and upstream lightningcss.

### Verification

New `describe("supports")` block in `test/js/bun/css/css.test.ts` covers: non-minified output preserves both rules merged into one block, minified output for two and three adjacent same-condition rules, a different-condition pair stays as two rules, and the nested-inside-selector case from #24770.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/css/css.test.ts -t supports
 1 pass / 4 fail   # .b / .c / border-left / border-bottom dropped

$ bun bd test test/js/bun/css/css.test.ts -t supports
 5 pass / 0 fail
```

Full `css.test.ts` (1124 tests) and `test/bundler/esbuild/css.test.ts` (53 tests) pass.
