### PR TITLE
spawn: preserve full 32-bit exit codes on Windows

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -600,7 +600,10 @@ impl<'a> State<'a> {
                         }
                     }
                     Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1).into();
+                        return bun_sys::SignalCode(*signal)
+                            .to_exit_code()
+                            .unwrap_or(1)
+                            .into();
                     }
                     _ => return 1,
                 }

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -587,7 +587,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub(crate) fn finalize(&mut self) -> u8 {
+    pub(crate) fn finalize(&mut self) -> u32 {
         if self.aborted {
             let _ = self.redraw(true);
         }
@@ -600,7 +600,7 @@ impl<'a> State<'a> {
                         }
                     }
                     Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1);
+                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1).into();
                     }
                     _ => return 1,
                 }
@@ -1061,7 +1061,7 @@ pub(crate) fn run_scripts_with_filter(
 
     let status = state.finalize();
 
-    Global::exit(status as u32);
+    Global::exit(status);
 }
 
 fn has_cycle(current: &mut ProcessHandle) -> bool {

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -518,7 +518,10 @@ impl<'a> State<'a> {
                         }
                     }
                     Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1).into();
+                        return bun_sys::SignalCode(*signal)
+                            .to_exit_code()
+                            .unwrap_or(1)
+                            .into();
                     }
                     _ => return 1,
                 }

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -508,7 +508,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub(crate) fn finalize(&self) -> u8 {
+    pub(crate) fn finalize(&self) -> u32 {
         for handle in self.handles.iter() {
             if let Some(proc) = &handle.process {
                 match &proc.status {
@@ -518,7 +518,7 @@ impl<'a> State<'a> {
                         }
                     }
                     Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1);
+                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1).into();
                     }
                     _ => return 1,
                 }
@@ -1219,7 +1219,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     }
 
     let status = state.finalize();
