### PR TITLE
usockets: stop reusePort from setting SO_REUSEADDR on Windows TCP listeners

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1098,11 +1098,9 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
 
 #if _WIN32
     //  Windows SO_REUSEADDR lets any local process rebind an in-use TCP port and
-    //  receive its connections. Never set it on TCP listeners (libuv issue #1360).
-    //  bsd_create_udp_socket keeps honoring LIBUS_LISTEN_REUSE_ADDR for multicast.
-    //  SO_REUSEPORT does not exist; when the caller tolerates that (no DISALLOW),
-    //  promote to SO_EXCLUSIVEADDRUSE so reusePort is not a downgrade from the
-    //  Bun.serve exclusive default. Callers that set DISALLOW get ENOTSUP instead.
+    //  receive its connections (libuv issue #1360), so drop it for TCP; the UDP
+    //  path in bsd_create_udp_socket still honors it. SO_REUSEPORT does not exist:
+    //  callers that set DISALLOW see ENOTSUP, others fall back to SO_EXCLUSIVEADDRUSE.
     options &= ~LIBUS_LISTEN_REUSE_ADDR;
     if ((options & LIBUS_LISTEN_REUSE_PORT) && !(options & LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE)) {
         options = (options & ~LIBUS_LISTEN_REUSE_PORT) | LIBUS_LISTEN_EXCLUSIVE_PORT;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1097,10 +1097,9 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
 ) {
 
 #if _WIN32
-    //  Windows SO_REUSEADDR lets any local process rebind an in-use TCP port and
-    //  receive its connections (libuv issue #1360), so drop it for TCP; the UDP
-    //  path in bsd_create_udp_socket still honors it. SO_REUSEPORT does not exist:
-    //  callers that set DISALLOW see ENOTSUP, others fall back to SO_EXCLUSIVEADDRUSE.
+    //  Windows SO_REUSEADDR lets any process steal an in-use TCP port (libuv #1360),
+    //  so drop it for TCP (bsd_create_udp_socket keeps it). SO_REUSEPORT does not
+    //  exist: DISALLOW callers see ENOTSUP, others fall back to SO_EXCLUSIVEADDRUSE.
     options &= ~LIBUS_LISTEN_REUSE_ADDR;
     if ((options & LIBUS_LISTEN_REUSE_PORT) && !(options & LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE)) {
         options = (options & ~LIBUS_LISTEN_REUSE_PORT) | LIBUS_LISTEN_EXCLUSIVE_PORT;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1100,10 +1100,17 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     //  Windows SO_REUSEADDR lets any local process rebind an in-use TCP port and
     //  receive its connections. Never set it on TCP listeners (libuv issue #1360).
     //  bsd_create_udp_socket keeps honoring LIBUS_LISTEN_REUSE_ADDR for multicast.
+    //  SO_REUSEPORT does not exist; when the caller tolerates that (no DISALLOW),
+    //  promote to SO_EXCLUSIVEADDRUSE so reusePort is not a downgrade from the
+    //  Bun.serve exclusive default. Callers that set DISALLOW get ENOTSUP instead.
     options &= ~LIBUS_LISTEN_REUSE_ADDR;
+    if ((options & LIBUS_LISTEN_REUSE_PORT) && !(options & LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE)) {
+        options = (options & ~LIBUS_LISTEN_REUSE_PORT) | LIBUS_LISTEN_EXCLUSIVE_PORT;
+    }
 #endif
 
     if (bsd_set_reuse(listenFd, options) != 0) {
+        *error = LIBUS_ERR;
         return LIBUS_SOCKET_ERROR;
     }
 

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1096,6 +1096,13 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     int* error
 ) {
 
+#if _WIN32
+    //  Windows SO_REUSEADDR lets any local process rebind an in-use TCP port and
+    //  receive its connections. Never set it on TCP listeners (libuv issue #1360).
+    //  bsd_create_udp_socket keeps honoring LIBUS_LISTEN_REUSE_ADDR for multicast.
+    options &= ~LIBUS_LISTEN_REUSE_ADDR;
+#endif
+
     if (bsd_set_reuse(listenFd, options) != 0) {
         return LIBUS_SOCKET_ERROR;
     }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -596,8 +596,10 @@ impl ServerConfig {
     }
 
     pub fn get_usockets_options(&self) -> i32 {
-        // Unlike Node.js, we set exclusive port in case reuse port is not set
-        let mut out: i32 = if self.reuse_port {
+        // Unlike Node.js, we set exclusive port in case reuse port is not set.
+        // Windows has no SO_REUSEPORT and its SO_REUSEADDR allows port hijacking,
+        // so reusePort must not drop the SO_EXCLUSIVEADDRUSE protection there.
+        let mut out: i32 = if self.reuse_port && !cfg!(windows) {
             bun_uws_sys::LIBUS_LISTEN_REUSE_PORT | bun_uws_sys::LIBUS_LISTEN_REUSE_ADDR
         } else {
             bun_uws_sys::LIBUS_LISTEN_EXCLUSIVE_PORT

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -596,10 +596,8 @@ impl ServerConfig {
     }
 
     pub fn get_usockets_options(&self) -> i32 {
-        // Unlike Node.js, we set exclusive port in case reuse port is not set.
-        // Windows has no SO_REUSEPORT and its SO_REUSEADDR allows port hijacking,
-        // so reusePort must not drop the SO_EXCLUSIVEADDRUSE protection there.
-        let mut out: i32 = if self.reuse_port && !cfg!(windows) {
+        // Unlike Node.js, we set exclusive port in case reuse port is not set
+        let mut out: i32 = if self.reuse_port {
             bun_uws_sys::LIBUS_LISTEN_REUSE_PORT | bun_uws_sys::LIBUS_LISTEN_REUSE_ADDR
         } else {
             bun_uws_sys::LIBUS_LISTEN_EXCLUSIVE_PORT

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -522,7 +522,11 @@ impl SocketConfig {
         let mut flags: i32 = if self.exclusive {
             uws::LIBUS_LISTEN_EXCLUSIVE_PORT
         } else if self.reuse_port {
-            uws::LIBUS_LISTEN_REUSE_PORT | uws::LIBUS_LISTEN_REUSE_ADDR
+            // libuv's UV_TCP_REUSEPORT fails on platforms without SO_REUSEPORT
+            // load balancing (notably Windows); do the same so net.Server reports it.
+            uws::LIBUS_LISTEN_REUSE_PORT
+                | uws::LIBUS_LISTEN_REUSE_ADDR
+                | uws::LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE
         } else {
             uws::LIBUS_LISTEN_DEFAULT
         };

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -220,7 +220,6 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     const SOL_SOCKET = 0xffff;
     const SO_REUSEADDR = 0x0004;
     const INVALID_SOCKET = 0xffffffffffffffffn;
-    const WSAEADDRINUSE = 10048;
     const WSAEACCES = 10013;
 
     const s = ws2.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -1,4 +1,5 @@
 import { file, serve } from "bun";
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isWindows, tmpdirSync } from "harness";
 import type { NetworkInterfaceInfo } from "node:os";
@@ -176,21 +177,70 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     expect(port).toBeInteger();
 
     let second: ReturnType<typeof serve> | undefined;
+    let thrown: unknown;
     try {
-      expect(() => {
-        second = serve({
-          port,
-          hostname: "127.0.0.1",
-          reusePort: true,
-          fetch: () => new Response("second"),
-        });
-      }).toThrow(/EADDRINUSE|in use/i);
+      second = serve({
+        port,
+        hostname: "127.0.0.1",
+        reusePort: true,
+        fetch: () => new Response("second"),
+      });
+    } catch (e) {
+      thrown = e;
     } finally {
       second?.stop(true);
     }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
 
     const res = await fetch(`http://127.0.0.1:${port}/`);
     expect(await res.text()).toBe("first");
+  });
+
+  test("Bun.serve({reusePort:true}) sets SO_EXCLUSIVEADDRUSE so a SO_REUSEADDR hijacker cannot bind", () => {
+    const ws2 = dlopen("ws2_32.dll", {
+      socket: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.u64 },
+      setsockopt: { args: [FFIType.u64, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+      bind: { args: [FFIType.u64, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+      closesocket: { args: [FFIType.u64], returns: FFIType.i32 },
+      WSAGetLastError: { args: [], returns: FFIType.i32 },
+    }).symbols;
+
+    using first = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      reusePort: true,
+      fetch: () => new Response("first"),
+    });
+    const port = first.port;
+
+    const AF_INET = 2;
+    const SOCK_STREAM = 1;
+    const IPPROTO_TCP = 6;
+    const SOL_SOCKET = 0xffff;
+    const SO_REUSEADDR = 0x0004;
+    const INVALID_SOCKET = 0xffffffffffffffffn;
+    const WSAEADDRINUSE = 10048;
+    const WSAEACCES = 10013;
+
+    const s = ws2.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    expect(BigInt(s)).not.toBe(INVALID_SOCKET);
+    try {
+      const one = new Int32Array([1]);
+      expect(ws2.setsockopt(s, SOL_SOCKET, SO_REUSEADDR, ptr(one), 4)).toBe(0);
+
+      // sockaddr_in: family(u16 LE), port(u16 BE), addr(4 bytes), zero(8 bytes)
+      const sa = new Uint8Array(16);
+      new DataView(sa.buffer).setUint16(0, AF_INET, true);
+      new DataView(sa.buffer).setUint16(2, port, false);
+      sa.set([127, 0, 0, 1], 4);
+
+      const rc = ws2.bind(s, ptr(sa), sa.length);
+      const err = ws2.WSAGetLastError();
+      expect({ rc, err }).toEqual({ rc: -1, err: WSAEACCES });
+    } finally {
+      ws2.closesocket(s);
+    }
   });
 
   test("Bun.listen({reusePort:true}) does not let a second listener bind the port", () => {
@@ -204,17 +254,20 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     expect(port).toBeInteger();
 
     let second: ReturnType<typeof Bun.listen> | undefined;
+    let thrown: unknown;
     try {
-      expect(() => {
-        second = Bun.listen({
-          port,
-          hostname: "127.0.0.1",
-          reusePort: true,
-          socket: { data() {}, open() {}, close() {}, error() {} },
-        });
-      }).toThrow(/EADDRINUSE|in use/i);
+      second = Bun.listen({
+        port,
+        hostname: "127.0.0.1",
+        reusePort: true,
+        socket: { data() {}, open() {}, close() {}, error() {} },
+      });
+    } catch (e) {
+      thrown = e;
     } finally {
       second?.stop(true);
     }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
   });
 });

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -1,7 +1,8 @@
 import { file, serve } from "bun";
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "harness";
+import { isArm64, isWindows, tmpdirSync } from "harness";
+import net from "node:net";
 import type { NetworkInterfaceInfo } from "node:os";
 import { networkInterfaces } from "node:os";
 import { join } from "node:path";
@@ -197,7 +198,8 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     expect(await res.text()).toBe("first");
   });
 
-  test("Bun.serve({reusePort:true}) sets SO_EXCLUSIVEADDRUSE so a SO_REUSEADDR hijacker cannot bind", () => {
+  // bun:ffi dlopen() is unavailable on Windows arm64 (TinyCC is disabled there).
+  test.skipIf(isArm64)("Bun.serve({reusePort:true}) sets SO_EXCLUSIVEADDRUSE so a SO_REUSEADDR hijacker cannot bind", () => {
     const ws2 = dlopen("ws2_32.dll", {
       socket: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.u64 },
       setsockopt: { args: [FFIType.u64, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
@@ -242,21 +244,12 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     }
   });
 
-  test("Bun.listen({reusePort:true}) does not let a second listener bind the port", () => {
-    using first = Bun.listen({
-      port: 0,
-      hostname: "127.0.0.1",
-      reusePort: true,
-      socket: { data() {}, open() {}, close() {}, error() {} },
-    });
-    const port = first.port;
-    expect(port).toBeInteger();
-
-    let second: ReturnType<typeof Bun.listen> | undefined;
+  test("Bun.listen({reusePort:true}) reports ENOTSUP (matches Node's UV_TCP_REUSEPORT behavior)", () => {
+    let listener: ReturnType<typeof Bun.listen> | undefined;
     let thrown: unknown;
     try {
-      second = Bun.listen({
-        port,
+      listener = Bun.listen({
+        port: 0,
         hostname: "127.0.0.1",
         reusePort: true,
         socket: { data() {}, open() {}, close() {}, error() {} },
@@ -264,9 +257,26 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
     } catch (e) {
       thrown = e;
     } finally {
-      second?.stop(true);
+      listener?.stop(true);
     }
     expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
+    expect((thrown as NodeJS.ErrnoException).code).toBe("ENOTSUP");
+  });
+
+  test("net.Server.listen({reusePort:true}) emits 'error' so checkSupportReusePort() rejects", async () => {
+    const server = net.createServer();
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    server.on("listening", () => {
+      server.close();
+      reject(new Error("listening fired; expected an error event"));
+    });
+    server.on("error", err => {
+      server.close();
+      resolve(err);
+    });
+    server.listen({ port: 0, reusePort: true });
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as NodeJS.ErrnoException).syscall).toBe("listen");
   });
 });

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -199,50 +199,53 @@ describe.skipIf(!isWindows)("reusePort on Windows", () => {
   });
 
   // bun:ffi dlopen() is unavailable on Windows arm64 (TinyCC is disabled there).
-  test.skipIf(isArm64)("Bun.serve({reusePort:true}) sets SO_EXCLUSIVEADDRUSE so a SO_REUSEADDR hijacker cannot bind", () => {
-    const ws2 = dlopen("ws2_32.dll", {
-      socket: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.u64 },
-      setsockopt: { args: [FFIType.u64, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
-      bind: { args: [FFIType.u64, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
-      closesocket: { args: [FFIType.u64], returns: FFIType.i32 },
-      WSAGetLastError: { args: [], returns: FFIType.i32 },
-    }).symbols;
+  test.skipIf(isArm64)(
+    "Bun.serve({reusePort:true}) sets SO_EXCLUSIVEADDRUSE so a SO_REUSEADDR hijacker cannot bind",
+    () => {
+      const ws2 = dlopen("ws2_32.dll", {
+        socket: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.u64 },
+        setsockopt: { args: [FFIType.u64, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+        bind: { args: [FFIType.u64, FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+        closesocket: { args: [FFIType.u64], returns: FFIType.i32 },
+        WSAGetLastError: { args: [], returns: FFIType.i32 },
+      }).symbols;
 
-    using first = serve({
-      port: 0,
-      hostname: "127.0.0.1",
-      reusePort: true,
-      fetch: () => new Response("first"),
-    });
-    const port = first.port;
+      using first = serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        reusePort: true,
+        fetch: () => new Response("first"),
+      });
+      const port = first.port;
 
-    const AF_INET = 2;
-    const SOCK_STREAM = 1;
-    const IPPROTO_TCP = 6;
-    const SOL_SOCKET = 0xffff;
-    const SO_REUSEADDR = 0x0004;
-    const INVALID_SOCKET = 0xffffffffffffffffn;
-    const WSAEACCES = 10013;
+      const AF_INET = 2;
+      const SOCK_STREAM = 1;
+      const IPPROTO_TCP = 6;
+      const SOL_SOCKET = 0xffff;
+      const SO_REUSEADDR = 0x0004;
+      const INVALID_SOCKET = 0xffffffffffffffffn;
+      const WSAEACCES = 10013;
 
-    const s = ws2.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    expect(BigInt(s)).not.toBe(INVALID_SOCKET);
-    try {
-      const one = new Int32Array([1]);
-      expect(ws2.setsockopt(s, SOL_SOCKET, SO_REUSEADDR, ptr(one), 4)).toBe(0);
+      const s = ws2.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+      expect(BigInt(s)).not.toBe(INVALID_SOCKET);
+      try {
+        const one = new Int32Array([1]);
+        expect(ws2.setsockopt(s, SOL_SOCKET, SO_REUSEADDR, ptr(one), 4)).toBe(0);
 
-      // sockaddr_in: family(u16 LE), port(u16 BE), addr(4 bytes), zero(8 bytes)
-      const sa = new Uint8Array(16);
-      new DataView(sa.buffer).setUint16(0, AF_INET, true);
-      new DataView(sa.buffer).setUint16(2, port, false);
-      sa.set([127, 0, 0, 1], 4);
+        // sockaddr_in: family(u16 LE), port(u16 BE), addr(4 bytes), zero(8 bytes)
+        const sa = new Uint8Array(16);
+        new DataView(sa.buffer).setUint16(0, AF_INET, true);
+        new DataView(sa.buffer).setUint16(2, port, false);
+        sa.set([127, 0, 0, 1], 4);
 
-      const rc = ws2.bind(s, ptr(sa), sa.length);
-      const err = ws2.WSAGetLastError();
-      expect({ rc, err }).toEqual({ rc: -1, err: WSAEACCES });
-    } finally {
-      ws2.closesocket(s);
-    }
-  });
+        const rc = ws2.bind(s, ptr(sa), sa.length);
+        const err = ws2.WSAGetLastError();
+        expect({ rc, err }).toEqual({ rc: -1, err: WSAEACCES });
+      } finally {
+        ws2.closesocket(s);
+      }
+    },
+  );
 
   test("Bun.listen({reusePort:true}) reports ENOTSUP (matches Node's UV_TCP_REUSEPORT behavior)", () => {
     let listener: ReturnType<typeof Bun.listen> | undefined;

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -160,3 +160,61 @@ describe.each([
     });
   });
 });
+
+// Windows has no SO_REUSEPORT. Its SO_REUSEADDR lets any local process rebind an
+// in-use TCP port and receive its connections, so reusePort:true must not fall
+// back to SO_REUSEADDR there. See libuv issue #1360.
+describe.skipIf(!isWindows)("reusePort on Windows", () => {
+  test("Bun.serve({reusePort:true}) does not let a second listener bind the port", async () => {
+    using first = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      reusePort: true,
+      fetch: () => new Response("first"),
+    });
+    const port = first.port;
+    expect(port).toBeInteger();
+
+    let second: ReturnType<typeof serve> | undefined;
+    try {
+      expect(() => {
+        second = serve({
+          port,
+          hostname: "127.0.0.1",
+          reusePort: true,
+          fetch: () => new Response("second"),
+        });
+      }).toThrow(/EADDRINUSE|in use/i);
+    } finally {
+      second?.stop(true);
+    }
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(await res.text()).toBe("first");
+  });
+
+  test("Bun.listen({reusePort:true}) does not let a second listener bind the port", () => {
+    using first = Bun.listen({
+      port: 0,
+      hostname: "127.0.0.1",
+      reusePort: true,
+      socket: { data() {}, open() {}, close() {}, error() {} },
+    });
+    const port = first.port;
+    expect(port).toBeInteger();
+
+    let second: ReturnType<typeof Bun.listen> | undefined;
+    try {
+      expect(() => {
+        second = Bun.listen({
+          port,
+          hostname: "127.0.0.1",
+          reusePort: true,
+          socket: { data() {}, open() {}, close() {}, error() {} },
+        });
+      }).toThrow(/EADDRINUSE|in use/i);
+    } finally {
+      second?.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

On Windows there is no `SO_REUSEPORT`. `bsd_set_reuseaddr` in `packages/bun-usockets/src/bsd.c` has no Windows guard on its `#else` arm, so when `Bun.serve({reusePort: true})` or `Bun.listen({reusePort: true})` passes `LIBUS_LISTEN_REUSE_ADDR`, the TCP listen path sets `SO_REUSEADDR` on the socket.

On Windows `SO_REUSEADDR` does not have Unix TIME_WAIT semantics: it lets **any** local process bind the same port and receive the original listener's new connections (no same-user check). The adjacent unconditional block in `bsd_bind_listen_fd` already refuses to set `SO_REUSEADDR` on Windows for exactly this reason, citing libuv issue #1360, but the explicit `LIBUS_LISTEN_REUSE_ADDR` flag bypassed that guard via `bsd_set_reuse`.

## Repro (Windows)

```js
const s1 = Bun.serve({ port: 0, hostname: "127.0.0.1", reusePort: true, fetch: () => new Response("s1") });
const s2 = Bun.serve({ port: s1.port, hostname: "127.0.0.1", reusePort: true, fetch: () => new Response("s2") });
// before: s2 binds successfully (SO_REUSEADDR is set on both)
// after:  s2 throws EADDRINUSE
```

A raw Winsock socket with `SO_REUSEADDR` could bind the same port and intercept connections.

## Fix

`packages/bun-usockets/src/bsd.c`, `bsd_bind_listen_fd` (TCP listen path only, Windows only):
- Masks `LIBUS_LISTEN_REUSE_ADDR` so TCP listeners never get `SO_REUSEADDR` on Windows. The UDP path (`bsd_create_udp_socket`) is unchanged and still honors the flag for multicast, matching libuv.
- When `LIBUS_LISTEN_REUSE_PORT` is requested without `LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE`, promotes to `LIBUS_LISTEN_EXCLUSIVE_PORT`. This keeps `Bun.serve({reusePort:true})` on Windows at the same `SO_EXCLUSIVEADDRUSE` protection as the default, instead of silently dropping it.
- Writes `*error` when `bsd_set_reuse` fails so the ENOTSUP errno reaches the caller.

`src/runtime/socket/Handlers.rs`: `Bun.listen({reusePort:true})` now sets `LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE`, so on Windows it throws with `code: "ENOTSUP"` instead of silently binding without reuse. This matches libuv/Node's `UV_TCP_REUSEPORT` behavior, and makes `net.createServer().listen({reusePort:true})` emit `'error'` so the upstream `checkSupportReusePort()` probe in `test/js/node/test/common/net.js` rejects and the Node parallel `test-net-reuseport.js` / `test-child-process-net-reuseport.js` tests self-skip on Windows (as they do in Node). On Linux/macOS/BSD `SO_REUSEPORT` succeeds so this flag is a no-op.

`ServerConfig::get_usockets_options()` is unchanged; the same options value feeds the HTTP/3 UDP listener, which still goes through `bsd_create_udp_socket` and keeps `SO_REUSEADDR` on Windows.

## node:cluster impact

`net.Server` clustering uses `RoundRobinHandle` (primary accepts and distributes over IPC) and is unaffected.

`http.Server` clustering currently has each worker call `Bun.serve({reusePort: true})` directly (see the TODO in `src/js/node/_http_server.ts`). On Windows that relied on this `SO_REUSEADDR` fallback. After this change the second worker's bind fails with `EADDRINUSE`, which surfaces the lack of safe port sharing instead of quietly enabling hijacking. `test/js/node/cluster/test-docs-http-server.ts` was already skipping on Windows CI.

## Verification

New tests in `test/js/bun/http/serve-listen.test.ts` under `describe.skipIf(!isWindows)("reusePort on Windows", ...)`:

- `Bun.serve({reusePort:true})`: second in-process bind throws `EADDRINUSE`; first server still responds.
- `Bun.serve({reusePort:true})` + Winsock FFI hijacker: a raw socket with `SO_REUSEADDR` fails `bind()` with `WSAEACCES`, proving `SO_EXCLUSIVEADDRUSE` is set. Skipped on Windows arm64 where `bun:ffi` `dlopen` is unavailable.
- `Bun.listen({reusePort:true})`: throws with `code: "ENOTSUP"`.
- `net.Server.listen({reusePort:true})`: emits `'error'`.

On a Windows x64 build of this branch all four pass; against the released 1.4.0 binary all four fail. Also verified on the same build: the Node parallel `test-net-reuseport.js` and `test-child-process-net-reuseport.js` now print `Skipped: The reusePort option is not supported`; `fetch-http3-client.test.ts` "port reuse" case still passes; node:dgram `reuseAddr` still allows two UDP sockets on one port; `tcp-server.test.ts` and `cluster.test.ts` pass. On Linux, `Bun.listen({reusePort:true})` still lets two listeners share a port via `SO_REUSEPORT`.

The fix is entirely inside `#if _WIN32` in bsd.c plus one unconditional `DISALLOW_REUSE_PORT_FAILURE` flag in Handlers.rs that is a no-op where `SO_REUSEPORT` succeeds, so the added tests are Windows-only and skip elsewhere.
