### PR TITLE
docs(module-resolution): correct extension order and stale TypeScript claims

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -3,7 +3,7 @@ title: "Module Resolution"
 description: "How Bun resolves modules and handles imports in JavaScript and TypeScript"
 ---
 
-The JavaScript ecosystem is in a years-long transition from CommonJS modules to native ES modules (ESM). TypeScript enforces its own rules around import extensions that aren't compatible with ESM, and build tools re-map paths through incompatible mechanisms. Bun aims to provide a consistent and predictable module resolution system that works without configuration.
+The JavaScript ecosystem is in a years-long transition from CommonJS modules to native ES modules (ESM), and different runtimes and build tools have historically disagreed on how import specifiers map to files on disk. Bun aims to provide a consistent and predictable module resolution system that works without configuration.
 
 ## Syntax
 
@@ -36,27 +36,37 @@ Here `./hello` is a relative path with no extension. **Extensioned imports are o
 
 - `./hello.tsx`
 - `./hello.jsx`
+- `./hello.mts`
 - `./hello.ts`
 - `./hello.mjs`
 - `./hello.js`
+- `./hello.cts`
 - `./hello.cjs`
 - `./hello.json`
 - `./hello/index.tsx`
 - `./hello/index.jsx`
+- `./hello/index.mts`
 - `./hello/index.ts`
 - `./hello/index.mjs`
 - `./hello/index.js`
+- `./hello/index.cts`
 - `./hello/index.cjs`
 - `./hello/index.json`
 
-If the import path includes an extension, Bun only checks for a file with that exact extension.
+<Note>
+  The exact order varies by context: `require()` tries CommonJS extensions (`.cts`, `.cjs`) before ESM ones (`.mts`,
+  `.mjs`), and imports inside `node_modules` try JavaScript extensions before TypeScript ones. The list above shows the
+  order for a local ESM `import`.
+</Note>
+
+If the import path includes an extension, Bun checks for that exact file first. If no exact match exists, Bun falls back to trying the extension list above appended to the full path (so `./hello.world` can resolve to `./hello.world.ts`).
 
 ```ts index.ts icon="/icons/typescript.svg"
 import { hello } from "./hello";
 import { hello } from "./hello.ts"; // this works
 ```
 
