### PR TITLE
Bun.write: fix file-to-file copy resolving 0 bytes on Windows and macOS overwrite

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -562,7 +562,9 @@ impl CopyFile {
                                 self.system_error = Some(err.to_system_error());
                                 return Err(bun_errno::from_errno(err.errno as i32).into());
                             }
-                            bun_sys::Result::Ok(()) => {}
+                            bun_sys::Result::Ok(()) => {
+                                self.read_len = total_written as SizeType;
+                            }
                         }
                     }
                     _ => {
@@ -571,7 +573,13 @@ impl CopyFile {
                     }
                 }
             }
-            bun_sys::Result::Ok(()) => {}
+            bun_sys::Result::Ok(()) => {
+                // fcopyfile() doesn't report a byte count; stat the destination
+                // (opened with O_TRUNC above) to learn how many bytes were written.
+                if let bun_sys::Result::Ok(st) = bun_sys::fstat(self.destination_fd) {
+                    self.read_len = SizeType::try_from(st.st_size).expect("int cast");
+                }
+            }
         }
         Ok(())
     }
@@ -891,6 +899,7 @@ impl CopyFile {
                             self.destination_fd,
                             i64::try_from(self.max_length).expect("int cast"),
                         );
+                        self.read_len = self.max_length;
                     }
                 } else if self.do_read_write_loop_capped(self.max_length).is_err() {
                     self.do_close();
@@ -1753,6 +1762,63 @@ impl<'a> CopyFileWindows<'a> {
         );
     }
 
+    /// libuv's `uv_fs_copyfile` does not populate `req->statbuf`, so after a
+    /// successful copy we issue an async stat on the destination to learn how
+    /// many bytes were written before resolving the promise.
+    fn stat_destination_after_copy(&mut self) {
+        let mut pathbuf = PathBuffer::uninit();
+        let path_ptr: *const core::ffi::c_char =
+            match &self.destination_file_store.data.as_file().pathlike {
+                PathOrFileDescriptor::Path(_) => self
+                    .destination_file_store
+                    .data
+                    .as_file()
+                    .pathlike
+                    .path()
+                    .slice_z(&mut pathbuf)
+                    .as_ptr(),
+                PathOrFileDescriptor::Fd(fd) => {
+                    // copyfile() already resolved this fd to a path; re-derive it.
+                    match bun_sys::get_fd_path(*fd, &mut pathbuf) {
+                        Ok(out) => {
+                            let len = out.len();
+                            pathbuf[len] = 0;
+                            // SAFETY: pathbuf[len] == 0 written above
+                            bun_core::ZStr::from_buf(&pathbuf[..], len).as_ptr()
+                        }
+                        Err(_) => {
+                            self.on_complete(0);
+                            return;
+                        }
+                    }
+                }
+            };
+
+        let loop_ = self.event_loop.uv_loop();
+        self.io_request.deinit();
+        // SAFETY: all-zero is a valid libuv::fs_t
+        self.io_request = bun_core::ffi::zeroed::<libuv::fs_t>();
+        self.io_request.data = core::ptr::from_mut(self).cast::<c_void>();
+        // SAFETY: FFI — `loop_` is the live VM uv loop, `io_request` was just zeroed,
+        // `path_ptr` is NUL-terminated (from `slice_z`/`ZStr`) and live for this call
+        // (libuv `strdup`s it), and `on_stat_after_copy_file` is a valid `uv_fs_cb`.
+        let rc = unsafe {
+            libuv::uv_fs_stat(
+                loop_,
+                &mut self.io_request,
+                path_ptr,
+                Some(on_stat_after_copy_file),
+            )
+        };
+
+        if rc.errno().is_some() {
+            // The copy already succeeded; if stat fails to enqueue, still resolve.
+            self.on_complete(0);
+            return;
+        }
+        self.event_loop.ref_keep_alive();
+    }
+
     /// SAFETY: `this` must have been produced by `heap::alloc` in `init()` and
     /// not yet destroyed. After this call `this` is dangling.
     pub(crate) unsafe fn destroy(this: *mut Self) {
@@ -1878,8 +1944,28 @@ extern "C" fn on_copy_file(req: *mut libuv::fs_t) {
         return;
     }
 
-    let size = this.io_request.statbuf.size();
-    this.on_complete(size as usize);
+    this.stat_destination_after_copy();
+}
+
+#[cfg(windows)]
+extern "C" fn on_stat_after_copy_file(req: *mut libuv::fs_t) {
+    // SAFETY: see `on_read` — recover from `req->data` (whole-struct provenance),
+    // not `from_field_ptr!`; then access the request only via `this.io_request`.
+    let this: &mut CopyFileWindows = unsafe { &mut *(*req).data.cast::<CopyFileWindows>() };
+    debug_assert!(core::ptr::addr_of_mut!(this.io_request) == req);
+
+    let event_loop = this.event_loop;
+    event_loop.unref_keep_alive();
+    let rc = this.io_request.result;
+
+    bun_sys::syslog!("uv_fs_stat() = {}", rc);
+    let size = if rc.err_enum_e().is_some() {
+        // The copy already succeeded; if the follow-up stat fails, still resolve.
+        0
+    } else {
+        this.io_request.statbuf.size() as usize
+    };
+    this.on_complete(size);
 }
 
 #[cfg(windows)]

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -275,6 +275,31 @@ const IS_UV_FS_COPYFILE_DISABLED =
     }
   });
 
