### PR TITLE
http: reject requests with multiple Host header field lines (RFC 9112 5.4)

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -770,6 +770,10 @@ public:
     TemplatedApp &&setFlags(bool requireHostHeader, bool useStrictMethodValidation) {
         httpContext->getSocketContextData()->flags.requireHostHeader = requireHostHeader;
         httpContext->getSocketContextData()->flags.useStrictMethodValidation = useStrictMethodValidation;
+        /* setFlags is the node:http configuration entry point (Bun.serve never calls it).
+         * Node.js accepts duplicate Host header lines and keeps the first value, so opt
+         * out of the RFC 9112 5.4 rejection here to preserve Node.js compatibility. */
+        httpContext->getSocketContextData()->flags.rejectDuplicateHostHeader = false;
         return std::move(*this);
     }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -278,7 +278,7 @@ private:
 
         /* The return value is entirely up to us to interpret. The HttpParser cares only for whether the returned value is DIFFERENT from passed user */
 
-        auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+        auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader, httpContextData->flags.rejectDuplicateHostHeader, httpContextData->flags.useStrictMethodValidation, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
             /* For every request we reset the timeout and hang until user makes action */

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -34,6 +34,9 @@ struct HttpFlags {
     bool requireHostHeader: 1 = true;
     bool isAuthorized: 1 = false;
     bool useStrictMethodValidation: 1 = false;
+    /* RFC 9112 5.4: reject a request carrying more than one Host header line.
+     * node:http clears this (Node.js accepts duplicates and keeps the first). */
+    bool rejectDuplicateHostHeader: 1 = true;
 };
 
 template <bool SSL>

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -896,18 +896,19 @@ namespace uWS
                     hostHeaderCount++;
                 }
             }
-            /* RFC 9112 5.4: an HTTP/1.1 request with no Host header, or with more than one,
-             * MUST be answered with 400. Upgrade and CONNECT requests are exempt: Node.js
-             * dispatches them through the 'upgrade'/'connect' events before its Host
-             * requirement is enforced. An empty Host value is permitted (it is not absent). */
-            if (!req->ancientHttp && requireHostHeader
+            /* RFC 9112 5.4: a request with more than one Host header field line MUST be
+             * answered with 400. Not exempted for Upgrade/CONNECT/HTTP-1.0: the duplicate
+             * makes the request's authority ambiguous regardless of method or version. */
+            if (requireHostHeader && hostHeaderCount > 1) {
+                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER);
+            }
+            /* RFC 9112 5.4: an HTTP/1.1 request with no Host header MUST be answered with
+             * 400 (an empty value is permitted; it is not absent). Upgrade and CONNECT are
+             * exempt from the missing-Host check: Node.js dispatches them through the
+             * 'upgrade'/'connect' events before its Host requirement is enforced. */
+            if (!req->ancientHttp && requireHostHeader && hostHeaderCount == 0
                 && !isConnectRequest && !req->getHeader("upgrade").data()) {
-                if (hostHeaderCount == 0) {
-                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_MISSING_HOST_HEADER);
-                }
-                if (hostHeaderCount > 1) {
-                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER);
-                }
+                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_MISSING_HOST_HEADER);
             }
 
             /* RFC 9112 6.3

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -858,7 +858,7 @@ namespace uWS
 
     /* This is the only caller of getHeaders and is thus the deepest part of the parser. */
     template <bool ConsumeMinimally>
