### PR TITLE
semver: treat tab/CR/LF as comparator separators in range parsing

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -869,9 +869,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 }
 
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
             b'<' => {
                 if input.len() > i + 1 && input[i + 1] == b'=' {
@@ -882,17 +880,13 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 }
 
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
             b'=' | b'v' => {
                 token.tag = TokenTag::Version;
                 is_or = true;
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
             b'~' => {
                 token.tag = TokenTag::Tilda;
@@ -902,16 +896,12 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                     i += 1;
                 }
 
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
             b'^' => {
                 token.tag = TokenTag::Caret;
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
             b'0'..=b'9' | b'X' | b'x' | b'*' => {
                 token.tag = TokenTag::Version;
@@ -923,24 +913,21 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 while i < input.len() && input[i] == b'|' {
                     i += 1;
                 }
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
                 is_or = true;
                 token.tag = TokenTag::None;
                 skip_round = true;
             }
             b'-' => {
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
             }
-            b' ' => {
+            // node-semver splits comparator sets on /\s+/, so treat tab/newline/CR/VT/FF
+            // the same as a space instead of letting them fall through to the catch-all
+            // arm below (which would swallow the following comparator as a "tagged version").
+            b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C => {
                 i += 1;
-                while i < input.len() && input[i] == b' ' {
-                    i += 1;
-                }
+                i += strings::length_of_leading_whitespace_ascii(&input[i..]);
                 skip_round = true;
             }
             _ => {
@@ -950,7 +937,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 // skip tagged versions
                 // we are assuming this is the beginning of a tagged version like "boop"
                 // "1.0.0 || boop"
-                while i < input.len() && input[i] != b' ' && input[i] != b'|' {
+                while i < input.len()
+                    && !strings::WHITESPACE_CHARS.contains(&input[i])
+                    && input[i] != b'|'
+                {
                     i += 1;
                 }
                 skip_round = true;
@@ -972,7 +962,8 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
             i += parse_result.len as usize;
             let rollback = i;
 
-            let maybe_hyphenate = i < input.len() && (input[i] == b' ' || input[i] == b'-');
+            let maybe_hyphenate = i < input.len()
+                && (strings::WHITESPACE_CHARS.contains(&input[i]) || input[i] == b'-');
 
             // TODO: can we do this without rolling back?
             let hyphenate: bool = maybe_hyphenate

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -181,6 +181,33 @@ describe("Bun.semver.order()", () => {
 });
 
 describe("Bun.semver.satisfies()", () => {
+  test("tab/newline/CR between comparators", () => {
+    // node-semver splits comparator sets on /\s+/. A comparator preceded by a
+    // non-space ASCII whitespace byte must not be discarded.
+    for (const ws of ["\t", "\n", "\r", "\v", "\f", " \t", "\t\n "]) {
+      // under-match: the dropped comparator was a ||-branch
+      testSatisfies(`>=1.0.0 ||${ws}<0.5.0`, "0.1.0", true);
+      testSatisfies(`>=1.0.0${ws}||${ws}<0.5.0`, "0.1.0", true);
+      testSatisfies(`1 ||${ws}2 || 9`, "2.0.0", true);
+      // over-match: the dropped comparator was the only one
+      testSatisfies(`${ws}<0.5.0`, "9.9.9", false);
+      testSatisfies(`${ws}<0.5.0`, "0.1.0", true);
+      // hyphen ranges
+      testSatisfies(`0.1.0${ws}- 0.2.0`, "0.1.0", true);
+      testSatisfies(`0.1.0${ws}- 0.2.0`, "0.3.0", false);
+      testSatisfies(`0.1.0 -${ws}0.2.0`, "0.1.0", true);
+      testSatisfies(`0.1.0${ws}-${ws}0.2.0`, "0.3.0", false);
+      // whitespace after comparator operators
+      testSatisfies(`<${ws}2.0.0`, "0.2.9", true);
+      testSatisfies(`>=${ws}2.0.0`, "0.2.9", false);
+      testSatisfies(`^${ws}1.0.0`, "1.2.0", true);
+      testSatisfies(`~${ws}1.2.0`, "1.2.9", true);
+      // a real tagged version separated by non-space whitespace is still skipped
+      testSatisfies(`1.0.0 ||${ws}boop`, "1.0.0", true);
+      testSatisfies(`boop${ws}|| 1.0.0`, "1.0.0", true);
+    }
+  });
+
   test("expected errors", () => {
     expect(satisfies).toBeInstanceOf(Function);
     expect(() => {


### PR DESCRIPTION
## What does this PR do?

node-semver splits comparator sets on `/\s+/`, so tab, newline, CR, VT, and FF are valid separators anywhere a space is. The range tokenizer in `SemverQuery::parse` only recognized the `0x20` space byte: any other ASCII whitespace preceding a comparator fell through to the catch-all arm, which treated it as the start of a "tagged version" token (the `"1.0.0 || boop"` shape) and scanned forward to the next space or `|`, silently discarding the real comparator it scanned past.

### Repro

```js
const npm = require("semver"); // 7.8.5

// under-match: a ||-branch preceded by \t is dropped, so the branch matches nothing
npm.satisfies("0.1.0", ">=1.0.0 ||\t<0.5.0");        // true
Bun.semver.satisfies("0.1.0", ">=1.0.0 ||\t<0.5.0"); // false (before)

// over-match: a sole comparator preceded by \t is dropped, leaving an empty
// group that matches everything
npm.satisfies("9.9.9", "\t<0.5.0");                  // false
Bun.semver.satisfies("9.9.9", "\t<0.5.0");           // true (before)

// hyphen ranges with a tab next to the '-' also lost the range
npm.satisfies("0.1.0", "0.1.0\t- 0.2.0");            // true
Bun.semver.satisfies("0.1.0", "0.1.0\t- 0.2.0");     // false (before)
```

The same applies to `\n`, `\r`, `\v`, and `\f`.

### Fix

In `src/semver/SemverQuery.rs` `parse()`:

- replace every `while input[i] == b' '` skip loop with `strings::length_of_leading_whitespace_ascii` (already used by the hyphen-range lookahead a few lines below);
- widen the bare `b' '` match arm to `b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C` so those bytes don't reach the catch-all "tagged version" arm;
- stop the tagged-version scan at any ASCII whitespace, not just space;
- accept any ASCII whitespace (not just space) in the `maybe_hyphenate` check.

All sites now use the same whitespace set as `strings::WHITESPACE_CHARS`.

### Verification

- New test `"tab/newline/CR between comparators"` in `test/cli/install/semver.test.ts` covers `\t \n \r \v \f` and mixed runs, for `||`-branches, leading-only comparators, hyphen ranges on both sides, post-operator whitespace, and tagged-version skipping (420 assertions).
- All 91 assertions cross-checked against `semver@7.8.5`.
- Full `semver.test.ts` suite: 27 pass / 0 fail.