### PR TITLE
node:http client: preserve AsyncLocalStorage context on reused keep-alive sockets

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -60,6 +60,7 @@ function onCreateConnection(this: any, err, socket) {
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const kError = Symbol("kError");
 const kPath = Symbol("kPath");
+const kRequestAsyncContext = Symbol("kRequestAsyncContext");
 
 const kLenientAll = HTTPParser.kLenientAll | 0;
 const kLenientNone = HTTPParser.kLenientNone | 0;
@@ -486,7 +487,13 @@ function ondrain() {
   const msg = this._httpMessage;
   if (msg && !msg.finished && msg[kNeedDrain]) {
     msg[kNeedDrain] = false;
-    msg.emit("drain");
+    const prev = $getInternalField($asyncContext, 0);
+    $putInternalField($asyncContext, 0, msg[kRequestAsyncContext]);
+    try {
+      msg.emit("drain");
+    } finally {
+      $putInternalField($asyncContext, 0, prev);
+    }
   }
 }
 
@@ -495,6 +502,16 @@ function socketCloseListener() {
   const req = socket._httpMessage;
   $debug("HTTP socket close");
 
+  const prev = $getInternalField($asyncContext, 0);
+  $putInternalField($asyncContext, 0, req[kRequestAsyncContext]);
+  try {
+    socketCloseListenerInner(socket, req);
+  } finally {
+    $putInternalField($asyncContext, 0, prev);
+  }
+}
+
+function socketCloseListenerInner(socket, req) {
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
   const parser = socket.parser;
@@ -543,6 +560,16 @@ function socketErrorListener(err) {
   const req = socket._httpMessage;
   $debug("SOCKET ERROR:", err);
 
+  const prev = $getInternalField($asyncContext, 0);
+  if (req) $putInternalField($asyncContext, 0, req[kRequestAsyncContext]);
+  try {
+    socketErrorListenerInner(socket, req, err);
+  } finally {
+    $putInternalField($asyncContext, 0, prev);
+  }
+}
+
+function socketErrorListenerInner(socket, req, err) {
   if (req) {
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
@@ -567,6 +594,16 @@ function socketOnEnd() {
   const req = this._httpMessage;
   const parser = this.parser;
 
+  const prev = $getInternalField($asyncContext, 0);
+  $putInternalField($asyncContext, 0, req[kRequestAsyncContext]);
+  try {
+    socketOnEndInner(socket, req, parser);
+  } finally {
+    $putInternalField($asyncContext, 0, prev);
+  }
+}
+
+function socketOnEndInner(socket, req, parser) {
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
@@ -587,6 +624,19 @@ function socketOnData(d) {
 
   $assert(parser && parser.socket === socket);
 
+  // A reused keep-alive socket fires 'data' in the context captured at
+  // connect time; re-enter the owning request's context (saved in onSocket)
+  // before the parser dispatches 'response'/'data'/'end' to user code.
+  const prev = $getInternalField($asyncContext, 0);
+  $putInternalField($asyncContext, 0, req[kRequestAsyncContext]);
+  try {
+    socketOnDataInner(socket, req, parser, d);
+  } finally {
+    $putInternalField($asyncContext, 0, prev);
+  }
+}
+
+function socketOnDataInner(socket, req, parser, d) {
   const ret = parser.execute(d);
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
@@ -924,6 +974,10 @@ function listenSocketTimeout(req) {
 }
 
 ClientRequest.prototype.onSocket = function onSocket(socket, err) {
+  // Capture this request's async context so the socket-level listeners
+  // (which fire in the socket-creation context on a reused keep-alive
+  // connection) can dispatch to user code in the right AsyncLocalStorage scope.
+  this[kRequestAsyncContext] = $getInternalField($asyncContext, 0);
   // Attach the error listener synchronously so that any errors emitted on
   // the socket before onSocketNT runs (e.g. from a blocklist check or other
   // next-tick error) are forwarded to the request and can be caught by the

--- a/test/js/node/async_hooks/async-context/async-context-http-client-keepalive-reuse.js
+++ b/test/js/node/async_hooks/async-context/async-context-http-client-keepalive-reuse.js
@@ -2,10 +2,9 @@ process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
 const http = require("http");
 
-// A keep-alive agent reuses the same TCP socket for sequential requests. The
-// native socket's data callback captures the async context at connect time,
-// so on a reused connection the 'response'/'data'/'end' path must re-enter the
-// owning ClientRequest's context rather than inherit the first request's.
+// A keep-alive agent reuses one TCP socket for sequential requests, so the
+// 'response'/'data'/'end' path must re-enter the owning ClientRequest's
+// context rather than inherit whichever request first connected the socket.
 
 const als = new AsyncLocalStorage();
 let failed = false;

--- a/test/js/node/async_hooks/async-context/async-context-http-client-keepalive-reuse.js
+++ b/test/js/node/async_hooks/async-context/async-context-http-client-keepalive-reuse.js
@@ -1,0 +1,74 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+const http = require("http");
+
+// A keep-alive agent reuses the same TCP socket for sequential requests. The
+// native socket's data callback captures the async context at connect time,
+// so on a reused connection the 'response'/'data'/'end' path must re-enter the
+// owning ClientRequest's context rather than inherit the first request's.
+
+const als = new AsyncLocalStorage();
+let failed = false;
+const sockets = [];
+
+const server = http.createServer((req, res) => res.end("ok"));
+
+server.listen(0, "127.0.0.1", () => {
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+
+  function check(want, what) {
+    const got = als.getStore();
+    if (got !== want) {
+      console.error(`FAIL: ${what} for ${want} saw ${JSON.stringify(got)}`);
+      failed = true;
+    }
+  }
+
+  function one(store) {
+    return new Promise((resolve, reject) => {
+      als.run(store, () => {
+        const req = http.request(
+          { host: "127.0.0.1", port: server.address().port, path: "/", agent },
+          res => {
+            check(store, "response callback");
+            res.on("data", () => check(store, "response 'data'"));
+            res.on("end", () => {
+              check(store, "response 'end'");
+              resolve();
+            });
+            res.on("error", reject);
+          },
+        );
+        req.on("socket", s => {
+          sockets.push(s);
+          check(store, "'socket' event");
+        });
+        req.on("close", () => check(store, "'close' event"));
+        req.on("error", reject);
+        req.end();
+      });
+    });
+  }
+
+  (async () => {
+    await one("R1");
+    // Wait for the socket to be returned to the free pool.
+    await new Promise(r => setImmediate(() => setImmediate(r)));
+    await one("R2");
+    await one("R3");
+
+    if (sockets[0] !== sockets[1] || sockets[1] !== sockets[2]) {
+      console.error("FAIL: keep-alive socket was not reused");
+      failed = true;
+    }
+
+    agent.destroy();
+    server.close();
+    process.exit(failed ? 1 : 0);
+  })().catch(err => {
+    console.error(err);
+    agent.destroy();
+    server.close();
+    process.exit(1);
+  });
+});

--- a/test/js/node/http/node-http-als-keepalive.test.ts
+++ b/test/js/node/http/node-http-als-keepalive.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+// The native TCP socket captures the async context once at connect time; a
+// keep-alive agent reuses that socket for later requests, so 'response'/'data'
+// /'end' must re-enter the owning request's AsyncLocalStorage scope rather
+// than inherit the first request's.
+test("AsyncLocalStorage context is preserved across keep-alive socket reuse", async () => {
+  const als = new AsyncLocalStorage<string>();
+  const server = http.createServer((req, res) => res.end("ok"));
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  const sockets: unknown[] = [];
+  const seen: Record<string, Record<string, string | undefined>> = {};
+
+  try {
+    const one = (store: string) =>
+      new Promise<void>((resolve, reject) =>
+        als.run(store, () => {
+          const req = http.request({ host: "127.0.0.1", port, path: "/", agent }, res => {
+            seen[store].response = als.getStore();
+            res.on("data", () => (seen[store].data = als.getStore()));
+            res.on("end", () => {
+              seen[store].end = als.getStore();
+              resolve();
+            });
+            res.on("error", reject);
+          });
+          seen[store] = {};
+          req.on("socket", s => {
+            sockets.push(s);
+            seen[store].socket = als.getStore();
+          });
+          req.on("error", reject);
+          req.end();
+        }),
+      );
+
+    await one("R1");
+    await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+    await one("R2");
+    await one("R3");
+
+    // The same pooled socket served all three requests.
+    expect(sockets).toEqual([sockets[0], sockets[0], sockets[0]]);
+    // Each request's 'socket'/'response'/'data'/'end' saw its own store,
+    // not the context the native socket captured at connect time (R1).
+    expect(seen).toEqual({
+      R1: { socket: "R1", response: "R1", data: "R1", end: "R1" },
+      R2: { socket: "R2", response: "R2", data: "R2", end: "R2" },
+      R3: { socket: "R3", response: "R3", data: "R3", end: "R3" },
+    });
+  } finally {
+    agent.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http-als-keepalive.test.ts
+++ b/test/js/node/http/node-http-als-keepalive.test.ts
@@ -2,12 +2,11 @@ import { expect, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { once } from "node:events";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 
-// The native TCP socket captures the async context once at connect time; a
-// keep-alive agent reuses that socket for later requests, so 'response'/'data'
-// /'end' must re-enter the owning request's AsyncLocalStorage scope rather
-// than inherit the first request's.
+// A keep-alive agent reuses one TCP socket for later requests, so
+// 'response'/'data'/'end' must re-enter the owning request's ALS scope
+// rather than inherit whichever request first connected the socket.
 test("AsyncLocalStorage context is preserved across keep-alive socket reuse", async () => {
   const als = new AsyncLocalStorage<string>();
   const server = http.createServer((req, res) => res.end("ok"));
@@ -55,6 +54,55 @@ test("AsyncLocalStorage context is preserved across keep-alive socket reuse", as
       R2: { socket: "R2", response: "R2", data: "R2", end: "R2" },
       R3: { socket: "R3", response: "R3", data: "R3", end: "R3" },
     });
+  } finally {
+    agent.destroy();
+    server.close();
+  }
+});
+
+test("AsyncLocalStorage context is preserved for 'error' on a reused keep-alive socket", async () => {
+  const als = new AsyncLocalStorage<string>();
+  // net.Server so the second request can be answered with a raw socket destroy.
+  const server = net.createServer(sock => {
+    let reqs = 0;
+    sock.on("data", () => {
+      reqs++;
+      if (reqs === 1) sock.write("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: 2\r\n\r\nok");
+      else sock.destroy();
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  const sockets: unknown[] = [];
+
+  try {
+    await new Promise<void>((resolve, reject) =>
+      als.run("R1", () => {
+        const q = http.request({ host: "127.0.0.1", port, agent }, res => {
+          res.resume();
+          res.on("end", resolve);
+          res.on("error", reject);
+        });
+        q.on("socket", s => sockets.push(s));
+        q.on("error", reject);
+        q.end();
+      }),
+    );
+    await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+    const errorStore = await new Promise<string | undefined>((resolve, reject) =>
+      als.run("R2", () => {
+        const q = http.request({ host: "127.0.0.1", port, agent });
+        q.on("socket", s => sockets.push(s));
+        q.on("response", () => reject(new Error("expected a socket error, got a response")));
+        q.on("error", () => resolve(als.getStore()));
+        q.end();
+      }),
+    );
+
+    expect({ reused: sockets[0] === sockets[1], errorStore }).toEqual({ reused: true, errorStore: "R2" });
   } finally {
     agent.destroy();
     server.close();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -7,6 +7,7 @@
  */
 import { bunEnv, bunExe, exampleSite, randomPort, tls as tlsCert } from "harness";
 import { createTest } from "node-harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { EventEmitter, once } from "node:events";
 import nodefs from "node:fs";
 import http, {
@@ -28,7 +29,6 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
-import { AsyncLocalStorage } from "node:async_hooks";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -28,6 +28,7 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
+import { AsyncLocalStorage } from "node:async_hooks";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
@@ -3748,4 +3749,57 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   const d = new OutgoingMessage();
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
+});
+
+it("AsyncLocalStorage context is preserved across keep-alive socket reuse", async () => {
+  const als = new AsyncLocalStorage<string>();
+  const server = createServer((req, res) => res.end("ok"));
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+  const sockets: unknown[] = [];
+  const seen: Record<string, Record<string, string | undefined>> = {};
+
+  try {
+    const one = (store: string) =>
+      new Promise<void>((resolve, reject) =>
+        als.run(store, () => {
+          const req = http.request({ host: "127.0.0.1", port, path: "/", agent }, res => {
+            seen[store].response = als.getStore();
+            res.on("data", () => (seen[store].data = als.getStore()));
+            res.on("end", () => {
+              seen[store].end = als.getStore();
+              resolve();
+            });
+            res.on("error", reject);
+          });
+          seen[store] = {};
+          req.on("socket", s => {
+            sockets.push(s);
+            seen[store].socket = als.getStore();
+          });
+          req.on("error", reject);
+          req.end();
+        }),
+      );
+
+    await one("R1");
+    await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+    await one("R2");
+    await one("R3");
+
+    // The same pooled socket served all three requests.
+    expect(sockets).toEqual([sockets[0], sockets[0], sockets[0]]);
+    // Each request's 'socket'/'response'/'data'/'end' saw its own store,
+    // not the context the native socket captured at connect time (R1).
+    expect(seen).toEqual({
+      R1: { socket: "R1", response: "R1", data: "R1", end: "R1" },
+      R2: { socket: "R2", response: "R2", data: "R2", end: "R2" },
+      R3: { socket: "R3", response: "R3", data: "R3", end: "R3" },
+    });
+  } finally {
+    agent.destroy();
+    server.close();
+  }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -7,7 +7,6 @@
  */
 import { bunEnv, bunExe, exampleSite, randomPort, tls as tlsCert } from "harness";
 import { createTest } from "node-harness";
-import { AsyncLocalStorage } from "node:async_hooks";
 import { EventEmitter, once } from "node:events";
 import nodefs from "node:fs";
 import http, {
@@ -3749,57 +3748,4 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   const d = new OutgoingMessage();
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
-});
-
-it("AsyncLocalStorage context is preserved across keep-alive socket reuse", async () => {
-  const als = new AsyncLocalStorage<string>();
-  const server = createServer((req, res) => res.end("ok"));
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address() as AddressInfo;
-  const agent = new Agent({ keepAlive: true, maxSockets: 1 });
-  const sockets: unknown[] = [];
-  const seen: Record<string, Record<string, string | undefined>> = {};
-
-  try {
-    const one = (store: string) =>
-      new Promise<void>((resolve, reject) =>
-        als.run(store, () => {
-          const req = http.request({ host: "127.0.0.1", port, path: "/", agent }, res => {
-            seen[store].response = als.getStore();
-            res.on("data", () => (seen[store].data = als.getStore()));
-            res.on("end", () => {
-              seen[store].end = als.getStore();
-              resolve();
-            });
-            res.on("error", reject);
-          });
-          seen[store] = {};
-          req.on("socket", s => {
-            sockets.push(s);
-            seen[store].socket = als.getStore();
-          });
-          req.on("error", reject);
-          req.end();
-        }),
-      );
-
-    await one("R1");
-    await new Promise<void>(r => setImmediate(() => setImmediate(r)));
-    await one("R2");
-    await one("R3");
-
-    // The same pooled socket served all three requests.
-    expect(sockets).toEqual([sockets[0], sockets[0], sockets[0]]);
-    // Each request's 'socket'/'response'/'data'/'end' saw its own store,
-    // not the context the native socket captured at connect time (R1).
-    expect(seen).toEqual({
-      R1: { socket: "R1", response: "R1", data: "R1", end: "R1" },
-      R2: { socket: "R2", response: "R2", data: "R2", end: "R2" },
-      R3: { socket: "R3", response: "R3", data: "R3", end: "R3" },
-    });
-  } finally {
-    agent.destroy();
-    server.close();
-  }
 });


### PR DESCRIPTION
## Problem

When a `node:http` client request is served by a keep-alive agent's pooled (reused) socket, every `'response'`, `'data'` and `'end'` callback for that request runs in the `AsyncLocalStorage` context of the **first** request that ever used that socket.

```js
import { AsyncLocalStorage } from "node:async_hooks";
import http from "node:http";
const als = new AsyncLocalStorage();
const srv = http.createServer((_, res) => res.end("ok")).listen(0, "127.0.0.1");
await new Promise(r => srv.on("listening", r));
const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
const one = store => new Promise(done => als.run(store, () => {
  http.request({ host: "127.0.0.1", port: srv.address().port, agent }, res => {
    console.log(store, "response cb:", als.getStore());
    res.on("end", () => { console.log(store, "end:", als.getStore()); done(); });
    res.resume();
  }).end();
}));
await one("R1");
await new Promise(r => setImmediate(r));
await one("R2");   // Bun: sees "R1" in response/end; Node: "R2"
```

The socket *is* reused in both runtimes; with `Connection: close` (fresh socket per request) Bun is correct. Since `http.globalAgent` defaults to keep-alive, this is the default path for most code and breaks APM / distributed-tracing / multi-tenant libraries that rely on `AsyncLocalStorage`.

## Cause

Bun's native TCP socket wraps its `onData`/`onEnd`/`onClose`/`onError` callbacks with `AsyncContextFrame::withAsyncContextIfNeeded` once, when `net.connect()` creates the socket. That captured context is the first request's. On reuse the agent hands the already-connected socket to the next request without reconnecting, so every native `'data'` dispatch still restores request #1's frame before `socketOnData` runs, and the parser delivers `'response'`/`'data'`/`'end'` to the wrong store.

Node.js avoids this because `HTTPParser` is an `AsyncWrap` whose callbacks run in the per-request `HTTPINCOMINGMESSAGE` scope set by `parser.initialize()`; Bun's `HTTPClientAsyncResource` stub was never entered.

## Fix

Capture the owning request's async context in `ClientRequest.prototype.onSocket` (which runs in that request's scope for fresh, reused and queued sockets alike) and re-enter it in the socket-level listeners that dispatch to user code: `socketOnData`, `socketOnEnd`, `socketCloseListener`, `socketErrorListener`, `ondrain`. The swap uses the `$asyncContext` internal field directly, matching the pattern `process.nextTick` uses.

## Verification

New fixture `test/js/node/async_hooks/async-context/async-context-http-client-keepalive-reuse.js` makes three sequential requests over a `maxSockets: 1` keep-alive agent and asserts that `'socket'`, `'response'`, `'data'`, `'end'` and `'close'` on each request see that request's own store, plus asserts the socket was actually reused.

```
bun bd test test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts -t http-client-keepalive-reuse
```

Fail-before (src stashed):
```
FAIL: response callback for R2 saw "R1"
FAIL: response 'data' for R2 saw "R1"
FAIL: response 'end' for R2 saw "R1"
FAIL: 'close' event for R2 saw "R1"
... (same for R3)
```
Pass-after: exit 0, matching `node`.

Full `AsyncLocalStorage-tracking.test.ts` suite (75 tests) and `test/js/node/http/node-http.test.ts` pass (the one pre-existing `request via http proxy, issue#4295` failure reproduces on main with `ECONNREFUSED` and is unrelated).