### PR TITLE
Bun.serve websocket: treat a 1-byte Close body as a protocol error

### DIFF
--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -128,6 +128,11 @@ struct CloseFrame {
 static inline CloseFrame parseClosePayload(char *src, size_t length) {
     /* If we get no code or message, default to reporting 1005 no status code present */
     CloseFrame cf = {1005, nullptr, 0};
+    if (length == 1) {
+        /* RFC 6455 §5.5.1: if a body is present its first two bytes MUST be the
+         * status code, so a 1-byte body is malformed. Only length 0 maps to 1005. */
+        return {1006, nullptr, 0};
+    }
     if (length >= 2) {
         memcpy(&cf.code, src, 2);
         cf = {cond_byte_swap<uint16_t>(cf.code), src + 2, length - 2};

--- a/test/js/bun/websocket/websocket-server-close-frame.test.ts
+++ b/test/js/bun/websocket/websocket-server-close-frame.test.ts
@@ -1,0 +1,141 @@
+// RFC 6455 section 5.5.1: when a Close frame carries a body, the first two
+// bytes MUST be the 2-byte status code, so a 1-byte body is malformed and must
+// be treated like any other invalid Close payload, not as "no status received".
+import { serve } from "bun";
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+
+describe.concurrent("Bun.serve received Close frame validation", () => {
+  function maskedClose(payload: Buffer): Buffer {
+    const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+    const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+    return Buffer.concat([Buffer.from([0x88, 0x80 | payload.length]), mask, masked]);
+  }
+
+  // Raw TCP WebSocket client against a Bun.serve websocket server: perform the
+  // upgrade, then expose the server's close() callback and every frame byte it
+  // writes back.
+  async function connectRaw() {
+    const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
+    const server = serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("upgrade failed", { status: 400 });
+      },
+      websocket: {
+        perMessageDeflate: false,
+        message() {},
+        close(ws, code, reason) {
+          serverClose.resolve({ code, reason });
+        },
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    const upgraded = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    socket.on("close", () => {
+      closed.resolve();
+      upgraded.reject(new Error("socket closed before the 101 response"));
+    });
+    socket.on("error", (error: Error) => {
+      closed.resolve();
+      upgraded.reject(error);
+    });
+
+    let frameBytes = Buffer.alloc(0);
+    const onFrameData = (chunk: Buffer) => {
+      frameBytes = Buffer.concat([frameBytes, chunk]);
+    };
+
+    let head = Buffer.alloc(0);
+    const onHead = (chunk: Buffer) => {
+      head = Buffer.concat([head, chunk]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      socket.off("data", onHead);
+      socket.on("data", onFrameData);
+      const headText = head.subarray(0, end).toString();
+      if (!headText.startsWith("HTTP/1.1 101")) {
+        upgraded.reject(new Error(`upgrade failed: ${headText.split("\r\n")[0]}`));
+        return;
+      }
+      const rest = head.subarray(end + 4);
+      if (rest.length) onFrameData(rest);
+      upgraded.resolve();
+    };
+    socket.on("data", onHead);
+    socket.write(
+      "GET / HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "\r\n",
+    );
+    try {
+      await upgraded.promise;
+    } catch (error) {
+      socket.destroy();
+      server.stop(true);
+      throw error;
+    }
+
+    return {
+      socket,
+      serverClose: serverClose.promise,
+      closed: closed.promise,
+      frames: () => frameBytes,
+      [Symbol.dispose]() {
+        socket.destroy();
+        server.stop(true);
+      },
+    };
+  }
+
+  // Autobahn 7.3.2: a 1-byte Close body is a protocol error. The server's
+  // close() handler must report it like every other invalid Close payload
+  // (1006), not as 1005 "no status received" which a valid empty body maps to.
+  it("a Close frame with a 1-byte body is reported as abnormal (1006)", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(maskedClose(Buffer.from([0x00])));
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "" });
+    await raw.closed;
+    // 1006 is never put on the wire: the reply is a bodyless Close.
+    expect(raw.frames()).toEqual(Buffer.from([0x88, 0x00]));
+  });
+
+  // Control: a well-formed empty Close body is the one case that maps to 1005.
+  it("an empty Close body reports 1005 (no status received)", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(maskedClose(Buffer.alloc(0)));
+    expect(await raw.serverClose).toEqual({ code: 1005, reason: "" });
+    await raw.closed;
+    expect(raw.frames()).toEqual(Buffer.from([0x88, 0x00]));
+  });
+
+  // Control: a valid code is echoed and delivered verbatim.
+  it("a valid code is echoed and delivered to close()", async () => {
+    using raw = await connectRaw();
+    raw.socket.write(maskedClose(Buffer.from([0x03, 0xe8, 0x62, 0x79, 0x65])));
+    expect(await raw.serverClose).toEqual({ code: 1000, reason: "bye" });
+    await raw.closed;
+    expect(raw.frames()).toEqual(Buffer.from([0x88, 0x05, 0x03, 0xe8, 0x62, 0x79, 0x65]));
+  });
+
+  // The other malformed-Close-body cases (reserved code, bad UTF-8 reason) all
+  // map to 1006 via the same parseClosePayload routine the 1-byte case feeds.
+  it.each([
+    ["a reserved code (999)", Buffer.from([0x03, 0xe7])],
+    ["a code forbidden on the wire (1005)", Buffer.from([0x03, 0xed])],
+    ["a non-UTF-8 reason", Buffer.from([0x03, 0xe8, 0xc3, 0x28])],
+  ])("%s is reported as abnormal (1006)", async (_, body) => {
+    using raw = await connectRaw();
+    raw.socket.write(maskedClose(body));
+    expect(await raw.serverClose).toEqual({ code: 1006, reason: "" });
+    await raw.closed;
+    expect(raw.frames()).toEqual(Buffer.from([0x88, 0x00]));
+  });
+});


