### PR TITLE
Bun.semver: accept trailing whitespace like node-semver

### DIFF
--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -517,7 +517,7 @@ impl<T: VersionInt> VersionType<T> {
             }
 
             match input[i] {
-                b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C => {
+                b' ' => {
                     is_done = true;
                     break;
                 }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -517,7 +517,7 @@ impl<T: VersionInt> VersionType<T> {
             }
 
             match input[i] {
-                b' ' => {
+                b' ' | b'\t' | b'\n' | b'\r' | 0x0B | 0x0C => {
                     is_done = true;
                     break;
                 }

--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -16,6 +16,22 @@ pub fn create(global: &JSGlobalObject) -> JSValue {
     )
 }
 
+/// node-semver's `SemVer` constructor `.trim()`s its input. JS
+/// `String.prototype.trim()` removes ECMA-262 `WhiteSpace` + `LineTerminator`,
+/// which includes non-ASCII code points (NBSP, BOM, Zs, LS/PS).
+fn trim_semver_input(bytes: &[u8]) -> &[u8] {
+    fn is_js_trimmed(c: char) -> bool {
+        matches!(
+            c as u32,
+            0x0009 | 0x000A | 0x000B | 0x000C | 0x000D | 0x2028 | 0x2029 | 0xFEFF
+        ) || strings::is_unicode_space_separator(c as u32)
+    }
+    match core::str::from_utf8(bytes) {
+        Ok(s) => s.trim_matches(is_js_trimmed).as_bytes(),
+        Err(_) => strings::trim(bytes, &strings::WHITESPACE_CHARS),
+    }
+}
+
 #[bun_jsc::host_fn]
 pub(crate) fn order(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // `to_slice()` owns its buffer and frees it on Drop.
@@ -32,15 +48,26 @@ pub(crate) fn order(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
     let left = left_string.to_slice(global);
     let right = right_string.to_slice(global);
 
-    if !strings::is_all_ascii(left.slice()) {
-        return Ok(JSValue::js_number_from_int32(0));
-    }
-    if !strings::is_all_ascii(right.slice()) {
-        return Ok(JSValue::js_number_from_int32(0));
-    }
+    let left_trimmed = trim_semver_input(left.slice());
+    let right_trimmed = trim_semver_input(right.slice());
 
-    let left_result = Version::parse(SlicedString::init(left.slice(), left.slice()));
-    let right_result = Version::parse(SlicedString::init(right.slice(), right.slice()));
+    let left_result = if strings::is_all_ascii(left_trimmed) {
+        Version::parse(SlicedString::init(left_trimmed, left_trimmed))
+    } else {
+        return Err(global.throw(format_args!(
+            "Invalid SemVer: {}\n",
+            bstr::BStr::new(left.slice()),
+        )));
+    };
+
+    let right_result = if strings::is_all_ascii(right_trimmed) {
+        Version::parse(SlicedString::init(right_trimmed, right_trimmed))
+    } else {
+        return Err(global.throw(format_args!(
+            "Invalid SemVer: {}\n",
+            bstr::BStr::new(right.slice()),
+        )));
+    };
 
     if !left_result.valid {
         return Err(global.throw(format_args!(
@@ -60,7 +87,7 @@ pub(crate) fn order(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
     let right_version = right_result.version.max();
 
     Ok(
-        match left_version.order_without_build(right_version, left.slice(), right.slice()) {
+        match left_version.order_without_build(right_version, left_trimmed, right_trimmed) {
             Ordering::Equal => JSValue::js_number_from_int32(0),
             Ordering::Greater => JSValue::js_number_from_int32(1),
             Ordering::Less => JSValue::js_number_from_int32(-1),
@@ -82,14 +109,17 @@ pub(crate) fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
     let left = left_string.to_slice(global);
     let right = right_string.to_slice(global);
 
-    if !strings::is_all_ascii(left.slice()) {
+    let left_trimmed = trim_semver_input(left.slice());
+    let right_trimmed = trim_semver_input(right.slice());
+
+    if !strings::is_all_ascii(left_trimmed) {
         return Ok(JSValue::FALSE);
     }
-    if !strings::is_all_ascii(right.slice()) {
+    if !strings::is_all_ascii(right_trimmed) {
         return Ok(JSValue::FALSE);
     }
 
-    let left_result = Version::parse(SlicedString::init(left.slice(), left.slice()));
+    let left_result = Version::parse(SlicedString::init(left_trimmed, left_trimmed));
     if left_result.wildcard != query::token::Wildcard::None {
         return Ok(JSValue::FALSE);
     }
@@ -98,8 +128,8 @@ pub(crate) fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
 
     // `Query::parse` can only fail with OOM.
     let right_group = match query::parse(
-        right.slice(),
-        SlicedString::init(right.slice(), right.slice()),
+        right_trimmed,
+        SlicedString::init(right_trimmed, right_trimmed),
     ) {
         Ok(g) => g,
         Err(_) => return Err(global.throw_out_of_memory()),
@@ -111,7 +141,7 @@ pub(crate) fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
 
     Ok(JSValue::js_boolean(right_group.satisfies(
         left_version,
-        right.slice(),
-        left.slice(),
+        right_trimmed,
+        left_trimmed,
     )))
 }

--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -120,7 +120,7 @@ pub(crate) fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
     }
 
     let left_result = Version::parse(SlicedString::init(left_trimmed, left_trimmed));
-    if left_result.wildcard != query::token::Wildcard::None {
+    if !left_result.valid || left_result.wildcard != query::token::Wildcard::None {
         return Ok(JSValue::FALSE);
     }
 

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -78,6 +78,12 @@ describe("Bun.semver.order()", () => {
       "2.0.0\r",
       "10.0.0\r",
     ]);
+
+    // interior whitespace is not trimmed; node-semver rejects these.
+    for (const ws of ["\t", "\n", "\r", "\v", "\f"]) {
+      expect(() => order(`1.0.0${ws}9.9.9`, "5.0.0")).toThrow("Invalid SemVer");
+      expect(satisfies(`1.0.0${ws}9.9.9`, "*")).toBe(false);
+    }
   });
 
   // JS .trim() also removes non-ASCII whitespace (NBSP, BOM, Zs, LS/PS).

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -253,6 +253,14 @@ describe("Bun.semver.satisfies()", () => {
     expect(satisfies("1.2.3", "1.2.3\u00E9")).toBe(false);
   });
 
+  test("empty or whitespace-only version never satisfies", () => {
+    for (const s of ["", " ", "   ", "\t\n", "\r\n", "\u00A0", "\uFEFF"]) {
+      expect(satisfies(s, "*")).toBe(false);
+      expect(satisfies(s, ">=0")).toBe(false);
+      expect(satisfies(s, "0.0.0")).toBe(false);
+    }
+  });
+
   test("failures does not cause weird memory issues", () => {
     for (let i = 0; i < 1e5; i++) {
       if (!satisfies("1.2.3", "1.2.3")) {
@@ -830,7 +838,7 @@ test("a range with a dangling '-' after a skipped tag does not crash the parser"
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual([true, true, false, true, false, true, true]);
+  expect(JSON.parse(stdout)).toEqual([false, true, false, true, false, true, true]);
   expect(exitCode).toBe(0);
 });
 

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -60,6 +60,41 @@ describe("Bun.semver.order()", () => {
     expect(order(`\n\t1.2.3`, " 1.2.3")).toBe(0);
     expect(order(`\r\t\n\r1.2.3`, " 1.2.3")).toBe(0);
   });
+
+  // node-semver .trim()s its input. Bun skipped these as a prefix but only
+  // accepted ' ' as a trailing terminator, so order() threw on \t \n \r \v \f.
+  test("trailing whitespace", () => {
+    for (const ws of [" ", "\t", "\n", "\r", "\v", "\f", "\r\n", " \t\n\r\v\f"]) {
+      expect(order(`1.2.3${ws}`, "1.0.0")).toBe(1);
+      expect(order("1.0.0", `1.2.3${ws}`)).toBe(-1);
+      expect(order(`1.2.3${ws}`, `1.2.3${ws}`)).toBe(0);
+      expect(order(`${ws}1.2.3${ws}`, "1.2.3")).toBe(0);
+      expect(order(`1.2.3-beta${ws}`, "1.2.3-beta")).toBe(0);
+      expect(order(`1.2.3+build${ws}`, "1.2.3")).toBe(0);
+    }
+
+    expect("1.0.0\r\n10.0.0\r\n2.0.0\r\n".split("\n").filter(Boolean).toSorted(order)).toEqual([
+      "1.0.0\r",
+      "2.0.0\r",
+      "10.0.0\r",
+    ]);
+  });
+
+  // JS .trim() also removes non-ASCII whitespace (NBSP, BOM, Zs, LS/PS).
+  // Bun's is_all_ascii guard returned 0 instead of trimming first.
+  test("non-ASCII whitespace is trimmed like node-semver", () => {
+    for (const ws of ["\u00A0", "\u2003", "\u3000", "\uFEFF", "\u2028", "\u2029"]) {
+      expect(order(`1.2.3${ws}`, "9.9.9")).toBe(-1);
+      expect(order(`${ws}1.2.3`, "9.9.9")).toBe(-1);
+      expect(order(`${ws}1.2.3${ws}`, "1.2.3")).toBe(0);
+      expect(order("9.9.9", `${ws}1.2.3${ws}`)).toBe(1);
+    }
+
+    // non-ASCII that isn't trimmable whitespace is invalid, matching
+    // node-semver's compare() which throws on invalid input.
+    expect(() => order("1.2.3\u00E9", "1.0.0")).toThrow("Invalid SemVer");
+    expect(() => order("1.0.0", "1.2.3\u00E9")).toThrow("Invalid SemVer");
+  });
   // https://github.com/npm/node-semver/blob/14d263faa156e408a033b9b12a2f87735c2df42c/test/fixtures/comparisons.js#L4
   test("comparisons", () => {
     var tests = [
@@ -202,6 +237,20 @@ describe("Bun.semver.satisfies()", () => {
     expect(() => {
       satisfies("~1.2.3", Symbol.for("1.2.3"));
     }).toThrow("Cannot convert a symbol to a string");
+  });
+
+  test("non-ASCII whitespace is trimmed like node-semver", () => {
+    for (const ws of ["\u00A0", "\u2003", "\u3000", "\uFEFF", "\u2028", "\u2029"]) {
+      expect(satisfies(`1.2.3${ws}`, "*")).toBe(true);
+      expect(satisfies(`${ws}1.2.3${ws}`, "^1.0.0")).toBe(true);
+      expect(satisfies("1.2.3", `${ws}^1.0.0${ws}`)).toBe(true);
+      expect(satisfies(`${ws}1.2.3${ws}`, `${ws}1.2.3${ws}`)).toBe(true);
+    }
+
+    // non-ASCII that isn't trimmable whitespace: invalid version never
+    // satisfies (node-semver catches and returns false).
+    expect(satisfies("1.2.3\u00E9", "*")).toBe(false);
+    expect(satisfies("1.2.3", "1.2.3\u00E9")).toBe(false);
   });
 
   test("failures does not cause weird memory issues", () => {


### PR DESCRIPTION
## What does this PR do?

`Bun.semver.order()` threw `Invalid SemVer` on a version with trailing `\t` `\n` `\r` `\v` `\f`, even though these are all accepted by node-semver (whose `SemVer` constructor `.trim()`s its input) and accepted by Bun itself as *leading* whitespace. This broke the documented `Array.sort(Bun.semver.order)` use on any CRLF input:

```js
Bun.semver.order("\r1.2.3", "1.0.0");   // 1 (leading: accepted)
Bun.semver.order("1.2.3\r", "1.0.0");   // THROWS "Invalid SemVer: 1.2.3"

"1.0.0\r\n10.0.0\r\n2.0.0\r\n".split("\n").filter(Boolean).toSorted(Bun.semver.order);
// THROWS "Invalid SemVer: 10.0.0"
```

Separately, the `is_all_ascii` guard in `Bun.semver.{order,satisfies}` returned `0` / `false` on any non-ASCII input. JS `String.prototype.trim()` (which node-semver uses) also removes non-ASCII whitespace (NBSP, BOM, Unicode Zs, LS/PS), so these were silently wrong:

```js
Bun.semver.order("1.2.3\u00A0", "9.9.9");     // 0      (node-semver: -1)
Bun.semver.satisfies("1.2.3\u00A0", "*");     // false  (node-semver: true)
```

## How did you fix it?

In `Bun.semver.{order,satisfies}`: trim ECMA-262 `WhiteSpace` + `LineTerminator` from both inputs before the `is_all_ascii` check, matching node-semver's `.trim()`. `order()` now throws on remaining non-ASCII (matching node-semver's `compare()`) instead of returning `0`; `satisfies()` still returns `false`. `satisfies()` now also returns `false` when the version is invalid (previously only gated on wildcard, so `satisfies("", "*")` and whitespace-only versions returned `true`; node-semver returns `false`).

`Version::parse` is unchanged: the trim in the binding layer handles trailing whitespace, and leaving the parser alone keeps `order("1.0.0\n9.9.9", ...)` throwing on interior whitespace the way node-semver does.

## How did you verify your code works?

Added tests in `test/cli/install/semver.test.ts` covering every ASCII whitespace byte (leading, trailing, and interior), the `Array.sort` CRLF scenario, the non-ASCII whitespace set (NBSP, EM SPACE, IDEOGRAPHIC SPACE, BOM, LS, PS), and empty/whitespace-only versions. All expectations verified against node-semver 7.8.5. Existing `semver.test.ts` suite (30 tests) passes. Updated the captured expectation in the dangling-`-` fuzz test for `satisfies("", ...)` to `false` (matches node-semver).