### PR TITLE
node:string_decoder: reset lastTotal when a buffered partial completes

### DIFF
--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -318,6 +318,8 @@ ResetScope::ResetScope(JSStringDecoder* decoder)
 
 ResetScope::~ResetScope()
 {
+    // Node's FlushData only clears MissingBytes/BufferedBytes; it leaves the
+    // incomplete-character buffer (lastChar) intact, so m_lastChar stays as-is.
     m_decoder->m_lastTotal = 0;
     m_decoder->m_lastNeed = 0;
 }

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -282,6 +282,7 @@ JSC::JSString* JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalOb
                 RELEASE_AND_RETURN(throwScope, firstHalf);
             offset = m_lastNeed;
             m_lastNeed = 0;
+            m_lastTotal = 0;
             if (offset == length)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
 
@@ -319,7 +320,6 @@ ResetScope::~ResetScope()
 {
     m_decoder->m_lastTotal = 0;
     m_decoder->m_lastNeed = 0;
-    memset(m_decoder->m_lastChar, 0, 4);
 }
 
 JSC::JSString*

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -264,6 +264,44 @@ it("normalizes the encoding name like Node", () => {
   });
 });
 
+// Node's lastTotal getter is MissingBytes + BufferedBytes; Node clears BufferedBytes when a buffered
+// partial is emitted so lastTotal returns to 0. end() resets lastNeed/lastTotal but leaves lastChar.
+// Decoded output was always correct; this is purely about the observable legacy state triple.
+describe("lastNeed/lastTotal/lastChar state matches Node after completing a split character", () => {
+  const state = d => ({ lastNeed: d.lastNeed, lastTotal: d.lastTotal, lastChar: Array.from(d.lastChar) });
+
+  it.each([
+    ["utf8", [[0xf0], [0x9f, 0x98, 0x80]], "😀", [240, 159, 152, 128]],
+    ["utf8", [[0xe2, 0x82], [0xac]], "€", [226, 130, 172, 0]],
+    ["utf8", [[0xcc], [0xcc, 0x8c]], "\ufffd\u030c", [204, 0, 0, 0]],
+    ["utf16le", [[0x41], [0x00, 0x42, 0x00]], "AB", [65, 0, 0, 0]],
+    ["utf16le", [[0x3d, 0xd8], [0x00, 0xde]], "😀", [61, 216, 0, 222]],
+    ["base64", [[0x41], [0x42, 0x43]], "QUJD", [65, 66, 67, 0]],
+    ["base64url", [[0x41], [0x42, 0x43]], "QUJD", [65, 66, 67, 0]],
+  ])("%s %j", (encoding, chunks, expected, lastChar) => {
+    const d = new RealStringDecoder(encoding);
+    let out = "";
+    for (const c of chunks) out += d.write(Buffer.from(c));
+    expect(out).toBe(expected);
+    expect(state(d)).toEqual({ lastNeed: 0, lastTotal: 0, lastChar });
+  });
+
+  it("utf8: completing a partial then starting a new one sets fresh state", () => {
+    const d = new RealStringDecoder("utf8");
+    d.write(Buffer.from([0xf0]));
+    expect(d.write(Buffer.from([0x9f, 0x98, 0x80, 0xe2]))).toBe("😀");
+    expect(state(d)).toEqual({ lastNeed: 2, lastTotal: 3, lastChar: [226, 159, 152, 128] });
+  });
+
+  it("end() resets lastNeed/lastTotal but leaves lastChar bytes intact", () => {
+    const d = new RealStringDecoder("utf8");
+    d.write(Buffer.from([0xf0]));
+    expect(state(d)).toEqual({ lastNeed: 3, lastTotal: 4, lastChar: [240, 0, 0, 0] });
+    expect(d.end()).toBe("\ufffd");
+    expect(state(d)).toEqual({ lastNeed: 0, lastTotal: 0, lastChar: [240, 0, 0, 0] });
+  });
+});
+
 it("invalid utf-8 input, pr #3562", () => {
   const decoder = new RealStringDecoder("utf-8");
   let output = "";

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -275,7 +275,15 @@ describe("lastNeed/lastTotal/lastChar state matches Node after completing a spli
     ["utf8", [[0xe2, 0x82], [0xac]], "€", [226, 130, 172, 0]],
     ["utf8", [[0xcc], [0xcc, 0x8c]], "\ufffd\u030c", [204, 0, 0, 0]],
     ["utf16le", [[0x41], [0x00, 0x42, 0x00]], "AB", [65, 0, 0, 0]],
-    ["utf16le", [[0x3d, 0xd8], [0x00, 0xde]], "😀", [61, 216, 0, 222]],
+    [
+      "utf16le",
+      [
+        [0x3d, 0xd8],
+        [0x00, 0xde],
+      ],
+      "😀",
+      [61, 216, 0, 222],
+    ],
     ["base64", [[0x41], [0x42, 0x43]], "QUJD", [65, 66, 67, 0]],
     ["base64url", [[0x41], [0x42, 0x43]], "QUJD", [65, 66, 67, 0]],
   ])("%s %j", (encoding, chunks, expected, lastChar) => {


### PR DESCRIPTION
## What does this PR do?

`StringDecoder` exposes the legacy `lastNeed` / `lastTotal` / `lastChar` state triple for compatibility with the userland `string_decoder` package and `readable-stream` shims. In Node, `lastTotal` is computed as `MissingBytes + BufferedBytes`, and Node clears `BufferedBytes` once `write()` emits a completed partial character, so the decoder returns to `{lastNeed: 0, lastTotal: 0}`. Bun was only clearing `m_lastNeed`, leaving `m_lastTotal` stale for the rest of the decoder's life (a `{lastNeed: 0, lastTotal: N}` state Node can never produce), for every stateful encoding (utf8, utf16le, base64, base64url).

A second divergence: `end()`'s `ResetScope` zeroed `m_lastChar`; Node's `FlushData` only clears `MissingBytes`/`BufferedBytes` and leaves the incomplete-character buffer bytes intact.

Decoded string output was already byte-identical to Node; this is purely about the observable state.

### Repro

```js
import { StringDecoder } from "node:string_decoder";
const d = new StringDecoder("utf8");
d.write(Buffer.from([0xf0]));
d.write(Buffer.from([0x9f, 0x98, 0x80]));
console.log(d.lastNeed, d.lastTotal);
// node:        0 0
// bun before:  0 4
// bun after:   0 0
```

### Fix

- In `JSStringDecoder::write`, set `m_lastTotal = 0` alongside `m_lastNeed = 0` at the point the buffered partial is emitted from `fillLast`. If the remainder of the buffer starts a new partial, `text()` assigns fresh values for both.
- Drop the `memset(m_lastChar, 0, 4)` from `ResetScope` so `end()` matches Node.

### How did you verify your code works?

- New `describe` block in `test/js/node/string_decoder/string-decoder.test.js` covering utf8 (4-byte split, 3-byte split, bad-continuation path), utf16le (split code unit, split surrogate pair), base64, base64url, the complete-then-start-new-partial path, and `end()` leaving `lastChar` intact. All expected values were captured from Node v26.3.0. 8/9 cases fail on the unpatched build.
- Full `string-decoder.test.js` suite passes (95 tests).
- `test/js/node/test/parallel/test-string-decoder.js`, `test-string-decoder-end.js`, `test-string-decoder-fuzz.js` all pass.