### PR TITLE
http: use RFC 1950 header check for Content-Encoding: deflate sniffing

### DIFF
--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -10,8 +10,24 @@ pub enum Decompressor {
     Zlib(bun_zlib::InflateDecoder),
     Brotli(Box<bun_brotli::StreamingDecoder>),
     Zstd(Box<bun_zstd::StreamingDecoder>),
+    /// `Content-Encoding: deflate` with only one body byte delivered so far.
+    /// Holds that byte until a second arrives so the RFC 1950 zlib-header
+    /// sniff (which needs both CMF and FLG) can decide zlib-wrapped vs raw.
+    PendingDeflate(u8),
     #[default]
     None,
+}
+
+/// RFC 1950 §2.2 zlib header: CMF low nibble = 8 (deflate), high nibble <= 7
+/// (window), and big-endian CMF|FLG is a multiple of 31. RFC 9110 §8.4.1.2
+/// says `Content-Encoding: deflate` is zlib-wrapped; some origins send raw.
+fn is_zlib_header(chunk: &[u8]) -> bool {
+    match *chunk {
+        [b0, b1, ..] => {
+            (b0 & 0x0f) == 8 && (b0 >> 4) <= 7 && ((u16::from(b0) << 8) | u16::from(b1)) % 31 == 0
+        }
+        _ => false,
+    }
 }
 
 impl Decompressor {
@@ -24,11 +40,11 @@ impl Decompressor {
             Encoding::Gzip | Encoding::Deflate => {
                 // zlib.MAX_WBITS = 15
                 // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
-                // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
+                // to (de-)compress deflate format with headers we use wbits = 0 (auto-detect window from header)
                 // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
                 let window_bits = if encoding == Encoding::Gzip {
                     bun_zlib::MAX_WBITS | 16
-                } else if first_chunk.len() > 1 && first_chunk[0] == 120 {
+                } else if is_zlib_header(first_chunk) {
                     0
                 } else {
                     -bun_zlib::MAX_WBITS
@@ -62,7 +78,28 @@ impl Decompressor {
         if !encoding.is_compressed() {
             return Ok(());
         }
+
+        // If the first deflate body segment was a single byte, it was stashed
+        // in PendingDeflate; prepend it now so init() can sniff the 2-byte
+        // zlib header. This path runs at most once per response.
+        let mut prefixed;
+        let buffer = if let Decompressor::PendingDeflate(b0) = *self {
+            prefixed = Vec::with_capacity(1 + buffer.len());
+            prefixed.push(b0);
+            prefixed.extend_from_slice(buffer);
+            *self = Decompressor::None;
+            prefixed.as_slice()
+        } else {
+            buffer
+        };
+
         if matches!(self, Decompressor::None) {
+            if encoding == Encoding::Deflate && buffer.len() < 2 && !is_done {
+                if let &[b0] = buffer {
+                    *self = Decompressor::PendingDeflate(b0);
+                }
+                return Err(bun_core::err!("ShortRead"));
+            }
             self.init(encoding, buffer)?;
         }
         let out = &mut body_out_str.list;
@@ -70,7 +107,7 @@ impl Decompressor {
             Decompressor::Zlib(reader) => Ok(reader.decompress(buffer, out, is_done)?),
             Decompressor::Brotli(reader) => reader.decompress(buffer, out, is_done),
             Decompressor::Zstd(reader) => Ok(reader.decompress(buffer, out, is_done)?),
-            Decompressor::None => {
+            Decompressor::None | Decompressor::PendingDeflate(_) => {
                 unreachable!("Invalid encoding. This code should not be reachable")
             }
         }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, gcTick } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
-import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
+import { brotliCompressSync, deflateRawSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
 import path from "path";
 
 const gzipped = path.join(import.meta.dir, "fixture.html.gz");
@@ -448,4 +448,79 @@ describe("empty compressed responses", () => {
       }
     });
   }
+});
+
+describe("Content-Encoding: deflate zlib-header sniff", () => {
+  const plain = Buffer.alloc(2000, "The quick brown fox jumps over the lazy dog. ");
+  // RFC 1950 zlib streams: windowBits < 15 emit CMF bytes other than 0x78
+  // (0x18/0x28/0x38/0x48/0x58/0x68). All are valid `Content-Encoding: deflate`
+  // per RFC 9110 §8.4.1.2; Node and curl decode them.
+  const bodies: Record<string, Buffer> = { raw: deflateRawSync(plain) };
+  for (let wb = 8; wb <= 15; wb++) bodies[`wb${wb}`] = deflateSync(plain, { windowBits: wb });
+
+  it("decodes every zlib windowBits and raw deflate", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = new URL(req.url).pathname.slice(1);
+        return new Response(bodies[name], {
+          headers: { "Content-Encoding": "deflate", "Content-Type": "text/plain" },
+        });
+      },
+    });
+    const results: Record<string, unknown> = {};
+    for (const name of Object.keys(bodies)) {
+      try {
+        const got = Buffer.from(await (await fetch(`${server.url}${name}`)).arrayBuffer());
+        results[name] = { cmf: bodies[name][0], len: got.length, ok: got.equals(plain) };
+      } catch (e) {
+        results[name] = { cmf: bodies[name][0], error: String((e as any)?.code ?? e) };
+      }
+    }
+    expect(results).toEqual(
+      Object.fromEntries(
+        Object.keys(bodies).map(n => [n, { cmf: bodies[n][0], len: plain.length, ok: true }]),
+      ),
+    );
+  });
+
+  // A zlib stream whose first delivered body segment is a single byte must
+  // still be recognised as zlib-wrapped (the RFC 1950 header is two bytes),
+  // and raw deflate must still be recognised as raw under the same split.
+  it("decodes when the first body segment is 1 byte", async () => {
+    const results: Record<string, unknown> = {};
+    for (const name of ["wb15", "wb9", "raw"]) {
+      const body = bodies[name];
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          data(socket, data) {
+            socket.data = (socket.data ?? "") + data;
+            if (!socket.data.includes("\r\n\r\n")) return;
+            const head = `HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`;
+            socket.write(Buffer.concat([Buffer.from(head), body.subarray(0, 1)]));
+            socket.flush();
+            (async () => {
+              await Bun.sleep(20);
+              socket.write(body.subarray(1));
+              socket.flush();
+              socket.end();
+            })();
+          },
+        },
+      });
+      try {
+        const got = Buffer.from(await (await fetch(`http://127.0.0.1:${server.port}/`)).arrayBuffer());
+        results[name] = { len: got.length, ok: got.equals(plain) };
+      } catch (e) {
+        results[name] = { error: String((e as any)?.code ?? e) };
+      }
+    }
+    expect(results).toEqual({
+      wb15: { len: plain.length, ok: true },
+      wb9: { len: plain.length, ok: true },
+      raw: { len: plain.length, ok: true },
+    });
+  });
 });

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -478,9 +478,7 @@ describe("Content-Encoding: deflate zlib-header sniff", () => {
       }
     }
     expect(results).toEqual(
-      Object.fromEntries(
-        Object.keys(bodies).map(n => [n, { cmf: bodies[n][0], len: plain.length, ok: true }]),
-      ),
+      Object.fromEntries(Object.keys(bodies).map(n => [n, { cmf: bodies[n][0], len: plain.length, ok: true }])),
     );
   });
 


