### PR TITLE
css: preserve url() query/fragment suffix when rewriting asset references

### DIFF
--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -412,16 +412,37 @@ impl<'a> Printer<'a> {
         };
         let record = &import_info.import_records[import_record_idx as usize];
         if record.source_index.is_valid() {
+            // A `url()`'s `?query`/`#fragment` (e.g. `url(sprites.svg#icon)`) is
+            // stripped by the resolver to find the file; re-append it to the
+            // rewritten reference so the fragment still addresses the element.
+            let suffix: &[u8] = if record.kind == bun_ast::ImportKind::Url {
+                match bun_core::strings::index_of_any(record.original_path, b"?#") {
+                    Some(i) => &record.original_path[i..],
+                    None => b"",
+                }
+            } else {
+                b""
+            };
+            let arena = self.arena;
+            let with_suffix = |url: &'a [u8]| -> &'a [u8] {
+                if suffix.is_empty() {
+                    return url;
+                }
+                let buf = arena.alloc_slice_fill_copy(url.len() + suffix.len(), 0u8);
+                buf[..url.len()].copy_from_slice(url);
+                buf[url.len()..].copy_from_slice(suffix);
+                buf
+            };
             // It has an inlined url for CSS
             let urls_for_css = import_info.ast_urls_for_css[record.source_index.get() as usize];
             if !urls_for_css.is_empty() {
-                return Ok(urls_for_css);
+                return Ok(with_suffix(urls_for_css));
             }
             // It is a chunk URL
             let unique_key_for_additional_file =
                 import_info.ast_unique_key_for_additional_file[record.source_index.get() as usize];
             if !unique_key_for_additional_file.is_empty() {
-                return Ok(unique_key_for_additional_file);
+                return Ok(with_suffix(unique_key_for_additional_file));
             }
         }
         // External URL stays as-is

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -424,7 +424,7 @@ impl<'a> Printer<'a> {
                 b""
             };
             let arena = self.arena;
-            let with_suffix = |url: &'a [u8]| -> &'a [u8] {
+            let with_suffix = |url: &'a [u8], suffix: &[u8]| -> &'a [u8] {
                 if suffix.is_empty() {
                     return url;
                 }
@@ -433,16 +433,21 @@ impl<'a> Printer<'a> {
                 buf[url.len()..].copy_from_slice(suffix);
                 buf
             };
-            // It has an inlined url for CSS
+            // It has an inlined data: URL for CSS. A `?query` here lands in the
+            // base64 body and fails decoding, so keep only the `#fragment`.
             let urls_for_css = import_info.ast_urls_for_css[record.source_index.get() as usize];
             if !urls_for_css.is_empty() {
-                return Ok(with_suffix(urls_for_css));
+                let fragment: &[u8] = match bun_core::strings::index_of_char(suffix, b'#') {
+                    Some(i) => &suffix[i as usize..],
+                    None => b"",
+                };
+                return Ok(with_suffix(urls_for_css, fragment));
             }
-            // It is a chunk URL
+            // It is a chunk URL (copied asset): keep the full `?query#fragment`.
             let unique_key_for_additional_file =
                 import_info.ast_unique_key_for_additional_file[record.source_index.get() as usize];
             if !unique_key_for_additional_file.is_empty() {
-                return Ok(with_suffix(unique_key_for_additional_file));
+                return Ok(with_suffix(unique_key_for_additional_file, suffix));
             }
         }
         // External URL stays as-is

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1180,6 +1180,85 @@ b {
     },
   });
 
