### PR TITLE
s3: treat AbortMultipartUpload 204 as success, stop retrying rollback

### DIFF
--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -114,8 +114,8 @@ use bun_s3_signing::storage_class::StorageClass;
 use crate::webcore::ResumableSinkBackpressure;
 use crate::webcore::s3::multipart_options::MultiPartUploadOptions;
 use crate::webcore::s3::simple_request::{
-    self as s3_simple_request, S3CommitResult, S3DownloadResult, S3PartResult, S3UploadResult,
-    execute_simple_s3_request,
+    self as s3_simple_request, S3CommitResult, S3DeleteResult, S3DownloadResult, S3PartResult,
+    S3UploadResult, execute_simple_s3_request,
 };
 
 type JsTerminatedResult<T> = Result<T, bun_jsc::JsTerminated>;
@@ -775,7 +775,7 @@ impl MultiPartUpload {
 
     /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload
     pub fn on_rollback_multi_part_request(
-        result: S3UploadResult,
+        result: S3DeleteResult,
         this: *mut c_void,
     ) -> JsTerminatedResult<()> {
         let this = this.cast::<Self>();
@@ -787,7 +787,7 @@ impl MultiPartUpload {
             BStr::new(&this_ref.upload_id)
         );
         match result {
-            S3UploadResult::Failure(_err) => {
+            S3DeleteResult::Failure(_err) => {
                 if this_ref.options.retry > 0 {
                     this_ref.options.retry -= 1;
                     // retry rollback
@@ -798,7 +798,9 @@ impl MultiPartUpload {
                 MultiPartUpload::deref_(this);
                 Ok(())
             }
-            S3UploadResult::Success => {
+            // AbortMultipartUpload answers 204; a 404 means the uploadId is
+            // already gone. Either way the rollback is complete.
+            S3DeleteResult::Success | S3DeleteResult::NotFound(_) => {
                 // SAFETY: `this` is live (final-step ref held until this deref).
                 MultiPartUpload::deref_(this);
                 Ok(())
@@ -863,7 +865,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
+            s3_simple_request::S3Callback::Delete(Self::on_rollback_multi_part_request),
             callback_context,
         )
     }

--- a/test/js/bun/s3/s3-multipart-abort.test.ts
+++ b/test/js/bun/s3/s3-multipart-abort.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// AbortMultipartUpload returns 204 No Content on success (AWS, MinIO, R2, Ceph).
+// Previously the multipart rollback registered an Upload callback, which only
+// accepts 200, so every 204 was classified as a failure and the abort was
+// re-sent `retry` more times for each failed multipart upload. The same
+// misclassification meant a 404 NoSuchUpload (an already-gone uploadId) also
+// retried to exhaustion.
+
+function fixture(abortHandler: string) {
+  return `
+const requests = [];
+const server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const url = new URL(req.url);
+    await req.arrayBuffer();
+    if (req.method === "POST" && url.search.startsWith("?uploads")) {
+      requests.push("initiate");
+      return new Response(
+        '<?xml version="1.0" encoding="UTF-8"?>\\n' +
+          "<InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key>" +
+          "<UploadId>up-1</UploadId></InitiateMultipartUploadResult>",
+        { status: 200, headers: { "Content-Type": "application/xml" } },
+      );
+    }
+    if (req.method === "PUT" && url.searchParams.has("partNumber")) {
+      requests.push("part");
+      // Fail every part so the writer gives up and rolls back.
+      return new Response(
+        '<?xml version="1.0" encoding="UTF-8"?>\\n' +
+          "<Error><Code>InternalError</Code><Message>try again</Message></Error>",
+        { status: 500, headers: { "Content-Type": "application/xml" } },
+      );
+    }
+    if (req.method === "DELETE" && url.searchParams.has("uploadId")) {
+      requests.push("abort");
+      ${abortHandler}
+    }
+    requests.push(req.method + " " + url.pathname + url.search);
+    return new Response(null, { status: 404 });
+  },
+});
+
+const client = new Bun.S3Client({
+  endpoint: "http://127.0.0.1:" + server.port,
+  bucket: "b",
+  accessKeyId: "AK",
+  secretAccessKey: "SK",
+  region: "us-east-1",
+});
+
+const writer = client.file("obj.bin").writer({
+  partSize: 5 * 1024 * 1024,
+  queueSize: 1,
+  retry: 3,
+});
+writer.write(new Uint8Array(5 * 1024 * 1024));
+writer.write(new Uint8Array(32));
+let rejected = false;
+try {
+  await writer.end();
+} catch {
+  rejected = true;
+}
+
+// The in-flight rollback request keeps the event loop alive via its own
+// KeepAlive ref, so once the rollback chain is done the process drains and
+// beforeExit fires without any time-based wait.
+server.unref();
+let printed = false;
+process.on("beforeExit", () => {
+  if (printed) return;
+  printed = true;
+  console.log(JSON.stringify({
+    rejected,
+    aborts: requests.filter(r => r === "abort").length,
+    requests,
+  }));
+  server.stop(true);
+});
+`;
+}
+
+const env = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+describe("S3 multipart rollback (AbortMultipartUpload)", () => {
+  test.concurrent("sends exactly one abort when the server answers 204 No Content", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`return new Response(null, { status: 204 });`)],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: {
+        rejected: true,
+        aborts: 1,
+        // retry: 3 means 4 part attempts, then one rollback.
+        requests: ["initiate", "part", "part", "part", "part", "abort"],
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(proc.signalCode).toBeNull();
+  });
+
+  test.concurrent("does not retry after 404 NoSuchUpload", async () => {
+    const abortHandler = `return new Response(
+        '<?xml version="1.0" encoding="UTF-8"?>\\n' +
+          "<Error><Code>NoSuchUpload</Code>" +
+          "<Message>The specified upload does not exist.</Message></Error>",
+        { status: 404, headers: { "Content-Type": "application/xml" } },
+      );`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(abortHandler)],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: {
+        rejected: true,
+        aborts: 1,
+        requests: ["initiate", "part", "part", "part", "part", "abort"],
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(proc.signalCode).toBeNull();
+  });
+
+  test.concurrent("still retries on a genuine 5xx failure", async () => {
+    // 500 on abort is a real failure; best-effort rollback should retry.
+    const abortHandler = `return new Response(
+        '<?xml version="1.0" encoding="UTF-8"?>\\n' +
+          "<Error><Code>InternalError</Code><Message>boom</Message></Error>",
+        { status: 500, headers: { "Content-Type": "application/xml" } },
+      );`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(abortHandler)],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = JSON.parse(stdout.trim());
+    expect({ out, stderr, exitCode }).toEqual({
+      out: {
+        rejected: true,
+        aborts: 4,
+        requests: ["initiate", "part", "part", "part", "part", "abort", "abort", "abort", "abort"],
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(proc.signalCode).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

When a multipart upload fails, `S3File.writer()` sends `AbortMultipartUpload` to clean up the server-side parts. S3 (and MinIO, R2, Ceph) answer that request with **204 No Content**, but Bun classified 204 as a failure and re-sent the abort `retry` more times for every failed upload: 4 requests with the default `retry: 3`, up to 256 with `retry: 255`. Against real S3 the 2nd..Nth abort of an already-aborted upload id answers 404 `NoSuchUpload`, also non-200, so every configured retry was always spent. There is no user-visible error (rollback is best-effort), only wasted round-trips against an endpoint that may already be rate-limiting.

## Reproduction

Local S3 stub that 500s every part (forces rollback) and answers the abort with 204:

```
retry: 3
wire: initiate, part, part, part, part, abort, abort, abort, abort
aborts: 4   (expected: 1)
```

## Cause

`rollback_multi_part_request` in `src/runtime/webcore/s3/multipart.rs` registers its callback as `S3Callback::Upload`. The `Callback::Upload` arm in `on_response` (`src/runtime/webcore/s3/simple_request.rs`) accepts only status 200; anything else routes through `error_with_body(Failure)`. So 204 reached `on_rollback_multi_part_request` as `S3UploadResult::Failure`, which retried until `options.retry` ran out.

## Fix

Register the rollback as `S3Callback::Delete` instead; that is the semantic match for a DELETE request, and its dispatch already accepts `200 | 204` as success. Its 404 path maps to `S3DeleteResult::NotFound`, which the handler now also treats as complete: an already-gone upload id is not something to retry.

## Verification

New `test/js/bun/s3/s3-multipart-abort.test.ts` runs a local S3 stub in a spawned subprocess (the S3 client ignores `NO_PROXY`, so the fixture needs a clean env) and, for each abort response variant, asserts the exact request sequence observed on the wire:

* 204 No Content: exactly one `abort` after the four part retries
* 404 NoSuchUpload: exactly one `abort`
* 500 InternalError: four `abort`s (retry behavior preserved for genuine failures)

The fixture waits for the rollback chain via `beforeExit` (the in-flight rollback request's `KeepAlive` pins the event loop), so the assertion is deterministic with no time-based sleeps.

```
bun bd test test/js/bun/s3/s3-multipart-abort.test.ts
 3 pass  0 fail
```

Gate proof: with `src/` stashed, the 204 and 404 tests fail with `aborts: 4`; with the fix, all three pass.