### PR TITLE
node:tls: accept DataView for key/cert/ca options

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -10,7 +10,13 @@ function isPemArray(obj: unknown): obj is [{ pem: unknown }] {
 }
 
 function isValidTLSItem(obj: unknown) {
-  if (typeof obj === "string" || isArrayBufferView(obj) || isArrayBuffer(obj) || $inheritsBlob(obj) || isPemArray(obj)) {
+  if (
+    typeof obj === "string" ||
+    isArrayBufferView(obj) ||
+    isArrayBuffer(obj) ||
+    $inheritsBlob(obj) ||
+    isPemArray(obj)
+  ) {
     return true;
   }
 

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,4 @@
-const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { isArrayBufferView, isArrayBuffer } = require("node:util/types");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -10,7 +10,7 @@ function isPemArray(obj: unknown): obj is [{ pem: unknown }] {
 }
 
 function isValidTLSItem(obj: unknown) {
-  if (typeof obj === "string" || isTypedArray(obj) || isArrayBuffer(obj) || $inheritsBlob(obj) || isPemArray(obj)) {
+  if (typeof obj === "string" || isArrayBufferView(obj) || isArrayBuffer(obj) || $inheritsBlob(obj) || isPemArray(obj)) {
     return true;
   }
 

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -41,9 +41,11 @@ describe("tls.createSecureContext key/cert/ca input types", () => {
       const received = await new Promise<string>((resolve, reject) => {
         const client = tls.connect({ port, host: "127.0.0.1", ca: asDataView(ca1), servername: "agent1" });
         let data = "";
+        let ended = false;
         client.on("data", chunk => (data += chunk));
-        client.on("end", () => resolve(data));
+        client.on("end", () => ((ended = true), resolve(data)));
         client.on("error", reject);
+        client.on("close", () => ended || reject(new Error("client closed before 'end'")));
       });
       expect(received).toBe("hello");
     } finally {

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -1,5 +1,68 @@
 import { describe, expect, it } from "bun:test";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
 import * as tls from "node:tls";
+
+const agent1Key = readFileSync(join(import.meta.dir, "fixtures", "agent1-key.pem"));
+const agent1Cert = readFileSync(join(import.meta.dir, "fixtures", "agent1-cert.pem"));
+const ca1 = readFileSync(join(import.meta.dir, "fixtures", "ca1-cert.pem"));
+
+function asDataView(buf: Buffer): DataView {
+  // Back the view with a fresh ArrayBuffer holding exactly these bytes.
+  const copy = new Uint8Array(buf);
+  return new DataView(copy.buffer, copy.byteOffset, copy.byteLength);
+}
+
+describe("tls.createSecureContext key/cert/ca input types", () => {
+  // Node.js accepts any ArrayBufferView (Buffer, TypedArray, DataView) for
+  // key/cert/ca; the error message Bun emits on rejection even lists DataView
+  // as an accepted type, so rejecting a DataView contradicts Bun's own message.
+  it("accepts DataView for key, cert, and ca", () => {
+    expect(() => tls.createSecureContext({ key: asDataView(agent1Key), cert: agent1Cert })).not.toThrow();
+    expect(() => tls.createSecureContext({ key: agent1Key, cert: asDataView(agent1Cert) })).not.toThrow();
+    expect(() => tls.createSecureContext({ ca: asDataView(ca1) })).not.toThrow();
+    expect(() => tls.createSecureContext({ ca: [asDataView(ca1)] })).not.toThrow();
+    expect(() =>
+      tls.createSecureContext({ key: asDataView(agent1Key), cert: asDataView(agent1Cert), ca: asDataView(ca1) }),
+    ).not.toThrow();
+  });
+
+  it("DataView key/cert/ca produce a working TLS connection", async () => {
+    const server = tls.createServer(
+      { key: asDataView(agent1Key), cert: asDataView(agent1Cert) },
+      socket => {
+        socket.end("hello");
+      },
+    );
+    try {
+      server.listen(0);
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      const received = await new Promise<string>((resolve, reject) => {
+        const client = tls.connect({ port, host: "127.0.0.1", ca: asDataView(ca1), servername: "agent1" });
+        let data = "";
+        client.on("data", chunk => (data += chunk));
+        client.on("end", () => resolve(data));
+        client.on("error", reject);
+      });
+      expect(received).toBe("hello");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("still rejects types that are neither string nor ArrayBufferView", () => {
+    expect(() => tls.createSecureContext({ key: 123 as any, cert: agent1Cert })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => tls.createSecureContext({ cert: {} as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+});
 
 describe("tls.createSecureContext extra arguments test", () => {
   it("should throw an error if the privateKeyEngine is not a string", () => {

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -30,12 +30,9 @@ describe("tls.createSecureContext key/cert/ca input types", () => {
   });
 
   it("DataView key/cert/ca produce a working TLS connection", async () => {
-    const server = tls.createServer(
-      { key: asDataView(agent1Key), cert: asDataView(agent1Cert) },
-      socket => {
-        socket.end("hello");
-      },
-    );
+    const server = tls.createServer({ key: asDataView(agent1Key), cert: asDataView(agent1Cert) }, socket => {
+      socket.end("hello");
+    });
     try {
       server.listen(0);
       await once(server, "listening");


### PR DESCRIPTION
## What does this PR do?

`tls.createSecureContext` (and by extension `tls.createServer`, `tls.connect`, `https.request`, `https.createServer`) rejected `DataView` values for the `key`, `cert`, and `ca` options with `ERR_INVALID_ARG_TYPE`, even though the thrown message itself listed `DataView` as an accepted type:

```
The "options.key" property must be of type string or an instance of Buffer,
TypedArray, DataView, or BunFile. Received an instance of DataView
```

Node.js accepts any `ArrayBufferView` for these options (`validateKeyOrCertOption` in `lib/internal/tls/secure-context.js` uses `isArrayBufferView`).

### Reproduction

```js
import tls from "node:tls";
const dv = s => { const b = Buffer.from(s); return new DataView(b.buffer, b.byteOffset, b.byteLength); };
tls.createSecureContext({ key: dv(KEY), cert: CERT });
// node: ok
// bun:  TypeError [ERR_INVALID_ARG_TYPE]: ... DataView, or BunFile. Received an instance of DataView
```

### Cause

`isValidTLSItem` in `src/js/internal/tls.ts` used `isTypedArray` from `node:util/types`, which returns `false` for `DataView`. The native `SSLConfig` converter (`IDLArrayBufferRef::tryConvert`) already accepts `DataView` via the `JSArrayBufferView` downcast, so only the JS-side predicate was too narrow.

### Fix

Swap `isTypedArray` for `isArrayBufferView`, matching both Node's check and the error message Bun already emits.

### How did you verify your code works?

New tests in `test/js/node/tls/node-tls-create-secure-context-args.test.ts`:
- `createSecureContext` with `DataView` for each of `key`, `cert`, `ca` (scalar and array) does not throw
- end-to-end: a `tls.createServer` with `DataView` key/cert accepts a `tls.connect` with a `DataView` `ca` and transfers data
- non-string / non-`ArrayBufferView` values are still rejected with `ERR_INVALID_ARG_TYPE`

Before the fix the first two tests fail with `ERR_INVALID_ARG_TYPE`; after, all pass.