### PR TITLE
install: accept any digest of the strongest integrity algorithm (SSRI any-match)

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -916,7 +916,13 @@ impl NetworkTask {
             // (cleared immediately below); `put()` runs `Task::drop` on the
             // slot — the Task was fully initialized via
             // `enqueue::create_extract_task_for_streaming` so this is sound.
+            // `request.extract` is the active union member (tag Extract, set in
+            // `init_extract_task`) and owns `tarball.integrity_alternates`;
+            // drop it explicitly because `Task::drop` never reaches
+            // `ManuallyDrop` union payloads. `deinit_payload()` must not be
+            // used here: `data` is still zeroed on this never-ran task.
             unsafe {
+                ManuallyDrop::drop(&mut (*self.streaming_extract_task).request.extract);
                 manager
                     .preallocated_resolve_tasks
                     .put(self.streaming_extract_task);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1924,6 +1924,7 @@ fn enqueue_local_tarball(
                     temp_dir: get_temporary_directory(this).handle.fd(),
                     dependency_id,
                     integrity: *integrity,
+                    integrity_alternates: this.lockfile.integrity_alternates_for(integrity),
                     url: StringOrTinyString::init_append_if_needed(
                         path,
                         &mut crate::network_task::filename_store_appender(),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1647,6 +1647,7 @@ fn init_extract_task(
                             .options
                             .do_
                             .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
+                        integrity_alternates: tarball.integrity_alternates.clone(),
                         ..*tarball
                     },
                 }),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -256,12 +256,14 @@ pub fn enqueue_tarball_for_reading(
     }
 
     let integrity = this.lockfile.packages.items_meta()[package_id as usize].integrity;
+    let name_hash = this.lockfile.packages.items_name_hash()[package_id as usize];
 
     let task = enqueue_local_tarball(
         this,
         task_id,
         dependency_id,
         alias,
+        name_hash,
         path,
         resolution,
         &integrity,
@@ -1577,6 +1579,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         task_id,
                         id,
                         dep_name,
+                        dependency.name_hash,
                         url,
                         &res,
                         &Integrity::default(),
@@ -1859,6 +1862,7 @@ fn enqueue_local_tarball(
     task_id: Task::Id,
     dependency_id: DependencyID,
     name: &[u8],
+    name_hash: PackageNameHash,
     path: &[u8],
     resolution: &Resolution,
     integrity: &Integrity,
@@ -1925,7 +1929,9 @@ fn enqueue_local_tarball(
                     temp_dir: get_temporary_directory(this).handle.fd(),
                     dependency_id,
                     integrity: *integrity,
-                    integrity_alternates: this.lockfile.integrity_alternates_for(integrity),
+                    integrity_alternates: this
+                        .lockfile
+                        .integrity_alternates_for(name_hash, integrity),
                     url: StringOrTinyString::init_append_if_needed(
                         path,
                         &mut crate::network_task::filename_store_appender(),

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1854,6 +1854,9 @@ pub fn generate_network_task_for_tarball<'a>(
         skip_verify: false,
         in_trusted_dependencies: this.lockfile.in_trusted_dependencies(pkg_name),
         integrity: package.meta.integrity,
+        integrity_alternates: this
+            .lockfile
+            .integrity_alternates_for(&package.meta.integrity),
         url: strings::StringOrTinyString::init_append_if_needed(
             url,
             &mut crate::network_task::filename_store_appender(),

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1856,7 +1856,7 @@ pub fn generate_network_task_for_tarball<'a>(
         integrity: package.meta.integrity,
         integrity_alternates: this
             .lockfile
-            .integrity_alternates_for(&package.meta.integrity),
+            .integrity_alternates_for(package.name_hash, &package.meta.integrity),
         url: strings::StringOrTinyString::init_append_if_needed(
             url,
             &mut crate::network_task::filename_store_appender(),

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -216,7 +216,7 @@ impl TarballStream {
             &if tarball.skip_verify {
                 integrity::IntegrityAlternates::default()
             } else {
-                tarball.integrity_alternates
+                tarball.integrity_alternates.clone()
             },
             compute_if_missing,
         );

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -213,6 +213,11 @@ impl TarballStream {
             } else {
                 tarball.integrity
             },
+            &if tarball.skip_verify {
+                integrity::IntegrityAlternates::default()
+            } else {
+                tarball.integrity_alternates
+            },
             compute_if_missing,
         );
 

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -12,7 +12,7 @@ use bun_semver::Version;
 use bun_sys::{self as sys, Dir, Fd};
 
 use bun_install::install::{self as Install, DependencyID, ExtractData};
-use bun_install::integrity::Integrity;
+use bun_install::integrity::{Integrity, IntegrityAlternates};
 use bun_install::npm::{self as Npm};
 use bun_install::package_manager_real::PackageManager;
 use bun_install::package_manager_real::directories;
@@ -38,6 +38,9 @@ pub struct ExtractTarball {
     pub skip_verify: bool, // = false
     pub in_trusted_dependencies: bool,
     pub integrity: Integrity, // = Integrity::default()
+    /// Other accepted digests of `integrity.tag` (SSRI any-match). Empty in
+    /// the common single-digest case.
+    pub integrity_alternates: IntegrityAlternates,
     pub url: StringOrTinyString,
     /// BACKREF: PackageManager owns the task pool that owns this struct.
     pub package_manager: bun_ptr::BackRef<PackageManager>,
@@ -47,7 +50,11 @@ impl ExtractTarball {
     #[inline]
     pub fn run(&self, log: &mut bun_ast::Log, bytes: &[u8]) -> Result<ExtractData, Error> {
         if !self.skip_verify && self.integrity.tag.is_supported() {
-            if !self.integrity.verify(bytes) {
+            if !self.integrity.verify(bytes)
+                && !self
+                    .integrity_alternates
+                    .verify_bytes(self.integrity.tag, bytes)
+            {
                 log.add_error_fmt(
                     None,
                     bun_ast::Loc::EMPTY,

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -50,10 +50,12 @@ impl ExtractTarball {
     #[inline]
     pub fn run(&self, log: &mut bun_ast::Log, bytes: &[u8]) -> Result<ExtractData, Error> {
         if !self.skip_verify && self.integrity.tag.is_supported() {
-            if !self.integrity.verify(bytes)
-                && !self
-                    .integrity_alternates
-                    .verify_bytes(self.integrity.tag, bytes)
+            // Hash once, then accept a match against the primary digest or any
+            // alternate of the same algorithm (SSRI any-match).
+            let tag = self.integrity.tag;
+            let digest = Integrity::hash_by_tag(tag, bytes);
+            if !self.integrity.matches_digest(&digest)
+                && !self.integrity_alternates.matches(tag, &digest)
             {
                 log.add_error_fmt(
                     None,

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -235,9 +235,20 @@ impl Integrity {
         Self::verify_by_tag(self.tag, bytes, &self.value)
     }
 
-    pub fn verify_by_tag(tag: Tag, bytes: &[u8], sum: &[u8]) -> bool {
-        let mut digest: [u8; DIGEST_BUF_LEN] = [0u8; DIGEST_BUF_LEN];
+    /// True if `digest` (already computed with `self.tag`) equals this value.
+    pub fn matches_digest(&self, digest: &[u8]) -> bool {
+        let len = self.tag.digest_len();
+        if len == 0 || digest.len() < len {
+            return false;
+        }
+        strings::eql_long(&self.value[0..len], &digest[0..len], true)
+    }
 
+    /// Hash `bytes` with `tag`, writing the digest into the first
+    /// `tag.digest_len()` bytes of the returned buffer (rest zero). Returns an
+    /// all-zero buffer for unsupported tags.
+    pub fn hash_by_tag(tag: Tag, bytes: &[u8]) -> [u8; DIGEST_BUF_LEN] {
+        let mut digest: [u8; DIGEST_BUF_LEN] = EMPTY_DIGEST_BUF;
         match tag {
             Tag::SHA1 => {
                 const LEN: usize = SHA1_DIGEST_LEN;
@@ -246,7 +257,6 @@ impl Integrity {
                     .expect("infallible: size matches");
                 // SAFETY: engine is null (default).
                 unsafe { Crypto::SHA1::hash(bytes, ptr, core::ptr::null_mut()) };
-                strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA512 => {
                 const LEN: usize = SHA512_DIGEST_LEN;
@@ -255,7 +265,6 @@ impl Integrity {
                     .expect("infallible: size matches");
                 // SAFETY: engine is null (default).
                 unsafe { Crypto::SHA512::hash(bytes, ptr, core::ptr::null_mut()) };
-                strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA256 => {
                 const LEN: usize = SHA256_DIGEST_LEN;
@@ -264,7 +273,6 @@ impl Integrity {
                     .expect("infallible: size matches");
                 // SAFETY: engine is null (default).
                 unsafe { Crypto::SHA256::hash(bytes, ptr, core::ptr::null_mut()) };
-                strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA384 => {
                 const LEN: usize = SHA384_DIGEST_LEN;
@@ -273,10 +281,19 @@ impl Integrity {
                     .expect("infallible: size matches");
                 // SAFETY: engine is null (default).
                 unsafe { Crypto::SHA384::hash(bytes, ptr, core::ptr::null_mut()) };
-                strings::eql_long(ptr, &sum[0..LEN], true)
             }
-            _ => false,
+            _ => {}
         }
+        digest
+    }
+
+    pub fn verify_by_tag(tag: Tag, bytes: &[u8], sum: &[u8]) -> bool {
+        let len = tag.digest_len();
+        if len == 0 {
+            return false;
+        }
+        let digest = Self::hash_by_tag(tag, bytes);
+        strings::eql_long(&digest[0..len], &sum[0..len], true)
     }
 }
 
@@ -373,20 +390,6 @@ impl IntegrityAlternates {
         }
         for i in 0..self.count as usize {
             if strings::eql_long(&self.values[i][0..len], &digest[0..len], true) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// True if `bytes` hashed with `tag` matches any alternate. Used by the
-    /// non-streaming extract path, which has no precomputed digest.
-    pub fn verify_bytes(&self, tag: Tag, bytes: &[u8]) -> bool {
-        if self.tag != tag || self.count == 0 {
-            return false;
-        }
-        for i in 0..self.count as usize {
-            if Integrity::verify_by_tag(tag, bytes, &self.values[i]) {
                 return true;
             }
         }

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -100,6 +100,45 @@ impl Integrity {
         strongest
     }
 
+    /// Like [`parse`], but also returns the other digests of the strongest
+    /// algorithm present in a multi-entry SSRI string. W3C SRI §3.3.4 and
+    /// npm's `ssri` pick the strongest algorithm and accept a match against
+    /// *any* of its digests, so a tarball matching a non-first digest must
+    /// still verify. The primary (first strongest) digest is returned in the
+    /// `Integrity`; the remaining ones go into `IntegrityAlternates`.
+    pub fn parse_with_alternates(buf: &[u8]) -> (Integrity, IntegrityAlternates) {
+        let primary = Self::parse(buf);
+        let mut alternates = IntegrityAlternates::default();
+        if primary.tag == Tag::UNKNOWN {
+            return (primary, alternates);
+        }
+        let len = primary.tag.digest_len();
+        for entry in buf.split(|c: &u8| c.is_ascii_whitespace()) {
+            let parsed = Self::parse_entry(entry);
+            if parsed.tag != primary.tag {
+                continue;
+            }
+            // Skip the primary digest itself and any duplicate already stored.
+            if strings::eql_long(&parsed.value[0..len], &primary.value[0..len], true) {
+                continue;
+            }
+            let mut dup = false;
+            for i in 0..alternates.count as usize {
+                if strings::eql_long(&alternates.values[i][0..len], &parsed.value[0..len], true) {
+                    dup = true;
+                    break;
+                }
+            }
+            if dup {
+                continue;
+            }
+            if !alternates.push(primary.tag, &parsed.value) {
+                break;
+            }
+        }
+        (primary, alternates)
+    }
+
     fn parse_entry(buf: &[u8]) -> Integrity {
         if buf.len() < b"sha256-".len() {
             return Integrity {
@@ -267,6 +306,94 @@ impl fmt::Display for Integrity {
     }
 }
 
+/// Maximum number of *alternate* digests (of the strongest algorithm) carried
+/// alongside the primary `Integrity`. SSRI allows any number of digests per
+/// algorithm; beyond this cap the extra ones are ignored. npm publishes a
+/// single digest per algorithm, so multiple same-algorithm digests only appear
+/// in hand-edited or migrated lockfiles and unusual third-party registries.
+pub const MAX_INTEGRITY_ALTERNATES: usize = 3;
+
+/// Additional digests of the strongest algorithm found in a multi-entry SSRI
+/// string (see [`Integrity::parse_with_alternates`]). The primary digest lives
+/// in a companion [`Integrity`]; these are the others that must also be
+/// accepted at verify time. Runtime-only: never serialized to the lockfile or
+/// the npm manifest cache. The lockfile writer re-emits them next to the
+/// primary so the multi-digest shape round-trips.
+#[derive(Clone, Copy)]
+pub struct IntegrityAlternates {
+    pub tag: Tag,
+    pub count: u8,
+    pub values: [[u8; DIGEST_BUF_LEN]; MAX_INTEGRITY_ALTERNATES],
+}
+
+impl Default for IntegrityAlternates {
+    fn default() -> Self {
+        Self {
+            tag: Tag::UNKNOWN,
+            count: 0,
+            values: [EMPTY_DIGEST_BUF; MAX_INTEGRITY_ALTERNATES],
+        }
+    }
+}
+
+impl IntegrityAlternates {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    fn push(&mut self, tag: Tag, value: &[u8; DIGEST_BUF_LEN]) -> bool {
+        let i = self.count as usize;
+        if i >= MAX_INTEGRITY_ALTERNATES {
+            return false;
+        }
+        self.tag = tag;
+        self.values[i] = *value;
+        self.count += 1;
+        true
+    }
+
+    /// Iterate the stored alternate digests as `Integrity` values, for
+    /// re-emitting them in the lockfile next to the primary.
+    pub fn iter(&self) -> impl Iterator<Item = Integrity> + '_ {
+        let tag = self.tag;
+        self.values[0..self.count as usize]
+            .iter()
+            .map(move |value| Integrity { tag, value: *value })
+    }
+
+    /// True if `digest` (already computed with `tag`) equals any alternate.
+    pub fn matches(&self, tag: Tag, digest: &[u8]) -> bool {
+        if self.tag != tag || self.count == 0 {
+            return false;
+        }
+        let len = tag.digest_len();
+        if len == 0 || digest.len() < len {
+            return false;
+        }
+        for i in 0..self.count as usize {
+            if strings::eql_long(&self.values[i][0..len], &digest[0..len], true) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// True if `bytes` hashed with `tag` matches any alternate. Used by the
+    /// non-streaming extract path, which has no precomputed digest.
+    pub fn verify_bytes(&self, tag: Tag, bytes: &[u8]) -> bool {
+        if self.tag != tag || self.count == 0 {
+            return false;
+        }
+        for i in 0..self.count as usize {
+            if Integrity::verify_by_tag(tag, bytes, &self.values[i]) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 // Any u8 must be a valid bit pattern, since this is read from on-disk
 // lockfiles. A `#[repr(u8)] enum` would be UB for unknown discriminants, so we
 // use a transparent newtype with associated consts instead.
@@ -334,6 +461,8 @@ impl Tag {
 /// tarball) we default to SHA-512 to match `for_bytes`.
 pub(crate) struct Streaming {
     pub expected: Integrity,
+    /// Other accepted digests of `expected.tag` (SSRI any-match).
+    pub alternates: IntegrityAlternates,
     pub hasher: Hasher,
 }
 
@@ -346,9 +475,14 @@ pub(crate) enum Hasher {
 }
 
 impl Streaming {
-    pub(crate) fn init(expected: &Integrity, compute_if_missing: bool) -> Streaming {
+    pub(crate) fn init(
+        expected: &Integrity,
+        alternates: &IntegrityAlternates,
+        compute_if_missing: bool,
+    ) -> Streaming {
         Streaming {
             expected: *expected,
+            alternates: *alternates,
             hasher: match expected.tag {
                 Tag::SHA1 => Hasher::Sha1(Crypto::SHA1::init()),
                 Tag::SHA256 => Hasher::Sha256(Crypto::SHA256::init()),
@@ -441,7 +575,11 @@ impl Streaming {
             return false;
         }
         let len = self.expected.tag.digest_len();
-        strings::eql_long(&computed.value[0..len], &self.expected.value[0..len], true)
+        if strings::eql_long(&computed.value[0..len], &self.expected.value[0..len], true) {
+            return true;
+        }
+        // SSRI any-match: accept any other digest of the strongest algorithm.
+        self.alternates.matches(computed.tag, &computed.value)
     }
 }
 

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -100,6 +100,13 @@ impl Integrity {
         strongest
     }
 
+    /// True if the SSRI string carries more than one whitespace-separated
+    /// entry, i.e. it may have alternate digests of the strongest algorithm.
+    #[inline]
+    pub fn is_multi_entry(buf: &[u8]) -> bool {
+        buf.iter().any(|c| c.is_ascii_whitespace())
+    }
+
     /// Like [`parse`], but also returns the other digests of the strongest
     /// algorithm present in a multi-entry SSRI string. W3C SRI §3.3.4 and
     /// npm's `ssri` pick the strongest algorithm and accept a match against
@@ -108,11 +115,11 @@ impl Integrity {
     /// `Integrity`; the remaining ones go into `IntegrityAlternates`.
     pub fn parse_with_alternates(buf: &[u8]) -> (Integrity, IntegrityAlternates) {
         let primary = Self::parse(buf);
-        let mut alternates = IntegrityAlternates::default();
         if primary.tag == Tag::UNKNOWN {
-            return (primary, alternates);
+            return (primary, IntegrityAlternates::default());
         }
         let len = primary.tag.digest_len();
+        let mut extras: Vec<[u8; DIGEST_BUF_LEN]> = Vec::new();
         for entry in buf.split(|c: &u8| c.is_ascii_whitespace()) {
             let parsed = Self::parse_entry(entry);
             if parsed.tag != primary.tag {
@@ -122,20 +129,22 @@ impl Integrity {
             if strings::eql_long(&parsed.value[0..len], &primary.value[0..len], true) {
                 continue;
             }
-            let mut dup = false;
-            for i in 0..alternates.count as usize {
-                if strings::eql_long(&alternates.values[i][0..len], &parsed.value[0..len], true) {
-                    dup = true;
-                    break;
-                }
-            }
-            if dup {
+            if extras
+                .iter()
+                .any(|v| strings::eql_long(&v[0..len], &parsed.value[0..len], true))
+            {
                 continue;
             }
-            if !alternates.push(primary.tag, &parsed.value) {
-                break;
-            }
+            extras.push(parsed.value);
         }
+        let alternates = if extras.is_empty() {
+            IntegrityAlternates::default()
+        } else {
+            IntegrityAlternates {
+                tag: primary.tag,
+                values: extras.into_boxed_slice(),
+            }
+        };
         (primary, alternates)
     }
 
@@ -323,32 +332,24 @@ impl fmt::Display for Integrity {
     }
 }
 
-/// Maximum number of *alternate* digests (of the strongest algorithm) carried
-/// alongside the primary `Integrity`. SSRI allows any number of digests per
-/// algorithm; beyond this cap the extra ones are ignored. npm publishes a
-/// single digest per algorithm, so multiple same-algorithm digests only appear
-/// in hand-edited or migrated lockfiles and unusual third-party registries.
-pub const MAX_INTEGRITY_ALTERNATES: usize = 3;
-
 /// Additional digests of the strongest algorithm found in a multi-entry SSRI
 /// string (see [`Integrity::parse_with_alternates`]). The primary digest lives
 /// in a companion [`Integrity`]; these are the others that must also be
-/// accepted at verify time. Runtime-only: never serialized to the lockfile or
-/// the npm manifest cache. The lockfile writer re-emits them next to the
-/// primary so the multi-digest shape round-trips.
-#[derive(Clone, Copy)]
+/// accepted at verify time. The lockfile writer re-emits them next to the
+/// primary so the multi-digest shape round-trips. Empty (no heap allocation)
+/// in the common single-digest case.
+#[derive(Clone)]
 pub struct IntegrityAlternates {
     pub tag: Tag,
-    pub count: u8,
-    pub values: [[u8; DIGEST_BUF_LEN]; MAX_INTEGRITY_ALTERNATES],
+    pub values: Box<[[u8; DIGEST_BUF_LEN]]>,
 }
 
 impl Default for IntegrityAlternates {
+    #[inline]
     fn default() -> Self {
         Self {
             tag: Tag::UNKNOWN,
-            count: 0,
-            values: [EMPTY_DIGEST_BUF; MAX_INTEGRITY_ALTERNATES],
+            values: Box::default(),
         }
     }
 }
@@ -356,44 +357,30 @@ impl Default for IntegrityAlternates {
 impl IntegrityAlternates {
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.count == 0
-    }
-
-    fn push(&mut self, tag: Tag, value: &[u8; DIGEST_BUF_LEN]) -> bool {
-        let i = self.count as usize;
-        if i >= MAX_INTEGRITY_ALTERNATES {
-            return false;
-        }
-        self.tag = tag;
-        self.values[i] = *value;
-        self.count += 1;
-        true
+        self.values.is_empty()
     }
 
     /// Iterate the stored alternate digests as `Integrity` values, for
     /// re-emitting them in the lockfile next to the primary.
     pub fn iter(&self) -> impl Iterator<Item = Integrity> + '_ {
         let tag = self.tag;
-        self.values[0..self.count as usize]
+        self.values
             .iter()
             .map(move |value| Integrity { tag, value: *value })
     }
 
     /// True if `digest` (already computed with `tag`) equals any alternate.
     pub fn matches(&self, tag: Tag, digest: &[u8]) -> bool {
-        if self.tag != tag || self.count == 0 {
+        if self.tag != tag || self.values.is_empty() {
             return false;
         }
         let len = tag.digest_len();
         if len == 0 || digest.len() < len {
             return false;
         }
-        for i in 0..self.count as usize {
-            if strings::eql_long(&self.values[i][0..len], &digest[0..len], true) {
-                return true;
-            }
-        }
-        false
+        self.values
+            .iter()
+            .any(|v| strings::eql_long(&v[0..len], &digest[0..len], true))
     }
 }
 
@@ -485,7 +472,7 @@ impl Streaming {
     ) -> Streaming {
         Streaming {
             expected: *expected,
-            alternates: *alternates,
+            alternates: alternates.clone(),
             hasher: match expected.tag {
                 Tag::SHA1 => Hasher::Sha1(Crypto::SHA1::init()),
                 Tag::SHA256 => Hasher::Sha256(Crypto::SHA256::init()),

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1235,8 +1235,8 @@ impl Lockfile {
             }
 
             // Carry the integrity-alternates side-table across the rebuild. It
-            // is keyed by the primary digest bytes, and `Package::clone` copies
-            // `meta.integrity` verbatim, so the keys stay valid.
+            // is keyed by (name hash, primary digest bytes); `Package::clone`
+            // copies both verbatim, so the keys stay valid.
             if !old.integrity_alternates.is_empty() {
                 new.integrity_alternates = core::mem::take(&mut old.integrity_alternates);
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -218,12 +218,16 @@ pub struct Lockfile {
 
     /// Alternate digests of the strongest algorithm for packages whose SSRI
     /// integrity string carried more than one (W3C SRI §3.3.4 any-match),
-    /// keyed by the primary digest bytes (`Integrity.value`). Populated from
-    /// the parse paths (`bun.lock`, npm manifest, migrations) and consulted
-    /// both at tarball verify time and when re-emitting the lockfile so the
-    /// shape round-trips. Empty in the common single-digest case.
-    /// Runtime-only — never serialised.
-    pub integrity_alternates: BunHashMap<[u8; DIGEST_BUF_LEN], IntegrityAlternates>,
+    /// keyed by (package name hash, primary digest bytes) so alternates never
+    /// apply to a different package that happens to share a primary digest.
+    /// Both key parts are copied verbatim by `Package::clone`, so entries stay
+    /// valid across the `clean` rebuild. Populated from the parse paths
+    /// (`bun.lock`, npm manifest, migrations) and consulted both at tarball
+    /// verify time and when re-emitting the lockfile so the shape round-trips.
+    /// Empty in the common single-digest case. Runtime-only — never
+    /// serialised.
+    pub integrity_alternates:
+        BunHashMap<(PackageNameHash, [u8; DIGEST_BUF_LEN]), IntegrityAlternates>,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -2161,6 +2165,7 @@ impl Lockfile {
     /// No-op when there are no alternates or the integrity is unsupported.
     pub fn record_integrity_alternates(
         &mut self,
+        name_hash: PackageNameHash,
         integrity: &Integrity,
         alternates: &IntegrityAlternates,
     ) {
@@ -2169,17 +2174,21 @@ impl Lockfile {
         }
         bun_core::handle_oom(
             self.integrity_alternates
-                .put(integrity.value, alternates.clone()),
+                .put((name_hash, integrity.value), alternates.clone()),
         );
     }
 
-    /// Alternate digests recorded for `integrity`, or an empty set.
-    pub fn integrity_alternates_for(&self, integrity: &Integrity) -> IntegrityAlternates {
+    /// Alternate digests recorded for a package's `integrity`, or an empty set.
+    pub fn integrity_alternates_for(
+        &self,
+        name_hash: PackageNameHash,
+        integrity: &Integrity,
+    ) -> IntegrityAlternates {
         if !integrity.tag.is_supported() {
             return IntegrityAlternates::default();
         }
         self.integrity_alternates
-            .get(&integrity.value)
+            .get(&(name_hash, integrity.value))
             .cloned()
             .unwrap_or_default()
     }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -219,11 +219,11 @@ pub struct Lockfile {
     /// Alternate digests of the strongest algorithm for packages whose SSRI
     /// integrity string carried more than one (W3C SRI §3.3.4 any-match),
     /// keyed by the primary digest bytes (`Integrity.value`). Populated from
-    /// the parse paths (`bun.lock`, migrations) and consulted both at tarball
-    /// verify time and when re-emitting the lockfile so the shape round-trips.
-    /// Empty in the common single-digest case. Runtime-only — never
-    /// serialised.
-    pub integrity_alternates: std::collections::HashMap<[u8; DIGEST_BUF_LEN], IntegrityAlternates>,
+    /// the parse paths (`bun.lock`, npm manifest, migrations) and consulted
+    /// both at tarball verify time and when re-emitting the lockfile so the
+    /// shape round-trips. Empty in the common single-digest case.
+    /// Runtime-only — never serialised.
+    pub integrity_alternates: BunHashMap<[u8; DIGEST_BUF_LEN], IntegrityAlternates>,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -1234,7 +1234,7 @@ impl Lockfile {
             // is keyed by the primary digest bytes, and `Package::clone` copies
             // `meta.integrity` verbatim, so the keys stay valid.
             if !old.integrity_alternates.is_empty() {
-                new.integrity_alternates = old.integrity_alternates.clone();
+                new.integrity_alternates = core::mem::take(&mut old.integrity_alternates);
             }
         }
 
@@ -2153,7 +2153,7 @@ impl Lockfile {
             // `get_package_id` applies from id 0.
             loaded_package_count: 0,
             exact_pinned: DynamicBitSet::default(),
-            integrity_alternates: std::collections::HashMap::new(),
+            integrity_alternates: BunHashMap::default(),
         }
     }
 
@@ -2162,13 +2162,15 @@ impl Lockfile {
     pub fn record_integrity_alternates(
         &mut self,
         integrity: &Integrity,
-        alternates: IntegrityAlternates,
+        alternates: &IntegrityAlternates,
     ) {
         if alternates.is_empty() || !integrity.tag.is_supported() {
             return;
         }
-        self.integrity_alternates
-            .insert(integrity.value, alternates);
+        bun_core::handle_oom(
+            self.integrity_alternates
+                .put(integrity.value, alternates.clone()),
+        );
     }
 
     /// Alternate digests recorded for `integrity`, or an empty set.
@@ -2178,7 +2180,7 @@ impl Lockfile {
         }
         self.integrity_alternates
             .get(&integrity.value)
-            .copied()
+            .cloned()
             .unwrap_or_default()
     }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -26,6 +26,7 @@ use bun_sha_hmac as Crypto;
 use bun_sys::{self as sys, Fd, File};
 
 use crate::config_version::ConfigVersion;
+use crate::integrity::{DIGEST_BUF_LEN, Integrity, IntegrityAlternates};
 use crate::migration;
 use crate::package_manager::WorkspaceFilter;
 use crate::package_manager_real::{
@@ -214,6 +215,15 @@ pub struct Lockfile {
     /// happened to land first. Runtime-only — never serialised; sized lazily
     /// in `mark_exact_pin`.
     pub exact_pinned: DynamicBitSet,
+
+    /// Alternate digests of the strongest algorithm for packages whose SSRI
+    /// integrity string carried more than one (W3C SRI §3.3.4 any-match),
+    /// keyed by the primary digest bytes (`Integrity.value`). Populated from
+    /// the parse paths (`bun.lock`, migrations) and consulted both at tarball
+    /// verify time and when re-emitting the lockfile so the shape round-trips.
+    /// Empty in the common single-digest case. Runtime-only — never
+    /// serialised.
+    pub integrity_alternates: std::collections::HashMap<[u8; DIGEST_BUF_LEN], IntegrityAlternates>,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -1219,6 +1229,13 @@ impl Lockfile {
                 new.workspace_versions.re_index()?;
                 new.workspace_paths.re_index()?;
             }
+
+            // Carry the integrity-alternates side-table across the rebuild. It
+            // is keyed by the primary digest bytes, and `Package::clone` copies
+            // `meta.integrity` verbatim, so the keys stay valid.
+            if !old.integrity_alternates.is_empty() {
+                new.integrity_alternates = old.integrity_alternates.clone();
+            }
         }
 
         // When you run `"bun add react"
@@ -2136,7 +2153,33 @@ impl Lockfile {
             // `get_package_id` applies from id 0.
             loaded_package_count: 0,
             exact_pinned: DynamicBitSet::default(),
+            integrity_alternates: std::collections::HashMap::new(),
         }
+    }
+
+    /// Record alternate digests for a package's integrity (SSRI any-match).
+    /// No-op when there are no alternates or the integrity is unsupported.
+    pub fn record_integrity_alternates(
+        &mut self,
+        integrity: &Integrity,
+        alternates: IntegrityAlternates,
+    ) {
+        if alternates.is_empty() || !integrity.tag.is_supported() {
+            return;
+        }
+        self.integrity_alternates
+            .insert(integrity.value, alternates);
+    }
+
+    /// Alternate digests recorded for `integrity`, or an empty set.
+    pub fn integrity_alternates_for(&self, integrity: &Integrity) -> IntegrityAlternates {
+        if !integrity.tag.is_supported() {
+            return IntegrityAlternates::default();
+        }
+        self.integrity_alternates
+            .get(&integrity.value)
+            .copied()
+            .unwrap_or_default()
     }
 
     /// Snapshot `packages.len()` as the "loaded from lockfile" watermark.

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -753,6 +753,16 @@ impl Package<u64> {
 
         let package_version = *package_version_ptr;
 
+        // Recover any alternate digests of the strongest algorithm (W3C SRI
+        // §3.3.4 any-match) from the raw multi-entry integrity string. Done
+        // before `string_builder` borrows the lockfile.
+        if !package_version.integrity_str.is_empty() {
+            let (_, alternates) = crate::integrity::Integrity::parse_with_alternates(
+                package_version.integrity_str.slice(&manifest.string_buf),
+            );
+            lockfile.record_integrity_alternates(&package_version.integrity, &alternates);
+        }
+
         let dependency_groups: &[DependencyGroup] = &{
             let mut out: Vec<DependencyGroup> = Vec::with_capacity(4);
             if FEATURES.dependencies {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -760,7 +760,11 @@ impl Package<u64> {
             let (_, alternates) = crate::integrity::Integrity::parse_with_alternates(
                 package_version.integrity_str.slice(&manifest.string_buf),
             );
-            lockfile.record_integrity_alternates(&package_version.integrity, &alternates);
+            lockfile.record_integrity_alternates(
+                manifest.pkg.name.hash,
+                &package_version.integrity,
+                &alternates,
+            );
         }
 
         let dependency_groups: &[DependencyGroup] = &{

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2684,7 +2684,8 @@ pub fn parse_into_binary_lockfile(
                         );
                         pkg.meta.integrity = Integrity::default();
                     }
-                    lockfile.record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
+                    lockfile
+                        .record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
 
                     // Fail closed: otherwise a tampered lockfile could redirect
                     // the tarball URL off-registry and install arbitrary content

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -32,7 +32,7 @@ use crate::{
 use crate::bin_real::ToJsonStyle;
 use crate::config_version::ConfigVersion;
 use crate::extract_tarball as ExtractTarball;
-use crate::integrity::Integrity;
+use crate::integrity::{Integrity, IntegrityAlternates};
 use crate::npm::Negatable;
 use crate::package_manager_real::Options as PackageManagerOptions;
 use crate::repository::RepositoryExt as _;
@@ -306,6 +306,7 @@ impl Stringifier {
         let pkg_name_hashes: &[PackageNameHash] = pkgs.items_name_hash();
         let pkg_metas: &[Meta] = pkgs.items_meta();
         let pkg_bins = pkgs.items_bin();
+        let pkg_alternates = &lockfile.integrity_alternates;
 
         let mut temp_buf: Vec<u8> = Vec::new();
 
@@ -860,7 +861,13 @@ impl Stringifier {
                             )?;
 
                             if pkg_meta.integrity.tag.is_supported() {
-                                write!(writer, ", \"{}\"]", pkg_meta.integrity)?;
+                                write!(writer, ", \"")?;
+                                Self::write_integrity_field(
+                                    writer,
+                                    &pkg_meta.integrity,
+                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                )?;
+                                write!(writer, "\"]")?;
                             } else {
                                 writer.write_byte(b']')?;
                             }
@@ -890,7 +897,13 @@ impl Stringifier {
                             )?;
 
                             if pkg_meta.integrity.tag.is_supported() {
-                                write!(writer, ", \"{}\"]", pkg_meta.integrity)?;
+                                write!(writer, ", \"")?;
+                                Self::write_integrity_field(
+                                    writer,
+                                    &pkg_meta.integrity,
+                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                )?;
+                                write!(writer, "\"]")?;
                             } else {
                                 writer.write_byte(b']')?;
                             }
@@ -965,7 +978,13 @@ impl Stringifier {
                                 &mut path_buf,
                             )?;
 
-                            write!(writer, ", \"{}\"]", pkg_meta.integrity)?;
+                            write!(writer, ", \"")?;
+                            Self::write_integrity_field(
+                                writer,
+                                &pkg_meta.integrity,
+                                pkg_alternates.get(&pkg_meta.integrity.value),
+                            )?;
+                            write!(writer, "\"]")?;
                         }
                         ResolutionTag::Workspace => {
                             write!(
@@ -1016,10 +1035,15 @@ impl Stringifier {
                             if pkg_meta.integrity.tag.is_supported() {
                                 write!(
                                     writer,
-                                    ", {}, \"{}\"]",
+                                    ", {}, \"",
                                     repo.resolved.fmt_json(buf, Default::default()),
-                                    pkg_meta.integrity,
                                 )?;
+                                Self::write_integrity_field(
+                                    writer,
+                                    &pkg_meta.integrity,
+                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                )?;
+                                write!(writer, "\"]")?;
                             } else {
                                 write!(
                                     writer,
@@ -1397,6 +1421,23 @@ impl Stringifier {
         writer.write_all(b"},")?;
 
         optional_peers_buf.clear();
+        Ok(())
+    }
+
+    /// Write the integrity value (without surrounding quotes), re-emitting any
+    /// recorded alternate digests space-separated so a multi-digest SSRI string
+    /// round-trips (W3C SRI §3.3.4 any-match).
+    fn write_integrity_field(
+        writer: &mut Writer,
+        integrity: &Integrity,
+        alternates: Option<&IntegrityAlternates>,
+    ) -> Result<(), WriteError> {
+        write!(writer, "{}", integrity)?;
+        if let Some(alts) = alternates {
+            for alt in alts.iter() {
+                write!(writer, " {}", alt)?;
+            }
+        }
         Ok(())
     }
 
@@ -2627,7 +2668,9 @@ pub fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    pkg.meta.integrity = Integrity::parse(integrity_str);
+                    let (integrity, integrity_alternates) =
+                        Integrity::parse_with_alternates(integrity_str);
+                    pkg.meta.integrity = integrity;
                     if !integrity_str.is_empty() && !pkg.meta.integrity.tag.is_supported() {
                         // Surface — don't fail — for npm parity (`npm install`
                         // proceeds on a malformed lockfile integrity, treating
@@ -2641,6 +2684,7 @@ pub fn parse_into_binary_lockfile(
                         );
                         pkg.meta.integrity = Integrity::default();
                     }
+                    lockfile.record_integrity_alternates(&pkg.meta.integrity, integrity_alternates);
 
                     // Fail closed: otherwise a tampered lockfile could redirect
                     // the tarball URL off-registry and install arbitrary content
@@ -2665,7 +2709,9 @@ pub fn parse_into_binary_lockfile(
                     // integrity is optional for tarball deps (backward compat)
                     if i < pkg_info.len() {
                         if let Some(integrity_str) = pkg_info[i].as_str() {
-                            pkg.meta.integrity = Integrity::parse(integrity_str);
+                            let (integrity, integrity_alternates) =
+                                Integrity::parse_with_alternates(integrity_str);
+                            pkg.meta.integrity = integrity;
                             if !integrity_str.is_empty() && !pkg.meta.integrity.tag.is_supported() {
                                 log.add_warning(
                                     Some(source),
@@ -2674,6 +2720,10 @@ pub fn parse_into_binary_lockfile(
                                 );
                                 pkg.meta.integrity = Integrity::default();
                             }
+                            lockfile.record_integrity_alternates(
+                                &pkg.meta.integrity,
+                                integrity_alternates,
+                            );
                         }
                     }
                 }
@@ -2729,7 +2779,9 @@ pub fn parse_into_binary_lockfile(
                     // Optional integrity hash (added to pin tarball content)
                     if i < pkg_info.len() {
                         if let Some(integrity_str) = pkg_info[i].as_str() {
-                            pkg.meta.integrity = Integrity::parse(integrity_str);
+                            let (integrity, integrity_alternates) =
+                                Integrity::parse_with_alternates(integrity_str);
+                            pkg.meta.integrity = integrity;
                             if !integrity_str.is_empty() && !pkg.meta.integrity.tag.is_supported() {
                                 log.add_warning(
                                     Some(source),
@@ -2738,6 +2790,10 @@ pub fn parse_into_binary_lockfile(
                                 );
                                 pkg.meta.integrity = Integrity::default();
                             }
+                            lockfile.record_integrity_alternates(
+                                &pkg.meta.integrity,
+                                integrity_alternates,
+                            );
                         }
                     }
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2684,7 +2684,7 @@ pub fn parse_into_binary_lockfile(
                         );
                         pkg.meta.integrity = Integrity::default();
                     }
-                    lockfile.record_integrity_alternates(&pkg.meta.integrity, integrity_alternates);
+                    lockfile.record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
 
                     // Fail closed: otherwise a tampered lockfile could redirect
                     // the tarball URL off-registry and install arbitrary content
@@ -2722,7 +2722,7 @@ pub fn parse_into_binary_lockfile(
                             }
                             lockfile.record_integrity_alternates(
                                 &pkg.meta.integrity,
-                                integrity_alternates,
+                                &integrity_alternates,
                             );
                         }
                     }
@@ -2792,7 +2792,7 @@ pub fn parse_into_binary_lockfile(
                             }
                             lockfile.record_integrity_alternates(
                                 &pkg.meta.integrity,
-                                integrity_alternates,
+                                &integrity_alternates,
                             );
                         }
                     }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -865,7 +865,10 @@ impl Stringifier {
                                 Self::write_integrity_field(
                                     writer,
                                     &pkg_meta.integrity,
-                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                    pkg_alternates.get(&(
+                                        pkg_name_hashes[pkg_id as usize],
+                                        pkg_meta.integrity.value,
+                                    )),
                                 )?;
                                 write!(writer, "\"]")?;
                             } else {
@@ -901,7 +904,10 @@ impl Stringifier {
                                 Self::write_integrity_field(
                                     writer,
                                     &pkg_meta.integrity,
-                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                    pkg_alternates.get(&(
+                                        pkg_name_hashes[pkg_id as usize],
+                                        pkg_meta.integrity.value,
+                                    )),
                                 )?;
                                 write!(writer, "\"]")?;
                             } else {
@@ -982,7 +988,10 @@ impl Stringifier {
                             Self::write_integrity_field(
                                 writer,
                                 &pkg_meta.integrity,
-                                pkg_alternates.get(&pkg_meta.integrity.value),
+                                pkg_alternates.get(&(
+                                    pkg_name_hashes[pkg_id as usize],
+                                    pkg_meta.integrity.value,
+                                )),
                             )?;
                             write!(writer, "\"]")?;
                         }
@@ -1041,7 +1050,10 @@ impl Stringifier {
                                 Self::write_integrity_field(
                                     writer,
                                     &pkg_meta.integrity,
-                                    pkg_alternates.get(&pkg_meta.integrity.value),
+                                    pkg_alternates.get(&(
+                                        pkg_name_hashes[pkg_id as usize],
+                                        pkg_meta.integrity.value,
+                                    )),
                                 )?;
                                 write!(writer, "\"]")?;
                             } else {
@@ -2684,8 +2696,11 @@ pub fn parse_into_binary_lockfile(
                         );
                         pkg.meta.integrity = Integrity::default();
                     }
-                    lockfile
-                        .record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
+                    lockfile.record_integrity_alternates(
+                        name_hash,
+                        &pkg.meta.integrity,
+                        &integrity_alternates,
+                    );
 
                     // Fail closed: otherwise a tampered lockfile could redirect
                     // the tarball URL off-registry and install arbitrary content
@@ -2722,6 +2737,7 @@ pub fn parse_into_binary_lockfile(
                                 pkg.meta.integrity = Integrity::default();
                             }
                             lockfile.record_integrity_alternates(
+                                name_hash,
                                 &pkg.meta.integrity,
                                 &integrity_alternates,
                             );
@@ -2792,6 +2808,7 @@ pub fn parse_into_binary_lockfile(
                                 pkg.meta.integrity = Integrity::default();
                             }
                             lockfile.record_integrity_alternates(
+                                name_hash,
                                 &pkg.meta.integrity,
                                 &integrity_alternates,
                             );

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -767,7 +767,7 @@ pub(crate) fn migrate_npm_lockfile<'a>(
                 let (primary, alternates) = Integrity::parse_with_alternates(
                     integrity.as_str().ok_or(crate::Error::InvalidNPMLockfile)?,
                 );
-                this.record_integrity_alternates(&primary, &alternates);
+                this.record_integrity_alternates(name_hash, &primary, &alternates);
                 primary
             } else {
                 Integrity::default()

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -764,7 +764,11 @@ pub(crate) fn migrate_npm_lockfile<'a>(
             },
 
             integrity: if let Some(integrity) = pkg.get(b"integrity") {
-                Integrity::parse(integrity.as_str().ok_or(crate::Error::InvalidNPMLockfile)?)
+                let (primary, alternates) = Integrity::parse_with_alternates(
+                    integrity.as_str().ok_or(crate::Error::InvalidNPMLockfile)?,
+                );
+                this.record_integrity_alternates(&primary, &alternates);
+                primary
             } else {
                 Integrity::default()
             },

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -740,6 +740,11 @@ pub struct PackageVersion {
 
     /// Unix timestamp when this version was published (0 if unknown)
     pub publish_timestamp_ms: f64,
+
+    /// Raw `dist.integrity` string, stored only when it carries more than one
+    /// entry so `Package::from_npm` can recover the alternate digests of the
+    /// strongest algorithm (W3C SRI §3.3.4 any-match). Empty otherwise.
+    pub integrity_str: ExternalString,
 }
 
 impl Default for PackageVersion {
@@ -766,6 +771,7 @@ impl Default for PackageVersion {
             has_install_script: false,
             _padding_tail: [0; 2],
             publish_timestamp_ms: 0.0,
+            integrity_str: ExternalString::default(),
         }
     }
 }
@@ -793,8 +799,8 @@ impl PackageVersion {
 // means a cross-version cache read will mis-slice — fail loudly at compile
 // time instead. (Full per-type asserts live in `padding_checker::layout_asserts`.)
 const _: () = assert!(
-    core::mem::size_of::<PackageVersion>() == 240,
-    "Npm.PackageVersion layout drifted from Zig spec (expected 240 bytes); \
+    core::mem::size_of::<PackageVersion>() == 256,
+    "Npm.PackageVersion layout drifted (expected 256 bytes); \
      bump PackageManifest::Serializer::VERSION if intentional",
 );
 
@@ -830,6 +836,15 @@ const _: () = {
     assert!(
         offset_of!(PackageVersion, publish_timestamp_ms)
             == offset_of!(PackageVersion, _padding_tail) + 2
+    );
+    // `integrity_str` follows `publish_timestamp_ms` (f64, ends at 240) with no gap.
+    assert!(
+        offset_of!(PackageVersion, integrity_str)
+            == offset_of!(PackageVersion, publish_timestamp_ms) + size_of::<f64>()
+    );
+    assert!(
+        offset_of!(PackageVersion, integrity_str) + size_of::<ExternalString>()
+            == size_of::<PackageVersion>()
     );
 };
 
@@ -932,9 +947,10 @@ pub mod package_manifest {
         // - v0.0.5: added bundled dependencies
         // - v0.0.6: changed semver major/minor/patch to each use u64 instead of u32
         // - v0.0.7: added version publish times and extended manifest flag for minimum release age
-        pub const VERSION: &'static str = "bun-npm-manifest-cache-v0.0.7\n";
+        // - v0.0.8: added raw integrity string for multi-entry SSRI (any-match)
+        pub const VERSION: &'static str = "bun-npm-manifest-cache-v0.0.8\n";
         const HEADER_BYTES: &'static str =
-            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.7\n");
+            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.8\n");
 
         // Field order is hardcoded (descending alignment). Re-verify if the
         // layout changes.
@@ -2109,14 +2125,19 @@ impl PackageManifest {
 
                 let version_obj = prop.value.as_object();
 
-                if let Some(tarball) = version_obj
+                if let Some(dist) = version_obj
                     .and_then(|o| o.get(b"dist"))
                     .and_then(|dist| dist.as_object())
-                    .and_then(|dist| dist.get(b"tarball"))
-                    .and_then(|tarball| tarball.as_str())
                 {
-                    string_builder.count(tarball);
-                    tarball_urls_count += (!tarball.is_empty()) as usize;
+                    if let Some(tarball) = dist.get(b"tarball").and_then(|t| t.as_str()) {
+                        string_builder.count(tarball);
+                        tarball_urls_count += (!tarball.is_empty()) as usize;
+                    }
+                    if let Some(integrity) = dist.get(b"integrity").and_then(|v| v.as_str()) {
+                        if Integrity::is_multi_entry(integrity) {
+                            string_builder.count(integrity);
+                        }
+                    }
                 }
 
                 'bin: {
@@ -2593,6 +2614,10 @@ impl PackageManifest {
                         if let Some(shasum_str) = dist.get(b"integrity").and_then(|v| v.as_str()) {
                             package_version.integrity = Integrity::parse(shasum_str);
                             if package_version.integrity.tag.is_supported() {
+                                if Integrity::is_multi_entry(shasum_str) {
+                                    package_version.integrity_str =
+                                        string_builder.append::<ExternalString>(shasum_str);
+                                }
                                 break 'integrity;
                             }
                         }

--- a/src/install/padding_checker.rs
+++ b/src/install/padding_checker.rs
@@ -196,6 +196,6 @@ pub mod layout_asserts {
     pin!(crate::lockfile::package::Scripts, size = 49, align = 1);
 
     // ── .npm manifest cache (PackageManifest.Serializer) ─────────────────
-    pin!(crate::npm::PackageVersion, size = 240, align = 8);
+    pin!(crate::npm::PackageVersion, size = 256, align = 8);
     pin!(crate::npm::NpmPackage, size = 120, align = 8);
 }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -910,7 +910,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                             Integrity::parse_with_alternates(integrity_str);
                         pkg.meta.integrity = integrity;
                         lockfile
-                            .record_integrity_alternates(&pkg.meta.integrity, integrity_alternates);
+                            .record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
                     }
                 }
 

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -910,6 +910,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                             Integrity::parse_with_alternates(integrity_str);
                         pkg.meta.integrity = integrity;
                         lockfile.record_integrity_alternates(
+                            name_hash,
                             &pkg.meta.integrity,
                             &integrity_alternates,
                         );

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -906,7 +906,11 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                             return Err(invalid_pnpm_lockfile());
                         };
 
-                        pkg.meta.integrity = Integrity::parse(integrity_str);
+                        let (integrity, integrity_alternates) =
+                            Integrity::parse_with_alternates(integrity_str);
+                        pkg.meta.integrity = integrity;
+                        lockfile
+                            .record_integrity_alternates(&pkg.meta.integrity, integrity_alternates);
                     }
                 }
 

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -909,8 +909,10 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                         let (integrity, integrity_alternates) =
                             Integrity::parse_with_alternates(integrity_str);
                         pkg.meta.integrity = integrity;
-                        lockfile
-                            .record_integrity_alternates(&pkg.meta.integrity, &integrity_alternates);
+                        lockfile.record_integrity_alternates(
+                            &pkg.meta.integrity,
+                            &integrity_alternates,
+                        );
                     }
                 }
 

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1185,7 +1185,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
         let integrity = if let Some(integrity) = entry.integrity {
             let (primary, alternates) = Integrity::parse_with_alternates(integrity);
-            this.record_integrity_alternates(&primary, &alternates);
+            this.record_integrity_alternates(name_hash, &primary, &alternates);
             primary
         } else {
             Integrity::default()

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1183,6 +1183,14 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             }
         };
 
+        let integrity = if let Some(integrity) = entry.integrity {
+            let (primary, alternates) = Integrity::parse_with_alternates(integrity);
+            this.record_integrity_alternates(&primary, &alternates);
+            primary
+        } else {
+            Integrity::default()
+        };
+
         this.packages.append(LockfilePackage {
             name: pkg_name,
             name_hash,
@@ -1212,11 +1220,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 },
                 man_dir: SemverString::default(),
                 has_install_script: HasInstallScript::False,
-                integrity: if let Some(integrity) = entry.integrity {
-                    Integrity::parse(integrity)
-                } else {
-                    Integrity::default()
-                },
+                integrity,
                 ..Default::default()
             },
             bin: Bin::init(),

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -750,15 +750,9 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  // https://github.com/oven-sh/bun/issues/33700
-  // SSRI (W3C SRI §3.3.4) and npm's `ssri` accept a tarball that matches ANY
-  // digest of the strongest algorithm, regardless of entry order. Bun kept
-  // only the first digest of the strongest algorithm, so a tarball matching a
-  // later same-algorithm digest hard-failed. A multi-digest integrity string
-  // only appears in hand-edited / migrated lockfiles, so this is exercised via
-  // a URL tarball pinned in a hand-written lockfile (a URL tarball verifies
-  // against the lockfile integrity on every platform, unlike a local tarball
-  // whose path is re-resolved).
+  // https://github.com/oven-sh/bun/issues/33700 — SSRI any-match: a tarball
+  // matching any digest of the strongest algorithm must verify. Uses a URL
+  // tarball (local-tarball paths are re-resolved per platform).
   function serveTarball(tgz: Buffer) {
     return Bun.serve({
       port: 0,
@@ -799,8 +793,8 @@ describe.concurrent("tarball integrity metadata forms", () => {
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     expect(stderr + stdout).not.toContain("Integrity check failed");
-    expect(await readdirSorted(join(String(dir), "node_modules", "baz"))).toContain("package.json");
     expect(exitCode).toBe(0);
+    expect(await readdirSorted(join(String(dir), "node_modules", "baz"))).toContain("package.json");
 
     // The multi-digest shape round-trips: re-emitted next to the primary.
     const lockContent = await file(join(String(dir), "bun.lock")).text();

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -756,36 +756,46 @@ describe.concurrent("tarball integrity metadata forms", () => {
   // only the first digest of the strongest algorithm, so a tarball matching a
   // later same-algorithm digest hard-failed. A multi-digest integrity string
   // only appears in hand-edited / migrated lockfiles, so this is exercised via
-  // a lockfile-pinned local tarball.
-  it("accepts a local tarball matching a non-first digest of the strongest algorithm", async () => {
+  // a URL tarball pinned in a hand-written lockfile (a URL tarball verifies
+  // against the lockfile integrity on every platform, unlike a local tarball
+  // whose path is re-resolved).
+  function serveTarball(tgz: Buffer) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        if (new URL(req.url).pathname.endsWith("/baz.tgz")) {
+          return new Response(tgz, { headers: { "content-length": String(tgz.length) } });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+  }
+
+  it("accepts a tarball matching a non-first digest of the strongest algorithm", async () => {
     const real = buildTarball(Buffer.from('{"name":"baz","version":"1.0.0"}\n'));
     const bogus = buildTarball(Buffer.from('{"name":"bogus","version":"9.9.9"}\n'));
 
-    using dir = tempDir("integrity-alt-match", {});
-    const tgzPath = join(String(dir), "baz.tgz");
-    await writeFile(tgzPath, real.tgz);
-    await writeFile(
-      join(String(dir), "package.json"),
-      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: tgzPath } }),
-    );
+    await using server = serveTarball(real.tgz);
+    const url = `http://127.0.0.1:${server.port}/baz.tgz`;
     // Bogus digest first (the one Bun used to pin to), real digest second. A
     // tarball matching only the second entry must still verify.
-    await writeFile(
-      join(String(dir), "bun.lock"),
-      JSON.stringify({
+    using dir = tempDir("integrity-alt-match", {
+      "package.json": JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: url } }),
+      "bun.lock": JSON.stringify({
         lockfileVersion: 1,
         configVersion: 1,
-        workspaces: { "": { name: "foo", dependencies: { baz: tgzPath } } },
-        packages: { baz: [`baz@${tgzPath}`, {}, `${bogus.sha512} ${real.sha512}`] },
+        workspaces: { "": { name: "foo", dependencies: { baz: url } } },
+        packages: { baz: [`baz@${url}`, {}, `${bogus.sha512} ${real.sha512}`] },
       }),
-    );
+    });
 
     await using proc = spawn({
-      cmd: [bunExe(), "install"],
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
       cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
       stdout: "pipe",
       stderr: "pipe",
-      env,
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     expect(stderr + stdout).not.toContain("Integrity check failed");
@@ -798,34 +808,29 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(lockContent).toContain(real.sha512);
   });
 
-  it("rejects a local tarball matching no digest of the strongest algorithm", async () => {
+  it("rejects a tarball matching no digest of the strongest algorithm", async () => {
     const real = buildTarball(Buffer.from('{"name":"baz","version":"1.0.0"}\n'));
     const bogus1 = buildTarball(Buffer.from('{"name":"bogus1","version":"9.9.9"}\n'));
     const bogus2 = buildTarball(Buffer.from('{"name":"bogus2","version":"8.8.8"}\n'));
 
-    using dir = tempDir("integrity-alt-none", {});
-    const tgzPath = join(String(dir), "baz.tgz");
-    await writeFile(tgzPath, real.tgz);
-    await writeFile(
-      join(String(dir), "package.json"),
-      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: tgzPath } }),
-    );
-    await writeFile(
-      join(String(dir), "bun.lock"),
-      JSON.stringify({
+    await using server = serveTarball(real.tgz);
+    const url = `http://127.0.0.1:${server.port}/baz.tgz`;
+    using dir = tempDir("integrity-alt-none", {
+      "package.json": JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: url } }),
+      "bun.lock": JSON.stringify({
         lockfileVersion: 1,
         configVersion: 1,
-        workspaces: { "": { name: "foo", dependencies: { baz: tgzPath } } },
-        packages: { baz: [`baz@${tgzPath}`, {}, `${bogus1.sha512} ${bogus2.sha512}`] },
+        workspaces: { "": { name: "foo", dependencies: { baz: url } } },
+        packages: { baz: [`baz@${url}`, {}, `${bogus1.sha512} ${bogus2.sha512}`] },
       }),
-    );
+    });
 
     await using proc = spawn({
       cmd: [bunExe(), "install"],
       cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
       stdout: "pipe",
       stderr: "pipe",
-      env,
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     expect(stderr + stdout).toContain("Integrity check failed");

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -749,6 +749,88 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/33700
+  // SSRI (W3C SRI §3.3.4) and npm's `ssri` accept a tarball that matches ANY
+  // digest of the strongest algorithm, regardless of entry order. Bun kept
+  // only the first digest of the strongest algorithm, so a tarball matching a
+  // later same-algorithm digest hard-failed. A multi-digest integrity string
+  // only appears in hand-edited / migrated lockfiles, so this is exercised via
+  // a lockfile-pinned local tarball.
+  it("accepts a local tarball matching a non-first digest of the strongest algorithm", async () => {
+    const real = buildTarball(Buffer.from('{"name":"baz","version":"1.0.0"}\n'));
+    const bogus = buildTarball(Buffer.from('{"name":"bogus","version":"9.9.9"}\n'));
+
+    using dir = tempDir("integrity-alt-match", {});
+    const tgzPath = join(String(dir), "baz.tgz");
+    await writeFile(tgzPath, real.tgz);
+    await writeFile(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: tgzPath } }),
+    );
+    // Bogus digest first (the one Bun used to pin to), real digest second. A
+    // tarball matching only the second entry must still verify.
+    await writeFile(
+      join(String(dir), "bun.lock"),
+      JSON.stringify({
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "foo", dependencies: { baz: tgzPath } } },
+        packages: { baz: [`baz@${tgzPath}`, {}, `${bogus.sha512} ${real.sha512}`] },
+      }),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).not.toContain("Integrity check failed");
+    expect(await readdirSorted(join(String(dir), "node_modules", "baz"))).toContain("package.json");
+    expect(exitCode).toBe(0);
+
+    // The multi-digest shape round-trips: re-emitted next to the primary.
+    const lockContent = await file(join(String(dir), "bun.lock")).text();
+    expect(lockContent).toContain(bogus.sha512);
+    expect(lockContent).toContain(real.sha512);
+  });
+
+  it("rejects a local tarball matching no digest of the strongest algorithm", async () => {
+    const real = buildTarball(Buffer.from('{"name":"baz","version":"1.0.0"}\n'));
+    const bogus1 = buildTarball(Buffer.from('{"name":"bogus1","version":"9.9.9"}\n'));
+    const bogus2 = buildTarball(Buffer.from('{"name":"bogus2","version":"8.8.8"}\n'));
+
+    using dir = tempDir("integrity-alt-none", {});
+    const tgzPath = join(String(dir), "baz.tgz");
+    await writeFile(tgzPath, real.tgz);
+    await writeFile(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: tgzPath } }),
+    );
+    await writeFile(
+      join(String(dir), "bun.lock"),
+      JSON.stringify({
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "foo", dependencies: { baz: tgzPath } } },
+        packages: { baz: [`baz@${tgzPath}`, {}, `${bogus1.sha512} ${bogus2.sha512}`] },
+      }),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).toContain("Integrity check failed");
+    expect(exitCode).not.toBe(0);
+  });
 });
 
 describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download failure (%s)", linker => {

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -750,6 +750,59 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  // https://github.com/oven-sh/bun/issues/33700 — SSRI any-match (W3C SRI
+  // §3.3.4): a tarball matching *any* digest of the strongest algorithm must
+  // verify, regardless of order. 1.4 pinned to the first and hard-failed.
+  it("accepts a registry tarball matching a non-first digest of the strongest algorithm", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const bogus = "sha512-" + Buffer.alloc(86, "A").toString() + "==";
+
+    // Bogus sha512 first, real sha512 second. An order-only flip of these two
+    // entries must not change install success.
+    await using server = serveManifest(`${bogus} ${real.sha512}`, real.tgz);
+    using dir = projectDir("integrity-registry-alt-match", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).not.toContain("Integrity check failed");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(await readdirSorted(join(String(dir), "node_modules", "pkg"))).toContain("package.json");
+
+    // Both digests round-trip into the lockfile so a later install from the
+    // lockfile alone (manifest cached) still accepts either.
+    const lockContent = await file(join(String(dir), "bun.lock")).text();
+    expect(lockContent).toContain(bogus);
+    expect(lockContent).toContain(real.sha512);
+  });
+
+  it("rejects a registry tarball matching no digest of the strongest algorithm", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const bogus1 = "sha512-" + Buffer.alloc(86, "A").toString() + "==";
+    const bogus2 = "sha512-" + Buffer.alloc(86, "B").toString() + "==";
+
+    await using server = serveManifest(`${bogus1} ${bogus2}`, real.tgz);
+    using dir = projectDir("integrity-registry-alt-none", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).toContain("Integrity check failed");
+    expect(stdout).not.toContain("1 package installed");
+    expect(exitCode).not.toBe(0);
+  });
+
   // https://github.com/oven-sh/bun/issues/33700 — SSRI any-match: a tarball
   // matching any digest of the strongest algorithm must verify. Uses a URL
   // tarball (local-tarball paths are re-resolved per platform).


### PR DESCRIPTION
## Problem

A multi-entry SSRI `integrity` string can carry more than one digest of the same (strongest) algorithm, e.g. `sha512-A sha512-B`. W3C SRI [§3.3.4](https://www.w3.org/TR/SRI/#does-response-match-metadatalist) and npm's [`ssri`](https://github.com/npm/ssri) pick the strongest algorithm and accept a tarball that matches **any** of its digests, regardless of entry order.

`Integrity::parse` kept only the first digest of the strongest algorithm:

```rust
// src/install/integrity.rs
for entry in buf.split(|c: &u8| c.is_ascii_whitespace()) {
    let parsed = Self::parse_entry(entry);
    if parsed.tag.0 > strongest.tag.0 {   // strict >: first same-tag entry wins
        strongest = parsed;
    }
}
```

So for `sha512-A sha512-B`, `B` is discarded and a tarball matching `B` hard-fails with `Integrity check failed` even though npm accepts it. The outcome also depended on entry order, which SRI says is irrelevant. This over-tightening was introduced by #33072 (before that, a multi-entry string decayed to `Tag::UNKNOWN` and verification was skipped) and was noted as a deviation in that PR.

npm publishes a single digest per algorithm, so the trigger is rare: hand-edited or migrated lockfiles, or third-party registries.

## Fix

Carry the other digests of the strongest algorithm from every parse site through to tarball verification:

- `Integrity::parse_with_alternates` returns the primary (first strongest) digest plus the remaining same-algorithm digests (`IntegrityAlternates`, a boxed digest slice, empty and allocation-free in the common single-digest case).
- A runtime-only side table on `Lockfile` (`integrity_alternates`) holds them, keyed by `(package name hash, primary digest bytes)` so alternates never apply to a different package. Both key parts are copied verbatim by `Package::clone`, so the table is carried across the lockfile `clean` rebuild. It is never serialized.
- All parse paths populate it: `bun.lock` (npm/tarball/git entries), the npm registry manifest (`dist.integrity` is kept as a raw string on `PackageVersion`, manifest cache bumped to v0.0.8, alternates recovered in `Package::from_npm`), and the pnpm-lock / yarn.lock / package-lock.json migrations.
- Streaming (`TarballStream`) and buffered (`ExtractTarball::run`) verification accept a match against the primary **or** any alternate; the buffered path hashes once and compares the digest against each.
- The `bun.lock` writer re-emits the alternates next to the primary so the multi-digest shape round-trips.
- The never-committed streaming task discard path drops the extract request explicitly so the boxed alternates are released (`Task.request` is a `ManuallyDrop` union that `Task::drop` cannot reach).

`Meta.integrity` stays a single 65-byte value; the binary lockfile format is unchanged.

## Verification

`test/cli/install/bun-install-tarball-integrity.test.ts`:

- registry manifest with `sha512-bogus sha512-real`: install succeeds (fails on main with `Integrity check failed`), and the all-bogus negative control still fails;
- lockfile-pinned URL tarball matching the **second** digest installs successfully and the multi-digest shape round-trips in the written lockfile;
- lockfile-pinned URL tarball matching **neither** digest still fails.

Confirmed fail-before: with `src/` reverted to main, the any-match tests fail with `Integrity check failed`; with the fix the full file passes (20/20).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf8dbdf39)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [358.86ms]
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [341.43ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [438.86ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [288.64ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [653.68ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [875.51ms]
(pass) tarb
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bd060f940)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity metadata forms > rejects a tarball matching no digest of the strongest algorithm [40.78ms]
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [87.16ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [86.02ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [86.65ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [88.11ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [86.51ms]
(pass) tarball integrity metadata forms > verifies the tarball against the strongest entry of a multi-hash integrity string [66.15ms]
(pass) tarball integrity metadata forms > verifies the tarball when the integrity entry carries an option suffix [59.37ms]
(pass) tarball integrity mismatch (hoisted) > should fail (not hang) when tarball bytes don't match manifest SHA-512 [88.24ms]
(pass) tarball inte
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf8dbdf39)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [355.94ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [457.86ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [413.24ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [604.69ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [322.36ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backwa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 785ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/47] gen cpp.rs (cppbind)
[4/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_ro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/NetworkTask.rs                         |   6 +
 .../PackageManager/PackageManagerEnqueue.rs        |   8 ++
 src/install/PackageManager/runTasks.rs             |   3 +
 src/install/TarballStream.rs                       |   5 +
 src/install/extract_tarball.rs                     |  13 +-
 src/install/integrity.rs                           | 146 +++++++++++++++++++--
 src/install/lockfile.rs                            |  54 ++++++++
 src/install/lockfile/Package.rs                    |  14 ++
 src/install/lockfile/bun.lock.rs                   |  92 +++++++++++--
 src/install/migration.rs                           |   6 +-
 src/install/npm.rs                                 |  43 ++++--
 src/install/padding_checker.rs                     |   2 +-
 src/install/pnpm.rs                                |   9 +-
 src/install/yarn.rs                                |  14 +-
 .../install/bun-install-tarball-integrity.test.ts  | 134 +++++++++++++++++++
 15 files changed, 512 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/NetworkTask.rs                                  1      1      0
src/install/PackageManager/PackageManagerEnqueue.rs         5      5      0
src/install/PackageManager/runTasks.rs                      2      3      0
src/install/TarballStream.rs                                2      1      0
src/install/extract_tarball.rs                              2      5      0
src/install/integrity.rs                                    2      9      0
src/install/lockfile.rs                                     8      8      0
src/install/lockfile/Package.rs                             1      0      0
src/install/lockfile/bun.lock.rs                            5     10      0
src/install/migration.rs                                    2      0      0
src/install/npm.rs                                          2      0      0
src/install/padding_checker.rs                              0      0      0
src/install/pnpm.rs                                         2      1      0
src/install/yarn.rs                                         1      0      0
test/cli/install/bun-install-tarball-integrity.test.ts      9      6      0
```

</details>

**root cause** · written by the author bot

The bug arose because `Integrity::parse` collapsed a multi-digest SSRI string to a single fixed-size value, keeping only the first digest of the strongest algorithm, so a tarball matching any other digest of that algorithm hard-failed verification even though npm's any-match semantics accept it. The fix introduces `parse_with_alternates` to retain every digest of the strongest algorithm and threads those alternates through a lockfile side-table keyed by package name hash and primary digest, into the tarball extraction tasks, and down to streaming verification. Verification then accepts a ma…

<!-- robobun:evidence:end -->