### PR TITLE
node:events: match Node's 'removeListener' payload for once-wrappers on the array path

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -339,8 +339,10 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
   if (list === undefined) return this;
 
   let position = -1;
+  let originalListener;
   for (let i = list.length - 1; i >= 0; i--) {
     if (list[i] === listener || list[i].listener === listener) {
+      originalListener = list[i].listener;
       position = i;
       break;
     }
@@ -353,9 +355,12 @@ EventEmitterPrototype.removeListener = function removeListener(type, listener) {
   if (list.length === 0) {
     delete events[type];
     this._eventsCount--;
+    // Node's single-listener fast path emits `list.listener || listener` (unwraps once-wrappers).
+    if (events.removeListener !== undefined) this.emit("removeListener", type, originalListener || listener);
+  } else if (events.removeListener !== undefined) {
+    // Node's array path emits the `listener` argument as passed (may be the onceWrapper itself).
+    this.emit("removeListener", type, listener);
   }
-
-  if (events.removeListener !== undefined) this.emit("removeListener", type, listener.listener || listener);
 
   return this;
 };

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -437,6 +437,82 @@ describe("EventEmitter", () => {
     expect(instance._events).toEqual({});
     expect(instance instanceof EventEmitter).toBe(true);
   });
+
+  // Node's removeListener has two code paths with different 'removeListener' payloads:
+  // a single stored listener emits `list.listener || listener` (unwraps once-wrappers),
+  // while the array path emits the `listener` argument exactly as passed.
+  test("'removeListener' event payload matches Node for once-wrappers", () => {
+    function probe(setup: (e: EventEmitter, f: () => void) => void) {
+      const e = new EventEmitter();
+      const orig = function f() {};
+      let got: any = null;
+      e.on("removeListener", (type, l) => {
+        if (type === "x") got = l;
+      });
+      setup(e, orig);
+      return {
+        gotOriginal: got === orig,
+        name: got && got.name,
+        listenerIsOriginal: got ? got.listener === orig : null,
+      };
+    }
+
+    expect({
+      // once() auto-removal with a single listener: Node's single-listener path unwraps.
+      singleOnceAutoRemove: probe((e, f) => {
+        e.once("x", f);
+        e.emit("x");
+      }),
+      // once() auto-removal with >=2 listeners: Node's array path emits the onceWrapper itself.
+      multiOnceAutoRemove: probe((e, f) => {
+        e.once("x", f);
+        e.on("x", () => {});
+        e.emit("x");
+      }),
+      // removeListener(type, wrapper) from rawListeners() with >=2 listeners: array path, wrapper as-is.
+      multiRemoveWrapper: probe((e, f) => {
+        e.once("x", f);
+        e.on("x", () => {});
+        e.removeListener("x", e.rawListeners("x")[0]);
+      }),
+      // removeListener(type, original) with >=2 listeners: array path emits the original passed in.
+      multiRemoveOriginal: probe((e, f) => {
+        e.once("x", f);
+        e.on("x", () => {});
+        e.removeListener("x", f);
+      }),
+      // prependOnceListener auto-removal with >=2 listeners: same array-path behavior.
+      multiPrependOnceAutoRemove: probe((e, f) => {
+        e.on("x", () => {});
+        e.prependOnceListener("x", f);
+        e.emit("x");
+      }),
+    }).toEqual({
+      singleOnceAutoRemove: { gotOriginal: true, name: "f", listenerIsOriginal: false },
+      multiOnceAutoRemove: { gotOriginal: false, name: "bound onceWrapper", listenerIsOriginal: true },
+      multiRemoveWrapper: { gotOriginal: false, name: "bound onceWrapper", listenerIsOriginal: true },
+      multiRemoveOriginal: { gotOriginal: true, name: "f", listenerIsOriginal: false },
+      multiPrependOnceAutoRemove: { gotOriginal: false, name: "bound onceWrapper", listenerIsOriginal: true },
+    });
+  });
+
+  test("removeAllListeners emits 'removeListener' with the original for a once() listener", () => {
+    const e = new EventEmitter();
+    const orig = function f() {};
+    const other = function g() {};
+    const got: Array<{ gotOriginal: boolean; gotOther: boolean; name: string }> = [];
+    e.on("removeListener", (type, l) => {
+      if (type === "x") got.push({ gotOriginal: l === orig, gotOther: l === other, name: l.name });
+    });
+    e.once("x", orig);
+    e.on("x", other);
+    e.removeAllListeners("x");
+    // LIFO: other removed via array path, then orig via single-listener path (unwrapped).
+    expect(got).toEqual([
+      { gotOriginal: false, gotOther: true, name: "g" },
+      { gotOriginal: true, gotOther: false, name: "f" },
+    ]);
+  });
 });
 
 describe("EventEmitter.on", () => {


### PR DESCRIPTION
## Repro

```js
import { EventEmitter } from "node:events";

function probe(label, setup) {
  const e = new EventEmitter();
  const orig = function f() {};
  let got = null;
  e.on("removeListener", (_t, l) => { got = l; });
  setup(e, orig);
  console.log(label, "| got original:", got === orig, "| fn name:", got && got.name);
}
probe("1-listener once auto-remove", (e, f) => { e.once("x", f); e.emit("x"); });
probe("2-listener once auto-remove", (e, f) => { e.once("x", f); e.on("x", () => {}); e.emit("x"); });
```

Node v26.3.0:
```
1-listener once auto-remove | got original: true  | fn name: f
2-listener once auto-remove | got original: false | fn name: bound onceWrapper
```

Bun (before):
```
1-listener once auto-remove | got original: true | fn name: f
2-listener once auto-remove | got original: true | fn name: f
```

## Cause

Node's `removeListener` has two code paths. When the event type has a single listener (stored as a bare function), it emits `list.listener || listener`, which unwraps a once-wrapper to the user's original function. When the type has an array of listeners, it emits the `listener` argument exactly as passed. `once()`'s auto-removal passes its internal `onceWrapper`, so on the array path Node emits the wrapper itself (whose `.listener` is the original).

Bun's `removeListener` always emitted `listener.listener || listener`, unwrapping on both paths. The same divergence applied to a manual `removeListener(type, wrapper)` where `wrapper` came from `rawListeners()`.

## Fix

Mirror Node's split in `src/js/node/events.ts`: after removal, if the list is now empty (the type had a single listener) emit `originalListener || listener` where `originalListener` is the matched entry's `.listener`; otherwise emit `listener` as passed. `removeAllListeners` already routes through `removeListener` in LIFO order, so its last removal hits the single-listener path and keeps emitting the original as before.

## Verification

- New tests in `test/js/node/events/event-emitter.test.ts` fail with `USE_SYSTEM_BUN=1` and pass with the fix.
- All 26 `test/js/node/test/parallel/test-event-emitter-*.js` tests pass.
