### PR TITLE
node:http: let server 'timeout' listeners veto the default socket destroy

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -5,7 +5,6 @@ const {
   setHeader,
   Headers,
   assignHeaders: assignHeadersFast,
-  setRequestTimeout,
   headersTuple,
   webRequestOrResponseHasBodyValue,
   setServerCustomOptions,
@@ -16,7 +15,6 @@ const {
   setHeader: (headers: Headers, name: string, value: string) => void;
   Headers: (typeof globalThis)["Headers"];
   assignHeaders: (object: any, req: Request, headersTuple: any) => boolean;
-  setRequestTimeout: (req: Request, timeout: number) => boolean;
   headersTuple: any;
   webRequestOrResponseHasBodyValue: (arg: any) => boolean;
   setServerCustomOptions: (
@@ -580,7 +578,6 @@ export {
   setHeader,
   setIsNextIncomingMessageHTTPS,
   setMaxHTTPHeaderSize,
-  setRequestTimeout,
   setServerCustomOptions,
   statusCodeSymbol,
   statusMessageSymbol,

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -11,7 +11,6 @@ const {
   setServerCustomOptions,
   getCompleteWebRequestOrResponseBodyValueAsArrayBuffer,
   drainMicrotasks,
-  setServerIdleTimeout,
 } = $cpp("NodeHTTP.cpp", "createNodeHTTPInternalBinding") as {
   getHeader: (headers: Headers, name: string) => string | undefined;
   setHeader: (headers: Headers, name: string, value: string) => void;
@@ -29,7 +28,6 @@ const {
   ) => void;
   getCompleteWebRequestOrResponseBodyValueAsArrayBuffer: (arg: any) => ArrayBuffer | undefined;
   drainMicrotasks: () => void;
-  setServerIdleTimeout: (server: any, timeout: number) => void;
 };
 
 const getRawKeys = $newCppFunction("JSFetchHeaders.cpp", "jsFetchHeaders_getRawKeys", 0);
@@ -88,7 +86,6 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
-const kDeferredTimeouts = Symbol("deferredTimeouts");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -543,7 +540,6 @@ export {
   kBodyChunks,
   kClearTimeout,
   kCloseCallback,
-  kDeferredTimeouts,
   kDeprecatedReplySymbol,
   kEmitState,
   kEmptyObject,
@@ -586,7 +582,6 @@ export {
   setMaxHTTPHeaderSize,
   setRequestTimeout,
   setServerCustomOptions,
-  setServerIdleTimeout,
   statusCodeSymbol,
   statusMessageSymbol,
   timeoutTimerSymbol,

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -378,6 +378,8 @@ function onDataIncomingMessage(
     return;
   }
 
+  this.socket?._unrefTimer?.();
+
   if (chunk && !this._dumped) this.push(chunk);
 
   if (isLast) {

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -54,6 +54,7 @@ function onIncomingMessageResumeNodeHTTPResponse(this: IncomingMessage) {
   if (handle && !this.destroyed) {
     const resumed = handle.resume();
     if (resumed && resumed !== true) {
+      this.socket?._unrefTimer?.();
       const bodyReadState = handle.hasBody;
       if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
         emitEOFIncomingMessage(this);
@@ -350,6 +351,7 @@ IncomingMessage.prototype._read = function _read(_n) {
   if ((bodyReadState & NodeHTTPBodyReadState.hasBufferedDataDuringPause) !== 0) {
     const drained = handle.drainRequestBody();
     if (drained && !this._dumped) {
+      socket?._unrefTimer?.();
       this.push(drained);
     }
   }

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -19,7 +19,6 @@ const {
   NodeHTTPBodyReadState,
   emitEOFIncomingMessage,
   NodeHTTPResponseAbortEvent,
-  setRequestTimeout,
   kAbortController,
 } = require("internal/http");
 
@@ -302,13 +301,7 @@ ObjectDefineProperty(IncomingMessage.prototype, "signal", {
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
   if (callback) this.on("timeout", callback);
-
-  const handle = this[kHandle];
-  if (handle) {
-    setRequestTimeout(handle, Math.ceil(msecs / 1000));
-  } else {
-    this.socket?.setTimeout(msecs);
-  }
+  this.socket?.setTimeout(msecs);
   return this;
 };
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1350,11 +1350,17 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     if (existing) clearTimeout(existing);
     if (msecs === 0) {
       this.#timeoutTimer = null;
-      if (callback) this.removeListener("timeout", callback);
+      if (callback !== undefined) {
+        validateFunction(callback, "callback");
+        this.removeListener("timeout", callback);
+      }
     } else {
       const bound = (this.#boundOnTimeout ??= this._onTimeout.bind(this));
       this.#timeoutTimer = setTimeout(bound, msecs).unref();
-      if (callback) this.once("timeout", callback);
+      if (callback !== undefined) {
+        validateFunction(callback, "callback");
+        this.once("timeout", callback);
+      }
     }
     return this;
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -608,6 +608,14 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           socket = new NodeHTTPServerSocket(server, socketHandle, !!tls);
         }
 
+        // Like Node.js's connectionListenerInternal: the server timeout is
+        // applied to the socket before any request routing (so it also covers
+        // CONNECT and upgrade tunnels); a user-set per-socket timeout is
+        // refreshed, not cleared.
+        const serverTimeoutMs = server.timeout;
+        if (serverTimeoutMs) socket.setTimeout(serverTimeoutMs);
+        else socket._unrefTimer();
+
         const http_req = new RequestClass(kHandle, url, method, headersObject, headersArray, handle, hasBody, socket);
         if (isAncientHTTP) {
           http_req.httpVersion = "1.0";
@@ -710,9 +718,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           server.emit("connection", socket);
         }
 
-        const serverTimeoutMs = server.timeout;
-        if (serverTimeoutMs) socket.setTimeout(serverTimeoutMs);
-        else socket._unrefTimer();
         socket[kRequest] = http_req;
         // Node.js (llhttp) only flags a request as an upgrade when it carries
         // both an Upgrade header and a Connection header with the "upgrade"
@@ -1353,6 +1358,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   _write(_chunk, _encoding, _callback) {
+    this._unrefTimer();
     const handle = this[kHandle];
     let err;
     try {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -711,7 +711,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
 
         const serverTimeoutMs = server.timeout;
-        if (serverTimeoutMs || socket.timeout) socket.setTimeout(serverTimeoutMs || 0);
+        if (serverTimeoutMs) socket.setTimeout(serverTimeoutMs);
+        else socket._unrefTimer();
         socket[kRequest] = http_req;
         // Node.js (llhttp) only flags a request as an upgrade when it carries
         // both an Upgrade header and a Connection header with the "upgrade"
@@ -1183,7 +1184,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     const response = handle?.response;
     // If there is a response, and it has pending data,
     // we suppress the timeout because a write is in progress.
-    if (response && response.writableLength > 0) {
+    if (response && response.bufferedAmount > 0) {
       this._unrefTimer();
       return;
     }
@@ -2204,6 +2205,8 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
     result = handle.write(chunk, encoding, allowWritesToContinue.bind(this), strictContentLength(this));
   }
 
+  this[fakeSocketSymbol]?._unrefTimer();
+
   if (result < 0) {
     if (callback) {
       // The write was buffered due to backpressure.
@@ -2367,6 +2370,7 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
   } else {
     handle.write(data, encoding, callback, strictContentLength(this));
   }
+  this[fakeSocketSymbol]?._unrefTimer();
 };
 
 const kSnapshotStatusCode = Symbol("kSnapshotStatusCode");
@@ -2516,6 +2520,7 @@ function callWriteHeadIfObservable(self, headerState) {
 }
 
 function allowWritesToContinue() {
+  this[fakeSocketSymbol]?._unrefTimer();
   this._callPendingCallbacks();
   this.emit("drain");
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -609,12 +609,16 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
 
         // Like Node.js's connectionListenerInternal: the server timeout is
-        // applied to the socket before any request routing (so it also covers
-        // CONNECT and upgrade tunnels); a user-set per-socket timeout is
-        // refreshed, not cleared.
-        const serverTimeoutMs = server.timeout;
-        if (serverTimeoutMs) socket.setTimeout(serverTimeoutMs);
-        else socket._unrefTimer();
+        // applied once per connection (before any request routing, so it also
+        // covers CONNECT and upgrade tunnels) and before 'connection' fires so
+        // a user listener can override it; subsequent keep-alive requests only
+        // refresh the existing timer.
+        if (isSocketNew) {
+          const serverTimeoutMs = server.timeout;
+          if (serverTimeoutMs) socket.setTimeout(serverTimeoutMs);
+        } else {
+          socket._unrefTimer();
+        }
 
         const http_req = new RequestClass(kHandle, url, method, headersObject, headersArray, handle, hasBody, socket);
         if (isAncientHTTP) {
@@ -1042,6 +1046,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   #pendingCallback = null;
   #timeoutTimer = null;
   #boundOnTimeout = null;
+  #lastBufferedAmount = 0;
   constructor(server: Server, handle, encrypted) {
     super();
     this.server = server;
@@ -1187,12 +1192,16 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   _onTimeout() {
     const handle = this[kHandle];
     const response = handle?.response;
-    // If there is a response, and it has pending data,
-    // we suppress the timeout because a write is in progress.
-    if (response && response.bufferedAmount > 0) {
+    // Like Node.js's net.Socket._onTimeout: only suppress when the buffered
+    // amount has changed since the last check (progress), so a stalled write
+    // still emits 'timeout' instead of looping forever.
+    const buffered = response ? response.bufferedAmount : 0;
+    if (buffered > 0 && buffered !== this.#lastBufferedAmount) {
+      this.#lastBufferedAmount = buffered;
       this._unrefTimer();
       return;
     }
+    this.#lastBufferedAmount = buffered;
     this.emit("timeout");
   }
   _unrefTimer() {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -27,7 +27,6 @@ const {
   kRealListen,
   tlsSymbol,
   optionsSymbol,
-  kDeferredTimeouts,
   kDeprecatedReplySymbol,
   headerStateSymbol,
   NodeHTTPHeaderState,
@@ -51,7 +50,6 @@ const {
   eofInProgress,
   runSymbol,
   drainMicrotasks,
-  setServerIdleTimeout,
   setServerCustomOptions,
   getMaxHTTPHeaderSize,
   fakeSocketSymbol,
@@ -254,6 +252,7 @@ function Server(options, callback): void {
 
   this.listening = false;
   this._unref = false;
+  this.timeout = 0;
   this.maxRequestsPerSocket = 0;
   this.maxHeadersCount = null;
   this[kInternalSocketData] = undefined;
@@ -711,6 +710,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           server.emit("connection", socket);
         }
 
+        const serverTimeoutMs = server.timeout;
+        if (serverTimeoutMs || socket.timeout) socket.setTimeout(serverTimeoutMs || 0);
         socket[kRequest] = http_req;
         // Node.js (llhttp) only flags a request as an upgrade when it carries
         // both an Upgrade header and a Connection header with the "upgrade"
@@ -920,25 +921,16 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.once("listening", onListen);
     }
 
-    if (this[kDeferredTimeouts]) {
-      for (const { msecs, callback } of this[kDeferredTimeouts]) {
-        this.setTimeout(msecs, callback);
-      }
-      delete this[kDeferredTimeouts];
-    }
-
     setTimeout(emitListeningNextTick, 1, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
   }
 };
 
+// Like Node.js: the server records the value and applies it to each new
+// connection via socket.setTimeout(); the socket emits 'timeout' and a
+// listener on any of req/res/server vetoes the default destroy.
 Server.prototype.setTimeout = function (msecs, callback) {
-  const server = this[serverSymbol];
-  if (server) {
-    setServerIdleTimeout(server, Math.ceil(msecs / 1000));
-    if (typeof callback === "function") this.once("timeout", callback);
-  } else {
-    (this[kDeferredTimeouts] ??= []).push({ msecs, callback });
-  }
+  this.timeout = msecs;
+  if (typeof callback === "function") this.on("timeout", callback);
   return this;
 };
 
@@ -1042,6 +1034,8 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   _httpMessage;
   _secureEstablished = false;
   #pendingCallback = null;
+  #timeoutTimer = null;
+  #boundOnTimeout = null;
   constructor(server: Server, handle, encrypted) {
     super();
     this.server = server;
@@ -1086,6 +1080,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     }
   }
   #onDrain() {
+    this._unrefTimer();
     const handle = this[kHandle];
     this[kBytesWritten] = handle ? (handle.response?.getBytesWritten?.() ?? handle.bytesWritten ?? 0) : 0;
     const callback = this.#pendingCallback;
@@ -1096,6 +1091,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     this.emit("drain");
   }
   #onData(chunk, last) {
+    this._unrefTimer();
     if (chunk) {
       this.push(chunk);
     }
@@ -1122,6 +1118,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
   #onClose() {
     this[kHandle] = null;
+    const timer = this.#timeoutTimer;
+    if (timer) {
+      clearTimeout(timer);
+      this.#timeoutTimer = null;
+    }
     this.server?.[kTrackedConnections]?.delete(this);
 
     // Node.js's `socketOnClose` → `abortIncoming()` only destroys requests
@@ -1183,12 +1184,13 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     // If there is a response, and it has pending data,
     // we suppress the timeout because a write is in progress.
     if (response && response.writableLength > 0) {
+      this._unrefTimer();
       return;
     }
     this.emit("timeout");
   }
   _unrefTimer() {
-    // for compatibility
+    this.#timeoutTimer?.refresh();
   }
 
   address() {
@@ -1324,7 +1326,18 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     return this;
   }
 
-  setTimeout(_timeout, _callback) {
+  setTimeout(msecs, callback) {
+    this.timeout = msecs;
+    const existing = this.#timeoutTimer;
+    if (existing) clearTimeout(existing);
+    if (msecs === 0) {
+      this.#timeoutTimer = null;
+      if (callback) this.removeListener("timeout", callback);
+    } else {
+      const bound = (this.#boundOnTimeout ??= this._onTimeout.bind(this));
+      this.#timeoutTimer = setTimeout(bound, msecs).unref();
+      if (callback) this.once("timeout", callback);
+    }
     return this;
   }
 
@@ -1687,6 +1700,8 @@ function stopServerResponsePerf(this: any) {
 function endSocketOnFinishIfNeeded(socket, res) {
   if (res[kMustCloseConnection]) {
     socket?.end();
+  } else {
+    socket?._unrefTimer();
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -15,6 +15,7 @@ const {
   validateInteger,
   validateFunction,
 } = require("internal/validators");
+const { getTimerDuration } = require("internal/timers");
 const { ConnResetException, hasObserver, startPerf, stopPerf } = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
@@ -1342,7 +1343,9 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   setTimeout(msecs, callback) {
+    if (this.destroyed) return this;
     this.timeout = msecs;
+    msecs = getTimerDuration(msecs, "msecs");
     const existing = this.#timeoutTimer;
     if (existing) clearTimeout(existing);
     if (msecs === 0) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -35,8 +35,6 @@ BUN_DECLARE_HOST_FUNCTION(jsFunctionRequestOrResponseHasBodyValue);
 BUN_DECLARE_HOST_FUNCTION(jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer);
 extern "C" uWS::HttpRequest* Request__getUWSRequest(void*);
 extern "C" void Request__setInternalEventCallback(void*, EncodedJSValue, JSC::JSGlobalObject*);
-extern "C" void Request__setTimeout(void*, EncodedJSValue, JSC::JSGlobalObject*);
-extern "C" bool NodeHTTPResponse__setTimeout(void*, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSValue, bool require_host_header, bool use_strict_method_validation);
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setMaxHTTPHeaderSize(JSC::JSGlobalObject*, EncodedJSValue, uint64_t);
@@ -971,28 +969,6 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPAssignEventCallback, (JSGlobalObject * globalObje
     return JSValue::encode(jsNull());
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsHTTPSetTimeout, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // This is an internal binding.
-    JSValue requestValue = callFrame->uncheckedArgument(0);
-    JSValue seconds = callFrame->uncheckedArgument(1);
-
-    ASSERT(callFrame->argumentCount() == 2);
-
-    if (auto* jsRequest = dynamicDowncast<WebCore::JSRequest>(requestValue)) {
-        Request__setTimeout(jsRequest->wrapped(), JSValue::encode(seconds), globalObject);
-    }
-
-    if (auto* nodeHttpResponse = dynamicDowncast<WebCore::JSNodeHTTPResponse>(requestValue)) {
-        NodeHTTPResponse__setTimeout(nodeHttpResponse->wrapped(), JSValue::encode(seconds), globalObject);
-    }
-
-    return JSValue::encode(jsUndefined());
-}
-
 JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -1163,10 +1139,6 @@ JSValue createNodeHTTPInternalBinding(Zig::GlobalObject* globalObject)
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "assignEventCallback"_s)),
         JSC::JSFunction::create(vm, globalObject, 2, "assignEventCallback"_s, jsHTTPAssignEventCallback, ImplementationVisibility::Public), 0);
-
-    obj->putDirect(
-        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setRequestTimeout"_s)),
-        JSC::JSFunction::create(vm, globalObject, 2, "setRequestTimeout"_s, jsHTTPSetTimeout, ImplementationVisibility::Public), 0);
 
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setServerCustomOptions"_s)),

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -37,7 +37,6 @@ extern "C" uWS::HttpRequest* Request__getUWSRequest(void*);
 extern "C" void Request__setInternalEventCallback(void*, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" void Request__setTimeout(void*, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" bool NodeHTTPResponse__setTimeout(void*, EncodedJSValue, JSC::JSGlobalObject*);
-extern "C" void Server__setIdleTimeout(EncodedJSValue, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSValue, bool require_host_header, bool use_strict_method_validation);
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setMaxHTTPHeaderSize(JSC::JSGlobalObject*, EncodedJSValue, uint64_t);
@@ -993,21 +992,6 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetTimeout, (JSGlobalObject * globalObject, CallF
 
     return JSValue::encode(jsUndefined());
 }
-JSC_DEFINE_HOST_FUNCTION(jsHTTPSetServerIdleTimeout, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // This is an internal binding.
-    JSValue serverValue = callFrame->uncheckedArgument(0);
-    JSValue seconds = callFrame->uncheckedArgument(1);
-
-    ASSERT(callFrame->argumentCount() == 2);
-
-    Server__setIdleTimeout(JSValue::encode(serverValue), JSValue::encode(seconds), globalObject);
-
-    return JSValue::encode(jsUndefined());
-}
 
 JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
@@ -1183,10 +1167,6 @@ JSValue createNodeHTTPInternalBinding(Zig::GlobalObject* globalObject)
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setRequestTimeout"_s)),
         JSC::JSFunction::create(vm, globalObject, 2, "setRequestTimeout"_s, jsHTTPSetTimeout, ImplementationVisibility::Public), 0);
-
-    obj->putDirect(
-        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setServerIdleTimeout"_s)),
-        JSC::JSFunction::create(vm, globalObject, 2, "setServerIdleTimeout"_s, jsHTTPSetServerIdleTimeout, ImplementationVisibility::Public), 0);
 
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setServerCustomOptions"_s)),

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2126,4 +2126,3 @@ pub unsafe extern "C" fn NodeHTTPResponse__createForJS(
     unsafe { *node_response_ptr = response };
     js_this
 }
-

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1,5 +1,5 @@
 use core::cell::Cell;
-use core::ffi::{c_uint, c_void};
+use core::ffi::c_void;
 use core::ptr;
 
 use bitflags::bitflags;
@@ -2127,30 +2127,3 @@ pub unsafe extern "C" fn NodeHTTPResponse__createForJS(
     js_this
 }
 
-impl NodeHTTPResponse {
-    #[uws::uws_callback(export = "NodeHTTPResponse__setTimeout")]
-    pub(crate) fn ffi_set_timeout(&self, seconds: JSValue, global_this: &JSGlobalObject) -> bool {
-        if !seconds.is_number() {
-            let _: jsc::JsError =
-                global_this.throw_invalid_argument_type_value(b"timeout", b"number", seconds);
-            return false;
-        }
-
-        let flags = self.flags.get();
-        let Some(raw) = self.raw_response.get() else {
-            return false;
-        };
-        if flags.contains(Flags::REQUEST_HAS_COMPLETED)
-            || flags.contains(Flags::SOCKET_CLOSED)
-            || flags.contains(Flags::UPGRADED)
-        {
-            return false;
-        }
-
-        // ECMAScript ToUint32 — same bit pattern as
-        // ToInt32 reinterpreted as unsigned (negative inputs wrap, e.g. -1 → u32::MAX).
-        let secs = (seconds.to_int32() as c_uint).min(255) as u8;
-        raw.timeout(secs);
-        true
-    }
-}

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1456,10 +1456,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.listener.is_some() || (Self::HAS_H3 && self.h3_listener.is_some())
     }
 
-    pub fn set_idle_timeout(&mut self, seconds: core::ffi::c_uint) {
-        self.config.idle_timeout = seconds.min(255) as u8;
-    }
-
     pub fn set_flags(&mut self, require_host_header: bool, use_strict_method_validation: bool) {
         if let Some(app) = self.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3567,58 +3567,6 @@ pub enum AnyUserRouteList<'a> {
 }
 
 // ─── Exported fns ────────────────────────────────────────────────────────────
-#[unsafe(no_mangle)]
-pub(super) extern "C" fn Server__setIdleTimeout(
-    server: JSValue,
-    seconds: JSValue,
-    global: &JSGlobalObject,
-) {
-    match server_set_idle_timeout_(server, seconds, global) {
-        Ok(()) => {}
-        Err(JsError::Thrown) => {}
-        Err(JsError::OutOfMemory) => {
-            let _ = global.throw_out_of_memory_value();
-        }
-        Err(JsError::Terminated) => {}
-    }
-}
-
-pub(super) fn server_set_idle_timeout_(
-    server: JSValue,
-    seconds: JSValue,
-    global: &JSGlobalObject,
-) -> JsResult<()> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The 'this' value is not a Server."
-        )));
-    }
-
-    if !seconds.is_number() {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The provided value is not of type 'number'."
-        )));
-    }
-    let value = seconds.to_u32();
-    if let Some(this) = server.as_::<HTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<HTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<DebugHTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<DebugHTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The 'this' value is not a Server."
-        )));
-    }
-    Ok(())
-}
 
 pub(super) fn server_set_on_client_error_(
     global: &JSGlobalObject,

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -398,20 +398,6 @@ impl Request {
         self.request_context.enable_timeout_events();
     }
 
-    #[bun_uws::uws_callback(export = "Request__setTimeout")]
-    pub fn ffi_set_timeout(&self, seconds: JSValue, global_this: &JSGlobalObject) {
-        if !seconds.is_number() {
-            let _ = global_this.throw(format_args!(
-                "Failed to set timeout: The provided value is not of type 'number'."
-            ));
-            return;
-        }
-
-        // `JSValue.toU32` clamps via JS ToUint32 rules,
-        // not signed wrap-then-reinterpret like `to_int32() as c_uint` would do.
-        self.set_timeout(seconds.to_u32() as c_uint);
-    }
-
     /// `BunRequest.prototype.clone` (the `Bun.serve` `routes:` subclass) goes
     /// through `JSBunRequest::clone` -> here, not through [`Self::do_clone`],
     /// so it needs the same fetch-spec step-1 usability check.

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1,7 +1,6 @@
 //! https://developer.mozilla.org/en-US/docs/Web/API/Request
 
 use core::cell::Cell;
-use core::ffi::c_uint;
 use core::ptr::NonNull;
 use std::borrow::Cow;
 
@@ -1663,10 +1662,6 @@ impl Request {
         // Box<Request> drops on the error path automatically
         self.clone_into(&mut req, global_this, false)?;
         Ok(req)
-    }
-
-    pub fn set_timeout(&self, seconds: c_uint) {
-        let _ = self.request_context.set_timeout(seconds);
     }
 }
 

--- a/test/js/bun/test/parallel/test-http-should-emit-timeout-event-when-using-server-setTimeout.ts
+++ b/test/js/bun/test/parallel/test-http-should-emit-timeout-event-when-using-server-setTimeout.ts
@@ -6,9 +6,13 @@ const { expect } = createTest(import.meta.path);
 await using server = http.createServer().listen(0);
 await once(server, "listening");
 let callBackCalled = false;
-server.setTimeout(100, () => {
+// Node.js: once a 'timeout' listener is installed the runtime does not
+// destroy the socket; the listener decides. Destroy it here so the fetch
+// below completes and the server can close.
+server.setTimeout(100, socket => {
   callBackCalled = true;
   console.log("Called timeout");
+  socket.destroy();
 });
 
 fetch(`http://localhost:${server.address().port}`, { verbose: true })

--- a/test/js/bun/test/parallel/test-http-should-emit-timeout-event.ts
+++ b/test/js/bun/test/parallel/test-http-should-emit-timeout-event.ts
@@ -12,8 +12,11 @@ fetch(`http://localhost:${server.address().port}`)
 const [req, res] = await once(server, "request");
 expect(req.complete).toBe(false);
 let callBackCalled = false;
+// Node.js: a 'timeout' listener vetoes the default socket destroy, so the
+// callback must destroy the socket itself for the server to close cleanly.
 req.setTimeout(100, () => {
   callBackCalled = true;
+  req.socket.destroy();
 });
 await once(req, "timeout");
 expect(callBackCalled).toBe(true);

--- a/test/js/node/http/node-http-server-setTimeout.test.ts
+++ b/test/js/node/http/node-http-server-setTimeout.test.ts
@@ -1,7 +1,7 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
-import { once } from "node:events";
 
 // https://nodejs.org/api/http.html#serversettimeoutmsecs-callback
 // Once a 'timeout' listener is installed on the server (or on req/res), the

--- a/test/js/node/http/node-http-server-setTimeout.test.ts
+++ b/test/js/node/http/node-http-server-setTimeout.test.ts
@@ -156,4 +156,44 @@ describe("http.Server.prototype.setTimeout", () => {
       cleanup(srv, client);
     }
   });
+
+  test.concurrent("an actively-writing response is not destroyed by server.setTimeout()", async () => {
+    // Response body writes refresh the socket's inactivity timer, like
+    // Node.js's net.Socket._writeGeneric -> _unrefTimer().
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const srv = await listen((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Transfer-Encoding": "chunked" });
+      let n = 0;
+      const i = setInterval(() => {
+        if (!res.write(".")) res.once("drain", () => {});
+        if (++n === 8) {
+          clearInterval(i);
+          res.end();
+        }
+      }, 100);
+      req.socket.on("close", () => clearInterval(i));
+    });
+    // Shorter than the interval between writes: if writes did not refresh the
+    // timer, the default-destroy would fire between the first two chunks.
+    srv.setTimeout(250);
+    srv.on("timeout", () => resolve("timeout"));
+
+    const client = await connectAndWrite((srv.address() as net.AddressInfo).port, "GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+    let body = "";
+    client.on("data", d => {
+      body += d.toString("latin1");
+      if (body.includes("\r\n0\r\n\r\n")) resolve("finished");
+    });
+    client.on("close", () => resolve("close"));
+
+    try {
+      expect(await promise).toBe("finished");
+      // Eight body bytes, one per chunk (after the header block).
+      const chunks = body.slice(body.indexOf("\r\n\r\n") + 4);
+      expect(chunks.match(/\./g)?.length).toBe(8);
+    } finally {
+      cleanup(srv, client);
+    }
+  });
 });

--- a/test/js/node/http/node-http-server-setTimeout.test.ts
+++ b/test/js/node/http/node-http-server-setTimeout.test.ts
@@ -196,4 +196,28 @@ describe("http.Server.prototype.setTimeout", () => {
       cleanup(srv, client);
     }
   });
+
+  test.concurrent("req.setTimeout(0) clears the server-armed socket timer", async () => {
+    // All four entry points (server/socket/req/res.setTimeout) share one timer.
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const srv = await listen((req, _res) => {
+      req.resume();
+      req.setTimeout(0);
+    });
+    srv.setTimeout(200);
+    srv.on("timeout", () => resolve("timeout"));
+
+    const client = await connectAndWrite(
+      (srv.address() as net.AddressInfo).port,
+      "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab",
+    );
+    client.on("close", () => resolve("close"));
+
+    try {
+      const winner = await Promise.race([promise, Bun.sleep(600).then(() => "alive")]);
+      expect(winner).toBe("alive");
+    } finally {
+      cleanup(srv, client);
+    }
+  });
 });

--- a/test/js/node/http/node-http-server-setTimeout.test.ts
+++ b/test/js/node/http/node-http-server-setTimeout.test.ts
@@ -1,0 +1,159 @@
+import { test, expect, describe } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import { once } from "node:events";
+
+// https://nodejs.org/api/http.html#serversettimeoutmsecs-callback
+// Once a 'timeout' listener is installed on the server (or on req/res), the
+// runtime must NOT destroy the socket on timeout; the listener decides.
+
+async function connectAndWrite(port: number, wire: string) {
+  const s = net.connect(port, "127.0.0.1");
+  s.setNoDelay(true);
+  s.on("error", () => {});
+  s.resume();
+  await once(s, "connect");
+  s.write(wire);
+  return s;
+}
+
+async function listen(handler: http.RequestListener) {
+  const srv = http.createServer(handler);
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  return srv;
+}
+
+function cleanup(srv: http.Server, client: net.Socket) {
+  try {
+    client.destroy();
+  } catch {}
+  try {
+    srv.close();
+    srv.closeAllConnections?.();
+  } catch {}
+}
+
+describe("http.Server.prototype.setTimeout", () => {
+  test("sets server.timeout and returns this", () => {
+    const srv = http.createServer();
+    expect(srv.timeout).toBe(0);
+    const ret = srv.setTimeout(1234);
+    expect(ret).toBe(srv);
+    expect(srv.timeout).toBe(1234);
+  });
+
+  test("callback is registered as a 'timeout' listener", () => {
+    const srv = http.createServer();
+    const cb = () => {};
+    srv.setTimeout(1234, cb);
+    expect(srv.listeners("timeout")).toContain(cb);
+  });
+
+  test.concurrent("a server 'timeout' listener vetoes the default destroy (stalled body)", async () => {
+    const srv = await listen((req, _res) => void req.resume());
+    srv.setTimeout(200);
+
+    const { promise, resolve } = Promise.withResolvers<{ event: string; socket?: any }>();
+    srv.on("timeout", socket => resolve({ event: "timeout", socket }));
+
+    const client = await connectAndWrite(
+      (srv.address() as net.AddressInfo).port,
+      "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab",
+    );
+    client.on("close", () => resolve({ event: "close" }));
+
+    try {
+      const { event, socket } = await promise;
+      // The 'timeout' event must fire before the connection is torn down.
+      expect(event).toBe("timeout");
+      expect(socket.destroyed).toBe(false);
+      // And the connection must still be open afterwards: the listener did
+      // not destroy, so the runtime must not either. Race a fresh 'timeout'
+      // (listener returning without destroying leaves the socket alive; the
+      // timer is one-shot until refreshed, but the old native path closed
+      // within a few ms of the event) against 'close'.
+      const winner = await Promise.race([
+        once(client, "close").then(() => "close"),
+        Bun.sleep(250).then(() => "alive"),
+      ]);
+      expect(winner).toBe("alive");
+      expect(socket.destroyed).toBe(false);
+    } finally {
+      cleanup(srv, client);
+    }
+  });
+
+  test.concurrent("a server 'timeout' listener vetoes the default destroy (idle keep-alive)", async () => {
+    const srv = await listen((req, res) => {
+      req.resume();
+      req.on("end", () => res.end("ok"));
+    });
+    srv.setTimeout(200);
+
+    const { promise, resolve } = Promise.withResolvers<{ event: string; socket?: any }>();
+    srv.on("timeout", socket => resolve({ event: "timeout", socket }));
+
+    const client = await connectAndWrite((srv.address() as net.AddressInfo).port, "GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+    client.on("close", () => resolve({ event: "close" }));
+
+    try {
+      const { event, socket } = await promise;
+      // An idle keep-alive connection reaped by the server timeout must
+      // emit 'timeout' (not close silently).
+      expect(event).toBe("timeout");
+      expect(socket.destroyed).toBe(false);
+      const winner = await Promise.race([
+        once(client, "close").then(() => "close"),
+        Bun.sleep(250).then(() => "alive"),
+      ]);
+      expect(winner).toBe("alive");
+      expect(socket.destroyed).toBe(false);
+    } finally {
+      cleanup(srv, client);
+    }
+  });
+
+  test.concurrent("with no listener, the socket is destroyed on timeout", async () => {
+    const srv = await listen((req, _res) => void req.resume());
+    srv.setTimeout(200);
+
+    const client = await connectAndWrite(
+      (srv.address() as net.AddressInfo).port,
+      "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab",
+    );
+    try {
+      await once(client, "close");
+    } finally {
+      cleanup(srv, client);
+    }
+  });
+
+  test.concurrent("a request 'timeout' listener also vetoes the default destroy", async () => {
+    const { promise, resolve } = Promise.withResolvers<{ event: string; socket?: any }>();
+    const srv = await listen((req, _res) => {
+      req.resume();
+      req.on("timeout", () => resolve({ event: "timeout", socket: req.socket }));
+    });
+    srv.setTimeout(200);
+
+    const client = await connectAndWrite(
+      (srv.address() as net.AddressInfo).port,
+      "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab",
+    );
+    client.on("close", () => resolve({ event: "close" }));
+
+    try {
+      const { event, socket } = await promise;
+      expect(event).toBe("timeout");
+      expect(socket.destroyed).toBe(false);
+      const winner = await Promise.race([
+        once(client, "close").then(() => "close"),
+        Bun.sleep(250).then(() => "alive"),
+      ]);
+      expect(winner).toBe("alive");
+    } finally {
+      cleanup(srv, client);
+    }
+  });
+});


### PR DESCRIPTION
Node's contract for `server.setTimeout(msecs)` is that once a `'timeout'` listener is installed on the server, req, or res, the runtime does not destroy the socket when the timeout fires; the listener decides. Bun fired the event and tore the connection down anyway, and an idle keep-alive connection reaped by the server timeout never emitted `'timeout'` at all.

## Repro

```js
import http from "node:http";
import net from "node:net";

const srv = http.createServer((q, r) => { q.resume(); });
srv.listen(0, "127.0.0.1", () => {
  srv.setTimeout(600);
  srv.on("timeout", () => {}); // records only, never destroys
  const s = net.connect(srv.address().port, "127.0.0.1");
  s.on("connect", () => s.write("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 900\r\n\r\nab"));
  s.on("close", () => console.log("server closed the connection"));
});
```

Node keeps the connection open (the listener vetoes the destroy). Bun closed it ~4s after connect regardless.

## Cause

`Server.prototype.setTimeout` called `setServerIdleTimeout(server, ceil(ms/1000))`, which sets the uWS per-connection idle timeout. When that fires, `HttpContext::onTimeout` runs the JS callback and then unconditionally `close()`s the socket:

```cpp
if (httpResponseData->onTimeout) {
    httpResponseData->onTimeout((HttpResponse<SSL> *)s, httpResponseData->userData);
}
return asyncSocket->close();
```

So `onNodeHTTPServerSocketTimeout`'s `if (!reqTimeout && !resTimeout && !serverTimeout) this.destroy()` was dead code: by the time it ran, the native close was already committed. For an idle keep-alive socket there is no `NodeHTTPResponse` attached, so no JS callback fired at all; the socket was closed silently.

## Fix

Drive the server timeout from an unref'd JS timer per connection, like Node.js. `Server.prototype.setTimeout` now only stores `this.timeout` and registers the callback. Each request on a connection arms `socket.setTimeout(server.timeout)`; the timer fires `socket._onTimeout()` -> `emit('timeout')` -> the existing `onNodeHTTPServerSocketTimeout` veto logic, which now actually decides. Activity (new request, body data, tunnel data/drain, response finish) refreshes the timer via `_unrefTimer()`, and the timer is cleared on close.

The native idle-timeout path is no longer used for `node:http` (the server already passes `idleTimeout: 0` to `Bun.serve`).

## Verification

```
$ bun bd test test/js/node/http/node-http-server-setTimeout.test.ts
 6 pass
$ USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http-server-setTimeout.test.ts
 1 pass
 5 fail
```

The one passing case on the old build is "with no listener, the socket is destroyed on timeout", which both implementations satisfy.