-    HttpParserResult fenceAndConsumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, char *data, unsigned int length, void *user, void *reserved, HttpRequest *req, MoveOnlyFunction<void *(void *, HttpRequest *)> &requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &dataHandler) {
+    HttpParserResult fenceAndConsumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool rejectDuplicateHostHeader, bool useStrictMethodValidation, char *data, unsigned int length, void *user, void *reserved, HttpRequest *req, MoveOnlyFunction<void *(void *, HttpRequest *)> &requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &dataHandler) {
 
         /* How much data we CONSUMED (to throw away) */
         unsigned int consumedTotal = 0;
@@ -898,8 +898,9 @@ namespace uWS
             }
             /* RFC 9112 5.4: a request with more than one Host header field line MUST be
              * answered with 400. Not exempted for Upgrade/CONNECT/HTTP-1.0: the duplicate
-             * makes the request's authority ambiguous regardless of method or version. */
-            if (requireHostHeader && hostHeaderCount > 1) {
+             * makes the request's authority ambiguous regardless of method or version.
+             * node:http opts out (Node.js accepts duplicates and keeps the first value). */
+            if (rejectDuplicateHostHeader && hostHeaderCount > 1) {
                 return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER);
             }
             /* RFC 9112 5.4: an HTTP/1.1 request with no Host header MUST be answered with
@@ -1050,7 +1051,7 @@ namespace uWS
     }
 
 public:
-    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
+    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool rejectDuplicateHostHeader, bool useStrictMethodValidation, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
         /* This resets BloomFilter by construction, but later we also reset it again.
         * Optimize this to skip resetting twice (req could be made global) */
         HttpRequest req;
@@ -1104,7 +1105,7 @@ public:
             fallback.append(data, maxCopyDistance);
 
             // break here on break
-            HttpParserResult consumed = fenceAndConsumePostPadded<true>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, fallback.data(), (unsigned int) fallback.length(), user, reserved, &req, requestHandler, dataHandler);
+            HttpParserResult consumed = fenceAndConsumePostPadded<true>(maxHeaderSize, isConnectRequest, requireHostHeader, rejectDuplicateHostHeader, useStrictMethodValidation, fallback.data(), (unsigned int) fallback.length(), user, reserved, &req, requestHandler, dataHandler);
             /* Return data will be different than user if we are upgraded to WebSocket or have an error */
             if (consumed.returnedData != user) {
                 return consumed;
@@ -1167,7 +1168,7 @@ public:
             }
         }
 
-        HttpParserResult consumed = fenceAndConsumePostPadded<false>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, data, length, user, reserved, &req, requestHandler, dataHandler);
+        HttpParserResult consumed = fenceAndConsumePostPadded<false>(maxHeaderSize, isConnectRequest, requireHostHeader, rejectDuplicateHostHeader, useStrictMethodValidation, data, length, user, reserved, &req, requestHandler, dataHandler);
         /* Return data will be different than user if we are upgraded to WebSocket or have an error */
         if (consumed.returnedData != user) {
             return consumed;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -65,6 +65,7 @@ namespace uWS
         HTTP_PARSER_ERROR_INVALID_EOF = 8,
         HTTP_PARSER_ERROR_INVALID_METHOD = 9,
         HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN = 10,
+        HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER = 11,
     };
 
 
@@ -886,18 +887,27 @@ namespace uWS
                 return HttpParserResult::error(HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE);
             }
 
-            /* Add all headers to bloom filter */
+            /* Add all headers to bloom filter, counting Host lines for the RFC 9112 5.4 check */
             req->bf.reset();
-
+            unsigned int hostHeaderCount = 0;
             for (HttpRequest::Header *h = req->headers; (++h)->key.length(); ) {
                 req->bf.add(h->key);
+                if (h->key.length() == 4 && !strncasecmp(h->key.data(), "host", 4)) {
+                    hostHeaderCount++;
+                }
             }
