### PR TITLE
Bun.serve: fall back to server authority when Host cannot form a valid request.url

### DIFF
--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -159,6 +159,23 @@ impl AnyRequestContext {
         dispatch!(self, None, |_T, ctx| ctx.get_remote_socket_info())
     }
 
+    /// The server's configured base URL (`scheme://authority[/path]`, no
+    /// trailing `/`). Used by `Request::ensure_url()` to synthesize a valid
+    /// absolute `request.url` when the client's Host header is absent
+    /// (HTTP/1.0) or cannot form a valid URL authority (RFC 9112 §3.3).
+    pub fn fallback_base_url(self) -> Option<&'static [u8]> {
+        dispatch!(self, None, |_T, ctx| {
+            let base = &*ctx.server.as_ref()?.base_url_string_for_joining;
+            if base.is_empty() {
+                return None;
+            }
+            // SAFETY: the server (BACKREF) outlives every RequestContext it
+            // allocates and `base_url_string_for_joining` is assigned once in
+            // `NewServer::init()`, never reassigned.
+            Some(unsafe { bun_ptr::detach_lifetime(base) })
+        })
+    }
+
     pub fn detach_request(self) {
         dispatch!(self, (), |_T, ctx| {
             ctx.req = None;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3094,27 +3094,12 @@ where
                 ))
             }));
             // NOTE: `ReqLike::{url,header}` both borrow `&mut req`; the
