### PR TITLE
node:events: return boolean from EventEmitterAsyncResource#emit

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -806,7 +806,7 @@ class EventEmitterAsyncResource extends EventEmitter {
   }
 
   emit(...args) {
-    this.asyncResource.runInAsyncScope(() => super.emit(...args));
+    return this.asyncResource.runInAsyncScope(() => super.emit(...args));
   }
 
   emitDestroy() {

--- a/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
+++ b/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
@@ -26,4 +26,19 @@ describe("EventEmitterAsyncResource", () => {
 
     expect(val).toBe(123);
   });
+  test("emit() returns a boolean like EventEmitter#emit", () => {
+    const ee = new EventEmitterAsyncResource({ name: "R" });
+    ee.on("e", () => {});
+    ee.on("error", () => {});
+
+    expect({
+      withListener: ee.emit("e"),
+      withoutListener: ee.emit("none"),
+      errorWithListener: ee.emit("error", new Error("x")),
+    }).toEqual({
+      withListener: true,
+      withoutListener: false,
+      errorWithListener: true,
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

`EventEmitterAsyncResource.prototype.emit()` always returned `undefined` instead of the boolean that `EventEmitter#emit` is documented to return (`true` if the event had listeners, `false` otherwise). This breaks the common Node idiom `if (!this.emit('error', e)) throw e;`, which would treat every event as unhandled even when a listener ran.

### Repro

```js
import { EventEmitterAsyncResource } from "node:events";
const r = new EventEmitterAsyncResource({ name: "R" });
r.on("e", () => {});
console.log(r.emit("e"));     // node: true,  bun before: undefined
console.log(r.emit("none"));  // node: false, bun before: undefined
```

### Cause

`emit()` called `this.asyncResource.runInAsyncScope(() => super.emit(...args))` without `return`. `runInAsyncScope` already forwards the callback's return value; the `return` keyword was missing.

### Fix

Added `return` in front of `runInAsyncScope`.

## How did you verify your code works?

Added a test to `test/js/node/async_hooks/EventEmitterAsyncResource.test.ts` asserting `emit()` returns `true` when listeners exist (including `error`) and `false` when none do. Fails on released bun, passes with this change.