### PR TITLE
css: keep '/' and '*' delims separated when minifying token lists

### DIFF
--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -383,6 +383,21 @@ impl TokenList {
                                 !has_whitespace && (*d == b'/' as u32 || *d == b'*' as u32);
                             debug_assert!(*d <= 0x7F);
                             dest.delim(*d as u8, ws_before)?;
+                            // `delim()` emits no surrounding whitespace when minifying, so
+                            // consecutive `/` and `*` delims would be printed adjacently and
+                            // form a `/*` or `*/` comment delimiter. Emit a real space when
+                            // the next token is the other half of that pair.
+                            if dest.minify && (*d == b'/' as u32 || *d == b'*' as u32) {
+                                if let Some(TokenOrValue::Token(Token::Delim(next))) =
+                                    self.v.get(i + 1)
+                                {
+                                    if (*d == b'/' as u32 && *next == b'*' as u32)
+                                        || (*d == b'*' as u32 && *next == b'/' as u32)
+                                    {
+                                        dest.write_char(b' ')?;
+                                    }
+                                }
+                            }
                         }
                         has_whitespace = true;
                     }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -96,6 +96,21 @@ describe("css tests", () => {
         padding: var(--custom-padding);
        }`,
     );
+
+    // Adjacent `/` and `*` delim tokens must not be printed as `/*` or `*/`
+    // when minifying, which would open/close a comment and swallow the rest of
+    // the stylesheet.
+    minify_test(":root { --a: x / * y }\n.k { color: red }", ":root{--a:x/ *y}.k{color:red}");
+    minify_test(":root { --a: x * / y }\n.k { color: red }", ":root{--a:x* /y}.k{color:red}");
+    minify_test(":root { --a: x / * / * y }", ":root{--a:x/ * / *y}");
+    minify_test(".foo { unknown-prop: a / * b }", ".foo{unknown-prop:a/ *b}");
+    minify_test(":root { --a: f(x / * y) }", ":root{--a:f(x/ *y)}");
+    // A lone `/` or `*` delim must still minify without extra whitespace.
+    minify_test(":root { --a: 16 / 9 }", ":root{--a:16/9}");
+    minify_test(":root { --a: x * y }", ":root{--a:x*y}");
+    minify_test(":root { --a: x / / y }", ":root{--a:x//y}");
+    // Non-minified output is unchanged.
+    cssTest(":root { --a: x / * y }", ":root {\n  --a: x / * y;\n}\n");
   });
 
   describe("pseudo-class edge case", () => {


### PR DESCRIPTION
## Repro

```js
const b = await Bun.build({ entrypoints: ["e.css"], minify: true });
// e.css:
//   :root { --a: x / * y }
//   .k { color: red }
console.log(await b.outputs[0].text());
// => :root{--a:x/*y}.k{color:red}
```

The `/*` after `x` opens a comment. Reparsing Bun's own output drops `.k { color: red }` (and everything after it) entirely. esbuild preserves the value byte-for-byte.

## Cause

`TokenList::to_css` (src/css/properties/custom.rs) already computes `ws_before = !has_whitespace && (d == '/' || d == '*')` precisely to prevent this, but `Printer::delim` routes `ws_before` through `Printer::whitespace()`, which writes nothing when minifying. The arm then sets `has_whitespace = true` regardless of whether a byte was actually written, so the following `*`'s guard is skipped too. Adjacent `/` and `*` delims collapse to `/*`.

The same applies to any unparsed property value (not just `--custom`) and to token-list arguments inside functions.

## Fix

After printing a `/` or `*` delim in minify mode, peek at the next token: if it's the other half of the pair, emit a real space via `write_char`. This is precise: a lone `/` or `*` (e.g. `--a: 16 / 9`) still minifies to `16/9` with no extra bytes, and non-minified output is unchanged.

| input | before | after |
| --- | --- | --- |
| `--a: x / * y` | `x/*y` | `x/ *y` |
| `--a: x * / y` | `x*/y` | `x* /y` |
| `--a: 16 / 9` | `16/9` | `16/9` |
| `--a: x / y` | `x/y` | `x/y` |
| `--a: x / / y` | `x//y` | `x//y` |

## Verification

New `minify_test` cases in `test/js/bun/css/css.test.ts` cover `/` then `*`, `*` then `/`, a chain `/ * / *`, unknown properties, function arguments, the unchanged single-delim cases, and the non-minified round-trip. They fail on the current release (`x/*y`) and pass with the fix. Full `css.test.ts` (1129 tests), `test/js/bun/css/doesnt_crash.test.ts` (61 tests), and `test/bundler/css/` (168 tests) pass.