-            /* Break if no host header (but we can have empty string which is different from nullptr).
-             * Upgrade and CONNECT requests are exempt: Node.js dispatches them through the
-             * 'upgrade'/'connect' events before its Host requirement is enforced. */
-            if (!req->ancientHttp && requireHostHeader && !req->getHeader("host").data()
+            /* RFC 9112 5.4: an HTTP/1.1 request with no Host header, or with more than one,
+             * MUST be answered with 400. Upgrade and CONNECT requests are exempt: Node.js
+             * dispatches them through the 'upgrade'/'connect' events before its Host
+             * requirement is enforced. An empty Host value is permitted (it is not absent). */
+            if (!req->ancientHttp && requireHostHeader
                 && !isConnectRequest && !req->getHeader("upgrade").data()) {
-                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_MISSING_HOST_HEADER);
+                if (hostHeaderCount == 0) {
+                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_MISSING_HOST_HEADER);
+                }
+                if (hostHeaderCount > 1) {
+                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER);
+                }
             }
 
             /* RFC 9112 6.3

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -970,6 +970,7 @@ enum HttpParserError {
   HTTP_PARSER_ERROR_INVALID_EOF = 8,
   HTTP_PARSER_ERROR_INVALID_METHOD = 9,
   HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN = 10,
+  HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER = 11,
 }
 function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, rawPacket: ArrayBuffer) {
   const self = this as Server;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -970,7 +970,6 @@ enum HttpParserError {
   HTTP_PARSER_ERROR_INVALID_EOF = 8,
   HTTP_PARSER_ERROR_INVALID_METHOD = 9,
   HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN = 10,
-  HTTP_PARSER_ERROR_DUPLICATE_HOST_HEADER = 11,
 }
 function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, rawPacket: ArrayBuffer) {
   const self = this as Server;

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1489,7 +1489,10 @@ describe("duplicate Host header field lines", () => {
     try {
       await new Promise<void>(resolve => server.listen(0, resolve));
       const { port } = server.address() as { port: number };
-      const response = await sendRaw(port, "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n");
+      const response = await sendRaw(
+        port,
+        "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n",
+      );
       expect(response).toContain("HTTP/1.1 400");
       expect(handlerReached).toBe(false);
     } finally {
@@ -1508,7 +1511,10 @@ describe("duplicate Host header field lines", () => {
     try {
       await new Promise<void>(resolve => server.listen(0, resolve));
       const { port } = server.address() as { port: number };
-      const response = await sendRaw(port, "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n");
+      const response = await sendRaw(
+        port,
+        "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n",
+      );
       expect(response).toContain("HTTP/1.1 200");
       expect(seen).toEqual([
         {

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1465,6 +1465,43 @@ describe("duplicate Host header field lines", () => {
     expect(handlerReached).toBe(false);
   });
 
+  test("Bun.serve rejects two Host header lines on a request carrying an Upgrade header", async () => {
+    // An Upgrade header exempts the request from the missing-Host check (so node:http can
+    // dispatch 'upgrade' before enforcing Host), but not from the duplicate-Host check:
+    // otherwise one attacker-controlled header would bypass the RFC 9112 5.4 MUST.
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        handlerReached = true;
+        return Response.json({ url: req.url, host: req.headers.get("host") });
+      },
+    });
+
+    const response = await sendRaw(
+      server.port,
+      "GET /x HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nUpgrade: h2c\r\nConnection: close\r\n\r\n",
+    );
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
+  test("Bun.serve rejects two Host header lines on an HTTP/1.0 request", async () => {
+    // HTTP/1.0 may omit Host, but a present-and-duplicated Host is ambiguous on any version.
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        handlerReached = true;
+        return new Response("OK");
+      },
+    });
+
+    const response = await sendRaw(server.port, "GET / HTTP/1.0\r\nHost: a.test\r\nHost: b.test\r\n\r\n");
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
   test("Bun.serve accepts a single Host header line (control)", async () => {
     await using server = Bun.serve({
       port: 0,
@@ -1492,6 +1529,28 @@ describe("duplicate Host header field lines", () => {
       const response = await sendRaw(
         port,
         "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n",
+      );
+      expect(response).toContain("HTTP/1.1 400");
+      expect(handlerReached).toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("node:http rejects two Host header lines even when an Upgrade header is present", async () => {
+    // An Upgrade header without Connection: upgrade falls through to normal dispatch in
+    // node:http; the duplicate-Host rejection must still apply on that path.
+    let handlerReached = false;
+    const server = createServer((req, res) => {
+      handlerReached = true;
+      res.end("OK");
+    });
+    try {
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      const { port } = server.address() as { port: number };
+      const response = await sendRaw(
+        port,
+        "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nUpgrade: h2c\r\nConnection: close\r\n\r\n",
       );
       expect(response).toContain("HTTP/1.1 400");
       expect(handlerReached).toBe(false);

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1516,55 +1516,14 @@ describe("duplicate Host header field lines", () => {
     expect(body).toEqual({ url: "http://a.test/exact", host: "a.test" });
   });
 
-  test("node:http rejects a request with two Host header lines", async () => {
-    // requireHostHeader defaults to true, so the same RFC 9112 5.4 check applies.
-    let handlerReached = false;
+  test("node:http serves a request with two Host header lines, keeping the first value", async () => {
+    // Node.js accepts duplicate Host header lines (llhttp leniency) and
+    // IncomingMessage keeps only the first value in req.headers.host. node:http has
+    // no req.url/headers split-brain (req.url is the bare request-target), so it
+    // opts out of the parser-level rejection for Node.js compatibility.
+    const seen: { url: string; host: string | undefined; rawHeaders: string[] }[] = [];
     const server = createServer((req, res) => {
-      handlerReached = true;
-      res.end("OK");
-    });
-    try {
-      await new Promise<void>(resolve => server.listen(0, resolve));
-      const { port } = server.address() as { port: number };
-      const response = await sendRaw(
-        port,
-        "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n",
-      );
-      expect(response).toContain("HTTP/1.1 400");
-      expect(handlerReached).toBe(false);
-    } finally {
-      server.close();
-    }
-  });
-
-  test("node:http rejects two Host header lines even when an Upgrade header is present", async () => {
-    // An Upgrade header without Connection: upgrade falls through to normal dispatch in
-    // node:http; the duplicate-Host rejection must still apply on that path.
-    let handlerReached = false;
-    const server = createServer((req, res) => {
-      handlerReached = true;
-      res.end("OK");
-    });
-    try {
-      await new Promise<void>(resolve => server.listen(0, resolve));
-      const { port } = server.address() as { port: number };
-      const response = await sendRaw(
-        port,
-        "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nUpgrade: h2c\r\nConnection: close\r\n\r\n",
-      );
-      expect(response).toContain("HTTP/1.1 400");
-      expect(handlerReached).toBe(false);
-    } finally {
-      server.close();
-    }
-  });
-
-  test("node:http with requireHostHeader:false serves a request with two Host header lines", async () => {
-    // The escape hatch: opting out of the Host requirement also opts out of the
-    // duplicate check, and the handler sees only the first value (Node semantics).
-    const seen: { host: string | undefined; rawHeaders: string[] }[] = [];
-    const server = createServer({ requireHostHeader: false }, (req, res) => {
-      seen.push({ host: req.headers.host, rawHeaders: req.rawHeaders });
+      seen.push({ url: req.url!, host: req.headers.host, rawHeaders: req.rawHeaders });
       res.end("OK");
     });
     try {
@@ -1577,6 +1536,7 @@ describe("duplicate Host header field lines", () => {
       expect(response).toContain("HTTP/1.1 200");
       expect(seen).toEqual([
         {
+          url: "/",
           host: "a.test",
           rawHeaders: ["Host", "a.test", "Host", "b.test", "Connection", "close"],
         },

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1502,6 +1502,25 @@ describe("duplicate Host header field lines", () => {
     expect(handlerReached).toBe(false);
   });
 
+  test("Bun.serve rejects two Host header lines on a CONNECT request", async () => {
+    // CONNECT is exempt from the missing-Host check, but not from the duplicate-Host check.
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        handlerReached = true;
+        return new Response("OK");
+      },
+    });
+
+    const response = await sendRaw(
+      server.port,
+      "CONNECT example.com:443 HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\n\r\n",
+    );
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
   test("Bun.serve accepts a single Host header line (control)", async () => {
     await using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1392,6 +1392,136 @@ test("rejects Transfer-Encoding header with empty value", async () => {
   expect(seen).not.toContain("GET /admin");
 });
 
+// RFC 9112 5.4: a request with more than one Host header field line MUST be
+// answered with 400. Serving it would let req.url (built from the first Host
+// line) and req.headers.get("host") (the comma-join of every line) disagree on
+// the request's authority, which is the host-header-confusion shape the MUST
+// exists to prevent.
+describe("duplicate Host header field lines", () => {
+  async function sendRaw(port: number, payload: string): Promise<string> {
+    const client = net.connect(port, "127.0.0.1");
+    return new Promise<string>((resolve, reject) => {
+      let data = "";
+      client.on("error", reject);
+      client.on("data", chunk => (data += chunk.toString()));
+      client.on("close", () => resolve(data));
+      client.write(payload);
+    });
+  }
+
+  test("Bun.serve rejects a request with two Host header lines", async () => {
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        handlerReached = true;
+        return Response.json({ url: req.url, host: req.headers.get("host") });
+      },
+    });
+
+    const response = await sendRaw(
+      server.port,
+      "GET /exact HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n",
+    );
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
+  test("Bun.serve rejects a request with three Host header lines of mixed casing", async () => {
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        handlerReached = true;
+        return new Response("OK");
+      },
+    });
+
+    const response = await sendRaw(
+      server.port,
+      "GET / HTTP/1.1\r\nHost: a.test\r\nHOST: b.test\r\nhost: c.test\r\nConnection: close\r\n\r\n",
+    );
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
+  test("Bun.serve rejects two identical Host header lines", async () => {
+    // Unlike Content-Length (where identical duplicates are permitted), Host is a
+    // singleton field: any repetition is rejected.
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        handlerReached = true;
+        return new Response("OK");
+      },
+    });
+
+    const response = await sendRaw(
+      server.port,
+      "GET / HTTP/1.1\r\nHost: a.test\r\nHost: a.test\r\nConnection: close\r\n\r\n",
+    );
+    expect(response).toContain("HTTP/1.1 400");
+    expect(handlerReached).toBe(false);
+  });
+
+  test("Bun.serve accepts a single Host header line (control)", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return Response.json({ url: req.url, host: req.headers.get("host") });
+      },
+    });
+
+    const response = await sendRaw(server.port, "GET /exact HTTP/1.1\r\nHost: a.test\r\nConnection: close\r\n\r\n");
+    expect(response).toContain("HTTP/1.1 200");
+    const body = JSON.parse(response.slice(response.indexOf("\r\n\r\n") + 4));
+    expect(body).toEqual({ url: "http://a.test/exact", host: "a.test" });
+  });
+
+  test("node:http rejects a request with two Host header lines", async () => {
+    // requireHostHeader defaults to true, so the same RFC 9112 5.4 check applies.
+    let handlerReached = false;
+    const server = createServer((req, res) => {
+      handlerReached = true;
+      res.end("OK");
+    });
+    try {
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      const { port } = server.address() as { port: number };
+      const response = await sendRaw(port, "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n");
+      expect(response).toContain("HTTP/1.1 400");
+      expect(handlerReached).toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("node:http with requireHostHeader:false serves a request with two Host header lines", async () => {
+    // The escape hatch: opting out of the Host requirement also opts out of the
+    // duplicate check, and the handler sees only the first value (Node semantics).
+    const seen: { host: string | undefined; rawHeaders: string[] }[] = [];
+    const server = createServer({ requireHostHeader: false }, (req, res) => {
+      seen.push({ host: req.headers.host, rawHeaders: req.rawHeaders });
+      res.end("OK");
+    });
+    try {
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      const { port } = server.address() as { port: number };
+      const response = await sendRaw(port, "GET / HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\nConnection: close\r\n\r\n");
+      expect(response).toContain("HTTP/1.1 200");
+      expect(seen).toEqual([
+        {
+          host: "a.test",
+          rawHeaders: ["Host", "a.test", "Host", "b.test", "Connection", "close"],
+        },
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+});
+
 describe("Host header field values in request.url", () => {
   // Windows refuses connections under accept-backlog/TIME_WAIT churn even while the
   // server is listening, so a refused connect (before anything was read) is retried.

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1746,21 +1746,24 @@ describe("HTTP Server Security Tests - Advanced", () => {
     test("duplicate request headers follow Node.js precedence rules", async () => {
       // Expected values verified against Node.js v24: singleton headers keep
       // the first value, joinable headers are comma-joined, Cookie joins with
-      // "; ", and Set-Cookie becomes an array.
+      // "; ", and Set-Cookie becomes an array. Duplicate Host lines are not
+      // exercised here: the parser now rejects them per RFC 9112 5.4 (the
+      // keep-first-value path is covered by the requireHostHeader:false test
+      // in test/js/bun/http/request-smuggling.test.ts).
       const { promise, resolve, reject } = Promise.withResolvers();
       server.on("request", (req, res) => {
         try {
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end("ok");
           resolve({
-            host: req.headers.host,
+            userAgent: req.headers["user-agent"],
             contentType: req.headers["content-type"],
             authorization: req.headers.authorization,
             accept: req.headers.accept,
             xCustom: req.headers["x-custom"],
             cookie: req.headers.cookie,
             setCookie: req.headers["set-cookie"],
-            rawHostCount: req.rawHeaders.filter(h => h.toLowerCase() === "host").length,
+            rawXCustomCount: req.rawHeaders.filter(h => h.toLowerCase() === "x-custom").length,
           });
         } catch (err) {
           reject(err);
@@ -1769,8 +1772,9 @@ describe("HTTP Server Security Tests - Advanced", () => {
 
       const msg = [
         "GET / HTTP/1.1",
-        "Host: first.example.com",
-        "Host: second.example.com",
+        "Host: example.com",
+        "User-Agent: first-ua",
+        "User-Agent: second-ua",
         "Content-Type: text/plain",
         "Content-Type: text/html",
         "Authorization: token1",
@@ -1792,7 +1796,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
       expect(response).toInclude("200");
       const headers: any = await promise;
       // Singleton headers keep the first value.
-      expect(headers.host).toBe("first.example.com");
+      expect(headers.userAgent).toBe("first-ua");
       expect(headers.contentType).toBe("text/plain");
       expect(headers.authorization).toBe("token1");
       // Other headers are joined with ", ".
@@ -1803,7 +1807,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
       // Set-Cookie is collected into an array.
       expect(headers.setCookie).toEqual(["x=1", "y=2"]);
       // rawHeaders still reports every received header.
-      expect(headers.rawHostCount).toBe(2);
+      expect(headers.rawXCustomCount).toBe(2);
     });
 
     test("duplicate request header edge cases follow Node.js precedence rules", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1746,24 +1746,21 @@ describe("HTTP Server Security Tests - Advanced", () => {
     test("duplicate request headers follow Node.js precedence rules", async () => {
       // Expected values verified against Node.js v24: singleton headers keep
       // the first value, joinable headers are comma-joined, Cookie joins with
-      // "; ", and Set-Cookie becomes an array. Duplicate Host lines are not
-      // exercised here: the parser now rejects them per RFC 9112 5.4 (the
-      // keep-first-value path is covered by the requireHostHeader:false test
-      // in test/js/bun/http/request-smuggling.test.ts).
+      // "; ", and Set-Cookie becomes an array.
       const { promise, resolve, reject } = Promise.withResolvers();
       server.on("request", (req, res) => {
         try {
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end("ok");
           resolve({
-            userAgent: req.headers["user-agent"],
+            host: req.headers.host,
             contentType: req.headers["content-type"],
             authorization: req.headers.authorization,
             accept: req.headers.accept,
             xCustom: req.headers["x-custom"],
             cookie: req.headers.cookie,
             setCookie: req.headers["set-cookie"],
-            rawXCustomCount: req.rawHeaders.filter(h => h.toLowerCase() === "x-custom").length,
+            rawHostCount: req.rawHeaders.filter(h => h.toLowerCase() === "host").length,
           });
         } catch (err) {
           reject(err);
@@ -1772,9 +1769,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
 
       const msg = [
         "GET / HTTP/1.1",
-        "Host: example.com",
-        "User-Agent: first-ua",
-        "User-Agent: second-ua",
+        "Host: first.example.com",
+        "Host: second.example.com",
         "Content-Type: text/plain",
         "Content-Type: text/html",
         "Authorization: token1",
@@ -1796,7 +1792,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
       expect(response).toInclude("200");
       const headers: any = await promise;
       // Singleton headers keep the first value.
-      expect(headers.userAgent).toBe("first-ua");
+      expect(headers.host).toBe("first.example.com");
       expect(headers.contentType).toBe("text/plain");
       expect(headers.authorization).toBe("token1");
       // Other headers are joined with ", ".
@@ -1807,7 +1803,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
       // Set-Cookie is collected into an array.
       expect(headers.setCookie).toEqual(["x=1", "y=2"]);
       // rawHeaders still reports every received header.
-      expect(headers.rawXCustomCount).toBe(2);
+      expect(headers.rawHostCount).toBe(2);
     });
 
     test("duplicate request header edge cases follow Node.js precedence rules", async () => {


### PR DESCRIPTION
## Problem

`Bun.serve` accepts an HTTP/1.1 request carrying two `Host` header lines and reports the two hosts inconsistently: `req.url` is synthesized from the first `Host` line while `req.headers.get("host")` is the comma-join of all lines.

```js
// GET /exact HTTP/1.1\r\nHost: a.test\r\nHost: b.test\r\n\r\n
// -> 200 OK
//    req.url                  === "http://a.test/exact"
//    req.headers.get("host")  === "a.test, b.test"
```

RFC 9112 5.4:
> A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field-value.

The split-brain authority is the host-header-confusion / cache-poisoning shape that MUST exists to prevent: vhost selection, cache keys, and Host allowlists typically read `headers.get("host")` while routing, redirects, and absolute-URL construction read `req.url`, so two components in one app disagree about which host was requested.

## Cause

`uWS::HttpRequest::getHeader("host")` returns the first match (what `Request::ensure_url` reads), while the WHATWG `Headers` object comma-joins every line. The parser's existing Host check only tested for absence.

## Fix

Count `Host` header lines in `fenceAndConsumePostPadded`, in the same loop that already builds the header bloom filter, and reject with 400 when more than one is present. The check is not exempted for Upgrade/CONNECT/HTTP-1.0 requests (the duplicate makes the authority ambiguous regardless of method or version).

The check is gated on a new `HttpFlags.rejectDuplicateHostHeader` bit, `true` by default. `node:http` clears it via `App::setFlags` (its configuration entry point) so `http.createServer()` keeps Node.js semantics: llhttp accepts duplicate Host lines and `IncomingMessage` reports only the first value in `req.headers.host`, with no `req.url`/headers split-brain since `req.url` is the bare request-target. The upstream `test-http-server-multiheaders{,2}.js` tests continue to pass.

## Verification

```
bun bd test test/js/bun/http/request-smuggling.test.ts   # 82 pass, 0 fail (7 new)
bun bd test/js/node/test/parallel/test-http-server-multiheaders.js    # exit 0
bun bd test/js/node/test/parallel/test-http-server-multiheaders2.js   # exit 0
```

The one-line `Host: a.test, b.test` spelling is not changed by this PR: it already falls into the invalid-Host-value path in `Request::is_valid_host_header` (the space is outside the RFC 3986 authority byte set), so `req.url` is the bare request target and no authority is synthesized.