### PR DESCRIPTION
A Close frame with a 1-byte body is a protocol error per RFC 6455 section 5.5.1 ("If there is a body, the first two bytes of the body MUST be a 2-byte unsigned integer") and Autobahn 7.3.2. `Bun.serve` accepted it as a clean codeless close: the `close(ws, code, reason)` handler reported `1005` ("no status received") with an empty reason, indistinguishable from a valid empty Close body, and the server completed the close handshake normally.

## Repro

```js
import net from "node:net";

const srv = Bun.serve({
  port: 0,
  fetch(req, s) { if (s.upgrade(req)) return; return new Response("no", { status: 400 }); },
  websocket: { message() {}, close(ws, code, reason) { console.log("close:", code, JSON.stringify(reason)); } },
});
const s = net.connect(srv.port, "127.0.0.1", () => s.write(
  "GET / HTTP/1.1\r\nHost: h\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
  "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"));
let h = false, buf = Buffer.alloc(0);
s.on("data", c => {
  buf = Buffer.concat([buf, c]);
  if (!h) {
    const i = buf.indexOf("\r\n\r\n"); if (i < 0) return; h = true;
    // masked CLOSE frame with a single payload byte
    const key = Buffer.from([1, 2, 3, 4]);
    s.write(Buffer.concat([Buffer.from([0x88, 0x81]), key, Buffer.from([0x00 ^ key[0]])]));
  }
});
```

Before: `close: 1005 ""` (same as an empty Close body).
After: `close: 1006 ""` (same as every other malformed Close body).

## Cause

`parseClosePayload()` in `packages/bun-uws/src/WebSocketProtocol.h` starts from `{1005, nullptr, 0}` and only enters its validation block under `length >= 2`, so `length == 1` fell straight through to the 1005 default.

## Fix

`length == 1` returns `{1006, nullptr, 0}`, matching the existing handling of every other malformed Close body (a reserved/out-of-range code or a non-UTF-8 reason). Only `length == 0` maps to 1005. The client `WebSocket` already rejects a 1-byte Close body (`recv_close` checks `body_remain == 1` first).

## Verification

New `test/js/bun/websocket/websocket-server-close-frame.test.ts` drives a raw TCP client against `Bun.serve` and asserts both the `close()` handler arguments and the reply frame on the wire for: a 1-byte body (1006), an empty body (1005), a valid code (echoed), and the existing malformed-body cases (reserved code, forbidden-on-the-wire code, non-UTF-8 reason, all 1006). The 1-byte test fails on the released binary with `code: 1005` and passes with this change; the controls pass on both.