### PR TITLE
child_process: match Node's option validation error identity

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -5,6 +5,8 @@ const { kHandle } = require("internal/shared");
 const {
   validateBoolean,
   validateFunction,
+  validateInteger,
+  validateNumber,
   validateString,
   validateAbortSignal,
   validateArray,
@@ -35,7 +37,6 @@ const ArrayPrototypeSplice = Array.prototype.splice;
 
 var ArrayBufferIsView = ArrayBuffer.isView;
 
-var NumberIsInteger = Number.isInteger;
 var StringPrototypeIncludes = String.prototype.includes;
 var Uint8ArrayPrototypeIncludes = Uint8Array.prototype.includes;
 
@@ -234,8 +235,8 @@ function execFile(file, args, options, callback) {
     killSignal: options.killSignal,
     uid: options.uid,
     gid: options.gid,
-    windowsHide: options.windowsHide,
-    windowsVerbatimArguments: options.windowsVerbatimArguments,
+    windowsHide: !!options.windowsHide,
+    windowsVerbatimArguments: !!options.windowsVerbatimArguments,
     shell: options.shell,
     signal: options.signal,
   });
@@ -1826,8 +1827,8 @@ class Control extends EventEmitter {
 //------------------------------------------------------------------------------
 
 function validateMaxBuffer(maxBuffer) {
-  if (maxBuffer != null && !(typeof maxBuffer === "number" && maxBuffer >= 0)) {
-    throw $ERR_OUT_OF_RANGE("options.maxBuffer", "a positive number", maxBuffer);
+  if (maxBuffer != null) {
+    validateNumber(maxBuffer, "options.maxBuffer", 0);
   }
 }
 
@@ -1844,8 +1845,8 @@ function validateArgumentsNullCheck(args, propName) {
 }
 
 function validateTimeout(timeout) {
-  if (timeout != null && !(NumberIsInteger(timeout) && timeout >= 0)) {
-    throw $ERR_OUT_OF_RANGE("timeout", "an unsigned integer", timeout);
+  if (timeout != null) {
+    validateInteger(timeout, "timeout", 0);
   }
 }
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -828,3 +828,80 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
     expect(r.error?.code).toBe("ENOTSUP");
   });
 });
+
+describe("option validation error identity (Node.js compat)", () => {
+  const cmd = `"${bunExe()}" -e 0`;
+  const file = bunExe();
+  const args = ["-e", "0"];
+
+  describe("maxBuffer", () => {
+    it.each(["big", 2n, true, {}])("non-number %p throws ERR_INVALID_ARG_TYPE (TypeError)", v => {
+      // @ts-ignore
+      expect(() => execFile(file, args, { maxBuffer: v }, () => {})).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      // @ts-ignore
+      expect(() => execFileSync(file, args, { maxBuffer: v })).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+
+    it.each([-1, NaN])("out-of-range number %p throws ERR_OUT_OF_RANGE (RangeError)", v => {
+      expect(() => execFile(file, args, { maxBuffer: v }, () => {})).toThrow(
+        expect.objectContaining({ name: "RangeError", code: "ERR_OUT_OF_RANGE" }),
+      );
+      expect(() => execFileSync(file, args, { maxBuffer: v })).toThrow(
+        expect.objectContaining({ name: "RangeError", code: "ERR_OUT_OF_RANGE" }),
+      );
+    });
+  });
+
+  describe("timeout", () => {
+    it.each(["soon", 2n, true, {}])("non-number %p throws ERR_INVALID_ARG_TYPE (TypeError)", v => {
+      for (const f of [
+        // @ts-ignore
+        () => execFile(file, args, { timeout: v }, () => {}),
+        // @ts-ignore
+        () => spawn(file, args, { timeout: v }),
+        // @ts-ignore
+        () => execFileSync(file, args, { timeout: v }),
+      ]) {
+        expect(f).toThrow(expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }));
+      }
+    });
+
+    it.each([-1, 1.5, NaN])("out-of-range number %p throws ERR_OUT_OF_RANGE (RangeError)", v => {
+      for (const f of [
+        () => execFile(file, args, { timeout: v }, () => {}),
+        () => spawn(file, args, { timeout: v }),
+        () => execFileSync(file, args, { timeout: v }),
+      ]) {
+        expect(f).toThrow(expect.objectContaining({ name: "RangeError", code: "ERR_OUT_OF_RANGE" }));
+      }
+    });
+  });
+
+  describe("windowsHide / windowsVerbatimArguments", () => {
+    it("exec/execFile coerce to boolean instead of validating", async () => {
+      // @ts-ignore
+      const c1 = exec(cmd, { windowsHide: "yes", windowsVerbatimArguments: 1 }, () => {});
+      // @ts-ignore
+      const c2 = execFile(file, args, { windowsHide: "yes", windowsVerbatimArguments: 1 }, () => {});
+      expect(c1.spawnargs.length).toBeGreaterThan(0);
+      expect(c2.spawnargs.length).toBeGreaterThan(0);
+      await Promise.all([once(c1, "close"), once(c2, "close")]);
+    });
+
+    it.each([{ windowsHide: "yes" }, { windowsVerbatimArguments: 1 }])(
+      "spawn/spawnSync still validate %p",
+      (opt: any) => {
+        expect(() => spawn(file, args, opt)).toThrow(
+          expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+        );
+        expect(() => spawnSync(file, args, opt)).toThrow(
+          expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+        );
+      },
+    );
+  });
+});

