### PR TITLE
websocket: accept Connection header as a token list in the 101 response

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1295,7 +1295,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
         remain_buf: &[u8],
     ) {
         let mut upgrade_header = picohttp::Header::ZERO;
-        let mut connection_header = picohttp::Header::ZERO;
+        let mut connection_header_seen = false;
+        let mut connection_has_upgrade = false;
         let mut websocket_accept_header = picohttp::Header::ZERO;
         let mut protocol_header_seen = false;
 
@@ -1311,13 +1312,21 @@ impl<const SSL: bool> HTTPClient<SSL> {
         for header in response.headers.list {
             match header.name().len() {
                 len if len == b"Connection".len() => {
-                    if connection_header.name().is_empty()
-                        && strings::eql_case_insensitive_ascii_ignore_length(
-                            header.name(),
-                            b"Connection",
-                        )
-                    {
-                        connection_header = *header;
+                    if strings::eql_case_insensitive_ascii_ignore_length(
+                        header.name(),
+                        b"Connection",
+                    ) {
+                        // RFC 6455 §4.1: Connection must CONTAIN the token "Upgrade"
+                        // (case-insensitive). It is a comma-list (RFC 7230 §6.1) and
+                        // repeated field lines join (§3.2.2), so scan every line.
+                        connection_header_seen = true;
+                        let mut it = HeaderValueIterator::init(header.value());
+                        while let Some(token) = it.next() {
+                            if strings::eql_case_insensitive_ascii(token, b"Upgrade", true) {
+                                connection_has_upgrade = true;
+                                break;
+                            }
+                        }
                     }
                 }
                 len if len == b"Upgrade".len() => {
@@ -1512,12 +1521,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if connection_header
-            .name()
-            .len()
-            .min(connection_header.value().len())
-            == 0
-        {
+        if !connection_header_seen {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::MissingConnectionHeader) };
             return;
@@ -1541,7 +1545,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if !strings::eql_case_insensitive_ascii(connection_header.value(), b"Upgrade", true) {
+        if !connection_has_upgrade {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::InvalidConnectionHeader) };
             return;

--- a/test/js/web/websocket/websocket-accept-header-validation.test.ts
+++ b/test/js/web/websocket/websocket-accept-header-validation.test.ts
@@ -45,10 +45,9 @@ async function handshakeWithConnectionHeader(connectionLines: string): Promise<H
   }
 }
 
-// RFC 6455 §4.1 item 6: the |Connection| header field must CONTAIN a token that
-// is an ASCII case-insensitive match for "Upgrade". Connection is a comma-
-// separated token list (RFC 7230 §6.1), and multiple field lines are equivalent
-// to their comma-joined form (§3.2.2).
+// RFC 6455 §4.1 item 6: |Connection| must CONTAIN a token that case-insensitively
+// matches "Upgrade". It is a comma-list (RFC 7230 §6.1), and repeated field lines
+// are equivalent to their comma-joined form (§3.2.2).
 describe("WebSocket Connection header validation", () => {
   test.each([
     ["single token", "Connection: Upgrade\r\n"],

--- a/test/js/web/websocket/websocket-accept-header-validation.test.ts
+++ b/test/js/web/websocket/websocket-accept-header-validation.test.ts
@@ -2,6 +2,82 @@ import { TCPSocketListener } from "bun";
 import { describe, expect, test } from "bun:test";
 import { WebSocket } from "ws";
 
+type HandshakeOutcome = { opened: boolean; code: number; reason: string };
+
+async function handshakeWithConnectionHeader(connectionLines: string): Promise<HandshakeOutcome> {
+  let buf = "";
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, data) {
+        buf += data.toString("latin1");
+        if (!buf.includes("\r\n\r\n")) return;
+        const key = /sec-websocket-key: *(\S+)/i.exec(buf)?.[1] ?? "";
+        const hasher = new Bun.CryptoHasher("sha1");
+        hasher.update(key);
+        hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+        const accept = hasher.digest("base64");
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            connectionLines +
+            `Sec-WebSocket-Accept: ${accept}\r\n` +
+            "\r\n",
+        );
+        socket.flush();
+      },
+    },
+  });
+
+  const { promise, resolve } = Promise.withResolvers<HandshakeOutcome>();
+  let opened = false;
+  const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
+  ws.addEventListener("open", () => {
+    opened = true;
+    ws.close();
+  });
+  ws.addEventListener("close", e => resolve({ opened, code: e.code, reason: e.reason }));
+  try {
+    return await promise;
+  } finally {
+    ws.close();
+  }
+}
+
+// RFC 6455 §4.1 item 6: the |Connection| header field must CONTAIN a token that
+// is an ASCII case-insensitive match for "Upgrade". Connection is a comma-
+// separated token list (RFC 7230 §6.1), and multiple field lines are equivalent
+// to their comma-joined form (§3.2.2).
+describe("WebSocket Connection header validation", () => {
+  test.each([
+    ["single token", "Connection: Upgrade\r\n"],
+    ["lowercase", "Connection: upgrade\r\n"],
+    ["token list, Upgrade last", "Connection: keep-alive, Upgrade\r\n"],
+    ["token list, Upgrade first", "Connection: Upgrade, keep-alive\r\n"],
+    ["token list, extra whitespace", "Connection:  keep-alive ,  Upgrade \r\n"],
+    ["two field lines, Upgrade second", "Connection: keep-alive\r\nConnection: Upgrade\r\n"],
+    ["two field lines, Upgrade first", "Connection: Upgrade\r\nConnection: keep-alive\r\n"],
+  ])("accepts handshake when Connection contains Upgrade token (%s)", async (_label, lines) => {
+    const result = await handshakeWithConnectionHeader(lines);
+    expect(result).toEqual({ opened: true, code: 1000, reason: "" });
+  });
+
+  test.each([
+    ["keep-alive only", "Connection: keep-alive\r\n"],
+    ["close only", "Connection: close\r\n"],
+    ["substring but not a token", "Connection: Upgrade-Insecure\r\n"],
+  ])("rejects handshake when Connection lacks Upgrade token (%s)", async (_label, lines) => {
+    const result = await handshakeWithConnectionHeader(lines);
+    expect(result).toEqual({ opened: false, code: 1002, reason: "Invalid connection header" });
+  });
+
+  test("rejects handshake when Connection header is missing", async () => {
+    const result = await handshakeWithConnectionHeader("");
+    expect(result).toEqual({ opened: false, code: 1002, reason: "Missing connection header" });
+  });
+});
+
 describe("WebSocket Sec-WebSocket-Accept validation", () => {
   test("rejects handshake with incorrect Sec-WebSocket-Accept", async () => {
     let server: TCPSocketListener | undefined;


### PR DESCRIPTION
## Reproduction

```js
// Server responds with a conformant 101 whose Connection header is a token list:
//   HTTP/1.1 101 Switching Protocols
//   Upgrade: websocket
//   Connection: keep-alive, Upgrade
//   Sec-WebSocket-Accept: <correct>
new WebSocket(url); // close code 1002 "Invalid connection header"
```

Same for `Connection: Upgrade, keep-alive` and for two separate `Connection:` field lines where only one carries `Upgrade`.

## Cause

`process_response()` in `src/http_jsc/websocket_client/WebSocketUpgradeClient.rs` stored only the first `Connection` header line and then required its entire value to equal `"Upgrade"` case-insensitively:

```rust
if !strings::eql_case_insensitive_ascii(connection_header.value(), b"Upgrade", true) {
    unsafe { Self::terminate(this, ErrorCode::InvalidConnectionHeader) };
    return;
}
```

RFC 6455 section 4.1 item 6 requires only that the `Connection` header field *contain a token* that is an ASCII case-insensitive match for `"Upgrade"`. `Connection` is defined as a comma-separated token list (RFC 7230 section 6.1), and multiple field lines are equivalent to their comma-joined form (section 3.2.2). Chrome (`HttpResponseHeaders::HasHeaderValue`), Firefox (`nsHttp::FindToken`), and npm `ws` all accept these responses.

## Fix

Scan every `Connection` field line for the `"Upgrade"` token using the existing `HeaderValueIterator` (already used for `Sec-WebSocket-Protocol` in the same function). Responses that lack the header still fail with `MissingConnectionHeader`, and responses whose `Connection` tokens do not include `"Upgrade"` (for example `Connection: keep-alive` or `Connection: Upgrade-Insecure`) still fail with `InvalidConnectionHeader`.

## Verification

New tests in `test/js/web/websocket/websocket-accept-header-validation.test.ts` cover:
- single token, lowercase, token-list with `Upgrade` first/last, extra whitespace, and two field lines in both orders (all must open)
- `keep-alive` only, `close` only, and a substring-but-not-a-token value (all must fail with 1002 `"Invalid connection header"`)
- missing `Connection` header (must fail with 1002 `"Missing connection header"`)

Fail-before on the released binary:
```
9 pass
4 fail   (token list Upgrade last/first, extra whitespace, two field lines Upgrade second)
```

With the fix:
```
13 pass
0 fail
```