### PR TITLE
node:http: wire server.timeout to the idle timeout

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -88,7 +88,6 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
-const kDeferredTimeouts = Symbol("deferredTimeouts");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -543,7 +542,6 @@ export {
   kBodyChunks,
   kClearTimeout,
   kCloseCallback,
-  kDeferredTimeouts,
   kDeprecatedReplySymbol,
   kEmitState,
   kEmptyObject,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -27,7 +27,6 @@ const {
   kRealListen,
   tlsSymbol,
   optionsSymbol,
-  kDeferredTimeouts,
   kDeprecatedReplySymbol,
   headerStateSymbol,
   NodeHTTPHeaderState,
@@ -75,6 +74,7 @@ const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
+const kTimeout = Symbol("http.server.timeout");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
 // only created on the first request, and emission is gated per-request on the
@@ -320,6 +320,7 @@ function Server(options, callback): void {
 
   this[optionsSymbol] = options;
   storeHTTPOptions.$call(this, options);
+  this[kTimeout] = 0;
 
   if (callback) this.on("request", callback);
   return this;
@@ -920,25 +921,37 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.once("listening", onListen);
     }
 
-    if (this[kDeferredTimeouts]) {
-      for (const { msecs, callback } of this[kDeferredTimeouts]) {
-        this.setTimeout(msecs, callback);
-      }
-      delete this[kDeferredTimeouts];
+    const timeoutMs = this[kTimeout];
+    if (typeof timeoutMs === "number" && timeoutMs > 0) {
+      setServerIdleTimeout(this[serverSymbol], Math.ceil(timeoutMs / 1000));
     }
 
     setTimeout(emitListeningNextTick, 1, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
   }
 };
 
+// Node.js applies `this.timeout` to every new socket in connectionListener,
+// so `server.timeout = N` and `server.setTimeout(N)` are interchangeable; the
+// accessor keeps that equivalence on top of Bun's server-wide idle timeout.
+Object.defineProperty(Server.prototype, "timeout", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return this[kTimeout];
+  },
+  set(msecs) {
+    this[kTimeout] = msecs;
+    const server = this[serverSymbol];
+    if (server) {
+      const seconds = typeof msecs === "number" && msecs > 0 ? Math.ceil(msecs / 1000) : 0;
+      setServerIdleTimeout(server, seconds);
+    }
+  },
+});
+
 Server.prototype.setTimeout = function (msecs, callback) {
-  const server = this[serverSymbol];
-  if (server) {
-    setServerIdleTimeout(server, Math.ceil(msecs / 1000));
-    if (typeof callback === "function") this.once("timeout", callback);
-  } else {
-    (this[kDeferredTimeouts] ??= []).push({ msecs, callback });
-  }
+  this.timeout = msecs;
+  if (typeof callback === "function") this.on("timeout", callback);
   return this;
 };
 

--- a/test/js/node/http/node-http-server-timeout.test.ts
+++ b/test/js/node/http/node-http-server-timeout.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
+
+test("http.Server: server.timeout defaults to 0 and reflects setTimeout()", () => {
+  const srv = http.createServer(() => {});
+  try {
+    expect(srv.timeout).toBe(0);
+
+    const returned = srv.setTimeout(1234);
+    expect(returned).toBe(srv);
+    expect(srv.timeout).toBe(1234);
+
+    srv.timeout = 4321;
+    expect(srv.timeout).toBe(4321);
+
+    srv.setTimeout(0);
+    expect(srv.timeout).toBe(0);
+  } finally {
+    srv.close();
+  }
+});
+
+// Node.js treats `server.timeout = N` and `server.setTimeout(N)` as the same
+// knob; assigning the property must apply the idle timeout to subsequent
+// sockets so a stalled connection is eventually closed.
+test(
+  "http.Server: assigning server.timeout closes a stalled connection",
+  async () => {
+    const srv = http.createServer((req, res) => {
+      req.resume();
+      req.on("end", () => res.end("ok"));
+    });
+    try {
+      srv.listen(0, "127.0.0.1");
+      await once(srv, "listening");
+
+      srv.timeout = 500;
+      expect(srv.timeout).toBe(500);
+
+      const addr = srv.address() as net.AddressInfo;
+      const client = net.connect(addr.port, "127.0.0.1");
+      client.setNoDelay(true);
+      client.on("error", () => {});
+      client.resume();
+      await once(client, "connect");
+      // Complete request head, then stall the body.
+      client.write("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab");
+
+      const [timedOutSocket] = (await once(srv, "timeout")) as [net.Socket];
+      timedOutSocket.destroy();
+      await once(client, "close");
+
+      client.destroy();
+    } finally {
+      srv.closeAllConnections?.();
+      srv.close();
+    }
+  },
+  20_000,
+);

