### PR TITLE
build: enable Rust overflow-checks for asan and assertions builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,9 +181,9 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 # Pin these so the shim PE is byte-identical across bun's own profiles.
-# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,DEBUG_ASSERTIONS} for the main
-# bun_bin build and the shim build shares that env; without explicit values
-# here the env overrides on `release` would be inherited.
+# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,DEBUG_ASSERTIONS,OVERFLOW_CHECKS} for
+# the main bun_bin build and the shim build shares that env; without explicit
+# values here the env overrides on `release` would be inherited.
 debug-assertions = false
 overflow-checks = false
 

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -697,6 +697,19 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // `debug_assert!` sites compile to nothing under ASAN. The `dev` profile
     // (debug builds) already defaults it on, so this is a no-op there.
     env.CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
+
+    // Trap on `+ - * << >>` and unary neg overflow too. Cargo carries
+    // `overflow-checks` as its own profile key (default off on `release`), so
+    // the line above does not imply it: release-asan wrapped silently and ASAN
+    // never saw it. Overflow is the bug class ASAN cannot catch on its own —
+    // a wrapped length or index stays inside the allocation it then corrupts.
+    // In practice `usize` subtraction underflow dominates. `panic = "abort"`
+    // means these surface as SIGABRT, not catchable panics.
+    // `[profile.shim]` pins both keys off (it `inherits = "release"`, and a
+    // Windows *debug* build still runs `cargo --profile shim` with this env),
+    // so the shim PE stays byte-identical. Inert under `--profile dev`, which
+    // this var does not name and which already enables both.
+    env.CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS = "true";
   }
   if (rustflags.length > 0) env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -723,7 +723,7 @@ macro_rules! from_field_ptr {
 /// bun_core::impl_field_parent! { Assets => DevServer.assets; pub fn owner; fn owner_mut; }
 ///
 /// // (2) ref-only                   (&self -> &P)
-/// bun_core::impl_field_parent! { SubscriptionCtx => JSValkeyClient._subscription_ctx; fn parent; }
+/// bun_core::impl_field_parent! { Child => Parent.child; fn parent; }
 ///
 /// // (3) mut-only                   (&mut self -> *mut P)
 /// bun_core::impl_field_parent! { DirectoryWatchStore => DevServer.directory_watchers; fn mut owner; }
@@ -745,6 +745,13 @@ macro_rules! from_field_ptr {
 /// `$Parent.$field` for its entire lifetime. If `$Child` can exist
 /// standalone, the generated accessors are unsound; keep a hand-rolled
 /// `pub unsafe fn` instead.
+///
+/// **Do not combine with `JsCell<$Child>` / `UnsafeCell<$Child>`.** The
+/// generated `parent()` derives `*const $Parent` from `&self`, which carries
+/// provenance only for `$Child`'s bytes when `&self` came from
+/// `UnsafeCell::get()`. Accessing sibling fields of `$Parent` through it is
+/// UB and LLVM dead-stores the writes (#33726). Pass `&$Parent` explicitly
+/// from the caller that already has it instead.
 #[macro_export]
 macro_rules! impl_field_parent {
     // ref + raw-mut pair

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -76,10 +76,6 @@ pub struct SubscriptionCtx {
 /// free-fns plus `to_js`/`from_js`. Re-exported here as `Js`.
 pub use crate::generated_classes::js_RedisClient as Js;
 
-// SAFETY: `SubscriptionCtx` lives at `JSValkeyClient._subscription_ctx`
-// (intrusive backref). `JsCell<SubscriptionCtx>` is `#[repr(transparent)]`.
-bun_core::impl_field_parent! { SubscriptionCtx => JSValkeyClient._subscription_ctx; fn parent; }
-
 impl SubscriptionCtx {
     pub fn init(valkey_parent: &JSValkeyClient) -> JsResult<Self> {
         let callback_map = JSMap::create(&valkey_parent.global_object);
@@ -106,13 +102,8 @@ impl SubscriptionCtx {
         })
     }
 
-    fn subscription_callback_map(&self) -> &mut JSMap {
-        let parent_this = self
-            .parent()
-            .this_value
-            .get()
-            .try_get()
-            .expect("unreachable");
+    fn subscription_callback_map(&self, parent: &JSValkeyClient) -> &mut JSMap {
+        let parent_this = parent.this_value.get().try_get().expect("unreachable");
         let value_js = Js::subscription_callback_map_get_cached(parent_this).unwrap();
         // `JSMap` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
         // `from_js` returns a non-null heap cell when the slot was set by
@@ -121,29 +112,42 @@ impl SubscriptionCtx {
     }
 
     /// Get the total number of channels that this subscription context is subscribed to.
-    pub fn channels_subscribed_to_count(&self, global_object: &JSGlobalObject) -> JsResult<u32> {
-        let count = self.subscription_callback_map().size(global_object)?;
+    pub fn channels_subscribed_to_count(
+        &self,
+        parent: &JSValkeyClient,
+        global_object: &JSGlobalObject,
+    ) -> JsResult<u32> {
+        let count = self.subscription_callback_map(parent).size(global_object)?;
         Ok(count)
     }
 
     /// Test whether this context has any subscriptions. It is mandatory to
     /// guard deinit with this function.
-    pub fn has_subscriptions(&self, global_object: &JSGlobalObject) -> JsResult<bool> {
-        Ok(self.channels_subscribed_to_count(global_object)? > 0)
+    pub fn has_subscriptions(
+        &self,
+        parent: &JSValkeyClient,
+        global_object: &JSGlobalObject,
+    ) -> JsResult<bool> {
+        Ok(self.channels_subscribed_to_count(parent, global_object)? > 0)
     }
 
     pub fn clear_receive_handlers(
         &self,
+        parent: &JSValkeyClient,
         global_object: &JSGlobalObject,
         channel_name: JSValue,
     ) -> JsResult<()> {
-        let map = self.subscription_callback_map();
+        let map = self.subscription_callback_map(parent);
         let _ = map.remove(global_object, channel_name)?;
         Ok(())
     }
 
-    pub fn clear_all_receive_handlers(&self, global_object: &JSGlobalObject) -> JsResult<()> {
-        self.subscription_callback_map().clear(global_object)
+    pub fn clear_all_receive_handlers(
+        &self,
+        parent: &JSValkeyClient,
+        global_object: &JSGlobalObject,
+    ) -> JsResult<()> {
+        self.subscription_callback_map(parent).clear(global_object)
     }
 
     /// Remove a specific receive handler.
@@ -154,11 +158,12 @@ impl SubscriptionCtx {
     /// Note: This function will empty out the map entry if there are no more handlers registered.
     pub fn remove_receive_handler(
         &self,
+        parent: &JSValkeyClient,
         global_object: &JSGlobalObject,
         channel_name: JSValue,
         callback: JSValue,
     ) -> JsResult<Option<usize>> {
-        let map = self.subscription_callback_map();
+        let map = self.subscription_callback_map(parent);
 
         let existing = map.get(global_object, channel_name)?;
         if existing.is_undefined_or_null() {
@@ -198,17 +203,18 @@ impl SubscriptionCtx {
     /// Add a handler for receiving messages on a specific channel
     pub fn upsert_receive_handler(
         &self,
+        parent: &JSValkeyClient,
         global_object: &JSGlobalObject,
         channel_name: JSValue,
         callback: JSValue,
     ) -> JsResult<()> {
         // `BackRef` (Copy + Deref) detaches the borrow so the guard closure is
         // safe even though intervening JS may re-enter `&self`.
-        let parent_br = BackRef::new(self.parent());
+        let parent_br = BackRef::new(parent);
         let _guard = scopeguard::guard(parent_br, |p| {
             p.on_new_subscription_callback_insert();
         });
-        let map = self.subscription_callback_map();
+        let map = self.subscription_callback_map(parent);
 
         let handlers_array: JSValue;
         let mut is_new_channel = false;
@@ -244,11 +250,12 @@ impl SubscriptionCtx {
 
     pub fn get_callbacks(
         &self,
+        parent: &JSValkeyClient,
         global_object: &JSGlobalObject,
         channel_name: JSValue,
     ) -> JsResult<Option<JSValue>> {
         let result = self
-            .subscription_callback_map()
+            .subscription_callback_map(parent)
             .get(global_object, channel_name)?;
         if result == JSValue::UNDEFINED {
             return Ok(None);
@@ -260,11 +267,12 @@ impl SubscriptionCtx {
     /// Handles both single callbacks and arrays of callbacks
     pub fn invoke_callbacks(
         &self,
+        parent: &JSValkeyClient,
         global_object: &JSGlobalObject,
         channel_name: JSValue,
         args: &[JSValue],
     ) -> JsResult<()> {
-        let Some(callbacks) = self.get_callbacks(global_object, channel_name)? else {
+        let Some(callbacks) = self.get_callbacks(parent, global_object, channel_name)? else {
             debug!(
                 "No callbacks found for channel {}",
                 // `JSString` is an `opaque_ffi!` ZST — `opaque_ref` is the safe
@@ -285,7 +293,7 @@ impl SubscriptionCtx {
         // The user may, for example, unsubscribe in the callbacks, or even stop the client.
         // `BackRef` (Copy + Deref) detaches the borrow so the guard closure is
         // safe even though intervening JS may re-enter `&self`.
-        let parent_br = BackRef::new(self.parent());
+        let parent_br = BackRef::new(parent);
         let _update = scopeguard::guard(parent_br, |p| p.update_poll_ref());
 
         // If callbacks is an array, iterate and call each one
@@ -300,22 +308,29 @@ impl SubscriptionCtx {
         Ok(())
     }
 
-    fn is_deletable(&self, global_object: &JSGlobalObject) -> JsResult<bool> {
+    fn is_deletable(
+        &self,
+        parent: &JSValkeyClient,
+        global_object: &JSGlobalObject,
+    ) -> JsResult<bool> {
         // The user may request .close(), in which case we can dispose of the subscription object.
         // If that is the case, finalized will be true. Otherwise, we should treat the object as
         // disposable if there are no active subscriptions.
-        Ok(self.parent().client.get().flags.finalized || !self.has_subscriptions(global_object)?)
+        Ok(
+            parent.client.get().flags.finalized
+                || !self.has_subscriptions(parent, global_object)?,
+        )
     }
 
     // Cannot be `Drop` — takes a `global_object` param. Exposed as explicit
     // `close` per PORTING.md (never expose `pub fn deinit`).
-    pub fn close(&self, global_object: &JSGlobalObject) {
+    pub fn close(&self, parent: &JSValkeyClient, global_object: &JSGlobalObject) {
         if cfg!(debug_assertions) {
-            let go = self.parent().global_object;
-            debug_assert!(self.is_deletable(&go).expect("unreachable"));
+            let go = parent.global_object;
+            debug_assert!(self.is_deletable(parent, &go).expect("unreachable"));
         }
 
-        if let Some(parent_this) = self.parent().this_value.get().try_get() {
+        if let Some(parent_this) = parent.this_value.get().try_get() {
             Js::subscription_callback_map_set_cached(
                 parent_this,
                 global_object,
@@ -335,15 +350,11 @@ impl SubscriptionCtx {
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). The codegen
 // shim still emits `this: &mut RedisClient` — `&mut T`
-// auto-derefs to `&T` so the impls below compile against either. `JsCell` is
-// `#[repr(transparent)]`, so `from_field_ptr!`/`owner!` recovery (dispatch.rs,
-// `ValkeyClient::parent`) sees identical offsets.
+// auto-derefs to `&T` so the impls below compile against either.
 //
-// `#[repr(C)]`: `client` MUST be
-// at offset 0. `ValkeyClient::parent()` recovers the outer pointer via
-// `from_field_ptr!`, but belt-and-suspenders against any path that assumes
-// `*mut JSValkeyClient` and `*mut ValkeyClient` alias (the socket ext slot did
-// — see `connect()` below).
+// `#[repr(C)]`: `client` at offset 0 — belt-and-suspenders against any path
+// that assumes `*mut JSValkeyClient` and `*mut ValkeyClient` alias (the
+// socket ext slot did; see `connect()`).
 #[repr(C)]
 pub struct JSValkeyClient {
     pub client: JsCell<valkey::ValkeyClient>,
@@ -524,8 +535,8 @@ impl JSValkeyClient {
     #[allow(clippy::mut_from_ref)]
     pub(super) fn client_mut(&self) -> &mut valkey::ValkeyClient {
         // SAFETY: R-2 single-JS-thread invariant (see `JsCell` docs). The
-        // `&mut` is fresh per call site; reentrancy through
-        // `ValkeyClient::parent()` forms a shared `&JSValkeyClient` only.
+        // `&mut` is fresh per call site; re-entrant callers receive
+        // `&JSValkeyClient` as an explicit `parent` parameter alongside it.
         unsafe { self.client.get_mut() }
     }
 
@@ -971,7 +982,7 @@ impl JSValkeyClient {
             "removeSubscription: entering, has subscriptions: {}",
             self._subscription_ctx
                 .get()
-                .has_subscriptions(&self.global_object)
+                .has_subscriptions(self, &self.global_object)
                 .unwrap_or(false)
         );
         let _guard = self.ref_scope();
@@ -980,7 +991,7 @@ impl JSValkeyClient {
         if !self
             ._subscription_ctx
             .get()
-            .has_subscriptions(&self.global_object)
+            .has_subscriptions(self, &self.global_object)
             .unwrap_or(false)
         {
             let (q, p) = {
@@ -1099,7 +1110,7 @@ impl JSValkeyClient {
         if self.client.get().status == valkey::Status::Disconnected {
             return Ok(JSValue::UNDEFINED);
         }
-        self.client_mut().disconnect();
+        self.client_mut().disconnect(self);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -1335,6 +1346,7 @@ impl JSValkeyClient {
             ._subscription_ctx
             .get()
             .invoke_callbacks(
+                self,
                 &global_object,
                 channel_value,
                 &[message_value, channel_value],
@@ -1402,10 +1414,8 @@ impl JSValkeyClient {
         Ok(())
     }
 
-    // Callback for when Valkey client times out
-
     pub fn client_fail(&self, message: &[u8], err: protocol::RedisError) -> JsTerminatedResult<()> {
-        narrow_terminated(self.client_mut().fail(message, err))
+        narrow_terminated(self.client_mut().fail(self, message, err))
     }
 
     pub fn fail_with_js_value(&self, value: JSValue) {
@@ -1430,16 +1440,16 @@ impl JSValkeyClient {
         // would never run; close inline (this_value is cleared, no JS re-entry).
         if self.vm().is_shutting_down() {
             bun_core::hint::cold();
-            self.client_mut().close();
+            self.client_mut().close(self);
             return;
         }
 
         self.ref_();
         // socket close can potentially call JS so we need to enqueue the deinit
         struct Holder {
-            // BACKREF — JSValkeyClient is intrusively ref-counted (RefCount + @fieldParentPtr
-            // recovery in SubscriptionCtx::parent). The `self.ref_()` above / `(*ctx).deref()`
-            // in run() keep it alive across the task hop.
+            // BACKREF — JSValkeyClient is intrusively ref-counted; the
+            // `self.ref_()` above / `(*ctx).deref()` in run() keep it alive
+            // across the task hop.
             ctx: *const JSValkeyClient,
             task: jsc::AnyTask::AnyTask,
         }
@@ -1450,7 +1460,7 @@ impl JSValkeyClient {
                 let ctx = self_.ctx;
                 // SAFETY: single-threaded; intrusive ref taken before enqueue guarantees liveness.
                 unsafe {
-                    (*ctx).client_mut().close();
+                    (*ctx).client_mut().close(&*ctx);
                     JSValkeyClient::deref(ctx.cast_mut());
                 }
                 // self_ dropped here (Box freed).
@@ -1552,7 +1562,7 @@ impl JSValkeyClient {
             // `on_valkey_close()` consumes the socket ref; hand it over so it
             // isn't released twice.
             socket_ref.forget();
-            self.client_mut().on_valkey_close()?;
+            self.on_valkey_close()?;
             self.client_mut().status = valkey::Status::Disconnected;
             return Ok(());
         }
@@ -1705,7 +1715,7 @@ impl JSValkeyClient {
             || !self
                 ._subscription_ctx
                 .get()
-                .has_subscriptions(&self.global_object)
+                .has_subscriptions(self, &self.global_object)
                 .unwrap_or(false);
 
         let has_activity =
@@ -1789,7 +1799,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
 
     pub fn on_open(this: &JSValkeyClient, socket: SocketType<SSL>) -> JsTerminatedResult<()> {
         this.client_mut().socket = Self::_socket(socket);
-        narrow_terminated(this.client_mut().on_open(Self::_socket(socket)))
+        narrow_terminated(this.client_mut().on_open(this, Self::_socket(socket)))
     }
 
     pub fn on_handshake_(
@@ -1877,7 +1887,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
                     return Self::fail_handshake(this, vm, err);
                 }
             }
-            narrow_terminated(this.client_mut().start())?;
+            narrow_terminated(this.client_mut().start(this))?;
         } else {
             // if we are here is because the server rejected us, and the error_no is the cause of
             // this no matter if reject_unauthorized is false, because we were disconnected by the
@@ -1905,7 +1915,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
                     this.global_object.clear_exception();
                     this.client_mut().flags.is_authenticated = false;
                     this.client_mut().flags.is_manually_closed = true;
-                    this.client_mut().close();
+                    this.client_mut().close(this);
                     return Ok(());
                 }
             };
@@ -1921,11 +1931,12 @@ impl<const SSL: bool> SocketHandler<SSL> {
         let _exit = this.vm().enter_event_loop_scope();
         this.client_mut().flags.is_manually_closed = true;
         let this_br = BackRef::new(this);
-        let _close = scopeguard::guard(this_br, |p| p.client_mut().close());
-        narrow_terminated(
-            this.client_mut()
-                .fail_with_js_value(&this.global_object, err_value),
-        )
+        let _close = scopeguard::guard(this_br, |p| p.client_mut().close(&p));
+        narrow_terminated(this.client_mut().fail_with_js_value(
+            this,
+            &this.global_object,
+            err_value,
+        ))
     }
 
     // `pub const onHandshake = if (ssl) onHandshake_ else null;`
@@ -1953,7 +1964,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             p.update_poll_ref();
         });
 
-        let _ = this.client_mut().on_close(); // TODO: properly propagate exception upwards
+        let _ = this.client_mut().on_close(this);
     }
 
     pub fn on_end(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -1978,7 +1989,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             p.update_poll_ref();
         });
 
-        narrow_terminated(this.client_mut().on_close())
+        narrow_terminated(this.client_mut().on_close(this))
     }
 
     pub fn on_timeout(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -1993,7 +2004,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().socket = Self::_socket(socket);
 
         let _guard = this.ref_scope();
-        let _ = this.client_mut().on_data(data); // TODO: properly propagate exception upwards
+        let _ = this.client_mut().on_data(this, data);
         this.update_poll_ref();
     }
 

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1683,6 +1683,7 @@ impl JSValkeyClient {
                 // the SUBSCRIBE command fails? We have no way to roll back the addition of the
                 // handler.
                 this._subscription_ctx.get().upsert_receive_handler(
+                    this,
                     global,
                     channel_arg,
                     handler_callback,
@@ -1696,6 +1697,7 @@ impl JSValkeyClient {
             redis_channels.push(channel);
 
             this._subscription_ctx.get().upsert_receive_handler(
+                this,
                 global,
                 channel_or_many,
                 handler_callback,
@@ -1719,7 +1721,7 @@ impl JSValkeyClient {
                 // If we catch an error, we need to clean up any handlers we may have added and fall out of subscription mode
                 this._subscription_ctx
                     .get()
-                    .clear_all_receive_handlers(global)?;
+                    .clear_all_receive_handlers(this, global)?;
                 return send_err_to_js(global, "Failed to send SUBSCRIBE command", &err);
             }
         };
@@ -1768,7 +1770,7 @@ impl JSValkeyClient {
         if args_view.is_empty() {
             this._subscription_ctx
                 .get()
-                .clear_all_receive_handlers(global)?;
+                .clear_all_receive_handlers(this, global)?;
             return Self::send_unsubscribe_request_and_cleanup(
                 this,
                 frame.this(),
@@ -1817,6 +1819,7 @@ impl JSValkeyClient {
             redis_channels.push(ch);
 
             let remaining_listeners = match this._subscription_ctx.get().remove_receive_handler(
+                this,
                 global,
                 channel,
                 listener_cb,
@@ -1875,7 +1878,7 @@ impl JSValkeyClient {
                 // Clear the handlers for this channel
                 this._subscription_ctx
                     .get()
-                    .clear_receive_handlers(global, channel_arg)?;
+                    .clear_receive_handlers(this, global, channel_arg)?;
             }
         } else if channel_or_many.is_string() {
             // It is a single string channel
@@ -1886,7 +1889,7 @@ impl JSValkeyClient {
             // Clear the handlers for this channel
             this._subscription_ctx
                 .get()
-                .clear_receive_handlers(global, channel_or_many)?;
+                .clear_receive_handlers(this, global, channel_or_many)?;
         } else {
             return Err(global.throw_invalid_argument_type(
                 "unsubscribe",

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -330,12 +330,6 @@ fn reader_pos(reader: &protocol::ValkeyReader<'_>) -> usize {
     reader.pos()
 }
 
-// SAFETY: `ValkeyClient` lives at `JSValkeyClient.client` (intrusive embed via
-// `container_of`). `JsCell<ValkeyClient>` is `#[repr(transparent)]`, so the
-// field offset is unchanged. R-2: shared `&` only — every `JSValkeyClient`
-// method this reaches is `&self`.
-bun_core::impl_field_parent! { ValkeyClient => JSValkeyClient.client; fn parent; }
-
 impl ValkeyClient {
     /// Clean up resources used by the Valkey client
     // Cannot be `Drop` — takes a JSGlobalObject param and has JS side effects.
@@ -406,8 +400,6 @@ impl ValkeyClient {
             return false;
         }
 
-        self.ref_();
-
         // Start draining the command queue
         let mut total_bytelength: usize = 0;
 
@@ -450,8 +442,6 @@ impl ValkeyClient {
 
         let have_more = self.queue.readable_length() > 0;
         self.auto_flusher.registered.set(have_more);
-
-        self.deref();
 
         // Return true if we should schedule another flush
         have_more
@@ -525,7 +515,12 @@ impl ValkeyClient {
         Ok(())
     }
 
-    fn reject_in_flight_commands(&mut self, message: &[u8], err: RedisError) -> JsTerminated<()> {
+    fn reject_in_flight_commands(
+        &mut self,
+        parent: &JSValkeyClient,
+        message: &[u8],
+        err: RedisError,
+    ) -> JsTerminated<()> {
         if self.in_flight.readable_length() == 0 {
             return Ok(());
         }
@@ -546,7 +541,7 @@ impl ValkeyClient {
             return Ok(());
         }
 
-        let global_this = self.global_object();
+        let global_this = parent.global_object;
         let jsvalue = valkey_error_to_js(&global_this, message, err);
         let mut entries = command::entry::Queue::init();
         Self::reject_all_pending_commands(&mut self.in_flight, &mut entries, &global_this, jsvalue)
@@ -567,7 +562,12 @@ impl ValkeyClient {
     }
 
     /// Mark the connection as failed with error message
-    pub fn fail(&mut self, message: &[u8], err: RedisError) -> JsTerminated<()> {
+    pub fn fail(
+        &mut self,
+        parent: &JSValkeyClient,
+        message: &[u8],
+        err: RedisError,
+    ) -> JsTerminated<()> {
         debug!("failed: {}: {:?}", bstr::BStr::new(message), err);
         if self.flags.failed {
             return Ok(());
@@ -596,12 +596,17 @@ impl ValkeyClient {
             return Ok(());
         }
 
-        let global_this = self.global_object();
-        self.fail_with_js_value(&global_this, valkey_error_to_js(&global_this, message, err))
+        let global_this = parent.global_object;
+        self.fail_with_js_value(
+            parent,
+            &global_this,
+            valkey_error_to_js(&global_this, message, err),
+        )
     }
 
     pub fn fail_with_js_value(
         &mut self,
+        parent: &JSValkeyClient,
         global_this: &JSGlobalObject,
         jsvalue: JSValue,
     ) -> JsTerminated<()> {
@@ -618,12 +623,12 @@ impl ValkeyClient {
 
         if !self.connection_ready() {
             self.flags.is_manually_closed = true;
-            self.close();
+            self.close(parent);
         }
         val
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&mut self, parent: &JSValkeyClient) {
         let socket = core::mem::replace(
             &mut self.socket,
             AnySocket::SocketTcp(uws::SocketTCP::detached()),
@@ -646,28 +651,28 @@ impl ValkeyClient {
         socket.close(uws::CloseCode::Normal);
         if is_semi_socket {
             self.status = Status::Disconnected;
-            let _ = self.on_close();
+            let _ = self.on_close(parent);
         }
     }
 
     /// Handle connection closed event
-    pub fn on_close(&mut self) -> JsTerminated<()> {
+    pub fn on_close(&mut self, parent: &JSValkeyClient) -> JsTerminated<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
 
         // If manually closing, don't attempt to reconnect
         if self.flags.is_manually_closed {
             debug!("skip reconnecting since the connection is manually closed");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
-            self.on_valkey_close()?;
+            self.fail(parent, b"Connection closed", RedisError::ConnectionClosed)?;
+            parent.on_valkey_close()?;
             return Ok(());
         }
 
         // If auto reconnect is disabled, just fail
         if !self.flags.enable_auto_reconnect {
             debug!("skip reconnecting since auto reconnect is disabled");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
-            self.on_valkey_close()?;
+            self.fail(parent, b"Connection closed", RedisError::ConnectionClosed)?;
+            parent.on_valkey_close()?;
             return Ok(());
         }
 
@@ -678,10 +683,11 @@ impl ValkeyClient {
         if delay_ms == 0 || self.retry_attempts > self.max_retries {
             debug!("Max retries reached or retry strategy returned 0, giving up reconnection");
             self.fail(
+                parent,
                 b"Max reconnection attempts reached",
                 RedisError::ConnectionClosed,
             )?;
-            self.on_valkey_close()?;
+            parent.on_valkey_close()?;
             return Ok(());
         }
 
@@ -694,10 +700,10 @@ impl ValkeyClient {
         self.flags.is_authenticated = false;
         self.flags.is_selecting_db_internal = false;
 
-        self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
+        self.reject_in_flight_commands(parent, b"Connection closed", RedisError::ConnectionClosed)?;
 
         // Signal reconnect timer should be started
-        self.on_valkey_reconnect();
+        parent.on_valkey_reconnect();
         Ok(())
     }
 
@@ -740,7 +746,7 @@ impl ValkeyClient {
     /// Process data received from socket
     ///
     /// Caller refs / derefs.
-    pub fn on_data(&mut self, data: &[u8]) -> JsTerminated<()> {
+    pub fn on_data(&mut self, parent: &JSValkeyClient, data: &[u8]) -> JsTerminated<()> {
         debug!(
             "Low-level onData called with {} bytes: {}",
             data.len(),
@@ -777,7 +783,7 @@ impl ValkeyClient {
                         return Ok(());
                     }
                     Err(err) => {
-                        self.fail(b"Failed to read data (buffer path)", err)?;
+                        self.fail(parent, b"Failed to read data (buffer path)", err)?;
                         return Ok(());
                     }
                 }
@@ -791,7 +797,7 @@ impl ValkeyClient {
                         // The scanner verified a complete reply is buffered, so
                         // a parse failure here (including `InvalidResponse`) is
                         // a protocol error, not a short read.
-                        self.fail(b"Failed to read data (buffer path)", err)?;
+                        self.fail(parent, b"Failed to read data (buffer path)", err)?;
                         return Ok(());
                     }
                 };
@@ -800,6 +806,7 @@ impl ValkeyClient {
                 let bytes_consumed = reader_pos(&reader) - before_read_pos;
                 if bytes_consumed == 0 && !remaining_buffer.is_empty() {
                     self.fail(
+                        parent,
                         b"Parser consumed 0 bytes unexpectedly (buffer path)",
                         RedisError::InvalidResponse,
                     )?;
@@ -811,7 +818,7 @@ impl ValkeyClient {
                 self.reply_scanner.reset();
 
                 let mut value_to_handle = value; // Use temp var for defer
-                self.handle_response(&mut value_to_handle)?;
+                self.handle_response(parent, &mut value_to_handle)?;
 
                 if self.status == Status::Disconnected || self.flags.failed {
                     return Ok(());
@@ -847,7 +854,7 @@ impl ValkeyClient {
                         return Ok(()); // Exit onData, next call will use the buffer path
                     } else {
                         // Any other error is fatal
-                        self.fail(b"Failed to read data (stack path)", err)?;
+                        self.fail(parent, b"Failed to read data (stack path)", err)?;
                         return Ok(());
                     }
                 }
@@ -859,6 +866,7 @@ impl ValkeyClient {
             if bytes_consumed == 0 {
                 // This case should ideally not happen if readValue succeeded and slice wasn't empty
                 self.fail(
+                    parent,
                     b"Parser consumed 0 bytes unexpectedly (stack path)",
                     RedisError::InvalidResponse,
                 )?;
@@ -870,7 +878,7 @@ impl ValkeyClient {
 
             // Handle the successfully parsed response
             let mut value_to_handle = value; // Use temp var for defer
-            self.handle_response(&mut value_to_handle)?;
+            self.handle_response(parent, &mut value_to_handle)?;
 
             // Check connection status after handling
             if self.status == Status::Disconnected || self.flags.failed {
@@ -891,11 +899,12 @@ impl ValkeyClient {
     /// Returns `handled` if we handled it, `fallthrough` if we did not.
     fn handle_subscribe_response(
         &mut self,
+        parent: &JSValkeyClient,
         value: &mut RESPValue,
         pair: Option<&mut command::PromisePair>,
     ) -> JsResult<SubscribeHandled> {
         // Resolve the promise with the potentially transformed value
-        let global_this = self.global_object();
+        let global_this = parent.global_object;
 
         debug!("Handling a subscribe response: {}", value);
         // SAFETY: `event_loop()` returns the live VM-owned `*mut EventLoop`; the guard holds the
@@ -911,21 +920,20 @@ impl ValkeyClient {
                 Ok(SubscribeHandled::Handled)
             }
             RESPValue::Push(push) => {
-                let p = self.parent();
-                let sub_count = p
+                let sub_count = parent
                     ._subscription_ctx
                     .get()
-                    .channels_subscribed_to_count(&global_this)?;
+                    .channels_subscribed_to_count(parent, &global_this)?;
 
                 if let Some(msg_type) = protocol::SubscriptionPushMessage::from_bytes(&push.kind) {
                     match msg_type {
                         protocol::SubscriptionPushMessage::Message => {
-                            self.on_valkey_message(&mut push.data);
+                            parent.on_valkey_message(&mut push.data);
                             Ok(SubscribeHandled::Handled)
                         }
                         protocol::SubscriptionPushMessage::Subscribe => {
-                            p.add_subscription();
-                            self.on_valkey_subscribe(value);
+                            parent.add_subscription();
+                            parent.on_valkey_subscribe(value);
 
                             // For SUBSCRIBE responses, only resolve the promise for the first channel confirmation
                             // Additional channel confirmations from multi-channel SUBSCRIBE commands don't need promise pairs
@@ -938,8 +946,8 @@ impl ValkeyClient {
                             Ok(SubscribeHandled::Handled)
                         }
                         protocol::SubscriptionPushMessage::Unsubscribe => {
-                            self.on_valkey_unsubscribe()?;
-                            self.parent().remove_subscription();
+                            parent.on_valkey_unsubscribe()?;
+                            parent.remove_subscription();
 
                             // For UNSUBSCRIBE responses, only resolve the promise if we have one
                             // Additional channel confirmations from multi-channel UNSUBSCRIBE commands don't need promise pairs
@@ -957,6 +965,7 @@ impl ValkeyClient {
                     // then this is an unexpected path.
                     bun_core::hint::cold();
                     self.fail(
+                        parent,
                         b"Push message is not a subscription message.",
                         RedisError::InvalidResponseType,
                     )?;
@@ -971,12 +980,16 @@ impl ValkeyClient {
         }
     }
 
-    fn handle_hello_response(&mut self, value: &mut RESPValue) -> JsTerminated<()> {
+    fn handle_hello_response(
+        &mut self,
+        parent: &JSValkeyClient,
+        value: &mut RESPValue,
+    ) -> JsTerminated<()> {
         debug!("Processing HELLO response");
 
         match value {
             RESPValue::Error(err) => {
-                self.fail(err, RedisError::AuthenticationFailed)?;
+                self.fail(parent, err, RedisError::AuthenticationFailed)?;
                 Ok(())
             }
             RESPValue::SimpleString(str_) => {
@@ -985,10 +998,11 @@ impl ValkeyClient {
                     self.flags.is_authenticated = true;
                     self.flags.is_reconnecting = false;
                     self.retry_attempts = 0;
-                    self.on_valkey_connect(value)?;
+                    parent.on_valkey_connect(value)?;
                     return Ok(());
                 }
                 self.fail(
+                    parent,
                     b"Authentication failed (unexpected response)",
                     RedisError::AuthenticationFailed,
                 )?;
@@ -1008,6 +1022,7 @@ impl ValkeyClient {
                                     debug!("Server protocol version: {}", proto_version);
                                     if proto_version != 3 {
                                         self.fail(
+                                            parent,
                                             b"Server does not support RESP3",
                                             RedisError::UnsupportedProtocol,
                                         )?;
@@ -1025,11 +1040,12 @@ impl ValkeyClient {
                 self.flags.is_authenticated = true;
                 self.flags.is_reconnecting = false;
                 self.retry_attempts = 0;
-                self.on_valkey_connect(value)?;
+                parent.on_valkey_connect(value)?;
                 Ok(())
             }
             _ => {
                 self.fail(
+                    parent,
                     b"Authentication failed with unexpected response",
                     RedisError::AuthenticationFailed,
                 )?;
@@ -1039,10 +1055,14 @@ impl ValkeyClient {
     }
 
     /// Handle Valkey protocol response
-    fn handle_response(&mut self, value: &mut RESPValue) -> JsTerminated<()> {
+    fn handle_response(
+        &mut self,
+        parent: &JSValkeyClient,
+        value: &mut RESPValue,
+    ) -> JsTerminated<()> {
         // Special handling for the initial HELLO response
         if !self.flags.is_authenticated {
-            self.handle_hello_response(value)?;
+            self.handle_hello_response(parent, value)?;
 
             // We've handled the HELLO response without consuming anything from the command queue
             return Ok(());
@@ -1054,13 +1074,14 @@ impl ValkeyClient {
 
             return match value {
                 RESPValue::Error(err_str) => {
-                    self.fail(err_str, RedisError::InvalidCommand)?;
+                    self.fail(parent, err_str, RedisError::InvalidCommand)?;
                     Ok(())
                 }
                 RESPValue::SimpleString(ok_str) => {
                     if ok_str.as_ref() != b"OK" {
                         // SELECT returned something other than "OK"
                         self.fail(
+                            parent,
                             b"SELECT command failed with non-OK response",
                             RedisError::InvalidResponse,
                         )?;
@@ -1077,6 +1098,7 @@ impl ValkeyClient {
                 _ => {
                     // Unexpected response type for SELECT
                     self.fail(
+                        parent,
                         b"Received non-SELECT response while in the SELECT state.",
                         RedisError::InvalidResponse,
                     )?;
@@ -1126,17 +1148,17 @@ impl ValkeyClient {
             .as_ref()
             .map(|p| p.meta.contains(command::Meta::SUBSCRIPTION_REQUEST))
             .unwrap_or(false);
-        if self.parent().is_subscriber() || request_is_subscribe {
+        if parent.is_subscriber() || request_is_subscribe {
             debug!("This client is a subscriber. Handling as subscriber...");
 
             match value {
                 RESPValue::Error(err) => {
-                    self.fail(err, RedisError::InvalidResponse)?;
+                    self.fail(parent, err, RedisError::InvalidResponse)?;
                     return Ok(());
                 }
                 RESPValue::Push(push) => {
                     if protocol::SubscriptionPushMessage::from_bytes(&push.kind).is_some() {
-                        if self.handle_subscribe_response(value, pair_maybe.as_mut())?
+                        if self.handle_subscribe_response(parent, value, pair_maybe.as_mut())?
                             == SubscribeHandled::Handled
                         {
                             return Ok(());
@@ -1144,6 +1166,7 @@ impl ValkeyClient {
                     } else {
                         bun_core::hint::cold();
                         self.fail(
+                            parent,
                             b"Unexpected push message kind without promise",
                             RedisError::InvalidResponseType,
                         )?;
@@ -1177,7 +1200,7 @@ impl ValkeyClient {
 
         // Resolve the promise with the potentially transformed value
         let promise_ptr = &mut pair.promise;
-        let global_this = self.global_object();
+        let global_this = parent.global_object;
 
         let _exit = self.vm.enter_event_loop_scope();
 
@@ -1194,7 +1217,7 @@ impl ValkeyClient {
     }
 
     /// Send authentication command to Valkey server
-    fn authenticate(&mut self) -> JsTerminated<()> {
+    fn authenticate(&mut self, parent: &JSValkeyClient) -> JsTerminated<()> {
         // First send HELLO command for RESP3 protocol
         debug!("Sending HELLO 3 command");
 
@@ -1233,7 +1256,11 @@ impl ValkeyClient {
         };
 
         if let Err(_err) = hello_write_result {
-            self.fail(b"Failed to write HELLO command", RedisError::OutOfMemory)?;
+            self.fail(
+                parent,
+                b"Failed to write HELLO command",
+                RedisError::OutOfMemory,
+            )?;
             return Ok(());
         }
 
@@ -1247,7 +1274,11 @@ impl ValkeyClient {
                 meta: command::Meta::default(),
             };
             if let Err(_err) = select_cmd.write(self.writer()) {
-                self.fail(b"Failed to write SELECT command", RedisError::OutOfMemory)?;
+                self.fail(
+                    parent,
+                    b"Failed to write SELECT command",
+                    RedisError::OutOfMemory,
+                )?;
                 return Ok(());
             }
             self.flags.is_selecting_db_internal = true;
@@ -1256,7 +1287,7 @@ impl ValkeyClient {
     }
 
     /// Handle socket open event
-    pub fn on_open(&mut self, socket: AnySocket) -> JsTerminated<()> {
+    pub fn on_open(&mut self, parent: &JSValkeyClient, socket: AnySocket) -> JsTerminated<()> {
         self.socket = socket;
         self.write_buffer.clear_and_free();
         self.read_buffer.clear_and_free();
@@ -1273,14 +1304,14 @@ impl ValkeyClient {
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
             // if is tls, we need to wait for the handshake to complete
-            self.start()?;
+            self.start(parent)?;
         }
         Ok(())
     }
 
     /// Start the connection process
-    pub fn start(&mut self) -> JsTerminated<()> {
-        self.authenticate()?;
+    pub fn start(&mut self, parent: &JSValkeyClient) -> JsTerminated<()> {
+        self.authenticate(parent)?;
         let _ = self.flush_data();
         Ok(())
     }
@@ -1342,13 +1373,15 @@ impl ValkeyClient {
     }
 
     pub fn on_writable(&mut self) {
-        self.ref_();
+        // No ref_/deref pair here: send_next_command() only touches queues and
+        // the socket (no JS re-entry), and every caller already holds a
+        // keep-alive ref across this call.
         self.send_next_command();
-        self.deref();
     }
 
     fn enqueue(
         &mut self,
+        global_this: &JSGlobalObject,
         command: &Command,
         mut promise: command::Promise,
     ) -> Result<(), crate::Error> {
@@ -1391,8 +1424,8 @@ impl ValkeyClient {
         match self.status {
             Status::Connecting | Status::Connected => {
                 if command.write(self.writer()).is_err() {
-                    let global = self.global_object();
-                    let _ = promise.reject(&global, Ok(global.create_out_of_memory_error()));
+                    let _ =
+                        promise.reject(global_this, Ok(global_this.create_out_of_memory_error()));
                     return Ok(());
                 }
             }
@@ -1437,7 +1470,7 @@ impl ValkeyClient {
             // Handle disconnected state with offline queue
             match self.status {
                 Status::Connected => {
-                    self.enqueue(&checked_command, promise)?;
+                    self.enqueue(global_this, &checked_command, promise)?;
 
                     // Schedule auto-flushing to process this command if pipelining is enabled
                     if self.flags.enable_auto_pipelining
@@ -1453,7 +1486,7 @@ impl ValkeyClient {
                 Status::Connecting | Status::Disconnected => {
                     // Only queue if offline queue is enabled
                     if self.flags.enable_offline_queue {
-                        self.enqueue(&checked_command, promise)?;
+                        self.enqueue(global_this, &checked_command, promise)?;
                     } else {
                         let _ = promise.reject(
                             global_this,
@@ -1475,11 +1508,11 @@ impl ValkeyClient {
     }
 
     /// Close the Valkey connection
-    pub fn disconnect(&mut self) {
+    pub fn disconnect(&mut self, parent: &JSValkeyClient) {
         self.flags.is_manually_closed = true;
         self.unregister_auto_flusher();
         if self.status == Status::Connected || self.status == Status::Connecting {
-            self.close();
+            self.close(parent);
         }
     }
 
@@ -1495,48 +1528,6 @@ impl ValkeyClient {
             .write(data)
             .map_err(|_| RedisError::OutOfMemory)?;
         Ok(data.len())
-    }
-
-    /// Increment reference count
-    pub fn ref_(&mut self) {
-        self.parent().ref_();
-    }
-
-    pub fn deref(&mut self) {
-        let parent = std::ptr::from_ref(self.parent()).cast_mut();
-        // SAFETY: only called in balanced `ref_()`/`deref()` pairs
-        // (`on_auto_flush`, `on_writable`), so the count stays > 0 and the
-        // outer `&mut self` protector is never invalidated by deallocation.
-        unsafe { JSValkeyClient::deref(parent) };
-    }
-
-    #[inline]
-    fn global_object(&mut self) -> GlobalRef {
-        self.parent().global_object
-    }
-
-    pub fn on_valkey_connect(&mut self, value: &mut RESPValue) -> JsTerminated<()> {
-        self.parent().on_valkey_connect(value)
-    }
-
-    pub fn on_valkey_subscribe(&mut self, value: &mut RESPValue) {
-        self.parent().on_valkey_subscribe(value);
-    }
-
-    pub fn on_valkey_unsubscribe(&mut self) -> JsResult<()> {
-        self.parent().on_valkey_unsubscribe()
-    }
-
-    pub fn on_valkey_message(&mut self, value: &mut [RESPValue]) {
-        self.parent().on_valkey_message(value);
-    }
-
-    pub fn on_valkey_reconnect(&mut self) {
-        self.parent().on_valkey_reconnect();
-    }
-
-    pub fn on_valkey_close(&mut self) -> JsTerminated<()> {
-        self.parent().on_valkey_close()
     }
 }
 

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -44,8 +44,7 @@ bun_core::declare_scope!(MySQLConnection, visible);
 // shim still emits `this: &mut JSMySQLConnection` — `&mut T` auto-derefs
 // to `&T` so the impls below compile against either.
 // `JsCell` is `#[repr(transparent)]`, so `from_field_ptr!` recovery
-// (`from_timer_ptr` / `MySQLConnection::get_js_connection`) sees identical
-// offsets.
+// (`from_timer_ptr`) sees identical offsets.
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = Self::deinit)]
 pub struct JSMySQLConnection {
@@ -62,8 +61,7 @@ pub struct JSMySQLConnection {
 
     // pub(crate): MySQLRequestQueue::advance reaches `connection.get().queue`
     // via a `ParentRef<JSMySQLConnection>` shared borrow; the inner protocol
-    // struct's `get_js_connection()` recovers the embedding via
-    // `from_field_ptr!` (offset unchanged — `JsCell` is transparent).
+    // struct receives the embedding as an explicit `parent` parameter.
     pub(crate) connection: JsCell<my_sql_connection::MySQLConnection>,
 
     pub auto_flusher: JsCell<AutoFlusher>,
@@ -174,9 +172,8 @@ impl JSMySQLConnection {
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn connection_mut(&self) -> &mut my_sql_connection::MySQLConnection {
         // SAFETY: R-2 single-JS-thread invariant (see `JsCell` docs). The
-        // `&mut` is fresh per call site; reentrancy through
-        // `MySQLConnection::get_js_connection()` forms a shared
-        // `&JSMySQLConnection` only.
+        // `&mut` is fresh per call site; reentrancy through the threaded
+        // `parent: &JSMySQLConnection` forms a shared borrow only.
         unsafe { self.connection.get_mut() }
     }
 
@@ -391,7 +388,7 @@ impl JSMySQLConnection {
         let _loop_guard = self.event_loop().entered();
         self.ensure_js_value_is_alive();
         if let Err(my_sql_connection::FlushQueueError::AuthenticationFailed) =
-            self.connection_mut().flush_queue()
+            self.connection_mut().flush_queue(self)
         {
             self.fail(
                 b"Authentication failed",
@@ -698,15 +695,15 @@ impl JSMySQLConnection {
     }
     #[inline]
     pub fn can_pipeline(&self) -> bool {
-        self.connection_mut().can_pipeline()
+        self.connection_mut().can_pipeline(self)
     }
     #[inline]
     pub fn can_prepare_query(&self) -> bool {
-        self.connection_mut().can_prepare_query()
+        self.connection_mut().can_prepare_query(self)
     }
     #[inline]
     pub fn can_execute_query(&self) -> bool {
-        self.connection_mut().can_execute_query()
+        self.connection_mut().can_execute_query(self)
     }
     #[inline]
     pub fn get_writer(&self) -> NewWriter<my_sql_connection::Writer> {
@@ -1063,7 +1060,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         let _loop_guard = this.event_loop().entered();
         this.ensure_js_value_is_alive();
 
-        if let Err(e) = this.connection_mut().read_and_process_data(data) {
+        if let Err(e) = this.connection_mut().read_and_process_data(this, data) {
             this.on_error(None, e);
         }
     }

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -124,10 +124,6 @@ impl Default for MySQLConnection {
     }
 }
 
-// SAFETY: `MySQLConnection` is the `connection` field embedded inside
-// `JSMySQLConnection`; never constructed standalone.
-bun_core::impl_field_parent! { MySQLConnection => JSMySQLConnection.connection; fn js_connection_ref; fn get_js_connection; }
-
 impl MySQLConnection {
     pub fn init(
         database: Box<[u8]>,
@@ -163,14 +159,14 @@ impl MySQLConnection {
         }
     }
 
-    pub fn can_pipeline(&mut self) -> bool {
-        self.queue.can_pipeline(self.js_connection_ref())
+    pub fn can_pipeline(&mut self, parent: &JSMySQLConnection) -> bool {
+        self.queue.can_pipeline(parent)
     }
-    pub fn can_prepare_query(&mut self) -> bool {
-        self.queue.can_prepare_query(self.js_connection_ref())
+    pub fn can_prepare_query(&mut self, parent: &JSMySQLConnection) -> bool {
+        self.queue.can_prepare_query(parent)
     }
-    pub fn can_execute_query(&mut self) -> bool {
-        self.queue.can_execute_query(self.js_connection_ref())
+    pub fn can_execute_query(&mut self, parent: &JSMySQLConnection) -> bool {
+        self.queue.can_execute_query(parent)
     }
 
     #[inline]
@@ -215,14 +211,14 @@ impl MySQLConnection {
         self.queue.add(request);
     }
 
-    pub fn flush_queue(&mut self) -> Result<(), FlushQueueError> {
+    pub fn flush_queue(&mut self, parent: &JSMySQLConnection) -> Result<(), FlushQueueError> {
         self.flush_data();
         if !self.flags.contains(ConnectionFlags::HAS_BACKPRESSURE) {
             if self.tls_status == TLSStatus::MessageSent {
-                self.upgrade_to_tls()?;
+                self.upgrade_to_tls(parent)?;
             } else {
                 // no backpressure yet so pipeline more if possible and flush again
-                self.advance();
+                self.advance(parent);
                 self.flush_data();
             }
         }
@@ -236,13 +232,12 @@ impl MySQLConnection {
     /// reaches the queue via `ParentRef`/`JsCell` shared borrows (all queue
     /// fields are interior-mutable), so no `&mut` to the queue bytes is ever
     /// materialised concurrently with the connection backref.
-    fn advance(&mut self) {
-        let js_connection = self.get_js_connection();
-        // `js_connection` is the `@fieldParentPtr` of `self` — non-null, live,
-        // full-allocation provenance. advance() only forms shared borrows of it
-        // (queue mutation goes through `Cell`/`JsCell`); the raw pointer is
-        // wrapped via the safe `ParentRef::from(NonNull)` inside.
-        MySQLRequestQueue::advance(js_connection);
+    fn advance(&mut self, parent: &JSMySQLConnection) {
+        // `parent` is the embedding `JSMySQLConnection` — non-null, live.
+        // advance() only forms shared borrows of it (queue mutation goes
+        // through `Cell`/`JsCell`); the raw pointer is wrapped via the safe
+        // `ParentRef::from(NonNull)` inside.
+        MySQLRequestQueue::advance(std::ptr::from_ref(parent).cast_mut());
     }
 
     fn flush_data(&mut self) {
@@ -317,7 +312,7 @@ impl MySQLConnection {
         // _options_buf dropped at scope exit (Box<[u8]> frees via Drop)
     }
 
-    pub fn upgrade_to_tls(&mut self) -> Result<(), FlushQueueError> {
+    pub fn upgrade_to_tls(&mut self, parent: &JSMySQLConnection) -> Result<(), FlushQueueError> {
         // Only adopt if we're currently a plain TCP socket.
         let Socket::SocketTcp(tcp) = &self.socket else {
             return Ok(());
@@ -369,7 +364,7 @@ impl MySQLConnection {
             return Err(FlushQueueError::AuthenticationFailed);
         };
 
-        let js_connection = self.get_js_connection();
+        let js_connection = std::ptr::from_ref(parent).cast_mut();
         let new_socket = new_socket.as_ptr();
         // SAFETY: `new_socket` is a live us_socket_t freshly returned by
         // `adopt_tls`; ext storage was sized for
@@ -474,7 +469,11 @@ impl MySQLConnection {
         Ok(false)
     }
 
-    pub fn read_and_process_data(&mut self, data: &[u8]) -> Result<(), AnyMySQLError> {
+    pub fn read_and_process_data(
+        &mut self,
+        parent: &JSMySQLConnection,
+        data: &[u8],
+    ) -> Result<(), AnyMySQLError> {
         self.flags.insert(ConnectionFlags::IS_PROCESSING_DATA);
         // The flag clear is hand-inlined before every return below
         // (scopeguard would need &mut self.flags).
@@ -489,7 +488,7 @@ impl MySQLConnection {
             let consumed = core::cell::Cell::new(0usize);
             let offset = core::cell::Cell::new(0usize);
             let reader = StackReader::init(data, &consumed, &offset);
-            match self.process_packets(reader) {
+            match self.process_packets(parent, reader) {
                 Ok(()) => {}
                 Err(err) => {
                     debug!(
@@ -532,7 +531,7 @@ impl MySQLConnection {
             // borrows `&mut self` twice. Construct the reader first; it holds a
             // `*mut Self` so the second borrow doesn't conflict.
             let reader = self.buffered_reader();
-            match self.process_packets(reader) {
+            match self.process_packets(parent, reader) {
                 Ok(()) => {}
                 Err(err) => {
                     debug!("processPackets with buffer: {}", <&'static str>::from(err));
@@ -566,6 +565,7 @@ impl MySQLConnection {
 
     pub fn process_packets<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         reader: NewReader<C>,
     ) -> Result<(), AnyMySQLError> {
         loop {
@@ -597,7 +597,7 @@ impl MySQLConnection {
             // Process packet based on connection state
             match self.status {
                 ConnectionState::Handshaking => {
-                    self.handle_handshake(reader)?;
+                    self.handle_handshake(parent, reader)?;
                     // If the handshake negotiated TLS, the SSLRequest has been sent and
                     // everything after this packet must arrive over the encrypted channel.
                     // Any bytes already buffered behind the handshake packet are plaintext
@@ -611,9 +611,9 @@ impl MySQLConnection {
                     }
                 }
                 ConnectionState::Authenticating | ConnectionState::AuthenticationAwaitingPk => {
-                    self.handle_auth(reader, header_length)?
+                    self.handle_auth(parent, reader, header_length)?
                 }
-                ConnectionState::Connected => self.handle_command(reader, header_length)?,
+                ConnectionState::Connected => self.handle_command(parent, reader, header_length)?,
                 _ => {
                     debug!("Unexpected packet in state {}", self.status as u8);
                     return Err(AnyMySQLError::UnexpectedPacket);
@@ -624,6 +624,7 @@ impl MySQLConnection {
 
     pub fn handle_handshake<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         reader: NewReader<C>,
     ) -> Result<(), AnyMySQLError> {
         let mut handshake = HandshakeV10::default();
@@ -686,7 +687,7 @@ impl MySQLConnection {
         }
 
         // Update status
-        self.set_status(ConnectionState::Authenticating);
+        self.set_status(parent, ConnectionState::Authenticating);
 
         // https://dev.mysql.com/doc/dev/mysql-server/8.4.6/page_protocol_connection_phase_packets_protocol_ssl_request.html
         if self.capabilities.CLIENT_SSL {
@@ -703,7 +704,7 @@ impl MySQLConnection {
             self.tls_status = TLSStatus::MessageSent;
             self.flush_data();
             if !self.flags.contains(ConnectionFlags::HAS_BACKPRESSURE) {
-                self.upgrade_to_tls()
+                self.upgrade_to_tls(parent)
                     .map_err(|_| AnyMySQLError::AuthenticationFailed)?;
             }
             return Ok(());
@@ -728,12 +729,13 @@ impl MySQLConnection {
 
     fn handle_handshake_decode_public_key<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         reader: NewReader<C>,
     ) -> Result<(), AnyMySQLError> {
         let mut response = Auth::caching_sha2_password::PublicKeyResponse::default();
         response.decode(reader)?;
         // revert back to authenticating since we received the public key
-        self.set_status(ConnectionState::Authenticating);
+        self.set_status(parent, ConnectionState::Authenticating);
 
         let encrypted_password = Auth::caching_sha2_password::EncryptedPassword {
             password: bun_ptr::RawSlice::new(&self.password),
@@ -746,7 +748,7 @@ impl MySQLConnection {
         Ok(())
     }
 
-    pub fn set_status(&mut self, status: ConnectionState) {
+    pub fn set_status(&mut self, parent: &JSMySQLConnection, status: ConnectionState) {
         if self.status == status {
             return;
         }
@@ -756,7 +758,7 @@ impl MySQLConnection {
         match status {
             ConnectionState::Connected => {
                 // `on_connection_estabilished` spelling is intentional (sic).
-                self.js_connection_ref().on_connection_estabilished();
+                parent.on_connection_estabilished();
             }
             _ => {}
         }
@@ -764,6 +766,7 @@ impl MySQLConnection {
 
     pub fn handle_auth<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         reader: NewReader<C>,
         header_length: u32, // u24 on the wire
     ) -> Result<(), AnyMySQLError> {
@@ -786,19 +789,19 @@ impl MySQLConnection {
                 };
                 ok.decode_internal(reader)?;
 
-                self.set_status(ConnectionState::Connected);
+                self.set_status(parent, ConnectionState::Connected);
 
                 self.status_flags = ok.status_flags;
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                 self.queue.mark_as_ready_for_query();
-                self.advance();
+                self.advance(parent);
             }
 
             x if x == PacketType::ERROR.0 => {
                 let mut err = ErrorPacket::default();
                 err.decode_internal(reader)?;
 
-                self.js_connection_ref().on_error_packet(None, &err);
+                parent.on_error_packet(None, &err);
                 return Err(AnyMySQLError::AuthenticationFailed);
             }
 
@@ -810,7 +813,7 @@ impl MySQLConnection {
                             reader.skip(1);
 
                             if self.status == ConnectionState::AuthenticationAwaitingPk {
-                                return self.handle_handshake_decode_public_key(reader);
+                                return self.handle_handshake_decode_public_key(parent, reader);
                             }
 
                             let mut response = Auth::caching_sha2_password::Response::default();
@@ -837,7 +840,10 @@ impl MySQLConnection {
                                             );
                                         }
                                         // we are in plain TCP so we need to request the public key
-                                        self.set_status(ConnectionState::AuthenticationAwaitingPk);
+                                        self.set_status(
+                                            parent,
+                                            ConnectionState::AuthenticationAwaitingPk,
+                                        );
                                         bun_core::scoped_log!(
                                             MySQLConnection,
                                             "awaiting public key"
@@ -926,6 +932,7 @@ impl MySQLConnection {
 
     pub fn handle_command<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         reader: NewReader<C>,
         header_length: u32, // u24 on the wire
     ) -> Result<(), AnyMySQLError> {
@@ -944,7 +951,7 @@ impl MySQLConnection {
         debug!("handleCommand");
         if request.is_simple() {
             // Regular query response
-            return self.handle_result_set(reader, header_length);
+            return self.handle_result_set(parent, reader, header_length);
         }
 
         // Handle based on request type
@@ -964,11 +971,11 @@ impl MySQLConnection {
                 }
                 mysql_statement::Status::Parsing => {
                     // We're waiting for prepare response
-                    self.handle_prepared_statement(reader, header_length)?;
+                    self.handle_prepared_statement(parent, reader, header_length)?;
                 }
                 mysql_statement::Status::Prepared => {
                     // We're waiting for execute response
-                    self.handle_result_set(reader, header_length)?;
+                    self.handle_result_set(parent, reader, header_length)?;
                 }
                 mysql_statement::Status::Failed => {
                     // `Data` is not `Clone`, so deep-copy the
@@ -988,14 +995,11 @@ impl MySQLConnection {
                     self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
                     self.queue.mark_as_ready_for_query();
                     self.queue.mark_current_request_as_finished(request);
-                    // R-2: `on_error_packet` is `&self`; route through the
-                    // audited `js_connection_ref()` container_of accessor (one
-                    // centralised unsafe). `*self` sits inside the parent's
-                    // `JsCell`, so re-entrant `connection_mut()` does not alias
-                    // this outer shared borrow.
-                    self.js_connection_ref()
-                        .on_error_packet(Some(request), &error_response);
-                    let _ = self.flush_queue();
+                    // R-2: `on_error_packet` is `&self`. `*self` sits inside the
+                    // parent's `JsCell`, so re-entrant `connection_mut()` does
+                    // not alias this outer shared borrow.
+                    parent.on_error_packet(Some(request), &error_response);
+                    let _ = self.flush_queue(parent);
                 }
             }
         }
@@ -1107,7 +1111,11 @@ impl MySQLConnection {
         }
     }
 
-    fn check_if_prepared_statement_is_done(&mut self, statement: &mut MySQLStatement) {
+    fn check_if_prepared_statement_is_done(
+        &mut self,
+        parent: &JSMySQLConnection,
+        statement: &mut MySQLStatement,
+    ) {
         bun_core::scoped_log!(
             MySQLConnection,
             "checkIfPreparedStatementIsDone: {} {} {} {}",
@@ -1125,12 +1133,13 @@ impl MySQLConnection {
             self.queue.mark_as_ready_for_query();
             self.queue.mark_as_prepared();
             statement.reset();
-            self.advance();
+            self.advance(parent);
         }
     }
 
     pub fn handle_prepared_statement<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         mut reader: NewReader<C>,
         header_length: u32, // u24 on the wire
     ) -> Result<(), AnyMySQLError> {
@@ -1169,7 +1178,7 @@ impl MySQLConnection {
             {
                 let mut eof = EOFPacket::default();
                 eof.decode_internal(reader)?;
-                self.check_if_prepared_statement_is_done(statement);
+                self.check_if_prepared_statement_is_done(parent, statement);
                 return Ok(());
             }
             if (statement.params_received as usize) < statement.params.len() {
@@ -1189,7 +1198,7 @@ impl MySQLConnection {
             // completion is deferred to the EOF handler above to avoid marking the
             // statement as prepared before the trailing EOF is consumed.
             if self.capabilities.CLIENT_DEPRECATE_EOF {
-                self.check_if_prepared_statement_is_done(statement);
+                self.check_if_prepared_statement_is_done(parent, statement);
             }
             return Ok(());
         }
@@ -1227,7 +1236,7 @@ impl MySQLConnection {
                     statement.columns_received = 0;
                 }
 
-                self.check_if_prepared_statement_is_done(statement);
+                self.check_if_prepared_statement_is_done(parent, statement);
             }
 
             PacketType::ERROR => {
@@ -1257,16 +1266,11 @@ impl MySQLConnection {
                 self.queue.mark_as_ready_for_query();
                 self.queue.mark_current_request_as_finished(request);
 
-                // R-2: `on_error_packet` is `&self`; `js_connection_ref()` is
-                // the audited container_of accessor (one centralised unsafe).
-                // The `&JSMySQLConnection` it yields lives only for this call —
-                // identical footprint to the prior `(*ptr).on_error_packet()`
-                // temporary — and `*self` sits inside the parent's `JsCell`, so
-                // re-entrant `connection_mut()` does not alias the outer
-                // shared borrow.
-                self.js_connection_ref()
-                    .on_error_packet(Some(request), &err);
-                self.advance();
+                // R-2: `on_error_packet` is `&self`. `*self` sits inside the
+                // parent's `JsCell`, so re-entrant `connection_mut()` does not
+                // alias the outer shared borrow.
+                parent.on_error_packet(Some(request), &err);
+                self.advance(parent);
             }
 
             _ => {
@@ -1290,6 +1294,7 @@ impl MySQLConnection {
     // `on_query_result` call (which may itself call `get_statement()`).
     fn handle_result_set_ok(
         &mut self,
+        parent: &JSMySQLConnection,
         request: &JSMySQLQuery,
         status_flags: StatusFlags,
         last_insert_id: u64,
@@ -1313,13 +1318,10 @@ impl MySQLConnection {
         // Short-lived borrow via the audited accessor; dropped before the
         // re-entrant `on_query_result` call below.
         let result_count = request.get_statement().map_or(0, |s| s.result_count);
-        // R-2: `on_query_result` is `&self`; `js_connection_ref()` is the
-        // audited container_of accessor. The `&JSMySQLConnection` lives only for
-        // this call (same footprint as the prior `(*ptr).on_query_result()`
-        // temporary). `*self` sits inside the parent's `JsCell` (`UnsafeCell`),
-        // so re-entrant `connection_mut()` writes through SharedRW provenance
-        // independent of this outer shared borrow.
-        self.js_connection_ref().on_query_result(
+        // R-2: `on_query_result` is `&self`. `*self` sits inside the parent's
+        // `JsCell` (`UnsafeCell`), so re-entrant `connection_mut()` writes
+        // through SharedRW provenance independent of this outer shared borrow.
+        parent.on_query_result(
             request,
             &MySQLQueryResult {
                 result_count,
@@ -1338,11 +1340,12 @@ impl MySQLConnection {
         // by queries added during onQueryResult is actually sent.
         // This fixes a race condition where the auto flusher may not be
         // registered if the queue's current item is completed (not pending).
-        let _ = self.flush_queue();
+        let _ = self.flush_queue(parent);
     }
 
     fn handle_result_set<C: ReaderContext>(
         &mut self,
+        parent: &JSMySQLConnection,
         mut reader: NewReader<C>,
         header_length: u32, // u24 on the wire
     ) -> Result<(), AnyMySQLError> {
@@ -1383,13 +1386,11 @@ impl MySQLConnection {
                 self.queue.mark_as_ready_for_query();
                 self.queue.mark_current_request_as_finished(request);
 
-                // R-2: `on_error_packet` is `&self`; route through the audited
-                // `js_connection_ref()` container_of accessor. `*self` lives
-                // inside the parent's `JsCell`, so re-entrant `connection_mut()`
-                // does not alias this outer shared borrow.
-                self.js_connection_ref()
-                    .on_error_packet(Some(request), &err);
-                let _ = self.flush_queue();
+                // R-2: `on_error_packet` is `&self`. `*self` lives inside the
+                // parent's `JsCell`, so re-entrant `connection_mut()` does not
+                // alias this outer shared borrow.
+                parent.on_error_packet(Some(request), &err);
+                let _ = self.flush_queue(parent);
             }
 
             packet_type => {
@@ -1412,6 +1413,7 @@ impl MySQLConnection {
                         // NLL: caller's `statement` borrow ends here;
                         // `handle_result_set_ok` re-fetches via the accessor.
                         self.handle_result_set_ok(
+                            parent,
                             request,
                             ok.status_flags,
                             ok.last_insert_id,
@@ -1513,7 +1515,7 @@ impl MySQLConnection {
                             // Final EOF after all row data - terminates the result set
                             let mut eof = EOFPacket::default();
                             eof.decode_internal(reader)?;
-                            self.handle_result_set_ok(request, eof.status_flags, 0, 0);
+                            self.handle_result_set_ok(parent, request, eof.status_flags, 0, 0);
                             return Ok(());
                         }
 
@@ -1521,6 +1523,7 @@ impl MySQLConnection {
                         ok.decode_internal(reader)?;
 
                         self.handle_result_set_ok(
+                            parent,
                             request,
                             ok.status_flags,
                             ok.last_insert_id,
@@ -1529,14 +1532,10 @@ impl MySQLConnection {
                         return Ok(());
                     }
 
-                    // R-2: `on_result_row` is `&self`; route through the audited
-                    // `js_connection_ref()` container_of accessor. The
-                    // `&JSMySQLConnection` is held only for this call (identical
-                    // footprint to the prior `(*ptr).on_result_row()` temporary);
-                    // `*self` sits inside the parent's `JsCell`, so re-entrant
-                    // `connection_mut()` does not alias this shared borrow.
-                    self.js_connection_ref()
-                        .on_result_row(request, statement, reader)?;
+                    // R-2: `on_result_row` is `&self`. `*self` sits inside the
+                    // parent's `JsCell`, so re-entrant `connection_mut()` does
+                    // not alias this shared borrow.
+                    parent.on_result_row(request, statement, reader)?;
                 }
             }
         }

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -219,6 +219,56 @@ describe("RedisClient TLS hostname verification", () => {
     });
   });
 
+  test("subscribe() after connect() does not dead-store the refcount increment", async () => {
+    // ValkeyClient and SubscriptionCtx used to reach JSValkeyClient via
+    // impl_field_parent!'s offset-subtracted parent(), but &self comes from
+    // JsCell::get() whose provenance covers only the child's bytes. Writing
+    // to ref_count through that pointer is UB: under overflow-checks LLVM
+    // dead-stored the increment in upsert_receive_handler and on_data's
+    // trailing deref_guard drove the count to 0 with the socket still open.
+    // https://github.com/oven-sh/bun/pull/33726
+    const server = tls.createServer({ key: localhostTls.key, cert: localhostTls.cert }, sock => {
+      let buf = Buffer.alloc(0);
+      let subs = 0;
+      const bulk = (s: string) => `$${Buffer.byteLength(s)}\r\n${s}\r\n`;
+      const push = (kind: string, ch: string, n: number) => `>3\r\n${bulk(kind)}${bulk(ch)}:${n}\r\n`;
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        let consumed: number;
+        while ((consumed = consumeRespArray(buf)) > 0) {
+          const head = buf.subarray(0, consumed).toString("latin1");
+          buf = buf.subarray(consumed);
+          const args = [...head.matchAll(/\$\d+\r\n([^\r]+)\r\n/g)].map(m => m[1]);
+          if (args[0] === "HELLO") sock.write("%1\r\n+proto\r\n:3\r\n");
+          else if (args[0] === "SUBSCRIBE") for (const ch of args.slice(1)) sock.write(push("subscribe", ch, ++subs));
+          else if (args[0] === "UNSUBSCRIBE")
+            for (const ch of args.slice(1)) sock.write(push("unsubscribe", ch, (subs = Math.max(0, subs - 1))));
+          else sock.write("+OK\r\n");
+        }
+      });
+      sock.on("error", () => {});
+    });
+    server.on("tlsClientError", () => {});
+    server.listen(0);
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+    const sub = new RedisClient(`rediss://127.0.0.1:${port}`, {
+      autoReconnect: false,
+      connectionTimeout: 5000,
+      tls: { ca: localhostTls.cert, rejectUnauthorized: true },
+    });
+    try {
+      await sub.connect();
+      await sub.subscribe(["a", "b", "c"], () => {});
+      await sub.unsubscribe("b");
+      await sub.unsubscribe(["a", "c"]);
+      expect(sub.connected).toBe(true);
+    } finally {
+      sub.close();
+      server.close();
+    }
+  });
+
   test.skipIf(isWindows)("skips hostname verification for redis+tls+unix:// sockets", async () => {
     // Unix-domain sockets have no hostname; a CA-trusted cert for the wrong
     // CN must still be accepted as long as the chain validates.

--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -301,14 +301,16 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
   test("send → short writes (1 byte) deliver complete frame to client", async () => {
     const fixture = /* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      let resolveServerClosed;
+      const serverClosed = new Promise(r => { resolveServerClosed = r; });
       const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
         fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
-        websocket: { open(ws) {}, message(ws, m) { ws.send(m); }, close() {} } });
+        websocket: { open(ws) {}, message(ws, m) { ws.send(m); }, close() { resolveServerClosed(); } } });
       fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
       const ws = new WebSocket("ws://127.0.0.1:" + s.port);
       ws.onopen = () => ws.send(Buffer.alloc(4096, 0x57).toString());
       ws.onmessage = (e) => { console.log(JSON.stringify({ len: e.data.length })); ws.close(); };
-      ws.onclose = () => { fault.clear(); process.exit(0); };
+      ws.onclose = async () => { fault.clear(); await serverClosed; s.stop(true); };
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -331,6 +333,8 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
     // the only test exercising that hook.
     const fixture = /* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      let resolveServerClosed;
+      const serverClosed = new Promise(r => { resolveServerClosed = r; });
       const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
         fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
         websocket: {
@@ -339,7 +343,7 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
             ws.send(Buffer.alloc(20000, 0x57));
           },
           message() {},
-          close() {},
+          close() { resolveServerClosed(); },
         } });
       const ws = new WebSocket("ws://127.0.0.1:" + s.port);
       ws.binaryType = "arraybuffer";
@@ -347,7 +351,7 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
         console.log(JSON.stringify({ len: e.data.byteLength }));
         ws.close();
       };
-      ws.onclose = () => { fault.clear(); s.stop(true); process.exit(0); };
+      ws.onclose = async () => { fault.clear(); await serverClosed; s.stop(true); };
       ws.onerror = () => { console.log(JSON.stringify({ err: true })); process.exit(1); };
     `;
     await using proc = Bun.spawn({


### PR DESCRIPTION
### What does this PR do?

Makes release-asan and release-assertions builds trap on Rust integer overflow. Today they don't, and nothing in CI does.

`rust.ts` already sets `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true` for `cfg.assertions` (#32520). But cargo carries `overflow-checks` as a **separate profile key**, defaulting to false on `release` — setting `debug-assertions` does not imply it. Measured on the real cargo invocation:

| build | `overflow-checks` compiled in |
|---|---|
| plain `release` (what ships) | no |
| `release` + `DEBUG_ASSERTIONS` — **today's ASAN** | **no** |
| `release` + `DEBUG_ASSERTIONS` + `OVERFLOW_CHECKS` — this PR | **yes** |

(Measured with `nm -u` on a crate with checked arithmetic. Note you can't check this by grepping `cargo -v` for `-C overflow-checks`: cargo only emits that flag when it *disagrees* with `-C debug-assertions`, so "checks on" prints nothing at all.)

So release-asan compiled `a * b`, `a - b`, and `a << b` as wrapping ops. Overflow is the one memory-safety-adjacent bug class ASAN cannot catch on its own — a wrapped length or index stays inside the allocation it then goes on to corrupt.

The shipped release build is unchanged. `--profile dev` already enables both keys and never reads a `CARGO_PROFILE_RELEASE_*` var. `[profile.shim]` keeps its explicit pins, which are load-bearing: `shimEnv` is derived from this `env`, and even a Windows *debug* build runs `cargo --profile shim`, so the shim PE stays byte-identical across profiles.

### How did you verify your code works?

Built a real `release-asan` binary (darwin arm64) and drove it.

**It catches a bug the ASAN lane previously ran straight past.** This branch is off `main`, so the `\u{...}` lexer overflow from #30825 is still present in the source:

```
$ ./build/release-asan/bun-asan repro.js        # \u{3333333316aaaaaaa}a
panic: attempt to multiply with overflow
exit=134
```

Before this change, that same binary printed a clean error and exited 1 — the overflow wrapped and the sticky range check happened to mask it. Valid escapes are unaffected (`\u{41}` → `A`, `\u{10FFFF}` → `10ffff`).

Other checks:

- `nm libbun_rust.a` on the asan build → 53 refs to `panic_const_mul_overflow`, plus the `add`/`sub`/`neg`/`shl`/`shr` variants.
- Configured `ci-rust-only` (no asan): `build.ninja` contains neither var — shipped artifacts untouched.
- `cargo --profile shim` with both vars set still emits `debug-assertions=off` and no overflow-checks. The manifest pin wins over the inherited env override.
- All ~200 workspace crates plus 281 lockfile deps compile clean with the flag; no new compile errors.

**Blast radius.** Ran the test suite under the overflow-checked asan binary: **20,547 tests across 1,112 files** (`test/bundler`, `test/regression`, `test/js/bun`, `test/js/web`) → **zero overflow aborts**. A second sweep over `test/js/node`, `test/cli`, `test/napi`, `test/v8`, `test/internal` was still running at time of writing, also zero.

I validated the detector rather than trusting a zero: planting an in-process overflow (transpiling the #30825 string via `Bun.Transpiler` inside a test) surfaces as `panic: attempt to multiply with overflow` in the harness log with exit 134. So the zeros above are real.

That said — the sweeps are darwin arm64 and skip `test/bake` / `test/integration`. **The ASAN lane on this PR is the real test.** If it surfaces latent overflows, they're pre-existing bugs this change is designed to find; `[profile.release.package.*]` (already used for `bun_react_compiler`) is available if a third-party crate needs an exemption.

### Things worth knowing

- **`usize` subtraction underflow is the dominant newly-armed class**, not multiplication — `len - 1`, `idx - offset`. Don't only go looking for `*`.
- **These abort, they don't panic.** `[profile.release]` sets `panic = "abort"`, so an overflow in an asan/assertions build is a SIGABRT (exit 134) through the crash handler, and will read as a *crash* in CI rather than a test failure.
- release-asan is now no longer bit-for-bit semantically equivalent to shipped release codegen — it traps where release wraps. That's the intent, but it means a repro that only reproduces on the asan lane may be an overflow the release build silently absorbs.
- Unrelated, found while testing: `bun run build:assert` (`release-assertions`) does not link on macOS — `Undefined symbol: WTF::RefTracker::reportLive`, a C++ `ASSERT_ENABLED` mismatch against the non-assertions prebuilt WebKit. `release-asan` links because it pulls the `-asan` WebKit prebuilt. Pre-existing; not touched here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/valkey/valkey-tls-verify.test.ts test/js/web/websocket/websocket-syscall-fault.test.ts

<!-- robobun:evidence:end -->