### PR TITLE
Bun.password: validate async hash/verify args like the sync forms

### DIFF
--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -753,15 +753,15 @@ pub(crate) fn js_password_object_hash(
         algorithm = AlgorithmValue::from_js(global_object, arguments[1])?;
     }
 
-    // TODO: this most likely should error like `hashSync` instead of stringifying.
-    //
-    // fromJS(...) orelse {
-    //   return globalObject.throwInvalidArgumentType("hash", "password", "string or TypedArray");
-    // }
-    let password_to_hash = StringOrBuffer::from_js_to_owned_slice(global_object, arguments[0])?;
-    // errdefer bun.default_allocator.free(password_to_hash) — Box<[u8]> drops on `?`.
+    let Some(string_or_buffer) = StringOrBuffer::from_js(global_object, arguments[0])? else {
+        return Err(global_object.throw_invalid_argument_type(
+            "hash",
+            "password",
+            "string or TypedArray",
+        ));
+    };
 
-    if password_to_hash.is_empty() {
+    if string_or_buffer.slice().is_empty() {
         return Err(
             global_object.throw_invalid_arguments(format_args!("password must not be empty"))
         );
@@ -769,7 +769,7 @@ pub(crate) fn js_password_object_hash(
 
     JSPasswordObject::hash::<false>(
         global_object,
-        password_to_hash.into_boxed_slice(),
+        Box::<[u8]>::from(string_or_buffer.slice()),
         algorithm,
     )
 }
@@ -856,36 +856,31 @@ pub(crate) fn js_password_object_verify(
         };
     }
 
-    // TODO: this most likely should error like `verifySync` instead of stringifying.
-    //
-    // fromJS(...) orelse {
-    //   return globalObject.throwInvalidArgumentType("hash", "password", "string or TypedArray");
-    // }
-    let owned_password = StringOrBuffer::from_js_to_owned_slice(global_object, arguments[0])?;
-
-    // TODO: this most likely should error like `verifySync` instead of stringifying.
-    //
-    // fromJS(...) orelse {
-    //   return globalObject.throwInvalidArgumentType("hash", "password", "string or TypedArray");
-    // }
-    let owned_hash = match StringOrBuffer::from_js_to_owned_slice(global_object, arguments[1]) {
-        Ok(h) => h,
-        Err(err) => {
-            drop(owned_password);
-            return Err(err);
-        }
+    let Some(password) = StringOrBuffer::from_js(global_object, arguments[0])? else {
+        return Err(global_object.throw_invalid_argument_type(
+            "verify",
+            "password",
+            "string or TypedArray",
+        ));
     };
 
-    if owned_hash.is_empty() {
-        drop(owned_password);
+    let Some(hash_) = StringOrBuffer::from_js(global_object, arguments[1])? else {
+        drop(password);
+        return Err(global_object.throw_invalid_argument_type(
+            "verify",
+            "hash",
+            "string or TypedArray",
+        ));
+    };
+
+    if hash_.slice().is_empty() {
         return Ok(JSPromise::resolved_promise_value(
             global_object,
             JSValue::FALSE,
         ));
     }
 
-    if owned_password.is_empty() {
-        drop(owned_hash);
+    if password.slice().is_empty() {
         return Ok(JSPromise::resolved_promise_value(
             global_object,
             JSValue::FALSE,
@@ -894,8 +889,8 @@ pub(crate) fn js_password_object_verify(
 
     JSPasswordObject::verify::<false>(
         global_object,
-        owned_password.into_boxed_slice(),
-        owned_hash.into_boxed_slice(),
+        Box::<[u8]>::from(password.slice()),
+        Box::<[u8]>::from(hash_.slice()),
         algorithm,
     )
 }

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -74,6 +74,18 @@ describe("hash", () => {
         expect(() => hash()).toThrow();
       });
 
+      test("password must be a string or TypedArray", () => {
+        for (const value of [undefined, null, 123, true, {}, []]) {
+          // @ts-expect-error
+          expect(() => hash(value)).toThrow(
+            expect.objectContaining({
+              name: "TypeError",
+              code: "ERR_INVALID_ARG_TYPE",
+            }),
+          );
+        }
+      });
+
       test("invalid algorithm throws", () => {
         // @ts-expect-error
         expect(() => hash(placeholder, "scrpyt")).toThrow();
@@ -185,6 +197,25 @@ describe("verify", () => {
         expect(await verify("$", "")).toBeFalse();
       });
 
+      test("password and hash must be a string or TypedArray", () => {
+        for (const value of [undefined, null, 123, true, {}, []]) {
+          // @ts-expect-error
+          expect(() => verify(value, "$")).toThrow(
+            expect.objectContaining({
+              name: "TypeError",
+              code: "ERR_INVALID_ARG_TYPE",
+            }),
+          );
+          // @ts-expect-error
+          expect(() => verify("$", value)).toThrow(
+            expect.objectContaining({
+              name: "TypeError",
+              code: "ERR_INVALID_ARG_TYPE",
+            }),
+          );
+        }
+      });
+
       test("invalid algorithm throws", () => {
         // @ts-expect-error
         expect(() => verify(placeholder, "$", "scrpyt")).toThrow();
@@ -243,6 +274,16 @@ describe("verify", () => {
       }
     }
   });
+});
+
+test("async verify() does not ToString-coerce an undefined password against a hash of the string 'undefined'", () => {
+  // The async path used to coerce via ToString, so `verify(undefined, h)`
+  // resolved `true` when `h` was a hash of the 9-byte string "undefined".
+  const h = password.hashSync("undefined", { algorithm: "bcrypt", cost: 4 });
+  expect(password.verifySync("undefined", h)).toBeTrue();
+  expect(() => password.verify(undefined as any, h)).toThrow(
+    expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+  );
 });
 
 // The async hashing tests below only await the thread-pooled password.hash /


### PR DESCRIPTION
## What

`Bun.password.hash()` and `Bun.password.verify()` (the async forms) now throw `TypeError[ERR_INVALID_ARG_TYPE]` for non-string/non-TypedArray `password`/`hash` arguments, matching what `hashSync`/`verifySync` already did.

## Why

The async entry points coerced any value via `ToString` before hashing. So `await Bun.password.hash(undefined)` resolved with a real, verifiable hash of the 9-byte string `"undefined"`, and `await Bun.password.verify(undefined, thatHash)` returned `true`. The sync forms already rejected these with `ERR_INVALID_ARG_TYPE`.

```js
// before
await Bun.password.hash(undefined, { algorithm: "bcrypt", cost: 4 })
// => "$2b$04$..."
Bun.password.hashSync(undefined, { algorithm: "bcrypt", cost: 4 })
// => TypeError [ERR_INVALID_ARG_TYPE]

const h = await Bun.password.hash(undefined, { algorithm: "bcrypt", cost: 4 });
Bun.password.verifySync("undefined", h)       // true  (hashed the literal string "undefined")
await Bun.password.verify(undefined, h)       // true
Bun.password.verifySync(undefined, h)         // TypeError [ERR_INVALID_ARG_TYPE]

await Bun.password.verify("x", 123)
// => rejects Error[PASSWORD_UNSUPPORTED_ALGORITHM]   (wrong error class)
Bun.password.verifySync("x", 123)
// => TypeError [ERR_INVALID_ARG_TYPE]
```

The async forms are the ones used in servers: `await Bun.password.hash(req.body.password)` with a missing field would silently store a hash of `"undefined"` rather than failing.

## How

`js_password_object_hash` / `js_password_object_verify` called `StringOrBuffer::from_js_to_owned_slice`, which falls back to JS `ToString` for any non-string/non-TypedArray value. The source already carried a `TODO: this most likely should error like hashSync instead of stringifying` at each site. Switched all three sites to the same `StringOrBuffer::from_js` + `throw_invalid_argument_type` that the sync arms use.

## Verified

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/password.test.ts -t "must be a string or TypedArray|ToString-coerce"
 2 pass
 3 fail

$ bun bd test test/js/bun/util/password.test.ts
 73 pass
 8 skip
 0 fail
```