### PR TITLE
Bun.serve: stop using sendfile(2) for file responses on macOS

### DIFF
--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -16,7 +16,13 @@ pub struct SendFile {
 impl SendFile {
     pub fn is_eligible(url: &URL) -> bool {
         // `if cfg!()` is fine here: both branches type-check (no platform-only items referenced).
-        if cfg!(windows) || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT {
+        // macOS: XNU's sendfile allocates mbufs with M_WAIT/no PCATCH before the
+        // SS_NBIO check, so under mbuf pressure it sleeps uninterruptibly and the
+        // process becomes unkillable. The buffered write path stays non-blocking.
+        if cfg!(windows)
+            || cfg!(target_os = "macos")
+            || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT
+        {
             return false;
         }
         url.is_http() && url.href.len() > 0

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -16,13 +16,7 @@ pub struct SendFile {
 impl SendFile {
     pub fn is_eligible(url: &URL) -> bool {
         // `if cfg!()` is fine here: both branches type-check (no platform-only items referenced).
-        // macOS: XNU's sendfile allocates mbufs with M_WAIT/no PCATCH before the
-        // SS_NBIO check, so under mbuf pressure it sleeps uninterruptibly and the
-        // process becomes unkillable. The buffered write path stays non-blocking.
-        if cfg!(windows)
-            || cfg!(target_os = "macos")
-            || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT
-        {
+        if cfg!(windows) || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT {
             return false;
         }
         url.is_http() && url.href.len() > 0

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -552,10 +552,9 @@ impl Drop for FileResponseStream {
 }
 
 fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> bool {
-    // Matches the cfg on `on_sendfile`. macOS is intentionally excluded: XNU's
-    // sendfile allocates mbufs with M_WAIT/no PCATCH before the SS_NBIO check,
-    // so under mbuf pressure it sleeps uninterruptibly and the process becomes
-    // unkillable. The BufferedReader path is fully non-blocking.
+    // Matches the cfg on `on_sendfile`. macOS is excluded: XNU's sendfile can
+    // sleep uninterruptibly under mbuf pressure, leaving the process unkillable;
+    // the BufferedReader path stays non-blocking.
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         let _ = (resp, file_type, length);

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -552,15 +552,16 @@ impl Drop for FileResponseStream {
 }
 
 fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> bool {
-    // On macOS, sendfile(2) can park uninterruptibly on an XNU turnstile under
-    // mbuf pressure and stay there after the peer task is torn down, leaving
-    // the process unkillable. The BufferedReader path is fully non-blocking.
-    #[cfg(any(windows, target_os = "macos"))]
+    // Matches the cfg on `on_sendfile`. macOS is intentionally excluded: XNU's
+    // sendfile allocates mbufs with M_WAIT/no PCATCH before the SS_NBIO check,
+    // so under mbuf pressure it sleeps uninterruptibly and the process becomes
+    // unkillable. The BufferedReader path is fully non-blocking.
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         let _ = (resp, file_type, length);
         return false;
     }
-    #[cfg(not(any(windows, target_os = "macos")))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // sendfile() needs a real socket fd; SSL writes go through BIO and H3
         // through lsquic stream frames — neither has one.

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -60,22 +60,22 @@ pub enum Mode {
 }
 
 struct Sendfile {
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     socket_fd: Fd,
     remain: u64,
     offset: u64,
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     has_set_on_writable: bool,
 }
 
 impl Default for Sendfile {
     fn default() -> Self {
         Self {
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             socket_fd: Fd::INVALID,
             remain: 0,
             offset: 0,
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             has_set_on_writable: false,
         }
     }
@@ -165,11 +165,11 @@ impl FileResponseStream {
 
         if use_sendfile {
             this.sendfile = Sendfile {
-                #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 socket_fd: opts.resp.get_native_handle(),
                 offset: opts.offset,
                 remain: opts.length.expect("can_sendfile gates None"),
-                #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 has_set_on_writable: false,
             };
             this.resp.prepare_for_sendfile();
@@ -402,55 +402,13 @@ impl FileResponseStream {
                 }
             }
         }
-        #[cfg(target_os = "macos")]
-        loop {
-            let mut sbytes: libc::off_t =
-                i64::try_from(self.sendfile.remain.min(i32::MAX as u64)).expect("int cast");
-            // SAFETY: both fds are valid open file descriptors owned by `self`;
-            // `sbytes` is a stack local; hdtr is null per spec.
-            let errno = sys::get_errno(unsafe {
-                sys::c::sendfile(
-                    self.fd.native(),
-                    self.sendfile.socket_fd.native(),
-                    i64::try_from(self.sendfile.offset).expect("int cast"),
-                    &raw mut sbytes,
-                    core::ptr::null_mut(),
-                    0,
-                )
-            });
-            let sent: u64 = u64::try_from(sbytes).expect("int cast");
-            self.sendfile.offset += sent;
-            self.sendfile.remain = self.sendfile.remain.saturating_sub(sent);
-
-            match errno {
-                sys::E::SUCCESS => {
-                    if self.sendfile.remain == 0 || sent == 0 {
-                        self.end_sendfile();
-                        return false;
-                    }
-                    return self.arm_sendfile_writable();
-                }
-                sys::E::EINTR => continue,
-                sys::E::EAGAIN => return self.arm_sendfile_writable(),
-                sys::E::EPIPE | sys::E::ENOTCONN => {
-                    self.end_sendfile();
-                    return false;
-                }
-                _ => {
-                    self.fail_with(
-                        sys::Error::from_code(errno, sys::Tag::sendfile).with_fd(self.fd),
-                    );
-                    return false;
-                }
-            }
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             unreachable!() // can_sendfile gates this
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn arm_sendfile_writable(&mut self) -> bool {
         bun_output::scoped_log!(FileResponseStream, "armSendfileWritable");
         if !self.sendfile.has_set_on_writable {
@@ -467,7 +425,7 @@ impl FileResponseStream {
         true
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn end_sendfile(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "endSendfile");
         if self.state.contains(State::RESPONSE_DONE) {
@@ -594,12 +552,15 @@ impl Drop for FileResponseStream {
 }
 
 fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> bool {
-    #[cfg(windows)]
+    // On macOS, sendfile(2) can park uninterruptibly on an XNU turnstile under
+    // mbuf pressure and stay there after the peer task is torn down, leaving
+    // the process unkillable. The BufferedReader path is fully non-blocking.
+    #[cfg(any(windows, target_os = "macos"))]
     {
         let _ = (resp, file_type, length);
         return false;
     }
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "macos")))]
     {
         // sendfile() needs a real socket fd; SSL writes go through BIO and H3
         // through lsquic stream frames — neither has one.

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2185,7 +2185,7 @@ it("file-response server exits when killed mid-send", async () => {
     cmd: [bunExe(), fixture],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
     stdin: "ignore",
   });
   const { value } = await proc.stdout.getReader().read();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -9,6 +9,7 @@ import {
   isIntelMacOS,
   isIPv4,
   isIPv6,
+  isMacOS,
   isPosix,
   tempDir,
   tls,
@@ -20,7 +21,7 @@ import { join, resolve } from "path";
 import { heapStats } from "bun:jsc";
 import { spawn } from "child_process";
 import net from "node:net";
-import { networkInterfaces } from "node:os";
+import { networkInterfaces, totalmem } from "node:os";
 import { tmpdir } from "os";
 
 let renderToReadableStream: any = null;
@@ -2139,8 +2140,12 @@ it.concurrent("should work with dispose keyword", async () => {
   expect(fetch(url)).rejects.toThrow();
 });
 
+// On 8 GB macOS boxes 5000 concurrent localhost connections exhaust the kernel
+// mbuf pool; the server used to wedge in sendfile(2) and become unkillable.
+// sendfile is no longer used on macOS, but the exhaustion itself still makes
+// this test unreliable there, so skip it on low-memory macOS runners.
 // prettier-ignore
-it("should be able to stop in the middle of a file response", async () => {
+it.skipIf(isMacOS && totalmem() < 12 * 1024 * 1024 * 1024)("should be able to stop in the middle of a file response", async () => {
   async function doRequest(url: string) {
     try {
       const response = await fetch(url, { signal: AbortSignal.timeout(10) });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2139,11 +2139,9 @@ it.concurrent("should work with dispose keyword", async () => {
   expect(fetch(url)).rejects.toThrow();
 });
 
-// The fixture serves a >1 MB file, the threshold at which the sendfile backend
-// is selected on platforms that use it. Each iteration opens several streams,
-// reads one chunk so they are provably mid-send, then kills the server and
-// awaits proc.exited. On macOS the old sendfile(2) path could park
-// uninterruptibly on an XNU turnstile and never exit; see can_sendfile().
+// Fixture serves a >1 MB file (the sendfile threshold). Each iteration reads
+// one chunk from several streams so the server is provably mid-send when
+// killed; on macOS the old sendfile(2) path could hang uninterruptibly here.
 it("should be able to stop in the middle of a file response", async () => {
   const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
   for (let i = 0; i < 3; i++) {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2139,75 +2139,37 @@ it.concurrent("should work with dispose keyword", async () => {
   expect(fetch(url)).rejects.toThrow();
 });
 
-// prettier-ignore
+// The fixture serves a >1 MB file, the threshold at which the sendfile backend
+// is selected on platforms that use it. Each iteration opens several streams,
+// reads one chunk so they are provably mid-send, then kills the server and
+// awaits proc.exited. On macOS the old sendfile(2) path could park
+// uninterruptibly on an XNU turnstile and never exit; see can_sendfile().
 it("should be able to stop in the middle of a file response", async () => {
-  async function doRequest(url: string) {
-    try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(10) });
-      const read = (response.body as ReadableStream<any>).getReader();
-      while (true) {
-        const { value, done } = await read.read();
-        if (done) break;
-      }
-      expect(response.status).toBe(200);
-    } catch {}
-  }
   const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
   for (let i = 0; i < 3; i++) {
-    const process = Bun.spawn([bunExe(), fixture], {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture],
       env: bunEnv,
       stderr: "inherit",
       stdout: "pipe",
       stdin: "ignore",
     });
-    const { value } = await process.stdout.getReader().read();
+    const { value } = await proc.stdout.getReader().read();
     const url = new TextDecoder().decode(value).trim();
-    // Kept well below the point where macOS's mbuf pool exhausts on CI runners.
-    const requests = [];
-    for (let j = 0; j < 512; j++) {
-      requests.push(doRequest(url));
+    // Deliberately small so macOS CI runners never approach mbuf exhaustion.
+    const readers: ReadableStreamDefaultReader[] = [];
+    for (let j = 0; j < 16; j++) {
+      const res = await fetch(url);
+      expect(res.status).toBe(200);
+      readers.push((res.body as ReadableStream).getReader());
     }
-    // only await a subset of requests (and kill the process)
-    await Promise.all(requests.slice(0, 128));
-    expect(process.exitCode || 0).toBe(0);
-    process.kill();
+    await Promise.all(readers.map(r => r.read()));
+    expect(proc.exitCode).toBe(null);
+    proc.kill();
+    await proc.exited;
+    expect(proc.signalCode).toBe("SIGTERM");
+    for (const r of readers) await r.cancel().catch(() => {});
   }
-}, 60_000);
-
-it("file-response server exits when killed mid-send", async () => {
-  // The fixture serves a >1 MB file, which is the threshold at which the
-  // sendfile backend is selected on platforms that use it. On macOS 26.3 the
-  // sendfile syscall could park uninterruptibly on a kernel turnstile when the
-  // peer stopped reading, leaving the server process unkillable. This test
-  // asserts the process actually exits after SIGTERM.
-  const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-    stdin: "ignore",
-  });
-  const { value } = await proc.stdout.getReader().read();
-  const url = new TextDecoder().decode(value).trim();
-
-  // Start a handful of streaming reads so the server has in-flight file
-  // responses with data queued in the socket send buffer, then stop reading.
-  const readers: ReadableStreamDefaultReader[] = [];
-  for (let i = 0; i < 8; i++) {
-    const res = await fetch(url);
-    expect(res.status).toBe(200);
-    const reader = (res.body as ReadableStream).getReader();
-    await reader.read();
-    readers.push(reader);
-  }
-
-  proc.kill();
-  await proc.exited;
-  for (const r of readers) await r.cancel().catch(() => {});
-
-  expect(proc.signalCode).toBe("SIGTERM");
-  expect(proc.killed).toBe(true);
 });
 
 it("should be able to abrupt stop the server", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -9,7 +9,6 @@ import {
   isIntelMacOS,
   isIPv4,
   isIPv6,
-  isMacOS,
   isPosix,
   tempDir,
   tls,
@@ -21,7 +20,7 @@ import { join, resolve } from "path";
 import { heapStats } from "bun:jsc";
 import { spawn } from "child_process";
 import net from "node:net";
-import { networkInterfaces, totalmem } from "node:os";
+import { networkInterfaces } from "node:os";
 import { tmpdir } from "os";
 
 let renderToReadableStream: any = null;
@@ -2140,12 +2139,8 @@ it.concurrent("should work with dispose keyword", async () => {
   expect(fetch(url)).rejects.toThrow();
 });
 
-// On 8 GB macOS boxes 5000 concurrent localhost connections exhaust the kernel
-// mbuf pool; the server used to wedge in sendfile(2) and become unkillable.
-// sendfile is no longer used on macOS, but the exhaustion itself still makes
-// this test unreliable there, so skip it on low-memory macOS runners.
 // prettier-ignore
-it.skipIf(isMacOS && totalmem() < 12 * 1024 * 1024 * 1024)("should be able to stop in the middle of a file response", async () => {
+it("should be able to stop in the middle of a file response", async () => {
   async function doRequest(url: string) {
     try {
       const response = await fetch(url, { signal: AbortSignal.timeout(10) });
@@ -2167,16 +2162,53 @@ it.skipIf(isMacOS && totalmem() < 12 * 1024 * 1024 * 1024)("should be able to st
     });
     const { value } = await process.stdout.getReader().read();
     const url = new TextDecoder().decode(value).trim();
+    // Kept well below the point where macOS's mbuf pool exhausts on CI runners.
     const requests = [];
-    for (let j = 0; j < 5_000; j++) {
+    for (let j = 0; j < 512; j++) {
       requests.push(doRequest(url));
     }
-    // only await for 1k requests (and kill the process)
-    await Promise.all(requests.slice(0, 1_000));
+    // only await a subset of requests (and kill the process)
+    await Promise.all(requests.slice(0, 128));
     expect(process.exitCode || 0).toBe(0);
     process.kill();
   }
 }, 60_000);
+
+it("file-response server exits when killed mid-send", async () => {
+  // The fixture serves a >1 MB file, which is the threshold at which the
+  // sendfile backend is selected on platforms that use it. On macOS 26.3 the
+  // sendfile syscall could park uninterruptibly on a kernel turnstile when the
+  // peer stopped reading, leaving the server process unkillable. This test
+  // asserts the process actually exits after SIGTERM.
+  const fixture = join(import.meta.dir, "server-bigfile-send.fixture.js");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const { value } = await proc.stdout.getReader().read();
+  const url = new TextDecoder().decode(value).trim();
+
+  // Start a handful of streaming reads so the server has in-flight file
+  // responses with data queued in the socket send buffer, then stop reading.
+  const readers: ReadableStreamDefaultReader[] = [];
+  for (let i = 0; i < 8; i++) {
+    const res = await fetch(url);
+    expect(res.status).toBe(200);
+    const reader = (res.body as ReadableStream).getReader();
+    await reader.read();
+    readers.push(reader);
+  }
+
+  proc.kill();
+  await proc.exited;
+  for (const r of readers) await r.cancel().catch(() => {});
+
+  expect(proc.signalCode).toBe("SIGTERM");
+  expect(proc.killed).toBe(true);
+});
 
 it("should be able to abrupt stop the server", async () => {
   for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
## Why

`darwin-test-arm64-5` (the 8 GB arm64 test runner) has been ending every CI day with a string of `buildkite-agent artifact download timed out` failures (#33116), and every nightly reboot ends in a watchdog panic. The box accumulates dozens of `bun-profile` processes stuck in state `U` / `?E` that hold ~130 MB of kernel socket buffers, which exhausts the mbuf pool and collapses network throughput to ~13 KB/s.

Sampling one of the wedged processes shows the server side parked in `sendfile(2)` on an XNU turnstile whose owner is a thread in a peer task that is already being torn down:

```
RequestContext::do_sendfile + 2108   (bun-profile)
  sendfile + 8                       (libsystem_kernel.dylib)
    ??? (kernel.release.t8112)
    (blocked by turnstile waiting for bun-profile [52438] thread 0x34160)
```

In XNU's `sendfile` (`bsd/kern/uipc_syscalls.c`), the mbuf-chain allocation at `:3940` uses `M_WAIT` at priority `PZERO-1` with no `PCATCH`, and it happens *before* the `SS_NBIO`/`sbspace()` check at `:4039-4040`. So `O_NONBLOCK` on the socket is never consulted for this wait, the sleep is uninterruptible, and `SIGKILL` simply pends. Capping the `sbytes` argument would shrink the allocation but can still land in the same uninterruptible wait when the pool is empty.

Process 52438 above is the client side of the same test, stuck in `?E` because `exit()` is closing its sockets while the mbuf pool is at `21504/21504` 4 KB clusters and `20M requests for memory denied`. Since neither side can make progress, `shutdown -r` hangs in vfs teardown and `AppleARMWatchdogTimer` hard-resets the box. The 16 GB runners recover because their larger pool drains before a second process lands on the same lock.

## What

`can_sendfile()` now returns `true` only on Linux/Android (matching the cfg on `on_sendfile`), so on macOS large plain-HTTP file responses take the `BufferedReader` path: chunked `read()` then non-blocking usockets `write()` with backpressure. That path is already used for SSL, HTTP/3, Windows, and files under 1 MB. The macOS `sendfile` call in `on_sendfile` and the cfg gates that kept it reachable are removed as dead code.

This does not prevent mbuf exhaustion; a burst of large localhost file responses can still fill the pool. The difference is recovery: `send()` on the `BufferedReader` path returns `ENOBUFS` when the pool is empty, and usockets' `bsd_would_block()` only treats `EWOULDBLOCK` as retryable, so `ENOBUFS` surfaces as a fatal write error, the socket is closed, its clusters are freed, and the process stays killable. `sendfile` sleeping uninterruptibly in the allocation path is what turned the same exhaustion into an unkillable process requiring a reboot.

### Not changed here: client-side file uploads

`fetch()` with a `Bun.file()` body over plain HTTP also uses `sendfile(2)` on macOS (`src/http/SendFile.rs`). That call site has the same kernel-level hazard, but its fallback when `is_eligible()` returns false is a synchronous whole-file read on the JS thread (`node_fs.read_file(..., Flavor::Sync)` at `fetch.rs:1741`, marked `TODO: make this async + lazy`). Trading a rare unkillable-under-mbuf-exhaustion risk for a guaranteed blocking read on every large upload is a different balance than the server case, so that path is left as-is. Tracked separately.

## Tests

The existing `should be able to stop in the middle of a file response` test is rewritten. The old shape fired 5000 fetches each with `AbortSignal.timeout(10)`; the 10 ms timer fires before the synchronous creation loop yields, so on fast machines every request aborts before connecting and the server sees none of them. The new shape opens 16 requests, reads one chunk from each so they are provably mid-send, asserts the server is still running, then kills it and `await proc.exited` with `signalCode === "SIGTERM"`, across three iterations. Deterministic and cheap enough to keep macOS coverage without driving runners toward mbuf exhaustion.

This test asserts the process stays killable mid-send; it does not induce mbuf exhaustion and would likely pass on an unfixed build on a machine with headroom. Reproducing the full deadlock in CI would require pinning the kernel mbuf pool, which is unsafe on shared runners.

## Verification

- `cargo check -p bun_runtime` clean on `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-freebsd`.
- `bun bd test test/js/bun/http/bun-serve-file.test.ts`: 67 pass, 0 fail.
- `bun bd test test/js/bun/http/serve.test.ts -t "stop in the middle"`: passes in ~2.3s with 54 assertions.
- macOS behavior is exercised by the existing file-response suite on the darwin CI lanes.

Closes #33116.