+  it("Bun.write(dest, Bun.file(src)) resolves with the number of bytes copied", async () => {
+    using dir = tempDir("bun-write-copy-size", {});
+    const src = join(dir, "src.txt");
+    const dst = join(dir, "dst.txt");
+    await Bun.write(src, "hello world");
+
+    // path -> path
+    const n1 = await Bun.write(dst, Bun.file(src));
+    expect(await Bun.file(dst).text()).toBe("hello world");
+    expect(n1).toBe(11);
+
+    // Bun.file(path) -> Bun.file(path), overwriting existing destination
+    const n2 = await Bun.write(Bun.file(dst), Bun.file(src));
+    expect(await Bun.file(dst).text()).toBe("hello world");
+    expect(n2).toBe(11);
+
+    // empty source file
+    const srcEmpty = join(dir, "src-empty.txt");
+    const dstEmpty = join(dir, "dst-empty.txt");
+    await Bun.write(srcEmpty, "");
+    const n3 = await Bun.write(dstEmpty, Bun.file(srcEmpty));
+    expect(await Bun.file(dstEmpty).text()).toBe("");
+    expect(n3).toBe(0);
+  });
+
   it("Bun.file", async () => {
     const file = path.join(import.meta.dir, "fetch.js.txt");
     await gcTick();


### PR DESCRIPTION
## Problem

`Bun.write(dest, Bun.file(src))` resolves with `0` instead of the number of bytes copied on two platform-specific paths. The file content is written correctly; only the promise's resolved value is wrong.

```js
await Bun.write("src.txt", "hello world");
const n = await Bun.write("dest.txt", Bun.file("src.txt"));
console.log(n); // Windows: 0, POSIX: 11
```

Any caller that checks `written === expected` as an integrity check fails.

## Cause

**Windows:** the `uv_fs_copyfile` completion handler reads `io_request.statbuf.size()` to learn how many bytes were copied (`on_copy_file` in `src/runtime/webcore/blob/copy_file.rs`). libuv's `fs__copyfile` never writes `req->statbuf`; it only sets the result code. The request struct is zero-initialized, so the reported size is always `0`. This also causes `on_complete` to run an unnecessary `truncate()` against pre-sized destinations.

**macOS:** when the destination already exists, `clonefile(2)` fails with `EEXIST` and control falls through to `fcopyfile`. Neither the `fcopyfile` success branch nor its `EBADF` read/write-loop fallback assigned `self.read_len`, so the promise resolved with the initial value `0`.

## Fix

**Windows:** after a successful `uv_fs_copyfile`, chain an async `uv_fs_stat` on the destination and pass the resulting `statbuf.size()` to `on_complete`. The destination path is re-derived from the file store the same way `copyfile()` already does. If the follow-up stat cannot be issued, the promise still resolves since the copy itself succeeded.

**macOS:** `do_fcopy_file_with_read_write_loop_fallback` now sets `self.read_len` on both success branches: an `fstat` of the (O_TRUNC-opened) destination after `fcopyfile`, or `total_written` from the `EBADF` loop. The caller caps `read_len` at `max_length` after `ftruncate`, mirroring the existing clonefile-success and FreeBSD paths.

## Verification

Windows, before fix:
```
error: expect(received).toBe(expected)
Expected: 11
Received: 0
```

Windows, after fix: 35/35 tests pass in `test/js/bun/io/bun-write.test.js` (including the `BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1` re-run).

Linux: behavior unchanged; the new test passes on POSIX as-is.

macOS: `cargo check -p bun_runtime --target aarch64-apple-darwin` passes; verified by CI.

Note: both bugs are platform-specific, so fail-before is reproducible on a Windows build (confirmed above) and a macOS build respectively.
