### PR TITLE
node:http: run server 'close' in the closer's async context, not listen()'s

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -91,7 +91,6 @@ function traceServerRequestEnd() {
   traceEvents.emitEvent("e", kHttpTraceCat, "http.server.request");
 }
 
-const getBunServerAllClosedPromise = $newRustFunction("node_http_binding.rs", "getBunServerAllClosedPromise", 1);
 const sendHelper = $newRustFunction("node_cluster_binding.rs", "sendHelperChild", 3);
 
 const kServerResponse = Symbol("ServerResponse");
@@ -107,7 +106,6 @@ const MathFloor = Math.floor;
 let cluster;
 
 function emitCloseServer(self: Server) {
-  callCloseCallback(self);
   self.emit("close");
 }
 function emitCloseNTServer(this: Server) {
@@ -370,7 +368,7 @@ Server.prototype.closeAllConnections = function () {
   clearInterval(this[kConnectionsCheckingInterval]);
   this.listening = false;
 
-  server.stop(true);
+  server.stop(true).$then(emitCloseNTServer.bind(this));
 };
 
 Server.prototype.getConnections = function (callback) {
@@ -398,10 +396,12 @@ Server.prototype.close = function (optionalCallback?) {
     return;
   }
   this[serverSymbol] = undefined;
-  if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
+  if (typeof optionalCallback === "function") this.once("close", optionalCallback);
   this.listening = false;
   server.closeIdleConnections();
-  server.stop();
+  // Attach the 'close' emission here so it inherits the closer's async context,
+  // matching Node.js (which schedules emitCloseNT from inside close()).
+  server.stop().$then(emitCloseNTServer.bind(this));
 };
 
 Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, ...args) {
@@ -901,7 +901,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       // },
     });
 