-    Global::exit(status as u32);
+    Global::exit(status);
 }
 
 fn has_runnable_extension(name: &[u8]) -> bool {

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -823,8 +823,8 @@ impl PmVersionCommand {
             }
             Ok(result) => {
                 if !result.is_ok() {
-                    let exit_code: i32 = match &result.status {
-                        ProcStatus::Exited(e) => i32::from(e.code),
+                    let exit_code: i64 = match &result.status {
+                        ProcStatus::Exited(e) => i64::from(e.code),
                         _ => -1,
                     };
                     Output::err_generic("Git add failed with exit code {}", (exit_code,));

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -1071,7 +1071,7 @@ impl UpgradeCommand {
                 if !result.status.is_ok() {
                     let _ = save_dir_.delete_tree(&version_name);
                     let exit_code: u32 = match &result.status {
-                        Status::Exited(e) => u32::from(e.code),
+                        Status::Exited(e) => e.code,
                         Status::Signaled(sig) => 128 + u32::from(*sig),
                         _ => 1,
                     };

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -902,9 +902,9 @@ impl ShellSubprocess {
 
     pub fn on_process_exit(&mut self, _: &Process, status: &Status, _: &Rusage) {
         log!("onProcessExit({:x})", std::ptr::from_mut(self) as usize);
-        let exit_code: Option<u8> = 'brk: {
+        let exit_code: Option<sh::ExitCode> = 'brk: {
             if let Status::Exited(exited) = &status {
-                break 'brk Some(exited.code);
+                break 'brk Some(exited.code as sh::ExitCode);
             }
 
             if matches!(status, Status::Err(_)) {
@@ -913,7 +913,7 @@ impl ShellSubprocess {
 
             if matches!(status, Status::Signaled(_)) {
                 if let Some(code) = status.signal_code() {
-                    break 'brk Some(code.to_exit_code().unwrap());
+                    break 'brk Some(code.to_exit_code().unwrap().into());
                 }
             }
 
@@ -927,7 +927,7 @@ impl ShellSubprocess {
             // `&mut self` is dead by NLL before `on_exit` re-enters interp.
             let cmd = unsafe { handle.cmd_mut() };
             if cmd.exit_code.is_none() {
-                cmd.on_exit(code.into());
+                cmd.on_exit(code);
             }
         }
     }

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -422,7 +422,7 @@ pub fn run(opts: RunOptions<'_>) -> core::result::Result<RunResult, bun_core::Er
     // Map `Status` → `Term` (the subset
     // `repository.exec` matches on — `Exited`/else).
     let term = match result.status {
-        Status::Exited(e) => Term::Exited(u32::from(e.code)),
+        Status::Exited(e) => Term::Exited(e.code),
         Status::Signaled(sig) => Term::Signal(u32::from(sig)),
         Status::Err(_) | Status::Running => Term::Unknown(0),
     };

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -509,8 +509,12 @@ impl Process {
         // `uv_spawn`; libuv never overwrites it. `process` is not
         // dereferenced again after this point.
         let this: &mut Process = unsafe { bun_ptr::callback_ctx::<Process>((*process).data) };
-        let exit_code: u8 = if exit_status >= 0 {
-            (exit_status as u64) as u8
+        // Windows exit codes are a full 32-bit DWORD (GetExitCodeProcess).
+        // NTSTATUS crash codes live in the high bits (e.g. 0xC0000005 for an
+        // access violation), so narrowing here would collapse them into small
+        // ambiguous integers.
+        let exit_code: u32 = if exit_status >= 0 {
+            exit_status as u32
         } else {
             0
         };
@@ -719,7 +723,9 @@ pub enum Status {
 
 #[derive(Clone, Copy, Default)]
 pub struct Exited {
-    pub code: u8,
+    /// POSIX `WEXITSTATUS` is 8 bits, but Windows `GetExitCodeProcess` returns
+    /// a full `DWORD`. Store the wide value so NTSTATUS crash codes survive.
+    pub code: u32,
     /// Raw signal number. `0` means "no signal".
     /// `SignalCode` discriminants are 1..=31; storing it as the
     /// enum and transmuting `0` would be UB. Convert via `Status::signal_code`.
@@ -733,7 +739,7 @@ impl Status {
 
     #[cfg(unix)]
     pub fn from(pid: PidT, waitpid_result: &Maybe<WaitPidResult>) -> Option<Status> {
-        let mut exit_code: Option<u8> = None;
+        let mut exit_code: Option<u32> = None;
         let mut signal: Option<u8> = None;
 
         match waitpid_result {
@@ -749,7 +755,7 @@ impl Status {
                 let status = result.status as c_int;
 
                 if libc::WIFEXITED(status) {
-                    exit_code = Some(libc::WEXITSTATUS(status) as u8);
+                    exit_code = Some(libc::WEXITSTATUS(status) as u32);
                     // True if the process terminated due to receipt of a signal.
                 }
 

--- a/test/js/bun/spawn/exit-code.test.ts
+++ b/test/js/bun/spawn/exit-code.test.ts
@@ -1,6 +1,7 @@
-import { spawnSync } from "bun";
-import { expect, it } from "bun:test";
-import { bunExe } from "harness";
+import { spawn, spawnSync } from "bun";
+import { describe, expect, it } from "bun:test";
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 it("process.exit(1) works", () => {
   const { exitCode } = spawnSync([bunExe(), import.meta.dir + "/exit-code-1.js"]);
@@ -25,4 +26,60 @@ it("handled promise rejection reports exit code 0", () => {
 it("process.exit(0) works", () => {
   const { exitCode } = spawnSync([bunExe(), import.meta.dir + "/exit-code-0.js"]);
   expect(exitCode).toBe(0);
+});
+
+// Windows exit codes are a full 32-bit DWORD. NTSTATUS crash codes
+// (e.g. 0xC0000005 access violation) live in the high bits and must not be
+// truncated to 8 bits on the way to JS.
+describe.skipIf(!isWindows)("Windows 32-bit exit codes", () => {
+  const comspec = process.env.comspec || "cmd.exe";
+
+  it("spawnSync preserves codes > 255", () => {
+    const { exitCode, success } = spawnSync({
+      cmd: [comspec, "/c", "exit 300"],
+      env: bunEnv,
+    });
+    expect({ exitCode, success }).toEqual({ exitCode: 300, success: false });
+  });
+
+  it("spawn preserves codes > 255", async () => {
+    await using proc = spawn({
+      cmd: [comspec, "/c", "exit 300"],
+      env: bunEnv,
+    });
+    const exited = await proc.exited;
+    expect({ exited, exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      exited: 300,
+      exitCode: 300,
+      signalCode: null,
+    });
+  });
+
+  it("spawn onExit callback receives codes > 255", async () => {
+    const { promise, resolve } = Promise.withResolvers<number | null>();
+    await using proc = spawn({
+      cmd: [comspec, "/c", "exit 300"],
+      env: bunEnv,
+      onExit(_proc, exitCode) {
+        resolve(exitCode);
+      },
+    });
+    await proc.exited;
+    expect(await promise).toBe(300);
+  });
+
+  it("preserves NTSTATUS-range codes (e.g. 0xC0000005)", () => {
+    // cmd.exe parses `exit N` as a signed 32-bit integer. -1073741819 is
+    // 0xC0000005 reinterpreted as a DWORD, i.e. STATUS_ACCESS_VIOLATION.
+    const { exitCode } = spawnSync({
+      cmd: [comspec, "/c", "exit -1073741819"],
+      env: bunEnv,
+    });
+    expect(exitCode).toBe(0xc0000005);
+  });
+
+  it("node:child_process spawnSync preserves codes > 255", () => {
+    const { status } = nodeSpawnSync(comspec, ["/c", "exit 300"], { env: bunEnv });
+    expect(status).toBe(300);
+  });
 });

--- a/test/js/bun/spawn/exit-code.test.ts
+++ b/test/js/bun/spawn/exit-code.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { spawnSync as nodeSpawnSync } from "node:child_process";
 import { bunEnv, bunExe, isWindows } from "harness";
+import { spawnSync as nodeSpawnSync } from "node:child_process";
 
 it("process.exit(1) works", () => {
   const { exitCode } = spawnSync([bunExe(), import.meta.dir + "/exit-code-1.js"]);


### PR DESCRIPTION
## Problem

Windows exit codes are a full 32-bit `DWORD` and NTSTATUS crash codes live in the high bits. A child dying of an access violation exits with `0xC0000005` (3221225477), heap corruption is `0xC0000374`, stack overflow is `0xC00000FD`, and so on.

Bun stored the exit code as `u8`, so every crash code collapsed into a meaningless small integer that is indistinguishable from a clean `process.exit(N)`:

| child actually exited with | Bun reported | Node reports |
|---|---|---|
| `0xC0000005` (access violation) | 5 | 3221225477 |
| `0xC0000374` (heap corruption) | 116 | 3221226356 |
| `0xC00000FD` (stack overflow) | 253 | 3221225725 |
| `300` | 44 | 300 |

The truncation happened in the libuv exit callback at `src/spawn/process.rs`, and the `u8` propagated through `Exited::code` to `subprocess.exitCode`, `await proc.exited`, the `onExit` callback, `Bun.spawnSync`, and `node:child_process`.

## Repro (Windows)

```js
const { spawnSync } = require('bun');
const { exitCode } = spawnSync({ cmd: ['cmd.exe', '/c', 'exit -1073741819'] });
console.log(exitCode); // 5 before, 3221225477 after (matches Node)
```

## Fix

Widen `Exited::code` from `u8` to `u32` and stop narrowing the libuv `exit_status` in `on_exit_uv`. POSIX `WEXITSTATUS` is genuinely 8 bits so behavior there is unchanged. Consumers that compared against small integers or widened to `u32`/`f64` continue to work; the handful that narrowed the return type (`filter_run`/`multi_run` `finalize`, `pm_version_command`) are updated. The shell's internal `ExitCode = u16` is kept and truncated at the boundary in `subproc.rs` since $? is conventionally a small integer there.

## Verification

Node v26.3.0 on Windows:

```
cmd /c exit -1073741819  -> { status: 3221225477, signal: null }
cmd /c exit 300          -> { status: 300, signal: null }
```

New tests in `test/js/bun/spawn/exit-code.test.ts` cover `Bun.spawnSync`, `Bun.spawn` (`.exited`, `.exitCode`, `onExit`), and `node:child_process.spawnSync`.

Windows (this change): `bun bd test test/js/bun/spawn/exit-code.test.ts` -> 10 pass, 0 fail
Windows (canary, fail-before): 5 pass, 5 fail (300 -> 44, 0xC0000005 -> 5)
Linux: 5 pass, 5 skip (POSIX WEXITSTATUS is 8-bit, new cases are Windows-only)

The new tests are `describe.skipIf(!isWindows)` because POSIX cannot observe exit codes above 255; the Windows CI lane exercises them.