### PR TITLE
fetch: resolve the promise once headers arrive even if body decompression fails

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4417,6 +4417,12 @@ impl<'a> HTTPClient<'a> {
             BodySize::Unknown
         };
 
+        // A followed redirect's intermediate head was only cloned to drive
+        // do_redirect(); on failure it must not surface as the final Response.
+        if self.state.flags.is_redirect_pending && self.state.fail.is_some() {
+            self.state.cloned_metadata = None;
+        }
+
         let mut certificate_info: Option<CertificateInfo> = None;
         if let Some(info) = self.state.certificate_info.take() {
             // transfer owner ship of the certificate info here

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1033,9 +1033,10 @@ impl FetchTasklet {
         };
 
         let result = if success {
-            // Head arrived together with a body failure: cancel any in-flight
-            // request-body sink with the real error so its `cancel(reason)`
-            // matches the split-read `on_body_received` path.
+            let resolved = self.on_resolve();
+            // Cancel the request-body sink last (as on_body_received does):
+            // `ResumableSink::cancel` runs the user's cancel callback
+            // synchronously, so the body error must already be stored.
             if self.result.fail.is_some() && self.sink_mut().is_some() {
                 let mut err = self.on_reject();
                 let err_js = err.to_js(&global_this);
@@ -1045,7 +1046,7 @@ impl FetchTasklet {
                 }
                 err.reset();
             }
-            StrongOptional::create(self.on_resolve(), &global_this)
+            StrongOptional::create(resolved, &global_this)
         } else {
             // in this case we wanna a jsc.Strong.Optional so we just convert it
             let mut value = self.on_reject();

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -999,12 +999,17 @@ impl FetchTasklet {
             return Ok(());
         }
 
+        // WHATWG fetch: once the response head is available the promise
+        // resolves; post-head failures (body decompression etc.) surface on
+        // the body reader regardless of whether head+body arrived in one read.
+        let success = self.result.is_success() || self.metadata.is_some();
+
         // Paired with the microtask drain after
         // startRequestStream above: the request-body sink may have set `abort_reason`
         // via writeEndRequest while the HTTP result is still a success — server HEADERS
         // raced ahead of the scheduled shutdown. Reject with that reason instead of
         // resolving a 200 Response. Makes wpt-h2 number-chunk test deterministic.
-        if self.result.is_success() && self.abort_reason.has() {
+        if success && self.abort_reason.has() {
             let promise = promise_value.as_any_promise().unwrap();
             let tracker = self.tracker;
             // get_abort_error consumes abort_reason and clears the signal handler.
@@ -1027,11 +1032,19 @@ impl FetchTasklet {
             this.promise = jsc::JSPromiseStrong::empty();
         };
 
-        // WHATWG fetch: once the response head is available the promise
-        // resolves; post-head failures (body decompression etc.) surface on
-        // the body reader regardless of whether head+body arrived in one read.
-        let success = self.result.is_success() || self.metadata.is_some();
         let result = if success {
+            // Head arrived together with a body failure: cancel any in-flight
+            // request-body sink with the real error so its `cancel(reason)`
+            // matches the split-read `on_body_received` path.
+            if self.result.fail.is_some() && self.sink_mut().is_some() {
+                let mut err = self.on_reject();
+                let err_js = err.to_js(&global_this);
+                err_js.ensure_still_alive();
+                if let Some(sink) = self.sink_mut() {
+                    sink.cancel(err_js);
+                }
+                err.reset();
+            }
             StrongOptional::create(self.on_resolve(), &global_this)
         } else {
             // in this case we wanna a jsc.Strong.Optional so we just convert it

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1027,7 +1027,10 @@ impl FetchTasklet {
             this.promise = jsc::JSPromiseStrong::empty();
         };
 
-        let success = self.result.is_success();
+        // WHATWG fetch: once the response head is available the promise
+        // resolves; post-head failures (body decompression etc.) surface on
+        // the body reader regardless of whether head+body arrived in one read.
+        let success = self.result.is_success() || self.metadata.is_some();
         let result = if success {
             StrongOptional::create(self.on_resolve(), &global_this)
         } else {
@@ -1668,6 +1671,11 @@ impl FetchTasklet {
     fn to_body_value(&mut self) -> BodyValue {
         if let Some(err) = self.get_abort_error() {
             return BodyValue::Error(err);
+        }
+        if self.result.fail.is_some() {
+            // Head received but body failed in the same callback; surface on
+            // the body so this matches the split-read `on_body_received` path.
+            return BodyValue::Error(self.on_reject());
         }
         if self.is_waiting_body {
             let mut pending = body::PendingValue::new(&self.global_this);

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -494,6 +494,34 @@ describe("corrupt compressed responses", () => {
       });
     }
   }
+
+  it("followed redirect with a malformed chunked body rejects fetch()", async () => {
+    // The intermediate 3xx head is not the caller's Response under
+    // redirect:"follow", so a body parse failure there must reject fetch()
+    // rather than resolving with the 302.
+    const srv = createNetServer(sock => {
+      sock.on("error", () => {});
+      sock.end(
+        "HTTP/1.1 302 Found\r\n" +
+          "Location: http://127.0.0.1:1/unreached\r\n" +
+          "Transfer-Encoding: chunked\r\n" +
+          "Connection: close\r\n\r\n" +
+          "ZZ\r\n",
+      );
+    });
+    const port = await listen(srv);
+    try {
+      await expect(fetch(`http://127.0.0.1:${port}/`, { redirect: "follow" })).rejects.toThrow();
+
+      // With redirect:"manual" the 302 *is* the final response.
+      const res = await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("http://127.0.0.1:1/unreached");
+      await expect(res.arrayBuffer()).rejects.toThrow();
+    } finally {
+      srv.close();
+    }
+  });
 });
 
 describe("empty compressed responses", () => {

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -426,6 +426,76 @@ it("fetch() with a buffered gzip response whose decompressed size exceeds 1 GiB 
   });
 }, 60_000);
 
+describe("corrupt compressed responses", () => {
+  // A body decompression failure is a body error: fetch() must resolve (status
+  // and headers are available) and the body reader rejects. Previously, when
+  // head+body arrived in a single read, the decompress error failed the HTTP
+  // task before the head reached JS and fetch() itself rejected, so the error
+  // surface depended on packet timing.
+  const corrupt = (compress: (b: Buffer) => Buffer) => {
+    const payload = compress(Buffer.alloc(18000, "The quick brown fox jumps over the lazy dog. "));
+    // Flip a run of early bytes so every codec reports a decode error (br/zstd
+    // store this input near-literally, so a single mid-stream flip passes).
+    for (let i = 2; i < 8; i++) payload[i] ^= 0xff;
+    return payload;
+  };
+  const bodies = {
+    gzip: corrupt(gzipSync),
+    deflate: corrupt(deflateSync),
+    br: corrupt(brotliCompressSync),
+    zstd: corrupt(zstdCompressSync),
+  };
+  const listen = (srv: import("node:net").Server) =>
+    new Promise<number>(r => srv.listen(0, "127.0.0.1", () => r((srv.address() as { port: number }).port)));
+
+  for (const [encoding, body] of Object.entries(bodies)) {
+    for (const framing of ["content-length", "chunked"] as const) {
+      it(`${encoding} ${framing}: fetch() resolves, body read rejects`, async () => {
+        const head =
+          framing === "content-length"
+            ? `HTTP/1.1 200 OK\r\nx-marker: present\r\nContent-Encoding: ${encoding}\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`
+            : `HTTP/1.1 200 OK\r\nx-marker: present\r\nContent-Encoding: ${encoding}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n`;
+        const payload =
+          framing === "content-length"
+            ? body
+            : Buffer.concat([Buffer.from(body.length.toString(16) + "\r\n"), body, Buffer.from("\r\n0\r\n\r\n")]);
+
+        // Single write so head+body land in one client read (the case that
+        // previously rejected fetch()). The split-read timing was already
+        // correct and is equivalent after this fix.
+        const srv = createNetServer(sock => {
+          sock.on("error", () => {});
+          sock.end(Buffer.concat([Buffer.from(head), payload]));
+        });
+        const port = await listen(srv);
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/`);
+          expect(res.status).toBe(200);
+          expect(res.headers.get("x-marker")).toBe("present");
+          const bodyErr = await res.arrayBuffer().then(
+            () => null,
+            e => e,
+          );
+          expect(bodyErr).toBeInstanceOf(Error);
+          // The streaming body reader must surface the same failure.
+          const res2 = await fetch(`http://127.0.0.1:${port}/`);
+          expect(res2.status).toBe(200);
+          const reader = res2.body!.getReader();
+          let streamErr: unknown = null;
+          try {
+            while (!(await reader.read()).done) {}
+          } catch (e) {
+            streamErr = e;
+          }
+          expect(streamErr).toBeInstanceOf(Error);
+        } finally {
+          srv.close();
+        }
+      });
+    }
+  }
+});
+
 describe("empty compressed responses", () => {
   // A response that declares Content-Encoding but sends zero body bytes must
   // resolve as an empty body, like Node — not fail with ZlibError.

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -439,16 +439,16 @@ describe("corrupt compressed responses", () => {
     for (let i = 2; i < 8; i++) payload[i] ^= 0xff;
     return payload;
   };
-  const bodies = {
-    gzip: corrupt(gzipSync),
-    deflate: corrupt(deflateSync),
-    br: corrupt(brotliCompressSync),
-    zstd: corrupt(zstdCompressSync),
+  const bodies: Record<string, [Buffer, string]> = {
+    gzip: [corrupt(gzipSync), "ZlibError"],
+    deflate: [corrupt(deflateSync), "ZlibError"],
+    br: [corrupt(brotliCompressSync), "BrotliDecompressionError"],
+    zstd: [corrupt(zstdCompressSync), "ZstdDecompressionError"],
   };
   const listen = (srv: import("node:net").Server) =>
     new Promise<number>(r => srv.listen(0, "127.0.0.1", () => r((srv.address() as { port: number }).port)));
 
-  for (const [encoding, body] of Object.entries(bodies)) {
+  for (const [encoding, [body, errorCode]] of Object.entries(bodies)) {
     for (const framing of ["content-length", "chunked"] as const) {
       it(`${encoding} ${framing}: fetch() resolves, body read rejects`, async () => {
         const head =
@@ -477,6 +477,7 @@ describe("corrupt compressed responses", () => {
             e => e,
           );
           expect(bodyErr).toBeInstanceOf(Error);
+          expect((bodyErr as { code?: string }).code).toBe(errorCode);
           // The streaming body reader must surface the same failure.
           const res2 = await fetch(`http://127.0.0.1:${port}/`);
           expect(res2.status).toBe(200);
@@ -488,6 +489,7 @@ describe("corrupt compressed responses", () => {
             streamErr = e;
           }
           expect(streamErr).toBeInstanceOf(Error);
+          expect((streamErr as { code?: string }).code).toBe(errorCode);
         } finally {
           srv.close();
         }
@@ -511,13 +513,23 @@ describe("corrupt compressed responses", () => {
     });
     const port = await listen(srv);
     try {
-      await expect(fetch(`http://127.0.0.1:${port}/`, { redirect: "follow" })).rejects.toThrow();
+      const followErr = await fetch(`http://127.0.0.1:${port}/`, { redirect: "follow" }).then(
+        r => ({ status: r.status }),
+        e => e,
+      );
+      expect(followErr).toBeInstanceOf(Error);
+      expect((followErr as { code?: string }).code).toBe("InvalidHTTPResponse");
 
       // With redirect:"manual" the 302 *is* the final response.
       const res = await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toBe("http://127.0.0.1:1/unreached");
-      await expect(res.arrayBuffer()).rejects.toThrow();
+      const bodyErr = await res.arrayBuffer().then(
+        () => null,
+        e => e,
+      );
+      expect(bodyErr).toBeInstanceOf(Error);
+      expect((bodyErr as { code?: string }).code).toBe("InvalidHTTPResponse");
     } finally {
       srv.close();
     }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -522,6 +522,36 @@ describe("corrupt compressed responses", () => {
       srv.close();
     }
   });
+
+  it("redirect loop with a non-empty body rejects with TooManyRedirects", async () => {
+    // Real-world 302s carry an HTML body, which routes the intermediate
+    // head through clone_metadata(); hitting the redirect limit must still
+    // reject fetch() rather than resolve with that 302.
+    const body = "<html><body>Moved.</body></html>";
+    const srv = createNetServer(sock => {
+      sock.on("error", () => {});
+      let acc = "";
+      sock.on("data", d => {
+        acc += d;
+        if (!acc.includes("\r\n\r\n")) return;
+        acc = "";
+        sock.end(
+          `HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:${port}/loop\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`,
+        );
+      });
+    });
+    const port = await listen(srv);
+    try {
+      const err = await fetch(`http://127.0.0.1:${port}/`).then(
+        r => ({ status: r.status }),
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect((err as { code?: string }).code).toBe("TooManyRedirects");
+    } finally {
+      srv.close();
+    }
+  });
 });
 
 describe("empty compressed responses", () => {


### PR DESCRIPTION
## What

When a compressed response's head and body arrive in a single TCP read and the body fails to decompress, `fetch()` now resolves with a `Response` (status, headers intact) and the body reader rejects. Previously `fetch()` rejected outright and the `Response` was lost.

## Repro

```js
import net from "node:net";
import zlib from "node:zlib";

const GZ = zlib.gzipSync(Buffer.alloc(18000, "x"));
GZ[Math.floor(GZ.length / 2)] ^= 0xff; // corrupt mid-stream

const srv = net.createServer(c => {
  c.on("error", () => {});
  c.end(Buffer.concat([
    Buffer.from(`HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: ${GZ.length}\r\nConnection: close\r\n\r\n`),
    GZ,
  ]));
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));

try {
  const res = await fetch(`http://127.0.0.1:${srv.address().port}/`);
  console.log("status", res.status);           // before: unreachable
  await res.arrayBuffer().catch(e => console.log("body:", e.code));
} catch (e) {
  console.log("fetch REJECTED", e.code);       // before: ZlibError
}
srv.close();
```

Before:
```
fetch REJECTED ZlibError
```
After (matches Node):
```
status 200
body: ZlibError
```

If the server delays the body by a few ms so it lands in a second read, Bun already resolved `fetch()` and errored the body reader. So the same response bytes reported through two different API surfaces depending on where the kernel split the read, and small loopback responses almost always hit the broken path.

## Cause

`FetchTasklet::on_progress_update` decided resolve vs. reject on `result.is_success()` alone. When the HTTP thread parses the head, runs the body decompressor, and fails, it delivers one callback with both `metadata` and `fail` set; the tasklet saw `fail` and rejected, never constructing the `Response`. On the split-read timing the head is delivered first (`is_waiting_body` set), and the later failure routes through `on_body_received`, which only errors the body.

## Fix

Gate promise resolution on `metadata.is_some()` as well: once the response head is available the promise resolves per WHATWG fetch. `to_body_value` returns `BodyValue::Error(on_reject())` when a `fail` is present so `res.text()` / `res.body` reject with the decompression error, same as the split-read path. This also covers the equivalent h2/h3 coalesced-callback timing.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-gzip.test.ts -t "corrupt"   # 0 pass, 8 fail
bun bd           test test/js/web/fetch/fetch-gzip.test.ts -t "corrupt"        # 8 pass, 0 fail
```

Related regression tests (`18413-truncation`, `fetch.stream.test.ts -t "can handle corrupted"`) still pass: they already caught the error from either `fetch()` or the body read.