### PR TITLE
node:fs: implement FileHandle.readableWebStream() per Node.js contract

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -698,11 +698,81 @@ function asyncWrap(fn: any, name: string) {
       return this.close();
     }
 
-    readableWebStream(_options = kEmptyObject) {
-      const fd = this[kFd];
-      throwEBADFIfNecessary("readableWebStream", fd);
+    readableWebStream(options = kEmptyObject) {
+      if (this[kFd] === -1) throw $ERR_INVALID_STATE("The FileHandle is closed");
+      if (this[kClosePromise]) throw $ERR_INVALID_STATE("The FileHandle is closing");
+      if (this[kLocked]) throw $ERR_INVALID_STATE("The FileHandle is locked");
+      this[kLocked] = true;
 
-      return Bun.file(fd).stream();
+      validateObject(options, "options");
+      const { type = "bytes", autoClose = false } = options;
+
+      validateBoolean(autoClose, "options.autoClose");
+
+      if (type !== "bytes") {
+        process.emitWarning(
+          'A non-"bytes" options.type has no effect. A byte-oriented steam is ' + "always created.",
+          "ExperimentalWarning",
+        );
+      }
+
+      const handle = this;
+      let done = false;
+      let streamController;
+
+      const ondone = async () => {
+        if (done) return;
+        done = true;
+        handle.removeListener("close", onClose);
+        handle[kUnref]();
+        if (autoClose) await handle.close();
+      };
+
+      const readable = new ReadableStream({
+        type: "bytes",
+        autoAllocateChunkSize: 16384,
+
+        start(controller) {
+          streamController = controller;
+        },
+
+        async pull(controller) {
+          if (done) return;
+          const view = controller.byobRequest.view;
+          const { bytesRead } = await handle.read(view, view.byteOffset, view.byteLength);
+
+          // fh.close() may have cancelled us while the read was in flight.
+          if (done) return;
+
+          if (bytesRead === 0) {
+            controller.close();
+            await ondone();
+          }
+
+          controller.byobRequest.respond(bytesRead);
+        },
+
+        async cancel() {
+          await ondone();
+        },
+      });
+
+      // close() emits 'close' before the fd is released (the stream holds a
+      // ref); end the stream here so kUnref lets the pending close resolve.
+      function onClose() {
+        if (done) return;
+        done = true;
+        try {
+          streamController.close();
+          streamController.byobRequest?.respond(0);
+        } catch {}
+        handle[kUnref]();
+      }
+
+      this[kRef]();
+      this.once("close", onClose);
+
+      return readable;
     }
 
     createReadStream(options = kEmptyObject) {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -702,7 +702,6 @@ function asyncWrap(fn: any, name: string) {
       if (this[kFd] === -1) throw $ERR_INVALID_STATE("The FileHandle is closed");
       if (this[kClosePromise]) throw $ERR_INVALID_STATE("The FileHandle is closing");
       if (this[kLocked]) throw $ERR_INVALID_STATE("The FileHandle is locked");
-      this[kLocked] = true;
 
       validateObject(options, "options");
       const { type = "bytes", autoClose = false } = options;
@@ -715,6 +714,8 @@ function asyncWrap(fn: any, name: string) {
           "ExperimentalWarning",
         );
       }
+
+      this[kLocked] = true;
 
       const handle = this;
       let done = false;
@@ -738,18 +739,23 @@ function asyncWrap(fn: any, name: string) {
 
         async pull(controller) {
           if (done) return;
-          const view = controller.byobRequest.view;
-          const { bytesRead } = await handle.read(view, view.byteOffset, view.byteLength);
+          try {
+            const view = controller.byobRequest.view;
+            const { bytesRead } = await handle.read(view, 0, view.byteLength);
 
-          // fh.close() may have cancelled us while the read was in flight.
-          if (done) return;
+            // fh.close() may have cancelled us while the read was in flight.
+            if (done) return;
 
-          if (bytesRead === 0) {
-            controller.close();
+            if (bytesRead === 0) {
+              controller.close();
+              await ondone();
+            }
+
+            controller.byobRequest.respond(bytesRead);
+          } catch (err) {
             await ondone();
+            throw err;
           }
-
-          controller.byobRequest.respond(bytesRead);
         },
 
         async cancel() {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -743,8 +743,16 @@ function asyncWrap(fn: any, name: string) {
             const view = controller.byobRequest.view;
             const { bytesRead } = await handle.read(view, 0, view.byteLength);
 
-            // fh.close() may have cancelled us while the read was in flight.
-            if (done) return;
+            if (done) {
+              // fh.close() fired while the read was in flight; onClose already
+              // closed the controller. Settle any pending BYOB read (the
+              // buffer is now unpinned, so this succeeds where onClose's
+              // attempt may have thrown).
+              try {
+                controller.byobRequest?.respond(0);
+              } catch {}
+              return;
+            }
 
             if (bytesRead === 0) {
               controller.close();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -426,18 +426,17 @@ describe("FileHandle", () => {
 
   it("FileHandle#readableWebStream validates options", async () => {
     using dir = tempDir("fh-rws-validate", { "a.txt": "x" });
-    {
-      await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
-      expect(() => fh.readableWebStream("string" as any)).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
-    }
-    {
-      await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
-      expect(() => fh.readableWebStream({ autoClose: 1 as any })).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
-    }
+    await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    expect(() => fh.readableWebStream("string" as any)).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => fh.readableWebStream({ autoClose: 1 as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    // A validation throw must not leave the handle locked.
+    const s = fh.readableWebStream();
+    expect(s).toBeInstanceOf(ReadableStream);
+    await s.cancel();
   });
 
   it("FileHandle#readableWebStream supports BYOB reader", async () => {
@@ -447,6 +446,18 @@ describe("FileHandle", () => {
     const { value, done } = await reader.read(new Uint8Array(3));
     expect(done).toBe(false);
     expect(Buffer.from(value!).toString()).toBe("hel");
+    reader.releaseLock();
+  });
+
+  it("FileHandle#readableWebStream BYOB reads into a subarray with non-zero byteOffset", async () => {
+    using dir = tempDir("fh-rws-byob-off", { "a.txt": "hello world!" });
+    await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    const reader = fh.readableWebStream().getReader({ mode: "byob" });
+    const backing = new ArrayBuffer(32);
+    const { value, done } = await reader.read(new Uint8Array(backing, 8, 5));
+    expect(done).toBe(false);
+    expect(value!.byteOffset).toBe(8);
+    expect(Buffer.from(value!).toString()).toBe("hello");
     reader.releaseLock();
   });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -360,6 +360,96 @@ describe("FileHandle", () => {
     reader.releaseLock();
   });
 
+  it("FileHandle#readableWebStream throws ERR_INVALID_STATE on second call", async () => {
+    using dir = tempDir("fh-rws-locked", { "a.txt": "x" });
+    await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    const s1 = fh.readableWebStream();
+    expect(() => fh.readableWebStream()).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: expect.stringContaining("locked") }),
+    );
+    await s1.cancel();
+  });
+
+  it("FileHandle#readableWebStream throws ERR_INVALID_STATE when the handle is closed", async () => {
+    using dir = tempDir("fh-rws-closed", { "a.txt": "x" });
+    const fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    await fh.close();
+    expect(() => fh.readableWebStream()).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: expect.stringContaining("closed") }),
+    );
+  });
+
+  it("FileHandle#readableWebStream autoClose closes the handle after the stream is consumed", async () => {
+    using dir = tempDir("fh-rws-autoclose", { "a.txt": "hello world" });
+    const fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    const closed = new Promise<void>(resolve => fh.once("close", () => resolve()));
+    const reader = fh.readableWebStream({ autoClose: true }).getReader();
+    let text = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += Buffer.from(value).toString();
+    }
+    await closed;
+    expect(text).toBe("hello world");
+    expect(fh.fd).toBe(-1);
+    await expect(fh.stat()).rejects.toThrow(expect.objectContaining({ code: "EBADF" }));
+  });
+
+  it("FileHandle#readableWebStream autoClose closes the handle on cancel", async () => {
+    using dir = tempDir("fh-rws-autoclose-cancel", { "a.txt": "hello world" });
+    const fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    const closed = new Promise<void>(resolve => fh.once("close", () => resolve()));
+    const stream = fh.readableWebStream({ autoClose: true });
+    await stream.cancel();
+    await closed;
+    expect(fh.fd).toBe(-1);
+  });
+
+  it("FileHandle#readableWebStream stops when the FileHandle is closed", async () => {
+    using dir = tempDir("fh-rws-close-stops", { "a.bin": Buffer.alloc(1_000_000, "V") });
+    const fh = await fs.promises.open(path.join(String(dir), "a.bin"), "r");
+    const reader = fh.readableWebStream().getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(first.value!.byteLength).toBeGreaterThan(0);
+    await fh.close();
+    let bytesAfterClose = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesAfterClose += value!.byteLength;
+    }
+    expect(bytesAfterClose).toBe(0);
+    expect(fh.fd).toBe(-1);
+  });
+
+  it("FileHandle#readableWebStream validates options", async () => {
+    using dir = tempDir("fh-rws-validate", { "a.txt": "x" });
+    {
+      await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+      expect(() => fh.readableWebStream("string" as any)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    }
+    {
+      await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+      expect(() => fh.readableWebStream({ autoClose: 1 as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    }
+  });
+
+  it("FileHandle#readableWebStream supports BYOB reader", async () => {
+    using dir = tempDir("fh-rws-byob", { "a.txt": "hello" });
+    await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");
+    const reader = fh.readableWebStream().getReader({ mode: "byob" });
+    const { value, done } = await reader.read(new Uint8Array(3));
+    expect(done).toBe(false);
+    expect(Buffer.from(value!).toString()).toBe("hel");
+    reader.releaseLock();
+  });
+
   it("FileHandle#createReadStream", async () => {
     await using fd = await fs.promises.open(__filename);
     const readable = fd.createReadStream();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -424,6 +424,20 @@ describe("FileHandle", () => {
     expect(fh.fd).toBe(-1);
   });
 
+  it("FileHandle#readableWebStream BYOB read settles when close() fires mid-read", async () => {
+    using dir = tempDir("fh-rws-byob-midclose", { "a.bin": Buffer.alloc(1_000_000, "Q") });
+    const fh = await fs.promises.open(path.join(String(dir), "a.bin"), "r");
+    const reader = fh.readableWebStream().getReader({ mode: "byob" });
+    await 0;
+    const pending = reader.read(new Uint8Array(65536));
+    const closeP = fh.close();
+    const { done } = await pending;
+    expect(done).toBe(true);
+    await closeP;
+    expect(fh.fd).toBe(-1);
+    expect((await reader.read(new Uint8Array(1))).done).toBe(true);
+  });
+
   it("FileHandle#readableWebStream validates options", async () => {
     using dir = tempDir("fh-rws-validate", { "a.txt": "x" });
     await using fh = await fs.promises.open(path.join(String(dir), "a.txt"), "r");


### PR DESCRIPTION
## What does this PR do?

`FileHandle.readableWebStream()` was a one-liner delegating to `Bun.file(fd).stream()`, which `dup(2)`s the fd into a stream completely detached from the `FileHandle`. That loses the entire documented contract:

| | Node.js | Bun (before) |
|---|---|---|
| `autoClose: true` | handle is closed after stream ends | ignored, fd leaks |
| second `readableWebStream()` | throws `ERR_INVALID_STATE` | allowed |
| `await fh.close()` mid-stream | stream ends, 0 bytes after | entire rest of file delivered from invisible dup'd fd |
| `options` validation | `validateObject` / `validateBoolean` | ignored |
| BYOB reader | supported (`type: 'bytes'`) | `TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController` |

## Repro

```js
import * as fsp from "node:fs/promises";
import * as fs from "node:fs";
fs.writeFileSync("/tmp/c", Buffer.alloc(2_000_000, "V"));
const fh = await fsp.open("/tmp/c", "r");
const rd = fh.readableWebStream().getReader();
await rd.read();
await fh.close();
let after = 0;
for (;;) { const { done, value } = await rd.read(); if (done) break; after += value.byteLength; }
console.log("bytes after close():", after);
// node:        0
// bun before:  1737856
```

## Fix

Port Node's implementation (`lib/internal/fs/promises.js` `readableWebStream`): a `type: 'bytes'` `ReadableStream` whose `pull()` reads through `handle.read()` under the FileHandle's `kRef`/`kUnref` ref-count, sets `kLocked`, honors `autoClose`, validates `options`, and listens for the handle's `'close'` event to end the stream and release its ref so `close()` can resolve.

Node uses its internal `readableStreamCancel(readable)` in the close listener (bypasses the locked check); Bun doesn't expose that from JS, so the close listener closes the controller directly and responds 0 to any pending BYOB request, then `kUnref`s. `pull()` re-checks a `done` flag after the awaited read so a close-during-read doesn't try to respond to an already-completed BYOB request.

## How did you verify your code works?

New tests in `test/js/node/fs/fs.test.ts` covering all five rows above plus cancel-with-autoClose; all fail on `USE_SYSTEM_BUN=1 bun test` and pass on `bun bd test`. fd-leak probe over 50 iterations of each path (`autoClose` loop, close-stops loop, cancel loop) shows zero fd delta, matching Node. Full `test/js/node/fs/fs.test.ts` (388 tests) and related `test/js/node/test/parallel/test-fs-*file-handle*` pass unchanged.