--- a/test/js/node/http/node-http-server-timeout.test.ts
+++ b/test/js/node/http/node-http-server-timeout.test.ts
@@ -25,38 +25,34 @@ test("http.Server: server.timeout defaults to 0 and reflects setTimeout()", () =
 // Node.js treats `server.timeout = N` and `server.setTimeout(N)` as the same
 // knob; assigning the property must apply the idle timeout to subsequent
 // sockets so a stalled connection is eventually closed.
-test(
-  "http.Server: assigning server.timeout closes a stalled connection",
-  async () => {
-    const srv = http.createServer((req, res) => {
-      req.resume();
-      req.on("end", () => res.end("ok"));
-    });
-    try {
-      srv.listen(0, "127.0.0.1");
-      await once(srv, "listening");
+test("http.Server: assigning server.timeout closes a stalled connection", async () => {
+  const srv = http.createServer((req, res) => {
+    req.resume();
+    req.on("end", () => res.end("ok"));
+  });
+  try {
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
 
-      srv.timeout = 500;
-      expect(srv.timeout).toBe(500);
+    srv.timeout = 500;
+    expect(srv.timeout).toBe(500);
 
-      const addr = srv.address() as net.AddressInfo;
-      const client = net.connect(addr.port, "127.0.0.1");
-      client.setNoDelay(true);
-      client.on("error", () => {});
-      client.resume();
-      await once(client, "connect");
-      // Complete request head, then stall the body.
-      client.write("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab");
+    const addr = srv.address() as net.AddressInfo;
+    const client = net.connect(addr.port, "127.0.0.1");
+    client.setNoDelay(true);
+    client.on("error", () => {});
+    client.resume();
+    await once(client, "connect");
+    // Complete request head, then stall the body.
+    client.write("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab");
 
-      const [timedOutSocket] = (await once(srv, "timeout")) as [net.Socket];
-      timedOutSocket.destroy();
-      await once(client, "close");
+    const [timedOutSocket] = (await once(srv, "timeout")) as [net.Socket];
+    timedOutSocket.destroy();
+    await once(client, "close");
 
-      client.destroy();
-    } finally {
-      srv.closeAllConnections?.();
-      srv.close();
-    }
-  },
-  20_000,
-);
+    client.destroy();
+  } finally {
+    srv.closeAllConnections?.();
+    srv.close();
+  }
+}, 20_000);


### PR DESCRIPTION
## What

`http.Server.prototype.setTimeout` mapped `msecs` onto the native idle timeout but never stored `this.timeout`, and there was no `timeout` accessor at all, so the two documented spellings of the same knob diverged:

- `server.timeout` always read `undefined` (Node.js default: `0`)
- `server.setTimeout(N)` was enforced but did not update `server.timeout`
- `server.timeout = N` was a plain expando the server never consulted: the app reads back `N` and gets no timeout

## Repro

```js
import http from 'node:http';
const s = http.createServer(() => {});
console.log(s.timeout);            // undefined (Node.js: 0)
s.setTimeout(1234);
console.log(s.timeout);            // undefined (Node.js: 1234)
```

And `server.timeout = 500` after `listen()` leaves a stalled-body connection open indefinitely, where Node.js closes it after ~500 ms.

## Fix

Add a `timeout` accessor on `Server.prototype`: the getter returns the stored msecs (initialized to `0`), the setter stores the value and, when the native server is listening, routes through `setServerIdleTimeout`. `setTimeout` now writes through the accessor and, like Node.js, registers its callback with `on('timeout', ...)` rather than `once`. The deferred-timeouts array is no longer needed: the stored value is applied at listen time.

## Verification

`test/js/node/http/node-http-server-timeout.test.ts` covers the property semantics (default `0`, `setTimeout` writes it, assignment reads back) and that `server.timeout = N` after `listen()` actually closes a stalled connection. Both tests fail on the current release and pass with the fix. The existing `test-http-should-emit-timeout-event-when-using-server-setTimeout` still passes.