### PR TITLE
node:events: make EventEmitterAsyncResource match Node.js

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -30,6 +30,7 @@ const {
   validateNumber,
   validateBoolean,
   validateFunction,
+  validateString,
 } = require("internal/validators");
 
 const types = require("node:util/types");
@@ -750,7 +751,7 @@ function _getMaxListeners(emitter) {
   return emitter?._maxListeners ?? defaultMaxListeners;
 }
 
-let AsyncResource = null;
+let kReferencingAsyncResource = null;
 
 function getMaxListeners(emitterOrTarget) {
   if (typeof emitterOrTarget?.getMaxListeners === "function") {
@@ -792,25 +793,58 @@ function addAbortListener(signal, listener) {
 }
 
 class EventEmitterAsyncResource extends EventEmitter {
-  triggerAsyncId;
-  asyncResource;
+  #asyncResource;
 
-  constructor(options) {
-    if (!AsyncResource) {
-      AsyncResource = require("node:async_hooks").AsyncResource;
+  constructor(options = undefined) {
+    let name;
+    if (typeof options === "string") {
+      name = options;
+      options = undefined;
+    } else {
+      if (new.target === EventEmitterAsyncResource) {
+        validateString(options?.name, "options.name");
+      }
+      name = options?.name || new.target.name;
     }
-    var { captureRejections = false, triggerAsyncId, name = new.target.name, requireManualDestroy } = options || {};
-    super({ captureRejections });
-    this.triggerAsyncId = triggerAsyncId ?? 0;
-    this.asyncResource = new AsyncResource(name, { triggerAsyncId, requireManualDestroy });
+    super(options);
+
+    if (kReferencingAsyncResource === null) {
+      const { AsyncResource } = require("node:async_hooks");
+      kReferencingAsyncResource = class EventEmitterReferencingAsyncResource extends AsyncResource {
+        #eventEmitter;
+
+        constructor(ee, type, opts) {
+          super(type, opts);
+          this.#eventEmitter = ee;
+        }
+
+        get eventEmitter() {
+          return this.#eventEmitter;
+        }
+      };
+    }
+    this.#asyncResource = new kReferencingAsyncResource(this, name, options);
   }
 
-  emit(...args) {
-    this.asyncResource.runInAsyncScope(() => super.emit(...args));
+  emit(event, ...args) {
+    const asyncResource = this.#asyncResource;
+    return asyncResource.runInAsyncScope(super.emit, this, event, ...args);
   }
 
   emitDestroy() {
-    this.asyncResource.emitDestroy();
+    this.#asyncResource.emitDestroy();
+  }
+
+  get asyncId() {
+    return this.#asyncResource.asyncId();
+  }
+
+  get triggerAsyncId() {
+    return this.#asyncResource.triggerAsyncId();
+  }
+
+  get asyncResource() {
+    return this.#asyncResource;
   }
 }
 

--- a/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
+++ b/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
@@ -41,7 +41,13 @@ describe("EventEmitterAsyncResource", () => {
 
     for (const key of ["asyncId", "triggerAsyncId", "asyncResource"]) {
       const desc = Object.getOwnPropertyDescriptor(EventEmitterAsyncResource.prototype, key)!;
-      expect({ key, get: typeof desc.get, set: desc.set, enumerable: desc.enumerable, configurable: desc.configurable }).toEqual({
+      expect({
+        key,
+        get: typeof desc.get,
+        set: desc.set,
+        enumerable: desc.enumerable,
+        configurable: desc.configurable,
+      }).toEqual({
         key,
         get: "function",
         set: undefined,
@@ -64,9 +70,7 @@ describe("EventEmitterAsyncResource", () => {
         message: expect.stringContaining('"options.name"'),
       }),
     );
-    expect(() => new EventEmitterAsyncResource({})).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-    );
+    expect(() => new EventEmitterAsyncResource({})).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
     expect(() => new EventEmitterAsyncResource({ name: 42 })).toThrow(
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );

--- a/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
+++ b/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from "async_hooks";
+import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import { describe, expect, test } from "bun:test";
 import EventEmitter, { EventEmitterAsyncResource } from "events";
 
@@ -25,5 +25,87 @@ describe("EventEmitterAsyncResource", () => {
     });
 
     expect(val).toBe(123);
+  });
+
+  test("asyncResource is an EventEmitterReferencingAsyncResource with an eventEmitter back-reference", () => {
+    const ee = new EventEmitterAsyncResource({ name: "X" });
+    expect(ee.asyncResource).toBeInstanceOf(AsyncResource);
+    expect(ee.asyncResource.constructor.name).toBe("EventEmitterReferencingAsyncResource");
+    expect("eventEmitter" in ee.asyncResource).toBe(true);
+    expect(ee.asyncResource.eventEmitter).toBe(ee);
+  });
+
+  test("prototype has asyncId/triggerAsyncId/asyncResource getters", () => {
+    const names = Object.getOwnPropertyNames(EventEmitterAsyncResource.prototype).sort();
+    expect(names).toEqual(["asyncId", "asyncResource", "constructor", "emit", "emitDestroy", "triggerAsyncId"]);
+
+    for (const key of ["asyncId", "triggerAsyncId", "asyncResource"]) {
+      const desc = Object.getOwnPropertyDescriptor(EventEmitterAsyncResource.prototype, key)!;
+      expect({ key, get: typeof desc.get, set: desc.set, enumerable: desc.enumerable, configurable: desc.configurable }).toEqual({
+        key,
+        get: "function",
+        set: undefined,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+
+    const ee = new EventEmitterAsyncResource({ name: "X" });
+    expect(typeof ee.asyncId).toBe("number");
+    expect(typeof ee.triggerAsyncId).toBe("number");
+    expect(ee.asyncResource).toBeInstanceOf(AsyncResource);
+  });
+
+  test("requires options.name when instantiated directly", () => {
+    expect(() => new EventEmitterAsyncResource()).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"options.name"'),
+      }),
+    );
+    expect(() => new EventEmitterAsyncResource({})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => new EventEmitterAsyncResource({ name: 42 })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+
+  test("subclasses may omit options.name and default to the constructor name", () => {
+    class Foo extends EventEmitterAsyncResource {}
+    const foo = new Foo();
+    expect(foo.asyncResource.eventEmitter).toBe(foo);
+    expect(foo.asyncResource.type).toBe("Foo");
+
+    class Bar extends EventEmitterAsyncResource {}
+    const bar = new Bar({ name: "Override" });
+    expect(bar.asyncResource.type).toBe("Override");
+  });
+
+  test("accepts a string as the resource name", () => {
+    const ee = new EventEmitterAsyncResource("MyName");
+    expect(ee.asyncResource.type).toBe("MyName");
+    expect(ee.asyncResource.eventEmitter).toBe(ee);
+  });
+
+  test("emit returns a boolean", () => {
+    const ee = new EventEmitterAsyncResource({ name: "X" });
+    ee.on("foo", () => {});
+    expect(ee.emit("foo")).toBe(true);
+    expect(ee.emit("bar")).toBe(false);
+  });
+
+  test("getters and methods throw TypeError on invalid receiver", () => {
+    const proto = EventEmitterAsyncResource.prototype;
+    for (const key of ["asyncId", "triggerAsyncId", "asyncResource"]) {
+      expect(() => Reflect.get(proto, key, {})).toThrow(TypeError);
+    }
+    expect(() => proto.emit.call({}, "x")).toThrow(TypeError);
+    expect(() => proto.emitDestroy.call({})).toThrow(TypeError);
+
+    const ee = new EventEmitterAsyncResource({ name: "X" });
+    const resourceProto = Object.getPrototypeOf(ee.asyncResource);
+    expect(() => Reflect.get(resourceProto, "eventEmitter", {})).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Repro

```js
import { EventEmitterAsyncResource } from "node:events";

const r = new EventEmitterAsyncResource({ name: "X" });
console.log(r.asyncResource?.constructor?.name);
console.log("eventEmitter" in Object(r.asyncResource));
console.log(r.asyncResource?.eventEmitter === r);
console.log(Object.getOwnPropertyNames(EventEmitterAsyncResource.prototype).sort().join(","));
try { new EventEmitterAsyncResource(); console.log("no throw"); } catch (e) { console.log(e.code); }
```

| | Node v26.3.0 | Bun (before) |
|---|---|---|
| `asyncResource.constructor.name` | `EventEmitterReferencingAsyncResource` | `AsyncResource` |
| `"eventEmitter" in asyncResource` | `true` | `false` |
| `asyncResource.eventEmitter === r` | `true` | `false` |
| prototype own names | `asyncId,asyncResource,constructor,emit,emitDestroy,triggerAsyncId` | `constructor,emit,emitDestroy` |
| `new EventEmitterAsyncResource()` | throws `ERR_INVALID_ARG_TYPE` | no throw |

## Cause

`src/js/node/events.ts` constructed `this.asyncResource = new AsyncResource(name, ...)` directly and stored `asyncResource` / `triggerAsyncId` as own instance properties. There was no `EventEmitterReferencingAsyncResource` subclass, no `eventEmitter` back-reference, no prototype accessors, and no `options.name` validation. `emit()` also discarded the `runInAsyncScope` return value.

## Fix

Rewrote the class to mirror Node's [implementation](https://github.com/nodejs/node/blob/v26.3.0/lib/events.js#L103-L201):

- `asyncResource` is an `EventEmitterReferencingAsyncResource` (extends `AsyncResource`) with a `#eventEmitter` private field exposed via an `eventEmitter` getter.
- `asyncId`, `triggerAsyncId`, and `asyncResource` are prototype getters backed by a `#asyncResource` private field, so accessing them on an invalid receiver throws `TypeError` like Node.
- When instantiated directly (`new.target === EventEmitterAsyncResource`), `options.name` is validated with `validateString` and throws `ERR_INVALID_ARG_TYPE` if missing or not a string. Subclasses default to `new.target.name`. A bare string argument is still accepted as the name.
- `emit()` now returns the boolean from `super.emit` (also addressed by #33688; this change subsumes it).

`AsyncResource` continues to be required lazily on first construction to avoid a bootstrap cycle with `node:async_hooks`.

## Verification

Added tests to `test/js/node/async_hooks/EventEmitterAsyncResource.test.ts` covering the back-reference, prototype shape, `options.name` validation, subclass defaulting, string-name form, `emit()` return value, and invalid-receiver errors. All new tests fail on the released binary and pass with this change; the existing `node:events` and `node:async_hooks` suites remain green.