### PR TITLE
bun:ffi: use LoadLibraryExW on Windows so dlopen accepts non-ASCII paths

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6095,7 +6095,7 @@ unsafe impl Send for DynLib {}
 // synchronized, so `&DynLib` may be shared across threads.
 unsafe impl Sync for DynLib {}
 impl DynLib {
-    /// `dlopen(path, RTLD_LAZY)` / `LoadLibraryA(path)`.
+    /// `dlopen(path, RTLD_LAZY)` / `LoadLibraryW(path)`.
     pub fn open(path: &[u8]) -> core::result::Result<Self, bun_core::Error> {
         let mut buf = bun_paths::PathBuffer::default();
         // `std.DynLib.open` returns `error.NameTooLong`; never truncate (could
@@ -6161,7 +6161,7 @@ pub mod RTLD {
     pub const LOCAL: i32 = 0;
 }
 
-/// `dlopen(filename, flags)`. Windows → `LoadLibraryA`.
+/// `dlopen(filename, flags)`. Windows → `LoadLibraryExW` (UTF-8 → UTF-16).
 pub fn dlopen(filename: &ZStr, flags: i32) -> Option<*mut c_void> {
     #[cfg(unix)]
     {
@@ -6172,8 +6172,16 @@ pub fn dlopen(filename: &ZStr, flags: i32) -> Option<*mut c_void> {
     #[cfg(windows)]
     {
         let _ = flags;
-        // SAFETY: filename is NUL-terminated.
-        let p = unsafe { bun_windows_sys::externs::LoadLibraryA(filename.as_ptr()) };
+        // `filename` is UTF-8; the `A` entry point would decode it as the
+        // system ANSI codepage and mangle any non-ASCII byte. Widen and use
+        // the `W` entry point like every other Windows path in this crate.
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
+        let wpath = bun_paths::string_paths::to_w_path(&mut wbuf, filename.as_bytes());
+        // SAFETY: `to_w_path` NUL-terminates `wbuf`; `hFile` is reserved (NULL);
+        // `dwFlags = 0` is equivalent to `LoadLibraryW`.
+        let p = unsafe {
+            bun_windows_sys::kernel32::LoadLibraryExW(wpath.as_ptr(), core::ptr::null_mut(), 0)
+        };
         if p.is_null() { None } else { Some(p.cast()) }
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6177,10 +6177,23 @@ pub fn dlopen(filename: &ZStr, flags: i32) -> Option<*mut c_void> {
         // the `W` entry point like every other Windows path in this crate.
         let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_w_path(&mut wbuf, filename.as_bytes());
-        // SAFETY: `to_w_path` NUL-terminates `wbuf`; `hFile` is reserved (NULL);
-        // `dwFlags = 0` is equivalent to `LoadLibraryW`.
+        // Match libuv `uv_dlopen` (and Bun's own `process.dlopen`): request
+        // altered search so dependent DLLs resolve next to the loaded module.
+        // MSDN documents that flag as undefined for relative paths, so only
+        // set it when absolute; bare names keep the standard search order.
+        const LOAD_WITH_ALTERED_SEARCH_PATH: u32 = 0x0000_0008;
+        let dw_flags = if bun_paths::is_absolute_windows(filename.as_bytes()) {
+            LOAD_WITH_ALTERED_SEARCH_PATH
+        } else {
+            0
+        };
+        // SAFETY: `to_w_path` NUL-terminates `wbuf`; `hFile` is reserved (NULL).
         let p = unsafe {
-            bun_windows_sys::kernel32::LoadLibraryExW(wpath.as_ptr(), core::ptr::null_mut(), 0)
+            bun_windows_sys::kernel32::LoadLibraryExW(
+                wpath.as_ptr(),
+                core::ptr::null_mut(),
+                dw_flags,
+            )
         };
         if p.is_null() { None } else { Some(p.cast()) }
     }

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -678,7 +678,7 @@ it.skipIf(!isWindows)("dlopen accepts non-ASCII library paths on Windows", async
     const src = join(process.env.SystemRoot || "C:\\\\Windows", "System32", "version.dll");
     const results = {};
     for (const name of ["caf\\u00e9", "\\u65e5\\u672c\\u8a9e"]) {
-      const dir = join(process.argv[2], "bun-ffi-" + name);
+      const dir = join(process.env.FIXTURE_DIR, "bun-ffi-" + name);
       mkdirSync(dir, { recursive: true });
       const dll = join(dir, "version.dll");
       copyFileSync(src, dll);
@@ -692,8 +692,8 @@ it.skipIf(!isWindows)("dlopen accepts non-ASCII library paths on Windows", async
   `;
   using dir = tempDir("ffi-dlopen-unicode", {});
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture, String(dir)],
-    env: bunEnv,
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, FIXTURE_DIR: String(dir) },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -666,6 +666,44 @@ it("dlopen throws an error instead of returning it", () => {
   expect(err).toBeTruthy();
 });
 
+// Windows: dlopen must accept paths with non-ASCII characters. Previously the
+// path was handed to LoadLibraryA as UTF-8, which the OS decodes as the system
+// ANSI codepage, so any non-ASCII byte mangled the path.
+it.skipIf(!isWindows)("dlopen accepts non-ASCII library paths on Windows", async () => {
+  const fixture = `
+    const { dlopen, FFIType } = require("bun:ffi");
+    const { mkdirSync, copyFileSync } = require("node:fs");
+    const { join } = require("node:path");
+
+    const src = join(process.env.SystemRoot || "C:\\\\Windows", "System32", "version.dll");
+    const results = {};
+    for (const name of ["caf\\u00e9", "\\u65e5\\u672c\\u8a9e"]) {
+      const dir = join(process.argv[2], "bun-ffi-" + name);
+      mkdirSync(dir, { recursive: true });
+      const dll = join(dir, "version.dll");
+      copyFileSync(src, dll);
+      const lib = dlopen(dll, {
+        GetFileVersionInfoSizeW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.u32 },
+      });
+      results[name] = typeof lib.symbols.GetFileVersionInfoSizeW;
+      lib.close();
+    }
+    console.log(JSON.stringify(results));
+  `;
+  using dir = tempDir("ffi-dlopen-unicode", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture, String(dir)],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+  expect({ results, stderr, exitCode }).toMatchObject({
+    results: { "caf\u00e9": "function", "\u65e5\u672c\u8a9e": "function" },
+    exitCode: 0,
+  });
+});
+
 it('suffix does not start with a "."', () => {
   expect(suffix).not.toMatch(/^\./);
 });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -666,10 +666,13 @@ it("dlopen throws an error instead of returning it", () => {
   expect(err).toBeTruthy();
 });
 
+// TinyCC, which implements JSCallback and CFunction, is unavailable on Windows ARM64.
+const isFFIUnavailable = isWindows && isArm64;
+
 // Windows: dlopen must accept paths with non-ASCII characters. Previously the
 // path was handed to LoadLibraryA as UTF-8, which the OS decodes as the system
 // ANSI codepage, so any non-ASCII byte mangled the path.
-it.skipIf(!isWindows)("dlopen accepts non-ASCII library paths on Windows", async () => {
+it.skipIf(!isWindows || isFFIUnavailable)("dlopen accepts non-ASCII library paths on Windows", async () => {
   const fixture = `
     const { dlopen, FFIType } = require("bun:ffi");
     const { mkdirSync, copyFileSync } = require("node:fs");
@@ -714,9 +717,6 @@ it(".ptr is not leaked", () => {
     expect(fn.ptr).toBeUndefined();
   }
 });
-
-// TinyCC, which implements JSCallback and CFunction, is unavailable on Windows ARM64.
-const isFFIUnavailable = isWindows && isArm64;
 
 // Runs in a subprocess: `bun test`'s exit path does not finalize the CFunction's native handle,
 // which the ASan lane's leak checker then reports against this file.


### PR DESCRIPTION
## Repro (Windows)

```js
import { dlopen, FFIType } from "bun:ffi";
import { mkdirSync, copyFileSync } from "node:fs";

mkdirSync("C:\\tmp\\日本語", { recursive: true });
copyFileSync("C:\\Windows\\System32\\version.dll", "C:\\tmp\\日本語\\version.dll");

dlopen("C:\\tmp\\日本語\\version.dll", {
  GetFileVersionInfoSizeW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.u32 },
});
```

Before: throws `Failed to open library "C:\tmp\日本語\version.dll": error code 126` (ERROR_MOD_NOT_FOUND). The same DLL loads fine from an ASCII path. Also fails for `café` and any other non-ASCII component.

## Cause

`sys::dlopen` on Windows called `LoadLibraryA` with the UTF-8 path bytes. `LoadLibraryA` decodes its argument as the system ANSI codepage (cp1252 on most Western installs, cp932 on Japanese, etc.), so every non-ASCII UTF-8 byte sequence is misread and the file is not found. This affects any `bun:ffi` user whose DLL lives under a profile directory with a non-ASCII username, which is routine on non-English Windows.

## Fix

Convert the UTF-8 path to UTF-16 via `bun_paths::string_paths::to_w_path` and call `LoadLibraryExW(path, NULL, 0)`, matching how every other Windows path in `bun_sys` is handled. `dwFlags = 0` preserves the default DLL search order so bare names like `"kernel32.dll"` keep working.

## Verification

On Windows x64 (system ACP cp1252):

```
$env:USE_SYSTEM_BUN="1"; bun test test/js/bun/ffi/ffi.test.js -t "non-ASCII"
(fail) dlopen accepts non-ASCII library paths on Windows
  error: Failed to open library "...\bun-ffi-café\version.dll": error code 126

bun bd test test/js/bun/ffi/ffi.test.js -t "non-ASCII"
(pass) dlopen accepts non-ASCII library paths on Windows [486ms]
```

Full `ffi.test.js` and `ffi-error-messages.test.ts` pass on Windows with the change (13 pass, 5 skip, 0 fail), including the existing `dlopen("kernel32.dll", ...)` name-only lookup test.

The test is Windows-only (`it.skipIf(!isWindows)`); on Linux it is skipped.