### PR TITLE
s3: abort the multipart upload when CompleteMultipartUpload fails

### DIFF
--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -662,15 +662,34 @@ impl MultiPartUpload {
         result: S3DownloadResult,
         this: *mut c_void,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
-        // `adopt` consumes the prior +1 on Drop.
-        // SAFETY: callback context — a ref was taken before the request was queued.
-        let _deref_guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this) };
+        let this_ptr = this.cast::<Self>();
         // SAFETY: callback context — `this` is live (a ref was taken before the request)
-        let this = unsafe { &mut *this };
+        let this = unsafe { &mut *this_ptr };
         if this.state == State::Finished {
+            // The upload was failed while CreateMultipartUpload was in flight.
+            // If the server already created an upload id, abort it so the
+            // server-side upload and its parts are not orphaned. The rollback
+            // chain consumes the in-flight ref; otherwise release it here.
+            if let S3DownloadResult::Success(response) = result {
+                let slice = response.body.list.as_slice();
+                if let Some(start) = strings::index_of(slice, b"<UploadId>") {
+                    let value_start = start + b"<UploadId>".len();
+                    if let Some(end) = strings::index_of(slice, b"</UploadId>") {
+                        if end >= value_start {
+                            this.upload_id = Box::<[u8]>::from(&slice[value_start..end]);
+                        }
+                    }
+                }
+                if !this.upload_id.is_empty() && this.upload_id.len() <= Self::MAX_UPLOAD_ID_LEN {
+                    return this.rollback_multi_part_request();
+                }
+            }
+            MultiPartUpload::deref_(this_ptr);
             return Ok(());
         }
