### PR TITLE
crypto: validate pbkdf2 keylen/iterations as integers and reject keylen=0

### DIFF
--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -8,11 +8,7 @@ use bun_jsc::{
 
 use crate::node::StringOrBuffer;
 
-use crate::crypto::create_crypto_error;
 use crate::crypto::evp::{self, Algorithm};
-
-// BoringSSL error code; not yet exported by `bun_boringssl_sys`.
-const EVP_R_MEMORY_LIMIT_EXCEEDED: u32 = 132;
 
 pub(crate) struct PBKDF2 {
     pub password: StringOrBuffer,
@@ -46,6 +42,10 @@ impl PBKDF2 {
 
         output.fill(0);
         debug_assert!(self.length <= i32::try_from(output.len()).expect("int cast"));
+        // Node.js (OpenSSL) rejects a zero-length derivation; BoringSSL accepts it.
+        if length == 0 {
+            return false;
+        }
         boringssl::ERR_clear_error();
         // SAFETY: password/salt point to valid slices for the given lengths;
         // algorithm.md() returns a non-null EVP_MD; output is writable for `length` bytes.
@@ -92,7 +92,7 @@ impl PBKDF2 {
 
         let keylen_num = arg3.as_number();
 
-        if keylen_num.is_infinite() || keylen_num.is_nan() {
+        if !arg3.is_any_int() {
             return Err(global_this.throw_range_error(
                 keylen_num,
                 bun_jsc::RangeErrorOptions {
@@ -117,11 +117,7 @@ impl PBKDF2 {
 
         let keylen: i32 = keylen_num as i32;
 
-        if global_this.has_exception() {
-            return Err(bun_jsc::JsError::Thrown);
-        }
-
-        if !arg2.is_any_int() {
+        if !arg2.is_number() {
             return Err(global_this.throw_invalid_argument_type_value(
                 b"iterations",
                 b"number",
@@ -129,25 +125,32 @@ impl PBKDF2 {
             ));
         }
 
-        let iteration_count = arg2.coerce_to_int64(global_this)?;
+        let iterations_num = arg2.as_number();
 
-        if !global_this.has_exception()
-            && (iteration_count < 1 || iteration_count > i32::MAX as i64)
-        {
+        if !arg2.is_any_int() {
             return Err(global_this.throw_range_error(
-                iteration_count,
+                iterations_num,
                 bun_jsc::RangeErrorOptions {
                     field_name: b"iterations",
-                    min: 1,
-                    max: i32::MAX as i64 + 1,
+                    msg: b"an integer",
                     ..Default::default()
                 },
             ));
         }
 
-        if global_this.has_exception() {
-            return Err(bun_jsc::JsError::Thrown);
+        if iterations_num < 1.0 || iterations_num > i32::MAX as f64 {
+            return Err(global_this.throw_range_error(
+                iterations_num,
+                bun_jsc::RangeErrorOptions {
+                    field_name: b"iterations",
+                    min: 1,
+                    max: i32::MAX as i64,
+                    ..Default::default()
+                },
+            ));
         }
+
+        let iteration_count: i64 = iterations_num as i64;
 
         let algorithm = 'brk: {
             if !arg4.is_string() {
@@ -268,7 +271,7 @@ pub(crate) struct Pbkdf2Ctx {
     /// (`from_js(.., is_async=true)` already protected the buffers).
     pub pbkdf2: bun_jsc::ThreadSafe<PBKDF2>,
     pub output: Vec<u8>,
-    pub err: Option<u32>,
+    pub err: bool,
     pub promise: JSPromiseStrong,
 }
 
@@ -278,14 +281,14 @@ impl AnyTaskJobCtx for Pbkdf2Ctx {
         // `Vec` allocation aborts on OOM; use try_reserve to surface an error instead.
         let mut buf = Vec::new();
         if buf.try_reserve_exact(len).is_err() {
-            self.err = Some(EVP_R_MEMORY_LIMIT_EXCEEDED);
+            self.err = true;
             return;
         }
         buf.resize(len, 0);
         self.output = buf;
 
         if !self.pbkdf2.run(&mut self.output) {
-            self.err = Some(boringssl::ERR_get_error());
+            self.err = true;
             boringssl::ERR_clear_error();
 
             self.output = Vec::new();
@@ -294,9 +297,9 @@ impl AnyTaskJobCtx for Pbkdf2Ctx {
 
     fn then(&mut self, global_this: &JSGlobalObject) -> JsResult<()> {
         let promise = self.promise.swap();
-        if let Some(err) = self.err {
-            promise
-                .reject_with_async_stack(global_this, Ok(create_crypto_error(global_this, err)))?;
+        if self.err {
+            let err = global_this.create_error_instance(format_args!("PBKDF2 derivation failed"));
+            promise.reject_with_async_stack(global_this, Ok(err))?;
             return Ok(());
         }
 
@@ -322,7 +325,7 @@ pub(crate) fn create_job(global_this: &JSGlobalObject, data: PBKDF2) -> *mut Job
             // `from_js(.., is_async=true)` already protected — adopt, don't re-protect.
             pbkdf2: bun_jsc::ThreadSafe::adopt(data),
             output: Vec::new(),
-            err: None,
+            err: false,
             promise: JSPromiseStrong::init(global_this),
         },
     )

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -92,7 +92,7 @@ impl PBKDF2 {
 
         let keylen_num = arg3.as_number();
 
-        if !arg3.is_any_int() {
+        if !arg3.is_integer() {
             return Err(global_this.throw_range_error(
                 keylen_num,
                 bun_jsc::RangeErrorOptions {
@@ -127,7 +127,7 @@ impl PBKDF2 {
 
         let iterations_num = arg2.as_number();
 
-        if !arg2.is_any_int() {
+        if !arg2.is_integer() {
             return Err(global_this.throw_range_error(
                 iterations_num,
                 bun_jsc::RangeErrorOptions {

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -1116,8 +1116,7 @@ mod _impl {
 
         if !data.run(output.slice_mut()) {
             boringssl::c::ERR_clear_error();
-            let err =
-                global_this.create_error_instance(format_args!("PBKDF2 derivation failed"));
+            let err = global_this.create_error_instance(format_args!("PBKDF2 derivation failed"));
             return Err(global_this.throw_value(err));
         }
 

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -727,7 +727,6 @@ mod _impl {
     use crate::node::util::validators;
     use bun_jsc::{ErrorCode, JSFunction, JSType};
 
-    use crate::crypto::create_crypto_error;
     use crate::crypto::pbkdf2::{self, PBKDF2};
 
     impl Scrypt {
@@ -1116,8 +1115,9 @@ mod _impl {
         };
 
         if !data.run(output.slice_mut()) {
-            let err = create_crypto_error(global_this, boringssl::c::ERR_get_error());
             boringssl::c::ERR_clear_error();
+            let err =
+                global_this.create_error_instance(format_args!("PBKDF2 derivation failed"));
             return Err(global_this.throw_value(err));
         }
 

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -156,10 +156,12 @@ describe("invalid inputs", () => {
   });
 });
 
-test("keylen=0 fails sync", () => {
-  expect(() => crypto.pbkdf2Sync("p", "s", 1, 0, "sha256")).toThrow(
-    expect.objectContaining({ name: "Error", message: "PBKDF2 derivation failed" }),
-  );
+[0, -0].forEach(input => {
+  test(`keylen=${Object.is(input, -0) ? "-0" : "0"} fails sync`, () => {
+    expect(() => crypto.pbkdf2Sync("p", "s", 1, input, "sha256")).toThrow(
+      expect.objectContaining({ name: "Error", message: "PBKDF2 derivation failed" }),
+    );
+  });
 });
 
 test("keylen=0 fails async via callback", async () => {
@@ -177,7 +179,7 @@ test("keylen=0 fails async via callback", async () => {
   expect(err.message).toBe("PBKDF2 derivation failed");
 });
 
-[-1, 2147483648, 4294967296].forEach(input => {
+[-1, 2147483648, 4294967296, 2 ** 52].forEach(input => {
   test(`${input} keylen`, () => {
     expect(() => crypto.pbkdf2("password", "salt", 1, input, "sha256")).toThrow(
       `The value of "keylen" is out of range. It must be >= 0 and <= 2147483647. Received ${input}`,

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -139,6 +139,13 @@ describe("invalid inputs", () => {
 
 [Infinity, -Infinity, NaN, 1.5, 0.5].forEach(input => {
   test(`${input} iterations`, () => {
+    expect(() => crypto.pbkdf2("password", "salt", input, 8, "sha256", () => {})).toThrow(
+      expect.objectContaining({
+        name: "RangeError",
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "iterations" is out of range. It must be an integer. Received ${input}`,
+      }),
+    );
     expect(() => crypto.pbkdf2Sync("password", "salt", input, 8, "sha256")).toThrow(
       expect.objectContaining({
         name: "RangeError",

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -118,12 +118,56 @@ describe("invalid inputs", () => {
   });
 });
 
-[Infinity, -Infinity, NaN].forEach(input => {
+[Infinity, -Infinity, NaN, 32.9, 1.5, 0.5, -0.5].forEach(input => {
   test(`${input} keylen`, () => {
     expect(() => crypto.pbkdf2("password", "salt", 1, input, "sha256")).toThrow(
-      `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
+      expect.objectContaining({
+        name: "RangeError",
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
+      }),
+    );
+    expect(() => crypto.pbkdf2Sync("password", "salt", 1, input, "sha256")).toThrow(
+      expect.objectContaining({
+        name: "RangeError",
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
+      }),
     );
   });
+});
+
+[Infinity, -Infinity, NaN, 1.5, 0.5].forEach(input => {
+  test(`${input} iterations`, () => {
+    expect(() => crypto.pbkdf2Sync("password", "salt", input, 8, "sha256")).toThrow(
+      expect.objectContaining({
+        name: "RangeError",
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "iterations" is out of range. It must be an integer. Received ${input}`,
+      }),
+    );
+  });
+});
+
+test("keylen=0 fails sync", () => {
+  expect(() => crypto.pbkdf2Sync("p", "s", 1, 0, "sha256")).toThrow(
+    expect.objectContaining({ name: "Error", message: "PBKDF2 derivation failed" }),
+  );
+});
+
+test("keylen=0 fails async via callback", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  let threwSync = false;
+  try {
+    crypto.pbkdf2("p", "s", 1, 0, "sha256", (err, key) => resolve({ err, key }));
+  } catch {
+    threwSync = true;
+  }
+  expect(threwSync).toBe(false);
+  const { err, key } = await promise;
+  expect(key).toBeUndefined();
+  expect(err).toBeInstanceOf(Error);
+  expect(err.message).toBe("PBKDF2 derivation failed");
 });
 
 [-1, 2147483648, 4294967296].forEach(input => {


### PR DESCRIPTION
Fixes #31657
Supersedes #31658 (which covers only the first of these three).

## Repro

```js
import crypto from "node:crypto";

crypto.pbkdf2Sync("p", "s", 1, 32.9, "sha256");
// bun : <Buffer 37 2c ... 32 bytes>   (silently floored)
// node: RangeError [ERR_OUT_OF_RANGE]: The value of "keylen" is out of range. It must be an integer. Received 32.9

crypto.pbkdf2Sync("p", "s", 1, 0, "sha256");
// bun : <Buffer >                     (empty)
// node: Error: PBKDF2 derivation failed

crypto.pbkdf2Sync("p", "s", 1.5, 8, "sha256");
// bun : TypeError [ERR_INVALID_ARG_TYPE]: The "iterations" argument must be of type number. Received type number (1.5)
// node: RangeError [ERR_OUT_OF_RANGE]: The value of "iterations" is out of range. It must be an integer. Received 1.5

crypto.pbkdf2("p", "s", 1, 0, "sha256", (e, k) => console.log(e, k));
// bun : null <Buffer >                (cb signature diverges)
// node: Error: PBKDF2 derivation failed undefined
```

Bun's own `scryptSync` and `hkdfSync` already reject a non-integer `keylen` the way Node does; only `pbkdf2` was inconsistent.

## Cause

In `PBKDF2::from_js` (`src/runtime/crypto/PBKDF2.rs`):

- `keylen` was checked for non-number, NaN/Infinity, and `[0, i32::MAX]` range, but never for integer-ness before `keylen_num as i32` truncated it. Node uses `validateInt32(keylen, 'keylen', 0)`.
- `iterations` was checked with `!arg2.is_any_int()`, which is true for both non-numbers and non-integer numbers, and that branch threw `ERR_INVALID_ARG_TYPE("iterations", "number", ...)`, producing "must be of type number. Received type number (1.5)". Node uses `validateInt32(iterations, 'iterations', 1)`, where a non-integer number is `ERR_OUT_OF_RANGE`.
- For `keylen == 0`, validation passes in both runtimes (min is 0), but OpenSSL's `PKCS5_PBKDF2_HMAC` fails on a zero-length output while BoringSSL accepts it, so Node throws/rejects "PBKDF2 derivation failed" and Bun returned an empty buffer.

## Fix

- `keylen`: replace the NaN/Infinity check with `!arg3.is_any_int()`, which rejects NaN, ±Infinity, and non-integer floats with the same `ERR_OUT_OF_RANGE` "must be an integer" message the existing tests already assert.
- `iterations`: split into `!is_number()` → `ERR_INVALID_ARG_TYPE` (unchanged for non-number inputs) and `!is_any_int()` → `ERR_OUT_OF_RANGE` "must be an integer". The range upper bound is also corrected from `i32::MAX + 1` to `i32::MAX` to match Node.
- `keylen == 0`: `PBKDF2::run()` now returns `false` for a zero-length output, and both the sync and async error paths surface a plain `Error("PBKDF2 derivation failed")` as Node does, instead of a BoringSSL error dump. The per-job `err` field is now a `bool` since the BoringSSL error code is no longer surfaced.

## Verification

New cases added to `test/js/node/crypto/pbkdf2.test.ts`:
- Non-integer `keylen` (`32.9`, `1.5`, `0.5`, `-0.5`) on both sync and async paths → `ERR_OUT_OF_RANGE` with "must be an integer".
- Non-integer `iterations` (`1.5`, `0.5`, `NaN`, `±Infinity`) → `ERR_OUT_OF_RANGE` with "must be an integer".
- `keylen = 0` sync → throws `Error("PBKDF2 derivation failed")`.
- `keylen = 0` async → does not throw synchronously; callback receives `(err, undefined)` with the same message.

`USE_SYSTEM_BUN=1 bun test test/js/node/crypto/pbkdf2.test.ts` → 11 of the new tests fail.
`bun bd test test/js/node/crypto/pbkdf2.test.ts` → 36 pass / 0 fail.
`bun bd test/js/node/test/parallel/test-crypto-pbkdf2.js` → still exits 0.
