### PR TITLE
node:http: wire server socket/response setTimeout to the native inactivity timer

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -16,6 +16,7 @@ const {
   validateFunction,
 } = require("internal/validators");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
+const { getTimerDuration } = require("internal/timers");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
@@ -1327,6 +1328,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
 
   setTimeout(msecs, callback) {
     this.timeout = msecs;
+    msecs = getTimerDuration(msecs, "msecs");
     if (msecs === 0) {
       if (callback !== undefined) {
         validateFunction(callback, "callback");

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -51,6 +51,7 @@ const {
   eofInProgress,
   runSymbol,
   drainMicrotasks,
+  setRequestTimeout,
   setServerIdleTimeout,
   setServerCustomOptions,
   getMaxHTTPHeaderSize,
@@ -1324,7 +1325,24 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     return this;
   }
 
-  setTimeout(_timeout, _callback) {
+  setTimeout(msecs, callback) {
+    this.timeout = msecs;
+    if (msecs === 0) {
+      if (callback !== undefined) {
+        validateFunction(callback, "callback");
+        this.removeListener("timeout", callback);
+      }
+    } else if (callback !== undefined) {
+      validateFunction(callback, "callback");
+      this.once("timeout", callback);
+    }
+    // The per-connection inactivity timer lives on the native
+    // NodeHTTPResponse (handle.response); its onabort callback emits
+    // "timeout" on this socket via onServerRequestEvent.
+    const response = this[kHandle]?.response;
+    if (response) {
+      setRequestTimeout(response, Math.ceil(msecs / 1000));
+    }
     return this;
   }
 

--- a/test/js/node/http/node-http-server-socket-timeout.test.ts
+++ b/test/js/node/http/node-http-server-socket-timeout.test.ts
@@ -95,16 +95,28 @@ describe.concurrent("http server: per-connection setTimeout", () => {
   );
 
   test("socket.setTimeout(0, cb) removes the listener and clears socket.timeout", async () => {
-    let results: { timeoutAfterSet: number; timeoutAfterClear: number; returned: unknown; socket: unknown } | undefined;
+    let results:
+      | {
+          timeoutAfterSet: number;
+          timeoutAfterClear: number;
+          listenersAfterSet: number;
+          listenersAfterClear: number;
+          returned: unknown;
+          socket: unknown;
+        }
+      | undefined;
 
     const server = http.createServer((req, res) => {
       const socket = req.socket;
       const cb = () => {};
+      const baseListeners = socket.listenerCount("timeout");
       socket.setTimeout(2000, cb);
       const timeoutAfterSet = socket.timeout;
+      const listenersAfterSet = socket.listenerCount("timeout") - baseListeners;
       const returned = socket.setTimeout(0, cb);
       const timeoutAfterClear = socket.timeout;
-      results = { timeoutAfterSet, timeoutAfterClear, returned, socket };
+      const listenersAfterClear = socket.listenerCount("timeout") - baseListeners;
+      results = { timeoutAfterSet, timeoutAfterClear, listenersAfterSet, listenersAfterClear, returned, socket };
       res.end("ok");
     });
     await once(server.listen(0, "127.0.0.1"), "listening");
@@ -118,8 +130,56 @@ describe.concurrent("http server: per-connection setTimeout", () => {
     }
 
     expect(results).toBeDefined();
-    expect(results!.timeoutAfterSet).toBe(2000);
-    expect(results!.timeoutAfterClear).toBe(0);
+    expect({
+      timeoutAfterSet: results!.timeoutAfterSet,
+      timeoutAfterClear: results!.timeoutAfterClear,
+      listenersAfterSet: results!.listenersAfterSet,
+      listenersAfterClear: results!.listenersAfterClear,
+    }).toEqual({
+      timeoutAfterSet: 2000,
+      timeoutAfterClear: 0,
+      listenersAfterSet: 1,
+      listenersAfterClear: 0,
+    });
     expect(results!.returned).toBe(results!.socket);
+  });
+
+  test("socket.setTimeout validates msecs like net.Socket", async () => {
+    let errors: Record<string, string | undefined> | undefined;
+
+    const server = http.createServer((req, res) => {
+      const socket = req.socket;
+      const codeOf = (fn: () => void) => {
+        try {
+          fn();
+          return undefined;
+        } catch (e) {
+          return (e as NodeJS.ErrnoException).code;
+        }
+      };
+      errors = {
+        negative: codeOf(() => socket.setTimeout(-1)),
+        nan: codeOf(() => socket.setTimeout(NaN)),
+        string: codeOf(() => socket.setTimeout("foo" as unknown as number)),
+        badCallback: codeOf(() => socket.setTimeout(1000, "nope" as unknown as () => void)),
+      };
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await res.text()).toBe("ok");
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+    }
+
+    expect(errors).toEqual({
+      negative: "ERR_OUT_OF_RANGE",
+      nan: "ERR_OUT_OF_RANGE",
+      string: "ERR_INVALID_ARG_TYPE",
+      badCallback: "ERR_INVALID_ARG_TYPE",
+    });
   });
 });

--- a/test/js/node/http/node-http-server-socket-timeout.test.ts
+++ b/test/js/node/http/node-http-server-socket-timeout.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net, { type AddressInfo } from "node:net";
+
+// The uSockets per-connection inactivity timer has seconds granularity on a
+// coarse wheel, so a 1s timeout may take a few seconds to fire. These tests
+// only assert that the three documented spellings of the same knob all arm the
+// timer and deliver a 'timeout' event; the wheel granularity is covered
+// elsewhere.
+
+type Armer = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  onTimeout: () => void,
+) => { returned: unknown; expected: unknown; timeoutReadback: number };
+
+const STALL = "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab";
+
+describe.concurrent("http server: per-connection setTimeout", () => {
+  test.each([
+    [
+      "response.setTimeout(msecs, cb)",
+      ((req, res, onTimeout) => {
+        const returned = res.setTimeout(1000, onTimeout);
+        return { returned, expected: res, timeoutReadback: req.socket.timeout };
+      }) as Armer,
+    ],
+    [
+      "socket.setTimeout(msecs, cb)",
+      ((req, res, onTimeout) => {
+        const returned = req.socket.setTimeout(1000, onTimeout);
+        return { returned, expected: req.socket, timeoutReadback: req.socket.timeout };
+      }) as Armer,
+    ],
+    [
+      "request.setTimeout(msecs, cb)",
+      ((req, res, onTimeout) => {
+        const returned = req.setTimeout(1000, onTimeout);
+        return { returned, expected: req, timeoutReadback: req.socket.timeout };
+      }) as Armer,
+    ],
+  ])(
+    "%s arms the inactivity timer on a stalled request body",
+    async (_name, arm) => {
+      let timeoutFired = false;
+      let chainsCorrectly = false;
+      let timeoutReadback: number | undefined;
+
+      const server = http.createServer((req, res) => {
+        const { returned, expected, timeoutReadback: readback } = arm(req, res, () => {
+          timeoutFired = true;
+          req.socket.destroy();
+        });
+        chainsCorrectly = returned === expected;
+        timeoutReadback = readback;
+        req.resume();
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { port } = server.address() as AddressInfo;
+      try {
+        const client = net.connect(port, "127.0.0.1");
+        client.on("error", () => {});
+        await once(client, "connect");
+        client.setNoDelay(true);
+        // Send headers + a body prefix, then never complete the body so the
+        // connection is idle from the server's perspective.
+        client.write(STALL);
+        client.resume();
+
+        // The server-side timeout callback destroys the socket, which closes
+        // this client connection.
+        await once(client, "close");
+      } finally {
+        server.closeAllConnections?.();
+        server.close();
+      }
+
+      expect({ timeoutFired, chainsCorrectly }).toEqual({
+        timeoutFired: true,
+        chainsCorrectly: true,
+      });
+      // Node.js writes back the msecs value to socket.timeout for the socket
+      // and response spellings (request.setTimeout does not forward to the
+      // socket in Node, so that entry is allowed to read 0).
+      if (_name !== "request.setTimeout(msecs, cb)") {
+        expect(timeoutReadback).toBe(1000);
+      }
+    },
+    15_000,
+  );
+
+  test("socket.setTimeout(0, cb) removes the listener and clears socket.timeout", async () => {
+    let results: { timeoutAfterSet: number; timeoutAfterClear: number; returned: unknown; socket: unknown } | undefined;
+
+    const server = http.createServer((req, res) => {
+      const socket = req.socket;
+      const cb = () => {};
+      socket.setTimeout(2000, cb);
+      const timeoutAfterSet = socket.timeout;
+      const returned = socket.setTimeout(0, cb);
+      const timeoutAfterClear = socket.timeout;
+      results = { timeoutAfterSet, timeoutAfterClear, returned, socket };
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await res.text()).toBe("ok");
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+    }
+
+    expect(results).toBeDefined();
+    expect(results!.timeoutAfterSet).toBe(2000);
+    expect(results!.timeoutAfterClear).toBe(0);
+    expect(results!.returned).toBe(results!.socket);
+  });
+});

--- a/test/js/node/http/node-http-server-socket-timeout.test.ts
+++ b/test/js/node/http/node-http-server-socket-timeout.test.ts
@@ -48,7 +48,11 @@ describe.concurrent("http server: per-connection setTimeout", () => {
       let timeoutReadback: number | undefined;
 
       const server = http.createServer((req, res) => {
-        const { returned, expected, timeoutReadback: readback } = arm(req, res, () => {
+        const {
+          returned,
+          expected,
+          timeoutReadback: readback,
+        } = arm(req, res, () => {
           timeoutFired = true;
           req.socket.destroy();
         });

--- a/test/js/node/http/node-http-server-socket-timeout.test.ts
+++ b/test/js/node/http/node-http-server-socket-timeout.test.ts
@@ -84,9 +84,10 @@ describe.concurrent("http server: per-connection setTimeout", () => {
         timeoutFired: true,
         chainsCorrectly: true,
       });
-      // Node.js writes back the msecs value to socket.timeout for the socket
-      // and response spellings (request.setTimeout does not forward to the
-      // socket in Node, so that entry is allowed to read 0).
+      // Bun's server-side IncomingMessage.setTimeout currently calls the
+      // native setRequestTimeout(handle, ...) directly rather than routing
+      // through this.socket.setTimeout as Node does, so socket.timeout is not
+      // updated for the request spelling (pre-existing).
       if (_name !== "request.setTimeout(msecs, cb)") {
         expect(timeoutReadback).toBe(1000);
       }


### PR DESCRIPTION
## Problem

Inside a `node:http` server request handler, two of the three documented spellings of the per-connection inactivity timeout are silent no-ops:

```js
const srv = http.createServer((req, res) => {
  req.socket.setTimeout(1000, cb); // never fires, connection held forever
  res.setTimeout(1000, cb);        // never fires
  req.setTimeout(1000, cb);        // works
  req.socket.timeout;              // always 0
});
```

`socket.setTimeout()` inside `server.on('connection', ...)` is the canonical slowloris / slow-client mitigation in Node.js, and `res.setTimeout()` is what a lot of middleware reaches for. On Bun both return `this` without arming anything; the stalled connection is held open indefinitely with no error and no event.

## Cause

`NodeHTTPServerSocket.setTimeout` in `src/js/node/_http_server.ts` was a stub (`setTimeout(_timeout, _callback) { return this; }`). Both `ServerResponse.prototype.setTimeout` and `OutgoingMessage.prototype.setTimeout` delegate to `this.socket.setTimeout(...)`, i.e. to that stub. `IncomingMessage.prototype.setTimeout` instead calls the native `setRequestTimeout(handle, ...)` directly, which is why the `req.` spelling already worked.

The timeout event plumbing was already in place: `handle.onabort` is wired to `onServerRequestEvent`, which emits `"timeout"` on the socket, and `onNodeHTTPServerSocketTimeout` forwards it to `req`/`res`/`server`.

## Fix

Have `NodeHTTPServerSocket.setTimeout(msecs, cb)` store `this.timeout`, register/remove `cb` with `net.Socket` semantics (`once` / `removeListener`), and arm the same native timer via `setRequestTimeout(handle.response, Math.ceil(msecs / 1000))` that `IncomingMessage` already uses. `handle.response` is the current `NodeHTTPResponse`, which `jsHTTPSetTimeout` already dispatches on.

## Verification

`test/js/node/http/node-http-server-socket-timeout.test.ts` opens a raw client that sends headers plus a body prefix and then stalls, and checks that each of `request.setTimeout`, `response.setTimeout`, and `socket.setTimeout` delivers a `timeout` callback (which destroys the socket, closing the client connection) and returns `this`. A separate case asserts `socket.timeout` reads back the armed value and that `setTimeout(0, cb)` clears it.

On main, `response.setTimeout` / `socket.setTimeout` never fire (tests time out) and `socket.timeout` reads `0`; with this change all four cases pass.

<details><summary>before / after</summary>

```
main:
  request.setTimeout(400,cb)  closes at ~4000 ms, req-timeout fires
  response.setTimeout(400,cb) serverClosedConnAfterMs: null, events: []
  socket.setTimeout(400,cb)   serverClosedConnAfterMs: null, events: []
  socket.timeout readback     socket.timeout=0

this PR:
  all three spellings fire the callback and close the stalled connection
  socket.timeout readback     socket.timeout=400
```
</details>