-If you import `from "*.js{x}"`, Bun also checks for a matching `*.ts{x}` file, to be compatible with TypeScript's [ES module support](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#new-file-extensions).
+There's one additional rule for TypeScript compatibility: if you import `from "*.js"` or `from "*.jsx"`, Bun also checks for a matching `*.ts` or `*.tsx` file, and `from "*.mjs"` also matches `*.mts`. This mirrors the behavior of the TypeScript compiler's [module resolution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution), which lets source files reference each other by their compiled output paths.
 
 ```ts index.ts icon="/icons/typescript.svg"
 import { hello } from "./hello";
@@ -200,8 +210,9 @@ Once it finds the `foo` package, Bun reads its `package.json` to determine the p
   "exports": {
     "bun": "./index.js",
     "node": "./index.js",
-    "require": "./index.js", // if importer is CommonJS
-    "import": "./index.mjs", // if importer is ES module
+    "node-addons": "./index.js", // unless --no-addons was passed
+    "require": "./index.js", // if the importer uses require()
+    "import": "./index.mjs", // if the importer uses import
     "default": "./index.js"
   }
 }
@@ -247,7 +258,7 @@ import stuff from "foo/index.mjs"; // this doesn't
   in the `"bun"` condition, Bun imports and executes your TypeScript source files directly.
 </Note>
 
-If `exports` is not defined, Bun falls back to `"module"` (ESM imports only) then [`"main"`](https://nodejs.org/api/packages.html#main).
+If `exports` is not defined, Bun falls back to the legacy top-level entrypoint fields. At runtime Bun prefers [`"main"`](https://nodejs.org/api/packages.html#main) when it's present, and uses `"module"` otherwise.
 
 ```json package.json icon="file-json"
 {
@@ -298,7 +309,7 @@ Bun supports import path re-mapping through TypeScript's [`compilerOptions.paths
 }
 ```
 
-Bun also supports [Node.js-style subpath imports](https://nodejs.org/api/packages.html#subpath-imports) in `package.json`, where mapped paths must start with `#`. This approach doesn’t work as well with editors, but you can use both options together.
+Bun also supports [Node.js-style subpath imports](https://nodejs.org/api/packages.html#subpath-imports) in `package.json`, where mapped paths must start with `#`. TypeScript and editors resolve these too, and you can use both mechanisms together.
 
 ```json package.json icon="file-json"
 {

--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -66,7 +66,7 @@ import { hello } from "./hello";
 import { hello } from "./hello.ts"; // this works
 ```
 
-There's one additional rule for TypeScript compatibility: if you import `from "*.js"` or `from "*.jsx"`, Bun also checks for a matching `*.ts` or `*.tsx` file, and `from "*.mjs"` also matches `*.mts`. This mirrors the behavior of the TypeScript compiler's [module resolution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution), which lets source files reference each other by their compiled output paths.
+There's one additional rule for TypeScript compatibility: if you import `from "*.js"` or `from "*.jsx"`, Bun also checks for a matching `*.ts` or `*.tsx` file, and outside `node_modules` `from "*.mjs"` also matches `*.mts`. This follows the TypeScript compiler's [file extension substitution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution), which lets source files reference each other by their compiled output paths. Note that unlike TypeScript, Bun doesn't rewrite `.cjs` to `.cts`.
 
 ```ts index.ts icon="/icons/typescript.svg"
 import { hello } from "./hello";
@@ -209,8 +209,8 @@ Once it finds the `foo` package, Bun reads its `package.json` to determine the p
   "name": "foo",
   "exports": {
     "bun": "./index.js",
-    "node": "./index.js",
     "node-addons": "./index.js", // unless --no-addons was passed
+    "node": "./index.js",
     "require": "./index.js", // if the importer uses require()
     "import": "./index.mjs", // if the importer uses import
     "default": "./index.js"
@@ -258,7 +258,7 @@ import stuff from "foo/index.mjs"; // this doesn't
   in the `"bun"` condition, Bun imports and executes your TypeScript source files directly.
 </Note>
 
-If `exports` is not defined, Bun falls back to the legacy top-level entrypoint fields. At runtime Bun prefers [`"main"`](https://nodejs.org/api/packages.html#main) when it's present, and uses `"module"` otherwise.
+If `exports` is not defined, Bun falls back to the legacy top-level entrypoint fields. At runtime Bun prefers [`"main"`](https://nodejs.org/api/packages.html#main) (or an implicit `index.*` file) when present, and uses `"module"` otherwise.
 
 ```json package.json icon="file-json"
 {


### PR DESCRIPTION
Audit of the claims on the [Module Resolution](https://bun.com/docs/runtime/module-resolution) page against the current resolver source and TypeScript documentation. Several statements were incorrect or outdated.

### Extension resolution order

The page listed `.tsx, .jsx, .ts, .mjs, .js, .cjs, .json` and omitted `.mts`/`.cts`. The actual ESM order in [`src/bundler/options.rs` `MODULE_EXTENSION_ORDER`](https://github.com/oven-sh/bun/blob/main/src/bundler/options.rs) is `.tsx, .jsx, .mts, .ts, .mjs, .js, .cts, .cjs, .json`, confirmed empirically:

```
$ for ext in tsx jsx ts mjs js cjs json mts cts; do echo "export const v = '$ext'" > hello.$ext; done
$ bun -e 'import {v} from "./hello"; console.log(v)'   # repeat, delete winner
tsx jsx mts ts mjs js cts cjs json
```

Added a note that the order differs for `require()` (CJS-first) and inside `node_modules` (JS-first).

### "An explicit extension is matched exactly"

Not true. Bun tries the exact path first, then falls back to appending extensions, so `./foo.bar` can resolve to `./foo.bar.ts`. Reworded.

### `.js` -> `.ts` extension substitution

The page only mentioned `.js{x}` -> `.ts{x}`. The resolver also rewrites `.mjs` -> `.mts` (see `load_as_file` in `src/resolver/resolver.rs`). Updated, and replaced the TS 4.7 release-notes link with the current handbook section on [file extension substitution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution).

### Export conditions

Added `node-addons`, which Bun enables by default (disabled via `--no-addons`). Reworded the `require`/`import` comments: they depend on the import statement, not the module format of the importing file.

### `main`/`module` fallback

The page said Bun "falls back to `module` (ESM imports only) then `main`". At runtime Bun actually prefers `main` when both are present (the `auto_main` path in `src/resolver/resolver.rs`), and `module` is used for `require()` too when `main` is absent. Reworded.

### Outdated TypeScript claims

- Removed "TypeScript enforces its own rules around import extensions that aren't compatible with ESM" from the intro. Modern TypeScript supports `.ts` extensions (`allowImportingTsExtensions`) and can rewrite them on emit (`rewriteRelativeImportExtensions`), so this framing is no longer accurate.
- Removed "[subpath imports] don't work as well with editors". TypeScript and VS Code have resolved `package.json` `"imports"` for several releases.