### PR TITLE
node:tls: skip checkServerIdentity on resumed sessions

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -415,7 +415,10 @@ const SocketHandlers: SocketHandler = {
     self.emit("secure", self);
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && typeof checkServerIdentity === "function") {
+    // Node skips the identity check when the server resumed our session: the
+    // peer's identity was established on the full handshake that issued the
+    // ticket (lib/internal/tls/wrap.js onConnectSecure).
+    if (!verifyError && !socket.isSessionReused() && typeof checkServerIdentity === "function") {
       const hostname = self.servername || self._host || "localhost";
       const cert = self.getPeerCertificate(true);
       if (cert) {
@@ -1151,7 +1154,10 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.emit("secure", self);
     self.alpnProtocol = socket.alpnProtocol;
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && typeof checkServerIdentity === "function") {
+    // Node skips the identity check when the server resumed our session: the
+    // peer's identity was established on the full handshake that issued the
+    // ticket (lib/internal/tls/wrap.js onConnectSecure).
+    if (!verifyError && !socket.isSessionReused() && typeof checkServerIdentity === "function") {
       const hostname = self.servername || self._host || "localhost";
       const cert = self.getPeerCertificate(true);
       if (cert) {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -800,7 +800,13 @@ it("skips checkServerIdentity on a resumed session (Node parity)", async () => {
   // A counting checkServerIdentity is not invoked on the resumed connection.
   let calls = 0;
   const a = await resume({ checkServerIdentity: () => (calls++, undefined) });
-  expect({ ...a, calls }).toEqual({ reused: true, authorized: true, authorizationError: undefined, result: "ok", calls: 0 });
+  expect({ ...a, calls }).toEqual({
+    reused: true,
+    authorized: true,
+    authorizationError: undefined,
+    result: "ok",
+    calls: 0,
+  });
 
   // A checkServerIdentity that returns an Error (certificate pinning) does not
   // run, so the resumed connection succeeds and is authorized.

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -747,3 +747,70 @@ it("https.request reports an impossible version window as a TLS error, not a cer
   await once(response, "end");
   expect(body).toBe("ok");
 });
+
+it("skips checkServerIdentity on a resumed session (Node parity)", async () => {
+  // Node gates onConnectSecure's identity check on !this.isSessionReused(): the
+  // peer was verified on the full handshake that issued the ticket.
+  await using server = tls.createServer({ ...COMMON_CERT_ }, c => {
+    c.on("error", () => {});
+    c.end("x");
+  });
+  server.on("tlsClientError", () => {});
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  // Full handshake: capture the ticket. Wait for the server's 'end' so the
+  // post-handshake NewSessionTicket has arrived before resuming.
+  let ticket: Buffer | undefined;
+  const first = tlsConnect({ port, host: "127.0.0.1", ca: COMMON_CERT_.cert, servername: "localhost" });
+  first.once("session", s => (ticket = s));
+  first.on("data", () => {});
+  first.on("error", () => {});
+  await once(first, "close");
+  expect(first.authorized).toBe(true);
+  expect(Buffer.isBuffer(ticket)).toBe(true);
+
+  type Outcome = { reused: boolean; authorized: boolean; authorizationError: unknown; result: string };
+  const resume = (extra: tls.ConnectionOptions) =>
+    new Promise<Outcome>(resolve => {
+      let done = false;
+      const s = tlsConnect({
+        port,
+        host: "127.0.0.1",
+        ca: COMMON_CERT_.cert,
+        servername: "localhost",
+        session: ticket,
+        ...extra,
+      });
+      const finish = (result: string) => {
+        if (done) return;
+        done = true;
+        s.destroy();
+        resolve({ reused, authorized: s.authorized, authorizationError: s.authorizationError, result });
+      };
+      let reused = false;
+      s.on("secureConnect", () => {
+        reused = s.isSessionReused();
+      });
+      s.on("data", () => {});
+      s.on("end", () => finish("ok"));
+      s.on("error", (e: any) => finish(String(e.code ?? e.message)));
+    });
+
+  // A counting checkServerIdentity is not invoked on the resumed connection.
+  let calls = 0;
+  const a = await resume({ checkServerIdentity: () => (calls++, undefined) });
+  expect({ ...a, calls }).toEqual({ reused: true, authorized: true, authorizationError: undefined, result: "ok", calls: 0 });
+
+  // A checkServerIdentity that returns an Error (certificate pinning) does not
+  // run, so the resumed connection succeeds and is authorized.
+  const b = await resume({
+    checkServerIdentity: () => Object.assign(new Error("pin mismatch"), { code: "EPIN" }),
+  });
+  expect(b).toEqual({ reused: true, authorized: true, authorizationError: undefined, result: "ok" });
+
+  // A servername absent from the certificate's SAN still connects when the
+  // server accepts the ticket: the default hostname check is skipped too.
+  const c = await resume({ servername: "not-in-cert.example" });
+  expect(c).toEqual({ reused: true, authorized: true, authorizationError: undefined, result: "ok" });
+});


### PR DESCRIPTION
## What does this PR do?

Node's `onConnectSecure` (`lib/internal/tls/wrap.js`) gates the server-identity check on `!this.isSessionReused()`:

```js
// Verify that server's identity matches it's certificate's names
// Unless server has resumed our existing session
if (!verifyError && !this.isSessionReused()) {
  const cert = this.getPeerCertificate(true);
  verifyError = options.checkServerIdentity(hostname, cert);
}
```

Bun ran the check unconditionally in both client handshake handlers in `src/js/node/net.ts`, so on a resumed session:

- a custom `checkServerIdentity` was invoked again (call counts / side effects calibrated to full handshakes fired on every connection),
- a `checkServerIdentity` that returns an `Error` (certificate pinning) tore the resumed connection down,
- a `servername` absent from the certificate's SAN failed with `ERR_TLS_CERT_ALTNAME_INVALID` even though the server accepted the ticket.

Node connects cleanly in all three cases because the peer's identity was established on the full handshake that issued the ticket.

## Reproduction

```js
import tls from 'node:tls';
// server with cert for SAN DNS:localhost
// first connection: full handshake, capture 'session' ticket
// second connection: tls.connect({ session: ticket, checkServerIdentity: () => calls++ })
```

| | node v26.3.0 | bun before | bun after |
|---|---|---|---|
| resumed + counting `checkServerIdentity` | `reused=true csi=0` | `reused=true csi=1` | `reused=true csi=0` |
| resumed + `servername` not in cert | `reused=true ok` | `ERR_TLS_CERT_ALTNAME_INVALID` | `reused=true ok` |
| resumed + `checkServerIdentity` returns Error | `reused=true ok` | `EPIN` | `reused=true ok` |

## Fix

Add `!socket.isSessionReused()` to the identity-check gate in both `handshake` handlers (`SocketHandlers` and `SocketHandlers2`).

## How did you verify your code works?

New test in `test/js/node/tls/node-tls-connect.test.ts` covering all three cases; fails on `USE_SYSTEM_BUN=1` with `calls: 1` vs expected `0`, passes with this change. `test-tls-client-resume.js`, `test-tls-client-resume-12.js`, `test-https-client-resume.js`, `test-https-client-checkServerIdentity.js`, `test-tls-check-server-identity.js`, `test-tls-ticket*.js` and `node-tls-connect.test.ts` all pass.