-            // returned slices alias the same uWS-owned header buffer. Format
-            // the `https://{host}` prefix while `host` is borrowed so the
-            // second `&mut req` borrow for `url` is unconflicted.
-            let prefix: Option<Vec<u8>> = ReqLike::header(req, b"host").map(|host| {
-                let fmt = bun_fmt::HostFormatter {
-                    is_https: true,
-                    host,
-                    port: None,
-                };
-                let mut s = Vec::new();
-                write!(&mut s, "https://{}", fmt).ok();
-                s
-            });
+            // returned slices alias the same uWS-owned header buffer. Copy
+            // `host` out before taking the second `&mut req` borrow for `url`.
+            let host: Option<Vec<u8>> = ReqLike::header(req, b"host").map(<[u8]>::to_vec);
             let path = ReqLike::url(req);
             if !path.is_empty() && path[0] == b'/' {
-                if let Some(mut s) = prefix {
-                    s.extend_from_slice(path);
-                    request_object.url.set(BunString::clone_utf8(&s));
-                } else {
-                    request_object.url.set(BunString::clone_utf8(path));
-                }
+                request_object.set_url_for_origin_form(host.as_deref(), path);
             } else {
                 request_object.url.set(BunString::clone_utf8(path));
             }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -859,10 +859,6 @@ impl Request {
                     .header(b"host")
                     .filter(|host| Self::is_valid_host_header(host))
                 {
-                    // With `port: None`, HostFormatter always emits exactly `host`, so the
-                    // formatted byte-count is just `host.len()`. Avoid the `core::fmt::write`
-                    // vtable dispatch that `bun_fmt::count(format_args!(...))` incurs — this
-                    // runs once per request via JSC extra-memory accounting.
                     return self.get_protocol().len() + host.len() + req_url.len();
                 }
                 if let Some(base) = self.request_context.fallback_base_url() {
@@ -973,65 +969,51 @@ impl Request {
         debug_assert!(!req_url.is_empty() && req_url[0] == b'/');
 
         if let Some(host) = host.filter(|h| Self::is_valid_host_header(h)) {
-            // With `port: None`, HostFormatter always emits exactly `host`. Compute the
-            // length and assemble the URL with straight slice copies instead of going
-            // through `core::fmt::write` (which is not monomorphized and shows up in
-            // per-request profiles).
-            let protocol = self.get_protocol();
-            let url_bytelength = protocol.len() + host.len() + req_url.len();
-
-            if url_bytelength < 128 {
-                let mut buffer = [0u8; 128];
-                let url = {
-                    let mut at = 0;
-                    buffer[at..at + protocol.len()].copy_from_slice(protocol);
-                    at += protocol.len();
-                    buffer[at..at + host.len()].copy_from_slice(host);
-                    at += host.len();
-                    buffer[at..at + req_url.len()].copy_from_slice(req_url);
-                    at += req_url.len();
-                    &buffer[..at]
-                };
-
-                let href = bun_url::href_from_string(&BunString::from_bytes(url));
-                if !href.is_empty() {
-                    if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
-                        self.url.set(BunString::clone_latin1(&url[..href.length()]));
-                        href.deref();
-                    } else {
-                        self.url.set(href);
-                    }
-                    return;
-                }
-            } else {
-                if strings::is_all_ascii(host) && strings::is_all_ascii(req_url) {
-                    let (new_url, bytes) = BunString::create_uninitialized_latin1(url_bytelength);
-                    self.url.set(new_url);
-                    // exact space was counted above
-                    let (a, rest) = bytes.split_at_mut(protocol.len());
-                    let (b, c) = rest.split_at_mut(host.len());
-                    a.copy_from_slice(protocol);
-                    b.copy_from_slice(host);
-                    c.copy_from_slice(req_url);
-                } else {
-                    // slow path
-                    let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);
-                    temp_url.extend_from_slice(protocol);
-                    temp_url.extend_from_slice(host);
-                    temp_url.extend_from_slice(req_url);
-                    // `defer bun.default_allocator.free(temp_url)` → Vec drops at scope end
-                    self.url.set(BunString::clone_utf8(&temp_url));
-                }
-
-                let href = bun_url::href_from_string(&self.url.get());
-                if !href.is_empty() {
-                    self.url.set(href);
-                    return;
-                }
+            if self.try_set_url(&[self.get_protocol(), host, req_url]) {
+                return;
             }
         }
-
         self.set_url_from_fallback_authority(req_url);
+    }
+
+    /// Concatenate `parts`, run through the WHATWG URL parser, and on success
+    /// set `self.url` to the normalized href. Assembled with slice copies (no
+    /// `core::fmt::write`), using a stack buffer under 128 bytes and writing
+    /// straight into a `WTFStringImpl` for longer ASCII input so
+    /// `href_from_string`'s `toWTFString()` is a ref-bump rather than a copy.
+    fn try_set_url(&self, parts: &[&[u8]]) -> bool {
+        let len: usize = parts.iter().map(|p| p.len()).sum();
+        let concat = |dst: &mut [u8]| {
+            let mut at = 0;
+            for p in parts {
+                dst[at..at + p.len()].copy_from_slice(p);
+                at += p.len();
+            }
+        };
+
+        let href = if len < 128 {
+            let mut stack = [0u8; 128];
+            concat(&mut stack[..len]);
+            bun_url::href_from_string(&BunString::from_bytes(&stack[..len]))
+        } else if parts.iter().all(|p| strings::is_all_ascii(p)) {
+            let (s, bytes) = BunString::create_uninitialized_latin1(len);
+            concat(bytes);
+            let href = bun_url::href_from_string(&s);
+            s.deref();
+            href
+        } else {
+            let mut heap = Vec::with_capacity(len);
+            for p in parts {
+                heap.extend_from_slice(p);
+            }
+            bun_url::href_from_string(&BunString::from_bytes(&heap))
+        };
+
+        if href.is_empty() {
+            return false;
+        }
+        self.url.set(href);
+        true
     }
 
     /// Cold path for [`set_url_for_origin_form`]: the client sent no Host, a
@@ -1042,17 +1024,7 @@ impl Request {
     fn set_url_from_fallback_authority(&self, req_url: &[u8]) {
         if let Some(base) = self.request_context.fallback_base_url() {
             let origin = bun_url::origin_from_slice(base).unwrap_or(base);
-            let mut buf = Vec::with_capacity(origin.len() + req_url.len());
-            buf.extend_from_slice(origin);
-            buf.extend_from_slice(req_url);
-            let href = bun_url::href_from_string(&BunString::from_bytes(&buf));
-            if !href.is_empty() {
-                if core::ptr::eq(href.byte_slice().as_ptr(), buf.as_ptr()) {
-                    self.url.set(BunString::clone_latin1(&buf[..href.length()]));
-                    href.deref();
-                } else {
-                    self.url.set(href);
-                }
+            if self.try_set_url(&[origin, req_url]) {
                 return;
             }
         }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -865,6 +865,9 @@ impl Request {
                     // runs once per request via JSC extra-memory accounting.
                     return self.get_protocol().len() + host.len() + req_url.len();
                 }
+                if let Some(base) = self.request_context.fallback_base_url() {
+                    return base.len() + req_url.len();
+                }
             }
             return req_url.len();
         }
@@ -906,9 +909,11 @@ impl Request {
         }
     }
 
-    /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set. A Host value outside it, or an empty
-    /// one, cannot form a URL authority, so `request.url` synthesis falls back to the
-    /// configured host instead of pasting the client bytes into the URL.
+    /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set. Rejects Host values that
+    /// cannot possibly form a URL authority so the fast path skips straight to
+    /// the server-authority fallback; values that pass here may still be
+    /// structurally invalid (port out of range, unclosed `[`, bad percent
+    /// escape), which `href_from_string` then catches.
     fn is_valid_host_header(host: &[u8]) -> bool {
         !host.is_empty()
             && host.iter().all(|&c| {
@@ -947,80 +952,8 @@ impl Request {
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
             if !req_url.is_empty() && req_url[0] == b'/' {
-                if let Some(host) = req
-                    .header(b"host")
-                    .filter(|host| Self::is_valid_host_header(host))
-                {
-                    // With `port: None`, HostFormatter always emits exactly `host`. Compute the
-                    // length and assemble the URL with straight slice copies instead of going
-                    // through `core::fmt::write` (which is not monomorphized and shows up in
-                    // per-request profiles).
-                    let protocol = self.get_protocol();
-                    let url_bytelength = protocol.len() + host.len() + req_url.len();
-
-                    #[cfg(debug_assertions)]
-                    debug_assert!(self.size_of_url() == url_bytelength);
-
-                    if url_bytelength < 128 {
-                        let mut buffer = [0u8; 128];
-                        let url = {
-                            let mut at = 0;
-                            buffer[at..at + protocol.len()].copy_from_slice(protocol);
-                            at += protocol.len();
-                            buffer[at..at + host.len()].copy_from_slice(host);
-                            at += host.len();
-                            buffer[at..at + req_url.len()].copy_from_slice(&req_url);
-                            at += req_url.len();
-                            &buffer[..at]
-                        };
-
-                        #[cfg(debug_assertions)]
-                        debug_assert!(self.size_of_url() == url.len());
-
-                        let href = bun_url::href_from_string(&BunString::from_bytes(url));
-                        if !href.is_empty() {
-                            if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
-                                self.url.set(BunString::clone_latin1(&url[..href.length()]));
-                                href.deref();
-                            } else {
-                                self.url.set(href);
-                            }
-                        } else {
-                            // TODO: what is the right thing to do for invalid URLS?
-                            self.url.set(BunString::clone_utf8(url));
-                        }
-
-                        return Ok(());
-                    }
-
-                    if strings::is_all_ascii(host) && strings::is_all_ascii(&req_url) {
-                        let (new_url, bytes) =
-                            BunString::create_uninitialized_latin1(url_bytelength);
-                        self.url.set(new_url);
-                        // exact space was counted above
-                        let (a, rest) = bytes.split_at_mut(protocol.len());
-                        let (b, c) = rest.split_at_mut(host.len());
-                        a.copy_from_slice(protocol);
-                        b.copy_from_slice(host);
-                        c.copy_from_slice(&req_url);
-                    } else {
-                        // slow path
-                        let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);
-                        temp_url.extend_from_slice(protocol);
-                        temp_url.extend_from_slice(host);
-                        temp_url.extend_from_slice(&req_url);
-                        // `defer bun.default_allocator.free(temp_url)` → Vec drops at scope end
-                        self.url.set(BunString::clone_utf8(&temp_url));
-                    }
-
-                    let href = bun_url::href_from_string(&self.url.get());
-                    // TODO: what is the right thing to do for invalid URLS?
-                    if !href.is_empty() {
-                        self.url.set(href);
-                    }
-
-                    return Ok(());
-                }
+                self.set_url_for_origin_form(req.header(b"host"), &req_url);
+                return Ok(());
             }
 
             #[cfg(debug_assertions)]
@@ -1028,6 +961,101 @@ impl Request {
             self.url.set(BunString::clone_utf8(&req_url));
         }
         Ok(())
+    }
+
+    /// Synthesize and set `self.url` for an origin-form request target
+    /// (`req_url` starts with `/`). Uses `host` as the authority when it
+    /// yields a valid WHATWG URL, else falls back to the server's configured
+    /// authority (RFC 9112 §3.3) so the result is always a valid absolute URL
+    /// that `new URL(req.url)` and `new Request(req)` accept.
+    pub(crate) fn set_url_for_origin_form(&self, host: Option<&[u8]>, req_url: &[u8]) {
+        debug_assert!(!req_url.is_empty() && req_url[0] == b'/');
+
+        if let Some(host) = host.filter(|h| Self::is_valid_host_header(h)) {
+            // With `port: None`, HostFormatter always emits exactly `host`. Compute the
+            // length and assemble the URL with straight slice copies instead of going
+            // through `core::fmt::write` (which is not monomorphized and shows up in
+            // per-request profiles).
+            let protocol = self.get_protocol();
+            let url_bytelength = protocol.len() + host.len() + req_url.len();
+
+            if url_bytelength < 128 {
+                let mut buffer = [0u8; 128];
+                let url = {
+                    let mut at = 0;
+                    buffer[at..at + protocol.len()].copy_from_slice(protocol);
+                    at += protocol.len();
+                    buffer[at..at + host.len()].copy_from_slice(host);
+                    at += host.len();
+                    buffer[at..at + req_url.len()].copy_from_slice(req_url);
+                    at += req_url.len();
+                    &buffer[..at]
+                };
+
+                let href = bun_url::href_from_string(&BunString::from_bytes(url));
+                if !href.is_empty() {
+                    if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
+                        self.url.set(BunString::clone_latin1(&url[..href.length()]));
+                        href.deref();
+                    } else {
+                        self.url.set(href);
+                    }
+                    return;
+                }
+            } else {
+                if strings::is_all_ascii(host) && strings::is_all_ascii(req_url) {
+                    let (new_url, bytes) = BunString::create_uninitialized_latin1(url_bytelength);
+                    self.url.set(new_url);
+                    // exact space was counted above
+                    let (a, rest) = bytes.split_at_mut(protocol.len());
+                    let (b, c) = rest.split_at_mut(host.len());
+                    a.copy_from_slice(protocol);
+                    b.copy_from_slice(host);
+                    c.copy_from_slice(req_url);
+                } else {
+                    // slow path
+                    let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);
+                    temp_url.extend_from_slice(protocol);
+                    temp_url.extend_from_slice(host);
+                    temp_url.extend_from_slice(req_url);
+                    // `defer bun.default_allocator.free(temp_url)` → Vec drops at scope end
+                    self.url.set(BunString::clone_utf8(&temp_url));
+                }
+
+                let href = bun_url::href_from_string(&self.url.get());
+                if !href.is_empty() {
+                    self.url.set(href);
+                    return;
+                }
+            }
+        }
+
+        self.set_url_from_fallback_authority(req_url);
+    }
+
+    /// Cold path for [`set_url_for_origin_form`]: the client sent no Host, a
+    /// Host outside the RFC 3986 authority byte set, or one that parsed to an
+    /// invalid URL (port > 65535, unclosed IPv6 bracket, bad percent escape).
+    /// RFC 9112 §3.3 directs the server to substitute its own authority.
+    #[cold]
+    fn set_url_from_fallback_authority(&self, req_url: &[u8]) {
+        if let Some(base) = self.request_context.fallback_base_url() {
+            let origin = bun_url::origin_from_slice(base).unwrap_or(base);
+            let mut buf = Vec::with_capacity(origin.len() + req_url.len());
+            buf.extend_from_slice(origin);
+            buf.extend_from_slice(req_url);
+            let href = bun_url::href_from_string(&BunString::from_bytes(&buf));
+            if !href.is_empty() {
+                if core::ptr::eq(href.byte_slice().as_ptr(), buf.as_ptr()) {
+                    self.url.set(BunString::clone_latin1(&buf[..href.length()]));
+                    href.deref();
+                } else {
+                    self.url.set(href);
+                }
+                return;
+            }
+        }
+        self.url.set(BunString::clone_utf8(req_url));
     }
 }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -866,7 +866,8 @@ impl Request {
                     return self.get_protocol().len() + host.len() + req_url.len();
                 }
                 if let Some(base) = self.request_context.fallback_base_url() {
-                    return base.len() + req_url.len();
+                    return bun_url::origin_from_slice(base).map_or(base.len(), <[u8]>::len)
+                        + req_url.len();
                 }
             }
             return req_url.len();

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -862,8 +862,7 @@ impl Request {
                     return self.get_protocol().len() + host.len() + req_url.len();
                 }
                 if let Some(base) = self.request_context.fallback_base_url() {
-                    return bun_url::origin_from_slice(base).map_or(base.len(), <[u8]>::len)
-                        + req_url.len();
+                    return Self::fallback_origin(base).len() + req_url.len();
                 }
             }
             return req_url.len();
