### PR TITLE
child_process: keep subprocess.stdin null after exit for non-pipe stdio

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1126,7 +1126,8 @@ class ChildProcess extends EventEmitter {
 
       // If there was an error while spawning the subprocess, then we will never have any IO to drain.
       if (err) {
-        this.#stdioOptions[1] = this.#stdioOptions[2] = "destroyed";
+        if (this.#stdioOptions[1] === "pipe") this.#stdioOptions[1] = "destroyed";
+        if (this.#stdioOptions[2] === "pipe") this.#stdioOptions[2] = "destroyed";
       }
 
       const stdout = this.#stdout,

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1120,7 +1120,7 @@ class ChildProcess extends EventEmitter {
     {
       if (this.#stdin) {
         this.#stdin.destroy();
-      } else {
+      } else if (this.#stdioOptions[0] === "pipe") {
         this.#stdioOptions[0] = "destroyed";
       }
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -237,13 +237,6 @@ describe("spawn()", () => {
       expect(child.stderr).toBe(null);
     });
 
-    it("is consistent regardless of when the getter is first read", async () => {
-      const child = spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["ignore", "ignore", "ignore"] });
-      const before = child.stdin;
-      await once(child, "close");
-      expect({ before, after: child.stdin }).toEqual({ before: null, after: null });
-    });
-
     it("fork() default stdio", async () => {
       const dir = tmpdirSync();
       const kid = path.join(dir, "kid.cjs");

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -2,7 +2,7 @@ import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
-import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
+import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { promisify } from "node:util";
 import path from "path";
@@ -222,6 +222,43 @@ describe("spawn()", () => {
     expect(child2.stdin).toBe(null);
     expect(child2.stdout).toBe(null);
     expect(child2.stderr).toBe(null);
+  });
+
+  describe("stdin for non-pipe stdio[0] stays null after exit", () => {
+    it.each([
+      ["ignore", ["ignore", "ignore", "ignore"]],
+      ["inherit", ["inherit", "ignore", "ignore"]],
+      ["fd 0", [0, "ignore", "ignore"]],
+    ] as const)("spawn stdio[0]=%s", async (_, stdio) => {
+      const child = spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: stdio as any });
+      await once(child, "close");
+      expect(child.stdin).toBe(null);
+      expect(child.stdout).toBe(null);
+      expect(child.stderr).toBe(null);
+    });
+
+    it("is consistent regardless of when the getter is first read", async () => {
+      const child = spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["ignore", "ignore", "ignore"] });
+      const before = child.stdin;
+      await once(child, "close");
+      expect({ before, after: child.stdin }).toEqual({ before: null, after: null });
+    });
+
+    it("fork() default stdio", async () => {
+      const dir = tmpdirSync();
+      const kid = path.join(dir, "kid.cjs");
+      fs.writeFileSync(kid, "process.exit(0)");
+      const child = fork(kid, [], { execPath: bunExe(), env: bunEnv });
+      await once(child, "close");
+      expect(child.stdin).toBe(null);
+    });
+
+    it("stdio[0]='pipe' still yields a destroyed Writable after exit", async () => {
+      const child = spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["pipe", "ignore", "ignore"] });
+      await once(child, "close");
+      expect(child.stdin).not.toBe(null);
+      expect(child.stdin!.destroyed).toBe(true);
+    });
   });
 
   it("should allow us to set cwd", async () => {


### PR DESCRIPTION
## What does this PR do?

Node documents that for any non-`pipe` stdio[0] configuration (`'ignore'`, `'inherit'`, an fd, `fork()`'s default), `subprocess.stdin` is `null`. The `if (child.stdin) child.stdin.end(data)` guard is the documented idiom for distinguishing piped from non-piped children.

In Bun, the value of `subprocess.stdin` depended on *when* it was first read: `null` while the child was alive, but a destroyed `Writable` if first accessed after the child exited. Cleanup code that runs on `'exit'`/`'close'` and branches on `child.stdin` would take the wrong path.

### Repro

```js
const cp = require("node:child_process");
const a = cp.spawn(process.execPath, ["-e", "0"], { stdio: ["ignore", "pipe", "ignore"] });
a.once("close", () => console.log(a.stdin));
// node: null
// bun (before): Writable { ..., destroyed: true }
```

### Cause

`ChildProcess.#handleOnExit` marked `#stdioOptions[0] = "destroyed"` whenever the lazy `#stdin` had not yet been materialized, clobbering the real slot-0 kind. The subsequent getter then took the `case "destroyed"` branch of `#getBunSpawnIo(0)` and fabricated a dummy destroyed `Writable` instead of the `null` the `'ignore'`/`'inherit'`/default branches would have returned.

### Fix

Only overwrite `#stdioOptions[0]` with `"destroyed"` when the original value was `"pipe"`, since that is the only configuration where stdin is a stream that needs a destroyed placeholder.

## How did you verify your code works?

New tests in `test/js/node/child_process/child_process.test.ts` cover `'ignore'`, `'inherit'`, fd `0`, and `fork()`'s default stdio, all first-read after `'close'`, plus a consistency check (before vs after) and a regression guard that `'pipe'` still yields a destroyed writable.

Fail-before with released bun:
```
(fail) spawn stdio[0]=ignore
(fail) spawn stdio[0]=inherit
(fail) spawn stdio[0]=fd 0
(fail) fork() default stdio
```

Pass-after with this change: 6 pass, 0 fail.