+        // `adopt` consumes the prior +1 on Drop.
+        // SAFETY: callback context — a ref was taken before the request was queued.
+        let _deref_guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this_ptr) };
         match result {
             S3DownloadResult::Failure(err) => {
                 scoped_log!(
@@ -755,12 +774,14 @@ impl MultiPartUpload {
                     return Ok(());
                 }
                 this_ref.state = State::Finished;
-                // The deref must run after the callback:
-                let r =
-                    (this_ref.callback)(S3UploadResult::Failure(err), this_ref.callback_context);
-                // SAFETY: `this` is live (final-step ref held until this deref).
-                MultiPartUpload::deref_(this);
-                r
+                (this_ref.callback)(S3UploadResult::Failure(err), this_ref.callback_context)?;
+                // Launder `self` after the callback (see `fail()`); it may have
+                // re-entered via the JS wrapper. Then issue a best-effort
+                // AbortMultipartUpload so the uploaded parts are not orphaned.
+                // The rollback chain consumes the final-step ref.
+                let this: *mut Self = core::hint::black_box(this);
+                // SAFETY: `this` is live (final-step ref still held).
+                unsafe { (*this).rollback_multi_part_request() }
             }
             S3CommitResult::Success => {
                 this_ref.state = State::Finished;

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -767,14 +767,22 @@ impl MultiPartUpload {
                     return Ok(());
                 }
                 this_ref.state = State::Finished;
-                (this_ref.callback)(S3UploadResult::Failure(err), this_ref.callback_context)?;
+                let r =
+                    (this_ref.callback)(S3UploadResult::Failure(err), this_ref.callback_context);
                 // Launder `self` after the callback (see `fail()`); it may have
                 // re-entered via the JS wrapper. Then issue a best-effort
                 // AbortMultipartUpload so the uploaded parts are not orphaned.
-                // The rollback chain consumes the final-step ref.
+                // The rollback chain consumes the final-step ref; on a
+                // terminated VM release it directly so refcounts stay balanced.
                 let this: *mut Self = core::hint::black_box(this);
-                // SAFETY: `this` is live (final-step ref still held).
-                unsafe { (*this).rollback_multi_part_request() }
+                if r.is_ok() {
+                    // SAFETY: `this` is live (final-step ref still held).
+                    unsafe { (*this).rollback_multi_part_request() }
+                } else {
+                    // SAFETY: `this` is live (final-step ref held until this deref).
+                    MultiPartUpload::deref_(this);
+                    r
+                }
             }
             S3CommitResult::Success => {
                 this_ref.state = State::Finished;

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -657,6 +657,20 @@ impl MultiPartUpload {
         }
     }
 
+    /// Extract and validate the `<UploadId>` from a CreateMultipartUpload body.
+    fn parse_upload_id(body: &[u8]) -> Option<Box<[u8]>> {
+        let start = strings::index_of(body, b"<UploadId>")? + b"<UploadId>".len();
+        let end = strings::index_of(body, b"</UploadId>")?;
+        let id = body.get(start..end)?;
+        if id.is_empty()
+            || id.len() > Self::MAX_UPLOAD_ID_LEN
+            || id.iter().any(|b| !b.is_ascii() || b.is_ascii_control())
+        {
+            return None;
+        }
+        Some(Box::<[u8]>::from(id))
+    }
+
     /// Result of the Multipart request, after this we can start draining the parts
     pub fn start_multi_part_request_result(
         result: S3DownloadResult,
@@ -671,16 +685,8 @@ impl MultiPartUpload {
             // server-side upload and its parts are not orphaned. The rollback
             // chain consumes the in-flight ref; otherwise release it here.
             if let S3DownloadResult::Success(response) = result {
-                let slice = response.body.list.as_slice();
-                if let Some(start) = strings::index_of(slice, b"<UploadId>") {
-                    let value_start = start + b"<UploadId>".len();
-                    if let Some(end) = strings::index_of(slice, b"</UploadId>") {
-                        if end >= value_start {
-                            this.upload_id = Box::<[u8]>::from(&slice[value_start..end]);
-                        }
-                    }
-                }
-                if !this.upload_id.is_empty() && this.upload_id.len() <= Self::MAX_UPLOAD_ID_LEN {
+                if let Some(id) = Self::parse_upload_id(response.body.list.as_slice()) {
+                    this.upload_id = id;
                     return this.rollback_multi_part_request();
                 }
             }
@@ -703,24 +709,10 @@ impl MultiPartUpload {
             }
             S3DownloadResult::Success(response) => {
                 // response.body is bun.MutableString — `list` is a Vec<u8>
-                let slice = response.body.list.as_slice();
                 // PERF: upload_id is duped out of the body instead of slicing into it
-                if let Some(start) = strings::index_of(slice, b"<UploadId>") {
-                    let value_start = start + b"<UploadId>".len();
-                    if let Some(end) = strings::index_of(slice, b"</UploadId>") {
-                        if end >= value_start {
-                            this.upload_id = Box::<[u8]>::from(&slice[value_start..end]);
-                        }
-                    }
-                }
+                let id = Self::parse_upload_id(response.body.list.as_slice());
                 this.uploadid_buffer = response.body;
-                if this.upload_id.is_empty()
-                    || this.upload_id.len() > Self::MAX_UPLOAD_ID_LEN
-                    || this
-                        .upload_id
-                        .iter()
-                        .any(|b| !b.is_ascii() || b.is_ascii_control())
-                {
+                let Some(id) = id else {
                     // Unknown type of response error from AWS
                     scoped_log!(
                         S3MultiPartUpload,
@@ -732,7 +724,8 @@ impl MultiPartUpload {
                         message: b"Failed to initiate multipart upload",
                     })?;
                     return Ok(());
-                }
+                };
+                this.upload_id = id;
                 scoped_log!(
                     S3MultiPartUpload,
                     "startMultiPartRequestResult {} success id: {}",

--- a/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
+++ b/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
@@ -102,37 +102,33 @@ const env = {
   https_proxy: undefined,
 };
 
+async function run(failMode: "commit" | "part") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture(failMode)],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) expect({ stdout, stderr, exitCode }).toEqual({ stdout, stderr: "", exitCode: 0 });
+  return JSON.parse(stdout.trim()) as { outcome: string; aborts: number; requests: string[] };
+}
+
 describe("S3 multipart upload aborts the server-side upload on failure", () => {
   test.concurrent("UploadPart failure triggers AbortMultipartUpload", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture("part")],
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = JSON.parse(stdout.trim());
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    const result = await run("part");
     expect(result.outcome).toBe("rejected:InternalError");
     expect(result.requests).toContain("DELETE ?uploadId -> 204");
     expect(result.aborts).toBeGreaterThanOrEqual(1);
   });
 
   test.concurrent("CompleteMultipartUpload failure triggers AbortMultipartUpload", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture("commit")],
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = JSON.parse(stdout.trim());
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    const result = await run("commit");
     // The writer should reject, parts should have succeeded, commit retried,
     // and then an AbortMultipartUpload must be issued so the server-side
     // upload (and its parts) are not left orphaned.
     expect(result.outcome).toBe("rejected:InternalError");
-    expect(result.requests.filter((r: string) => r.startsWith("PUT ?partNumber"))).toEqual([
+    expect(result.requests.filter(r => r.startsWith("PUT ?partNumber"))).toEqual([
       "PUT ?partNumber=1 -> 200",
       "PUT ?partNumber=2 -> 200",
     ]);

--- a/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
+++ b/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A local S3 stub that records every request line. `failMode` controls which
+// stage of the multipart lifecycle permanently errors so we can observe
+// whether Bun sends AbortMultipartUpload (DELETE ?uploadId) afterward.
+function fixture(failMode: "commit" | "part") {
+  return String.raw`
+import * as net from "node:net";
+
+const requests: string[] = [];
+let aborts = 0;
+const xml = (s: string) => '<?xml version="1.0" encoding="UTF-8"?>\n' + s;
+
+const server = net.createServer(socket => {
+  let buf = Buffer.alloc(0);
+  socket.on("error", () => {});
+  socket.on("data", chunk => {
+    buf = Buffer.concat([buf, chunk]);
+    for (;;) {
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+      const head = buf.toString("latin1", 0, headerEnd);
+      const contentLength = Number(/^content-length: *(\d+)/im.exec(head)?.[1] ?? 0);
+      if (buf.length < headerEnd + 4 + contentLength) return;
+      buf = buf.subarray(headerEnd + 4 + contentLength);
+
+      const [method, target] = head.split("\r\n")[0].split(" ");
+      const qs = target.includes("?") ? new URLSearchParams(target.split("?")[1]) : new URLSearchParams();
+      let tag = "";
+      if (qs.has("uploads")) tag = "?uploads";
+      else if (qs.has("partNumber")) tag = "?partNumber=" + qs.get("partNumber");
+      else if (qs.has("uploadId")) tag = "?uploadId";
+
+      let status = 200, body = "", extraHeader = "";
+      if (method === "POST" && qs.has("uploads")) {
+        body = xml("<InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><UploadId>up-1</UploadId></InitiateMultipartUploadResult>");
+      } else if (method === "PUT" && qs.has("partNumber")) {
+        if (${JSON.stringify(failMode)} === "part") {
+          status = 500;
+          body = xml("<Error><Code>InternalError</Code><Message>part fail</Message></Error>");
+        } else {
+          extraHeader = 'ETag: "etag-' + qs.get("partNumber") + '"\r\n';
+        }
+      } else if (method === "POST" && qs.has("uploadId")) {
+        status = 500;
+        body = xml("<Error><Code>InternalError</Code><Message>commit fail</Message></Error>");
+      } else if (method === "DELETE" && qs.has("uploadId")) {
+        status = 204;
+        aborts++;
+      }
+      requests.push(method + " " + tag + " -> " + status);
+      const bodyBuf = Buffer.from(body);
+      socket.write(
+        "HTTP/1.1 " + status + " X\r\n" +
+        extraHeader +
+        "Connection: keep-alive\r\n" +
+        "Content-Length: " + (status === 204 ? 0 : bodyBuf.length) + "\r\n\r\n",
+      );
+      if (status !== 204 && bodyBuf.length) socket.write(bodyBuf);
+    }
+  });
+});
+await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+const port = (server.address() as net.AddressInfo).port;
+
+const client = new Bun.S3Client({
+  endpoint: "http://127.0.0.1:" + port,
+  bucket: "b",
+  accessKeyId: "AK",
+  secretAccessKey: "SK",
+  region: "us-east-1",
+});
+const writer = client.file("obj.bin").writer({ partSize: 5 * 1024 * 1024, queueSize: 1, retry: 1 });
+writer.write(new Uint8Array(5 * 1024 * 1024));
+writer.write(new Uint8Array(64));
+
+let outcome: string;
+try {
+  await writer.end();
+  outcome = "resolved";
+} catch (e: any) {
+  outcome = "rejected:" + (e?.code ?? e?.name ?? String(e));
+}
+
+// Allow the best-effort AbortMultipartUpload to be issued and observed.
+const deadline = Date.now() + 2000;
+while (aborts === 0 && Date.now() < deadline) {
+  await Bun.sleep(25);
+}
+
+console.log(JSON.stringify({ outcome, aborts, requests }));
+process.exit(0);
+`;
+}
+
+const env = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+describe("S3 multipart upload aborts the server-side upload on failure", () => {
+  test.concurrent("UploadPart failure triggers AbortMultipartUpload", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture("part")],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = JSON.parse(stdout.trim());
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(result.outcome).toBe("rejected:InternalError");
+    expect(result.requests).toContain("DELETE ?uploadId -> 204");
+    expect(result.aborts).toBeGreaterThanOrEqual(1);
+  });
+
+  test.concurrent("CompleteMultipartUpload failure triggers AbortMultipartUpload", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture("commit")],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = JSON.parse(stdout.trim());
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    // The writer should reject, parts should have succeeded, commit retried,
+    // and then an AbortMultipartUpload must be issued so the server-side
+    // upload (and its parts) are not left orphaned.
+    expect(result.outcome).toBe("rejected:InternalError");
+    expect(result.requests.filter((r: string) => r.startsWith("PUT ?partNumber"))).toEqual([
+      "PUT ?partNumber=1 -> 200",
+      "PUT ?partNumber=2 -> 200",
+    ]);
+    expect(result.requests).toContain("DELETE ?uploadId -> 204");
+    expect(result.aborts).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
+++ b/test/js/bun/s3/s3-multipart-abort-on-fail.test.ts
@@ -100,6 +100,10 @@ const env = {
   HTTPS_PROXY: undefined,
   http_proxy: undefined,
   https_proxy: undefined,
+  // The S3 writer's NetworkSink is owned by the JS wrapper and is only freed
+  // on GC; process.exit() skips that, which LSan reports. That leak exists on
+  // main for the success path too and is not what this test observes.
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
 };
 
 async function run(failMode: "commit" | "part") {


### PR DESCRIPTION
## What

When `CompleteMultipartUpload` ultimately fails (retries exhausted), `Bun.S3Client` now sends `AbortMultipartUpload` so the server-side upload and its already-uploaded parts are cleaned up. Previously the promise was rejected but no abort was sent, leaving the initiated upload orphaned on the server (stored and billed, invisible to `ListObjectsV2`) with no way for the caller to abort it since the `UploadId` is never exposed.

## Reproduction

Local S3 stub: `CreateMultipartUpload` and `UploadPart` succeed, `CompleteMultipartUpload` permanently returns 500.

```ts
const w = s3.file("obj.bin").writer({ partSize: 5 * 1024 * 1024, queueSize: 1, retry: 2 });
w.write(new Uint8Array(5 * 1024 * 1024));
w.write(new Uint8Array(64));
await w.end(); // rejects S3Error code=InternalError
```

Wire before:
```
POST ?uploads -> 200
PUT ?partNumber=1 -> 200
PUT ?partNumber=2 -> 200
POST ?uploadId -> 500  (x3, retries)
```
No `DELETE ?uploadId`. Upload `up1` and both parts are orphaned server-side.

Real-world shapes for a permanently-failing commit: `InvalidPart`, `EntityTooSmall`, `NoSuchUpload`, persistent 5xx, and the documented AWS "HTTP 200 with an `<Error>` body".

## Cause

In `src/runtime/webcore/s3/multipart.rs`:

* `on_commit_multi_part_request`'s failure arm set `state = Finished`, rejected the promise, and released its ref without calling `rollback_multi_part_request()`. A part that ultimately fails already triggers rollback via `fail()`; the commit path simply never wired it up.
* `start_multi_part_request_result` returned early when `state == Finished` (upload failed while `CreateMultipartUpload` was still in flight) without looking at the freshly-received `UploadId`, so that upload was also never aborted.

## Fix

* `on_commit_multi_part_request` failure arm now calls `rollback_multi_part_request()` (best-effort, same as `fail()`) after rejecting the promise. The rollback chain consumes the final-step ref that the direct `deref_()` previously released.
* `start_multi_part_request_result` now parses the `UploadId` out of a late-arriving success response when `state == Finished` and issues the abort, transferring the in-flight ref to the rollback chain.

## Verification

New `test/js/bun/s3/s3-multipart-abort-on-fail.test.ts` runs a local S3 stub for two scenarios:

* `UploadPart` permanently 500s: asserts `DELETE ?uploadId` is sent (control; already worked).
* `CompleteMultipartUpload` permanently 500s: asserts parts succeeded, the writer rejects with `InternalError`, and `DELETE ?uploadId` is sent.

Fails on `main` (0 aborts observed on the commit-fail wire), passes with this change.