### PR TITLE
lexer: fix `\u{...}` escape overflow and unterminated-brace accept

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -836,7 +836,8 @@ lexer_impl_header! {
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
                                     if !iterator.next(&mut iter) {
-                                        break 'variable_length;
+                                        // Ran out of literal before the closing `}`.
+                                        return self.syntax_error();
                                     }
                                     c3 = iter.c;
 
@@ -849,7 +850,9 @@ lexer_impl_header! {
                                         break 'variable_length;
                                     }
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        // Saturate: `is_out_of_range` is sticky, so any
+                                        // digit count still reports the range error.
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1051,7 +1051,8 @@ impl<'a> Lexer<'a> {
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
                                     if !iterator.next(&mut iter) {
-                                        break 'variable_length;
+                                        // Ran out of literal before the closing `}`.
+                                        return self.syntax_error();
                                     }
                                     c3 = iter.c;
 
@@ -1064,7 +1065,9 @@ impl<'a> Lexer<'a> {
                                         break 'variable_length;
                                     }
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        // Saturate: `is_out_of_range` is sticky, so any
+                                        // digit count still reports the range error.
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -68,6 +68,36 @@ test("Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings", 
   expect(Bun.TOML.parse(input).k).toBe("a\nb\tc");
 });
 
+const overflowingDigits = Buffer.alloc(64, "f").toString();
+
+// https://github.com/oven-sh/bun/issues/30825
+// The TOML lexer carries a copy of the JS lexer's variable-length `\u{...}` loop and
+// inherited both of its bugs: `value * 16` trapped in debug builds once the escape had
+// enough hex digits to overflow `i64`, and falling off the end of the literal before the
+// closing `}` accepted the half-parsed value (`"\u{41"` decoded to `"A"`).
+test("Bun.TOML.parse rejects out-of-range \\u{...} escapes without overflowing (#30825)", () => {
+  expect(() => Bun.TOML.parse('a = "\\u{3333333316aaaaaaa}"')).toThrow("Unicode escape sequence is out of range");
+  expect(() => Bun.TOML.parse(`a = "\\u{${overflowingDigits}}"`)).toThrow("Unicode escape sequence is out of range");
+  expect(() => Bun.TOML.parse(`a = "\\u{0000${overflowingDigits}}"`)).toThrow(
+    "Unicode escape sequence is out of range",
+  );
+  expect(() => Bun.TOML.parse('a = "\\u{110000}"')).toThrow("Unicode escape sequence is out of range");
+});
+
+test("Bun.TOML.parse rejects \\u{...} escapes with no closing brace (#30825)", () => {
+  expect(() => Bun.TOML.parse('a = "\\u{41"')).toThrow("Syntax Error");
+  expect(() => Bun.TOML.parse('a = "\\u{"')).toThrow("Syntax Error");
+  expect(() => Bun.TOML.parse('a = "\\u{110000"')).toThrow("Syntax Error");
+  expect(() => Bun.TOML.parse(`a = "\\u{${overflowingDigits}"`)).toThrow("Syntax Error");
+});
+
+test("Bun.TOML.parse still accepts in-range \\u{...} escapes (#30825)", () => {
+  expect(Bun.TOML.parse('a = "\\u{41}"')).toEqual({ a: "A" });
+  // Long enough to overflow if the leading zeros were counted as significant digits.
+  expect(Bun.TOML.parse(`a = "\\u{${Buffer.alloc(64, "0").toString()}41}"`)).toEqual({ a: "A" });
+  expect(Bun.TOML.parse('a = "\\u{10FFFF}"')).toEqual({ a: "\u{10FFFF}" });
+});
+
 // https://github.com/oven-sh/bun/issues/31252
 // `Lexer::expect` in the TOML lexer logs a mismatch via `add_range_error` and
 // then falls through to `next()` for error recovery, so the parser returned

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -355,3 +355,103 @@ describe("invalid-escape caret points at the backslash (#31134)", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/30825
+// Two bugs in the variable-length `\u{...}` loop of `decode_escape_sequences`:
+//   1. `value = value * 16 | d` overflowed `i64` once the escape carried enough
+//      hex digits, trapping in debug builds. `is_out_of_range` is sticky and the
+//      value only grows, so saturating the multiply keeps the range error intact.
+//   2. Running out of literal before the closing `}` broke out of the loop and
+//      used the half-parsed value: `"\u{41"` decoded to `"A"` and `"\u{"` to NUL.
+//      esbuild and JSC both reject these.
+describe("pathological `\\u{...}` escapes (#30825)", () => {
+  const run = (source: string) => {
+    using dir = tempDir("u-brace", { "test.js": source });
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), join(dir, "test.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      cwd: String(dir),
+    });
+    return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+  };
+
+  // Any run of ~16+ significant hex digits pushes the accumulator past `i64::MAX`.
+  const overflowing = Buffer.alloc(64, "f").toString();
+
+  const outOfRange = [
+    { name: "identifier (issue repro)", source: "\\u{3333333316aaaaaaa}a" },
+    { name: "double-quoted string", source: 'var a = "\\u{3333333316aaaaaaa}";' },
+    { name: "single-quoted string", source: "var a = '\\u{3333333316aaaaaaa}';" },
+    { name: "template literal", source: "var a = `\\u{3333333316aaaaaaa}`;" },
+    { name: "64 hex digits", source: `var a = "\\u{${overflowing}}";` },
+    { name: "leading zeros then overflow", source: `var a = "\\u{0000${overflowing}}";` },
+    { name: "one past U+10FFFF", source: 'var a = "\\u{110000}";' },
+    // A template head's text ends at `${`, not at a quote.
+    { name: "template head before a substitution", source: "var x = 1; var a = `\\u{110000}${x}`;" },
+  ];
+
+  test.each(outOfRange)("$name → out-of-range error", ({ source }) => {
+    const { stderr, exitCode } = run(source);
+    expect(stderr).toContain("error: Unicode escape sequence is out of range");
+    expect(exitCode).toBe(1);
+  });
+
+  // The literal ends before `}`. esbuild and JSC both reject; the out-of-range
+  // case is a syntax error too, because the missing brace is found first.
+  const unterminated = [
+    { name: "double-quoted, digits", source: 'var a = "\\u{41";' },
+    { name: "double-quoted, no digits", source: 'var a = "\\u{";' },
+    { name: "single-quoted, digits", source: "var a = '\\u{41';" },
+    { name: "template literal, digits", source: "var a = `\\u{41`;" },
+    { name: "digits are out of range", source: 'var a = "\\u{110000";' },
+    { name: "digits overflow the accumulator", source: `var a = "\\u{${overflowing}";` },
+    // The head's text ends at `${`, so the brace is missing there too. Before the
+    // fix this cooked to "A" + x + "}".
+    { name: "template head before a substitution", source: "var x = 1; var a = `\\u{41${x}}`;" },
+  ];
+
+  test.each(unterminated)("$name → syntax error", ({ source }) => {
+    const { stderr, exitCode } = run(source);
+    expect(stderr).toContain("error: Syntax Error");
+    // The missing brace is reported, not the value it would have produced.
+    expect(stderr).not.toContain("out of range");
+    expect(exitCode).toBe(1);
+  });
+
+  test("in-range escapes still decode, however many leading zeros", () => {
+    const { stdout, exitCode } = run(
+      [
+        `console.log("\\u{41}");`,
+        // Long enough to overflow if the leading zeros were counted as digits.
+        `console.log("\\u{${Buffer.alloc(64, "0").toString()}41}");`,
+        `console.log("\\u{10FFFF}".codePointAt(0).toString(16));`,
+        `console.log("\\u{1F600}".length);`,
+        "console.log(`\\u{42}`);",
+        "const \\u{43} = 3; console.log(C);",
+      ].join("\n"),
+    );
+    expect(stdout).toBe("A\nA\n10ffff\n2\nB\n3\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Tagged templates keep their raw text and never reach the escape decoder, so
+  // neither new error path may leak into them: the cooked value stays undefined.
+  test("tagged templates still expose raw text for invalid escapes", () => {
+    const { stdout, exitCode } = run(
+      [
+        "const x = 1;",
+        "function tag(s) { return `${s[0]} ${s.raw[0]}`; }",
+        "console.log(tag`\\u{110000}`);",
+        "console.log(tag`\\u{41`);",
+        "console.log(tag`\\u{3333333316aaaaaaa}`);",
+        "console.log(tag`\\u{41${x}}`);",
+      ].join("\n"),
+    );
+    expect(stdout).toBe(
+      "undefined \\u{110000}\nundefined \\u{41\nundefined \\u{3333333316aaaaaaa}\nundefined \\u{41\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #30825, plus a second bug found in the same loop.

**1. Integer overflow (the reported bug).** The variable-length `\u{...}` branch of `decode_escape_sequences` accumulated hex digits with `value * 16`. Enough digits pushes the `i64` past its max and debug builds trap:

```
$ bun-debug -e 'let x = "\u{3333333316aaaaaaa}"'
panic: attempt to multiply with overflow (src/js_parser/lexer.rs:864)
```

Now saturates. `is_out_of_range` is sticky and `value` only grows, so the flag is always set (at ~6 digits) long before the accumulator can clamp (at ~16) — the range error still reports for any digit count, including 100k digits.

The issue also wondered whether release builds might *accept* such an escape when the multiply wraps. They don't, for the same reason: any value big enough to overflow exceeded `1_114_111` several digits earlier, and the flag is never cleared. Released Bun 1.4.0 correctly errors. `overflow-checks` is off in every release profile — including release-asan and release-assertions, which set `debug-assertions=on` but leave `overflow-checks=off` — so only `bun-debug` ever crashed.

**2. Unterminated `\u{` silently accepted (affects release).** The same loop `break`s out on end-of-input and uses the half-parsed value when the literal ends before the closing `}`. On Bun today:

```js
"\u{41"          // -> "A"              node: SyntaxError
"\u{"            // -> ""         node: SyntaxError
`\u{41${x}}`     // -> "A" + x + "}"    node: SyntaxError   (a template head's text ends at `${`)
```

esbuild — which this lexer is ported from — rejects all three, as does JSC. Now they're syntax errors. Tagged templates are unaffected: they pass their raw text through and never reach the decoder, so `` tag`\u{41` `` still yields `cooked === undefined` with the raw text intact.

**Both bugs were present in the TOML lexer's copy of the loop**, reachable via `Bun.TOML.parse`, `import x from "./x.toml"`, and `bunfig.toml`. Fixed there too. `grep -rn "'variable_length" src/` confirms those are the only two copies; the JSON and YAML decoders use a fixed digit count and already error on end-of-input.

### How did you verify your code works?

Every case checked against **node** and the in-repo **esbuild** — all three now agree on accept/reject:

| input | node | esbuild | bun (after) |
|---|---|---|---|
| `"\u{3333333316aaaaaaa}"` | Undefined Unicode code-point | out of range | out of range |
| `"\u{110000}"` | Undefined Unicode code-point | out of range | out of range |
| `"\u{110000"` | Undefined Unicode code-point | Syntax error | Syntax Error |
| `"\u{41"` | Invalid Unicode escape | Syntax error | Syntax Error |
| `"\u{"` | Invalid Unicode escape | Syntax error | Syntax Error |
| `"\u{00...0041}"` (64 zeros) | `A` | `A` | `A` |

Tests added to `test/regression/issue/invalid-escape-sequences.test.ts` and `test/js/bun/resolve/toml/toml-parse.test.ts` — covering the identifier/string/template/TOML matrix, both quote styles, the U+10FFFF boundary, 64-digit and leading-zero inputs, template heads before a substitution, and the negative contract that tagged templates keep their raw text and cooked `undefined`.

Both clauses proven load-bearing:

- Backing out `saturating_mul` and rebuilding debug → 6 tests fail and the TOML case aborts the runner.
- `USE_SYSTEM_BUN=1` → the 7 unterminated tests fail. (The out-of-range tests *cannot* fail there, since release doesn't trap — which is exactly why the first check exists.)

Also driven by hand: the original repro through `bun <file>` and `bun build`; `import x from "./bad.toml"`; a `bunfig.toml` with the bad escape (previously panicked at startup); 100k hex digits (0.17s, no trap); the `IS_JSON` path still rejects `\u{` before the loop; a TOML quoted key at file offset 0; and a minify round-trip of valid escapes.

Noticed while in here, **not** fixed (all pre-existing, same lineage as #30893): the TOML copy of `hex_start` still subtracts `width3`, the off-by-one the JS twin has a comment explaining it removed, so out-of-range carets in TOML point one byte left; multiline TOML strings pass `start` but slice text from `start + 2`; TOML rejects `\x` only in *multiline* strings (the `IS_JSON` guard was transplanted onto `ALLOW_MULTILINE`); and TOML has no `\U` escape and silently swallows unknown ones. Happy to take those in a follow-up.