--- a/test/js/node/test/parallel/test-child-process-fork-timeout-kill-signal.js
+++ b/test/js/node/test/parallel/test-child-process-fork-timeout-kill-signal.js
@@ -27,11 +27,11 @@ const { getEventListeners } = require('events');
   // Verify timeout verification
   throws(() => fork(fixtures.path('child-process-stay-alive-forever.js'), {
     timeout: 'badValue',
-  }), /ERR_OUT_OF_RANGE/);
+  }), /ERR_INVALID_ARG_TYPE/);
 
   throws(() => fork(fixtures.path('child-process-stay-alive-forever.js'), {
     timeout: {},
-  }), /ERR_OUT_OF_RANGE/);
+  }), /ERR_INVALID_ARG_TYPE/);
 }
 
 {

--- a/test/js/node/test/parallel/test-child-process-spawn-timeout-kill-signal.js
+++ b/test/js/node/test/parallel/test-child-process-spawn-timeout-kill-signal.js
@@ -28,11 +28,11 @@ const aliveForeverFile = 'child-process-stay-alive-forever.js';
   // Verify timeout verification
   throws(() => spawn(process.execPath, [fixtures.path(aliveForeverFile)], {
     timeout: 'badValue',
-  }), /ERR_OUT_OF_RANGE/);
+  }), /ERR_INVALID_ARG_TYPE/);
 
   throws(() => spawn(process.execPath, [fixtures.path(aliveForeverFile)], {
     timeout: {},
-  }), /ERR_OUT_OF_RANGE/);
+  }), /ERR_INVALID_ARG_TYPE/);
 }
 
 {

--- a/test/js/node/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/js/node/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -152,12 +152,12 @@ if (!common.isWindows) {
   pass('timeout', 1);
   pass('timeout', 0);
   fail('timeout', -1, invalidRangeError);
-  fail('timeout', true, invalidRangeError);
-  fail('timeout', false, invalidRangeError);
-  fail('timeout', __dirname, invalidRangeError);
-  fail('timeout', [], invalidRangeError);
-  fail('timeout', {}, invalidRangeError);
-  fail('timeout', common.mustNotCall(), invalidRangeError);
+  fail('timeout', true, invalidArgTypeError);
+  fail('timeout', false, invalidArgTypeError);
+  fail('timeout', __dirname, invalidArgTypeError);
+  fail('timeout', [], invalidArgTypeError);
+  fail('timeout', {}, invalidArgTypeError);
+  fail('timeout', common.mustNotCall(), invalidArgTypeError);
   fail('timeout', NaN, invalidRangeError);
   fail('timeout', Infinity, invalidRangeError);
   fail('timeout', 3.1, invalidRangeError);
@@ -175,12 +175,12 @@ if (!common.isWindows) {
   fail('maxBuffer', -1, invalidRangeError);
   fail('maxBuffer', NaN, invalidRangeError);
   fail('maxBuffer', -Infinity, invalidRangeError);
-  fail('maxBuffer', true, invalidRangeError);
-  fail('maxBuffer', false, invalidRangeError);
-  fail('maxBuffer', __dirname, invalidRangeError);
-  fail('maxBuffer', [], invalidRangeError);
-  fail('maxBuffer', {}, invalidRangeError);
-  fail('maxBuffer', common.mustNotCall(), invalidRangeError);
+  fail('maxBuffer', true, invalidArgTypeError);
+  fail('maxBuffer', false, invalidArgTypeError);
+  fail('maxBuffer', __dirname, invalidArgTypeError);
+  fail('maxBuffer', [], invalidArgTypeError);
+  fail('maxBuffer', {}, invalidArgTypeError);
+  fail('maxBuffer', common.mustNotCall(), invalidArgTypeError);
 }
 
 {


### PR DESCRIPTION
## What

Aligns `node:child_process` option validation with Node.js for three mismatched cases:

1. Non-number `maxBuffer` / `timeout` now throw `TypeError` `ERR_INVALID_ARG_TYPE` (was `RangeError` `ERR_OUT_OF_RANGE`). Out-of-range numbers still throw `ERR_OUT_OF_RANGE`.
2. `exec` / `execFile` coerce `windowsHide` and `windowsVerbatimArguments` with `!!` before forwarding to `spawn`, so a truthy non-boolean no longer throws synchronously. `spawn` / `spawnSync` / `fork` continue to validate them strictly, same as Node.

## Repro

```js
const cp = require("node:child_process");
cp.exec("printf x", { maxBuffer: "big" }, () => {});
// node:  TypeError ERR_INVALID_ARG_TYPE
// bun (before): RangeError ERR_OUT_OF_RANGE

cp.execFile("printf", ["x"], { windowsHide: "yes" }, () => {});
// node:  spawns successfully
// bun (before): TypeError ERR_INVALID_ARG_TYPE
```

## Cause

`validateMaxBuffer` / `validateTimeout` were hand-rolled checks that conflated wrong-type and out-of-range into a single `ERR_OUT_OF_RANGE`. Node's `lib/child_process.js` delegates to `validateNumber(maxBuffer, 'options.maxBuffer', 0)` and `validateInteger(timeout, 'timeout', 0)`, which do a type check first.

`execFile` passed `windowsHide` / `windowsVerbatimArguments` through to `spawn` unchanged; Node's `execFile` passes `!!options.windowsHide` / `!!options.windowsVerbatimArguments`, so `normalizeSpawnArguments`'s `validateBoolean` never sees the raw user value on that path.

## Fix

- `validateMaxBuffer` / `validateTimeout` now call the shared `validateNumber` / `validateInteger` from `internal/validators` (same as Node).
- `execFile` coerces both Windows options to boolean before calling `spawn`.
- Three `test/js/node/test/parallel/` copies that had been locally patched to expect `ERR_OUT_OF_RANGE` for non-number `timeout` / `maxBuffer` are restored to the upstream Node assertions.

## Verification

New tests in `test/js/node/child_process/child_process.test.ts` cover the full matrix (non-number vs out-of-range, and exec/execFile vs spawn/spawnSync for the Windows options). Fail-before/pass-after verified:

```
# without src fix
9 fail / 7 pass
# with src fix
16 pass / 0 fail
```