@@ -1023,12 +1022,25 @@ impl Request {
     #[cold]
     fn set_url_from_fallback_authority(&self, req_url: &[u8]) {
         if let Some(base) = self.request_context.fallback_base_url() {
-            let origin = bun_url::origin_from_slice(base).unwrap_or(base);
-            if self.try_set_url(&[origin, req_url]) {
+            if self.try_set_url(&[Self::fallback_origin(base), req_url]) {
                 return;
             }
         }
         self.url.set(BunString::clone_utf8(req_url));
+    }
+
+    /// Origin prefix (`scheme://authority`) of `base_url_string_for_joining`.
+    /// ServerConfig validates `base` to have no userinfo/query/fragment, so the
+    /// origin is the prefix up to the first `/` past `://`. A byte scan avoids
+    /// `origin_from_slice`, whose `pathStart()` offset is computed on the
+    /// WHATWG-canonicalized form and would mis-slice a non-canonical authority
+    /// (uncompressed IPv6, leading-zero port) in the raw input.
+    fn fallback_origin(base: &[u8]) -> &[u8] {
+        let after_scheme = strings::index_of(base, b"://").map_or(0, |i| i + 3);
+        match strings::index_of_char_pos(base, b'/', after_scheme) {
+            Some(i) => &base[..i],
+            None => base,
+        }
     }
 }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1030,15 +1030,18 @@ impl Request {
     }
 
     /// Origin prefix (`scheme://authority`) of `base_url_string_for_joining`.
-    /// ServerConfig validates `base` to have no userinfo/query/fragment, so the
-    /// origin is the prefix up to the first `/` past `://`. A byte scan avoids
+    /// ServerConfig validates `base` to have no userinfo, so the origin is the
+    /// prefix up to the first `/`, `?`, or `#` past `://`. A byte scan avoids
     /// `origin_from_slice`, whose `pathStart()` offset is computed on the
     /// WHATWG-canonicalized form and would mis-slice a non-canonical authority
     /// (uncompressed IPv6, leading-zero port) in the raw input.
     fn fallback_origin(base: &[u8]) -> &[u8] {
         let after_scheme = strings::index_of(base, b"://").map_or(0, |i| i + 3);
-        match strings::index_of_char_pos(base, b'/', after_scheme) {
-            Some(i) => &base[..i],
+        match base[after_scheme..]
+            .iter()
+            .position(|&c| matches!(c, b'/' | b'?' | b'#'))
+        {
+            Some(i) => &base[..after_scheme + i],
             None => base,
         }
     }

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1428,25 +1428,31 @@ describe("Host header field values in request.url", () => {
     ["example.com#frag"],
     ["example.com\\other:8080"],
     ["[::1]:3000?q"],
-  ])("an HTTP/1.1 request whose Host header is %j is served, with the server's authority as request.url", async host => {
-    await using server = Bun.serve({
-      port: 0,
-      hostname: "127.0.0.1",
-      fetch(req) {
-        return new Response(req.url);
-      },
-    });
+  ])(
+    "an HTTP/1.1 request whose Host header is %j is served, with the server's authority as request.url",
+    async host => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          return new Response(req.url);
+        },
+      });
 