+  // A url()'s `?query` / `#fragment` suffix must survive path rewriting so that
+  // SVG fragment references like `url(sprites.svg#icon)` keep addressing the
+  // element inside the asset. esbuild also preserves these.
+  itBundled("css/URLQueryFragmentPreservedFileLoader", {
+    files: {
+      "/entry.css": /* css */ `
+        .a { mask: url(./sprites.svg#icon) }
+        .b { clip-path: url("./sprites.svg?v=3#c") }
+        .c { background: url(./sprites.svg) }
+        .d { --bg: url("./sprites.svg#custom") }
+      `,
+      "/sprites.svg": Buffer.alloc(128 * 1024 + 1, "Z").toString(),
+    },
+    loader: {
+      ".svg": "file",
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(/* css */ `
+/* entry.css */
+.a {
+  mask: url("./sprites-mrrzcz3w.svg#icon");
+}
+.b {
+  clip-path: url("./sprites-mrrzcz3w.svg?v=3#c");
+}
+.c {
+  background: url("./sprites-mrrzcz3w.svg");
+}
+.d {
+  --bg: url("./sprites-mrrzcz3w.svg#custom");
+}
+`);
+    },
+  });
+  itBundled("css/URLQueryFragmentPreservedDataURL", {
+    files: {
+      "/entry.css": /* css */ `
+        .a { mask: url(./small.svg#m1) }
+        .b { background: url("./small.svg?v=2") }
+        .c { background: url(./small.svg) }
+      `,
+      "/small.svg": `<svg xmlns="http://www.w3.org/2000/svg"><mask id="m1"/></svg>`,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(/* css */ `
+/* entry.css */
+.a {
+  mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==#m1");
+}
+.b {
+  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==?v=2");
+}
+.c {
+  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==");
+}
+`);
+    },
+  });
+  itBundled("css/URLQueryFragmentPreservedMinified", {
+    files: {
+      "/entry.css": /* css */ `
+        .a { mask: url(./sprites.svg#icon) }
+      `,
+      "/sprites.svg": Buffer.alloc(128 * 1024 + 1, "Z").toString(),
+    },
+    loader: {
+      ".svg": "file",
+    },
+    minifyWhitespace: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(
+        /* css */ `.a{mask:url(./sprites-mrrzcz3w.svg#icon)}`,
+      );
+    },
+  });
+
   itBundled("css/IgnoreURLsInAtRulePrelude", {
     // GENERATED
     files: {

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1220,21 +1220,27 @@ b {
       "/entry.css": /* css */ `
         .a { mask: url(./small.svg#m1) }
         .b { background: url("./small.svg?v=2") }
-        .c { background: url(./small.svg) }
+        .c { mask: url(./small.svg?v=2#m1) }
+        .d { background: url(./small.svg) }
       `,
       "/small.svg": `<svg xmlns="http://www.w3.org/2000/svg"><mask id="m1"/></svg>`,
     },
     outdir: "/out",
     onAfterBundle(api) {
+      // A `?query` appended to a base64 data: URL lands in the body and fails
+      // decoding, so only the `#fragment` is kept on the inline path.
       api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(/* css */ `
 /* entry.css */
 .a {
   mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==#m1");
 }
 .b {
-  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==?v=2");
+  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==");
 }
 .c {
+  mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==#m1");
+}
+.d {
   background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxtYXNrIGlkPSJtMSIvPjwvc3ZnPg==");
 }
 `);

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1253,9 +1253,7 @@ b {
     minifyWhitespace: true,
     outdir: "/out",
     onAfterBundle(api) {
-      api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(
-        /* css */ `.a{mask:url(./sprites-mrrzcz3w.svg#icon)}`,
-      );
+      api.expectFile("/out/entry.css").toEqualIgnoringWhitespace(/* css */ `.a{mask:url(./sprites-mrrzcz3w.svg#icon)}`);
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

A CSS `url()` with a fragment or query, e.g. `url(sprites.svg#icon)` or `url(file.svg?v=3#c)`, silently lost the `#icon` / `?v=3#c` part when the referenced asset was rewritten during bundling. This happened on both rewrite paths:

- the file-loader copy path (`url(./sprites-<hash>.svg)`)
- the data-URL inline path (`url(data:image/svg+xml;base64,...)`)

The fragment is load-bearing in CSS: SVG sprite / `<view>` / paint-server references and `mask` / `clip-path` / `filter` element references are all written `url(file.svg#id)`. After `bun build` they pointed at the whole document instead of the fragment, so the mask/clip/paint silently resolved to nothing.

### Repro

```js
import { mkdtempSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
const dir = mkdtempSync(join(tmpdir(), "css-"));
writeFileSync(join(dir, "big.svg"), `<svg xmlns="http://www.w3.org/2000/svg"><circle id="icon" r="4"/><!--${"x".repeat(140_000)}--></svg>`);
writeFileSync(join(dir, "small.svg"), `<svg xmlns="http://www.w3.org/2000/svg"><mask id="m1"/></svg>`);
writeFileSync(join(dir, "e.css"),
`.a { mask: url(./big.svg#icon) }
.b { clip-path: url("./big.svg?v=3#c") }
.c { mask: url(./small.svg#m1) }
`);
const b = await Bun.build({ entrypoints: [join(dir, "e.css")], outdir: join(dir, "out") });
console.log(await b.outputs.find(o => o.path.endsWith(".css")).text());
```

Before:
```css
.a { mask: url("./big-67xdwqqh.svg"); }               /* #icon gone */
.b { clip-path: url("./big-67xdwqqh.svg"); }          /* ?v=3#c gone */
.c { mask: url("data:image/svg+xml;base64,..."); }    /* #m1 gone */
```

After:
```css
.a { mask: url("./big-67xdwqqh.svg#icon"); }
.b { clip-path: url("./big-67xdwqqh.svg?v=3#c"); }
.c { mask: url("data:image/svg+xml;base64,...#m1"); }
```

### Cause

The resolver strips the `?#` suffix to find the file on disk (`src/resolver/resolver.rs:1464`) but the stripped suffix is never stored or re-appended. The CSS printer's `get_import_record_url` then emits the rewritten path or data URL keyed only by `source_index`, which has no per-reference suffix.

### Fix

The original specifier (with suffix) is already preserved on the import record as `original_path` before resolution overwrites `path`. When the CSS printer emits a rewritten `url()` reference for an `ImportKind::Url` record, it now re-appends the suffix from `original_path`:

- **file-loader path** (copied asset, real HTTP URL): the full `?query#fragment` is kept.
- **data-URL inline path**: only the `#fragment` is kept. A `?query` appended to a base64 `data:` URL lands in the body passed to forgiving-base64-decode (the Fetch data-URL processor excludes only the fragment when re-serializing) and fails on `?`, so the query is dropped there. A query on an inlined asset is meaningless anyway since there is no server to interpret it.

External references are unchanged since they keep their original text.

## How did you verify your code works?

Three new `itBundled` cases in `test/bundler/esbuild/css.test.ts`:
- `css/URLQueryFragmentPreservedFileLoader`: file-loader path with `#fragment`, `?query#fragment`, no suffix (unchanged), and a custom-property `--bg: url(...)` case
- `css/URLQueryFragmentPreservedDataURL`: data-URL inline path with `#fragment`, `?query` (dropped), `?query#fragment` (only `#fragment` kept), and no suffix
- `css/URLQueryFragmentPreservedMinified`: minified output path

All three fail on `main` and pass with the fix. The rest of `test/bundler/esbuild/css.test.ts` (56 tests) and `test/bundler/css/` (168 tests) continue to pass.
