### PR TITLE
http: decode all members of a multi-member gzip response body

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -318,8 +318,15 @@ impl<'a> InternalState<'a> {
                             &mut body_out_str.list,
                             bun_libdeflate::Encoding::Gzip,
                         );
-                        if result.status == bun_libdeflate::Status::Success {
+                        // libdeflate decodes a single gzip member; unconsumed
+                        // input means this is a multi-member stream (RFC 1952
+                        // §2.2). Let the zlib path handle it.
+                        if result.status == bun_libdeflate::Status::Success
+                            && result.read == buffer.len()
+                        {
                             still_needs_to_decompress = false;
+                        } else {
+                            body_out_str.list.clear();
                         }
 
                         break 'libdeflate;
@@ -340,7 +347,9 @@ impl<'a> InternalState<'a> {
                     },
                 );
 
-                if result.status == bun_libdeflate::Status::Success {
+                // libdeflate decodes a single member; unconsumed input means
+                // a multi-member gzip stream. Let the zlib path handle it.
+                if result.status == bun_libdeflate::Status::Success && result.read == buffer.len() {
                     body_out_str
                         .list
                         .reserve_exact(result.written.saturating_sub(body_out_str.list.len()));

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -1265,7 +1265,10 @@ impl InflateDecoder {
             // A prior call completed a gzip member at the chunk boundary.
             // If this chunk begins another member, reset and decode it.
             if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
-                self.reset();
+                if self.reset() != ReturnCode::Ok {
+                    self.state = State::Error;
+                    return Err(ZlibError::ZlibError);
+                }
             } else {
                 return Ok(());
             }
@@ -1291,7 +1294,10 @@ impl InflateDecoder {
                     // non-zero bytes may be another gzip member; trailing
                     // zero bytes are padding and end the stream.
                     if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
-                        self.reset();
+                        if self.reset() != ReturnCode::Ok {
+                            self.state = State::Error;
+                            return Err(ZlibError::ZlibError);
+                        }
                         continue;
                     }
                     return Ok(());

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -1263,8 +1263,10 @@ impl InflateDecoder {
         }
         if matches!(self.state, State::End) {
             // A prior call completed a gzip member at the chunk boundary.
-            // If this chunk begins another member, reset and decode it.
-            if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
+            // Only resume when the next byte is the gzip magic ID1 (RFC 1952
+            // §2.3.1); any other trailing bytes are tolerated as garbage so
+            // stray CRLF/footer junk does not turn into a decode error.
+            if self.multi_member && input.first() == Some(&0x1f) {
                 if self.reset() != ReturnCode::Ok {
                     self.state = State::Error;
                     return Err(ZlibError::ZlibError);
@@ -1290,10 +1292,11 @@ impl InflateDecoder {
             match rc {
                 ReturnCode::StreamEnd => {
                     self.state = State::End;
-                    // Matches Node's GUNZIP loop (node_zlib.cc): remaining
-                    // non-zero bytes may be another gzip member; trailing
-                    // zero bytes are padding and end the stream.
-                    if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
+                    // Continue only when the next byte is the gzip magic ID1
+                    // (0x1f). Anything else is trailing garbage/padding and
+                    // ends the stream, keeping prior tolerance for origins
+                    // that append stray bytes after a valid member.
+                    if self.multi_member && input.first() == Some(&0x1f) {
                         if self.reset() != ReturnCode::Ok {
                             self.state = State::Error;
                             return Err(ZlibError::ZlibError);

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -1183,6 +1183,11 @@ pub struct InflateDecoder {
     pub state: State,
     /// Decompression-bomb guard for [`decompress`](Self::decompress).
     pub max_output_size: usize,
+    /// RFC 1952 §2.2: a gzip file is a sequence of members. When true (set
+    /// for gzip-only `window_bits`), [`decompress`](Self::decompress) resets
+    /// on `Z_STREAM_END` and continues if input remains, so concatenated
+    /// members are all decoded instead of silently dropped after the first.
+    multi_member: bool,
 }
 
 impl InflateDecoder {
@@ -1191,6 +1196,8 @@ impl InflateDecoder {
             strm: Box::new(new_zstream()),
             state: State::Uninitialized,
             max_output_size: usize::MAX,
+            // `MAX_WBITS | 16` selects gzip-only decode (zlib manual).
+            multi_member: (16..32).contains(&window_bits),
         };
         // SAFETY: strm is fully initialized; version/size match the linked zlib.
         let rc = unsafe {
@@ -1251,8 +1258,17 @@ impl InflateDecoder {
         out: &mut Vec<u8>,
         is_done: bool,
     ) -> Result<(), ZlibError> {
-        if matches!(self.state, State::End | State::Error) {
+        if matches!(self.state, State::Error) {
             return Ok(());
+        }
+        if matches!(self.state, State::End) {
+            // A prior call completed a gzip member at the chunk boundary.
+            // If this chunk begins another member, reset and decode it.
+            if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
+                self.reset();
+            } else {
+                return Ok(());
+            }
         }
         loop {
             let remaining = self.max_output_size.saturating_sub(out.len());
@@ -1271,6 +1287,13 @@ impl InflateDecoder {
             match rc {
                 ReturnCode::StreamEnd => {
                     self.state = State::End;
+                    // Matches Node's GUNZIP loop (node_zlib.cc): remaining
+                    // non-zero bytes may be another gzip member; trailing
+                    // zero bytes are padding and end the stream.
+                    if self.multi_member && input.first().is_some_and(|&b| b != 0x00) {
+                        self.reset();
+                        continue;
+                    }
                     return Ok(());
                 }
                 ReturnCode::MemError => {

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -644,6 +644,50 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
     });
   });
 
+  // Last member's ISIZE trailer > 512 KiB (LibdeflateState::shared_buffer) so
+  // the libdeflate fast path takes the decompress_to_vec branch, which must
+  // also detect unconsumed input and fall through.
+  it("content-length, last member > 512 KiB (decompress_to_vec branch)", async () => {
+    const big = Buffer.alloc(600 * 1024, "BIG-LAST-MEMBER-");
+    const body = Buffer.concat([M1, gzipSync(big)]);
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.end(
+        Buffer.concat([
+          Buffer.from(
+            `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`,
+          ),
+          body,
+        ]),
+      );
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const expected = Buffer.concat([P1, big]);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const res = await fetch(process.argv[1]);
+           const buf = Buffer.from(await res.arrayBuffer());
+           console.log(buf.length, Bun.hash(buf).toString(16));`,
+          `http://127.0.0.1:${port}/`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: `${expected.length} ${Bun.hash(expected).toString(16)}`,
+        stderr: expect.not.stringContaining("error"),
+        exitCode: 0,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
   // Streaming body path (ResponseBodyStreaming signal set): exercises the
   // per-chunk Decompressor::decompress_chunk path with a member boundary
   // between chunks.

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -566,6 +566,129 @@ describe("corrupt compressed responses", () => {
   });
 });
 
+// RFC 1952 §2.2: a gzip file is a sequence of members. Concatenated members
+// (cat a.gz b.gz, bgzf, pigz, pre-compressed segment stitching) must all be
+// decoded. Previously fetch() silently returned only the first member.
+describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
+  const P1 = Buffer.alloc(18000, "The quick brown fox jumps over the lazy dog. ");
+  const P2 = Buffer.alloc(14000, "SECOND-MEMBER-");
+  const M1 = gzipSync(P1);
+  const M2 = gzipSync(P2);
+  const BODY = Buffer.concat([M1, M2]);
+  const EXPECT = Buffer.concat([P1, P2]).toString("utf8");
+
+  type Case = [label: string, pieces: Buffer[], chunked: boolean];
+  const cases: Case[] = [
+    ["content-length, one write", [BODY], false],
+    ["content-length, split mid member #1 trailer", [BODY.subarray(0, M1.length - 5), BODY.subarray(M1.length - 5)], false],
+    ["content-length, split at member boundary", [M1, M2], false],
+    ["chunked, one chunk", [BODY], true],
+    ["chunked, one chunk per member", [M1, M2], true],
+    // gzip padding: trailing zeros after the last member must be tolerated.
+    ["content-length, trailing zero padding", [Buffer.concat([BODY, Buffer.alloc(8)])], false],
+  ];
+
+  describe.each(["0", "1"])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", noLibdeflate => {
+    it.concurrent.each(cases)("%s", async (_label, pieces, chunked) => {
+      const total = pieces.reduce((n, p) => n + p.length, 0);
+      const server = createNetServer(socket => {
+        socket.on("error", () => {});
+        socket.setNoDelay(true);
+        const head = chunked
+          ? "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+          : `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: ${total}\r\nConnection: close\r\n\r\n`;
+        socket.write(head);
+        (async () => {
+          for (const p of pieces) {
+            if (chunked) {
+              socket.write(p.length.toString(16) + "\r\n");
+              socket.write(p);
+              socket.write("\r\n");
+            } else {
+              socket.write(p);
+            }
+            await new Promise(r => setImmediate(r));
+          }
+          socket.end(chunked ? "0\r\n\r\n" : undefined);
+        })().catch(() => socket.destroy());
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      try {
+        const { port } = server.address() as import("node:net").AddressInfo;
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const res = await fetch(process.argv[1]);
+             const buf = Buffer.from(await res.arrayBuffer());
+             process.stdout.write(buf);`,
+            `http://127.0.0.1:${port}/`,
+          ],
+          env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate },
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ len: stdout.length, stdout, stderr, exitCode }).toEqual({
+          len: EXPECT.length,
+          stdout: EXPECT,
+          stderr: expect.not.stringContaining("error"),
+          exitCode: 0,
+        });
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  // Streaming body path (ResponseBodyStreaming signal set): exercises the
+  // per-chunk Decompressor::decompress_chunk path with a member boundary
+  // between chunks.
+  it("streaming body, member boundary between chunks", async () => {
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.setNoDelay(true);
+      socket.write(
+        "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+      );
+      (async () => {
+        for (const p of [M1, M2]) {
+          socket.write(p.length.toString(16) + "\r\n");
+          socket.write(p);
+          socket.write("\r\n");
+          await new Promise(r => setImmediate(r));
+        }
+        socket.end("0\r\n\r\n");
+      })().catch(() => socket.destroy());
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const res = await fetch(process.argv[1]);
+           const chunks = [];
+           for await (const c of res.body) chunks.push(c);
+           process.stdout.write(Buffer.concat(chunks));`,
+          `http://127.0.0.1:${port}/`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ len: stdout.length, stdout, stderr, exitCode }).toEqual({
+        len: EXPECT.length,
+        stdout: EXPECT,
+        stderr: expect.not.stringContaining("error"),
+        exitCode: 0,
+      });
+    } finally {
+      server.close();
+    }
+  });
+});
+
 describe("empty compressed responses", () => {
   // A response that declares Content-Encoding but sends zero body bytes must
   // resolve as an empty body, like Node — not fail with ZlibError.

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -651,7 +651,7 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
   // must still decode successfully (prior Bun behavior, and what browsers /
   // curl / Go do). The multi-member loop only resumes on 0x1f so stray
   // CRLF/footer junk from misconfigured origins does not fail the fetch.
-  it.each(["0", "1"])("single member with trailing garbage (NO_LIBDEFLATE=%s)", async noLibdeflate => {
+  it.concurrent.each(["0", "1"])("single member with trailing garbage (NO_LIBDEFLATE=%s)", async noLibdeflate => {
     const body = Buffer.concat([M1, Buffer.from("\r\ngarbage")]);
     const server = createNetServer(socket => {
       socket.on("error", () => {});
@@ -693,7 +693,7 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
   // Last member's ISIZE trailer > 512 KiB (LibdeflateState::shared_buffer) so
   // the libdeflate fast path takes the decompress_to_vec branch, which must
   // also detect unconsumed input and fall through.
-  it("content-length, last member > 512 KiB (decompress_to_vec branch)", async () => {
+  it.concurrent("content-length, last member > 512 KiB (decompress_to_vec branch)", async () => {
     const big = Buffer.alloc(600 * 1024, "BIG-LAST-MEMBER-");
     const body = Buffer.concat([M1, gzipSync(big)]);
     const server = createNetServer(socket => {
@@ -737,7 +737,7 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
   // Streaming body path (ResponseBodyStreaming signal set): exercises the
   // per-chunk Decompressor::decompress_chunk path with a member boundary
   // between chunks.
-  it("streaming body, member boundary between chunks", async () => {
+  it.concurrent("streaming body, member boundary between chunks", async () => {
     const server = createNetServer(socket => {
       socket.on("error", () => {});
       socket.setNoDelay(true);

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -590,6 +590,9 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
     ["chunked, one chunk per member", [M1, M2], true],
     // gzip padding: trailing zeros after the last member must be tolerated.
     ["content-length, trailing zero padding", [Buffer.concat([BODY, Buffer.alloc(8)])], false],
+    // Trailing non-gzip-magic bytes after the last member must be tolerated
+    // as garbage (not treated as another member), matching browsers/curl/Go.
+    ["content-length, trailing CRLF garbage", [Buffer.concat([BODY, Buffer.from("\r\n")])], false],
   ];
 
   describe.each(["0", "1"])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", noLibdeflate => {
@@ -642,6 +645,49 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
         server.close();
       }
     });
+  });
+
+  // A single valid gzip member followed by non-gzip-magic trailing bytes
+  // must still decode successfully (prior Bun behavior, and what browsers /
+  // curl / Go do). The multi-member loop only resumes on 0x1f so stray
+  // CRLF/footer junk from misconfigured origins does not fail the fetch.
+  it.each(["0", "1"])("single member with trailing garbage (NO_LIBDEFLATE=%s)", async noLibdeflate => {
+    const body = Buffer.concat([M1, Buffer.from("\r\ngarbage")]);
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.end(
+        Buffer.concat([
+          Buffer.from(
+            `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`,
+          ),
+          body,
+        ]),
+      );
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const res = await fetch(process.argv[1]);
+           process.stdout.write(Buffer.from(await res.arrayBuffer()));`,
+          `http://127.0.0.1:${port}/`,
+        ],
+        env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ len: stdout.length, stdout, stderr, exitCode }).toEqual({
+        len: P1.length,
+        stdout: P1.toString(),
+        stderr: expect.not.stringContaining("error"),
+        exitCode: 0,
+      });
+    } finally {
+      server.close();
+    }
   });
 
   // Last member's ISIZE trailer > 512 KiB (LibdeflateState::shared_buffer) so

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -580,7 +580,11 @@ describe("fetch() decodes multi-member Content-Encoding: gzip", () => {
   type Case = [label: string, pieces: Buffer[], chunked: boolean];
   const cases: Case[] = [
     ["content-length, one write", [BODY], false],
-    ["content-length, split mid member #1 trailer", [BODY.subarray(0, M1.length - 5), BODY.subarray(M1.length - 5)], false],
+    [
+      "content-length, split mid member #1 trailer",
+      [BODY.subarray(0, M1.length - 5), BODY.subarray(M1.length - 5)],
+      false,
+    ],
     ["content-length, split at member boundary", [M1, M2], false],
     ["chunked, one chunk", [BODY], true],
     ["chunked, one chunk per member", [M1, M2], true],


### PR DESCRIPTION
## Problem

`fetch()` silently truncates a `Content-Encoding: gzip` response body made of concatenated gzip members to the first member, and resolves as a success. RFC 1952 section 2.2 defines a gzip file as a sequence of members; multi-member bodies are what `cat a.gz b.gz`, bgzf/WARC, `pigz`, and origins that stitch pre-compressed segments serve. Node/undici and browsers return the full concatenation; Bun's own `node:zlib.gunzipSync` on the same bytes returns all members.

## Reproduction

```js
import net from "node:net";
import zlib from "node:zlib";

const P1 = Buffer.alloc(18000, "The quick brown fox jumps over the lazy dog. ");
const P2 = Buffer.alloc(14000, "SECOND-MEMBER-");
const BODY = Buffer.concat([zlib.gzipSync(P1), zlib.gzipSync(P2)]);

const srv = net.createServer(c => {
  c.on("data", () => c.end(
    `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: ${BODY.length}\r\nConnection: close\r\n\r\n`
    + BODY.toString("latin1"), "latin1"));
}).listen(0, "127.0.0.1", async () => {
  const buf = await (await fetch(`http://127.0.0.1:${srv.address().port}/`)).arrayBuffer();
  console.log(buf.byteLength); // node: 32000, bun (before): 18000
  srv.close();
});
```

## Cause

Both decode paths stopped at the first `Z_STREAM_END`:

- The libdeflate one-shot fast path in `InternalState::decompress_bytes` treated `Status::Success` on member 1 as done without checking that `result.read == buffer.len()`.
- The streaming `InflateDecoder::decompress` set `state = End` on `Z_STREAM_END` and early-returned on every subsequent chunk, never resetting for the next member.

## Fix

- libdeflate fast path: only accept the result when the whole input was consumed; otherwise fall through to the zlib path (and clear any partial output first).
- `InflateDecoder`: for gzip-only window bits, after `Z_STREAM_END` reset the stream and continue if non-zero input remains, matching the loop in Node's `node_zlib.cc` (and Bun's own `NativeZlib` GUNZIP mode, which already did this).

## Verification

```
bun bd test test/js/web/fetch/fetch-gzip.test.ts
 45 pass, 0 fail
```

New tests cover Content-Length and chunked framing, member boundaries inside / between TCP segments, trailing zero padding, streaming body consumption, and both `BUN_FEATURE_FLAG_NO_LIBDEFLATE=0/1` paths. All fail on current main with `len: 18000` vs expected `32000`.