-    getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
     isHTTPS = this[serverSymbol].protocol === "https";
     // always set strict method validation to true for node.js compatibility
     setServerCustomOptions(

--- a/src/runtime/node/node_http_binding.rs
+++ b/src/runtime/node/node_http_binding.rs
@@ -1,44 +1,6 @@
-//! `node:http` native binding — `getBunServerAllClosedPromise` /
-//! `{get,set}MaxHTTPHeaderSize`.
+//! `node:http` native binding — `{get,set}MaxHTTPHeaderSize`.
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
-
-use crate::server::{DebugHTTPSServer, DebugHTTPServer, HTTPSServer, HTTPServer};
-
-pub(crate) fn get_bun_server_all_closed_promise(
-    global: &JSGlobalObject,
-    frame: &CallFrame,
-) -> JsResult<JSValue> {
-    let arguments = frame.arguments_old::<1>();
-    let arguments = arguments.slice();
-    if arguments.is_empty() {
-        return Err(global.throw_not_enough_arguments(
-            "getBunServerAllClosePromise",
-            1,
-            arguments.len(),
-        ));
-    }
-
-    let value = arguments[0];
-
-    // Try each heterogeneous server type in turn.
-    macro_rules! try_server {
-        ($ty:ty) => {
-            if let Some(server) = value.as_::<$ty>() {
-                // SAFETY: `JSValue::as_` returns a non-null pointer to the live
-                // JS-owned server instance; we hold the JS thread for the duration
-                // of this call so the GC cannot collect it under us.
-                return Ok(unsafe { &mut *server }.get_all_closed_promise(global));
-            }
-        };
-    }
-    try_server!(HTTPServer);
-    try_server!(HTTPSServer);
-    try_server!(DebugHTTPServer);
-    try_server!(DebugHTTPSServer);
-
-    Err(global.throw_invalid_argument_type_value("server", "bun.Server", value))
-}
 
 pub(crate) fn get_max_http_header_size(
     _global: &JSGlobalObject,

--- a/test/js/node/async_hooks/async-context/async-context-http-server-close.js
+++ b/test/js/node/async_hooks/async-context/async-context-http-server-close.js
@@ -1,0 +1,45 @@
+process.exitCode = 1;
+const { AsyncLocalStorage } = require("async_hooks");
+const http = require("http");
+
+const asyncLocalStorage = new AsyncLocalStorage();
+const order = [];
+let failed = false;
+
+const server = http.createServer((req, res) => res.end("ok"));
+
+asyncLocalStorage.run({ test: "register" }, () => {
+  server.on("close", () => {
+    order.push("listener");
+    if (asyncLocalStorage.getStore()?.test !== "close") {
+      console.error("FAIL: http.Server 'close' event lost context:", asyncLocalStorage.getStore());
+      failed = true;
+    }
+  });
+});
+
+asyncLocalStorage.run({ test: "listen" }, () => {
+  server.listen(0, "127.0.0.1", () => {
+    http.get({ port: server.address().port, host: "127.0.0.1", headers: { connection: "close" } }, res => {
+      res.resume();
+      res.on("end", () => {
+        asyncLocalStorage.run({ test: "close" }, () => {
+          server.close(() => {
+            order.push("cb");
+            if (asyncLocalStorage.getStore()?.test !== "close") {
+              console.error("FAIL: http.Server close(cb) lost context:", asyncLocalStorage.getStore());
+              failed = true;
+            }
+            // In Node.js the close callback is registered via once('close'),
+            // so the earlier-registered 'close' listener runs first.
+            if (order.join(",") !== "listener,cb") {
+              console.error("FAIL: http.Server close ordering:", order.join(","));
+              failed = true;
+            }
+            process.exit(failed ? 1 : 0);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/js/node/http/node-http-server-close-als.test.ts
+++ b/test/js/node/http/node-http-server-close-als.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createServer } from "node:http";
 

--- a/test/js/node/http/node-http-server-close-als.test.ts
+++ b/test/js/node/http/node-http-server-close-als.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createServer } from "node:http";
+
+test("http.Server 'close' runs in the closer's AsyncLocalStorage context, not listen()'s", async () => {
+  const als = new AsyncLocalStorage<string>();
+  const server = createServer((req, res) => res.end("ok"));
+  const events: { where: string; store: string | undefined }[] = [];
+
+  als.run("register", () => {
+    server.on("close", () => events.push({ where: "listener", store: als.getStore() }));
+  });
+
+  const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    als.run("listen", () => server.listen(0, "127.0.0.1", resolve));
+  });
+
+  als.run("closer", () => {
+    server.close(() => {
+      events.push({ where: "cb", store: als.getStore() });
+      onClosed();
+    });
+  });
+  await closed;
+
+  // Both the 'close' listener and close(cb) observe the store active at
+  // close() time, and close(cb) is a once('close') listener so the earlier
+  // registration fires first (matching Node's net.Server.prototype.close).
+  expect(events).toEqual([
+    { where: "listener", store: "closer" },
+    { where: "cb", store: "closer" },
+  ]);
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -7,7 +7,6 @@
  */
 import { bunEnv, bunExe, exampleSite, randomPort, tls as tlsCert } from "harness";
 import { createTest } from "node-harness";
-import { AsyncLocalStorage } from "node:async_hooks";
 import { EventEmitter, once } from "node:events";
 import nodefs from "node:fs";
 import http, {
@@ -3749,37 +3748,4 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   const d = new OutgoingMessage();
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
-});
-
-it("http.Server 'close' runs in the closer's AsyncLocalStorage context, not listen()'s", async () => {
-  const als = new AsyncLocalStorage<string>();
-  const server = createServer((req, res) => res.end("ok"));
-  const events: { where: string; store: string | undefined }[] = [];
-
-  als.run("register", () => {
-    server.on("close", () => events.push({ where: "listener", store: als.getStore() }));
-  });
-
-  const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    als.run("listen", () => server.listen(0, "127.0.0.1", resolve));
-  });
-
-  als.run("closer", () => {
-    server.close(() => {
-      events.push({ where: "cb", store: als.getStore() });
-      onClosed();
-    });
-  });
-  await closed;
-
-  // Both the 'close' listener and close(cb) observe the store active at
-  // close() time, and close(cb) is a once('close') listener so the earlier
-  // registration fires first (matching Node's net.Server.prototype.close).
-  expect(events).toEqual([
-    { where: "listener", store: "closer" },
-    { where: "cb", store: "closer" },
-  ]);
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -7,6 +7,7 @@
  */
 import { bunEnv, bunExe, exampleSite, randomPort, tls as tlsCert } from "harness";
 import { createTest } from "node-harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { EventEmitter, once } from "node:events";
 import nodefs from "node:fs";
 import http, {
@@ -3748,4 +3749,37 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   const d = new OutgoingMessage();
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
+});
+
+it("http.Server 'close' runs in the closer's AsyncLocalStorage context, not listen()'s", async () => {
+  const als = new AsyncLocalStorage<string>();
+  const server = createServer((req, res) => res.end("ok"));
+  const events: { where: string; store: string | undefined }[] = [];
+
+  als.run("register", () => {
+    server.on("close", () => events.push({ where: "listener", store: als.getStore() }));
+  });
+
+  const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    als.run("listen", () => server.listen(0, "127.0.0.1", resolve));
+  });
+
+  als.run("closer", () => {
+    server.close(() => {
+      events.push({ where: "cb", store: als.getStore() });
+      onClosed();
+    });
+  });
+  await closed;
+
+  // Both the 'close' listener and close(cb) observe the store active at
+  // close() time, and close(cb) is a once('close') listener so the earlier
+  // registration fires first (matching Node's net.Server.prototype.close).
+  expect(events).toEqual([
+    { where: "listener", store: "closer" },
+    { where: "cb", store: "closer" },
+  ]);
 });


### PR DESCRIPTION
## Repro

```js
import { AsyncLocalStorage } from "node:async_hooks";
import http from "node:http";
const als = new AsyncLocalStorage();
const srv = http.createServer((req, res) => res.end("ok"));
srv.on("close", () => console.log("'close' listener:", als.getStore()));
als.run("LISTEN", () =>
  srv.listen(0, "127.0.0.1", () =>
    als.run("CLOSER", () =>
      srv.close(() => console.log("close(cb):", als.getStore())),
    ),
  ),
);
// node :  'close' listener: CLOSER   close(cb): CLOSER
// bun  :  close(cb): LISTEN          'close' listener: LISTEN
```

Both the `close(cb)` callback and the `'close'` event listeners saw the `AsyncLocalStorage` store that was active when `listen()` was called, not the one active when `close()` was called. A `net.Server` running the identical pattern in the same process already gets `CLOSER` for both, so this is specific to the `node:http` server wrapper. `node:https` inherits the same `Server` and is affected too.

A secondary divergence visible in the same output: Bun invoked `close(cb)` before the `'close'` listeners, whereas Node registers `close(cb)` via `once('close')` so earlier-registered listeners fire first.

## Cause

`Server.prototype.listen` attached the `'close'` emission as a continuation created at listen time:

```js
getBunServerAllClosedPromise(this[serverSymbol]).$then(emitCloseNTServer.bind(this));
```

`.$then` captures the current `AsyncContextFrame`, so whatever store was active during `listen()` was snapshotted into the continuation and replayed for every future close. Node instead schedules `emitCloseNT` via `process.nextTick` from inside `close()`, so it inherits the closer's context.

## Fix

Attach the `'close'` emission from `close()` (and `closeAllConnections()`, which also stops the listener) using the promise `server.stop()` already returns, instead of pre-attaching it in `listen()`. Register `close(cb)` via `this.once('close', cb)` like Node's `net.Server.prototype.close` so listener ordering matches. `getBunServerAllClosedPromise` has no remaining callers and is removed.

## Verification

New `test/js/node/async_hooks/async-context/async-context-http-server-close.js` (picked up by the existing `AsyncLocalStorage-tracking.test.ts` runner) asserts both the `'close'` listener and `close(cb)` observe the closer's store and that the earlier-registered `'close'` listener runs before `close(cb)`. The fixture passes under Node and under the debug build, and fails under the released Bun. Also re-ran `node-http.test.ts`, `node-http-primoridals.test.ts`, and the Node `test-http-server-close-*` / `test-http{,s}-server-async-dispose` parallel tests with no new failures.