### PR TITLE
os: fall back to GetUserNameW for userInfo().username on Windows

### DIFF
--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1610,7 +1610,9 @@ mod _impl {
                 let name = scopeguard::guard(BunString::clone_utf16(name), |s| s.deref());
                 name.to_js(global_this)?
             } else {
-                ZigString::init(b"unknown").with_encoding().to_js(global_this)
+                ZigString::init(b"unknown")
+                    .with_encoding()
+                    .to_js(global_this)
             };
             result.put(global_this, b"username", username);
             result.put(global_this, b"uid", JSValue::js_number(-1.0));

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1600,13 +1600,19 @@ mod _impl {
 
         #[cfg(windows)]
         {
-            result.put(
-                global_this,
-                b"username",
-                ZigString::init(env_var::USER.get().unwrap_or(b"unknown"))
-                    .with_encoding()
-                    .to_js(global_this),
-            );
+            // Node takes the account name from GetUserNameW (via uv_os_get_passwd)
+            // and never reads the environment; keep the cheap USERNAME read but
+            // ask the OS when it is unset or empty (e.g. service/CI contexts).
+            let mut name_buf = [0u16; 257];
+            let username = if let Some(name) = env_var::USER.get_not_empty() {
+                ZigString::init(name).with_encoding().to_js(global_this)
+            } else if let Some(name) = windows::username_utf16(&mut name_buf) {
+                let name = scopeguard::guard(BunString::clone_utf16(name), |s| s.deref());
+                name.to_js(global_this)?
+            } else {
+                ZigString::init(b"unknown").with_encoding().to_js(global_this)
+            };
+            result.put(global_this, b"username", username);
             result.put(global_this, b"uid", JSValue::js_number(-1.0));
             result.put(global_this, b"gid", JSValue::js_number(-1.0));
             result.put(global_this, b"shell", JSValue::NULL);

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3460,6 +3460,18 @@ pub use bun_windows_sys::{
 
 // Bun__UVSignalHandle__{init,close}: see src/runtime/node/uv_signal_handle_windows.rs
 
+/// Account name from `GetUserNameW`, without the trailing NUL. `None` on failure.
+/// The buffer is `UNLEN + 1` (see the link in [`user_unique_id`]).
+pub fn username_utf16(buf: &mut [u16; 257]) -> Option<&[u16]> {
+    let mut size: u32 = buf.len() as u32;
+    // SAFETY: buf and size are valid
+    if unsafe { externs::GetUserNameW(buf.as_mut_ptr(), &mut size) } == 0 || size == 0 {
+        return None;
+    }
+    // On success `size` counts the copied chars including the terminating NUL.
+    Some(&buf[0..size as usize - 1])
+}
+
 /// Is not the actual UID of the user, but just a hash of username.
 pub fn user_unique_id() -> u32 {
     // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/165836c1-89d7-4abb-840d-80cf2510aa3e

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import * as os from "node:os";
+import { join } from "node:path";
 
 it("arch", () => {
   expect(["x64", "x86", "arm64"].some(arch => os.arch() === arch)).toBe(true);
@@ -126,6 +127,46 @@ it("userInfo", () => {
     expect(info.uid).toBe(-1);
     expect(info.gid).toBe(-1);
   }
+});
+
+const printUserInfo = `console.log(JSON.stringify({ username: require("os").userInfo().username, env: process.env.USERNAME ?? null }));`;
+
+async function expectOsAccountUsername(proc, expectedEnv) {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout, `stderr: ${stderr}`).toStartWith("{");
+  const info = JSON.parse(stdout);
+  expect(info.env).toBe(expectedEnv);
+  expect(typeof info.username).toBe("string");
+  expect(info.username).not.toBe("unknown");
+  expect(info.username.length).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+}
+
+it.concurrent.skipIf(!isWindows)("userInfo() reads the username from the OS when USERNAME is unset", async () => {
+  // Bun.spawn re-adds USERNAME to explicit envs (libuv's required-vars list),
+  // so a cmd.exe hop performs the real unset for the child bun.
+  using dir = tempDir("os-userinfo", {
+    "print-userinfo.js": printUserInfo,
+  });
+  await using proc = Bun.spawn({
+    cmd: ["cmd", "/d", "/s", "/c", `"set USERNAME=& "${bunExe()}" "${join(String(dir), "print-userinfo.js")}""`],
+    windowsVerbatimArguments: true,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await expectOsAccountUsername(proc, null);
+});
+
+it.concurrent.skipIf(!isWindows)("userInfo() reads the username from the OS when USERNAME is empty", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", printUserInfo],
+    env: { ...bunEnv, USERNAME: "" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await expectOsAccountUsername(proc, "");
 });
 
 it("cpus", () => {


### PR DESCRIPTION
## Summary

On Windows, `os.userInfo().username` was read only from the `USERNAME` environment variable, returning `"unknown"` when it is unset or empty — common in service and CI contexts (including children spawned without `USERNAME` by CI agents). Node returns the real account name there because it never reads the environment: `uv_os_get_passwd` gets the name from `GetUserNameW` ([libuv `win/util.c`](https://github.com/libuv/libuv/blob/v1.x/src/win/util.c#L1135-L1205)).

Repro (before → after, Node for reference):

```
$ env -u USERNAME bun -e "console.log(require('os').userInfo().username)"
unknown            # before
dylan              # after
$ env -u USERNAME node -e "console.log(require('os').userInfo().username)"
dylan
```

- Keep the cheap `USERNAME` read when it is set and non-empty (existing, test-codified behavior); when unset **or empty**, get the account name from `GetUserNameW` via a new `bun_sys::windows::username_utf16` helper (same stack-buffer pattern as the adjacent `user_unique_id`), converting the UTF-16 name directly into a JS string.
- `GetUserNameW` is called directly rather than through `uv_os_get_passwd` because libuv's Windows implementation requires `OpenProcessToken` + `GetUserProfileDirectoryW` to succeed *before* it reaches `GetUserNameW`, so it fails in no-profile service contexts — exactly the population this fixes — and it converts to WTF-8, which would mishandle account names containing unpaired surrogates on the UTF-8-marked string path.
- The other Windows fields already match Node: `uid`/`gid` are `-1`, `shell` is `null`, and `homedir` (via `uv_os_homedir`) already falls back to `GetUserProfileDirectoryW` when `USERPROFILE` is unset. Verified against Node with both `USERNAME` and `USERPROFILE` removed: identical values.

Deliberate divergences from Node, kept intentionally:
- When `USERNAME` is set, Bun returns it (Node always returns the `GetUserNameW` name). This preserves Bun's existing behavior asserted by the pre-existing `userInfo` test.
- If `GetUserNameW` itself fails (extraordinarily rare), Bun still degrades to `"unknown"` instead of throwing `ERR_SYSTEM_ERROR` like Node — `userInfo()` on Bun has never thrown here.

The POSIX arm has the same class of gap (`USER` unset → `"unknown"` where Node uses `getpwuid_r`, and `shell` → `"unknown"` where Node uses `pw_shell`); it is intentionally excluded — fixing it means deciding whether to adopt Node's throw-on-missing-passwd-entry behavior (e.g. `docker run -u 12345`), which deserves its own change.

## Test plan

- [x] New test: spawn bun with `USERNAME` truly unset and assert `userInfo().username` is a non-empty string ≠ `"unknown"`. `Bun.spawn` re-injects `USERNAME` into explicit envs (libuv required-vars list), so the test hops through `cmd /d /s /c "set USERNAME=& …"` with `windowsVerbatimArguments`; a precondition assertion (`process.env.USERNAME` is absent in the child) keeps the test from ever passing vacuously.
- [x] New test: spawn with `USERNAME=""` (empty survives spawn; distinct state from unset) and assert the same.
- [x] Both tests fail on bun without this change (`"unknown"` / empty string) and pass with it.
- [x] Full `test/js/node/os/os.test.js` (54/54) and ported `test/js/node/test/parallel/test-os.js` pass; `BUN_JSC_validateExceptionChecks=1` run clean.
- [x] Manually verified: unset → account name, empty → account name, `USERNAME=override` → `override`, repeated calls stable, non-ASCII `USERNAME` round-trips.