-    const response = await sendRawRequest(server, `GET /index HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
-    expect(response).toStartWith("HTTP/1.1 200");
-    // The handler ran, and none of the Host field's bytes were copied into the synthesized URL:
-    // the authority is the server's own configured hostname (RFC 9112 3.3 fallback).
-    const url = new URL(response.slice(response.indexOf("\r\n\r\n") + 4));
-    expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
-      hostname: "127.0.0.1",
-      pathname: "/index",
-    });
-  });
+      const response = await sendRawRequest(
+        server,
+        `GET /index HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`,
+      );
+      expect(response).toStartWith("HTTP/1.1 200");
+      // The handler ran, and none of the Host field's bytes were copied into the synthesized URL:
+      // the authority is the server's own configured hostname (RFC 9112 3.3 fallback).
+      const url = new URL(response.slice(response.indexOf("\r\n\r\n") + 4));
+      expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
+        hostname: "127.0.0.1",
+        pathname: "/index",
+      });
+    },
+  );
 
   test.each([
     ["example.com", "http://example.com/index"],

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1428,7 +1428,7 @@ describe("Host header field values in request.url", () => {
     ["example.com#frag"],
     ["example.com\\other:8080"],
     ["[::1]:3000?q"],
-  ])("an HTTP/1.1 request whose Host header is %j is served, with the request-target as request.url", async host => {
+  ])("an HTTP/1.1 request whose Host header is %j is served, with the server's authority as request.url", async host => {
     await using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -1439,8 +1439,13 @@ describe("Host header field values in request.url", () => {
 
     const response = await sendRawRequest(server, `GET /index HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
     expect(response).toStartWith("HTTP/1.1 200");
-    // The handler ran, and none of the Host field's bytes were copied into the synthesized URL.
-    expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/index");
+    // The handler ran, and none of the Host field's bytes were copied into the synthesized URL:
+    // the authority is the server's own configured hostname (RFC 9112 3.3 fallback).
+    const url = new URL(response.slice(response.indexOf("\r\n\r\n") + 4));
+    expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
+      hostname: "127.0.0.1",
+      pathname: "/index",
+    });
   });
 
   test.each([
@@ -1487,9 +1492,10 @@ describe("Host header field values in request.url", () => {
     }
   });
 
-  test("accepts an empty Host header field value on HTTP/1.1, serving a request URL with no host", async () => {
+  test("accepts an empty Host header field value on HTTP/1.1, falling back to the server's authority", async () => {
     await using server = Bun.serve({
       port: 0,
+      hostname: "127.0.0.1",
       fetch(req) {
         return new Response(req.url);
       },
@@ -1497,7 +1503,11 @@ describe("Host header field values in request.url", () => {
 
     const response = await sendRawRequest(server, "GET /index HTTP/1.1\r\nHost:\r\nConnection: close\r\n\r\n");
     expect(response).toContain("HTTP/1.1 200");
-    expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/index");
+    const url = new URL(response.slice(response.indexOf("\r\n\r\n") + 4));
+    expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
+      hostname: "127.0.0.1",
+      pathname: "/index",
+    });
   });
 
   test.each([
@@ -1518,6 +1528,10 @@ describe("Host header field values in request.url", () => {
       // RFC 3986 `uri-host [ ":" port ]`: unreserved / sub-delims / "%" / ":" / "[" / "]".
       // Every byte in [0x7f, 0xff] is outside that set, so neither URL uses any of them.
       const isHostByte = (char: string) => /^[A-Za-z0-9._~%!$&'()*+,;=:\[\]-]$/.test(char);
+
+      // The url the server falls back to when the Host can't form a valid authority.
+      const fallbackUrl = (await sendRawRequest(server, "GET /p HTTP/1.0\r\n\r\n")).split("\r\n\r\n")[1];
+      expect(new URL(fallbackUrl).pathname).toBe("/p");
 
       async function checkByte(byte: number) {
         const char = String.fromCharCode(byte);
@@ -1546,8 +1560,12 @@ describe("Host header field values in request.url", () => {
       expect(results).toEqual(
         bytes.map(byte => {
           const char = String.fromCharCode(byte);
-          // `req.url` carries the lowercased host (URL host normalization).
-          const url = isHostByte(char) ? `http://a${char.toLowerCase()}b/p` : "/p";
+          // `req.url` carries the lowercased host (URL host normalization) when the Host is in
+          // the RFC 3986 byte set AND forms a parseable URL; otherwise the server's own
+          // authority is substituted. `% : [ ]` pass the byte set but `a%b`/`a:b`/`a[b`/`a]b`
+          // are not valid WHATWG authorities, so they fall back too.
+          const candidate = `http://a${char}b/p`;
+          const url = isHostByte(char) && URL.canParse(candidate) ? new URL(candidate).href : fallbackUrl;
           return {
             char,
             http11Accepted: true,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -524,29 +524,136 @@ it("request.url should be based on the Host header", async () => {
   );
 });
 
-it.each([
-  ["HTTP/1.0", "GET /helloooo HTTP/1.0\r\nHost: a/b\r\n\r\n"],
-  ["HTTP/1.1", "GET /helloooo HTTP/1.1\r\nHost: a b\r\nConnection: close\r\n\r\n"],
-])("request.url is the request-target when the %s Host header is not a valid authority", async (_version, payload) => {
-  using server = Bun.serve({
-    port: 0,
-    hostname: "127.0.0.1",
-    fetch(req) {
-      return new Response(req.url);
-    },
+// `request.url` must always be a valid absolute URL so the documented
+// `new URL(req.url).pathname` pattern and `new Request(req)` never throw, even
+// when the client sends no Host (legal for HTTP/1.0; haproxy's default
+// `option httpchk` probe does this) or a Host that cannot form a URL authority.
+describe("request.url falls back to the server's authority when Host is unusable", () => {
+  async function play(port: number, payload: string): Promise<string> {
+    const socket = net.connect(port, "127.0.0.1");
+    try {
+      return await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        socket.on("error", reject);
+        socket.on("data", chunk => chunks.push(chunk));
+        socket.on("close", () => resolve(Buffer.concat(chunks).toString()));
+        socket.write(payload);
+      });
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  const longPath = "/long" + Buffer.alloc(160, "a").toString();
+  it.each([
+    ["HTTP/1.0 with no Host", "/helloooo", "GET /helloooo HTTP/1.0\r\n\r\n"],
+    ["HTTP/1.0 Host containing /", "/helloooo", "GET /helloooo HTTP/1.0\r\nHost: a/b\r\n\r\n"],
+    ["HTTP/1.1 Host containing a space", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: a b\r\nConnection: close\r\n\r\n"],
+    ["HTTP/1.1 Host with out-of-range port", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n"],
+    ["HTTP/1.1 Host with unclosed IPv6 bracket", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: [::1\r\nConnection: close\r\n\r\n"],
+    ["HTTP/1.1 Host with bad percent escape", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: a%zz\r\nConnection: close\r\n\r\n"],
+    ["HTTP/1.1 empty Host", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: \r\nConnection: close\r\n\r\n"],
+    ["HTTP/1.0 no Host, long path (>128 byte URL)", longPath, `GET ${longPath} HTTP/1.0\r\n\r\n`],
+    ["HTTP/1.1 Host with out-of-range port, long path", longPath, `GET ${longPath} HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n`],
+  ])("%s", async (_name, path, payload) => {
+    let observed: { url: string; cloneErr: string | null } | undefined;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        let cloneErr: string | null = null;
+        try {
+          new Request(req);
+        } catch (e) {
+          cloneErr = (e as Error).message;
+        }
+        observed = { url: req.url, cloneErr };
+        return new Response(new URL(req.url).pathname);
+      },
+      error(e) {
+        return new Response("HANDLER-THREW " + (e as Error).message, { status: 500 });
+      },
+    });
+
+    const raw = await play(server.port, payload);
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({ status: raw.slice(0, raw.indexOf("\r\n")), body, observed }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: path,
+      observed: { url: expect.any(String), cloneErr: null },
+    });
+    const url = new URL(observed!.url);
+    expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
+      hostname: "127.0.0.1",
+      pathname: path,
+    });
   });
 
-  const socket = net.connect(server.port, "127.0.0.1");
-  const response = await new Promise<string>((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    socket.on("error", reject);
-    socket.on("data", chunk => chunks.push(chunk));
-    socket.on("close", () => resolve(Buffer.concat(chunks).toString()));
-    socket.write(payload);
+  it("in the routes: handler (HTTP/1.0 no Host)", async () => {
+    let observed: string | undefined;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: {
+        "/app/*": req => {
+          observed = req.url;
+          return new Response(new URL(req.url).pathname);
+        },
+      },
+      fetch: () => new Response("fallback"),
+      error(e) {
+        return new Response("HANDLER-THREW " + (e as Error).message, { status: 500 });
+      },
+    });
+
+    const raw = await play(server.port, "GET /app/x HTTP/1.0\r\n\r\n");
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({ status: raw.slice(0, raw.indexOf("\r\n")), body }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "/app/x",
+    });
+    expect(new URL(observed!).pathname).toBe("/app/x");
   });
-  socket.destroy();
-  expect(response).toStartWith("HTTP/1.1 200");
-  expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/helloooo");
+
+  // When the fetch handler returns a Promise the url is materialized by
+  // `to_async()` before the uWS request handle is detached; cover that path.
+  it("in an async fetch handler (HTTP/1.0 no Host)", async () => {
+    let observed: string | undefined;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        await 1;
+        observed = req.url;
+        return new Response(new URL(req.url).pathname);
+      },
+      error(e) {
+        return new Response("HANDLER-THREW " + (e as Error).message, { status: 500 });
+      },
+    });
+
+    const raw = await play(server.port, "GET /late HTTP/1.0\r\n\r\n");
+    const body = raw.slice(raw.indexOf("\r\n\r\n") + 4);
+    expect({ status: raw.slice(0, raw.indexOf("\r\n")), body }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "/late",
+    });
+    expect(new URL(observed!).pathname).toBe("/late");
+  });
+
+  // A valid Host must still take precedence over the fallback.
+  it("still uses a valid Host header verbatim", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => new Response(req.url),
+    });
+    const raw = await play(
+      server.port,
+      "GET /helloooo HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n",
+    );
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("http://example.com/helloooo");
+  });
 });
 
 describe("streaming", () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -671,6 +671,24 @@ describe("request.url falls back to the server's authority when Host is unusable
     const raw = await play(server.port, "GET /helloooo HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n");
     expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("http://example.com/helloooo");
   });
+
+  it.each([
+    ["http://[0:0:0:0:0:0:0:1]:3000/", "[::1]"],
+    ["http://example.com:0080/api/v1/", "example.com"],
+  ])("with a non-canonical baseURI %j (HTTP/1.0 no Host)", async (baseURI, expectedHost) => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      baseURI,
+      fetch: req => new Response(req.url),
+    });
+    const raw = await play(server.port, "GET /x HTTP/1.0\r\n\r\n");
+    const url = new URL(raw.slice(raw.indexOf("\r\n\r\n") + 4));
+    expect({ hostname: url.hostname, pathname: url.pathname }).toEqual({
+      hostname: expectedHost,
+      pathname: "/x",
+    });
+  });
 });
 
 describe("streaming", () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -675,6 +675,8 @@ describe("request.url falls back to the server's authority when Host is unusable
   it.each([
     ["http://[0:0:0:0:0:0:0:1]:3000/", "[::1]"],
     ["http://example.com:0080/api/v1/", "example.com"],
+    ["http://example.com?tenant=a", "example.com"],
+    ["http://example.com#frag", "example.com"],
   ])("with a non-canonical baseURI %j (HTTP/1.0 no Host)", async (baseURI, expectedHost) => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -548,13 +548,33 @@ describe("request.url falls back to the server's authority when Host is unusable
   it.each([
     ["HTTP/1.0 with no Host", "/helloooo", "GET /helloooo HTTP/1.0\r\n\r\n"],
     ["HTTP/1.0 Host containing /", "/helloooo", "GET /helloooo HTTP/1.0\r\nHost: a/b\r\n\r\n"],
-    ["HTTP/1.1 Host containing a space", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: a b\r\nConnection: close\r\n\r\n"],
-    ["HTTP/1.1 Host with out-of-range port", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n"],
-    ["HTTP/1.1 Host with unclosed IPv6 bracket", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: [::1\r\nConnection: close\r\n\r\n"],
-    ["HTTP/1.1 Host with bad percent escape", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: a%zz\r\nConnection: close\r\n\r\n"],
+    [
+      "HTTP/1.1 Host containing a space",
+      "/helloooo",
+      "GET /helloooo HTTP/1.1\r\nHost: a b\r\nConnection: close\r\n\r\n",
+    ],
+    [
+      "HTTP/1.1 Host with out-of-range port",
+      "/helloooo",
+      "GET /helloooo HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n",
+    ],
+    [
+      "HTTP/1.1 Host with unclosed IPv6 bracket",
+      "/helloooo",
+      "GET /helloooo HTTP/1.1\r\nHost: [::1\r\nConnection: close\r\n\r\n",
+    ],
+    [
+      "HTTP/1.1 Host with bad percent escape",
+      "/helloooo",
+      "GET /helloooo HTTP/1.1\r\nHost: a%zz\r\nConnection: close\r\n\r\n",
+    ],
     ["HTTP/1.1 empty Host", "/helloooo", "GET /helloooo HTTP/1.1\r\nHost: \r\nConnection: close\r\n\r\n"],
     ["HTTP/1.0 no Host, long path (>128 byte URL)", longPath, `GET ${longPath} HTTP/1.0\r\n\r\n`],
-    ["HTTP/1.1 Host with out-of-range port, long path", longPath, `GET ${longPath} HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n`],
+    [
+      "HTTP/1.1 Host with out-of-range port, long path",
+      longPath,
+      `GET ${longPath} HTTP/1.1\r\nHost: h:99999\r\nConnection: close\r\n\r\n`,
+    ],
   ])("%s", async (_name, path, payload) => {
     let observed: { url: string; cloneErr: string | null } | undefined;
     using server = Bun.serve({
@@ -648,10 +668,7 @@ describe("request.url falls back to the server's authority when Host is unusable
       hostname: "127.0.0.1",
       fetch: req => new Response(req.url),
     });
-    const raw = await play(
-      server.port,
-      "GET /helloooo HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n",
-    );
+    const raw = await play(server.port, "GET /helloooo HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n");
     expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("http://example.com/helloooo");
   });
 });


### PR DESCRIPTION
## Problem

`Bun.serve` hands the handler a `Request` whose `req.url` is not a valid absolute URL whenever the request has no usable authority. `new URL(req.url)` and `new Request(req)` both throw, so the documented routing pattern 500s.

```js
using srv = Bun.serve({
  port: 0, hostname: '127.0.0.1',
  routes: { '/app/*': req => new Response(new URL(req.url).pathname) },
  fetch: () => new Response('fallback'),
});
// Raw: GET /app/x HTTP/1.0\r\n\r\n   (haproxy 'option httpchk' default probe)
// -> 500  TypeError: "/app/x" cannot be parsed as a URL.
```

Two derivation classes, both dispatched with a matched route:

| request | `req.url` before | `new URL(req.url)` |
| --- | --- | --- |
| HTTP/1.0, no Host | `/exact` | throws |
| `Host: a b` / `Host: ` (empty) | `/exact` | throws |
| `Host: h:99999` | `http://h:99999/exact` | throws |
| `Host: [::1` | `http://[::1/exact` | throws |
| `Host: a%zz` | `http://a%zz/exact` | throws |

The fetch spec requires `Request.url` to be the serialization of a URL record, and RFC 9112 3.3 says an HTTP/1.0 request with no Host takes the server's configured authority.

## Cause

`Request::ensure_url()` synthesized the URL as `protocol + Host + path` only when `is_valid_host_header()` (a pure byte-set check with no structure or port-range validation) accepted the Host, else fell through to `self.url.set(req_url)` (the bare path). Both synthesis branches carried a `// TODO: what is the right thing to do for invalid URLS?` when `href_from_string` rejected the result, and left the unparseable string in place.

## Fix

When the Host header is absent, fails the byte-set check, or yields a string the WHATWG parser rejects, synthesize `request.url` from the server's configured authority instead (`NewServer::base_url_string_for_joining`, exposed via a new `AnyRequestContext::fallback_base_url()`). The fast path for a valid Host is unchanged. The synthesis is extracted into `Request::set_url_for_origin_form()` so the HTTP/3 eager-URL path in `server_body.rs` shares the same byte filter, WHATWG normalization, and fallback.

Not in this PR: responding 400 before dispatch for HTTP/1.1 requests with an invalid Host (RFC 9112 3.2). That is a larger behavioral change with compat implications; this PR only guarantees `req.url` is always a valid absolute URL.

## Verification

```
bun bd test test/js/bun/http/serve.test.ts -t 'request.url falls back'
# 12 pass (fails 11/12 on unfixed bun)
```

Covers: HTTP/1.0 no Host, Host with `/`, space, out-of-range port, unclosed `[`, bad `%`, empty, long paths (>128 bytes), `routes:` handler, async handler (the `to_async()` materialization path), and a control case asserting a valid Host is still used verbatim.

Fixes #17348

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->