### PR DESCRIPTION
## Problem

`fetch()` fails with `ZlibError` on valid `Content-Encoding: deflate` responses whenever the zlib stream was produced with `windowBits < 15`, or whenever the first delivered body segment happens to be exactly one byte.

`Decompressor::init` classifies the response as zlib-wrapped vs raw deflate with a hard-coded test on the first delivered chunk:

```rust
} else if first_chunk.len() > 1 && first_chunk[0] == 120 {
```

`0x78` is only the CMF byte for a 32K window. A deflater configured with a smaller window emits CMF `0x08`/`0x18`/`0x28`/`0x38`/`0x48`/`0x58`/`0x68`, all valid RFC 1950 zlib streams and all exactly what `Content-Encoding: deflate` means per RFC 9110 §8.4.1.2. Bun decodes these as raw deflate and they hard-fail. And because the check also requires `len() > 1`, a normal `0x78` stream whose first body segment is exactly one byte also falls into raw-deflate mode.

Node, curl `--compressed`, and every browser decode these responses. Bun's own `zlib.inflateSync` decodes the identical bytes in the same process.

<details>
<summary>Reproduction</summary>

```js
import net from "node:net";
import zlib from "node:zlib";

const plain = Buffer.alloc(18000, "The quick brown fox jumps over the lazy dog. ");
const wb9 = zlib.deflateSync(plain, { windowBits: 9 }); // CMF = 0x18
const wb15 = zlib.deflateSync(plain);                   // CMF = 0x78

const srv = net.createServer(c => {
  c.on("data", () => {
    const head = `HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: ${wb9.length}\r\nConnection: close\r\n\r\n`;
    c.end(Buffer.concat([Buffer.from(head), wb9]));
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
console.log(await (await fetch(`http://127.0.0.1:${srv.address().port}/`)).arrayBuffer());
// node: ArrayBuffer(18000)
// bun:  ZlibError
```
</details>

## Fix

Replace the byte-equality test with the actual RFC 1950 §2.2 header check:

```
(b0 & 0x0f) == 8 && (b0 >> 4) <= 7 && ((b0 << 8) | b1) % 31 == 0
```

and defer the decision via a new `PendingDeflate(u8)` state when fewer than two body bytes have been delivered, instead of defaulting to raw deflate. Raw-deflate responses (non-standard but widely deployed) are still recognised.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-gzip.test.ts -t "zlib-header sniff"
 0 pass
 2 fail   # wb8..wb14 and 1-byte-first-segment cases: ZlibError

$ bun bd test test/js/web/fetch/fetch-gzip.test.ts
 34 pass
 0 fail
```