### PR TITLE
css: fix duplicate-rule detection erasing distinct custom properties and !important rules

### DIFF
--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1503,8 +1503,6 @@ impl UnparsedProperty {
     }
 
     pub(crate) fn eql(&self, rhs: &Self) -> bool {
-        // `PropertyId` is `Copy` (tag + optional `VendorPrefix`/`CustomPropertyName`)
-        // and derives `PartialEq` in `properties_generated.rs` — use `==` directly.
         self.property_id == rhs.property_id && self.value.eql(&rhs.value)
     }
 }
@@ -1554,7 +1552,7 @@ pub enum CustomPropertyName {
 
 // `DashedIdent`/`Ident` carry `*const [u8]` arena slices and
 // intentionally don't derive `PartialEq` (pointer-eq would be wrong).
-// `PropertyId` derives `PartialEq`, so compare the underlying bytes here.
+// Compare the underlying bytes.
 impl PartialEq for CustomPropertyName {
     fn eq(&self, other: &Self) -> bool {
         // SAFETY: arena-owned slices live for the parse session.

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -688,11 +688,9 @@ impl PropertyIdTag {
 /// A known CSS property name + (for prefixable properties) the vendor
 /// prefix it was parsed with. Variants without payload are unprefixed.
 //
-// Do NOT `#[derive(PartialEq, Eq)]` here — the spec-correct
-// equality ignores the
-// `Custom(CustomPropertyName)` payload and is hand-written below. A derived
-// impl would (a) conflict (E0119) and (b) diverge by comparing custom-name
-// bytes.
+// Do NOT `#[derive(PartialEq, Eq)]`: the `CustomPropertyName` payload holds
+// arena `*const [u8]` idents and a derived impl would compare raw pointers.
+// The hand-written impl below compares tag + prefix + custom-name bytes.
 #[derive(Debug, Clone, Copy)]
 pub enum PropertyId {
     BackgroundColor,
@@ -948,29 +946,31 @@ pub enum PropertyId {
     Custom(CustomPropertyName),
 }
 
-// `PropertyId` equality compares the tag, then *only* compares the payload
-// when its type is `VendorPrefix` — for `Custom` (whose payload is
-// `CustomPropertyName`) and all unit variants it returns `true` on tag match
-// alone. A derived `PartialEq` would compare the `CustomPropertyName` bytes,
-// diverging from the duplicate-detection semantics in `rules/style.rs`.
-// `prefix()` already returns the `VendorPrefix` payload for the 65 prefixed
-// variants and `VendorPrefix::empty()` for every other variant (including
-// `Custom`/`All`/`Unparsed`), so `tag` + `prefix` equality is exactly that.
+// `PropertyId` equality compares the tag, the `VendorPrefix` payload (via
+// `prefix()`, which is `VendorPrefix::empty()` for every non-prefixed
+// variant), and for `Custom` the property-name bytes: `--a` and `--b` are
+// distinct properties and must not collapse in duplicate-rule detection.
 impl PartialEq for PropertyId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.tag() == other.tag() && self.prefix() == other.prefix()
+        match (self, other) {
+            (PropertyId::Custom(a), PropertyId::Custom(b)) => a == b,
+            _ => self.tag() == other.tag() && self.prefix() == other.prefix(),
+        }
     }
 }
 
 impl Eq for PropertyId {}
 
-// Hash only the tag discriminant so PropertyId can key a hash map
-// consistent with `eq`.
+// Hash must agree with `eq`: tag + prefix + custom-name bytes.
 impl core::hash::Hash for PropertyId {
     #[inline]
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         (self.tag() as u16).hash(h);
+        self.prefix().bits().hash(h);
+        if let PropertyId::Custom(name) = self {
+            h.write(name.as_str());
+        }
     }
 }
 

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -36,18 +36,17 @@ impl<R> StyleRule<R> {
     /// Returns a hash of this rule for use when deduplicating.
     /// Includes the selectors and properties.
     pub fn hash_key(&self) -> u64 {
+        use core::hash::Hash;
         // Wyhash seeded with 0 — same algorithm as bun.hash
         let mut hasher = bun_wyhash::Wyhash::init(0);
         self.selectors.hash(&mut hasher);
-        // Inlined `DeclarationBlock::hash_property_ids`: hash just the u16
-        // property-id tag bytes.
+        // Hash the full `PropertyId` (tag + prefix + custom-name bytes) so
+        // distinct custom properties don't collide into one dedup bucket.
         for decl in self.declarations.declarations.iter() {
-            let tag = decl.property_id().tag() as u16;
-            hasher.update(&tag.to_ne_bytes());
+            decl.property_id().hash(&mut hasher);
         }
         for decl in self.declarations.important_declarations.iter() {
-            let tag = decl.property_id().tag() as u16;
-            hasher.update(&tag.to_ne_bytes());
+            decl.property_id().hash(&mut hasher);
         }
         hasher.final_()
     }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -1,6 +1,6 @@
 use crate as css;
 use crate::css_rules::{CssRule, CssRuleList, Location, MinifyContext};
-use crate::declaration::DeclarationBlock;
+use crate::declaration::{DeclarationBlock, DeclarationList};
 use crate::error::MinifyErr;
 use crate::selectors::selector;
 use crate::{PrintErr, Printer, VendorPrefix};
@@ -460,42 +460,24 @@ impl<R> StyleRule<R> {
     }
 
     /// Returns whether this rule is a duplicate of another rule.
-    /// This means it has the same selectors and properties.
+    /// This means it has the same selectors and defines the same properties.
     #[inline]
     pub fn is_duplicate(&self, other: &Self) -> bool {
-        self.declarations.len() == other.declarations.len()
-            && self.selectors.eql(&other.selectors)
-            && 'brk: {
-                let mut len = self
-                    .declarations
-                    .declarations
-                    .len()
-                    .min(other.declarations.declarations.len());
-                // len is the min of the two lengths, so truncation is intended.
-                for (a, b) in self.declarations.declarations[..len]
-                    .iter()
-                    .zip(&other.declarations.declarations[..len])
-                {
-                    // `PropertyId`'s `PartialEq` is a tag+prefix compare.
-                    if a.property_id() != b.property_id() {
-                        break 'brk false;
-                    }
-                }
-                len = self
-                    .declarations
-                    .important_declarations
-                    .len()
-                    .min(other.declarations.important_declarations.len());
-                for (a, b) in self.declarations.important_declarations[..len]
-                    .iter()
-                    .zip(&other.declarations.important_declarations[..len])
-                {
-                    if a.property_id() != b.property_id() {
-                        break 'brk false;
-                    }
-                }
-                true
-            }
+        let same_property_ids = |a: &DeclarationList<'_>, b: &DeclarationList<'_>| {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(a, b)| a.property_id() == b.property_id())
+        };
+        self.selectors.eql(&other.selectors)
+            && same_property_ids(
+                &self.declarations.declarations,
+                &other.declarations.declarations,
+            )
+            && same_property_ids(
+                &self.declarations.important_declarations,
+                &other.declarations.important_declarations,
+            )
     }
 }
 

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -54,9 +54,6 @@ impl Declaration {
 
 impl Declaration {
     pub(crate) fn eql(&self, other: &Self) -> bool {
-        // `PropertyId` carries its own tag+prefix `PartialEq` (see
-        // properties_generated.rs `impl PartialEq for PropertyId`); `value` is
-        // byte-slice equality.
         self.property_id == other.property_id && self.value == other.value
     }
 }
@@ -122,8 +119,7 @@ impl SupportsCondition {
 
     pub fn eql(&self, other: &SupportsCondition) -> bool {
         // Hand-expanded because `#[derive(CssEql)]` would require
-        // `PropertyId: CssEql` (it only provides the custom tag+prefix
-        // `PartialEq`). Tag mismatch → false, then field-wise structural eq.
+        // `PropertyId: CssEql` (it only provides `PartialEq`).
         match (self, other) {
             (Self::Not(a), Self::Not(b)) => a.eql(b),
             (Self::And(a), Self::And(b)) | (Self::Or(a), Self::Or(b)) => {

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -156,3 +156,47 @@ test("declaration merges do not drop partitioned incompatible selectors", () => 
     ".a {\n  color: #00f;\n}\n\n.b:focus-visible {\n  color: #00f;\n}\n",
   );
 });
+
+// `is_duplicate` compared every custom property as the same property id, so
+// a later same-selector rule declaring the same *count* of custom properties
+// erased the earlier one and every variable it defined. The rules below are
+// separated by an unrelated rule so the adjacent-merge path cannot hide the
+// deletion.
+test("duplicate-rule detection distinguishes custom property names", () => {
+  expect(cssInternals._test(":root{--a:1}.q{z-index:9}:root{--b:2}", "")).toBe(
+    ":root {\n  --a: 1;\n}\n\n.q {\n  z-index: 9;\n}\n\n:root {\n  --b: 2;\n}\n",
+  );
+  expect(cssInternals._test(".card{--pad:4px;--bg:#fff}.x{color:red}.card{--radius:2px;--fg:#000}", "")).toBe(
+    ".card {\n  --pad: 4px;\n  --bg: #fff;\n}\n\n" +
+      ".x {\n  color: red;\n}\n\n" +
+      ".card {\n  --radius: 2px;\n  --fg: #000;\n}\n",
+  );
+  // Same custom property name in both rules: the earlier one *is* dead.
+  expect(cssInternals.minifyTest(":root{--a:1}.q{z-index:9}:root{--a:2}", "")).toBe(".q{z-index:9}:root{--a:2}");
+  // Unknown (non-dashed) property names must also be distinguished.
+  expect(cssInternals.minifyTest(".a{foo:1}.q{z-index:9}.a{bar:2}", "")).toBe(".a{foo:1}.q{z-index:9}.a{bar:2}");
+});
+
+// `is_duplicate` compared the *total* declaration count but then zipped the
+// normal and !important lists separately, so a 1-normal rule matched a
+// 1-important rule and the !important winner was deleted, flipping the
+// cascade.
+test("duplicate-rule detection respects the normal/!important split", () => {
+  expect(cssInternals._test(".z{color:red !important}.q{z-index:9}.z{color:blue}", "")).toBe(
+    ".z {\n  color: red !important;\n}\n\n.q {\n  z-index: 9;\n}\n\n.z {\n  color: #00f;\n}\n",
+  );
+  // Reversed order: the later !important rule must not erase the earlier
+  // normal one either (it does not redeclare the same property at normal
+  // priority, so the earlier rule is not dead).
+  expect(cssInternals._test(".z{color:red}.q{z-index:9}.z{color:blue !important}", "")).toBe(
+    ".z {\n  color: red;\n}\n\n.q {\n  z-index: 9;\n}\n\n.z {\n  color: #00f !important;\n}\n",
+  );
+  // Mixed: (normal,important) vs (important,normal) for different properties.
+  expect(cssInternals.minifyTest(".z{color:red;top:0 !important}.q{z-index:9}.z{top:1px;color:blue !important}", "")).toBe(
+    ".z{color:red;top:0!important}.q{z-index:9}.z{top:1px;color:#00f!important}",
+  );
+  // Same split, same properties: the earlier rule *is* dead.
+  expect(cssInternals.minifyTest(".z{color:red !important}.q{z-index:9}.z{color:blue !important}", "")).toBe(
+    ".q{z-index:9}.z{color:#00f!important}",
+  );
+});

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -49,6 +49,10 @@ const script = `
       Array.from({ length: n }, (_, i) => \`.a{--x\${i}:\${i}}\`).join(""),
       undefined,
     ],
+    "scattered-custom-props": [
+      Array.from({ length: n }, (_, i) => \`:root{--x\${i}:\${i}}.q\${i}{z-index:9}\`).join(""),
+      undefined,
+    ],
     "distinct-selectors": [
       Array.from({ length: n }, (_, i) => \`.a\${i}{color:red}\`).join(""),
       { chrome: 80 << 16 },
@@ -84,6 +88,7 @@ test("duplicate declarations across merged rules minify in linear time instead o
       "OK:webkit-gradient",
       "OK:clamp",
       "OK:distinct-custom-props",
+      "OK:scattered-custom-props",
       "OK:distinct-selectors",
       "",
     ].join("\n"),

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -192,9 +192,9 @@ test("duplicate-rule detection respects the normal/!important split", () => {
     ".z {\n  color: red;\n}\n\n.q {\n  z-index: 9;\n}\n\n.z {\n  color: #00f !important;\n}\n",
   );
   // Mixed: (normal,important) vs (important,normal) for different properties.
-  expect(cssInternals.minifyTest(".z{color:red;top:0 !important}.q{z-index:9}.z{top:1px;color:blue !important}", "")).toBe(
-    ".z{color:red;top:0!important}.q{z-index:9}.z{top:1px;color:#00f!important}",
-  );
+  expect(
+    cssInternals.minifyTest(".z{color:red;top:0 !important}.q{z-index:9}.z{top:1px;color:blue !important}", ""),
+  ).toBe(".z{color:red;top:0!important}.q{z-index:9}.z{top:1px;color:#00f!important}");
   // Same split, same properties: the earlier rule *is* dead.
   expect(cssInternals.minifyTest(".z{color:red !important}.q{z-index:9}.z{color:blue !important}", "")).toBe(
     ".q{z-index:9}.z{color:#00f!important}",


### PR DESCRIPTION
### What does this PR do?

`StyleRule::is_duplicate` (src/css/rules/style.rs) decides whether an earlier rule is fully shadowed by a later rule with the same selectors and can be dropped. It runs on every `bun build` / `Bun.build` of CSS, minified or not, and across bundled files. Two port divergences from upstream lightningcss made it over-match and silently delete live rules:

#### Repro

```js
const dir = require("node:fs").mkdtempSync(require("node:os").tmpdir() + "/css-");
for (const [css, want] of [
  [":root { --a: 1 }\n.q { z-index: 9 }\n:root { --b: 2 }\n",                         "--a"],
  [".card { --pad:4px; --bg:#fff }\n.x { color:red }\n.card { --radius:2px; --fg:#000 }\n", "--pad"],
  [".z { color: red !important }\n.q { z-index: 9 }\n.z { color: blue }\n",           "important"],
]) {
  require("node:fs").writeFileSync(dir + "/e.css", css);
  const out = await (await Bun.build({ entrypoints: [dir + "/e.css"] })).outputs[0].text();
  console.log(out.includes(want) ? "ok" : "*** DELETED `" + want + "`\n" + out);
}
```

On 1.4.0 and current main: all three print `*** DELETED`. The `:root { --a: 1 }` block is gone so `var(--a)` resolves to nothing; the `.z { color: red !important }` winner is deleted so `.z`'s computed color flips from red to blue. No flags, no minify, exit 0, no warning.

#### Cause

1. `PropertyId`'s hand-written `PartialEq` (src/css/properties/properties_generated.rs) compared only the enum tag and vendor prefix, so `Custom(--a) == Custom(--b)`. Upstream derives `PartialEq` and compares the name bytes. `PartialEq` now compares the `CustomPropertyName` payload for `Custom` (and `Hash` is kept consistent with it). The other two users of this `PartialEq` (`SupportsDeclaration::eql`, `UnparsedProperty::eql`) also become correct for distinct custom / unknown property names.

2. `is_duplicate` compared `self.declarations.len() == other.declarations.len()` (the sum of normal + `!important`) but then zipped the two lists separately over `min()` lengths, so a rule with one normal declaration matched a rule with one `!important` declaration via two empty loops. It now compares each list's length independently, matching upstream.

#### Verification

- New tests in `test/js/bun/css/duplicate-declaration-merge-hang.test.ts` (where the existing dedup tests live) cover both faces plus the positive cases (true duplicates still collapse). Both fail on the unfixed build: `USE_SYSTEM_BUN=1 bun test` fails 2/2 new tests; `bun bd test` passes 6/6.
- `Bun.build` repro above now preserves all three rules.
- `test/js/bun/css/` (2237 pass) and `test/bundler/css/` (168 pass) are green; the `css-fuzz.test.ts` debug-build timeouts are pre-existing on main.
