### PR TITLE
semver: add "-0" prerelease floor to derived exclusive upper bounds

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -691,18 +691,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 while let Some(queries) = curr_list {
                     let mut curr: Option<&Semver::Query> = Some(&queries.head);
                     while let Some(query) = curr {
-                        // Probe with release boundaries: derived upper bounds carry a synthetic
-                        // `-0` prerelease which would route `Group::satisfies` through the
-                        // prerelease-tuple gate and reject a plain transitive range like `>=1.5.0`.
-                        let left = Semver::Version {
-                            tag: Default::default(),
-                            ..query.range.left.version
+                        // Derived `Lt` upper bounds carry a synthetic `-0` prerelease (see
+                        // `Tag::zero_pre`); strip it so the probe takes the release path in
+                        // `Group::satisfies`. Other ops keep any user-written prerelease.
+                        let probe = |c: &Semver::range::Comparator| {
+                            let mut v = c.version;
+                            if c.op == Semver::range::Op::Lt {
+                                v.tag = Default::default();
+                            }
+                            v
                         };
-                        let right = Semver::Version {
-                            tag: Default::default(),
-                            ..query.range.right.version
-                        };
-                        if group.satisfies(left, buf, buf) || group.satisfies(right, buf, buf) {
+                        if group.satisfies(probe(&query.range.left), buf, buf)
+                            || group.satisfies(probe(&query.range.right), buf, buf)
+                        {
                             name = aliased.npm().name;
                             name_hash =
                                 Semver::string::Builder::string_hash(this.lockfile.str(&name));

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -691,9 +691,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 while let Some(queries) = curr_list {
                     let mut curr: Option<&Semver::Query> = Some(&queries.head);
                     while let Some(query) = curr {
-                        if group.satisfies(query.range.left.version, buf, buf)
-                            || group.satisfies(query.range.right.version, buf, buf)
-                        {
+                        // Probe with release boundaries: derived upper bounds carry a synthetic
+                        // `-0` prerelease which would route `Group::satisfies` through the
+                        // prerelease-tuple gate and reject a plain transitive range like `>=1.5.0`.
+                        let left = Semver::Version {
+                            tag: Default::default(),
+                            ..query.range.left.version
+                        };
+                        let right = Semver::Version {
+                            tag: Default::default(),
+                            ..query.range.right.version
+                        };
+                        if group.satisfies(left, buf, buf) || group.satisfies(right, buf, buf) {
                             name = aliased.npm().name;
                             name_hash =
                                 Semver::string::Builder::string_hash(this.lockfile.str(&name));

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -6,6 +6,7 @@ use bun_collections::IntegerBitSet;
 use bun_core::strings;
 
 use crate::range::{Comparator, Op as RangeOp};
+use crate::version::Tag;
 use crate::{Range, SlicedString, Version, version};
 
 // Re-export sub-namespace so
@@ -633,7 +634,10 @@ impl Token {
                     };
                     range.right = Comparator {
                         op: RangeOp::Lt,
-                        ..Default::default()
+                        version: Version {
+                            tag: Tag::zero_pre(),
+                            ..Default::default()
+                        },
                     };
                     if let Some(minor) = version.minor {
                         range.left.version.minor = minor;
@@ -673,7 +677,10 @@ impl Token {
                     };
                     range.right = Comparator {
                         op: RangeOp::Lt,
-                        ..Default::default()
+                        version: Version {
+                            tag: Tag::zero_pre(),
+                            ..Default::default()
+                        },
                     };
                     if let Some(minor) = version.minor {
                         range.left.version.minor = minor;
@@ -742,6 +749,7 @@ impl Token {
                             major: version.major.unwrap_or(0),
                             minor: 0,
                             patch: 0,
+                            tag: Tag::zero_pre(),
                             ..Default::default()
                         },
                     },
@@ -793,6 +801,7 @@ impl Token {
                             major: version.major.unwrap_or(0),
                             minor: version.minor.unwrap_or(0),
                             patch: 0,
+                            tag: Tag::zero_pre(),
                             ..Default::default()
                         },
                     },
@@ -1030,10 +1039,11 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                         }
                     }
                     Wildcard::Minor => {
-                        // "1.0.0 - 1.x" --> ">=1.0.0 < 2.0.0"
+                        // "1.0.0 - 1.x" --> ">=1.0.0 <2.0.0-0"
                         second_version.major = second_version.major.saturating_add(1);
                         second_version.minor = 0;
                         second_version.patch = 0;
+                        second_version.tag = Tag::zero_pre();
 
                         Range {
                             left: Comparator {
@@ -1047,9 +1057,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                         }
                     }
                     Wildcard::Patch => {
-                        // "1.0.0 - 1.0.x" --> ">=1.0.0 <1.1.0"
+                        // "1.0.0 - 1.0.x" --> ">=1.0.0 <1.1.0-0"
                         second_version.minor = second_version.minor.saturating_add(1);
                         second_version.patch = 0;
+                        second_version.tag = Tag::zero_pre();
 
                         Range {
                             left: Comparator {

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -3,6 +3,7 @@ use core::fmt;
 
 use crate::Version;
 use crate::query::token::Wildcard;
+use crate::version::Tag;
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -75,6 +76,7 @@ impl Range {
                 let lhs = Version {
                     major: version.major.saturating_add(1),
                     // .raw = version.raw
+                    tag: Tag::zero_pre(),
                     ..Default::default()
                 };
                 let rhs = Version {
@@ -99,6 +101,7 @@ impl Range {
                     major: version.major,
                     minor: version.minor.saturating_add(1),
                     // .raw = version.raw;
+                    tag: Tag::zero_pre(),
                     ..Default::default()
                 };
                 let rhs = Version {

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -984,6 +984,16 @@ pub struct Tag {
 // TODO: support multiple tags
 
 impl Tag {
+    /// The lowest possible prerelease identifier (`-0`). node-semver appends this to every
+    /// derived exclusive upper bound so that `^1.2.3` desugars to `<2.0.0-0` and a prerelease
+    /// of the bound tuple (e.g. `2.0.0-rc.1`) is excluded.
+    pub fn zero_pre() -> Tag {
+        Tag {
+            pre: SlicedString::init(b"0", b"0").external(),
+            build: ExternalString::default(),
+        }
+    }
+
     pub fn order_pre(self, rhs: Tag, lhs_buf: &[u8], rhs_buf: &[u8]) -> Ordering {
         let lhs_str = self.pre.slice(lhs_buf);
         let rhs_str = rhs.pre.slice(rhs_buf);

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -804,7 +804,7 @@ exports[`dependency on workspace without version in package.json: version: 1 1`]
       "literal": "1",
       "npm": {
         "name": "no-deps",
-        "version": "<2.0.0 >=1.0.0"
+        "version": "<2.0.0-0 >=1.0.0"
       },
       "package_id": 3,
       "behavior": {
@@ -960,7 +960,7 @@ exports[`dependency on workspace without version in package.json: version: 1.* 1
       "literal": "1.*",
       "npm": {
         "name": "no-deps",
-        "version": "<2.0.0 >=1.0.0"
+        "version": "<2.0.0-0 >=1.0.0"
       },
       "package_id": 3,
       "behavior": {
@@ -1116,7 +1116,7 @@ exports[`dependency on workspace without version in package.json: version: 1.1.*
       "literal": "1.1.*",
       "npm": {
         "name": "no-deps",
-        "version": "<1.2.0 >=1.1.0"
+        "version": "<1.2.0-0 >=1.1.0"
       },
       "package_id": 3,
       "behavior": {

--- a/test/cli/install/__snapshots__/migrate-bun-lockb-v2.test.ts.snap
+++ b/test/cli/install/__snapshots__/migrate-bun-lockb-v2.test.ts.snap
@@ -12,7 +12,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "is-even",
       "npm": {
         "name": "is-even",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 2,
     },
@@ -25,7 +25,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "jquery",
       "npm": {
         "name": "jquery",
-        "version": ">=3.7.1 <3.8.0",
+        "version": ">=3.7.1 <3.8.0-0",
       },
       "package_id": 1,
     },
@@ -38,7 +38,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "is-odd",
       "npm": {
         "name": "is-odd",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 3,
     },
@@ -51,7 +51,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 4,
     },
@@ -64,7 +64,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "kind-of",
       "npm": {
         "name": "kind-of",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 5,
     },
@@ -77,7 +77,7 @@ exports[`migrate migrate-bun-lockb-v2 1`] = `
       "name": "is-buffer",
       "npm": {
         "name": "is-buffer",
-        "version": ">=1.1.5 <2.0.0",
+        "version": ">=1.1.5 <2.0.0-0",
       },
       "package_id": 6,
     },
@@ -314,7 +314,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.22.4 <4.0.0",
+        "version": ">=3.22.4 <4.0.0-0",
       },
       "package_id": 13,
     },
@@ -327,7 +327,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 12,
     },
@@ -340,7 +340,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "false",
       "npm": {
         "name": "false",
-        "version": ">=0.0.4 <0.0.5",
+        "version": ">=0.0.4 <0.0.5-0",
       },
       "package_id": 11,
     },
@@ -353,7 +353,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "jquery",
       "npm": {
         "name": "jquery",
-        "version": ">=3.7.1 <3.8.0",
+        "version": ">=3.7.1 <3.8.0-0",
       },
       "package_id": 10,
     },
@@ -366,7 +366,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "scheduler",
       "npm": {
         "name": "scheduler",
-        "version": ">=0.23.0 <0.24.0",
+        "version": ">=0.23.0 <0.24.0-0",
       },
       "package_id": 6,
     },
@@ -379,7 +379,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "is-even",
       "npm": {
         "name": "is-even",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 1,
     },
@@ -393,7 +393,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "lodash",
       "npm": {
         "name": "lodash",
-        "version": ">=4.17.21 <5.0.0",
+        "version": ">=4.17.21 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -406,7 +406,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "is-odd",
       "npm": {
         "name": "is-odd",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 2,
     },
@@ -419,7 +419,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 3,
     },
@@ -432,7 +432,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "kind-of",
       "npm": {
         "name": "kind-of",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 4,
     },
@@ -445,7 +445,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "is-buffer",
       "npm": {
         "name": "is-buffer",
-        "version": ">=1.1.5 <2.0.0",
+        "version": ">=1.1.5 <2.0.0-0",
       },
       "package_id": 5,
     },
@@ -458,7 +458,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "loose-envify",
       "npm": {
         "name": "loose-envify",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 8,
     },
@@ -471,7 +471,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 7,
     },
@@ -484,7 +484,7 @@ exports[`migrate migrate-bun-lockb-v2-most-features 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 9,
     },

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -736,9 +736,8 @@ describe("Bun.semver.satisfies()", () => {
   });
 
   test("desugared upper bounds exclude prereleases of the bound tuple", () => {
-    // node-semver desugars ^1.2.3 to ">=1.2.3 <2.0.0-0" (not "<2.0.0"): the "-0"
-    // is the lowest prerelease, so 2.0.0-rc.1 cannot satisfy the upper bound even
-    // when AND-ed with a comparator that names a prerelease on the same tuple.
+    // node-semver desugars ^1.2.3 to ">=1.2.3 <2.0.0-0" (not "<2.0.0"), so a
+    // prerelease of the bound tuple (e.g. 2.0.0-rc.1) is excluded.
     // https://github.com/npm/node-semver/blob/3a8a4309ae986c1967b3073ba88c9e69433d44cb/classes/range.js#L306
     const excludes = [
       // caret

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -735,6 +735,59 @@ describe("Bun.semver.satisfies()", () => {
     }
   });
 
+  test("desugared upper bounds exclude prereleases of the bound tuple", () => {
+    // node-semver desugars ^1.2.3 to ">=1.2.3 <2.0.0-0" (not "<2.0.0"): the "-0"
+    // is the lowest prerelease, so 2.0.0-rc.1 cannot satisfy the upper bound even
+    // when AND-ed with a comparator that names a prerelease on the same tuple.
+    // https://github.com/npm/node-semver/blob/3a8a4309ae986c1967b3073ba88c9e69433d44cb/classes/range.js#L306
+    const excludes = [
+      // caret
+      [">=2.0.0-rc.0 ^1.2.3", "2.0.0-rc.1"],
+      [">=0.2.0-rc.0 ^0.1.2", "0.2.0-rc.1"],
+      [">=0.0.2-rc.0 ^0.0.1", "0.0.2-rc.1"],
+      [">=2.0.0-rc.0 ^1", "2.0.0-rc.1"],
+      // tilde
+      ["~1.5.0 >=1.6.0-beta", "1.6.0-beta.2"],
+      [">=2.0.0-rc.0 ~1", "2.0.0-rc.1"],
+      // bare x-range / partial
+      ["1.5.x >=1.6.0-beta", "1.6.0-beta.2"],
+      ["1.5 >=1.6.0-beta", "1.6.0-beta.2"],
+      // <N.x / <N.M.x
+      [">=1.0.0-rc.0 <1.x", "1.0.0-rc.1"],
+      [">=1.2.0-rc.0 <1.2.x", "1.2.0-rc.1"],
+      // hyphen range with partial/x upper
+      ["1.0.0 - 1.5 >=1.6.0-beta", "1.6.0-beta.2"],
+      ["1.0.0 - 1.x >=2.0.0-rc.0", "2.0.0-rc.1"],
+      ["1.0.0 - 1.5.x >=1.6.0-beta", "1.6.0-beta.2"],
+    ];
+    for (const [range, version] of excludes) {
+      testSatisfies(range, version, false);
+    }
+
+    // the "-0" floor must not start rejecting things npm accepts
+    const includes = [
+      ["^1.2.3", "1.9.0"],
+      ["~1.2.3", "1.2.4"],
+      ["^1.2.3-alpha", "1.2.3-pre"],
+      ["1.5.x", "1.5.9"],
+      ["1.0.0 - 1.5", "1.5.9"],
+    ];
+    for (const [range, version] of includes) {
+      testSatisfies(range, version, true);
+    }
+
+    // unchanged controls: the single-comparator prerelease gate already handled these
+    for (const [range, version] of [
+      ["^1.2.3", "2.0.0-0"],
+      ["^1.2.3", "1.5.0-beta"],
+      ["^1.2.3-alpha", "2.0.0-alpha"],
+      ["~1.5.0", "1.6.0-beta.2"],
+      [">=1.6.0-beta <1.6.0-0", "1.6.0-beta.2"],
+    ]) {
+      testSatisfies(range, version, false);
+    }
+  });
+
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
   });

--- a/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
@@ -25,7 +25,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -38,7 +38,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/react-dom",
       "npm": {
         "name": "@types/react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 91,
     },
@@ -64,7 +64,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bun-types",
       "npm": {
         "name": "bun-types",
-        "version": ">=1.2.19 <2.0.0",
+        "version": ">=1.2.19 <2.0.0-0",
       },
       "package_id": 162,
     },
@@ -77,7 +77,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=9.33.0 <10.0.0",
+        "version": ">=9.33.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -90,7 +90,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-config-next",
       "npm": {
         "name": "eslint-config-next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 217,
     },
@@ -103,7 +103,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "next",
       "npm": {
         "name": "next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 350,
     },
@@ -142,7 +142,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -155,7 +155,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -168,7 +168,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tailwindcss",
       "npm": {
         "name": "tailwindcss",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 452,
     },
@@ -194,7 +194,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -207,7 +207,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -220,7 +220,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -233,7 +233,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -246,7 +246,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -259,7 +259,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-compilation-targets",
       "npm": {
         "name": "@babel/helper-compilation-targets",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 6,
     },
@@ -272,7 +272,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-module-transforms",
       "npm": {
         "name": "@babel/helper-module-transforms",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 9,
     },
@@ -285,7 +285,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helpers",
       "npm": {
         "name": "@babel/helpers",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 13,
     },
@@ -298,7 +298,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -311,7 +311,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -324,7 +324,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -337,7 +337,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -350,7 +350,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/remapping",
       "npm": {
         "name": "@jridgewell/remapping",
-        "version": ">=2.3.5 <3.0.0",
+        "version": ">=2.3.5 <3.0.0-0",
       },
       "package_id": 61,
     },
@@ -363,7 +363,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "convert-source-map",
       "npm": {
         "name": "convert-source-map",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 178,
     },
@@ -376,7 +376,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -389,7 +389,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gensync",
       "npm": {
         "name": "gensync",
-        "version": ">=1.0.0-beta.2 <2.0.0",
+        "version": ">=1.0.0-beta.2 <2.0.0-0",
       },
       "package_id": 254,
     },
@@ -402,7 +402,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=2.2.3 <3.0.0",
+        "version": ">=2.2.3 <3.0.0-0",
       },
       "package_id": 496,
     },
@@ -415,7 +415,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -428,7 +428,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -441,7 +441,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -454,7 +454,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.12 <0.4.0",
+        "version": ">=0.3.12 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -467,7 +467,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.28 <0.4.0",
+        "version": ">=0.3.28 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -480,7 +480,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "jsesc",
       "npm": {
         "name": "jsesc",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 320,
     },
@@ -493,7 +493,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/compat-data",
       "npm": {
         "name": "@babel/compat-data",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 3,
     },
@@ -506,7 +506,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-validator-option",
       "npm": {
         "name": "@babel/helper-validator-option",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 12,
     },
@@ -519,7 +519,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.0 <5.0.0",
+        "version": ">=4.24.0 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -532,7 +532,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=5.1.1 <6.0.0",
+        "version": ">=5.1.1 <6.0.0-0",
       },
       "package_id": 497,
     },
@@ -545,7 +545,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -558,7 +558,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -571,7 +571,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -584,7 +584,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-module-imports",
       "npm": {
         "name": "@babel/helper-module-imports",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 8,
     },
@@ -597,7 +597,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -610,7 +610,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -623,7 +623,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -636,7 +636,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -649,7 +649,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -662,7 +662,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -675,7 +675,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -688,7 +688,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -701,7 +701,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -714,7 +714,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -727,7 +727,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -740,7 +740,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-globals",
       "npm": {
         "name": "@babel/helper-globals",
-        "version": ">=7.28.0 <8.0.0",
+        "version": ">=7.28.0 <8.0.0-0",
       },
       "package_id": 7,
     },
@@ -753,7 +753,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -766,7 +766,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -779,7 +779,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -792,7 +792,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -805,7 +805,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-string-parser",
       "npm": {
         "name": "@babel/helper-string-parser",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 10,
     },
@@ -818,7 +818,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -844,7 +844,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -857,7 +857,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -870,7 +870,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -883,7 +883,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -896,7 +896,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -909,7 +909,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/object-schema",
       "npm": {
         "name": "@eslint/object-schema",
-        "version": ">=2.1.6 <3.0.0",
+        "version": ">=2.1.6 <3.0.0-0",
       },
       "package_id": 28,
     },
@@ -922,7 +922,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -935,7 +935,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -948,7 +948,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -961,7 +961,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -974,7 +974,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -987,7 +987,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.0.1 <11.0.0",
+        "version": ">=10.0.1 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -1000,7 +1000,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "globals",
       "npm": {
         "name": "globals",
-        "version": ">=14.0.0 <15.0.0",
+        "version": ">=14.0.0 <15.0.0-0",
       },
       "package_id": 499,
     },
@@ -1013,7 +1013,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -1026,7 +1026,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.2.1 <4.0.0",
+        "version": ">=3.2.1 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -1039,7 +1039,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -1052,7 +1052,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -1065,7 +1065,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-json-comments",
       "npm": {
         "name": "strip-json-comments",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 447,
     },
@@ -1078,7 +1078,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -1091,7 +1091,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -1104,7 +1104,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@humanfs/core",
       "npm": {
         "name": "@humanfs/core",
-        "version": ">=0.19.1 <0.20.0",
+        "version": ">=0.19.1 <0.20.0-0",
       },
       "package_id": 30,
     },
@@ -1117,7 +1117,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 500,
     },
@@ -1260,7 +1260,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.7.0 <2.0.0",
+        "version": ">=1.7.0 <2.0.0-0",
       },
       "package_id": 19,
     },
@@ -1273,7 +1273,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -1287,7 +1287,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width-cjs",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -1300,7 +1300,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -1314,7 +1314,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi-cjs",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -1327,7 +1327,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 503,
     },
@@ -1341,7 +1341,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "wrap-ansi-cjs",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -1354,7 +1354,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1367,7 +1367,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1380,7 +1380,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -1393,7 +1393,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1406,7 +1406,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/resolve-uri",
       "npm": {
         "name": "@jridgewell/resolve-uri",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 62,
     },
@@ -1419,7 +1419,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.4.14 <2.0.0",
+        "version": ">=1.4.14 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1432,7 +1432,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@emnapi/core",
       "npm": {
         "name": "@emnapi/core",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 18,
     },
@@ -1445,7 +1445,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 504,
     },
@@ -1458,7 +1458,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@tybys/wasm-util",
       "npm": {
         "name": "@tybys/wasm-util",
-        "version": ">=0.10.0 <0.11.0",
+        "version": ">=0.10.0 <0.11.0-0",
       },
       "package_id": 85,
     },
@@ -1497,7 +1497,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "run-parallel",
       "npm": {
         "name": "run-parallel",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 412,
     },
@@ -1523,7 +1523,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fastq",
       "npm": {
         "name": "fastq",
-        "version": ">=1.6.0 <2.0.0",
+        "version": ">=1.6.0 <2.0.0-0",
       },
       "package_id": 239,
     },
@@ -1536,7 +1536,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -1549,7 +1549,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "extract-zip",
       "npm": {
         "name": "extract-zip",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 233,
     },
@@ -1562,7 +1562,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "progress",
       "npm": {
         "name": "progress",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 391,
     },
@@ -1575,7 +1575,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "proxy-agent",
       "npm": {
         "name": "proxy-agent",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 393,
     },
@@ -1588,7 +1588,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.2 <8.0.0",
+        "version": ">=7.7.2 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -1601,7 +1601,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tar-fs",
       "npm": {
         "name": "tar-fs",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 453,
     },
@@ -1614,7 +1614,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yargs",
       "npm": {
         "name": "yargs",
-        "version": ">=17.7.2 <18.0.0",
+        "version": ">=17.7.2 <18.0.0-0",
       },
       "package_id": 490,
     },
@@ -1627,7 +1627,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.8.0 <3.0.0",
+        "version": ">=2.8.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1640,7 +1640,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1653,7 +1653,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.16.0 <7.17.0",
+        "version": ">=7.16.0 <7.17.0-0",
       },
       "package_id": 473,
     },
@@ -1666,7 +1666,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "csstype",
       "npm": {
         "name": "csstype",
-        "version": ">=3.2.2 <4.0.0",
+        "version": ">=3.2.2 <4.0.0-0",
       },
       "package_id": 182,
     },
@@ -1679,7 +1679,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.0 <20.0.0",
+        "version": ">=19.2.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -1705,7 +1705,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.2 <5.0.0",
+        "version": ">=4.12.2 <5.0.0-0",
       },
       "package_id": 508,
     },
@@ -1770,7 +1770,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=7.0.5 <8.0.0",
+        "version": ">=7.0.5 <8.0.0-0",
       },
       "package_id": 509,
     },
@@ -1783,7 +1783,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -1796,7 +1796,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -1809,7 +1809,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@typescript-eslint/parser",
       "npm": {
         "name": "@typescript-eslint/parser",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 94,
     },
@@ -1822,7 +1822,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1900,7 +1900,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -1913,7 +1913,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1939,7 +1939,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@typescript-eslint/tsconfig-utils",
       "npm": {
         "name": "@typescript-eslint/tsconfig-utils",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 97,
     },
@@ -1952,7 +1952,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@typescript-eslint/types",
       "npm": {
         "name": "@typescript-eslint/types",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 99,
     },
@@ -1965,7 +1965,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2069,7 +2069,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2082,7 +2082,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2095,7 +2095,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2173,7 +2173,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2186,7 +2186,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=10.2.2 <11.0.0",
+        "version": ">=10.2.2 <11.0.0-0",
       },
       "package_id": 511,
     },
@@ -2199,7 +2199,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -2212,7 +2212,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.15 <0.3.0",
+        "version": ">=0.2.15 <0.3.0-0",
       },
       "package_id": 513,
     },
@@ -2225,7 +2225,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2251,7 +2251,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.9.1 <5.0.0",
+        "version": ">=4.9.1 <5.0.0-0",
       },
       "package_id": 514,
     },
@@ -2303,7 +2303,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2342,7 +2342,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 515,
     },
@@ -2355,7 +2355,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@napi-rs/wasm-runtime",
       "npm": {
         "name": "@napi-rs/wasm-runtime",
-        "version": ">=0.2.11 <0.3.0",
+        "version": ">=0.2.11 <0.3.0-0",
       },
       "package_id": 65,
     },
@@ -2368,7 +2368,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=8.0.0 <9.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=8.0.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -2381,7 +2381,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -2394,7 +2394,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-json-stable-stringify",
       "npm": {
         "name": "fast-json-stable-stringify",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 237,
     },
@@ -2407,7 +2407,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "json-schema-traverse",
       "npm": {
         "name": "json-schema-traverse",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 323,
     },
@@ -2420,7 +2420,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "uri-js",
       "npm": {
         "name": "uri-js",
-        "version": ">=4.2.2 <5.0.0",
+        "version": ">=4.2.2 <5.0.0-0",
       },
       "package_id": 476,
     },
@@ -2433,7 +2433,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "color-convert",
       "npm": {
         "name": "color-convert",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 174,
     },
@@ -2446,7 +2446,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -2459,7 +2459,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.0.4 <3.0.0",
+        "version": ">=2.0.4 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -2472,7 +2472,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2485,7 +2485,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -2498,7 +2498,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2511,7 +2511,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2524,7 +2524,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2537,7 +2537,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.24.0 <2.0.0",
+        "version": ">=1.24.0 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2550,7 +2550,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2563,7 +2563,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -2576,7 +2576,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -2589,7 +2589,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -2602,7 +2602,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2615,7 +2615,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2628,7 +2628,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2641,7 +2641,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2654,7 +2654,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2667,7 +2667,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2680,7 +2680,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2693,7 +2693,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2706,7 +2706,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2719,7 +2719,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2732,7 +2732,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2745,7 +2745,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2758,7 +2758,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2771,7 +2771,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2784,7 +2784,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2797,7 +2797,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2810,7 +2810,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2823,7 +2823,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2836,7 +2836,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2849,7 +2849,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2862,7 +2862,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2875,7 +2875,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2888,7 +2888,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2901,7 +2901,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2914,7 +2914,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2927,7 +2927,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2940,7 +2940,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -2953,7 +2953,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2966,7 +2966,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2979,7 +2979,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2992,7 +2992,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3005,7 +3005,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3018,7 +3018,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.4 <4.0.0",
+        "version": ">=3.0.4 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -3031,7 +3031,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -3044,7 +3044,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.4 <5.0.0",
+        "version": ">=4.24.4 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -3057,7 +3057,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001702 <2.0.0",
+        "version": ">=1.0.30001702 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3070,7 +3070,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fraction.js",
       "npm": {
         "name": "fraction.js",
-        "version": ">=4.3.7 <5.0.0",
+        "version": ">=4.3.7 <5.0.0-0",
       },
       "package_id": 249,
     },
@@ -3083,7 +3083,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "normalize-range",
       "npm": {
         "name": "normalize-range",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 353,
     },
@@ -3096,7 +3096,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -3109,7 +3109,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -3122,7 +3122,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -3135,7 +3135,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -3148,7 +3148,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.5.4 <3.0.0",
+        "version": ">=2.5.4 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -3161,7 +3161,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -3174,7 +3174,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-stream",
       "npm": {
         "name": "bare-stream",
-        "version": ">=2.6.4 <3.0.0",
+        "version": ">=2.6.4 <3.0.0-0",
       },
       "package_id": 154,
     },
@@ -3201,7 +3201,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-os",
       "npm": {
         "name": "bare-os",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 152,
     },
@@ -3214,7 +3214,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.21.0 <3.0.0",
+        "version": ">=2.21.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -3255,7 +3255,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },
@@ -3281,7 +3281,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fill-range",
       "npm": {
         "name": "fill-range",
-        "version": ">=7.1.1 <8.0.0",
+        "version": ">=7.1.1 <8.0.0-0",
       },
       "package_id": 243,
     },
@@ -3294,7 +3294,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001726 <2.0.0",
+        "version": ">=1.0.30001726 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3307,7 +3307,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "electron-to-chromium",
       "npm": {
         "name": "electron-to-chromium",
-        "version": ">=1.5.173 <2.0.0",
+        "version": ">=1.5.173 <2.0.0-0",
       },
       "package_id": 200,
     },
@@ -3320,7 +3320,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "node-releases",
       "npm": {
         "name": "node-releases",
-        "version": ">=2.0.19 <3.0.0",
+        "version": ">=2.0.19 <3.0.0-0",
       },
       "package_id": 351,
     },
@@ -3333,7 +3333,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "update-browserslist-db",
       "npm": {
         "name": "update-browserslist-db",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 475,
     },
@@ -3359,7 +3359,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.0.0 <20.0.0",
+        "version": ">=19.0.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -3372,7 +3372,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3385,7 +3385,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3398,7 +3398,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3411,7 +3411,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "set-function-length",
       "npm": {
         "name": "set-function-length",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 418,
     },
@@ -3424,7 +3424,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3437,7 +3437,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -3450,7 +3450,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3463,7 +3463,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3476,7 +3476,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -3489,7 +3489,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "supports-color",
       "npm": {
         "name": "supports-color",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 450,
     },
@@ -3502,7 +3502,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fsevents",
       "npm": {
         "name": "fsevents",
-        "version": ">=2.3.2 <2.4.0",
+        "version": ">=2.3.2 <2.4.0-0",
       },
       "package_id": 250,
     },
@@ -3515,7 +3515,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "anymatch",
       "npm": {
         "name": "anymatch",
-        "version": ">=3.1.2 <3.2.0",
+        "version": ">=3.1.2 <3.2.0-0",
       },
       "package_id": 129,
     },
@@ -3528,7 +3528,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.2 <3.1.0",
+        "version": ">=3.0.2 <3.1.0-0",
       },
       "package_id": 159,
     },
@@ -3541,7 +3541,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <5.2.0",
+        "version": ">=5.1.2 <5.2.0-0",
       },
       "package_id": 516,
     },
@@ -3554,7 +3554,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-binary-path",
       "npm": {
         "name": "is-binary-path",
-        "version": ">=2.1.0 <2.2.0",
+        "version": ">=2.1.0 <2.2.0-0",
       },
       "package_id": 287,
     },
@@ -3567,7 +3567,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <4.1.0",
+        "version": ">=4.0.1 <4.1.0-0",
       },
       "package_id": 298,
     },
@@ -3580,7 +3580,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <3.1.0",
+        "version": ">=3.0.0 <3.1.0-0",
       },
       "package_id": 352,
     },
@@ -3593,7 +3593,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "readdirp",
       "npm": {
         "name": "readdirp",
-        "version": ">=3.6.0 <3.7.0",
+        "version": ">=3.6.0 <3.7.0-0",
       },
       "package_id": 404,
     },
@@ -3606,7 +3606,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "mitt",
       "npm": {
         "name": "mitt",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 343,
     },
@@ -3619,7 +3619,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.24.1 <4.0.0",
+        "version": ">=3.24.1 <4.0.0-0",
       },
       "package_id": 494,
     },
@@ -3645,7 +3645,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -3658,7 +3658,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -3671,7 +3671,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -3684,7 +3684,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "color-name",
       "npm": {
         "name": "color-name",
-        "version": ">=1.1.4 <1.2.0",
+        "version": ">=1.1.4 <1.2.0-0",
       },
       "package_id": 175,
     },
@@ -3697,7 +3697,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "env-paths",
       "npm": {
         "name": "env-paths",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 203,
     },
@@ -3710,7 +3710,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.3.0 <4.0.0",
+        "version": ">=3.3.0 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -3723,7 +3723,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -3736,7 +3736,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "parse-json",
       "npm": {
         "name": "parse-json",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 372,
     },
@@ -3763,7 +3763,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "path-key",
       "npm": {
         "name": "path-key",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 374,
     },
@@ -3776,7 +3776,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "shebang-command",
       "npm": {
         "name": "shebang-command",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 422,
     },
@@ -3789,7 +3789,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which",
       "npm": {
         "name": "which",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 478,
     },
@@ -3802,7 +3802,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3815,7 +3815,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3828,7 +3828,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3841,7 +3841,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3854,7 +3854,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3867,7 +3867,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3880,7 +3880,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3893,7 +3893,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3906,7 +3906,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3919,7 +3919,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -3932,7 +3932,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3945,7 +3945,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3958,7 +3958,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -3971,7 +3971,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -3984,7 +3984,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -3997,7 +3997,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4010,7 +4010,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ast-types",
       "npm": {
         "name": "ast-types",
-        "version": ">=0.13.4 <0.14.0",
+        "version": ">=0.13.4 <0.14.0-0",
       },
       "package_id": 141,
     },
@@ -4023,7 +4023,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "escodegen",
       "npm": {
         "name": "escodegen",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 215,
     },
@@ -4036,7 +4036,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -4049,7 +4049,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -4062,7 +4062,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -4075,7 +4075,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4088,7 +4088,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4101,7 +4101,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -4114,7 +4114,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-arrayish",
       "npm": {
         "name": "is-arrayish",
-        "version": ">=0.2.1 <0.3.0",
+        "version": ">=0.2.1 <0.3.0-0",
       },
       "package_id": 284,
     },
@@ -4127,7 +4127,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -4140,7 +4140,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "arraybuffer.prototype.slice",
       "npm": {
         "name": "arraybuffer.prototype.slice",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 140,
     },
@@ -4153,7 +4153,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -4166,7 +4166,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4179,7 +4179,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4192,7 +4192,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "data-view-buffer",
       "npm": {
         "name": "data-view-buffer",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 185,
     },
@@ -4205,7 +4205,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "data-view-byte-length",
       "npm": {
         "name": "data-view-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 186,
     },
@@ -4218,7 +4218,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "data-view-byte-offset",
       "npm": {
         "name": "data-view-byte-offset",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 187,
     },
@@ -4231,7 +4231,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -4244,7 +4244,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4257,7 +4257,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -4270,7 +4270,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4283,7 +4283,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-to-primitive",
       "npm": {
         "name": "es-to-primitive",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 212,
     },
@@ -4296,7 +4296,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.8 <2.0.0",
+        "version": ">=1.1.8 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -4309,7 +4309,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4322,7 +4322,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -4335,7 +4335,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-symbol-description",
       "npm": {
         "name": "get-symbol-description",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 259,
     },
@@ -4348,7 +4348,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4361,7 +4361,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4374,7 +4374,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4387,7 +4387,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4400,7 +4400,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4413,7 +4413,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -4426,7 +4426,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -4439,7 +4439,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -4452,7 +4452,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -4465,7 +4465,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -4478,7 +4478,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-negative-zero",
       "npm": {
         "name": "is-negative-zero",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 300,
     },
@@ -4491,7 +4491,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -4504,7 +4504,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -4517,7 +4517,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-shared-array-buffer",
       "npm": {
         "name": "is-shared-array-buffer",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 305,
     },
@@ -4530,7 +4530,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -4543,7 +4543,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -4556,7 +4556,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -4569,7 +4569,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -4582,7 +4582,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.4 <2.0.0",
+        "version": ">=1.13.4 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -4595,7 +4595,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4608,7 +4608,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.7 <5.0.0",
+        "version": ">=4.1.7 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -4621,7 +4621,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "own-keys",
       "npm": {
         "name": "own-keys",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 365,
     },
@@ -4634,7 +4634,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.4 <2.0.0",
+        "version": ">=1.5.4 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -4647,7 +4647,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -4660,7 +4660,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -4673,7 +4673,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -4686,7 +4686,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "set-proto",
       "npm": {
         "name": "set-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 420,
     },
@@ -4699,7 +4699,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "stop-iteration-iterator",
       "npm": {
         "name": "stop-iteration-iterator",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 436,
     },
@@ -4712,7 +4712,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.trim",
       "npm": {
         "name": "string.prototype.trim",
-        "version": ">=1.2.10 <2.0.0",
+        "version": ">=1.2.10 <2.0.0-0",
       },
       "package_id": 442,
     },
@@ -4725,7 +4725,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -4738,7 +4738,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.trimstart",
       "npm": {
         "name": "string.prototype.trimstart",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 444,
     },
@@ -4751,7 +4751,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-array-buffer",
       "npm": {
         "name": "typed-array-buffer",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 465,
     },
@@ -4764,7 +4764,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-array-byte-length",
       "npm": {
         "name": "typed-array-byte-length",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 466,
     },
@@ -4777,7 +4777,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-array-byte-offset",
       "npm": {
         "name": "typed-array-byte-offset",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 467,
     },
@@ -4790,7 +4790,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-array-length",
       "npm": {
         "name": "typed-array-length",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 468,
     },
@@ -4803,7 +4803,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "unbox-primitive",
       "npm": {
         "name": "unbox-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 472,
     },
@@ -4816,7 +4816,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.19 <2.0.0",
+        "version": ">=1.1.19 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -4829,7 +4829,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4842,7 +4842,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4855,7 +4855,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -4868,7 +4868,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -4881,7 +4881,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4894,7 +4894,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4907,7 +4907,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -4920,7 +4920,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4933,7 +4933,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4946,7 +4946,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4959,7 +4959,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4972,7 +4972,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4985,7 +4985,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4998,7 +4998,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -5011,7 +5011,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "iterator.prototype",
       "npm": {
         "name": "iterator.prototype",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 314,
     },
@@ -5024,7 +5024,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -5037,7 +5037,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5050,7 +5050,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5063,7 +5063,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -5076,7 +5076,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -5089,7 +5089,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5102,7 +5102,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5115,7 +5115,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -5128,7 +5128,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.0.5 <2.0.0",
+        "version": ">=1.0.5 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -5141,7 +5141,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -5154,7 +5154,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "source-map",
       "npm": {
         "name": "source-map",
-        "version": ">=0.6.1 <0.7.0",
+        "version": ">=0.6.1 <0.7.0-0",
       },
       "package_id": 432,
     },
@@ -5167,7 +5167,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -5180,7 +5180,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -5193,7 +5193,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5206,7 +5206,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 21,
     },
@@ -5219,7 +5219,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.1 <5.0.0",
+        "version": ">=4.12.1 <5.0.0-0",
       },
       "package_id": 22,
     },
@@ -5232,7 +5232,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/config-array",
       "npm": {
         "name": "@eslint/config-array",
-        "version": ">=0.21.0 <0.22.0",
+        "version": ">=0.21.0 <0.22.0-0",
       },
       "package_id": 23,
     },
@@ -5245,7 +5245,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/config-helpers",
       "npm": {
         "name": "@eslint/config-helpers",
-        "version": ">=0.3.1 <0.4.0",
+        "version": ">=0.3.1 <0.4.0-0",
       },
       "package_id": 24,
     },
@@ -5258,7 +5258,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -5271,7 +5271,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/eslintrc",
       "npm": {
         "name": "@eslint/eslintrc",
-        "version": ">=3.3.1 <4.0.0",
+        "version": ">=3.3.1 <4.0.0-0",
       },
       "package_id": 26,
     },
@@ -5297,7 +5297,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@eslint/plugin-kit",
       "npm": {
         "name": "@eslint/plugin-kit",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 29,
     },
@@ -5310,7 +5310,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@humanfs/node",
       "npm": {
         "name": "@humanfs/node",
-        "version": ">=0.16.6 <0.17.0",
+        "version": ">=0.16.6 <0.17.0-0",
       },
       "package_id": 31,
     },
@@ -5323,7 +5323,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@humanwhocodes/module-importer",
       "npm": {
         "name": "@humanwhocodes/module-importer",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 32,
     },
@@ -5336,7 +5336,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.4.2 <0.5.0",
+        "version": ">=0.4.2 <0.5.0-0",
       },
       "package_id": 33,
     },
@@ -5349,7 +5349,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/estree",
       "npm": {
         "name": "@types/estree",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 86,
     },
@@ -5362,7 +5362,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -5375,7 +5375,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -5388,7 +5388,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "chalk",
       "npm": {
         "name": "chalk",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 169,
     },
@@ -5401,7 +5401,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -5414,7 +5414,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5427,7 +5427,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "escape-string-regexp",
       "npm": {
         "name": "escape-string-regexp",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 214,
     },
@@ -5440,7 +5440,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-scope",
       "npm": {
         "name": "eslint-scope",
-        "version": ">=8.4.0 <9.0.0",
+        "version": ">=8.4.0 <9.0.0-0",
       },
       "package_id": 225,
     },
@@ -5453,7 +5453,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -5466,7 +5466,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.4.0 <11.0.0",
+        "version": ">=10.4.0 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -5479,7 +5479,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esquery",
       "npm": {
         "name": "esquery",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 229,
     },
@@ -5492,7 +5492,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5505,7 +5505,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -5518,7 +5518,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "file-entry-cache",
       "npm": {
         "name": "file-entry-cache",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 242,
     },
@@ -5531,7 +5531,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "find-up",
       "npm": {
         "name": "find-up",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 244,
     },
@@ -5544,7 +5544,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -5557,7 +5557,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -5570,7 +5570,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "imurmurhash",
       "npm": {
         "name": "imurmurhash",
-        "version": ">=0.1.4 <0.2.0",
+        "version": ">=0.1.4 <0.2.0-0",
       },
       "package_id": 280,
     },
@@ -5583,7 +5583,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -5596,7 +5596,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "json-stable-stringify-without-jsonify",
       "npm": {
         "name": "json-stable-stringify-without-jsonify",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 324,
     },
@@ -5609,7 +5609,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lodash.merge",
       "npm": {
         "name": "lodash.merge",
-        "version": ">=4.6.2 <5.0.0",
+        "version": ">=4.6.2 <5.0.0-0",
       },
       "package_id": 334,
     },
@@ -5622,7 +5622,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -5635,7 +5635,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -5648,7 +5648,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "optionator",
       "npm": {
         "name": "optionator",
-        "version": ">=0.9.3 <0.10.0",
+        "version": ">=0.9.3 <0.10.0-0",
       },
       "package_id": 364,
     },
@@ -5688,7 +5688,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.6 <0.4.0",
+        "version": ">=0.3.6 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -5701,7 +5701,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-import-resolver-typescript",
       "npm": {
         "name": "eslint-import-resolver-typescript",
-        "version": ">=3.5.2 <4.0.0",
+        "version": ">=3.5.2 <4.0.0-0",
       },
       "package_id": 219,
     },
@@ -5714,7 +5714,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-plugin-import",
       "npm": {
         "name": "eslint-plugin-import",
-        "version": ">=2.32.0 <3.0.0",
+        "version": ">=2.32.0 <3.0.0-0",
       },
       "package_id": 221,
     },
@@ -5727,7 +5727,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-plugin-jsx-a11y",
       "npm": {
         "name": "eslint-plugin-jsx-a11y",
-        "version": ">=6.10.0 <7.0.0",
+        "version": ">=6.10.0 <7.0.0-0",
       },
       "package_id": 222,
     },
@@ -5740,7 +5740,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-plugin-react",
       "npm": {
         "name": "eslint-plugin-react",
-        "version": ">=7.37.0 <8.0.0",
+        "version": ">=7.37.0 <8.0.0-0",
       },
       "package_id": 223,
     },
@@ -5753,7 +5753,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-plugin-react-hooks",
       "npm": {
         "name": "eslint-plugin-react-hooks",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 224,
     },
@@ -5779,7 +5779,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typescript-eslint",
       "npm": {
         "name": "typescript-eslint",
-        "version": ">=8.46.0 <9.0.0",
+        "version": ">=8.46.0 <9.0.0-0",
       },
       "package_id": 471,
     },
@@ -5819,7 +5819,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -5832,7 +5832,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -5845,7 +5845,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.4 <2.0.0",
+        "version": ">=1.22.4 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -5871,7 +5871,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.0 <5.0.0",
+        "version": ">=4.4.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5884,7 +5884,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-tsconfig",
       "npm": {
         "name": "get-tsconfig",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 260,
     },
@@ -5897,7 +5897,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-bun-module",
       "npm": {
         "name": "is-bun-module",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 289,
     },
@@ -5910,7 +5910,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "stable-hash",
       "npm": {
         "name": "stable-hash",
-        "version": ">=0.0.5 <0.0.6",
+        "version": ">=0.0.5 <0.0.6-0",
       },
       "package_id": 435,
     },
@@ -5923,7 +5923,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.13 <0.3.0",
+        "version": ">=0.2.13 <0.3.0-0",
       },
       "package_id": 458,
     },
@@ -5936,7 +5936,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "unrs-resolver",
       "npm": {
         "name": "unrs-resolver",
-        "version": ">=1.6.2 <2.0.0",
+        "version": ">=1.6.2 <2.0.0-0",
       },
       "package_id": 474,
     },
@@ -5990,7 +5990,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6003,7 +6003,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@rtsao/scc",
       "npm": {
         "name": "@rtsao/scc",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 82,
     },
@@ -6016,7 +6016,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.9 <4.0.0",
+        "version": ">=3.1.9 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6029,7 +6029,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.findlastindex",
       "npm": {
         "name": "array.prototype.findlastindex",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 136,
     },
@@ -6042,7 +6042,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -6055,7 +6055,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6068,7 +6068,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6081,7 +6081,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6094,7 +6094,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.9 <0.4.0",
+        "version": ">=0.3.9 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -6107,7 +6107,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-module-utils",
       "npm": {
         "name": "eslint-module-utils",
-        "version": ">=2.12.1 <3.0.0",
+        "version": ">=2.12.1 <3.0.0-0",
       },
       "package_id": 220,
     },
@@ -6120,7 +6120,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6133,7 +6133,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.1 <3.0.0",
+        "version": ">=2.16.1 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -6146,7 +6146,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -6159,7 +6159,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6172,7 +6172,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6185,7 +6185,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.groupby",
       "npm": {
         "name": "object.groupby",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 361,
     },
@@ -6198,7 +6198,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6211,7 +6211,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6224,7 +6224,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -6237,7 +6237,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tsconfig-paths",
       "npm": {
         "name": "tsconfig-paths",
-        "version": ">=3.15.0 <4.0.0",
+        "version": ">=3.15.0 <4.0.0-0",
       },
       "package_id": 462,
     },
@@ -6250,7 +6250,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=2.0.0 <3.0.0 || >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=2.0.0 <3.0.0-0 || >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6263,7 +6263,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "aria-query",
       "npm": {
         "name": "aria-query",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 132,
     },
@@ -6276,7 +6276,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6289,7 +6289,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6302,7 +6302,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ast-types-flow",
       "npm": {
         "name": "ast-types-flow",
-        "version": ">=0.0.8 <0.0.9",
+        "version": ">=0.0.8 <0.0.9-0",
       },
       "package_id": 142,
     },
@@ -6315,7 +6315,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "axe-core",
       "npm": {
         "name": "axe-core",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 146,
     },
@@ -6328,7 +6328,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "axobject-query",
       "npm": {
         "name": "axobject-query",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 147,
     },
@@ -6341,7 +6341,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "damerau-levenshtein",
       "npm": {
         "name": "damerau-levenshtein",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 183,
     },
@@ -6354,7 +6354,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -6367,7 +6367,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6380,7 +6380,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=3.3.5 <4.0.0",
+        "version": ">=3.3.5 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6393,7 +6393,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "language-tags",
       "npm": {
         "name": "language-tags",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 329,
     },
@@ -6406,7 +6406,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6419,7 +6419,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6432,7 +6432,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -6445,7 +6445,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.includes",
       "npm": {
         "name": "string.prototype.includes",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 439,
     },
@@ -6458,7 +6458,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6471,7 +6471,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6484,7 +6484,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.findlast",
       "npm": {
         "name": "array.prototype.findlast",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 135,
     },
@@ -6497,7 +6497,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6510,7 +6510,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.tosorted",
       "npm": {
         "name": "array.prototype.tosorted",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 139,
     },
@@ -6523,7 +6523,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6536,7 +6536,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-iterator-helpers",
       "npm": {
         "name": "es-iterator-helpers",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 208,
     },
@@ -6549,7 +6549,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.3.0 <6.0.0",
+        "version": ">=5.3.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6562,7 +6562,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6575,7 +6575,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=2.4.1 <3.0.0 || >=3.0.0 <4.0.0 && >=3.0.0 <4.0.0",
+        "version": ">=2.4.1 <3.0.0-0 || >=3.0.0 <4.0.0-0 && >=3.0.0 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6588,7 +6588,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6601,7 +6601,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.entries",
       "npm": {
         "name": "object.entries",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 359,
     },
@@ -6614,7 +6614,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6627,7 +6627,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6640,7 +6640,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "prop-types",
       "npm": {
         "name": "prop-types",
-        "version": ">=15.8.1 <16.0.0",
+        "version": ">=15.8.1 <16.0.0-0",
       },
       "package_id": 392,
     },
@@ -6653,7 +6653,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=2.0.0-next.5 <3.0.0",
+        "version": ">=2.0.0-next.5 <3.0.0-0",
       },
       "package_id": 518,
     },
@@ -6666,7 +6666,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6679,7 +6679,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.matchall",
       "npm": {
         "name": "string.prototype.matchall",
-        "version": ">=4.0.12 <5.0.0",
+        "version": ">=4.0.12 <5.0.0-0",
       },
       "package_id": 440,
     },
@@ -6692,7 +6692,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string.prototype.repeat",
       "npm": {
         "name": "string.prototype.repeat",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 441,
     },
@@ -6705,7 +6705,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=9.7.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=9.7.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6718,7 +6718,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -6731,7 +6731,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -6744,7 +6744,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hermes-parser",
       "npm": {
         "name": "hermes-parser",
-        "version": ">=0.25.1 <0.26.0",
+        "version": ">=0.25.1 <0.26.0-0",
       },
       "package_id": 275,
     },
@@ -6757,7 +6757,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -6770,7 +6770,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "zod-validation-error",
       "npm": {
         "name": "zod-validation-error",
-        "version": ">=3.5.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.5.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 495,
     },
@@ -6783,7 +6783,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6796,7 +6796,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "esrecurse",
       "npm": {
         "name": "esrecurse",
-        "version": ">=4.3.0 <5.0.0",
+        "version": ">=4.3.0 <5.0.0-0",
       },
       "package_id": 230,
     },
@@ -6809,7 +6809,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6822,7 +6822,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=8.15.0 <9.0.0",
+        "version": ">=8.15.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -6835,7 +6835,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "acorn-jsx",
       "npm": {
         "name": "acorn-jsx",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 123,
     },
@@ -6848,7 +6848,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -6861,7 +6861,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6874,7 +6874,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6887,7 +6887,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/yauzl",
       "npm": {
         "name": "@types/yauzl",
-        "version": ">=2.9.1 <3.0.0",
+        "version": ">=2.9.1 <3.0.0-0",
       },
       "package_id": 92,
     },
@@ -6900,7 +6900,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -6913,7 +6913,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-stream",
       "npm": {
         "name": "get-stream",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 258,
     },
@@ -6926,7 +6926,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yauzl",
       "npm": {
         "name": "yauzl",
-        "version": ">=2.10.0 <3.0.0",
+        "version": ">=2.10.0 <3.0.0-0",
       },
       "package_id": 492,
     },
@@ -6939,7 +6939,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -6952,7 +6952,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -6965,7 +6965,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -6978,7 +6978,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -6991,7 +6991,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -7004,7 +7004,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "reusify",
       "npm": {
         "name": "reusify",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 411,
     },
@@ -7017,7 +7017,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pend",
       "npm": {
         "name": "pend",
-        "version": ">=1.2.0 <1.3.0",
+        "version": ">=1.2.0 <1.3.0-0",
       },
       "package_id": 377,
     },
@@ -7031,7 +7031,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 379,
     },
@@ -7044,7 +7044,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "flat-cache",
       "npm": {
         "name": "flat-cache",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 245,
     },
@@ -7057,7 +7057,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "to-regex-range",
       "npm": {
         "name": "to-regex-range",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 459,
     },
@@ -7070,7 +7070,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "locate-path",
       "npm": {
         "name": "locate-path",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 333,
     },
@@ -7083,7 +7083,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "path-exists",
       "npm": {
         "name": "path-exists",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 373,
     },
@@ -7096,7 +7096,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "flatted",
       "npm": {
         "name": "flatted",
-        "version": ">=3.2.9 <4.0.0",
+        "version": ">=3.2.9 <4.0.0-0",
       },
       "package_id": 246,
     },
@@ -7109,7 +7109,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "keyv",
       "npm": {
         "name": "keyv",
-        "version": ">=4.5.4 <5.0.0",
+        "version": ">=4.5.4 <5.0.0-0",
       },
       "package_id": 327,
     },
@@ -7122,7 +7122,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7135,7 +7135,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -7148,7 +7148,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "signal-exit",
       "npm": {
         "name": "signal-exit",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 428,
     },
@@ -7161,7 +7161,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7174,7 +7174,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7187,7 +7187,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7200,7 +7200,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -7213,7 +7213,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7226,7 +7226,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7239,7 +7239,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -7252,7 +7252,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7265,7 +7265,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7278,7 +7278,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7291,7 +7291,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7304,7 +7304,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7317,7 +7317,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7330,7 +7330,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7343,7 +7343,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7356,7 +7356,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -7369,7 +7369,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7382,7 +7382,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7395,7 +7395,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -7408,7 +7408,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7421,7 +7421,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7434,7 +7434,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7447,7 +7447,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve-pkg-maps",
       "npm": {
         "name": "resolve-pkg-maps",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 410,
     },
@@ -7460,7 +7460,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "basic-ftp",
       "npm": {
         "name": "basic-ftp",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 156,
     },
@@ -7473,7 +7473,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "data-uri-to-buffer",
       "npm": {
         "name": "data-uri-to-buffer",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 184,
     },
@@ -7486,7 +7486,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7499,7 +7499,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "foreground-child",
       "npm": {
         "name": "foreground-child",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 248,
     },
@@ -7512,7 +7512,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "jackspeak",
       "npm": {
         "name": "jackspeak",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 315,
     },
@@ -7525,7 +7525,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=9.0.4 <10.0.0",
+        "version": ">=9.0.4 <10.0.0-0",
       },
       "package_id": 519,
     },
@@ -7538,7 +7538,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -7551,7 +7551,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "package-json-from-dist",
       "npm": {
         "name": "package-json-from-dist",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 370,
     },
@@ -7564,7 +7564,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "path-scurry",
       "npm": {
         "name": "path-scurry",
-        "version": ">=1.11.1 <2.0.0",
+        "version": ">=1.11.1 <2.0.0-0",
       },
       "package_id": 376,
     },
@@ -7577,7 +7577,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -7590,7 +7590,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7603,7 +7603,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7616,7 +7616,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7629,7 +7629,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7642,7 +7642,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7655,7 +7655,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7681,7 +7681,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7694,7 +7694,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7707,7 +7707,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7720,7 +7720,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": "<5.0.0 >=4.0.0",
+        "version": "<5.0.0-0 >=4.0.0",
       },
       "package_id": 188,
     },
@@ -7733,7 +7733,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "parent-module",
       "npm": {
         "name": "parent-module",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 371,
     },
@@ -7746,7 +7746,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve-from",
       "npm": {
         "name": "resolve-from",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 409,
     },
@@ -7759,7 +7759,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7772,7 +7772,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7785,7 +7785,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -7811,7 +7811,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "sprintf-js",
       "npm": {
         "name": "sprintf-js",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 434,
     },
@@ -7824,7 +7824,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7837,7 +7837,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7850,7 +7850,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7863,7 +7863,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "async-function",
       "npm": {
         "name": "async-function",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 143,
     },
@@ -7876,7 +7876,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7889,7 +7889,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7902,7 +7902,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7915,7 +7915,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -7928,7 +7928,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -7941,7 +7941,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "binary-extensions",
       "npm": {
         "name": "binary-extensions",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 157,
     },
@@ -7954,7 +7954,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7967,7 +7967,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7980,7 +7980,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.1 <8.0.0",
+        "version": ">=7.7.1 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -7993,7 +7993,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8006,7 +8006,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8019,7 +8019,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8032,7 +8032,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -8045,7 +8045,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8058,7 +8058,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8071,7 +8071,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8084,7 +8084,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8097,7 +8097,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8110,7 +8110,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8123,7 +8123,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8136,7 +8136,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-extglob",
       "npm": {
         "name": "is-extglob",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 294,
     },
@@ -8149,7 +8149,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8162,7 +8162,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8175,7 +8175,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8188,7 +8188,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -8201,7 +8201,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8214,7 +8214,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8227,7 +8227,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8240,7 +8240,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8253,7 +8253,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8266,7 +8266,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8279,7 +8279,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8292,7 +8292,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8305,7 +8305,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -8318,7 +8318,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8331,7 +8331,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8344,7 +8344,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8357,7 +8357,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -8370,7 +8370,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -8383,7 +8383,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8396,7 +8396,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8409,7 +8409,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8422,7 +8422,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -8435,7 +8435,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@pkgjs/parseargs",
       "npm": {
         "name": "@pkgjs/parseargs",
-        "version": ">=0.11.0 <0.12.0",
+        "version": ">=0.11.0 <0.12.0-0",
       },
       "package_id": 80,
     },
@@ -8448,7 +8448,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@isaacs/cliui",
       "npm": {
         "name": "@isaacs/cliui",
-        "version": ">=8.0.2 <9.0.0",
+        "version": ">=8.0.2 <9.0.0-0",
       },
       "package_id": 59,
     },
@@ -8461,7 +8461,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "argparse",
       "npm": {
         "name": "argparse",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 131,
     },
@@ -8474,7 +8474,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -8487,7 +8487,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.6 <4.0.0",
+        "version": ">=3.1.6 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -8500,7 +8500,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -8513,7 +8513,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.4 <5.0.0",
+        "version": ">=4.1.4 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -8526,7 +8526,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -8552,7 +8552,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "language-subtag-registry",
       "npm": {
         "name": "language-subtag-registry",
-        "version": ">=0.3.20 <0.4.0",
+        "version": ">=0.3.20 <0.4.0-0",
       },
       "package_id": 328,
     },
@@ -8565,7 +8565,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -8578,7 +8578,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -8591,7 +8591,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "p-locate",
       "npm": {
         "name": "p-locate",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 367,
     },
@@ -8604,7 +8604,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -8617,7 +8617,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.3 <4.0.0",
+        "version": ">=3.0.3 <4.0.0-0",
       },
       "package_id": 159,
     },
@@ -8630,7 +8630,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.3.1 <3.0.0",
+        "version": ">=2.3.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -8643,7 +8643,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 158,
     },
@@ -8656,7 +8656,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -8669,7 +8669,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -8682,7 +8682,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "thenify-all",
       "npm": {
         "name": "thenify-all",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 457,
     },
@@ -8799,7 +8799,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "sharp",
       "npm": {
         "name": "sharp",
-        "version": ">=0.34.4 <0.35.0",
+        "version": ">=0.34.4 <0.35.0-0",
       },
       "package_id": 421,
     },
@@ -8838,7 +8838,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "baseline-browser-mapping",
       "npm": {
         "name": "baseline-browser-mapping",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 155,
     },
@@ -8851,7 +8851,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001579 <2.0.0",
+        "version": ">=1.0.30001579 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -8891,7 +8891,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@opentelemetry/api",
       "npm": {
         "name": "@opentelemetry/api",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8905,7 +8905,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@playwright/test",
       "npm": {
         "name": "@playwright/test",
-        "version": ">=1.51.1 <2.0.0",
+        "version": ">=1.51.1 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8932,7 +8932,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -8945,7 +8945,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -8959,7 +8959,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "sass",
       "npm": {
         "name": "sass",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8972,7 +8972,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -8985,7 +8985,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8998,7 +8998,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9011,7 +9011,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9024,7 +9024,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -9037,7 +9037,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9050,7 +9050,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9063,7 +9063,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9076,7 +9076,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9089,7 +9089,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9102,7 +9102,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9115,7 +9115,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9128,7 +9128,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9141,7 +9141,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9154,7 +9154,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9167,7 +9167,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9180,7 +9180,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9193,7 +9193,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9206,7 +9206,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9219,7 +9219,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9232,7 +9232,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9245,7 +9245,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "wrappy",
       "npm": {
         "name": "wrappy",
-        "version": "<2.0.0 >=1.0.0",
+        "version": "<2.0.0-0 >=1.0.0",
       },
       "package_id": 485,
     },
@@ -9258,7 +9258,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "deep-is",
       "npm": {
         "name": "deep-is",
-        "version": ">=0.1.3 <0.2.0",
+        "version": ">=0.1.3 <0.2.0-0",
       },
       "package_id": 189,
     },
@@ -9271,7 +9271,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-levenshtein",
       "npm": {
         "name": "fast-levenshtein",
-        "version": ">=2.0.6 <3.0.0",
+        "version": ">=2.0.6 <3.0.0-0",
       },
       "package_id": 238,
     },
@@ -9284,7 +9284,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -9297,7 +9297,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -9310,7 +9310,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -9323,7 +9323,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "word-wrap",
       "npm": {
         "name": "word-wrap",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 483,
     },
@@ -9336,7 +9336,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -9349,7 +9349,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9362,7 +9362,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -9375,7 +9375,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yocto-queue",
       "npm": {
         "name": "yocto-queue",
-        "version": ">=0.1.0 <0.2.0",
+        "version": ">=0.1.0 <0.2.0-0",
       },
       "package_id": 493,
     },
@@ -9388,7 +9388,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "p-limit",
       "npm": {
         "name": "p-limit",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 366,
     },
@@ -9401,7 +9401,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@tootallnate/quickjs-emscripten",
       "npm": {
         "name": "@tootallnate/quickjs-emscripten",
-        "version": ">=0.23.0 <0.24.0",
+        "version": ">=0.23.0 <0.24.0-0",
       },
       "package_id": 84,
     },
@@ -9414,7 +9414,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9427,7 +9427,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9440,7 +9440,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-uri",
       "npm": {
         "name": "get-uri",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 261,
     },
@@ -9453,7 +9453,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9466,7 +9466,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9479,7 +9479,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pac-resolver",
       "npm": {
         "name": "pac-resolver",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 369,
     },
@@ -9492,7 +9492,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9505,7 +9505,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "degenerator",
       "npm": {
         "name": "degenerator",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 192,
     },
@@ -9518,7 +9518,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "netmask",
       "npm": {
         "name": "netmask",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 349,
     },
@@ -9531,7 +9531,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "callsites",
       "npm": {
         "name": "callsites",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 166,
     },
@@ -9544,7 +9544,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 521,
     },
@@ -9557,7 +9557,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "error-ex",
       "npm": {
         "name": "error-ex",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 204,
     },
@@ -9570,7 +9570,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "json-parse-even-better-errors",
       "npm": {
         "name": "json-parse-even-better-errors",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 322,
     },
@@ -9583,7 +9583,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -9596,7 +9596,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=10.2.0 <11.0.0",
+        "version": ">=10.2.0 <11.0.0-0",
       },
       "package_id": 522,
     },
@@ -9609,7 +9609,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=5.0.0 <6.0.0 || >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=7.0.0 <8.0.0",
+        "version": ">=5.0.0 <6.0.0-0 || >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=7.0.0 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -9622,7 +9622,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.11 <4.0.0",
+        "version": ">=3.3.11 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -9635,7 +9635,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -9648,7 +9648,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -9661,7 +9661,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -9674,7 +9674,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "read-cache",
       "npm": {
         "name": "read-cache",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 403,
     },
@@ -9687,7 +9687,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -9700,7 +9700,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9713,7 +9713,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "camelcase-css",
       "npm": {
         "name": "camelcase-css",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 167,
     },
@@ -9726,7 +9726,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.21 <9.0.0",
+        "version": ">=8.4.21 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9739,7 +9739,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -9752,7 +9752,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yaml",
       "npm": {
         "name": "yaml",
-        "version": ">=2.3.4 <3.0.0",
+        "version": ">=2.3.4 <3.0.0-0",
       },
       "package_id": 489,
     },
@@ -9793,7 +9793,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.1 <7.0.0",
+        "version": ">=6.1.1 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -9806,7 +9806,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.2.14 <9.0.0",
+        "version": ">=8.2.14 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9819,7 +9819,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "cssesc",
       "npm": {
         "name": "cssesc",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 181,
     },
@@ -9832,7 +9832,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "util-deprecate",
       "npm": {
         "name": "util-deprecate",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 477,
     },
@@ -9845,7 +9845,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "loose-envify",
       "npm": {
         "name": "loose-envify",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 335,
     },
@@ -9858,7 +9858,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -9871,7 +9871,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react-is",
       "npm": {
         "name": "react-is",
-        "version": ">=16.13.1 <17.0.0",
+        "version": ">=16.13.1 <17.0.0-0",
       },
       "package_id": 402,
     },
@@ -9884,7 +9884,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9897,7 +9897,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9910,7 +9910,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9923,7 +9923,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9936,7 +9936,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=7.14.1 <8.0.0",
+        "version": ">=7.14.1 <8.0.0-0",
       },
       "package_id": 336,
     },
@@ -9949,7 +9949,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pac-proxy-agent",
       "npm": {
         "name": "pac-proxy-agent",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 368,
     },
@@ -9962,7 +9962,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "proxy-from-env",
       "npm": {
         "name": "proxy-from-env",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 394,
     },
@@ -9975,7 +9975,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9988,7 +9988,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "end-of-stream",
       "npm": {
         "name": "end-of-stream",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 202,
     },
@@ -10001,7 +10001,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -10040,7 +10040,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "cosmiconfig",
       "npm": {
         "name": "cosmiconfig",
-        "version": ">=9.0.0 <10.0.0",
+        "version": ">=9.0.0 <10.0.0-0",
       },
       "package_id": 179,
     },
@@ -10079,7 +10079,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10118,7 +10118,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -10144,7 +10144,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10157,7 +10157,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ws",
       "npm": {
         "name": "ws",
-        "version": ">=8.18.3 <9.0.0",
+        "version": ">=8.18.3 <9.0.0-0",
       },
       "package_id": 486,
     },
@@ -10170,7 +10170,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "scheduler",
       "npm": {
         "name": "scheduler",
-        "version": ">=0.27.0 <0.28.0",
+        "version": ">=0.27.0 <0.28.0-0",
       },
       "package_id": 416,
     },
@@ -10183,7 +10183,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.4 <20.0.0",
+        "version": ">=19.2.4 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -10196,7 +10196,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pify",
       "npm": {
         "name": "pify",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 380,
     },
@@ -10209,7 +10209,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -10222,7 +10222,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10235,7 +10235,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10248,7 +10248,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -10261,7 +10261,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10274,7 +10274,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -10287,7 +10287,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10300,7 +10300,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10313,7 +10313,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-builtin-type",
       "npm": {
         "name": "which-builtin-type",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 480,
     },
@@ -10326,7 +10326,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10339,7 +10339,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10352,7 +10352,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10365,7 +10365,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10378,7 +10378,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10391,7 +10391,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -10404,7 +10404,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.0 <3.0.0",
+        "version": ">=2.16.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -10417,7 +10417,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -10430,7 +10430,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -10443,7 +10443,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "queue-microtask",
       "npm": {
         "name": "queue-microtask",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 399,
     },
@@ -10456,7 +10456,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10469,7 +10469,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10482,7 +10482,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10495,7 +10495,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -10508,7 +10508,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10521,7 +10521,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10534,7 +10534,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10547,7 +10547,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10560,7 +10560,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10573,7 +10573,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -10586,7 +10586,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10599,7 +10599,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10612,7 +10612,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -10625,7 +10625,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10638,7 +10638,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10651,7 +10651,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10664,7 +10664,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10677,7 +10677,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10690,7 +10690,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -10703,7 +10703,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10716,7 +10716,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -10729,7 +10729,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10742,7 +10742,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11067,7 +11067,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@img/colour",
       "npm": {
         "name": "@img/colour",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 34,
     },
@@ -11080,7 +11080,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "detect-libc",
       "npm": {
         "name": "detect-libc",
-        "version": ">=2.1.2 <3.0.0",
+        "version": ">=2.1.2 <3.0.0-0",
       },
       "package_id": 193,
     },
@@ -11093,7 +11093,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -11106,7 +11106,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "shebang-regex",
       "npm": {
         "name": "shebang-regex",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 423,
     },
@@ -11119,7 +11119,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11132,7 +11132,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11145,7 +11145,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel-list",
       "npm": {
         "name": "side-channel-list",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 425,
     },
@@ -11158,7 +11158,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11171,7 +11171,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel-weakmap",
       "npm": {
         "name": "side-channel-weakmap",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 427,
     },
@@ -11184,7 +11184,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11197,7 +11197,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11210,7 +11210,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11223,7 +11223,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11236,7 +11236,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11249,7 +11249,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11262,7 +11262,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11275,7 +11275,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11288,7 +11288,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11301,7 +11301,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11314,7 +11314,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11327,7 +11327,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ip-address",
       "npm": {
         "name": "ip-address",
-        "version": ">=9.0.5 <10.0.0",
+        "version": ">=9.0.5 <10.0.0-0",
       },
       "package_id": 282,
     },
@@ -11340,7 +11340,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "smart-buffer",
       "npm": {
         "name": "smart-buffer",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 429,
     },
@@ -11353,7 +11353,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -11366,7 +11366,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -11379,7 +11379,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "socks",
       "npm": {
         "name": "socks",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 430,
     },
@@ -11392,7 +11392,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11405,7 +11405,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11418,7 +11418,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.2.0 <3.0.0",
+        "version": ">=2.2.0 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -11431,7 +11431,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -11444,7 +11444,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "text-decoder",
       "npm": {
         "name": "text-decoder",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 455,
     },
@@ -11457,7 +11457,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 523,
     },
@@ -11470,7 +11470,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 296,
     },
@@ -11483,7 +11483,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -11496,7 +11496,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": null,
     },
@@ -11509,7 +11509,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": null,
     },
@@ -11522,7 +11522,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -11535,7 +11535,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11548,7 +11548,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11561,7 +11561,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11574,7 +11574,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11587,7 +11587,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11600,7 +11600,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11613,7 +11613,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11626,7 +11626,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11639,7 +11639,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11652,7 +11652,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11665,7 +11665,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -11678,7 +11678,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -11691,7 +11691,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11704,7 +11704,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.3 <2.0.0",
+        "version": ">=1.5.3 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -11717,7 +11717,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -11730,7 +11730,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -11743,7 +11743,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11756,7 +11756,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.17.5 <2.0.0",
+        "version": ">=1.17.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11769,7 +11769,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11782,7 +11782,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11795,7 +11795,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -11808,7 +11808,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11821,7 +11821,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11834,7 +11834,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11847,7 +11847,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -11860,7 +11860,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11873,7 +11873,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11886,7 +11886,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11899,7 +11899,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11912,7 +11912,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11925,7 +11925,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11938,7 +11938,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11951,7 +11951,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 126,
     },
@@ -11964,7 +11964,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": null,
     },
@@ -11990,7 +11990,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=16.8.0 || <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=19.0.0-0 <20.0.0",
+        "version": ">=16.8.0 || <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=19.0.0-0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -12003,7 +12003,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.2 <0.4.0",
+        "version": ">=0.3.2 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -12016,7 +12016,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "commander",
       "npm": {
         "name": "commander",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 176,
     },
@@ -12029,7 +12029,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob",
       "npm": {
         "name": "glob",
-        "version": ">=10.3.10 <11.0.0",
+        "version": ">=10.3.10 <11.0.0-0",
       },
       "package_id": 262,
     },
@@ -12042,7 +12042,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -12055,7 +12055,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "mz",
       "npm": {
         "name": "mz",
-        "version": ">=2.7.0 <3.0.0",
+        "version": ">=2.7.0 <3.0.0-0",
       },
       "package_id": 345,
     },
@@ -12068,7 +12068,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pirates",
       "npm": {
         "name": "pirates",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 381,
     },
@@ -12081,7 +12081,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ts-interface-checker",
       "npm": {
         "name": "ts-interface-checker",
-        "version": ">=0.1.9 <0.2.0",
+        "version": ">=0.1.9 <0.2.0-0",
       },
       "package_id": 461,
     },
@@ -12094,7 +12094,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-flag",
       "npm": {
         "name": "has-flag",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 268,
     },
@@ -12107,7 +12107,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@alloc/quick-lru",
       "npm": {
         "name": "@alloc/quick-lru",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 1,
     },
@@ -12120,7 +12120,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "arg",
       "npm": {
         "name": "arg",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 130,
     },
@@ -12133,7 +12133,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "chokidar",
       "npm": {
         "name": "chokidar",
-        "version": ">=3.6.0 <4.0.0",
+        "version": ">=3.6.0 <4.0.0-0",
       },
       "package_id": 170,
     },
@@ -12146,7 +12146,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "didyoumean",
       "npm": {
         "name": "didyoumean",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 195,
     },
@@ -12159,7 +12159,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "dlv",
       "npm": {
         "name": "dlv",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 196,
     },
@@ -12172,7 +12172,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-glob",
       "npm": {
         "name": "fast-glob",
-        "version": ">=3.3.2 <4.0.0",
+        "version": ">=3.3.2 <4.0.0-0",
       },
       "package_id": 236,
     },
@@ -12185,7 +12185,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -12198,7 +12198,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -12211,7 +12211,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "jiti",
       "npm": {
         "name": "jiti",
-        "version": ">=1.21.6 <2.0.0",
+        "version": ">=1.21.6 <2.0.0-0",
       },
       "package_id": 316,
     },
@@ -12224,7 +12224,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -12237,7 +12237,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -12250,7 +12250,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -12263,7 +12263,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "object-hash",
       "npm": {
         "name": "object-hash",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 355,
     },
@@ -12276,7 +12276,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -12289,7 +12289,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.47 <9.0.0",
+        "version": ">=8.4.47 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -12302,7 +12302,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-import",
       "npm": {
         "name": "postcss-import",
-        "version": ">=15.1.0 <16.0.0",
+        "version": ">=15.1.0 <16.0.0-0",
       },
       "package_id": 384,
     },
@@ -12315,7 +12315,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-js",
       "npm": {
         "name": "postcss-js",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 385,
     },
@@ -12328,7 +12328,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-load-config",
       "npm": {
         "name": "postcss-load-config",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 386,
     },
@@ -12341,7 +12341,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-nested",
       "npm": {
         "name": "postcss-nested",
-        "version": ">=6.2.0 <7.0.0",
+        "version": ">=6.2.0 <7.0.0-0",
       },
       "package_id": 387,
     },
@@ -12354,7 +12354,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.2 <7.0.0",
+        "version": ">=6.1.2 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -12367,7 +12367,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.8 <2.0.0",
+        "version": ">=1.22.8 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -12380,7 +12380,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "sucrase",
       "npm": {
         "name": "sucrase",
-        "version": ">=3.35.0 <4.0.0",
+        "version": ">=3.35.0 <4.0.0-0",
       },
       "package_id": 449,
     },
@@ -12393,7 +12393,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-fs",
       "npm": {
         "name": "bare-fs",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 151,
     },
@@ -12406,7 +12406,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -12419,7 +12419,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -12432,7 +12432,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tar-stream",
       "npm": {
         "name": "tar-stream",
-        "version": ">=3.1.5 <4.0.0",
+        "version": ">=3.1.5 <4.0.0-0",
       },
       "package_id": 454,
     },
@@ -12445,7 +12445,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12458,7 +12458,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -12471,7 +12471,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.15.0 <3.0.0",
+        "version": ">=2.15.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -12484,7 +12484,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12497,7 +12497,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -12510,7 +12510,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "thenify",
       "npm": {
         "name": "thenify",
-        "version": ">=3.1.0 && <4.0.0",
+        "version": ">=3.1.0 && <4.0.0-0",
       },
       "package_id": 456,
     },
@@ -12523,7 +12523,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.4.4 <7.0.0",
+        "version": ">=6.4.4 <7.0.0-0",
       },
       "package_id": 241,
     },
@@ -12536,7 +12536,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -12549,7 +12549,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 301,
     },
@@ -12575,7 +12575,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@types/json5",
       "npm": {
         "name": "@types/json5",
-        "version": ">=0.0.29 <0.0.30",
+        "version": ">=0.0.29 <0.0.30-0",
       },
       "package_id": 88,
     },
@@ -12588,7 +12588,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 325,
     },
@@ -12601,7 +12601,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -12614,7 +12614,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-bom",
       "npm": {
         "name": "strip-bom",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 446,
     },
@@ -12627,7 +12627,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -12640,7 +12640,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -12653,7 +12653,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -12666,7 +12666,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12679,7 +12679,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12692,7 +12692,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12705,7 +12705,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12718,7 +12718,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12731,7 +12731,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12744,7 +12744,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -12757,7 +12757,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12770,7 +12770,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12783,7 +12783,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12796,7 +12796,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12809,7 +12809,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12822,7 +12822,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12835,7 +12835,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12848,7 +12848,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12861,7 +12861,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12874,7 +12874,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12887,7 +12887,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -12900,7 +12900,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12965,7 +12965,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -12991,7 +12991,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13004,7 +13004,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -13017,7 +13017,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -13030,7 +13030,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13290,7 +13290,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "napi-postinstall",
       "npm": {
         "name": "napi-postinstall",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 347,
     },
@@ -13303,7 +13303,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.2.0 <4.0.0",
+        "version": ">=3.2.0 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13316,7 +13316,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -13342,7 +13342,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "punycode",
       "npm": {
         "name": "punycode",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 396,
     },
@@ -13355,7 +13355,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "isexe",
       "npm": {
         "name": "isexe",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 313,
     },
@@ -13368,7 +13368,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-bigint",
       "npm": {
         "name": "is-bigint",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 286,
     },
@@ -13381,7 +13381,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-boolean-object",
       "npm": {
         "name": "is-boolean-object",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 288,
     },
@@ -13394,7 +13394,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-number-object",
       "npm": {
         "name": "is-number-object",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 302,
     },
@@ -13407,7 +13407,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -13420,7 +13420,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -13433,7 +13433,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13446,7 +13446,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -13459,7 +13459,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13472,7 +13472,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-async-function",
       "npm": {
         "name": "is-async-function",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 285,
     },
@@ -13485,7 +13485,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -13498,7 +13498,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-finalizationregistry",
       "npm": {
         "name": "is-finalizationregistry",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 295,
     },
@@ -13511,7 +13511,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-generator-function",
       "npm": {
         "name": "is-generator-function",
-        "version": ">=1.0.10 <2.0.0",
+        "version": ">=1.0.10 <2.0.0-0",
       },
       "package_id": 297,
     },
@@ -13524,7 +13524,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -13537,7 +13537,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -13550,7 +13550,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -13563,7 +13563,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13576,7 +13576,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-collection",
       "npm": {
         "name": "which-collection",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 481,
     },
@@ -13589,7 +13589,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -13602,7 +13602,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-map",
       "npm": {
         "name": "is-map",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 299,
     },
@@ -13615,7 +13615,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -13628,7 +13628,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-weakmap",
       "npm": {
         "name": "is-weakmap",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 309,
     },
@@ -13641,7 +13641,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-weakset",
       "npm": {
         "name": "is-weakset",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 311,
     },
@@ -13654,7 +13654,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -13667,7 +13667,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -13680,7 +13680,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13693,7 +13693,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -13706,7 +13706,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -13719,7 +13719,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -13732,7 +13732,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13745,7 +13745,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -13758,7 +13758,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13771,7 +13771,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -13784,7 +13784,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13797,7 +13797,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13810,7 +13810,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -13824,7 +13824,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "bufferutil",
       "npm": {
         "name": "bufferutil",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13851,7 +13851,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "cliui",
       "npm": {
         "name": "cliui",
-        "version": ">=8.0.1 <9.0.0",
+        "version": ">=8.0.1 <9.0.0-0",
       },
       "package_id": 173,
     },
@@ -13864,7 +13864,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13877,7 +13877,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "get-caller-file",
       "npm": {
         "name": "get-caller-file",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 255,
     },
@@ -13890,7 +13890,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "require-directory",
       "npm": {
         "name": "require-directory",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 407,
     },
@@ -13903,7 +13903,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.3 <5.0.0",
+        "version": ">=4.2.3 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13916,7 +13916,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "y18n",
       "npm": {
         "name": "y18n",
-        "version": ">=5.0.5 <6.0.0",
+        "version": ">=5.0.5 <6.0.0-0",
       },
       "package_id": 487,
     },
@@ -13929,7 +13929,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yargs-parser",
       "npm": {
         "name": "yargs-parser",
-        "version": ">=21.1.1 <22.0.0",
+        "version": ">=21.1.1 <22.0.0-0",
       },
       "package_id": 491,
     },
@@ -13942,7 +13942,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "buffer-crc32",
       "npm": {
         "name": "buffer-crc32",
-        "version": ">=0.2.3 <0.3.0",
+        "version": ">=0.2.3 <0.3.0-0",
       },
       "package_id": 161,
     },
@@ -13955,7 +13955,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fd-slicer",
       "npm": {
         "name": "fd-slicer",
-        "version": ">=1.1.0 <1.2.0",
+        "version": ">=1.1.0 <1.2.0-0",
       },
       "package_id": 240,
     },
@@ -13968,7 +13968,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -13981,7 +13981,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "yallist",
       "npm": {
         "name": "yallist",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 488,
     },
@@ -13994,7 +13994,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eastasianwidth",
       "npm": {
         "name": "eastasianwidth",
-        "version": ">=0.2.0 <0.3.0",
+        "version": ">=0.2.0 <0.3.0-0",
       },
       "package_id": 199,
     },
@@ -14007,7 +14007,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -14020,7 +14020,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14033,7 +14033,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 525,
     },
@@ -14046,7 +14046,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=6.1.0 <7.0.0",
+        "version": ">=6.1.0 <7.0.0-0",
       },
       "package_id": 526,
     },
@@ -14059,7 +14059,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -14072,7 +14072,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14085,7 +14085,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -14098,7 +14098,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -14111,7 +14111,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -14124,7 +14124,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -14137,7 +14137,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -14150,7 +14150,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.4 <5.0.0",
+        "version": ">=4.0.4 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -14163,7 +14163,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": 527,
     },
@@ -14176,7 +14176,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14189,7 +14189,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14202,7 +14202,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14215,7 +14215,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14228,7 +14228,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 528,
     },
@@ -14241,7 +14241,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 529,
     },
@@ -14254,7 +14254,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14267,7 +14267,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -14280,7 +14280,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -14293,7 +14293,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": null,
     },
@@ -14306,7 +14306,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -14319,7 +14319,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14332,7 +14332,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14345,7 +14345,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14358,7 +14358,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -14371,7 +14371,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -14384,7 +14384,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -14397,7 +14397,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14410,7 +14410,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 530,
     },
@@ -14423,7 +14423,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.6 <4.0.0",
+        "version": ">=3.3.6 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -14436,7 +14436,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14449,7 +14449,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -14462,7 +14462,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 531,
     },
@@ -14475,7 +14475,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -14488,7 +14488,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14501,7 +14501,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14514,7 +14514,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 532,
     },
@@ -14528,7 +14528,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14541,7 +14541,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },

--- a/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
@@ -25,7 +25,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -38,7 +38,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/react-dom",
       "npm": {
         "name": "@types/react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 91,
     },
@@ -64,7 +64,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bun-types",
       "npm": {
         "name": "bun-types",
-        "version": ">=1.2.19 <2.0.0",
+        "version": ">=1.2.19 <2.0.0-0",
       },
       "package_id": 162,
     },
@@ -77,7 +77,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=9.33.0 <10.0.0",
+        "version": ">=9.33.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -90,7 +90,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-config-next",
       "npm": {
         "name": "eslint-config-next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 217,
     },
@@ -103,7 +103,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "next",
       "npm": {
         "name": "next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 350,
     },
@@ -142,7 +142,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -155,7 +155,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -168,7 +168,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tailwindcss",
       "npm": {
         "name": "tailwindcss",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 452,
     },
@@ -194,7 +194,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -207,7 +207,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -220,7 +220,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -233,7 +233,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -246,7 +246,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -259,7 +259,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-compilation-targets",
       "npm": {
         "name": "@babel/helper-compilation-targets",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 6,
     },
@@ -272,7 +272,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-module-transforms",
       "npm": {
         "name": "@babel/helper-module-transforms",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 9,
     },
@@ -285,7 +285,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helpers",
       "npm": {
         "name": "@babel/helpers",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 13,
     },
@@ -298,7 +298,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -311,7 +311,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -324,7 +324,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -337,7 +337,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -350,7 +350,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/remapping",
       "npm": {
         "name": "@jridgewell/remapping",
-        "version": ">=2.3.5 <3.0.0",
+        "version": ">=2.3.5 <3.0.0-0",
       },
       "package_id": 61,
     },
@@ -363,7 +363,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "convert-source-map",
       "npm": {
         "name": "convert-source-map",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 178,
     },
@@ -376,7 +376,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -389,7 +389,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gensync",
       "npm": {
         "name": "gensync",
-        "version": ">=1.0.0-beta.2 <2.0.0",
+        "version": ">=1.0.0-beta.2 <2.0.0-0",
       },
       "package_id": 254,
     },
@@ -402,7 +402,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=2.2.3 <3.0.0",
+        "version": ">=2.2.3 <3.0.0-0",
       },
       "package_id": 496,
     },
@@ -415,7 +415,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -428,7 +428,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -441,7 +441,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -454,7 +454,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.12 <0.4.0",
+        "version": ">=0.3.12 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -467,7 +467,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.28 <0.4.0",
+        "version": ">=0.3.28 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -480,7 +480,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "jsesc",
       "npm": {
         "name": "jsesc",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 320,
     },
@@ -493,7 +493,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/compat-data",
       "npm": {
         "name": "@babel/compat-data",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 3,
     },
@@ -506,7 +506,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-validator-option",
       "npm": {
         "name": "@babel/helper-validator-option",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 12,
     },
@@ -519,7 +519,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.0 <5.0.0",
+        "version": ">=4.24.0 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -532,7 +532,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=5.1.1 <6.0.0",
+        "version": ">=5.1.1 <6.0.0-0",
       },
       "package_id": 497,
     },
@@ -545,7 +545,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -558,7 +558,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -571,7 +571,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -584,7 +584,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-module-imports",
       "npm": {
         "name": "@babel/helper-module-imports",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 8,
     },
@@ -597,7 +597,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -610,7 +610,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -623,7 +623,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -636,7 +636,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -649,7 +649,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -662,7 +662,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -675,7 +675,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -688,7 +688,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -701,7 +701,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -714,7 +714,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -727,7 +727,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -740,7 +740,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-globals",
       "npm": {
         "name": "@babel/helper-globals",
-        "version": ">=7.28.0 <8.0.0",
+        "version": ">=7.28.0 <8.0.0-0",
       },
       "package_id": 7,
     },
@@ -753,7 +753,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -766,7 +766,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -779,7 +779,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -792,7 +792,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -805,7 +805,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-string-parser",
       "npm": {
         "name": "@babel/helper-string-parser",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 10,
     },
@@ -818,7 +818,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -844,7 +844,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -857,7 +857,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -870,7 +870,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -883,7 +883,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -896,7 +896,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -909,7 +909,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/object-schema",
       "npm": {
         "name": "@eslint/object-schema",
-        "version": ">=2.1.6 <3.0.0",
+        "version": ">=2.1.6 <3.0.0-0",
       },
       "package_id": 28,
     },
@@ -922,7 +922,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -935,7 +935,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -948,7 +948,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -961,7 +961,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -974,7 +974,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -987,7 +987,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.0.1 <11.0.0",
+        "version": ">=10.0.1 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -1000,7 +1000,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "globals",
       "npm": {
         "name": "globals",
-        "version": ">=14.0.0 <15.0.0",
+        "version": ">=14.0.0 <15.0.0-0",
       },
       "package_id": 499,
     },
@@ -1013,7 +1013,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -1026,7 +1026,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.2.1 <4.0.0",
+        "version": ">=3.2.1 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -1039,7 +1039,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -1052,7 +1052,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -1065,7 +1065,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-json-comments",
       "npm": {
         "name": "strip-json-comments",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 447,
     },
@@ -1078,7 +1078,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -1091,7 +1091,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -1104,7 +1104,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@humanfs/core",
       "npm": {
         "name": "@humanfs/core",
-        "version": ">=0.19.1 <0.20.0",
+        "version": ">=0.19.1 <0.20.0-0",
       },
       "package_id": 30,
     },
@@ -1117,7 +1117,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 500,
     },
@@ -1260,7 +1260,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.7.0 <2.0.0",
+        "version": ">=1.7.0 <2.0.0-0",
       },
       "package_id": 19,
     },
@@ -1273,7 +1273,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -1287,7 +1287,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width-cjs",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -1300,7 +1300,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -1314,7 +1314,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi-cjs",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -1327,7 +1327,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 503,
     },
@@ -1341,7 +1341,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "wrap-ansi-cjs",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -1354,7 +1354,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1367,7 +1367,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1380,7 +1380,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -1393,7 +1393,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1406,7 +1406,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/resolve-uri",
       "npm": {
         "name": "@jridgewell/resolve-uri",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 62,
     },
@@ -1419,7 +1419,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.4.14 <2.0.0",
+        "version": ">=1.4.14 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1432,7 +1432,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@emnapi/core",
       "npm": {
         "name": "@emnapi/core",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 18,
     },
@@ -1445,7 +1445,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 504,
     },
@@ -1458,7 +1458,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@tybys/wasm-util",
       "npm": {
         "name": "@tybys/wasm-util",
-        "version": ">=0.10.0 <0.11.0",
+        "version": ">=0.10.0 <0.11.0-0",
       },
       "package_id": 85,
     },
@@ -1497,7 +1497,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "run-parallel",
       "npm": {
         "name": "run-parallel",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 412,
     },
@@ -1523,7 +1523,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fastq",
       "npm": {
         "name": "fastq",
-        "version": ">=1.6.0 <2.0.0",
+        "version": ">=1.6.0 <2.0.0-0",
       },
       "package_id": 239,
     },
@@ -1536,7 +1536,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -1549,7 +1549,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "extract-zip",
       "npm": {
         "name": "extract-zip",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 233,
     },
@@ -1562,7 +1562,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "progress",
       "npm": {
         "name": "progress",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 391,
     },
@@ -1575,7 +1575,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "proxy-agent",
       "npm": {
         "name": "proxy-agent",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 393,
     },
@@ -1588,7 +1588,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.2 <8.0.0",
+        "version": ">=7.7.2 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -1601,7 +1601,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tar-fs",
       "npm": {
         "name": "tar-fs",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 453,
     },
@@ -1614,7 +1614,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yargs",
       "npm": {
         "name": "yargs",
-        "version": ">=17.7.2 <18.0.0",
+        "version": ">=17.7.2 <18.0.0-0",
       },
       "package_id": 490,
     },
@@ -1627,7 +1627,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.8.0 <3.0.0",
+        "version": ">=2.8.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1640,7 +1640,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1653,7 +1653,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.16.0 <7.17.0",
+        "version": ">=7.16.0 <7.17.0-0",
       },
       "package_id": 473,
     },
@@ -1666,7 +1666,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "csstype",
       "npm": {
         "name": "csstype",
-        "version": ">=3.2.2 <4.0.0",
+        "version": ">=3.2.2 <4.0.0-0",
       },
       "package_id": 182,
     },
@@ -1679,7 +1679,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.0 <20.0.0",
+        "version": ">=19.2.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -1705,7 +1705,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.2 <5.0.0",
+        "version": ">=4.12.2 <5.0.0-0",
       },
       "package_id": 508,
     },
@@ -1770,7 +1770,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=7.0.5 <8.0.0",
+        "version": ">=7.0.5 <8.0.0-0",
       },
       "package_id": 509,
     },
@@ -1783,7 +1783,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -1796,7 +1796,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -1809,7 +1809,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@typescript-eslint/parser",
       "npm": {
         "name": "@typescript-eslint/parser",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 94,
     },
@@ -1822,7 +1822,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1900,7 +1900,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -1913,7 +1913,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1939,7 +1939,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@typescript-eslint/tsconfig-utils",
       "npm": {
         "name": "@typescript-eslint/tsconfig-utils",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 97,
     },
@@ -1952,7 +1952,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@typescript-eslint/types",
       "npm": {
         "name": "@typescript-eslint/types",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 99,
     },
@@ -1965,7 +1965,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2069,7 +2069,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2082,7 +2082,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2095,7 +2095,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2173,7 +2173,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2186,7 +2186,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=10.2.2 <11.0.0",
+        "version": ">=10.2.2 <11.0.0-0",
       },
       "package_id": 511,
     },
@@ -2199,7 +2199,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -2212,7 +2212,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.15 <0.3.0",
+        "version": ">=0.2.15 <0.3.0-0",
       },
       "package_id": 513,
     },
@@ -2225,7 +2225,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2251,7 +2251,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.9.1 <5.0.0",
+        "version": ">=4.9.1 <5.0.0-0",
       },
       "package_id": 514,
     },
@@ -2303,7 +2303,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2342,7 +2342,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 515,
     },
@@ -2355,7 +2355,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@napi-rs/wasm-runtime",
       "npm": {
         "name": "@napi-rs/wasm-runtime",
-        "version": ">=0.2.11 <0.3.0",
+        "version": ">=0.2.11 <0.3.0-0",
       },
       "package_id": 65,
     },
@@ -2368,7 +2368,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=8.0.0 <9.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=8.0.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -2381,7 +2381,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -2394,7 +2394,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-json-stable-stringify",
       "npm": {
         "name": "fast-json-stable-stringify",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 237,
     },
@@ -2407,7 +2407,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "json-schema-traverse",
       "npm": {
         "name": "json-schema-traverse",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 323,
     },
@@ -2420,7 +2420,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "uri-js",
       "npm": {
         "name": "uri-js",
-        "version": ">=4.2.2 <5.0.0",
+        "version": ">=4.2.2 <5.0.0-0",
       },
       "package_id": 476,
     },
@@ -2433,7 +2433,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "color-convert",
       "npm": {
         "name": "color-convert",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 174,
     },
@@ -2446,7 +2446,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -2459,7 +2459,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.0.4 <3.0.0",
+        "version": ">=2.0.4 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -2472,7 +2472,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2485,7 +2485,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -2498,7 +2498,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2511,7 +2511,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2524,7 +2524,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2537,7 +2537,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.24.0 <2.0.0",
+        "version": ">=1.24.0 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2550,7 +2550,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2563,7 +2563,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -2576,7 +2576,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -2589,7 +2589,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -2602,7 +2602,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2615,7 +2615,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2628,7 +2628,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2641,7 +2641,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2654,7 +2654,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2667,7 +2667,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2680,7 +2680,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2693,7 +2693,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2706,7 +2706,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2719,7 +2719,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2732,7 +2732,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2745,7 +2745,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2758,7 +2758,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2771,7 +2771,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2784,7 +2784,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2797,7 +2797,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2810,7 +2810,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2823,7 +2823,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2836,7 +2836,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2849,7 +2849,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2862,7 +2862,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2875,7 +2875,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2888,7 +2888,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2901,7 +2901,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2914,7 +2914,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2927,7 +2927,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2940,7 +2940,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -2953,7 +2953,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2966,7 +2966,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2979,7 +2979,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2992,7 +2992,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3005,7 +3005,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3018,7 +3018,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.4 <4.0.0",
+        "version": ">=3.0.4 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -3031,7 +3031,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -3044,7 +3044,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.4 <5.0.0",
+        "version": ">=4.24.4 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -3057,7 +3057,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001702 <2.0.0",
+        "version": ">=1.0.30001702 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3070,7 +3070,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fraction.js",
       "npm": {
         "name": "fraction.js",
-        "version": ">=4.3.7 <5.0.0",
+        "version": ">=4.3.7 <5.0.0-0",
       },
       "package_id": 249,
     },
@@ -3083,7 +3083,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "normalize-range",
       "npm": {
         "name": "normalize-range",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 353,
     },
@@ -3096,7 +3096,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -3109,7 +3109,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -3122,7 +3122,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -3135,7 +3135,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -3148,7 +3148,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.5.4 <3.0.0",
+        "version": ">=2.5.4 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -3161,7 +3161,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -3174,7 +3174,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-stream",
       "npm": {
         "name": "bare-stream",
-        "version": ">=2.6.4 <3.0.0",
+        "version": ">=2.6.4 <3.0.0-0",
       },
       "package_id": 154,
     },
@@ -3201,7 +3201,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-os",
       "npm": {
         "name": "bare-os",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 152,
     },
@@ -3214,7 +3214,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.21.0 <3.0.0",
+        "version": ">=2.21.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -3255,7 +3255,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },
@@ -3281,7 +3281,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fill-range",
       "npm": {
         "name": "fill-range",
-        "version": ">=7.1.1 <8.0.0",
+        "version": ">=7.1.1 <8.0.0-0",
       },
       "package_id": 243,
     },
@@ -3294,7 +3294,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001726 <2.0.0",
+        "version": ">=1.0.30001726 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3307,7 +3307,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "electron-to-chromium",
       "npm": {
         "name": "electron-to-chromium",
-        "version": ">=1.5.173 <2.0.0",
+        "version": ">=1.5.173 <2.0.0-0",
       },
       "package_id": 200,
     },
@@ -3320,7 +3320,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "node-releases",
       "npm": {
         "name": "node-releases",
-        "version": ">=2.0.19 <3.0.0",
+        "version": ">=2.0.19 <3.0.0-0",
       },
       "package_id": 351,
     },
@@ -3333,7 +3333,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "update-browserslist-db",
       "npm": {
         "name": "update-browserslist-db",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 475,
     },
@@ -3359,7 +3359,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.0.0 <20.0.0",
+        "version": ">=19.0.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -3372,7 +3372,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3385,7 +3385,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3398,7 +3398,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3411,7 +3411,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "set-function-length",
       "npm": {
         "name": "set-function-length",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 418,
     },
@@ -3424,7 +3424,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3437,7 +3437,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -3450,7 +3450,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3463,7 +3463,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3476,7 +3476,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -3489,7 +3489,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "supports-color",
       "npm": {
         "name": "supports-color",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 450,
     },
@@ -3502,7 +3502,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fsevents",
       "npm": {
         "name": "fsevents",
-        "version": ">=2.3.2 <2.4.0",
+        "version": ">=2.3.2 <2.4.0-0",
       },
       "package_id": 250,
     },
@@ -3515,7 +3515,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "anymatch",
       "npm": {
         "name": "anymatch",
-        "version": ">=3.1.2 <3.2.0",
+        "version": ">=3.1.2 <3.2.0-0",
       },
       "package_id": 129,
     },
@@ -3528,7 +3528,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.2 <3.1.0",
+        "version": ">=3.0.2 <3.1.0-0",
       },
       "package_id": 159,
     },
@@ -3541,7 +3541,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <5.2.0",
+        "version": ">=5.1.2 <5.2.0-0",
       },
       "package_id": 516,
     },
@@ -3554,7 +3554,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-binary-path",
       "npm": {
         "name": "is-binary-path",
-        "version": ">=2.1.0 <2.2.0",
+        "version": ">=2.1.0 <2.2.0-0",
       },
       "package_id": 287,
     },
@@ -3567,7 +3567,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <4.1.0",
+        "version": ">=4.0.1 <4.1.0-0",
       },
       "package_id": 298,
     },
@@ -3580,7 +3580,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <3.1.0",
+        "version": ">=3.0.0 <3.1.0-0",
       },
       "package_id": 352,
     },
@@ -3593,7 +3593,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "readdirp",
       "npm": {
         "name": "readdirp",
-        "version": ">=3.6.0 <3.7.0",
+        "version": ">=3.6.0 <3.7.0-0",
       },
       "package_id": 404,
     },
@@ -3606,7 +3606,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "mitt",
       "npm": {
         "name": "mitt",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 343,
     },
@@ -3619,7 +3619,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.24.1 <4.0.0",
+        "version": ">=3.24.1 <4.0.0-0",
       },
       "package_id": 494,
     },
@@ -3645,7 +3645,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -3658,7 +3658,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -3671,7 +3671,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -3684,7 +3684,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "color-name",
       "npm": {
         "name": "color-name",
-        "version": ">=1.1.4 <1.2.0",
+        "version": ">=1.1.4 <1.2.0-0",
       },
       "package_id": 175,
     },
@@ -3697,7 +3697,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "env-paths",
       "npm": {
         "name": "env-paths",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 203,
     },
@@ -3710,7 +3710,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.3.0 <4.0.0",
+        "version": ">=3.3.0 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -3723,7 +3723,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -3736,7 +3736,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "parse-json",
       "npm": {
         "name": "parse-json",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 372,
     },
@@ -3763,7 +3763,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "path-key",
       "npm": {
         "name": "path-key",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 374,
     },
@@ -3776,7 +3776,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "shebang-command",
       "npm": {
         "name": "shebang-command",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 422,
     },
@@ -3789,7 +3789,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which",
       "npm": {
         "name": "which",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 478,
     },
@@ -3802,7 +3802,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3815,7 +3815,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3828,7 +3828,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3841,7 +3841,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3854,7 +3854,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3867,7 +3867,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3880,7 +3880,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3893,7 +3893,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3906,7 +3906,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3919,7 +3919,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -3932,7 +3932,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3945,7 +3945,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3958,7 +3958,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -3971,7 +3971,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -3984,7 +3984,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -3997,7 +3997,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4010,7 +4010,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ast-types",
       "npm": {
         "name": "ast-types",
-        "version": ">=0.13.4 <0.14.0",
+        "version": ">=0.13.4 <0.14.0-0",
       },
       "package_id": 141,
     },
@@ -4023,7 +4023,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "escodegen",
       "npm": {
         "name": "escodegen",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 215,
     },
@@ -4036,7 +4036,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -4049,7 +4049,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -4062,7 +4062,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -4075,7 +4075,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4088,7 +4088,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4101,7 +4101,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -4114,7 +4114,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-arrayish",
       "npm": {
         "name": "is-arrayish",
-        "version": ">=0.2.1 <0.3.0",
+        "version": ">=0.2.1 <0.3.0-0",
       },
       "package_id": 284,
     },
@@ -4127,7 +4127,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -4140,7 +4140,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "arraybuffer.prototype.slice",
       "npm": {
         "name": "arraybuffer.prototype.slice",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 140,
     },
@@ -4153,7 +4153,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -4166,7 +4166,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4179,7 +4179,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4192,7 +4192,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "data-view-buffer",
       "npm": {
         "name": "data-view-buffer",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 185,
     },
@@ -4205,7 +4205,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "data-view-byte-length",
       "npm": {
         "name": "data-view-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 186,
     },
@@ -4218,7 +4218,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "data-view-byte-offset",
       "npm": {
         "name": "data-view-byte-offset",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 187,
     },
@@ -4231,7 +4231,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -4244,7 +4244,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4257,7 +4257,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -4270,7 +4270,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4283,7 +4283,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-to-primitive",
       "npm": {
         "name": "es-to-primitive",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 212,
     },
@@ -4296,7 +4296,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.8 <2.0.0",
+        "version": ">=1.1.8 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -4309,7 +4309,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4322,7 +4322,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -4335,7 +4335,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-symbol-description",
       "npm": {
         "name": "get-symbol-description",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 259,
     },
@@ -4348,7 +4348,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4361,7 +4361,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4374,7 +4374,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4387,7 +4387,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4400,7 +4400,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4413,7 +4413,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -4426,7 +4426,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -4439,7 +4439,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -4452,7 +4452,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -4465,7 +4465,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -4478,7 +4478,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-negative-zero",
       "npm": {
         "name": "is-negative-zero",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 300,
     },
@@ -4491,7 +4491,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -4504,7 +4504,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -4517,7 +4517,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-shared-array-buffer",
       "npm": {
         "name": "is-shared-array-buffer",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 305,
     },
@@ -4530,7 +4530,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -4543,7 +4543,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -4556,7 +4556,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -4569,7 +4569,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -4582,7 +4582,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.4 <2.0.0",
+        "version": ">=1.13.4 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -4595,7 +4595,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4608,7 +4608,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.7 <5.0.0",
+        "version": ">=4.1.7 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -4621,7 +4621,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "own-keys",
       "npm": {
         "name": "own-keys",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 365,
     },
@@ -4634,7 +4634,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.4 <2.0.0",
+        "version": ">=1.5.4 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -4647,7 +4647,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -4660,7 +4660,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -4673,7 +4673,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -4686,7 +4686,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "set-proto",
       "npm": {
         "name": "set-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 420,
     },
@@ -4699,7 +4699,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "stop-iteration-iterator",
       "npm": {
         "name": "stop-iteration-iterator",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 436,
     },
@@ -4712,7 +4712,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.trim",
       "npm": {
         "name": "string.prototype.trim",
-        "version": ">=1.2.10 <2.0.0",
+        "version": ">=1.2.10 <2.0.0-0",
       },
       "package_id": 442,
     },
@@ -4725,7 +4725,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -4738,7 +4738,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.trimstart",
       "npm": {
         "name": "string.prototype.trimstart",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 444,
     },
@@ -4751,7 +4751,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-array-buffer",
       "npm": {
         "name": "typed-array-buffer",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 465,
     },
@@ -4764,7 +4764,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-array-byte-length",
       "npm": {
         "name": "typed-array-byte-length",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 466,
     },
@@ -4777,7 +4777,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-array-byte-offset",
       "npm": {
         "name": "typed-array-byte-offset",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 467,
     },
@@ -4790,7 +4790,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-array-length",
       "npm": {
         "name": "typed-array-length",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 468,
     },
@@ -4803,7 +4803,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "unbox-primitive",
       "npm": {
         "name": "unbox-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 472,
     },
@@ -4816,7 +4816,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.19 <2.0.0",
+        "version": ">=1.1.19 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -4829,7 +4829,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4842,7 +4842,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4855,7 +4855,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -4868,7 +4868,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -4881,7 +4881,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4894,7 +4894,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4907,7 +4907,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -4920,7 +4920,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4933,7 +4933,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4946,7 +4946,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4959,7 +4959,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4972,7 +4972,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4985,7 +4985,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4998,7 +4998,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -5011,7 +5011,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "iterator.prototype",
       "npm": {
         "name": "iterator.prototype",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 314,
     },
@@ -5024,7 +5024,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -5037,7 +5037,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5050,7 +5050,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5063,7 +5063,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -5076,7 +5076,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -5089,7 +5089,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5102,7 +5102,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5115,7 +5115,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -5128,7 +5128,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.0.5 <2.0.0",
+        "version": ">=1.0.5 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -5141,7 +5141,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -5154,7 +5154,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "source-map",
       "npm": {
         "name": "source-map",
-        "version": ">=0.6.1 <0.7.0",
+        "version": ">=0.6.1 <0.7.0-0",
       },
       "package_id": 432,
     },
@@ -5167,7 +5167,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -5180,7 +5180,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -5193,7 +5193,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5206,7 +5206,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 21,
     },
@@ -5219,7 +5219,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.1 <5.0.0",
+        "version": ">=4.12.1 <5.0.0-0",
       },
       "package_id": 22,
     },
@@ -5232,7 +5232,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/config-array",
       "npm": {
         "name": "@eslint/config-array",
-        "version": ">=0.21.0 <0.22.0",
+        "version": ">=0.21.0 <0.22.0-0",
       },
       "package_id": 23,
     },
@@ -5245,7 +5245,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/config-helpers",
       "npm": {
         "name": "@eslint/config-helpers",
-        "version": ">=0.3.1 <0.4.0",
+        "version": ">=0.3.1 <0.4.0-0",
       },
       "package_id": 24,
     },
@@ -5258,7 +5258,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -5271,7 +5271,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/eslintrc",
       "npm": {
         "name": "@eslint/eslintrc",
-        "version": ">=3.3.1 <4.0.0",
+        "version": ">=3.3.1 <4.0.0-0",
       },
       "package_id": 26,
     },
@@ -5297,7 +5297,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@eslint/plugin-kit",
       "npm": {
         "name": "@eslint/plugin-kit",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 29,
     },
@@ -5310,7 +5310,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@humanfs/node",
       "npm": {
         "name": "@humanfs/node",
-        "version": ">=0.16.6 <0.17.0",
+        "version": ">=0.16.6 <0.17.0-0",
       },
       "package_id": 31,
     },
@@ -5323,7 +5323,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@humanwhocodes/module-importer",
       "npm": {
         "name": "@humanwhocodes/module-importer",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 32,
     },
@@ -5336,7 +5336,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.4.2 <0.5.0",
+        "version": ">=0.4.2 <0.5.0-0",
       },
       "package_id": 33,
     },
@@ -5349,7 +5349,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/estree",
       "npm": {
         "name": "@types/estree",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 86,
     },
@@ -5362,7 +5362,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -5375,7 +5375,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -5388,7 +5388,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "chalk",
       "npm": {
         "name": "chalk",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 169,
     },
@@ -5401,7 +5401,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -5414,7 +5414,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5427,7 +5427,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "escape-string-regexp",
       "npm": {
         "name": "escape-string-regexp",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 214,
     },
@@ -5440,7 +5440,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-scope",
       "npm": {
         "name": "eslint-scope",
-        "version": ">=8.4.0 <9.0.0",
+        "version": ">=8.4.0 <9.0.0-0",
       },
       "package_id": 225,
     },
@@ -5453,7 +5453,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -5466,7 +5466,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.4.0 <11.0.0",
+        "version": ">=10.4.0 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -5479,7 +5479,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esquery",
       "npm": {
         "name": "esquery",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 229,
     },
@@ -5492,7 +5492,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5505,7 +5505,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -5518,7 +5518,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "file-entry-cache",
       "npm": {
         "name": "file-entry-cache",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 242,
     },
@@ -5531,7 +5531,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "find-up",
       "npm": {
         "name": "find-up",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 244,
     },
@@ -5544,7 +5544,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -5557,7 +5557,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -5570,7 +5570,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "imurmurhash",
       "npm": {
         "name": "imurmurhash",
-        "version": ">=0.1.4 <0.2.0",
+        "version": ">=0.1.4 <0.2.0-0",
       },
       "package_id": 280,
     },
@@ -5583,7 +5583,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -5596,7 +5596,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "json-stable-stringify-without-jsonify",
       "npm": {
         "name": "json-stable-stringify-without-jsonify",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 324,
     },
@@ -5609,7 +5609,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lodash.merge",
       "npm": {
         "name": "lodash.merge",
-        "version": ">=4.6.2 <5.0.0",
+        "version": ">=4.6.2 <5.0.0-0",
       },
       "package_id": 334,
     },
@@ -5622,7 +5622,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -5635,7 +5635,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -5648,7 +5648,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "optionator",
       "npm": {
         "name": "optionator",
-        "version": ">=0.9.3 <0.10.0",
+        "version": ">=0.9.3 <0.10.0-0",
       },
       "package_id": 364,
     },
@@ -5688,7 +5688,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.6 <0.4.0",
+        "version": ">=0.3.6 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -5701,7 +5701,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-import-resolver-typescript",
       "npm": {
         "name": "eslint-import-resolver-typescript",
-        "version": ">=3.5.2 <4.0.0",
+        "version": ">=3.5.2 <4.0.0-0",
       },
       "package_id": 219,
     },
@@ -5714,7 +5714,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-plugin-import",
       "npm": {
         "name": "eslint-plugin-import",
-        "version": ">=2.32.0 <3.0.0",
+        "version": ">=2.32.0 <3.0.0-0",
       },
       "package_id": 221,
     },
@@ -5727,7 +5727,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-plugin-jsx-a11y",
       "npm": {
         "name": "eslint-plugin-jsx-a11y",
-        "version": ">=6.10.0 <7.0.0",
+        "version": ">=6.10.0 <7.0.0-0",
       },
       "package_id": 222,
     },
@@ -5740,7 +5740,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-plugin-react",
       "npm": {
         "name": "eslint-plugin-react",
-        "version": ">=7.37.0 <8.0.0",
+        "version": ">=7.37.0 <8.0.0-0",
       },
       "package_id": 223,
     },
@@ -5753,7 +5753,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-plugin-react-hooks",
       "npm": {
         "name": "eslint-plugin-react-hooks",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 224,
     },
@@ -5779,7 +5779,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typescript-eslint",
       "npm": {
         "name": "typescript-eslint",
-        "version": ">=8.46.0 <9.0.0",
+        "version": ">=8.46.0 <9.0.0-0",
       },
       "package_id": 471,
     },
@@ -5819,7 +5819,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -5832,7 +5832,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -5845,7 +5845,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.4 <2.0.0",
+        "version": ">=1.22.4 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -5871,7 +5871,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.0 <5.0.0",
+        "version": ">=4.4.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5884,7 +5884,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-tsconfig",
       "npm": {
         "name": "get-tsconfig",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 260,
     },
@@ -5897,7 +5897,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-bun-module",
       "npm": {
         "name": "is-bun-module",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 289,
     },
@@ -5910,7 +5910,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "stable-hash",
       "npm": {
         "name": "stable-hash",
-        "version": ">=0.0.5 <0.0.6",
+        "version": ">=0.0.5 <0.0.6-0",
       },
       "package_id": 435,
     },
@@ -5923,7 +5923,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.13 <0.3.0",
+        "version": ">=0.2.13 <0.3.0-0",
       },
       "package_id": 458,
     },
@@ -5936,7 +5936,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "unrs-resolver",
       "npm": {
         "name": "unrs-resolver",
-        "version": ">=1.6.2 <2.0.0",
+        "version": ">=1.6.2 <2.0.0-0",
       },
       "package_id": 474,
     },
@@ -5990,7 +5990,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6003,7 +6003,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@rtsao/scc",
       "npm": {
         "name": "@rtsao/scc",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 82,
     },
@@ -6016,7 +6016,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.9 <4.0.0",
+        "version": ">=3.1.9 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6029,7 +6029,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.findlastindex",
       "npm": {
         "name": "array.prototype.findlastindex",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 136,
     },
@@ -6042,7 +6042,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -6055,7 +6055,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6068,7 +6068,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6081,7 +6081,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6094,7 +6094,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.9 <0.4.0",
+        "version": ">=0.3.9 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -6107,7 +6107,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-module-utils",
       "npm": {
         "name": "eslint-module-utils",
-        "version": ">=2.12.1 <3.0.0",
+        "version": ">=2.12.1 <3.0.0-0",
       },
       "package_id": 220,
     },
@@ -6120,7 +6120,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6133,7 +6133,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.1 <3.0.0",
+        "version": ">=2.16.1 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -6146,7 +6146,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -6159,7 +6159,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6172,7 +6172,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6185,7 +6185,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.groupby",
       "npm": {
         "name": "object.groupby",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 361,
     },
@@ -6198,7 +6198,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6211,7 +6211,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6224,7 +6224,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -6237,7 +6237,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tsconfig-paths",
       "npm": {
         "name": "tsconfig-paths",
-        "version": ">=3.15.0 <4.0.0",
+        "version": ">=3.15.0 <4.0.0-0",
       },
       "package_id": 462,
     },
@@ -6250,7 +6250,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=2.0.0 <3.0.0 || >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=2.0.0 <3.0.0-0 || >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6263,7 +6263,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "aria-query",
       "npm": {
         "name": "aria-query",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 132,
     },
@@ -6276,7 +6276,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6289,7 +6289,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6302,7 +6302,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ast-types-flow",
       "npm": {
         "name": "ast-types-flow",
-        "version": ">=0.0.8 <0.0.9",
+        "version": ">=0.0.8 <0.0.9-0",
       },
       "package_id": 142,
     },
@@ -6315,7 +6315,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "axe-core",
       "npm": {
         "name": "axe-core",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 146,
     },
@@ -6328,7 +6328,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "axobject-query",
       "npm": {
         "name": "axobject-query",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 147,
     },
@@ -6341,7 +6341,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "damerau-levenshtein",
       "npm": {
         "name": "damerau-levenshtein",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 183,
     },
@@ -6354,7 +6354,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -6367,7 +6367,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6380,7 +6380,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=3.3.5 <4.0.0",
+        "version": ">=3.3.5 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6393,7 +6393,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "language-tags",
       "npm": {
         "name": "language-tags",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 329,
     },
@@ -6406,7 +6406,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6419,7 +6419,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6432,7 +6432,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -6445,7 +6445,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.includes",
       "npm": {
         "name": "string.prototype.includes",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 439,
     },
@@ -6458,7 +6458,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6471,7 +6471,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6484,7 +6484,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.findlast",
       "npm": {
         "name": "array.prototype.findlast",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 135,
     },
@@ -6497,7 +6497,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6510,7 +6510,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.tosorted",
       "npm": {
         "name": "array.prototype.tosorted",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 139,
     },
@@ -6523,7 +6523,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6536,7 +6536,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-iterator-helpers",
       "npm": {
         "name": "es-iterator-helpers",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 208,
     },
@@ -6549,7 +6549,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.3.0 <6.0.0",
+        "version": ">=5.3.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6562,7 +6562,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6575,7 +6575,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=2.4.1 <3.0.0 || >=3.0.0 <4.0.0 && >=3.0.0 <4.0.0",
+        "version": ">=2.4.1 <3.0.0-0 || >=3.0.0 <4.0.0-0 && >=3.0.0 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6588,7 +6588,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6601,7 +6601,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.entries",
       "npm": {
         "name": "object.entries",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 359,
     },
@@ -6614,7 +6614,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6627,7 +6627,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6640,7 +6640,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "prop-types",
       "npm": {
         "name": "prop-types",
-        "version": ">=15.8.1 <16.0.0",
+        "version": ">=15.8.1 <16.0.0-0",
       },
       "package_id": 392,
     },
@@ -6653,7 +6653,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=2.0.0-next.5 <3.0.0",
+        "version": ">=2.0.0-next.5 <3.0.0-0",
       },
       "package_id": 518,
     },
@@ -6666,7 +6666,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6679,7 +6679,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.matchall",
       "npm": {
         "name": "string.prototype.matchall",
-        "version": ">=4.0.12 <5.0.0",
+        "version": ">=4.0.12 <5.0.0-0",
       },
       "package_id": 440,
     },
@@ -6692,7 +6692,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string.prototype.repeat",
       "npm": {
         "name": "string.prototype.repeat",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 441,
     },
@@ -6705,7 +6705,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=9.7.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=9.7.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6718,7 +6718,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -6731,7 +6731,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -6744,7 +6744,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hermes-parser",
       "npm": {
         "name": "hermes-parser",
-        "version": ">=0.25.1 <0.26.0",
+        "version": ">=0.25.1 <0.26.0-0",
       },
       "package_id": 275,
     },
@@ -6757,7 +6757,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -6770,7 +6770,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "zod-validation-error",
       "npm": {
         "name": "zod-validation-error",
-        "version": ">=3.5.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.5.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 495,
     },
@@ -6783,7 +6783,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6796,7 +6796,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "esrecurse",
       "npm": {
         "name": "esrecurse",
-        "version": ">=4.3.0 <5.0.0",
+        "version": ">=4.3.0 <5.0.0-0",
       },
       "package_id": 230,
     },
@@ -6809,7 +6809,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6822,7 +6822,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=8.15.0 <9.0.0",
+        "version": ">=8.15.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -6835,7 +6835,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "acorn-jsx",
       "npm": {
         "name": "acorn-jsx",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 123,
     },
@@ -6848,7 +6848,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -6861,7 +6861,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6874,7 +6874,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6887,7 +6887,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/yauzl",
       "npm": {
         "name": "@types/yauzl",
-        "version": ">=2.9.1 <3.0.0",
+        "version": ">=2.9.1 <3.0.0-0",
       },
       "package_id": 92,
     },
@@ -6900,7 +6900,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -6913,7 +6913,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-stream",
       "npm": {
         "name": "get-stream",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 258,
     },
@@ -6926,7 +6926,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yauzl",
       "npm": {
         "name": "yauzl",
-        "version": ">=2.10.0 <3.0.0",
+        "version": ">=2.10.0 <3.0.0-0",
       },
       "package_id": 492,
     },
@@ -6939,7 +6939,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -6952,7 +6952,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -6965,7 +6965,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -6978,7 +6978,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -6991,7 +6991,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -7004,7 +7004,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "reusify",
       "npm": {
         "name": "reusify",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 411,
     },
@@ -7017,7 +7017,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pend",
       "npm": {
         "name": "pend",
-        "version": ">=1.2.0 <1.3.0",
+        "version": ">=1.2.0 <1.3.0-0",
       },
       "package_id": 377,
     },
@@ -7031,7 +7031,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 379,
     },
@@ -7044,7 +7044,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "flat-cache",
       "npm": {
         "name": "flat-cache",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 245,
     },
@@ -7057,7 +7057,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "to-regex-range",
       "npm": {
         "name": "to-regex-range",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 459,
     },
@@ -7070,7 +7070,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "locate-path",
       "npm": {
         "name": "locate-path",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 333,
     },
@@ -7083,7 +7083,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "path-exists",
       "npm": {
         "name": "path-exists",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 373,
     },
@@ -7096,7 +7096,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "flatted",
       "npm": {
         "name": "flatted",
-        "version": ">=3.2.9 <4.0.0",
+        "version": ">=3.2.9 <4.0.0-0",
       },
       "package_id": 246,
     },
@@ -7109,7 +7109,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "keyv",
       "npm": {
         "name": "keyv",
-        "version": ">=4.5.4 <5.0.0",
+        "version": ">=4.5.4 <5.0.0-0",
       },
       "package_id": 327,
     },
@@ -7122,7 +7122,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7135,7 +7135,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -7148,7 +7148,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "signal-exit",
       "npm": {
         "name": "signal-exit",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 428,
     },
@@ -7161,7 +7161,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7174,7 +7174,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7187,7 +7187,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7200,7 +7200,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -7213,7 +7213,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7226,7 +7226,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7239,7 +7239,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -7252,7 +7252,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7265,7 +7265,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7278,7 +7278,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7291,7 +7291,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7304,7 +7304,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7317,7 +7317,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7330,7 +7330,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7343,7 +7343,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7356,7 +7356,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -7369,7 +7369,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7382,7 +7382,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7395,7 +7395,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -7408,7 +7408,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7421,7 +7421,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7434,7 +7434,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7447,7 +7447,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve-pkg-maps",
       "npm": {
         "name": "resolve-pkg-maps",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 410,
     },
@@ -7460,7 +7460,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "basic-ftp",
       "npm": {
         "name": "basic-ftp",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 156,
     },
@@ -7473,7 +7473,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "data-uri-to-buffer",
       "npm": {
         "name": "data-uri-to-buffer",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 184,
     },
@@ -7486,7 +7486,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7499,7 +7499,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "foreground-child",
       "npm": {
         "name": "foreground-child",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 248,
     },
@@ -7512,7 +7512,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "jackspeak",
       "npm": {
         "name": "jackspeak",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 315,
     },
@@ -7525,7 +7525,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=9.0.4 <10.0.0",
+        "version": ">=9.0.4 <10.0.0-0",
       },
       "package_id": 519,
     },
@@ -7538,7 +7538,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -7551,7 +7551,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "package-json-from-dist",
       "npm": {
         "name": "package-json-from-dist",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 370,
     },
@@ -7564,7 +7564,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "path-scurry",
       "npm": {
         "name": "path-scurry",
-        "version": ">=1.11.1 <2.0.0",
+        "version": ">=1.11.1 <2.0.0-0",
       },
       "package_id": 376,
     },
@@ -7577,7 +7577,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -7590,7 +7590,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7603,7 +7603,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7616,7 +7616,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7629,7 +7629,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7642,7 +7642,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7655,7 +7655,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7681,7 +7681,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7694,7 +7694,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7707,7 +7707,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7720,7 +7720,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": "<5.0.0 >=4.0.0",
+        "version": "<5.0.0-0 >=4.0.0",
       },
       "package_id": 188,
     },
@@ -7733,7 +7733,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "parent-module",
       "npm": {
         "name": "parent-module",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 371,
     },
@@ -7746,7 +7746,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve-from",
       "npm": {
         "name": "resolve-from",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 409,
     },
@@ -7759,7 +7759,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7772,7 +7772,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7785,7 +7785,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -7811,7 +7811,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "sprintf-js",
       "npm": {
         "name": "sprintf-js",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 434,
     },
@@ -7824,7 +7824,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7837,7 +7837,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7850,7 +7850,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7863,7 +7863,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "async-function",
       "npm": {
         "name": "async-function",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 143,
     },
@@ -7876,7 +7876,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7889,7 +7889,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7902,7 +7902,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7915,7 +7915,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -7928,7 +7928,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -7941,7 +7941,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "binary-extensions",
       "npm": {
         "name": "binary-extensions",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 157,
     },
@@ -7954,7 +7954,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7967,7 +7967,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7980,7 +7980,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.1 <8.0.0",
+        "version": ">=7.7.1 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -7993,7 +7993,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8006,7 +8006,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8019,7 +8019,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8032,7 +8032,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -8045,7 +8045,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8058,7 +8058,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8071,7 +8071,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8084,7 +8084,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8097,7 +8097,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8110,7 +8110,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8123,7 +8123,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8136,7 +8136,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-extglob",
       "npm": {
         "name": "is-extglob",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 294,
     },
@@ -8149,7 +8149,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8162,7 +8162,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8175,7 +8175,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8188,7 +8188,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -8201,7 +8201,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8214,7 +8214,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8227,7 +8227,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8240,7 +8240,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8253,7 +8253,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8266,7 +8266,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8279,7 +8279,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8292,7 +8292,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8305,7 +8305,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -8318,7 +8318,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8331,7 +8331,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8344,7 +8344,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8357,7 +8357,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -8370,7 +8370,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -8383,7 +8383,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8396,7 +8396,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8409,7 +8409,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8422,7 +8422,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -8435,7 +8435,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@pkgjs/parseargs",
       "npm": {
         "name": "@pkgjs/parseargs",
-        "version": ">=0.11.0 <0.12.0",
+        "version": ">=0.11.0 <0.12.0-0",
       },
       "package_id": 80,
     },
@@ -8448,7 +8448,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@isaacs/cliui",
       "npm": {
         "name": "@isaacs/cliui",
-        "version": ">=8.0.2 <9.0.0",
+        "version": ">=8.0.2 <9.0.0-0",
       },
       "package_id": 59,
     },
@@ -8461,7 +8461,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "argparse",
       "npm": {
         "name": "argparse",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 131,
     },
@@ -8474,7 +8474,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -8487,7 +8487,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.6 <4.0.0",
+        "version": ">=3.1.6 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -8500,7 +8500,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -8513,7 +8513,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.4 <5.0.0",
+        "version": ">=4.1.4 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -8526,7 +8526,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -8552,7 +8552,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "language-subtag-registry",
       "npm": {
         "name": "language-subtag-registry",
-        "version": ">=0.3.20 <0.4.0",
+        "version": ">=0.3.20 <0.4.0-0",
       },
       "package_id": 328,
     },
@@ -8565,7 +8565,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -8578,7 +8578,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -8591,7 +8591,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "p-locate",
       "npm": {
         "name": "p-locate",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 367,
     },
@@ -8604,7 +8604,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -8617,7 +8617,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.3 <4.0.0",
+        "version": ">=3.0.3 <4.0.0-0",
       },
       "package_id": 159,
     },
@@ -8630,7 +8630,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.3.1 <3.0.0",
+        "version": ">=2.3.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -8643,7 +8643,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 158,
     },
@@ -8656,7 +8656,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -8669,7 +8669,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -8682,7 +8682,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "thenify-all",
       "npm": {
         "name": "thenify-all",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 457,
     },
@@ -8799,7 +8799,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "sharp",
       "npm": {
         "name": "sharp",
-        "version": ">=0.34.4 <0.35.0",
+        "version": ">=0.34.4 <0.35.0-0",
       },
       "package_id": 421,
     },
@@ -8838,7 +8838,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "baseline-browser-mapping",
       "npm": {
         "name": "baseline-browser-mapping",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 155,
     },
@@ -8851,7 +8851,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001579 <2.0.0",
+        "version": ">=1.0.30001579 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -8891,7 +8891,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@opentelemetry/api",
       "npm": {
         "name": "@opentelemetry/api",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8905,7 +8905,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@playwright/test",
       "npm": {
         "name": "@playwright/test",
-        "version": ">=1.51.1 <2.0.0",
+        "version": ">=1.51.1 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8932,7 +8932,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -8945,7 +8945,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -8959,7 +8959,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "sass",
       "npm": {
         "name": "sass",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8972,7 +8972,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -8985,7 +8985,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8998,7 +8998,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9011,7 +9011,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9024,7 +9024,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -9037,7 +9037,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9050,7 +9050,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9063,7 +9063,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9076,7 +9076,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9089,7 +9089,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9102,7 +9102,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9115,7 +9115,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9128,7 +9128,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9141,7 +9141,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9154,7 +9154,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9167,7 +9167,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9180,7 +9180,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9193,7 +9193,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9206,7 +9206,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9219,7 +9219,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9232,7 +9232,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9245,7 +9245,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "wrappy",
       "npm": {
         "name": "wrappy",
-        "version": "<2.0.0 >=1.0.0",
+        "version": "<2.0.0-0 >=1.0.0",
       },
       "package_id": 485,
     },
@@ -9258,7 +9258,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "deep-is",
       "npm": {
         "name": "deep-is",
-        "version": ">=0.1.3 <0.2.0",
+        "version": ">=0.1.3 <0.2.0-0",
       },
       "package_id": 189,
     },
@@ -9271,7 +9271,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-levenshtein",
       "npm": {
         "name": "fast-levenshtein",
-        "version": ">=2.0.6 <3.0.0",
+        "version": ">=2.0.6 <3.0.0-0",
       },
       "package_id": 238,
     },
@@ -9284,7 +9284,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -9297,7 +9297,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -9310,7 +9310,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -9323,7 +9323,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "word-wrap",
       "npm": {
         "name": "word-wrap",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 483,
     },
@@ -9336,7 +9336,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -9349,7 +9349,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9362,7 +9362,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -9375,7 +9375,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yocto-queue",
       "npm": {
         "name": "yocto-queue",
-        "version": ">=0.1.0 <0.2.0",
+        "version": ">=0.1.0 <0.2.0-0",
       },
       "package_id": 493,
     },
@@ -9388,7 +9388,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "p-limit",
       "npm": {
         "name": "p-limit",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 366,
     },
@@ -9401,7 +9401,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@tootallnate/quickjs-emscripten",
       "npm": {
         "name": "@tootallnate/quickjs-emscripten",
-        "version": ">=0.23.0 <0.24.0",
+        "version": ">=0.23.0 <0.24.0-0",
       },
       "package_id": 84,
     },
@@ -9414,7 +9414,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9427,7 +9427,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9440,7 +9440,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-uri",
       "npm": {
         "name": "get-uri",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 261,
     },
@@ -9453,7 +9453,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9466,7 +9466,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9479,7 +9479,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pac-resolver",
       "npm": {
         "name": "pac-resolver",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 369,
     },
@@ -9492,7 +9492,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9505,7 +9505,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "degenerator",
       "npm": {
         "name": "degenerator",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 192,
     },
@@ -9518,7 +9518,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "netmask",
       "npm": {
         "name": "netmask",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 349,
     },
@@ -9531,7 +9531,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "callsites",
       "npm": {
         "name": "callsites",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 166,
     },
@@ -9544,7 +9544,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 521,
     },
@@ -9557,7 +9557,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "error-ex",
       "npm": {
         "name": "error-ex",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 204,
     },
@@ -9570,7 +9570,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "json-parse-even-better-errors",
       "npm": {
         "name": "json-parse-even-better-errors",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 322,
     },
@@ -9583,7 +9583,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -9596,7 +9596,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=10.2.0 <11.0.0",
+        "version": ">=10.2.0 <11.0.0-0",
       },
       "package_id": 522,
     },
@@ -9609,7 +9609,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=5.0.0 <6.0.0 || >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=7.0.0 <8.0.0",
+        "version": ">=5.0.0 <6.0.0-0 || >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=7.0.0 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -9622,7 +9622,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.11 <4.0.0",
+        "version": ">=3.3.11 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -9635,7 +9635,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -9648,7 +9648,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -9661,7 +9661,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -9674,7 +9674,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "read-cache",
       "npm": {
         "name": "read-cache",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 403,
     },
@@ -9687,7 +9687,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -9700,7 +9700,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9713,7 +9713,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "camelcase-css",
       "npm": {
         "name": "camelcase-css",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 167,
     },
@@ -9726,7 +9726,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.21 <9.0.0",
+        "version": ">=8.4.21 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9739,7 +9739,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -9752,7 +9752,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yaml",
       "npm": {
         "name": "yaml",
-        "version": ">=2.3.4 <3.0.0",
+        "version": ">=2.3.4 <3.0.0-0",
       },
       "package_id": 489,
     },
@@ -9793,7 +9793,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.1 <7.0.0",
+        "version": ">=6.1.1 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -9806,7 +9806,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.2.14 <9.0.0",
+        "version": ">=8.2.14 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9819,7 +9819,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "cssesc",
       "npm": {
         "name": "cssesc",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 181,
     },
@@ -9832,7 +9832,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "util-deprecate",
       "npm": {
         "name": "util-deprecate",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 477,
     },
@@ -9845,7 +9845,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "loose-envify",
       "npm": {
         "name": "loose-envify",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 335,
     },
@@ -9858,7 +9858,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -9871,7 +9871,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react-is",
       "npm": {
         "name": "react-is",
-        "version": ">=16.13.1 <17.0.0",
+        "version": ">=16.13.1 <17.0.0-0",
       },
       "package_id": 402,
     },
@@ -9884,7 +9884,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9897,7 +9897,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9910,7 +9910,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9923,7 +9923,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9936,7 +9936,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=7.14.1 <8.0.0",
+        "version": ">=7.14.1 <8.0.0-0",
       },
       "package_id": 336,
     },
@@ -9949,7 +9949,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pac-proxy-agent",
       "npm": {
         "name": "pac-proxy-agent",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 368,
     },
@@ -9962,7 +9962,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "proxy-from-env",
       "npm": {
         "name": "proxy-from-env",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 394,
     },
@@ -9975,7 +9975,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9988,7 +9988,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "end-of-stream",
       "npm": {
         "name": "end-of-stream",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 202,
     },
@@ -10001,7 +10001,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -10040,7 +10040,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "cosmiconfig",
       "npm": {
         "name": "cosmiconfig",
-        "version": ">=9.0.0 <10.0.0",
+        "version": ">=9.0.0 <10.0.0-0",
       },
       "package_id": 179,
     },
@@ -10079,7 +10079,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10118,7 +10118,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -10144,7 +10144,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10157,7 +10157,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ws",
       "npm": {
         "name": "ws",
-        "version": ">=8.18.3 <9.0.0",
+        "version": ">=8.18.3 <9.0.0-0",
       },
       "package_id": 486,
     },
@@ -10170,7 +10170,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "scheduler",
       "npm": {
         "name": "scheduler",
-        "version": ">=0.27.0 <0.28.0",
+        "version": ">=0.27.0 <0.28.0-0",
       },
       "package_id": 416,
     },
@@ -10183,7 +10183,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.4 <20.0.0",
+        "version": ">=19.2.4 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -10196,7 +10196,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pify",
       "npm": {
         "name": "pify",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 380,
     },
@@ -10209,7 +10209,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -10222,7 +10222,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10235,7 +10235,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10248,7 +10248,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -10261,7 +10261,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10274,7 +10274,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -10287,7 +10287,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10300,7 +10300,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10313,7 +10313,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-builtin-type",
       "npm": {
         "name": "which-builtin-type",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 480,
     },
@@ -10326,7 +10326,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10339,7 +10339,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10352,7 +10352,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10365,7 +10365,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10378,7 +10378,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10391,7 +10391,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -10404,7 +10404,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.0 <3.0.0",
+        "version": ">=2.16.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -10417,7 +10417,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -10430,7 +10430,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -10443,7 +10443,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "queue-microtask",
       "npm": {
         "name": "queue-microtask",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 399,
     },
@@ -10456,7 +10456,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10469,7 +10469,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10482,7 +10482,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10495,7 +10495,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -10508,7 +10508,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10521,7 +10521,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10534,7 +10534,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10547,7 +10547,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10560,7 +10560,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10573,7 +10573,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -10586,7 +10586,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10599,7 +10599,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10612,7 +10612,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -10625,7 +10625,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10638,7 +10638,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10651,7 +10651,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10664,7 +10664,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10677,7 +10677,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10690,7 +10690,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -10703,7 +10703,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10716,7 +10716,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -10729,7 +10729,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10742,7 +10742,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11067,7 +11067,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@img/colour",
       "npm": {
         "name": "@img/colour",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 34,
     },
@@ -11080,7 +11080,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "detect-libc",
       "npm": {
         "name": "detect-libc",
-        "version": ">=2.1.2 <3.0.0",
+        "version": ">=2.1.2 <3.0.0-0",
       },
       "package_id": 193,
     },
@@ -11093,7 +11093,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -11106,7 +11106,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "shebang-regex",
       "npm": {
         "name": "shebang-regex",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 423,
     },
@@ -11119,7 +11119,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11132,7 +11132,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11145,7 +11145,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel-list",
       "npm": {
         "name": "side-channel-list",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 425,
     },
@@ -11158,7 +11158,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11171,7 +11171,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel-weakmap",
       "npm": {
         "name": "side-channel-weakmap",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 427,
     },
@@ -11184,7 +11184,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11197,7 +11197,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11210,7 +11210,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11223,7 +11223,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11236,7 +11236,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11249,7 +11249,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11262,7 +11262,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11275,7 +11275,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11288,7 +11288,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11301,7 +11301,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11314,7 +11314,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11327,7 +11327,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ip-address",
       "npm": {
         "name": "ip-address",
-        "version": ">=9.0.5 <10.0.0",
+        "version": ">=9.0.5 <10.0.0-0",
       },
       "package_id": 282,
     },
@@ -11340,7 +11340,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "smart-buffer",
       "npm": {
         "name": "smart-buffer",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 429,
     },
@@ -11353,7 +11353,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -11366,7 +11366,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -11379,7 +11379,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "socks",
       "npm": {
         "name": "socks",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 430,
     },
@@ -11392,7 +11392,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11405,7 +11405,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11418,7 +11418,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.2.0 <3.0.0",
+        "version": ">=2.2.0 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -11431,7 +11431,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -11444,7 +11444,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "text-decoder",
       "npm": {
         "name": "text-decoder",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 455,
     },
@@ -11457,7 +11457,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 523,
     },
@@ -11470,7 +11470,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 296,
     },
@@ -11483,7 +11483,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -11496,7 +11496,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": null,
     },
@@ -11509,7 +11509,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": null,
     },
@@ -11522,7 +11522,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -11535,7 +11535,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11548,7 +11548,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11561,7 +11561,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11574,7 +11574,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11587,7 +11587,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11600,7 +11600,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11613,7 +11613,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11626,7 +11626,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11639,7 +11639,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11652,7 +11652,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11665,7 +11665,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -11678,7 +11678,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -11691,7 +11691,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11704,7 +11704,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.3 <2.0.0",
+        "version": ">=1.5.3 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -11717,7 +11717,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -11730,7 +11730,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -11743,7 +11743,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11756,7 +11756,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.17.5 <2.0.0",
+        "version": ">=1.17.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11769,7 +11769,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11782,7 +11782,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11795,7 +11795,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -11808,7 +11808,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11821,7 +11821,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11834,7 +11834,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11847,7 +11847,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -11860,7 +11860,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11873,7 +11873,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11886,7 +11886,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11899,7 +11899,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11912,7 +11912,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11925,7 +11925,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11938,7 +11938,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11951,7 +11951,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 126,
     },
@@ -11964,7 +11964,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": null,
     },
@@ -11990,7 +11990,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=16.8.0 || <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=19.0.0-0 <20.0.0",
+        "version": ">=16.8.0 || <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=19.0.0-0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -12003,7 +12003,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.2 <0.4.0",
+        "version": ">=0.3.2 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -12016,7 +12016,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "commander",
       "npm": {
         "name": "commander",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 176,
     },
@@ -12029,7 +12029,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob",
       "npm": {
         "name": "glob",
-        "version": ">=10.3.10 <11.0.0",
+        "version": ">=10.3.10 <11.0.0-0",
       },
       "package_id": 262,
     },
@@ -12042,7 +12042,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -12055,7 +12055,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "mz",
       "npm": {
         "name": "mz",
-        "version": ">=2.7.0 <3.0.0",
+        "version": ">=2.7.0 <3.0.0-0",
       },
       "package_id": 345,
     },
@@ -12068,7 +12068,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pirates",
       "npm": {
         "name": "pirates",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 381,
     },
@@ -12081,7 +12081,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ts-interface-checker",
       "npm": {
         "name": "ts-interface-checker",
-        "version": ">=0.1.9 <0.2.0",
+        "version": ">=0.1.9 <0.2.0-0",
       },
       "package_id": 461,
     },
@@ -12094,7 +12094,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-flag",
       "npm": {
         "name": "has-flag",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 268,
     },
@@ -12107,7 +12107,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@alloc/quick-lru",
       "npm": {
         "name": "@alloc/quick-lru",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 1,
     },
@@ -12120,7 +12120,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "arg",
       "npm": {
         "name": "arg",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 130,
     },
@@ -12133,7 +12133,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "chokidar",
       "npm": {
         "name": "chokidar",
-        "version": ">=3.6.0 <4.0.0",
+        "version": ">=3.6.0 <4.0.0-0",
       },
       "package_id": 170,
     },
@@ -12146,7 +12146,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "didyoumean",
       "npm": {
         "name": "didyoumean",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 195,
     },
@@ -12159,7 +12159,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "dlv",
       "npm": {
         "name": "dlv",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 196,
     },
@@ -12172,7 +12172,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-glob",
       "npm": {
         "name": "fast-glob",
-        "version": ">=3.3.2 <4.0.0",
+        "version": ">=3.3.2 <4.0.0-0",
       },
       "package_id": 236,
     },
@@ -12185,7 +12185,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -12198,7 +12198,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -12211,7 +12211,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "jiti",
       "npm": {
         "name": "jiti",
-        "version": ">=1.21.6 <2.0.0",
+        "version": ">=1.21.6 <2.0.0-0",
       },
       "package_id": 316,
     },
@@ -12224,7 +12224,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -12237,7 +12237,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -12250,7 +12250,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -12263,7 +12263,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "object-hash",
       "npm": {
         "name": "object-hash",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 355,
     },
@@ -12276,7 +12276,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -12289,7 +12289,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.47 <9.0.0",
+        "version": ">=8.4.47 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -12302,7 +12302,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-import",
       "npm": {
         "name": "postcss-import",
-        "version": ">=15.1.0 <16.0.0",
+        "version": ">=15.1.0 <16.0.0-0",
       },
       "package_id": 384,
     },
@@ -12315,7 +12315,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-js",
       "npm": {
         "name": "postcss-js",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 385,
     },
@@ -12328,7 +12328,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-load-config",
       "npm": {
         "name": "postcss-load-config",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 386,
     },
@@ -12341,7 +12341,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-nested",
       "npm": {
         "name": "postcss-nested",
-        "version": ">=6.2.0 <7.0.0",
+        "version": ">=6.2.0 <7.0.0-0",
       },
       "package_id": 387,
     },
@@ -12354,7 +12354,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.2 <7.0.0",
+        "version": ">=6.1.2 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -12367,7 +12367,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.8 <2.0.0",
+        "version": ">=1.22.8 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -12380,7 +12380,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "sucrase",
       "npm": {
         "name": "sucrase",
-        "version": ">=3.35.0 <4.0.0",
+        "version": ">=3.35.0 <4.0.0-0",
       },
       "package_id": 449,
     },
@@ -12393,7 +12393,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-fs",
       "npm": {
         "name": "bare-fs",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 151,
     },
@@ -12406,7 +12406,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -12419,7 +12419,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -12432,7 +12432,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tar-stream",
       "npm": {
         "name": "tar-stream",
-        "version": ">=3.1.5 <4.0.0",
+        "version": ">=3.1.5 <4.0.0-0",
       },
       "package_id": 454,
     },
@@ -12445,7 +12445,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12458,7 +12458,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -12471,7 +12471,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.15.0 <3.0.0",
+        "version": ">=2.15.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -12484,7 +12484,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12497,7 +12497,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -12510,7 +12510,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "thenify",
       "npm": {
         "name": "thenify",
-        "version": ">=3.1.0 && <4.0.0",
+        "version": ">=3.1.0 && <4.0.0-0",
       },
       "package_id": 456,
     },
@@ -12523,7 +12523,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.4.4 <7.0.0",
+        "version": ">=6.4.4 <7.0.0-0",
       },
       "package_id": 241,
     },
@@ -12536,7 +12536,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -12549,7 +12549,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 301,
     },
@@ -12575,7 +12575,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@types/json5",
       "npm": {
         "name": "@types/json5",
-        "version": ">=0.0.29 <0.0.30",
+        "version": ">=0.0.29 <0.0.30-0",
       },
       "package_id": 88,
     },
@@ -12588,7 +12588,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 325,
     },
@@ -12601,7 +12601,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -12614,7 +12614,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-bom",
       "npm": {
         "name": "strip-bom",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 446,
     },
@@ -12627,7 +12627,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -12640,7 +12640,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -12653,7 +12653,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -12666,7 +12666,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12679,7 +12679,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12692,7 +12692,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12705,7 +12705,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12718,7 +12718,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12731,7 +12731,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12744,7 +12744,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -12757,7 +12757,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12770,7 +12770,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12783,7 +12783,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12796,7 +12796,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12809,7 +12809,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12822,7 +12822,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12835,7 +12835,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12848,7 +12848,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12861,7 +12861,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12874,7 +12874,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12887,7 +12887,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -12900,7 +12900,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12965,7 +12965,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -12991,7 +12991,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13004,7 +13004,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -13017,7 +13017,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -13030,7 +13030,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13290,7 +13290,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "napi-postinstall",
       "npm": {
         "name": "napi-postinstall",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 347,
     },
@@ -13303,7 +13303,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.2.0 <4.0.0",
+        "version": ">=3.2.0 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13316,7 +13316,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -13342,7 +13342,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "punycode",
       "npm": {
         "name": "punycode",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 396,
     },
@@ -13355,7 +13355,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "isexe",
       "npm": {
         "name": "isexe",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 313,
     },
@@ -13368,7 +13368,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-bigint",
       "npm": {
         "name": "is-bigint",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 286,
     },
@@ -13381,7 +13381,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-boolean-object",
       "npm": {
         "name": "is-boolean-object",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 288,
     },
@@ -13394,7 +13394,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-number-object",
       "npm": {
         "name": "is-number-object",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 302,
     },
@@ -13407,7 +13407,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -13420,7 +13420,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -13433,7 +13433,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13446,7 +13446,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -13459,7 +13459,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13472,7 +13472,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-async-function",
       "npm": {
         "name": "is-async-function",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 285,
     },
@@ -13485,7 +13485,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -13498,7 +13498,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-finalizationregistry",
       "npm": {
         "name": "is-finalizationregistry",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 295,
     },
@@ -13511,7 +13511,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-generator-function",
       "npm": {
         "name": "is-generator-function",
-        "version": ">=1.0.10 <2.0.0",
+        "version": ">=1.0.10 <2.0.0-0",
       },
       "package_id": 297,
     },
@@ -13524,7 +13524,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -13537,7 +13537,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -13550,7 +13550,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -13563,7 +13563,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13576,7 +13576,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-collection",
       "npm": {
         "name": "which-collection",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 481,
     },
@@ -13589,7 +13589,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -13602,7 +13602,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-map",
       "npm": {
         "name": "is-map",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 299,
     },
@@ -13615,7 +13615,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -13628,7 +13628,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-weakmap",
       "npm": {
         "name": "is-weakmap",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 309,
     },
@@ -13641,7 +13641,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-weakset",
       "npm": {
         "name": "is-weakset",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 311,
     },
@@ -13654,7 +13654,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -13667,7 +13667,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -13680,7 +13680,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13693,7 +13693,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -13706,7 +13706,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -13719,7 +13719,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -13732,7 +13732,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13745,7 +13745,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -13758,7 +13758,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13771,7 +13771,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -13784,7 +13784,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13797,7 +13797,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13810,7 +13810,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -13824,7 +13824,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "bufferutil",
       "npm": {
         "name": "bufferutil",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13851,7 +13851,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "cliui",
       "npm": {
         "name": "cliui",
-        "version": ">=8.0.1 <9.0.0",
+        "version": ">=8.0.1 <9.0.0-0",
       },
       "package_id": 173,
     },
@@ -13864,7 +13864,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13877,7 +13877,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "get-caller-file",
       "npm": {
         "name": "get-caller-file",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 255,
     },
@@ -13890,7 +13890,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "require-directory",
       "npm": {
         "name": "require-directory",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 407,
     },
@@ -13903,7 +13903,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.3 <5.0.0",
+        "version": ">=4.2.3 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13916,7 +13916,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "y18n",
       "npm": {
         "name": "y18n",
-        "version": ">=5.0.5 <6.0.0",
+        "version": ">=5.0.5 <6.0.0-0",
       },
       "package_id": 487,
     },
@@ -13929,7 +13929,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yargs-parser",
       "npm": {
         "name": "yargs-parser",
-        "version": ">=21.1.1 <22.0.0",
+        "version": ">=21.1.1 <22.0.0-0",
       },
       "package_id": 491,
     },
@@ -13942,7 +13942,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "buffer-crc32",
       "npm": {
         "name": "buffer-crc32",
-        "version": ">=0.2.3 <0.3.0",
+        "version": ">=0.2.3 <0.3.0-0",
       },
       "package_id": 161,
     },
@@ -13955,7 +13955,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fd-slicer",
       "npm": {
         "name": "fd-slicer",
-        "version": ">=1.1.0 <1.2.0",
+        "version": ">=1.1.0 <1.2.0-0",
       },
       "package_id": 240,
     },
@@ -13968,7 +13968,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -13981,7 +13981,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "yallist",
       "npm": {
         "name": "yallist",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 488,
     },
@@ -13994,7 +13994,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eastasianwidth",
       "npm": {
         "name": "eastasianwidth",
-        "version": ">=0.2.0 <0.3.0",
+        "version": ">=0.2.0 <0.3.0-0",
       },
       "package_id": 199,
     },
@@ -14007,7 +14007,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -14020,7 +14020,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14033,7 +14033,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 525,
     },
@@ -14046,7 +14046,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=6.1.0 <7.0.0",
+        "version": ">=6.1.0 <7.0.0-0",
       },
       "package_id": 526,
     },
@@ -14059,7 +14059,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -14072,7 +14072,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14085,7 +14085,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -14098,7 +14098,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -14111,7 +14111,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -14124,7 +14124,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -14137,7 +14137,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -14150,7 +14150,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.4 <5.0.0",
+        "version": ">=4.0.4 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -14163,7 +14163,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": 527,
     },
@@ -14176,7 +14176,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14189,7 +14189,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14202,7 +14202,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14215,7 +14215,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14228,7 +14228,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 528,
     },
@@ -14241,7 +14241,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 529,
     },
@@ -14254,7 +14254,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14267,7 +14267,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -14280,7 +14280,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -14293,7 +14293,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": null,
     },
@@ -14306,7 +14306,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -14319,7 +14319,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14332,7 +14332,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14345,7 +14345,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14358,7 +14358,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -14371,7 +14371,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -14384,7 +14384,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -14397,7 +14397,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14410,7 +14410,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 530,
     },
@@ -14423,7 +14423,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.6 <4.0.0",
+        "version": ">=3.3.6 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -14436,7 +14436,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14449,7 +14449,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -14462,7 +14462,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 531,
     },
@@ -14475,7 +14475,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -14488,7 +14488,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14501,7 +14501,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14514,7 +14514,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 532,
     },
@@ -14528,7 +14528,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14541,7 +14541,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },

--- a/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
@@ -25,7 +25,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -38,7 +38,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/react-dom",
       "npm": {
         "name": "@types/react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 91,
     },
@@ -64,7 +64,7 @@ exports[`next build works: bun 1`] = `
       "name": "bun-types",
       "npm": {
         "name": "bun-types",
-        "version": ">=1.2.19 <2.0.0",
+        "version": ">=1.2.19 <2.0.0-0",
       },
       "package_id": 162,
     },
@@ -77,7 +77,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=9.33.0 <10.0.0",
+        "version": ">=9.33.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -90,7 +90,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-config-next",
       "npm": {
         "name": "eslint-config-next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 217,
     },
@@ -103,7 +103,7 @@ exports[`next build works: bun 1`] = `
       "name": "next",
       "npm": {
         "name": "next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 350,
     },
@@ -142,7 +142,7 @@ exports[`next build works: bun 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -155,7 +155,7 @@ exports[`next build works: bun 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -168,7 +168,7 @@ exports[`next build works: bun 1`] = `
       "name": "tailwindcss",
       "npm": {
         "name": "tailwindcss",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 452,
     },
@@ -194,7 +194,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -207,7 +207,7 @@ exports[`next build works: bun 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -220,7 +220,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -233,7 +233,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -246,7 +246,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -259,7 +259,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-compilation-targets",
       "npm": {
         "name": "@babel/helper-compilation-targets",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 6,
     },
@@ -272,7 +272,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-module-transforms",
       "npm": {
         "name": "@babel/helper-module-transforms",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 9,
     },
@@ -285,7 +285,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helpers",
       "npm": {
         "name": "@babel/helpers",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 13,
     },
@@ -298,7 +298,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -311,7 +311,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -324,7 +324,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -337,7 +337,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -350,7 +350,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/remapping",
       "npm": {
         "name": "@jridgewell/remapping",
-        "version": ">=2.3.5 <3.0.0",
+        "version": ">=2.3.5 <3.0.0-0",
       },
       "package_id": 61,
     },
@@ -363,7 +363,7 @@ exports[`next build works: bun 1`] = `
       "name": "convert-source-map",
       "npm": {
         "name": "convert-source-map",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 178,
     },
@@ -376,7 +376,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -389,7 +389,7 @@ exports[`next build works: bun 1`] = `
       "name": "gensync",
       "npm": {
         "name": "gensync",
-        "version": ">=1.0.0-beta.2 <2.0.0",
+        "version": ">=1.0.0-beta.2 <2.0.0-0",
       },
       "package_id": 254,
     },
@@ -402,7 +402,7 @@ exports[`next build works: bun 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=2.2.3 <3.0.0",
+        "version": ">=2.2.3 <3.0.0-0",
       },
       "package_id": 496,
     },
@@ -415,7 +415,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -428,7 +428,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -441,7 +441,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -454,7 +454,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.12 <0.4.0",
+        "version": ">=0.3.12 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -467,7 +467,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.28 <0.4.0",
+        "version": ">=0.3.28 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -480,7 +480,7 @@ exports[`next build works: bun 1`] = `
       "name": "jsesc",
       "npm": {
         "name": "jsesc",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 320,
     },
@@ -493,7 +493,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/compat-data",
       "npm": {
         "name": "@babel/compat-data",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 3,
     },
@@ -506,7 +506,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-validator-option",
       "npm": {
         "name": "@babel/helper-validator-option",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 12,
     },
@@ -519,7 +519,7 @@ exports[`next build works: bun 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.0 <5.0.0",
+        "version": ">=4.24.0 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -532,7 +532,7 @@ exports[`next build works: bun 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=5.1.1 <6.0.0",
+        "version": ">=5.1.1 <6.0.0-0",
       },
       "package_id": 497,
     },
@@ -545,7 +545,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -558,7 +558,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -571,7 +571,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -584,7 +584,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-module-imports",
       "npm": {
         "name": "@babel/helper-module-imports",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 8,
     },
@@ -597,7 +597,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -610,7 +610,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -623,7 +623,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -636,7 +636,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -649,7 +649,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -662,7 +662,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -675,7 +675,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -688,7 +688,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -701,7 +701,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -714,7 +714,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -727,7 +727,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -740,7 +740,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-globals",
       "npm": {
         "name": "@babel/helper-globals",
-        "version": ">=7.28.0 <8.0.0",
+        "version": ">=7.28.0 <8.0.0-0",
       },
       "package_id": 7,
     },
@@ -753,7 +753,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -766,7 +766,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -779,7 +779,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -792,7 +792,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -805,7 +805,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-string-parser",
       "npm": {
         "name": "@babel/helper-string-parser",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 10,
     },
@@ -818,7 +818,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -844,7 +844,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -857,7 +857,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -870,7 +870,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -883,7 +883,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -896,7 +896,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -909,7 +909,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/object-schema",
       "npm": {
         "name": "@eslint/object-schema",
-        "version": ">=2.1.6 <3.0.0",
+        "version": ">=2.1.6 <3.0.0-0",
       },
       "package_id": 28,
     },
@@ -922,7 +922,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -935,7 +935,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -948,7 +948,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -961,7 +961,7 @@ exports[`next build works: bun 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -974,7 +974,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -987,7 +987,7 @@ exports[`next build works: bun 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.0.1 <11.0.0",
+        "version": ">=10.0.1 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -1000,7 +1000,7 @@ exports[`next build works: bun 1`] = `
       "name": "globals",
       "npm": {
         "name": "globals",
-        "version": ">=14.0.0 <15.0.0",
+        "version": ">=14.0.0 <15.0.0-0",
       },
       "package_id": 499,
     },
@@ -1013,7 +1013,7 @@ exports[`next build works: bun 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -1026,7 +1026,7 @@ exports[`next build works: bun 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.2.1 <4.0.0",
+        "version": ">=3.2.1 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -1039,7 +1039,7 @@ exports[`next build works: bun 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -1052,7 +1052,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -1065,7 +1065,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-json-comments",
       "npm": {
         "name": "strip-json-comments",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 447,
     },
@@ -1078,7 +1078,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -1091,7 +1091,7 @@ exports[`next build works: bun 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -1104,7 +1104,7 @@ exports[`next build works: bun 1`] = `
       "name": "@humanfs/core",
       "npm": {
         "name": "@humanfs/core",
-        "version": ">=0.19.1 <0.20.0",
+        "version": ">=0.19.1 <0.20.0-0",
       },
       "package_id": 30,
     },
@@ -1117,7 +1117,7 @@ exports[`next build works: bun 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 500,
     },
@@ -1260,7 +1260,7 @@ exports[`next build works: bun 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.7.0 <2.0.0",
+        "version": ">=1.7.0 <2.0.0-0",
       },
       "package_id": 19,
     },
@@ -1273,7 +1273,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -1287,7 +1287,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width-cjs",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -1300,7 +1300,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -1314,7 +1314,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi-cjs",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -1327,7 +1327,7 @@ exports[`next build works: bun 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 503,
     },
@@ -1341,7 +1341,7 @@ exports[`next build works: bun 1`] = `
       "name": "wrap-ansi-cjs",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -1354,7 +1354,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1367,7 +1367,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1380,7 +1380,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -1393,7 +1393,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -1406,7 +1406,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/resolve-uri",
       "npm": {
         "name": "@jridgewell/resolve-uri",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 62,
     },
@@ -1419,7 +1419,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.4.14 <2.0.0",
+        "version": ">=1.4.14 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -1432,7 +1432,7 @@ exports[`next build works: bun 1`] = `
       "name": "@emnapi/core",
       "npm": {
         "name": "@emnapi/core",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 18,
     },
@@ -1445,7 +1445,7 @@ exports[`next build works: bun 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 504,
     },
@@ -1458,7 +1458,7 @@ exports[`next build works: bun 1`] = `
       "name": "@tybys/wasm-util",
       "npm": {
         "name": "@tybys/wasm-util",
-        "version": ">=0.10.0 <0.11.0",
+        "version": ">=0.10.0 <0.11.0-0",
       },
       "package_id": 85,
     },
@@ -1497,7 +1497,7 @@ exports[`next build works: bun 1`] = `
       "name": "run-parallel",
       "npm": {
         "name": "run-parallel",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 412,
     },
@@ -1523,7 +1523,7 @@ exports[`next build works: bun 1`] = `
       "name": "fastq",
       "npm": {
         "name": "fastq",
-        "version": ">=1.6.0 <2.0.0",
+        "version": ">=1.6.0 <2.0.0-0",
       },
       "package_id": 239,
     },
@@ -1536,7 +1536,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -1549,7 +1549,7 @@ exports[`next build works: bun 1`] = `
       "name": "extract-zip",
       "npm": {
         "name": "extract-zip",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 233,
     },
@@ -1562,7 +1562,7 @@ exports[`next build works: bun 1`] = `
       "name": "progress",
       "npm": {
         "name": "progress",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 391,
     },
@@ -1575,7 +1575,7 @@ exports[`next build works: bun 1`] = `
       "name": "proxy-agent",
       "npm": {
         "name": "proxy-agent",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 393,
     },
@@ -1588,7 +1588,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.2 <8.0.0",
+        "version": ">=7.7.2 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -1601,7 +1601,7 @@ exports[`next build works: bun 1`] = `
       "name": "tar-fs",
       "npm": {
         "name": "tar-fs",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 453,
     },
@@ -1614,7 +1614,7 @@ exports[`next build works: bun 1`] = `
       "name": "yargs",
       "npm": {
         "name": "yargs",
-        "version": ">=17.7.2 <18.0.0",
+        "version": ">=17.7.2 <18.0.0-0",
       },
       "package_id": 490,
     },
@@ -1627,7 +1627,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.8.0 <3.0.0",
+        "version": ">=2.8.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1640,7 +1640,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -1653,7 +1653,7 @@ exports[`next build works: bun 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.16.0 <7.17.0",
+        "version": ">=7.16.0 <7.17.0-0",
       },
       "package_id": 473,
     },
@@ -1666,7 +1666,7 @@ exports[`next build works: bun 1`] = `
       "name": "csstype",
       "npm": {
         "name": "csstype",
-        "version": ">=3.2.2 <4.0.0",
+        "version": ">=3.2.2 <4.0.0-0",
       },
       "package_id": 182,
     },
@@ -1679,7 +1679,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.0 <20.0.0",
+        "version": ">=19.2.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -1705,7 +1705,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.2 <5.0.0",
+        "version": ">=4.12.2 <5.0.0-0",
       },
       "package_id": 508,
     },
@@ -1770,7 +1770,7 @@ exports[`next build works: bun 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=7.0.5 <8.0.0",
+        "version": ">=7.0.5 <8.0.0-0",
       },
       "package_id": 509,
     },
@@ -1783,7 +1783,7 @@ exports[`next build works: bun 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -1796,7 +1796,7 @@ exports[`next build works: bun 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -1809,7 +1809,7 @@ exports[`next build works: bun 1`] = `
       "name": "@typescript-eslint/parser",
       "npm": {
         "name": "@typescript-eslint/parser",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 94,
     },
@@ -1822,7 +1822,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1900,7 +1900,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -1913,7 +1913,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -1939,7 +1939,7 @@ exports[`next build works: bun 1`] = `
       "name": "@typescript-eslint/tsconfig-utils",
       "npm": {
         "name": "@typescript-eslint/tsconfig-utils",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 97,
     },
@@ -1952,7 +1952,7 @@ exports[`next build works: bun 1`] = `
       "name": "@typescript-eslint/types",
       "npm": {
         "name": "@typescript-eslint/types",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 99,
     },
@@ -1965,7 +1965,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2069,7 +2069,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2082,7 +2082,7 @@ exports[`next build works: bun 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2095,7 +2095,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2173,7 +2173,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -2186,7 +2186,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=10.2.2 <11.0.0",
+        "version": ">=10.2.2 <11.0.0-0",
       },
       "package_id": 511,
     },
@@ -2199,7 +2199,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -2212,7 +2212,7 @@ exports[`next build works: bun 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.15 <0.3.0",
+        "version": ">=0.2.15 <0.3.0-0",
       },
       "package_id": 513,
     },
@@ -2225,7 +2225,7 @@ exports[`next build works: bun 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -2251,7 +2251,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.9.1 <5.0.0",
+        "version": ">=4.9.1 <5.0.0-0",
       },
       "package_id": 514,
     },
@@ -2303,7 +2303,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -2342,7 +2342,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 515,
     },
@@ -2355,7 +2355,7 @@ exports[`next build works: bun 1`] = `
       "name": "@napi-rs/wasm-runtime",
       "npm": {
         "name": "@napi-rs/wasm-runtime",
-        "version": ">=0.2.11 <0.3.0",
+        "version": ">=0.2.11 <0.3.0-0",
       },
       "package_id": 65,
     },
@@ -2368,7 +2368,7 @@ exports[`next build works: bun 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=8.0.0 <9.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=8.0.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -2381,7 +2381,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -2394,7 +2394,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-json-stable-stringify",
       "npm": {
         "name": "fast-json-stable-stringify",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 237,
     },
@@ -2407,7 +2407,7 @@ exports[`next build works: bun 1`] = `
       "name": "json-schema-traverse",
       "npm": {
         "name": "json-schema-traverse",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 323,
     },
@@ -2420,7 +2420,7 @@ exports[`next build works: bun 1`] = `
       "name": "uri-js",
       "npm": {
         "name": "uri-js",
-        "version": ">=4.2.2 <5.0.0",
+        "version": ">=4.2.2 <5.0.0-0",
       },
       "package_id": 476,
     },
@@ -2433,7 +2433,7 @@ exports[`next build works: bun 1`] = `
       "name": "color-convert",
       "npm": {
         "name": "color-convert",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 174,
     },
@@ -2446,7 +2446,7 @@ exports[`next build works: bun 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -2459,7 +2459,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.0.4 <3.0.0",
+        "version": ">=2.0.4 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -2472,7 +2472,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2485,7 +2485,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -2498,7 +2498,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2511,7 +2511,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2524,7 +2524,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2537,7 +2537,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.24.0 <2.0.0",
+        "version": ">=1.24.0 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2550,7 +2550,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2563,7 +2563,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -2576,7 +2576,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -2589,7 +2589,7 @@ exports[`next build works: bun 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -2602,7 +2602,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2615,7 +2615,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2628,7 +2628,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2641,7 +2641,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2654,7 +2654,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2667,7 +2667,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2680,7 +2680,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2693,7 +2693,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -2706,7 +2706,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2719,7 +2719,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2732,7 +2732,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2745,7 +2745,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -2758,7 +2758,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2771,7 +2771,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2784,7 +2784,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2797,7 +2797,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2810,7 +2810,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2823,7 +2823,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2836,7 +2836,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2849,7 +2849,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2862,7 +2862,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2875,7 +2875,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2888,7 +2888,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2901,7 +2901,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2914,7 +2914,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -2927,7 +2927,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -2940,7 +2940,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -2953,7 +2953,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -2966,7 +2966,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -2979,7 +2979,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -2992,7 +2992,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3005,7 +3005,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3018,7 +3018,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.4 <4.0.0",
+        "version": ">=3.0.4 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -3031,7 +3031,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -3044,7 +3044,7 @@ exports[`next build works: bun 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.4 <5.0.0",
+        "version": ">=4.24.4 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -3057,7 +3057,7 @@ exports[`next build works: bun 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001702 <2.0.0",
+        "version": ">=1.0.30001702 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3070,7 +3070,7 @@ exports[`next build works: bun 1`] = `
       "name": "fraction.js",
       "npm": {
         "name": "fraction.js",
-        "version": ">=4.3.7 <5.0.0",
+        "version": ">=4.3.7 <5.0.0-0",
       },
       "package_id": 249,
     },
@@ -3083,7 +3083,7 @@ exports[`next build works: bun 1`] = `
       "name": "normalize-range",
       "npm": {
         "name": "normalize-range",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 353,
     },
@@ -3096,7 +3096,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -3109,7 +3109,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -3122,7 +3122,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -3135,7 +3135,7 @@ exports[`next build works: bun 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -3148,7 +3148,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.5.4 <3.0.0",
+        "version": ">=2.5.4 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -3161,7 +3161,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -3174,7 +3174,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-stream",
       "npm": {
         "name": "bare-stream",
-        "version": ">=2.6.4 <3.0.0",
+        "version": ">=2.6.4 <3.0.0-0",
       },
       "package_id": 154,
     },
@@ -3201,7 +3201,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-os",
       "npm": {
         "name": "bare-os",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 152,
     },
@@ -3214,7 +3214,7 @@ exports[`next build works: bun 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.21.0 <3.0.0",
+        "version": ">=2.21.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -3255,7 +3255,7 @@ exports[`next build works: bun 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },
@@ -3281,7 +3281,7 @@ exports[`next build works: bun 1`] = `
       "name": "fill-range",
       "npm": {
         "name": "fill-range",
-        "version": ">=7.1.1 <8.0.0",
+        "version": ">=7.1.1 <8.0.0-0",
       },
       "package_id": 243,
     },
@@ -3294,7 +3294,7 @@ exports[`next build works: bun 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001726 <2.0.0",
+        "version": ">=1.0.30001726 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -3307,7 +3307,7 @@ exports[`next build works: bun 1`] = `
       "name": "electron-to-chromium",
       "npm": {
         "name": "electron-to-chromium",
-        "version": ">=1.5.173 <2.0.0",
+        "version": ">=1.5.173 <2.0.0-0",
       },
       "package_id": 200,
     },
@@ -3320,7 +3320,7 @@ exports[`next build works: bun 1`] = `
       "name": "node-releases",
       "npm": {
         "name": "node-releases",
-        "version": ">=2.0.19 <3.0.0",
+        "version": ">=2.0.19 <3.0.0-0",
       },
       "package_id": 351,
     },
@@ -3333,7 +3333,7 @@ exports[`next build works: bun 1`] = `
       "name": "update-browserslist-db",
       "npm": {
         "name": "update-browserslist-db",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 475,
     },
@@ -3359,7 +3359,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.0.0 <20.0.0",
+        "version": ">=19.0.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -3372,7 +3372,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3385,7 +3385,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3398,7 +3398,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3411,7 +3411,7 @@ exports[`next build works: bun 1`] = `
       "name": "set-function-length",
       "npm": {
         "name": "set-function-length",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 418,
     },
@@ -3424,7 +3424,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3437,7 +3437,7 @@ exports[`next build works: bun 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -3450,7 +3450,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -3463,7 +3463,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -3476,7 +3476,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -3489,7 +3489,7 @@ exports[`next build works: bun 1`] = `
       "name": "supports-color",
       "npm": {
         "name": "supports-color",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 450,
     },
@@ -3502,7 +3502,7 @@ exports[`next build works: bun 1`] = `
       "name": "fsevents",
       "npm": {
         "name": "fsevents",
-        "version": ">=2.3.2 <2.4.0",
+        "version": ">=2.3.2 <2.4.0-0",
       },
       "package_id": 250,
     },
@@ -3515,7 +3515,7 @@ exports[`next build works: bun 1`] = `
       "name": "anymatch",
       "npm": {
         "name": "anymatch",
-        "version": ">=3.1.2 <3.2.0",
+        "version": ">=3.1.2 <3.2.0-0",
       },
       "package_id": 129,
     },
@@ -3528,7 +3528,7 @@ exports[`next build works: bun 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.2 <3.1.0",
+        "version": ">=3.0.2 <3.1.0-0",
       },
       "package_id": 159,
     },
@@ -3541,7 +3541,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <5.2.0",
+        "version": ">=5.1.2 <5.2.0-0",
       },
       "package_id": 516,
     },
@@ -3554,7 +3554,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-binary-path",
       "npm": {
         "name": "is-binary-path",
-        "version": ">=2.1.0 <2.2.0",
+        "version": ">=2.1.0 <2.2.0-0",
       },
       "package_id": 287,
     },
@@ -3567,7 +3567,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <4.1.0",
+        "version": ">=4.0.1 <4.1.0-0",
       },
       "package_id": 298,
     },
@@ -3580,7 +3580,7 @@ exports[`next build works: bun 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <3.1.0",
+        "version": ">=3.0.0 <3.1.0-0",
       },
       "package_id": 352,
     },
@@ -3593,7 +3593,7 @@ exports[`next build works: bun 1`] = `
       "name": "readdirp",
       "npm": {
         "name": "readdirp",
-        "version": ">=3.6.0 <3.7.0",
+        "version": ">=3.6.0 <3.7.0-0",
       },
       "package_id": 404,
     },
@@ -3606,7 +3606,7 @@ exports[`next build works: bun 1`] = `
       "name": "mitt",
       "npm": {
         "name": "mitt",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 343,
     },
@@ -3619,7 +3619,7 @@ exports[`next build works: bun 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.24.1 <4.0.0",
+        "version": ">=3.24.1 <4.0.0-0",
       },
       "package_id": 494,
     },
@@ -3645,7 +3645,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -3658,7 +3658,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -3671,7 +3671,7 @@ exports[`next build works: bun 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -3684,7 +3684,7 @@ exports[`next build works: bun 1`] = `
       "name": "color-name",
       "npm": {
         "name": "color-name",
-        "version": ">=1.1.4 <1.2.0",
+        "version": ">=1.1.4 <1.2.0-0",
       },
       "package_id": 175,
     },
@@ -3697,7 +3697,7 @@ exports[`next build works: bun 1`] = `
       "name": "env-paths",
       "npm": {
         "name": "env-paths",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 203,
     },
@@ -3710,7 +3710,7 @@ exports[`next build works: bun 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.3.0 <4.0.0",
+        "version": ">=3.3.0 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -3723,7 +3723,7 @@ exports[`next build works: bun 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -3736,7 +3736,7 @@ exports[`next build works: bun 1`] = `
       "name": "parse-json",
       "npm": {
         "name": "parse-json",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 372,
     },
@@ -3763,7 +3763,7 @@ exports[`next build works: bun 1`] = `
       "name": "path-key",
       "npm": {
         "name": "path-key",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 374,
     },
@@ -3776,7 +3776,7 @@ exports[`next build works: bun 1`] = `
       "name": "shebang-command",
       "npm": {
         "name": "shebang-command",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 422,
     },
@@ -3789,7 +3789,7 @@ exports[`next build works: bun 1`] = `
       "name": "which",
       "npm": {
         "name": "which",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 478,
     },
@@ -3802,7 +3802,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3815,7 +3815,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3828,7 +3828,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3841,7 +3841,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3854,7 +3854,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3867,7 +3867,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3880,7 +3880,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -3893,7 +3893,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3906,7 +3906,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -3919,7 +3919,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -3932,7 +3932,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -3945,7 +3945,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -3958,7 +3958,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -3971,7 +3971,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -3984,7 +3984,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -3997,7 +3997,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4010,7 +4010,7 @@ exports[`next build works: bun 1`] = `
       "name": "ast-types",
       "npm": {
         "name": "ast-types",
-        "version": ">=0.13.4 <0.14.0",
+        "version": ">=0.13.4 <0.14.0-0",
       },
       "package_id": 141,
     },
@@ -4023,7 +4023,7 @@ exports[`next build works: bun 1`] = `
       "name": "escodegen",
       "npm": {
         "name": "escodegen",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 215,
     },
@@ -4036,7 +4036,7 @@ exports[`next build works: bun 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -4049,7 +4049,7 @@ exports[`next build works: bun 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -4062,7 +4062,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -4075,7 +4075,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4088,7 +4088,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4101,7 +4101,7 @@ exports[`next build works: bun 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -4114,7 +4114,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-arrayish",
       "npm": {
         "name": "is-arrayish",
-        "version": ">=0.2.1 <0.3.0",
+        "version": ">=0.2.1 <0.3.0-0",
       },
       "package_id": 284,
     },
@@ -4127,7 +4127,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -4140,7 +4140,7 @@ exports[`next build works: bun 1`] = `
       "name": "arraybuffer.prototype.slice",
       "npm": {
         "name": "arraybuffer.prototype.slice",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 140,
     },
@@ -4153,7 +4153,7 @@ exports[`next build works: bun 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -4166,7 +4166,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4179,7 +4179,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4192,7 +4192,7 @@ exports[`next build works: bun 1`] = `
       "name": "data-view-buffer",
       "npm": {
         "name": "data-view-buffer",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 185,
     },
@@ -4205,7 +4205,7 @@ exports[`next build works: bun 1`] = `
       "name": "data-view-byte-length",
       "npm": {
         "name": "data-view-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 186,
     },
@@ -4218,7 +4218,7 @@ exports[`next build works: bun 1`] = `
       "name": "data-view-byte-offset",
       "npm": {
         "name": "data-view-byte-offset",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 187,
     },
@@ -4231,7 +4231,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -4244,7 +4244,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4257,7 +4257,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -4270,7 +4270,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4283,7 +4283,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-to-primitive",
       "npm": {
         "name": "es-to-primitive",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 212,
     },
@@ -4296,7 +4296,7 @@ exports[`next build works: bun 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.8 <2.0.0",
+        "version": ">=1.1.8 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -4309,7 +4309,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4322,7 +4322,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -4335,7 +4335,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-symbol-description",
       "npm": {
         "name": "get-symbol-description",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 259,
     },
@@ -4348,7 +4348,7 @@ exports[`next build works: bun 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4361,7 +4361,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4374,7 +4374,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4387,7 +4387,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4400,7 +4400,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4413,7 +4413,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -4426,7 +4426,7 @@ exports[`next build works: bun 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -4439,7 +4439,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -4452,7 +4452,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -4465,7 +4465,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -4478,7 +4478,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-negative-zero",
       "npm": {
         "name": "is-negative-zero",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 300,
     },
@@ -4491,7 +4491,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -4504,7 +4504,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -4517,7 +4517,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-shared-array-buffer",
       "npm": {
         "name": "is-shared-array-buffer",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 305,
     },
@@ -4530,7 +4530,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -4543,7 +4543,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -4556,7 +4556,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -4569,7 +4569,7 @@ exports[`next build works: bun 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -4582,7 +4582,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.4 <2.0.0",
+        "version": ">=1.13.4 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -4595,7 +4595,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -4608,7 +4608,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.7 <5.0.0",
+        "version": ">=4.1.7 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -4621,7 +4621,7 @@ exports[`next build works: bun 1`] = `
       "name": "own-keys",
       "npm": {
         "name": "own-keys",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 365,
     },
@@ -4634,7 +4634,7 @@ exports[`next build works: bun 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.4 <2.0.0",
+        "version": ">=1.5.4 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -4647,7 +4647,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -4660,7 +4660,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -4673,7 +4673,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -4686,7 +4686,7 @@ exports[`next build works: bun 1`] = `
       "name": "set-proto",
       "npm": {
         "name": "set-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 420,
     },
@@ -4699,7 +4699,7 @@ exports[`next build works: bun 1`] = `
       "name": "stop-iteration-iterator",
       "npm": {
         "name": "stop-iteration-iterator",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 436,
     },
@@ -4712,7 +4712,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.trim",
       "npm": {
         "name": "string.prototype.trim",
-        "version": ">=1.2.10 <2.0.0",
+        "version": ">=1.2.10 <2.0.0-0",
       },
       "package_id": 442,
     },
@@ -4725,7 +4725,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -4738,7 +4738,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.trimstart",
       "npm": {
         "name": "string.prototype.trimstart",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 444,
     },
@@ -4751,7 +4751,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-array-buffer",
       "npm": {
         "name": "typed-array-buffer",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 465,
     },
@@ -4764,7 +4764,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-array-byte-length",
       "npm": {
         "name": "typed-array-byte-length",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 466,
     },
@@ -4777,7 +4777,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-array-byte-offset",
       "npm": {
         "name": "typed-array-byte-offset",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 467,
     },
@@ -4790,7 +4790,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-array-length",
       "npm": {
         "name": "typed-array-length",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 468,
     },
@@ -4803,7 +4803,7 @@ exports[`next build works: bun 1`] = `
       "name": "unbox-primitive",
       "npm": {
         "name": "unbox-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 472,
     },
@@ -4816,7 +4816,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.19 <2.0.0",
+        "version": ">=1.1.19 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -4829,7 +4829,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -4842,7 +4842,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -4855,7 +4855,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -4868,7 +4868,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -4881,7 +4881,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -4894,7 +4894,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -4907,7 +4907,7 @@ exports[`next build works: bun 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -4920,7 +4920,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -4933,7 +4933,7 @@ exports[`next build works: bun 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -4946,7 +4946,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -4959,7 +4959,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -4972,7 +4972,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -4985,7 +4985,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -4998,7 +4998,7 @@ exports[`next build works: bun 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -5011,7 +5011,7 @@ exports[`next build works: bun 1`] = `
       "name": "iterator.prototype",
       "npm": {
         "name": "iterator.prototype",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 314,
     },
@@ -5024,7 +5024,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -5037,7 +5037,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5050,7 +5050,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -5063,7 +5063,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -5076,7 +5076,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -5089,7 +5089,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5102,7 +5102,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -5115,7 +5115,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -5128,7 +5128,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.0.5 <2.0.0",
+        "version": ">=1.0.5 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -5141,7 +5141,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -5154,7 +5154,7 @@ exports[`next build works: bun 1`] = `
       "name": "source-map",
       "npm": {
         "name": "source-map",
-        "version": ">=0.6.1 <0.7.0",
+        "version": ">=0.6.1 <0.7.0-0",
       },
       "package_id": 432,
     },
@@ -5167,7 +5167,7 @@ exports[`next build works: bun 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -5180,7 +5180,7 @@ exports[`next build works: bun 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -5193,7 +5193,7 @@ exports[`next build works: bun 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5206,7 +5206,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 21,
     },
@@ -5219,7 +5219,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.1 <5.0.0",
+        "version": ">=4.12.1 <5.0.0-0",
       },
       "package_id": 22,
     },
@@ -5232,7 +5232,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/config-array",
       "npm": {
         "name": "@eslint/config-array",
-        "version": ">=0.21.0 <0.22.0",
+        "version": ">=0.21.0 <0.22.0-0",
       },
       "package_id": 23,
     },
@@ -5245,7 +5245,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/config-helpers",
       "npm": {
         "name": "@eslint/config-helpers",
-        "version": ">=0.3.1 <0.4.0",
+        "version": ">=0.3.1 <0.4.0-0",
       },
       "package_id": 24,
     },
@@ -5258,7 +5258,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -5271,7 +5271,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/eslintrc",
       "npm": {
         "name": "@eslint/eslintrc",
-        "version": ">=3.3.1 <4.0.0",
+        "version": ">=3.3.1 <4.0.0-0",
       },
       "package_id": 26,
     },
@@ -5297,7 +5297,7 @@ exports[`next build works: bun 1`] = `
       "name": "@eslint/plugin-kit",
       "npm": {
         "name": "@eslint/plugin-kit",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 29,
     },
@@ -5310,7 +5310,7 @@ exports[`next build works: bun 1`] = `
       "name": "@humanfs/node",
       "npm": {
         "name": "@humanfs/node",
-        "version": ">=0.16.6 <0.17.0",
+        "version": ">=0.16.6 <0.17.0-0",
       },
       "package_id": 31,
     },
@@ -5323,7 +5323,7 @@ exports[`next build works: bun 1`] = `
       "name": "@humanwhocodes/module-importer",
       "npm": {
         "name": "@humanwhocodes/module-importer",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 32,
     },
@@ -5336,7 +5336,7 @@ exports[`next build works: bun 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.4.2 <0.5.0",
+        "version": ">=0.4.2 <0.5.0-0",
       },
       "package_id": 33,
     },
@@ -5349,7 +5349,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/estree",
       "npm": {
         "name": "@types/estree",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 86,
     },
@@ -5362,7 +5362,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -5375,7 +5375,7 @@ exports[`next build works: bun 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -5388,7 +5388,7 @@ exports[`next build works: bun 1`] = `
       "name": "chalk",
       "npm": {
         "name": "chalk",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 169,
     },
@@ -5401,7 +5401,7 @@ exports[`next build works: bun 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -5414,7 +5414,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5427,7 +5427,7 @@ exports[`next build works: bun 1`] = `
       "name": "escape-string-regexp",
       "npm": {
         "name": "escape-string-regexp",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 214,
     },
@@ -5440,7 +5440,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-scope",
       "npm": {
         "name": "eslint-scope",
-        "version": ">=8.4.0 <9.0.0",
+        "version": ">=8.4.0 <9.0.0-0",
       },
       "package_id": 225,
     },
@@ -5453,7 +5453,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -5466,7 +5466,7 @@ exports[`next build works: bun 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.4.0 <11.0.0",
+        "version": ">=10.4.0 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -5479,7 +5479,7 @@ exports[`next build works: bun 1`] = `
       "name": "esquery",
       "npm": {
         "name": "esquery",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 229,
     },
@@ -5492,7 +5492,7 @@ exports[`next build works: bun 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -5505,7 +5505,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -5518,7 +5518,7 @@ exports[`next build works: bun 1`] = `
       "name": "file-entry-cache",
       "npm": {
         "name": "file-entry-cache",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 242,
     },
@@ -5531,7 +5531,7 @@ exports[`next build works: bun 1`] = `
       "name": "find-up",
       "npm": {
         "name": "find-up",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 244,
     },
@@ -5544,7 +5544,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -5557,7 +5557,7 @@ exports[`next build works: bun 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -5570,7 +5570,7 @@ exports[`next build works: bun 1`] = `
       "name": "imurmurhash",
       "npm": {
         "name": "imurmurhash",
-        "version": ">=0.1.4 <0.2.0",
+        "version": ">=0.1.4 <0.2.0-0",
       },
       "package_id": 280,
     },
@@ -5583,7 +5583,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -5596,7 +5596,7 @@ exports[`next build works: bun 1`] = `
       "name": "json-stable-stringify-without-jsonify",
       "npm": {
         "name": "json-stable-stringify-without-jsonify",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 324,
     },
@@ -5609,7 +5609,7 @@ exports[`next build works: bun 1`] = `
       "name": "lodash.merge",
       "npm": {
         "name": "lodash.merge",
-        "version": ">=4.6.2 <5.0.0",
+        "version": ">=4.6.2 <5.0.0-0",
       },
       "package_id": 334,
     },
@@ -5622,7 +5622,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -5635,7 +5635,7 @@ exports[`next build works: bun 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -5648,7 +5648,7 @@ exports[`next build works: bun 1`] = `
       "name": "optionator",
       "npm": {
         "name": "optionator",
-        "version": ">=0.9.3 <0.10.0",
+        "version": ">=0.9.3 <0.10.0-0",
       },
       "package_id": 364,
     },
@@ -5688,7 +5688,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.6 <0.4.0",
+        "version": ">=0.3.6 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -5701,7 +5701,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-import-resolver-typescript",
       "npm": {
         "name": "eslint-import-resolver-typescript",
-        "version": ">=3.5.2 <4.0.0",
+        "version": ">=3.5.2 <4.0.0-0",
       },
       "package_id": 219,
     },
@@ -5714,7 +5714,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-plugin-import",
       "npm": {
         "name": "eslint-plugin-import",
-        "version": ">=2.32.0 <3.0.0",
+        "version": ">=2.32.0 <3.0.0-0",
       },
       "package_id": 221,
     },
@@ -5727,7 +5727,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-plugin-jsx-a11y",
       "npm": {
         "name": "eslint-plugin-jsx-a11y",
-        "version": ">=6.10.0 <7.0.0",
+        "version": ">=6.10.0 <7.0.0-0",
       },
       "package_id": 222,
     },
@@ -5740,7 +5740,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-plugin-react",
       "npm": {
         "name": "eslint-plugin-react",
-        "version": ">=7.37.0 <8.0.0",
+        "version": ">=7.37.0 <8.0.0-0",
       },
       "package_id": 223,
     },
@@ -5753,7 +5753,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-plugin-react-hooks",
       "npm": {
         "name": "eslint-plugin-react-hooks",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 224,
     },
@@ -5779,7 +5779,7 @@ exports[`next build works: bun 1`] = `
       "name": "typescript-eslint",
       "npm": {
         "name": "typescript-eslint",
-        "version": ">=8.46.0 <9.0.0",
+        "version": ">=8.46.0 <9.0.0-0",
       },
       "package_id": 471,
     },
@@ -5819,7 +5819,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -5832,7 +5832,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -5845,7 +5845,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.4 <2.0.0",
+        "version": ">=1.22.4 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -5871,7 +5871,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.0 <5.0.0",
+        "version": ">=4.4.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -5884,7 +5884,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-tsconfig",
       "npm": {
         "name": "get-tsconfig",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 260,
     },
@@ -5897,7 +5897,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-bun-module",
       "npm": {
         "name": "is-bun-module",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 289,
     },
@@ -5910,7 +5910,7 @@ exports[`next build works: bun 1`] = `
       "name": "stable-hash",
       "npm": {
         "name": "stable-hash",
-        "version": ">=0.0.5 <0.0.6",
+        "version": ">=0.0.5 <0.0.6-0",
       },
       "package_id": 435,
     },
@@ -5923,7 +5923,7 @@ exports[`next build works: bun 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.13 <0.3.0",
+        "version": ">=0.2.13 <0.3.0-0",
       },
       "package_id": 458,
     },
@@ -5936,7 +5936,7 @@ exports[`next build works: bun 1`] = `
       "name": "unrs-resolver",
       "npm": {
         "name": "unrs-resolver",
-        "version": ">=1.6.2 <2.0.0",
+        "version": ">=1.6.2 <2.0.0-0",
       },
       "package_id": 474,
     },
@@ -5990,7 +5990,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6003,7 +6003,7 @@ exports[`next build works: bun 1`] = `
       "name": "@rtsao/scc",
       "npm": {
         "name": "@rtsao/scc",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 82,
     },
@@ -6016,7 +6016,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.9 <4.0.0",
+        "version": ">=3.1.9 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6029,7 +6029,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.findlastindex",
       "npm": {
         "name": "array.prototype.findlastindex",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 136,
     },
@@ -6042,7 +6042,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -6055,7 +6055,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6068,7 +6068,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -6081,7 +6081,7 @@ exports[`next build works: bun 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6094,7 +6094,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.9 <0.4.0",
+        "version": ">=0.3.9 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -6107,7 +6107,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-module-utils",
       "npm": {
         "name": "eslint-module-utils",
-        "version": ">=2.12.1 <3.0.0",
+        "version": ">=2.12.1 <3.0.0-0",
       },
       "package_id": 220,
     },
@@ -6120,7 +6120,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6133,7 +6133,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.1 <3.0.0",
+        "version": ">=2.16.1 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -6146,7 +6146,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -6159,7 +6159,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6172,7 +6172,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6185,7 +6185,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.groupby",
       "npm": {
         "name": "object.groupby",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 361,
     },
@@ -6198,7 +6198,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6211,7 +6211,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6224,7 +6224,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -6237,7 +6237,7 @@ exports[`next build works: bun 1`] = `
       "name": "tsconfig-paths",
       "npm": {
         "name": "tsconfig-paths",
-        "version": ">=3.15.0 <4.0.0",
+        "version": ">=3.15.0 <4.0.0-0",
       },
       "package_id": 462,
     },
@@ -6250,7 +6250,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=2.0.0 <3.0.0 || >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=2.0.0 <3.0.0-0 || >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6263,7 +6263,7 @@ exports[`next build works: bun 1`] = `
       "name": "aria-query",
       "npm": {
         "name": "aria-query",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 132,
     },
@@ -6276,7 +6276,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6289,7 +6289,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6302,7 +6302,7 @@ exports[`next build works: bun 1`] = `
       "name": "ast-types-flow",
       "npm": {
         "name": "ast-types-flow",
-        "version": ">=0.0.8 <0.0.9",
+        "version": ">=0.0.8 <0.0.9-0",
       },
       "package_id": 142,
     },
@@ -6315,7 +6315,7 @@ exports[`next build works: bun 1`] = `
       "name": "axe-core",
       "npm": {
         "name": "axe-core",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 146,
     },
@@ -6328,7 +6328,7 @@ exports[`next build works: bun 1`] = `
       "name": "axobject-query",
       "npm": {
         "name": "axobject-query",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 147,
     },
@@ -6341,7 +6341,7 @@ exports[`next build works: bun 1`] = `
       "name": "damerau-levenshtein",
       "npm": {
         "name": "damerau-levenshtein",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 183,
     },
@@ -6354,7 +6354,7 @@ exports[`next build works: bun 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -6367,7 +6367,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6380,7 +6380,7 @@ exports[`next build works: bun 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=3.3.5 <4.0.0",
+        "version": ">=3.3.5 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6393,7 +6393,7 @@ exports[`next build works: bun 1`] = `
       "name": "language-tags",
       "npm": {
         "name": "language-tags",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 329,
     },
@@ -6406,7 +6406,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6419,7 +6419,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6432,7 +6432,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -6445,7 +6445,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.includes",
       "npm": {
         "name": "string.prototype.includes",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 439,
     },
@@ -6458,7 +6458,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6471,7 +6471,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -6484,7 +6484,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.findlast",
       "npm": {
         "name": "array.prototype.findlast",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 135,
     },
@@ -6497,7 +6497,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -6510,7 +6510,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.tosorted",
       "npm": {
         "name": "array.prototype.tosorted",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 139,
     },
@@ -6523,7 +6523,7 @@ exports[`next build works: bun 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -6536,7 +6536,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-iterator-helpers",
       "npm": {
         "name": "es-iterator-helpers",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 208,
     },
@@ -6549,7 +6549,7 @@ exports[`next build works: bun 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.3.0 <6.0.0",
+        "version": ">=5.3.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6562,7 +6562,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -6575,7 +6575,7 @@ exports[`next build works: bun 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=2.4.1 <3.0.0 || >=3.0.0 <4.0.0 && >=3.0.0 <4.0.0",
+        "version": ">=2.4.1 <3.0.0-0 || >=3.0.0 <4.0.0-0 && >=3.0.0 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -6588,7 +6588,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -6601,7 +6601,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.entries",
       "npm": {
         "name": "object.entries",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 359,
     },
@@ -6614,7 +6614,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -6627,7 +6627,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -6640,7 +6640,7 @@ exports[`next build works: bun 1`] = `
       "name": "prop-types",
       "npm": {
         "name": "prop-types",
-        "version": ">=15.8.1 <16.0.0",
+        "version": ">=15.8.1 <16.0.0-0",
       },
       "package_id": 392,
     },
@@ -6653,7 +6653,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=2.0.0-next.5 <3.0.0",
+        "version": ">=2.0.0-next.5 <3.0.0-0",
       },
       "package_id": 518,
     },
@@ -6666,7 +6666,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -6679,7 +6679,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.matchall",
       "npm": {
         "name": "string.prototype.matchall",
-        "version": ">=4.0.12 <5.0.0",
+        "version": ">=4.0.12 <5.0.0-0",
       },
       "package_id": 440,
     },
@@ -6692,7 +6692,7 @@ exports[`next build works: bun 1`] = `
       "name": "string.prototype.repeat",
       "npm": {
         "name": "string.prototype.repeat",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 441,
     },
@@ -6705,7 +6705,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=9.7.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=9.7.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6718,7 +6718,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -6731,7 +6731,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -6744,7 +6744,7 @@ exports[`next build works: bun 1`] = `
       "name": "hermes-parser",
       "npm": {
         "name": "hermes-parser",
-        "version": ">=0.25.1 <0.26.0",
+        "version": ">=0.25.1 <0.26.0-0",
       },
       "package_id": 275,
     },
@@ -6757,7 +6757,7 @@ exports[`next build works: bun 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -6770,7 +6770,7 @@ exports[`next build works: bun 1`] = `
       "name": "zod-validation-error",
       "npm": {
         "name": "zod-validation-error",
-        "version": ">=3.5.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.5.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 495,
     },
@@ -6783,7 +6783,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -6796,7 +6796,7 @@ exports[`next build works: bun 1`] = `
       "name": "esrecurse",
       "npm": {
         "name": "esrecurse",
-        "version": ">=4.3.0 <5.0.0",
+        "version": ">=4.3.0 <5.0.0-0",
       },
       "package_id": 230,
     },
@@ -6809,7 +6809,7 @@ exports[`next build works: bun 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6822,7 +6822,7 @@ exports[`next build works: bun 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=8.15.0 <9.0.0",
+        "version": ">=8.15.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -6835,7 +6835,7 @@ exports[`next build works: bun 1`] = `
       "name": "acorn-jsx",
       "npm": {
         "name": "acorn-jsx",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 123,
     },
@@ -6848,7 +6848,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -6861,7 +6861,7 @@ exports[`next build works: bun 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6874,7 +6874,7 @@ exports[`next build works: bun 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -6887,7 +6887,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/yauzl",
       "npm": {
         "name": "@types/yauzl",
-        "version": ">=2.9.1 <3.0.0",
+        "version": ">=2.9.1 <3.0.0-0",
       },
       "package_id": 92,
     },
@@ -6900,7 +6900,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -6913,7 +6913,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-stream",
       "npm": {
         "name": "get-stream",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 258,
     },
@@ -6926,7 +6926,7 @@ exports[`next build works: bun 1`] = `
       "name": "yauzl",
       "npm": {
         "name": "yauzl",
-        "version": ">=2.10.0 <3.0.0",
+        "version": ">=2.10.0 <3.0.0-0",
       },
       "package_id": 492,
     },
@@ -6939,7 +6939,7 @@ exports[`next build works: bun 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -6952,7 +6952,7 @@ exports[`next build works: bun 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -6965,7 +6965,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -6978,7 +6978,7 @@ exports[`next build works: bun 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -6991,7 +6991,7 @@ exports[`next build works: bun 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -7004,7 +7004,7 @@ exports[`next build works: bun 1`] = `
       "name": "reusify",
       "npm": {
         "name": "reusify",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 411,
     },
@@ -7017,7 +7017,7 @@ exports[`next build works: bun 1`] = `
       "name": "pend",
       "npm": {
         "name": "pend",
-        "version": ">=1.2.0 <1.3.0",
+        "version": ">=1.2.0 <1.3.0-0",
       },
       "package_id": 377,
     },
@@ -7031,7 +7031,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 379,
     },
@@ -7044,7 +7044,7 @@ exports[`next build works: bun 1`] = `
       "name": "flat-cache",
       "npm": {
         "name": "flat-cache",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 245,
     },
@@ -7057,7 +7057,7 @@ exports[`next build works: bun 1`] = `
       "name": "to-regex-range",
       "npm": {
         "name": "to-regex-range",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 459,
     },
@@ -7070,7 +7070,7 @@ exports[`next build works: bun 1`] = `
       "name": "locate-path",
       "npm": {
         "name": "locate-path",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 333,
     },
@@ -7083,7 +7083,7 @@ exports[`next build works: bun 1`] = `
       "name": "path-exists",
       "npm": {
         "name": "path-exists",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 373,
     },
@@ -7096,7 +7096,7 @@ exports[`next build works: bun 1`] = `
       "name": "flatted",
       "npm": {
         "name": "flatted",
-        "version": ">=3.2.9 <4.0.0",
+        "version": ">=3.2.9 <4.0.0-0",
       },
       "package_id": 246,
     },
@@ -7109,7 +7109,7 @@ exports[`next build works: bun 1`] = `
       "name": "keyv",
       "npm": {
         "name": "keyv",
-        "version": ">=4.5.4 <5.0.0",
+        "version": ">=4.5.4 <5.0.0-0",
       },
       "package_id": 327,
     },
@@ -7122,7 +7122,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7135,7 +7135,7 @@ exports[`next build works: bun 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -7148,7 +7148,7 @@ exports[`next build works: bun 1`] = `
       "name": "signal-exit",
       "npm": {
         "name": "signal-exit",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 428,
     },
@@ -7161,7 +7161,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7174,7 +7174,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7187,7 +7187,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7200,7 +7200,7 @@ exports[`next build works: bun 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -7213,7 +7213,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7226,7 +7226,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -7239,7 +7239,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -7252,7 +7252,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7265,7 +7265,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7278,7 +7278,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7291,7 +7291,7 @@ exports[`next build works: bun 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7304,7 +7304,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7317,7 +7317,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7330,7 +7330,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7343,7 +7343,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7356,7 +7356,7 @@ exports[`next build works: bun 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -7369,7 +7369,7 @@ exports[`next build works: bun 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7382,7 +7382,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -7395,7 +7395,7 @@ exports[`next build works: bun 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -7408,7 +7408,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7421,7 +7421,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7434,7 +7434,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7447,7 +7447,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve-pkg-maps",
       "npm": {
         "name": "resolve-pkg-maps",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 410,
     },
@@ -7460,7 +7460,7 @@ exports[`next build works: bun 1`] = `
       "name": "basic-ftp",
       "npm": {
         "name": "basic-ftp",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 156,
     },
@@ -7473,7 +7473,7 @@ exports[`next build works: bun 1`] = `
       "name": "data-uri-to-buffer",
       "npm": {
         "name": "data-uri-to-buffer",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 184,
     },
@@ -7486,7 +7486,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7499,7 +7499,7 @@ exports[`next build works: bun 1`] = `
       "name": "foreground-child",
       "npm": {
         "name": "foreground-child",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 248,
     },
@@ -7512,7 +7512,7 @@ exports[`next build works: bun 1`] = `
       "name": "jackspeak",
       "npm": {
         "name": "jackspeak",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 315,
     },
@@ -7525,7 +7525,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=9.0.4 <10.0.0",
+        "version": ">=9.0.4 <10.0.0-0",
       },
       "package_id": 519,
     },
@@ -7538,7 +7538,7 @@ exports[`next build works: bun 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -7551,7 +7551,7 @@ exports[`next build works: bun 1`] = `
       "name": "package-json-from-dist",
       "npm": {
         "name": "package-json-from-dist",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 370,
     },
@@ -7564,7 +7564,7 @@ exports[`next build works: bun 1`] = `
       "name": "path-scurry",
       "npm": {
         "name": "path-scurry",
-        "version": ">=1.11.1 <2.0.0",
+        "version": ">=1.11.1 <2.0.0-0",
       },
       "package_id": 376,
     },
@@ -7577,7 +7577,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -7590,7 +7590,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -7603,7 +7603,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -7616,7 +7616,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -7629,7 +7629,7 @@ exports[`next build works: bun 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -7642,7 +7642,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -7655,7 +7655,7 @@ exports[`next build works: bun 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -7681,7 +7681,7 @@ exports[`next build works: bun 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7694,7 +7694,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -7707,7 +7707,7 @@ exports[`next build works: bun 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -7720,7 +7720,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": "<5.0.0 >=4.0.0",
+        "version": "<5.0.0-0 >=4.0.0",
       },
       "package_id": 188,
     },
@@ -7733,7 +7733,7 @@ exports[`next build works: bun 1`] = `
       "name": "parent-module",
       "npm": {
         "name": "parent-module",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 371,
     },
@@ -7746,7 +7746,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve-from",
       "npm": {
         "name": "resolve-from",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 409,
     },
@@ -7759,7 +7759,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -7772,7 +7772,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -7785,7 +7785,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -7811,7 +7811,7 @@ exports[`next build works: bun 1`] = `
       "name": "sprintf-js",
       "npm": {
         "name": "sprintf-js",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 434,
     },
@@ -7824,7 +7824,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -7837,7 +7837,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7850,7 +7850,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -7863,7 +7863,7 @@ exports[`next build works: bun 1`] = `
       "name": "async-function",
       "npm": {
         "name": "async-function",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 143,
     },
@@ -7876,7 +7876,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7889,7 +7889,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -7902,7 +7902,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7915,7 +7915,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -7928,7 +7928,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -7941,7 +7941,7 @@ exports[`next build works: bun 1`] = `
       "name": "binary-extensions",
       "npm": {
         "name": "binary-extensions",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 157,
     },
@@ -7954,7 +7954,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -7967,7 +7967,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -7980,7 +7980,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.1 <8.0.0",
+        "version": ">=7.7.1 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -7993,7 +7993,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8006,7 +8006,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8019,7 +8019,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8032,7 +8032,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -8045,7 +8045,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8058,7 +8058,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8071,7 +8071,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8084,7 +8084,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8097,7 +8097,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8110,7 +8110,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8123,7 +8123,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8136,7 +8136,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-extglob",
       "npm": {
         "name": "is-extglob",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 294,
     },
@@ -8149,7 +8149,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8162,7 +8162,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8175,7 +8175,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8188,7 +8188,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -8201,7 +8201,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8214,7 +8214,7 @@ exports[`next build works: bun 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -8227,7 +8227,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8240,7 +8240,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8253,7 +8253,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -8266,7 +8266,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8279,7 +8279,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8292,7 +8292,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -8305,7 +8305,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -8318,7 +8318,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8331,7 +8331,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8344,7 +8344,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8357,7 +8357,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -8370,7 +8370,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -8383,7 +8383,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -8396,7 +8396,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -8409,7 +8409,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -8422,7 +8422,7 @@ exports[`next build works: bun 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -8435,7 +8435,7 @@ exports[`next build works: bun 1`] = `
       "name": "@pkgjs/parseargs",
       "npm": {
         "name": "@pkgjs/parseargs",
-        "version": ">=0.11.0 <0.12.0",
+        "version": ">=0.11.0 <0.12.0-0",
       },
       "package_id": 80,
     },
@@ -8448,7 +8448,7 @@ exports[`next build works: bun 1`] = `
       "name": "@isaacs/cliui",
       "npm": {
         "name": "@isaacs/cliui",
-        "version": ">=8.0.2 <9.0.0",
+        "version": ">=8.0.2 <9.0.0-0",
       },
       "package_id": 59,
     },
@@ -8461,7 +8461,7 @@ exports[`next build works: bun 1`] = `
       "name": "argparse",
       "npm": {
         "name": "argparse",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 131,
     },
@@ -8474,7 +8474,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -8487,7 +8487,7 @@ exports[`next build works: bun 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.6 <4.0.0",
+        "version": ">=3.1.6 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -8500,7 +8500,7 @@ exports[`next build works: bun 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -8513,7 +8513,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.4 <5.0.0",
+        "version": ">=4.1.4 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -8526,7 +8526,7 @@ exports[`next build works: bun 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -8552,7 +8552,7 @@ exports[`next build works: bun 1`] = `
       "name": "language-subtag-registry",
       "npm": {
         "name": "language-subtag-registry",
-        "version": ">=0.3.20 <0.4.0",
+        "version": ">=0.3.20 <0.4.0-0",
       },
       "package_id": 328,
     },
@@ -8565,7 +8565,7 @@ exports[`next build works: bun 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -8578,7 +8578,7 @@ exports[`next build works: bun 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -8591,7 +8591,7 @@ exports[`next build works: bun 1`] = `
       "name": "p-locate",
       "npm": {
         "name": "p-locate",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 367,
     },
@@ -8604,7 +8604,7 @@ exports[`next build works: bun 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -8617,7 +8617,7 @@ exports[`next build works: bun 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.3 <4.0.0",
+        "version": ">=3.0.3 <4.0.0-0",
       },
       "package_id": 159,
     },
@@ -8630,7 +8630,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.3.1 <3.0.0",
+        "version": ">=2.3.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -8643,7 +8643,7 @@ exports[`next build works: bun 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 158,
     },
@@ -8656,7 +8656,7 @@ exports[`next build works: bun 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -8669,7 +8669,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -8682,7 +8682,7 @@ exports[`next build works: bun 1`] = `
       "name": "thenify-all",
       "npm": {
         "name": "thenify-all",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 457,
     },
@@ -8799,7 +8799,7 @@ exports[`next build works: bun 1`] = `
       "name": "sharp",
       "npm": {
         "name": "sharp",
-        "version": ">=0.34.4 <0.35.0",
+        "version": ">=0.34.4 <0.35.0-0",
       },
       "package_id": 421,
     },
@@ -8838,7 +8838,7 @@ exports[`next build works: bun 1`] = `
       "name": "baseline-browser-mapping",
       "npm": {
         "name": "baseline-browser-mapping",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 155,
     },
@@ -8851,7 +8851,7 @@ exports[`next build works: bun 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001579 <2.0.0",
+        "version": ">=1.0.30001579 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -8891,7 +8891,7 @@ exports[`next build works: bun 1`] = `
       "name": "@opentelemetry/api",
       "npm": {
         "name": "@opentelemetry/api",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8905,7 +8905,7 @@ exports[`next build works: bun 1`] = `
       "name": "@playwright/test",
       "npm": {
         "name": "@playwright/test",
-        "version": ">=1.51.1 <2.0.0",
+        "version": ">=1.51.1 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8932,7 +8932,7 @@ exports[`next build works: bun 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -8945,7 +8945,7 @@ exports[`next build works: bun 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -8959,7 +8959,7 @@ exports[`next build works: bun 1`] = `
       "name": "sass",
       "npm": {
         "name": "sass",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -8972,7 +8972,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -8985,7 +8985,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -8998,7 +8998,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9011,7 +9011,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9024,7 +9024,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -9037,7 +9037,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9050,7 +9050,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9063,7 +9063,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9076,7 +9076,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9089,7 +9089,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9102,7 +9102,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9115,7 +9115,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9128,7 +9128,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9141,7 +9141,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9154,7 +9154,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9167,7 +9167,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9180,7 +9180,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -9193,7 +9193,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -9206,7 +9206,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -9219,7 +9219,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -9232,7 +9232,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -9245,7 +9245,7 @@ exports[`next build works: bun 1`] = `
       "name": "wrappy",
       "npm": {
         "name": "wrappy",
-        "version": "<2.0.0 >=1.0.0",
+        "version": "<2.0.0-0 >=1.0.0",
       },
       "package_id": 485,
     },
@@ -9258,7 +9258,7 @@ exports[`next build works: bun 1`] = `
       "name": "deep-is",
       "npm": {
         "name": "deep-is",
-        "version": ">=0.1.3 <0.2.0",
+        "version": ">=0.1.3 <0.2.0-0",
       },
       "package_id": 189,
     },
@@ -9271,7 +9271,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-levenshtein",
       "npm": {
         "name": "fast-levenshtein",
-        "version": ">=2.0.6 <3.0.0",
+        "version": ">=2.0.6 <3.0.0-0",
       },
       "package_id": 238,
     },
@@ -9284,7 +9284,7 @@ exports[`next build works: bun 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -9297,7 +9297,7 @@ exports[`next build works: bun 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -9310,7 +9310,7 @@ exports[`next build works: bun 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -9323,7 +9323,7 @@ exports[`next build works: bun 1`] = `
       "name": "word-wrap",
       "npm": {
         "name": "word-wrap",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 483,
     },
@@ -9336,7 +9336,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -9349,7 +9349,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -9362,7 +9362,7 @@ exports[`next build works: bun 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -9375,7 +9375,7 @@ exports[`next build works: bun 1`] = `
       "name": "yocto-queue",
       "npm": {
         "name": "yocto-queue",
-        "version": ">=0.1.0 <0.2.0",
+        "version": ">=0.1.0 <0.2.0-0",
       },
       "package_id": 493,
     },
@@ -9388,7 +9388,7 @@ exports[`next build works: bun 1`] = `
       "name": "p-limit",
       "npm": {
         "name": "p-limit",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 366,
     },
@@ -9401,7 +9401,7 @@ exports[`next build works: bun 1`] = `
       "name": "@tootallnate/quickjs-emscripten",
       "npm": {
         "name": "@tootallnate/quickjs-emscripten",
-        "version": ">=0.23.0 <0.24.0",
+        "version": ">=0.23.0 <0.24.0-0",
       },
       "package_id": 84,
     },
@@ -9414,7 +9414,7 @@ exports[`next build works: bun 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9427,7 +9427,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9440,7 +9440,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-uri",
       "npm": {
         "name": "get-uri",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 261,
     },
@@ -9453,7 +9453,7 @@ exports[`next build works: bun 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9466,7 +9466,7 @@ exports[`next build works: bun 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9479,7 +9479,7 @@ exports[`next build works: bun 1`] = `
       "name": "pac-resolver",
       "npm": {
         "name": "pac-resolver",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 369,
     },
@@ -9492,7 +9492,7 @@ exports[`next build works: bun 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9505,7 +9505,7 @@ exports[`next build works: bun 1`] = `
       "name": "degenerator",
       "npm": {
         "name": "degenerator",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 192,
     },
@@ -9518,7 +9518,7 @@ exports[`next build works: bun 1`] = `
       "name": "netmask",
       "npm": {
         "name": "netmask",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 349,
     },
@@ -9531,7 +9531,7 @@ exports[`next build works: bun 1`] = `
       "name": "callsites",
       "npm": {
         "name": "callsites",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 166,
     },
@@ -9544,7 +9544,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 521,
     },
@@ -9557,7 +9557,7 @@ exports[`next build works: bun 1`] = `
       "name": "error-ex",
       "npm": {
         "name": "error-ex",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 204,
     },
@@ -9570,7 +9570,7 @@ exports[`next build works: bun 1`] = `
       "name": "json-parse-even-better-errors",
       "npm": {
         "name": "json-parse-even-better-errors",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 322,
     },
@@ -9583,7 +9583,7 @@ exports[`next build works: bun 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -9596,7 +9596,7 @@ exports[`next build works: bun 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=10.2.0 <11.0.0",
+        "version": ">=10.2.0 <11.0.0-0",
       },
       "package_id": 522,
     },
@@ -9609,7 +9609,7 @@ exports[`next build works: bun 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=5.0.0 <6.0.0 || >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=7.0.0 <8.0.0",
+        "version": ">=5.0.0 <6.0.0-0 || >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=7.0.0 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -9622,7 +9622,7 @@ exports[`next build works: bun 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.11 <4.0.0",
+        "version": ">=3.3.11 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -9635,7 +9635,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -9648,7 +9648,7 @@ exports[`next build works: bun 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -9661,7 +9661,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -9674,7 +9674,7 @@ exports[`next build works: bun 1`] = `
       "name": "read-cache",
       "npm": {
         "name": "read-cache",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 403,
     },
@@ -9687,7 +9687,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -9700,7 +9700,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9713,7 +9713,7 @@ exports[`next build works: bun 1`] = `
       "name": "camelcase-css",
       "npm": {
         "name": "camelcase-css",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 167,
     },
@@ -9726,7 +9726,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.21 <9.0.0",
+        "version": ">=8.4.21 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9739,7 +9739,7 @@ exports[`next build works: bun 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -9752,7 +9752,7 @@ exports[`next build works: bun 1`] = `
       "name": "yaml",
       "npm": {
         "name": "yaml",
-        "version": ">=2.3.4 <3.0.0",
+        "version": ">=2.3.4 <3.0.0-0",
       },
       "package_id": 489,
     },
@@ -9793,7 +9793,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.1 <7.0.0",
+        "version": ">=6.1.1 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -9806,7 +9806,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.2.14 <9.0.0",
+        "version": ">=8.2.14 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -9819,7 +9819,7 @@ exports[`next build works: bun 1`] = `
       "name": "cssesc",
       "npm": {
         "name": "cssesc",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 181,
     },
@@ -9832,7 +9832,7 @@ exports[`next build works: bun 1`] = `
       "name": "util-deprecate",
       "npm": {
         "name": "util-deprecate",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 477,
     },
@@ -9845,7 +9845,7 @@ exports[`next build works: bun 1`] = `
       "name": "loose-envify",
       "npm": {
         "name": "loose-envify",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 335,
     },
@@ -9858,7 +9858,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -9871,7 +9871,7 @@ exports[`next build works: bun 1`] = `
       "name": "react-is",
       "npm": {
         "name": "react-is",
-        "version": ">=16.13.1 <17.0.0",
+        "version": ">=16.13.1 <17.0.0-0",
       },
       "package_id": 402,
     },
@@ -9884,7 +9884,7 @@ exports[`next build works: bun 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -9897,7 +9897,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -9910,7 +9910,7 @@ exports[`next build works: bun 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -9923,7 +9923,7 @@ exports[`next build works: bun 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -9936,7 +9936,7 @@ exports[`next build works: bun 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=7.14.1 <8.0.0",
+        "version": ">=7.14.1 <8.0.0-0",
       },
       "package_id": 336,
     },
@@ -9949,7 +9949,7 @@ exports[`next build works: bun 1`] = `
       "name": "pac-proxy-agent",
       "npm": {
         "name": "pac-proxy-agent",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 368,
     },
@@ -9962,7 +9962,7 @@ exports[`next build works: bun 1`] = `
       "name": "proxy-from-env",
       "npm": {
         "name": "proxy-from-env",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 394,
     },
@@ -9975,7 +9975,7 @@ exports[`next build works: bun 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -9988,7 +9988,7 @@ exports[`next build works: bun 1`] = `
       "name": "end-of-stream",
       "npm": {
         "name": "end-of-stream",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 202,
     },
@@ -10001,7 +10001,7 @@ exports[`next build works: bun 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -10040,7 +10040,7 @@ exports[`next build works: bun 1`] = `
       "name": "cosmiconfig",
       "npm": {
         "name": "cosmiconfig",
-        "version": ">=9.0.0 <10.0.0",
+        "version": ">=9.0.0 <10.0.0-0",
       },
       "package_id": 179,
     },
@@ -10079,7 +10079,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10118,7 +10118,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -10144,7 +10144,7 @@ exports[`next build works: bun 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -10157,7 +10157,7 @@ exports[`next build works: bun 1`] = `
       "name": "ws",
       "npm": {
         "name": "ws",
-        "version": ">=8.18.3 <9.0.0",
+        "version": ">=8.18.3 <9.0.0-0",
       },
       "package_id": 486,
     },
@@ -10170,7 +10170,7 @@ exports[`next build works: bun 1`] = `
       "name": "scheduler",
       "npm": {
         "name": "scheduler",
-        "version": ">=0.27.0 <0.28.0",
+        "version": ">=0.27.0 <0.28.0-0",
       },
       "package_id": 416,
     },
@@ -10183,7 +10183,7 @@ exports[`next build works: bun 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.4 <20.0.0",
+        "version": ">=19.2.4 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -10196,7 +10196,7 @@ exports[`next build works: bun 1`] = `
       "name": "pify",
       "npm": {
         "name": "pify",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 380,
     },
@@ -10209,7 +10209,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -10222,7 +10222,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10235,7 +10235,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10248,7 +10248,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -10261,7 +10261,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10274,7 +10274,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -10287,7 +10287,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10300,7 +10300,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10313,7 +10313,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-builtin-type",
       "npm": {
         "name": "which-builtin-type",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 480,
     },
@@ -10326,7 +10326,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10339,7 +10339,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -10352,7 +10352,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10365,7 +10365,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -10378,7 +10378,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10391,7 +10391,7 @@ exports[`next build works: bun 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -10404,7 +10404,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.0 <3.0.0",
+        "version": ">=2.16.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -10417,7 +10417,7 @@ exports[`next build works: bun 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -10430,7 +10430,7 @@ exports[`next build works: bun 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -10443,7 +10443,7 @@ exports[`next build works: bun 1`] = `
       "name": "queue-microtask",
       "npm": {
         "name": "queue-microtask",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 399,
     },
@@ -10456,7 +10456,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -10469,7 +10469,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10482,7 +10482,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10495,7 +10495,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -10508,7 +10508,7 @@ exports[`next build works: bun 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10521,7 +10521,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10534,7 +10534,7 @@ exports[`next build works: bun 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -10547,7 +10547,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -10560,7 +10560,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10573,7 +10573,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -10586,7 +10586,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10599,7 +10599,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10612,7 +10612,7 @@ exports[`next build works: bun 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -10625,7 +10625,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -10638,7 +10638,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -10651,7 +10651,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10664,7 +10664,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -10677,7 +10677,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10690,7 +10690,7 @@ exports[`next build works: bun 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -10703,7 +10703,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -10716,7 +10716,7 @@ exports[`next build works: bun 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -10729,7 +10729,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -10742,7 +10742,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11067,7 +11067,7 @@ exports[`next build works: bun 1`] = `
       "name": "@img/colour",
       "npm": {
         "name": "@img/colour",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 34,
     },
@@ -11080,7 +11080,7 @@ exports[`next build works: bun 1`] = `
       "name": "detect-libc",
       "npm": {
         "name": "detect-libc",
-        "version": ">=2.1.2 <3.0.0",
+        "version": ">=2.1.2 <3.0.0-0",
       },
       "package_id": 193,
     },
@@ -11093,7 +11093,7 @@ exports[`next build works: bun 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -11106,7 +11106,7 @@ exports[`next build works: bun 1`] = `
       "name": "shebang-regex",
       "npm": {
         "name": "shebang-regex",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 423,
     },
@@ -11119,7 +11119,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11132,7 +11132,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11145,7 +11145,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel-list",
       "npm": {
         "name": "side-channel-list",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 425,
     },
@@ -11158,7 +11158,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11171,7 +11171,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel-weakmap",
       "npm": {
         "name": "side-channel-weakmap",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 427,
     },
@@ -11184,7 +11184,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11197,7 +11197,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11210,7 +11210,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11223,7 +11223,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11236,7 +11236,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11249,7 +11249,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11262,7 +11262,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11275,7 +11275,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11288,7 +11288,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11301,7 +11301,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -11314,7 +11314,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -11327,7 +11327,7 @@ exports[`next build works: bun 1`] = `
       "name": "ip-address",
       "npm": {
         "name": "ip-address",
-        "version": ">=9.0.5 <10.0.0",
+        "version": ">=9.0.5 <10.0.0-0",
       },
       "package_id": 282,
     },
@@ -11340,7 +11340,7 @@ exports[`next build works: bun 1`] = `
       "name": "smart-buffer",
       "npm": {
         "name": "smart-buffer",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 429,
     },
@@ -11353,7 +11353,7 @@ exports[`next build works: bun 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -11366,7 +11366,7 @@ exports[`next build works: bun 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -11379,7 +11379,7 @@ exports[`next build works: bun 1`] = `
       "name": "socks",
       "npm": {
         "name": "socks",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 430,
     },
@@ -11392,7 +11392,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11405,7 +11405,7 @@ exports[`next build works: bun 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11418,7 +11418,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.2.0 <3.0.0",
+        "version": ">=2.2.0 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -11431,7 +11431,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -11444,7 +11444,7 @@ exports[`next build works: bun 1`] = `
       "name": "text-decoder",
       "npm": {
         "name": "text-decoder",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 455,
     },
@@ -11457,7 +11457,7 @@ exports[`next build works: bun 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 523,
     },
@@ -11470,7 +11470,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 296,
     },
@@ -11483,7 +11483,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -11496,7 +11496,7 @@ exports[`next build works: bun 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": null,
     },
@@ -11509,7 +11509,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": null,
     },
@@ -11522,7 +11522,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -11535,7 +11535,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11548,7 +11548,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11561,7 +11561,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11574,7 +11574,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11587,7 +11587,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11600,7 +11600,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11613,7 +11613,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11626,7 +11626,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -11639,7 +11639,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11652,7 +11652,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -11665,7 +11665,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -11678,7 +11678,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -11691,7 +11691,7 @@ exports[`next build works: bun 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -11704,7 +11704,7 @@ exports[`next build works: bun 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.3 <2.0.0",
+        "version": ">=1.5.3 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -11717,7 +11717,7 @@ exports[`next build works: bun 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -11730,7 +11730,7 @@ exports[`next build works: bun 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -11743,7 +11743,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11756,7 +11756,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.17.5 <2.0.0",
+        "version": ">=1.17.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11769,7 +11769,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11782,7 +11782,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11795,7 +11795,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -11808,7 +11808,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11821,7 +11821,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -11834,7 +11834,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11847,7 +11847,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -11860,7 +11860,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11873,7 +11873,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -11886,7 +11886,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11899,7 +11899,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11912,7 +11912,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -11925,7 +11925,7 @@ exports[`next build works: bun 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -11938,7 +11938,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -11951,7 +11951,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 126,
     },
@@ -11964,7 +11964,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": null,
     },
@@ -11990,7 +11990,7 @@ exports[`next build works: bun 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=16.8.0 || <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=19.0.0-0 <20.0.0",
+        "version": ">=16.8.0 || <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=19.0.0-0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -12003,7 +12003,7 @@ exports[`next build works: bun 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.2 <0.4.0",
+        "version": ">=0.3.2 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -12016,7 +12016,7 @@ exports[`next build works: bun 1`] = `
       "name": "commander",
       "npm": {
         "name": "commander",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 176,
     },
@@ -12029,7 +12029,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob",
       "npm": {
         "name": "glob",
-        "version": ">=10.3.10 <11.0.0",
+        "version": ">=10.3.10 <11.0.0-0",
       },
       "package_id": 262,
     },
@@ -12042,7 +12042,7 @@ exports[`next build works: bun 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -12055,7 +12055,7 @@ exports[`next build works: bun 1`] = `
       "name": "mz",
       "npm": {
         "name": "mz",
-        "version": ">=2.7.0 <3.0.0",
+        "version": ">=2.7.0 <3.0.0-0",
       },
       "package_id": 345,
     },
@@ -12068,7 +12068,7 @@ exports[`next build works: bun 1`] = `
       "name": "pirates",
       "npm": {
         "name": "pirates",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 381,
     },
@@ -12081,7 +12081,7 @@ exports[`next build works: bun 1`] = `
       "name": "ts-interface-checker",
       "npm": {
         "name": "ts-interface-checker",
-        "version": ">=0.1.9 <0.2.0",
+        "version": ">=0.1.9 <0.2.0-0",
       },
       "package_id": 461,
     },
@@ -12094,7 +12094,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-flag",
       "npm": {
         "name": "has-flag",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 268,
     },
@@ -12107,7 +12107,7 @@ exports[`next build works: bun 1`] = `
       "name": "@alloc/quick-lru",
       "npm": {
         "name": "@alloc/quick-lru",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 1,
     },
@@ -12120,7 +12120,7 @@ exports[`next build works: bun 1`] = `
       "name": "arg",
       "npm": {
         "name": "arg",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 130,
     },
@@ -12133,7 +12133,7 @@ exports[`next build works: bun 1`] = `
       "name": "chokidar",
       "npm": {
         "name": "chokidar",
-        "version": ">=3.6.0 <4.0.0",
+        "version": ">=3.6.0 <4.0.0-0",
       },
       "package_id": 170,
     },
@@ -12146,7 +12146,7 @@ exports[`next build works: bun 1`] = `
       "name": "didyoumean",
       "npm": {
         "name": "didyoumean",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 195,
     },
@@ -12159,7 +12159,7 @@ exports[`next build works: bun 1`] = `
       "name": "dlv",
       "npm": {
         "name": "dlv",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 196,
     },
@@ -12172,7 +12172,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-glob",
       "npm": {
         "name": "fast-glob",
-        "version": ">=3.3.2 <4.0.0",
+        "version": ">=3.3.2 <4.0.0-0",
       },
       "package_id": 236,
     },
@@ -12185,7 +12185,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -12198,7 +12198,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -12211,7 +12211,7 @@ exports[`next build works: bun 1`] = `
       "name": "jiti",
       "npm": {
         "name": "jiti",
-        "version": ">=1.21.6 <2.0.0",
+        "version": ">=1.21.6 <2.0.0-0",
       },
       "package_id": 316,
     },
@@ -12224,7 +12224,7 @@ exports[`next build works: bun 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -12237,7 +12237,7 @@ exports[`next build works: bun 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -12250,7 +12250,7 @@ exports[`next build works: bun 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -12263,7 +12263,7 @@ exports[`next build works: bun 1`] = `
       "name": "object-hash",
       "npm": {
         "name": "object-hash",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 355,
     },
@@ -12276,7 +12276,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -12289,7 +12289,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.47 <9.0.0",
+        "version": ">=8.4.47 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -12302,7 +12302,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-import",
       "npm": {
         "name": "postcss-import",
-        "version": ">=15.1.0 <16.0.0",
+        "version": ">=15.1.0 <16.0.0-0",
       },
       "package_id": 384,
     },
@@ -12315,7 +12315,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-js",
       "npm": {
         "name": "postcss-js",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 385,
     },
@@ -12328,7 +12328,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-load-config",
       "npm": {
         "name": "postcss-load-config",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 386,
     },
@@ -12341,7 +12341,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-nested",
       "npm": {
         "name": "postcss-nested",
-        "version": ">=6.2.0 <7.0.0",
+        "version": ">=6.2.0 <7.0.0-0",
       },
       "package_id": 387,
     },
@@ -12354,7 +12354,7 @@ exports[`next build works: bun 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.2 <7.0.0",
+        "version": ">=6.1.2 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -12367,7 +12367,7 @@ exports[`next build works: bun 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.8 <2.0.0",
+        "version": ">=1.22.8 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -12380,7 +12380,7 @@ exports[`next build works: bun 1`] = `
       "name": "sucrase",
       "npm": {
         "name": "sucrase",
-        "version": ">=3.35.0 <4.0.0",
+        "version": ">=3.35.0 <4.0.0-0",
       },
       "package_id": 449,
     },
@@ -12393,7 +12393,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-fs",
       "npm": {
         "name": "bare-fs",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 151,
     },
@@ -12406,7 +12406,7 @@ exports[`next build works: bun 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -12419,7 +12419,7 @@ exports[`next build works: bun 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -12432,7 +12432,7 @@ exports[`next build works: bun 1`] = `
       "name": "tar-stream",
       "npm": {
         "name": "tar-stream",
-        "version": ">=3.1.5 <4.0.0",
+        "version": ">=3.1.5 <4.0.0-0",
       },
       "package_id": 454,
     },
@@ -12445,7 +12445,7 @@ exports[`next build works: bun 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12458,7 +12458,7 @@ exports[`next build works: bun 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -12471,7 +12471,7 @@ exports[`next build works: bun 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.15.0 <3.0.0",
+        "version": ">=2.15.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -12484,7 +12484,7 @@ exports[`next build works: bun 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -12497,7 +12497,7 @@ exports[`next build works: bun 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -12510,7 +12510,7 @@ exports[`next build works: bun 1`] = `
       "name": "thenify",
       "npm": {
         "name": "thenify",
-        "version": ">=3.1.0 && <4.0.0",
+        "version": ">=3.1.0 && <4.0.0-0",
       },
       "package_id": 456,
     },
@@ -12523,7 +12523,7 @@ exports[`next build works: bun 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.4.4 <7.0.0",
+        "version": ">=6.4.4 <7.0.0-0",
       },
       "package_id": 241,
     },
@@ -12536,7 +12536,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -12549,7 +12549,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 301,
     },
@@ -12575,7 +12575,7 @@ exports[`next build works: bun 1`] = `
       "name": "@types/json5",
       "npm": {
         "name": "@types/json5",
-        "version": ">=0.0.29 <0.0.30",
+        "version": ">=0.0.29 <0.0.30-0",
       },
       "package_id": 88,
     },
@@ -12588,7 +12588,7 @@ exports[`next build works: bun 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 325,
     },
@@ -12601,7 +12601,7 @@ exports[`next build works: bun 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -12614,7 +12614,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-bom",
       "npm": {
         "name": "strip-bom",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 446,
     },
@@ -12627,7 +12627,7 @@ exports[`next build works: bun 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -12640,7 +12640,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -12653,7 +12653,7 @@ exports[`next build works: bun 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -12666,7 +12666,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12679,7 +12679,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12692,7 +12692,7 @@ exports[`next build works: bun 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12705,7 +12705,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12718,7 +12718,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12731,7 +12731,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12744,7 +12744,7 @@ exports[`next build works: bun 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -12757,7 +12757,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12770,7 +12770,7 @@ exports[`next build works: bun 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12783,7 +12783,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12796,7 +12796,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -12809,7 +12809,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12822,7 +12822,7 @@ exports[`next build works: bun 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12835,7 +12835,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -12848,7 +12848,7 @@ exports[`next build works: bun 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -12861,7 +12861,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -12874,7 +12874,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -12887,7 +12887,7 @@ exports[`next build works: bun 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -12900,7 +12900,7 @@ exports[`next build works: bun 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -12965,7 +12965,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -12991,7 +12991,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13004,7 +13004,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -13017,7 +13017,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -13030,7 +13030,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13290,7 +13290,7 @@ exports[`next build works: bun 1`] = `
       "name": "napi-postinstall",
       "npm": {
         "name": "napi-postinstall",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 347,
     },
@@ -13303,7 +13303,7 @@ exports[`next build works: bun 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.2.0 <4.0.0",
+        "version": ">=3.2.0 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13316,7 +13316,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -13342,7 +13342,7 @@ exports[`next build works: bun 1`] = `
       "name": "punycode",
       "npm": {
         "name": "punycode",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 396,
     },
@@ -13355,7 +13355,7 @@ exports[`next build works: bun 1`] = `
       "name": "isexe",
       "npm": {
         "name": "isexe",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 313,
     },
@@ -13368,7 +13368,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-bigint",
       "npm": {
         "name": "is-bigint",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 286,
     },
@@ -13381,7 +13381,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-boolean-object",
       "npm": {
         "name": "is-boolean-object",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 288,
     },
@@ -13394,7 +13394,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-number-object",
       "npm": {
         "name": "is-number-object",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 302,
     },
@@ -13407,7 +13407,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -13420,7 +13420,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -13433,7 +13433,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13446,7 +13446,7 @@ exports[`next build works: bun 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -13459,7 +13459,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13472,7 +13472,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-async-function",
       "npm": {
         "name": "is-async-function",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 285,
     },
@@ -13485,7 +13485,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -13498,7 +13498,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-finalizationregistry",
       "npm": {
         "name": "is-finalizationregistry",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 295,
     },
@@ -13511,7 +13511,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-generator-function",
       "npm": {
         "name": "is-generator-function",
-        "version": ">=1.0.10 <2.0.0",
+        "version": ">=1.0.10 <2.0.0-0",
       },
       "package_id": 297,
     },
@@ -13524,7 +13524,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -13537,7 +13537,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -13550,7 +13550,7 @@ exports[`next build works: bun 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -13563,7 +13563,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -13576,7 +13576,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-collection",
       "npm": {
         "name": "which-collection",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 481,
     },
@@ -13589,7 +13589,7 @@ exports[`next build works: bun 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -13602,7 +13602,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-map",
       "npm": {
         "name": "is-map",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 299,
     },
@@ -13615,7 +13615,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -13628,7 +13628,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-weakmap",
       "npm": {
         "name": "is-weakmap",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 309,
     },
@@ -13641,7 +13641,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-weakset",
       "npm": {
         "name": "is-weakset",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 311,
     },
@@ -13654,7 +13654,7 @@ exports[`next build works: bun 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -13667,7 +13667,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -13680,7 +13680,7 @@ exports[`next build works: bun 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -13693,7 +13693,7 @@ exports[`next build works: bun 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -13706,7 +13706,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -13719,7 +13719,7 @@ exports[`next build works: bun 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -13732,7 +13732,7 @@ exports[`next build works: bun 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -13745,7 +13745,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -13758,7 +13758,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13771,7 +13771,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -13784,7 +13784,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13797,7 +13797,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13810,7 +13810,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -13824,7 +13824,7 @@ exports[`next build works: bun 1`] = `
       "name": "bufferutil",
       "npm": {
         "name": "bufferutil",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -13851,7 +13851,7 @@ exports[`next build works: bun 1`] = `
       "name": "cliui",
       "npm": {
         "name": "cliui",
-        "version": ">=8.0.1 <9.0.0",
+        "version": ">=8.0.1 <9.0.0-0",
       },
       "package_id": 173,
     },
@@ -13864,7 +13864,7 @@ exports[`next build works: bun 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -13877,7 +13877,7 @@ exports[`next build works: bun 1`] = `
       "name": "get-caller-file",
       "npm": {
         "name": "get-caller-file",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 255,
     },
@@ -13890,7 +13890,7 @@ exports[`next build works: bun 1`] = `
       "name": "require-directory",
       "npm": {
         "name": "require-directory",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 407,
     },
@@ -13903,7 +13903,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.3 <5.0.0",
+        "version": ">=4.2.3 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -13916,7 +13916,7 @@ exports[`next build works: bun 1`] = `
       "name": "y18n",
       "npm": {
         "name": "y18n",
-        "version": ">=5.0.5 <6.0.0",
+        "version": ">=5.0.5 <6.0.0-0",
       },
       "package_id": 487,
     },
@@ -13929,7 +13929,7 @@ exports[`next build works: bun 1`] = `
       "name": "yargs-parser",
       "npm": {
         "name": "yargs-parser",
-        "version": ">=21.1.1 <22.0.0",
+        "version": ">=21.1.1 <22.0.0-0",
       },
       "package_id": 491,
     },
@@ -13942,7 +13942,7 @@ exports[`next build works: bun 1`] = `
       "name": "buffer-crc32",
       "npm": {
         "name": "buffer-crc32",
-        "version": ">=0.2.3 <0.3.0",
+        "version": ">=0.2.3 <0.3.0-0",
       },
       "package_id": 161,
     },
@@ -13955,7 +13955,7 @@ exports[`next build works: bun 1`] = `
       "name": "fd-slicer",
       "npm": {
         "name": "fd-slicer",
-        "version": ">=1.1.0 <1.2.0",
+        "version": ">=1.1.0 <1.2.0-0",
       },
       "package_id": 240,
     },
@@ -13968,7 +13968,7 @@ exports[`next build works: bun 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -13981,7 +13981,7 @@ exports[`next build works: bun 1`] = `
       "name": "yallist",
       "npm": {
         "name": "yallist",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 488,
     },
@@ -13994,7 +13994,7 @@ exports[`next build works: bun 1`] = `
       "name": "eastasianwidth",
       "npm": {
         "name": "eastasianwidth",
-        "version": ">=0.2.0 <0.3.0",
+        "version": ">=0.2.0 <0.3.0-0",
       },
       "package_id": 199,
     },
@@ -14007,7 +14007,7 @@ exports[`next build works: bun 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -14020,7 +14020,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14033,7 +14033,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 525,
     },
@@ -14046,7 +14046,7 @@ exports[`next build works: bun 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=6.1.0 <7.0.0",
+        "version": ">=6.1.0 <7.0.0-0",
       },
       "package_id": 526,
     },
@@ -14059,7 +14059,7 @@ exports[`next build works: bun 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -14072,7 +14072,7 @@ exports[`next build works: bun 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -14085,7 +14085,7 @@ exports[`next build works: bun 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -14098,7 +14098,7 @@ exports[`next build works: bun 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -14111,7 +14111,7 @@ exports[`next build works: bun 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -14124,7 +14124,7 @@ exports[`next build works: bun 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -14137,7 +14137,7 @@ exports[`next build works: bun 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -14150,7 +14150,7 @@ exports[`next build works: bun 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.4 <5.0.0",
+        "version": ">=4.0.4 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -14163,7 +14163,7 @@ exports[`next build works: bun 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": 527,
     },
@@ -14176,7 +14176,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14189,7 +14189,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14202,7 +14202,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14215,7 +14215,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14228,7 +14228,7 @@ exports[`next build works: bun 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 528,
     },
@@ -14241,7 +14241,7 @@ exports[`next build works: bun 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 529,
     },
@@ -14254,7 +14254,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14267,7 +14267,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -14280,7 +14280,7 @@ exports[`next build works: bun 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -14293,7 +14293,7 @@ exports[`next build works: bun 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": null,
     },
@@ -14306,7 +14306,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -14319,7 +14319,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -14332,7 +14332,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14345,7 +14345,7 @@ exports[`next build works: bun 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -14358,7 +14358,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -14371,7 +14371,7 @@ exports[`next build works: bun 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -14384,7 +14384,7 @@ exports[`next build works: bun 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -14397,7 +14397,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14410,7 +14410,7 @@ exports[`next build works: bun 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 530,
     },
@@ -14423,7 +14423,7 @@ exports[`next build works: bun 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.6 <4.0.0",
+        "version": ">=3.3.6 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -14436,7 +14436,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14449,7 +14449,7 @@ exports[`next build works: bun 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -14462,7 +14462,7 @@ exports[`next build works: bun 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 531,
     },
@@ -14475,7 +14475,7 @@ exports[`next build works: bun 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -14488,7 +14488,7 @@ exports[`next build works: bun 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -14501,7 +14501,7 @@ exports[`next build works: bun 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -14514,7 +14514,7 @@ exports[`next build works: bun 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 532,
     },
@@ -14528,7 +14528,7 @@ exports[`next build works: bun 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -14541,7 +14541,7 @@ exports[`next build works: bun 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },
@@ -28004,7 +28004,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -28017,7 +28017,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/react-dom",
       "npm": {
         "name": "@types/react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 91,
     },
@@ -28043,7 +28043,7 @@ exports[`next build works: node 1`] = `
       "name": "bun-types",
       "npm": {
         "name": "bun-types",
-        "version": ">=1.2.19 <2.0.0",
+        "version": ">=1.2.19 <2.0.0-0",
       },
       "package_id": 162,
     },
@@ -28056,7 +28056,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=9.33.0 <10.0.0",
+        "version": ">=9.33.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -28069,7 +28069,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-config-next",
       "npm": {
         "name": "eslint-config-next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 217,
     },
@@ -28082,7 +28082,7 @@ exports[`next build works: node 1`] = `
       "name": "next",
       "npm": {
         "name": "next",
-        "version": ">=16.1.0 <17.0.0",
+        "version": ">=16.1.0 <17.0.0-0",
       },
       "package_id": 350,
     },
@@ -28121,7 +28121,7 @@ exports[`next build works: node 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -28134,7 +28134,7 @@ exports[`next build works: node 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=19.2.3 <20.0.0",
+        "version": ">=19.2.3 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -28147,7 +28147,7 @@ exports[`next build works: node 1`] = `
       "name": "tailwindcss",
       "npm": {
         "name": "tailwindcss",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 452,
     },
@@ -28173,7 +28173,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -28186,7 +28186,7 @@ exports[`next build works: node 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -28199,7 +28199,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -28212,7 +28212,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -28225,7 +28225,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -28238,7 +28238,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-compilation-targets",
       "npm": {
         "name": "@babel/helper-compilation-targets",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 6,
     },
@@ -28251,7 +28251,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-module-transforms",
       "npm": {
         "name": "@babel/helper-module-transforms",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 9,
     },
@@ -28264,7 +28264,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helpers",
       "npm": {
         "name": "@babel/helpers",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 13,
     },
@@ -28277,7 +28277,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -28290,7 +28290,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -28303,7 +28303,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -28316,7 +28316,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28329,7 +28329,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/remapping",
       "npm": {
         "name": "@jridgewell/remapping",
-        "version": ">=2.3.5 <3.0.0",
+        "version": ">=2.3.5 <3.0.0-0",
       },
       "package_id": 61,
     },
@@ -28342,7 +28342,7 @@ exports[`next build works: node 1`] = `
       "name": "convert-source-map",
       "npm": {
         "name": "convert-source-map",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 178,
     },
@@ -28355,7 +28355,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -28368,7 +28368,7 @@ exports[`next build works: node 1`] = `
       "name": "gensync",
       "npm": {
         "name": "gensync",
-        "version": ">=1.0.0-beta.2 <2.0.0",
+        "version": ">=1.0.0-beta.2 <2.0.0-0",
       },
       "package_id": 254,
     },
@@ -28381,7 +28381,7 @@ exports[`next build works: node 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=2.2.3 <3.0.0",
+        "version": ">=2.2.3 <3.0.0-0",
       },
       "package_id": 496,
     },
@@ -28394,7 +28394,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -28407,7 +28407,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -28420,7 +28420,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28433,7 +28433,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.12 <0.4.0",
+        "version": ">=0.3.12 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -28446,7 +28446,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.28 <0.4.0",
+        "version": ">=0.3.28 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -28459,7 +28459,7 @@ exports[`next build works: node 1`] = `
       "name": "jsesc",
       "npm": {
         "name": "jsesc",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 320,
     },
@@ -28472,7 +28472,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/compat-data",
       "npm": {
         "name": "@babel/compat-data",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 3,
     },
@@ -28485,7 +28485,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-validator-option",
       "npm": {
         "name": "@babel/helper-validator-option",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 12,
     },
@@ -28498,7 +28498,7 @@ exports[`next build works: node 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.0 <5.0.0",
+        "version": ">=4.24.0 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -28511,7 +28511,7 @@ exports[`next build works: node 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=5.1.1 <6.0.0",
+        "version": ">=5.1.1 <6.0.0-0",
       },
       "package_id": 497,
     },
@@ -28524,7 +28524,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -28537,7 +28537,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -28550,7 +28550,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28563,7 +28563,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-module-imports",
       "npm": {
         "name": "@babel/helper-module-imports",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 8,
     },
@@ -28576,7 +28576,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -28589,7 +28589,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/traverse",
       "npm": {
         "name": "@babel/traverse",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 16,
     },
@@ -28602,7 +28602,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -28615,7 +28615,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -28628,7 +28628,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28641,7 +28641,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28654,7 +28654,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -28667,7 +28667,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -28680,7 +28680,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28693,7 +28693,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 2,
     },
@@ -28706,7 +28706,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/generator",
       "npm": {
         "name": "@babel/generator",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 5,
     },
@@ -28719,7 +28719,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-globals",
       "npm": {
         "name": "@babel/helper-globals",
-        "version": ">=7.28.0 <8.0.0",
+        "version": ">=7.28.0 <8.0.0-0",
       },
       "package_id": 7,
     },
@@ -28732,7 +28732,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -28745,7 +28745,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/template",
       "npm": {
         "name": "@babel/template",
-        "version": ">=7.28.6 <8.0.0",
+        "version": ">=7.28.6 <8.0.0-0",
       },
       "package_id": 15,
     },
@@ -28758,7 +28758,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/types",
       "npm": {
         "name": "@babel/types",
-        "version": ">=7.29.0 <8.0.0",
+        "version": ">=7.29.0 <8.0.0-0",
       },
       "package_id": 17,
     },
@@ -28771,7 +28771,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -28784,7 +28784,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-string-parser",
       "npm": {
         "name": "@babel/helper-string-parser",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 10,
     },
@@ -28797,7 +28797,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.28.5 <8.0.0",
+        "version": ">=7.28.5 <8.0.0-0",
       },
       "package_id": 11,
     },
@@ -28823,7 +28823,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -28836,7 +28836,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -28849,7 +28849,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -28862,7 +28862,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -28875,7 +28875,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -28888,7 +28888,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/object-schema",
       "npm": {
         "name": "@eslint/object-schema",
-        "version": ">=2.1.6 <3.0.0",
+        "version": ">=2.1.6 <3.0.0-0",
       },
       "package_id": 28,
     },
@@ -28901,7 +28901,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.1 <5.0.0",
+        "version": ">=4.3.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -28914,7 +28914,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -28927,7 +28927,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -28940,7 +28940,7 @@ exports[`next build works: node 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -28953,7 +28953,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -28966,7 +28966,7 @@ exports[`next build works: node 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.0.1 <11.0.0",
+        "version": ">=10.0.1 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -28979,7 +28979,7 @@ exports[`next build works: node 1`] = `
       "name": "globals",
       "npm": {
         "name": "globals",
-        "version": ">=14.0.0 <15.0.0",
+        "version": ">=14.0.0 <15.0.0-0",
       },
       "package_id": 499,
     },
@@ -28992,7 +28992,7 @@ exports[`next build works: node 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -29005,7 +29005,7 @@ exports[`next build works: node 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.2.1 <4.0.0",
+        "version": ">=3.2.1 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -29018,7 +29018,7 @@ exports[`next build works: node 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -29031,7 +29031,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -29044,7 +29044,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-json-comments",
       "npm": {
         "name": "strip-json-comments",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 447,
     },
@@ -29057,7 +29057,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -29070,7 +29070,7 @@ exports[`next build works: node 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -29083,7 +29083,7 @@ exports[`next build works: node 1`] = `
       "name": "@humanfs/core",
       "npm": {
         "name": "@humanfs/core",
-        "version": ">=0.19.1 <0.20.0",
+        "version": ">=0.19.1 <0.20.0-0",
       },
       "package_id": 30,
     },
@@ -29096,7 +29096,7 @@ exports[`next build works: node 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 500,
     },
@@ -29239,7 +29239,7 @@ exports[`next build works: node 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.7.0 <2.0.0",
+        "version": ">=1.7.0 <2.0.0-0",
       },
       "package_id": 19,
     },
@@ -29252,7 +29252,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -29266,7 +29266,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width-cjs",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -29279,7 +29279,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -29293,7 +29293,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi-cjs",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -29306,7 +29306,7 @@ exports[`next build works: node 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 503,
     },
@@ -29320,7 +29320,7 @@ exports[`next build works: node 1`] = `
       "name": "wrap-ansi-cjs",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -29333,7 +29333,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -29346,7 +29346,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -29359,7 +29359,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -29372,7 +29372,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/trace-mapping",
       "npm": {
         "name": "@jridgewell/trace-mapping",
-        "version": ">=0.3.24 <0.4.0",
+        "version": ">=0.3.24 <0.4.0-0",
       },
       "package_id": 64,
     },
@@ -29385,7 +29385,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/resolve-uri",
       "npm": {
         "name": "@jridgewell/resolve-uri",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 62,
     },
@@ -29398,7 +29398,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/sourcemap-codec",
       "npm": {
         "name": "@jridgewell/sourcemap-codec",
-        "version": ">=1.4.14 <2.0.0",
+        "version": ">=1.4.14 <2.0.0-0",
       },
       "package_id": 63,
     },
@@ -29411,7 +29411,7 @@ exports[`next build works: node 1`] = `
       "name": "@emnapi/core",
       "npm": {
         "name": "@emnapi/core",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 18,
     },
@@ -29424,7 +29424,7 @@ exports[`next build works: node 1`] = `
       "name": "@emnapi/runtime",
       "npm": {
         "name": "@emnapi/runtime",
-        "version": ">=1.4.3 <2.0.0",
+        "version": ">=1.4.3 <2.0.0-0",
       },
       "package_id": 504,
     },
@@ -29437,7 +29437,7 @@ exports[`next build works: node 1`] = `
       "name": "@tybys/wasm-util",
       "npm": {
         "name": "@tybys/wasm-util",
-        "version": ">=0.10.0 <0.11.0",
+        "version": ">=0.10.0 <0.11.0-0",
       },
       "package_id": 85,
     },
@@ -29476,7 +29476,7 @@ exports[`next build works: node 1`] = `
       "name": "run-parallel",
       "npm": {
         "name": "run-parallel",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 412,
     },
@@ -29502,7 +29502,7 @@ exports[`next build works: node 1`] = `
       "name": "fastq",
       "npm": {
         "name": "fastq",
-        "version": ">=1.6.0 <2.0.0",
+        "version": ">=1.6.0 <2.0.0-0",
       },
       "package_id": 239,
     },
@@ -29515,7 +29515,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -29528,7 +29528,7 @@ exports[`next build works: node 1`] = `
       "name": "extract-zip",
       "npm": {
         "name": "extract-zip",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 233,
     },
@@ -29541,7 +29541,7 @@ exports[`next build works: node 1`] = `
       "name": "progress",
       "npm": {
         "name": "progress",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 391,
     },
@@ -29554,7 +29554,7 @@ exports[`next build works: node 1`] = `
       "name": "proxy-agent",
       "npm": {
         "name": "proxy-agent",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 393,
     },
@@ -29567,7 +29567,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.2 <8.0.0",
+        "version": ">=7.7.2 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -29580,7 +29580,7 @@ exports[`next build works: node 1`] = `
       "name": "tar-fs",
       "npm": {
         "name": "tar-fs",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 453,
     },
@@ -29593,7 +29593,7 @@ exports[`next build works: node 1`] = `
       "name": "yargs",
       "npm": {
         "name": "yargs",
-        "version": ">=17.7.2 <18.0.0",
+        "version": ">=17.7.2 <18.0.0-0",
       },
       "package_id": 490,
     },
@@ -29606,7 +29606,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.8.0 <3.0.0",
+        "version": ">=2.8.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -29619,7 +29619,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -29632,7 +29632,7 @@ exports[`next build works: node 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.16.0 <7.17.0",
+        "version": ">=7.16.0 <7.17.0-0",
       },
       "package_id": 473,
     },
@@ -29645,7 +29645,7 @@ exports[`next build works: node 1`] = `
       "name": "csstype",
       "npm": {
         "name": "csstype",
-        "version": ">=3.2.2 <4.0.0",
+        "version": ">=3.2.2 <4.0.0-0",
       },
       "package_id": 182,
     },
@@ -29658,7 +29658,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.2.0 <20.0.0",
+        "version": ">=19.2.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -29684,7 +29684,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.2 <5.0.0",
+        "version": ">=4.12.2 <5.0.0-0",
       },
       "package_id": 508,
     },
@@ -29749,7 +29749,7 @@ exports[`next build works: node 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=7.0.5 <8.0.0",
+        "version": ">=7.0.5 <8.0.0-0",
       },
       "package_id": 509,
     },
@@ -29762,7 +29762,7 @@ exports[`next build works: node 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -29775,7 +29775,7 @@ exports[`next build works: node 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -29788,7 +29788,7 @@ exports[`next build works: node 1`] = `
       "name": "@typescript-eslint/parser",
       "npm": {
         "name": "@typescript-eslint/parser",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 94,
     },
@@ -29801,7 +29801,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -29879,7 +29879,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -29892,7 +29892,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -29918,7 +29918,7 @@ exports[`next build works: node 1`] = `
       "name": "@typescript-eslint/tsconfig-utils",
       "npm": {
         "name": "@typescript-eslint/tsconfig-utils",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 97,
     },
@@ -29931,7 +29931,7 @@ exports[`next build works: node 1`] = `
       "name": "@typescript-eslint/types",
       "npm": {
         "name": "@typescript-eslint/types",
-        "version": ">=8.57.0 <9.0.0",
+        "version": ">=8.57.0 <9.0.0-0",
       },
       "package_id": 99,
     },
@@ -29944,7 +29944,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -30048,7 +30048,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -30061,7 +30061,7 @@ exports[`next build works: node 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -30074,7 +30074,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -30152,7 +30152,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.3 <5.0.0",
+        "version": ">=4.4.3 <5.0.0-0",
       },
       "package_id": 510,
     },
@@ -30165,7 +30165,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=10.2.2 <11.0.0",
+        "version": ">=10.2.2 <11.0.0-0",
       },
       "package_id": 511,
     },
@@ -30178,7 +30178,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -30191,7 +30191,7 @@ exports[`next build works: node 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.15 <0.3.0",
+        "version": ">=0.2.15 <0.3.0-0",
       },
       "package_id": 513,
     },
@@ -30204,7 +30204,7 @@ exports[`next build works: node 1`] = `
       "name": "ts-api-utils",
       "npm": {
         "name": "ts-api-utils",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 460,
     },
@@ -30230,7 +30230,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.9.1 <5.0.0",
+        "version": ">=4.9.1 <5.0.0-0",
       },
       "package_id": 514,
     },
@@ -30282,7 +30282,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -30321,7 +30321,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 515,
     },
@@ -30334,7 +30334,7 @@ exports[`next build works: node 1`] = `
       "name": "@napi-rs/wasm-runtime",
       "npm": {
         "name": "@napi-rs/wasm-runtime",
-        "version": ">=0.2.11 <0.3.0",
+        "version": ">=0.2.11 <0.3.0-0",
       },
       "package_id": 65,
     },
@@ -30347,7 +30347,7 @@ exports[`next build works: node 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 && >=8.0.0 <9.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 && >=8.0.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -30360,7 +30360,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -30373,7 +30373,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-json-stable-stringify",
       "npm": {
         "name": "fast-json-stable-stringify",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 237,
     },
@@ -30386,7 +30386,7 @@ exports[`next build works: node 1`] = `
       "name": "json-schema-traverse",
       "npm": {
         "name": "json-schema-traverse",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 323,
     },
@@ -30399,7 +30399,7 @@ exports[`next build works: node 1`] = `
       "name": "uri-js",
       "npm": {
         "name": "uri-js",
-        "version": ">=4.2.2 <5.0.0",
+        "version": ">=4.2.2 <5.0.0-0",
       },
       "package_id": 476,
     },
@@ -30412,7 +30412,7 @@ exports[`next build works: node 1`] = `
       "name": "color-convert",
       "npm": {
         "name": "color-convert",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 174,
     },
@@ -30425,7 +30425,7 @@ exports[`next build works: node 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -30438,7 +30438,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.0.4 <3.0.0",
+        "version": ">=2.0.4 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -30451,7 +30451,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -30464,7 +30464,7 @@ exports[`next build works: node 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -30477,7 +30477,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30490,7 +30490,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -30503,7 +30503,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30516,7 +30516,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.24.0 <2.0.0",
+        "version": ">=1.24.0 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30529,7 +30529,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -30542,7 +30542,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -30555,7 +30555,7 @@ exports[`next build works: node 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -30568,7 +30568,7 @@ exports[`next build works: node 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -30581,7 +30581,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30594,7 +30594,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30607,7 +30607,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30620,7 +30620,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -30633,7 +30633,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -30646,7 +30646,7 @@ exports[`next build works: node 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -30659,7 +30659,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30672,7 +30672,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -30685,7 +30685,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30698,7 +30698,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30711,7 +30711,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -30724,7 +30724,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -30737,7 +30737,7 @@ exports[`next build works: node 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -30750,7 +30750,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30763,7 +30763,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30776,7 +30776,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30789,7 +30789,7 @@ exports[`next build works: node 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -30802,7 +30802,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30815,7 +30815,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30828,7 +30828,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30841,7 +30841,7 @@ exports[`next build works: node 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -30854,7 +30854,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30867,7 +30867,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30880,7 +30880,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30893,7 +30893,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -30906,7 +30906,7 @@ exports[`next build works: node 1`] = `
       "name": "es-shim-unscopables",
       "npm": {
         "name": "es-shim-unscopables",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 211,
     },
@@ -30919,7 +30919,7 @@ exports[`next build works: node 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -30932,7 +30932,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -30945,7 +30945,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -30958,7 +30958,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -30971,7 +30971,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -30984,7 +30984,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -30997,7 +30997,7 @@ exports[`next build works: node 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.4 <4.0.0",
+        "version": ">=3.0.4 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -31010,7 +31010,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -31023,7 +31023,7 @@ exports[`next build works: node 1`] = `
       "name": "browserslist",
       "npm": {
         "name": "browserslist",
-        "version": ">=4.24.4 <5.0.0",
+        "version": ">=4.24.4 <5.0.0-0",
       },
       "package_id": 160,
     },
@@ -31036,7 +31036,7 @@ exports[`next build works: node 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001702 <2.0.0",
+        "version": ">=1.0.30001702 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -31049,7 +31049,7 @@ exports[`next build works: node 1`] = `
       "name": "fraction.js",
       "npm": {
         "name": "fraction.js",
-        "version": ">=4.3.7 <5.0.0",
+        "version": ">=4.3.7 <5.0.0-0",
       },
       "package_id": 249,
     },
@@ -31062,7 +31062,7 @@ exports[`next build works: node 1`] = `
       "name": "normalize-range",
       "npm": {
         "name": "normalize-range",
-        "version": ">=0.1.2 <0.2.0",
+        "version": ">=0.1.2 <0.2.0-0",
       },
       "package_id": 353,
     },
@@ -31075,7 +31075,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -31088,7 +31088,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -31101,7 +31101,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.1.0 <9.0.0",
+        "version": ">=8.1.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -31114,7 +31114,7 @@ exports[`next build works: node 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -31127,7 +31127,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.5.4 <3.0.0",
+        "version": ">=2.5.4 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -31140,7 +31140,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -31153,7 +31153,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-stream",
       "npm": {
         "name": "bare-stream",
-        "version": ">=2.6.4 <3.0.0",
+        "version": ">=2.6.4 <3.0.0-0",
       },
       "package_id": 154,
     },
@@ -31180,7 +31180,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-os",
       "npm": {
         "name": "bare-os",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 152,
     },
@@ -31193,7 +31193,7 @@ exports[`next build works: node 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.21.0 <3.0.0",
+        "version": ">=2.21.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -31234,7 +31234,7 @@ exports[`next build works: node 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },
@@ -31260,7 +31260,7 @@ exports[`next build works: node 1`] = `
       "name": "fill-range",
       "npm": {
         "name": "fill-range",
-        "version": ">=7.1.1 <8.0.0",
+        "version": ">=7.1.1 <8.0.0-0",
       },
       "package_id": 243,
     },
@@ -31273,7 +31273,7 @@ exports[`next build works: node 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001726 <2.0.0",
+        "version": ">=1.0.30001726 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -31286,7 +31286,7 @@ exports[`next build works: node 1`] = `
       "name": "electron-to-chromium",
       "npm": {
         "name": "electron-to-chromium",
-        "version": ">=1.5.173 <2.0.0",
+        "version": ">=1.5.173 <2.0.0-0",
       },
       "package_id": 200,
     },
@@ -31299,7 +31299,7 @@ exports[`next build works: node 1`] = `
       "name": "node-releases",
       "npm": {
         "name": "node-releases",
-        "version": ">=2.0.19 <3.0.0",
+        "version": ">=2.0.19 <3.0.0-0",
       },
       "package_id": 351,
     },
@@ -31312,7 +31312,7 @@ exports[`next build works: node 1`] = `
       "name": "update-browserslist-db",
       "npm": {
         "name": "update-browserslist-db",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 475,
     },
@@ -31338,7 +31338,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/react",
       "npm": {
         "name": "@types/react",
-        "version": ">=19.0.0 <20.0.0",
+        "version": ">=19.0.0 <20.0.0-0",
       },
       "package_id": 90,
     },
@@ -31351,7 +31351,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -31364,7 +31364,7 @@ exports[`next build works: node 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -31377,7 +31377,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -31390,7 +31390,7 @@ exports[`next build works: node 1`] = `
       "name": "set-function-length",
       "npm": {
         "name": "set-function-length",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 418,
     },
@@ -31403,7 +31403,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -31416,7 +31416,7 @@ exports[`next build works: node 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -31429,7 +31429,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -31442,7 +31442,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -31455,7 +31455,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -31468,7 +31468,7 @@ exports[`next build works: node 1`] = `
       "name": "supports-color",
       "npm": {
         "name": "supports-color",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 450,
     },
@@ -31481,7 +31481,7 @@ exports[`next build works: node 1`] = `
       "name": "fsevents",
       "npm": {
         "name": "fsevents",
-        "version": ">=2.3.2 <2.4.0",
+        "version": ">=2.3.2 <2.4.0-0",
       },
       "package_id": 250,
     },
@@ -31494,7 +31494,7 @@ exports[`next build works: node 1`] = `
       "name": "anymatch",
       "npm": {
         "name": "anymatch",
-        "version": ">=3.1.2 <3.2.0",
+        "version": ">=3.1.2 <3.2.0-0",
       },
       "package_id": 129,
     },
@@ -31507,7 +31507,7 @@ exports[`next build works: node 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.2 <3.1.0",
+        "version": ">=3.0.2 <3.1.0-0",
       },
       "package_id": 159,
     },
@@ -31520,7 +31520,7 @@ exports[`next build works: node 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <5.2.0",
+        "version": ">=5.1.2 <5.2.0-0",
       },
       "package_id": 516,
     },
@@ -31533,7 +31533,7 @@ exports[`next build works: node 1`] = `
       "name": "is-binary-path",
       "npm": {
         "name": "is-binary-path",
-        "version": ">=2.1.0 <2.2.0",
+        "version": ">=2.1.0 <2.2.0-0",
       },
       "package_id": 287,
     },
@@ -31546,7 +31546,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <4.1.0",
+        "version": ">=4.0.1 <4.1.0-0",
       },
       "package_id": 298,
     },
@@ -31559,7 +31559,7 @@ exports[`next build works: node 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <3.1.0",
+        "version": ">=3.0.0 <3.1.0-0",
       },
       "package_id": 352,
     },
@@ -31572,7 +31572,7 @@ exports[`next build works: node 1`] = `
       "name": "readdirp",
       "npm": {
         "name": "readdirp",
-        "version": ">=3.6.0 <3.7.0",
+        "version": ">=3.6.0 <3.7.0-0",
       },
       "package_id": 404,
     },
@@ -31585,7 +31585,7 @@ exports[`next build works: node 1`] = `
       "name": "mitt",
       "npm": {
         "name": "mitt",
-        "version": ">=3.0.1 <4.0.0",
+        "version": ">=3.0.1 <4.0.0-0",
       },
       "package_id": 343,
     },
@@ -31598,7 +31598,7 @@ exports[`next build works: node 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.24.1 <4.0.0",
+        "version": ">=3.24.1 <4.0.0-0",
       },
       "package_id": 494,
     },
@@ -31624,7 +31624,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -31637,7 +31637,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -31650,7 +31650,7 @@ exports[`next build works: node 1`] = `
       "name": "wrap-ansi",
       "npm": {
         "name": "wrap-ansi",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 484,
     },
@@ -31663,7 +31663,7 @@ exports[`next build works: node 1`] = `
       "name": "color-name",
       "npm": {
         "name": "color-name",
-        "version": ">=1.1.4 <1.2.0",
+        "version": ">=1.1.4 <1.2.0-0",
       },
       "package_id": 175,
     },
@@ -31676,7 +31676,7 @@ exports[`next build works: node 1`] = `
       "name": "env-paths",
       "npm": {
         "name": "env-paths",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 203,
     },
@@ -31689,7 +31689,7 @@ exports[`next build works: node 1`] = `
       "name": "import-fresh",
       "npm": {
         "name": "import-fresh",
-        "version": ">=3.3.0 <4.0.0",
+        "version": ">=3.3.0 <4.0.0-0",
       },
       "package_id": 279,
     },
@@ -31702,7 +31702,7 @@ exports[`next build works: node 1`] = `
       "name": "js-yaml",
       "npm": {
         "name": "js-yaml",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 318,
     },
@@ -31715,7 +31715,7 @@ exports[`next build works: node 1`] = `
       "name": "parse-json",
       "npm": {
         "name": "parse-json",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 372,
     },
@@ -31742,7 +31742,7 @@ exports[`next build works: node 1`] = `
       "name": "path-key",
       "npm": {
         "name": "path-key",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 374,
     },
@@ -31755,7 +31755,7 @@ exports[`next build works: node 1`] = `
       "name": "shebang-command",
       "npm": {
         "name": "shebang-command",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 422,
     },
@@ -31768,7 +31768,7 @@ exports[`next build works: node 1`] = `
       "name": "which",
       "npm": {
         "name": "which",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 478,
     },
@@ -31781,7 +31781,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -31794,7 +31794,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -31807,7 +31807,7 @@ exports[`next build works: node 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -31820,7 +31820,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -31833,7 +31833,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -31846,7 +31846,7 @@ exports[`next build works: node 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -31859,7 +31859,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -31872,7 +31872,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -31885,7 +31885,7 @@ exports[`next build works: node 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -31898,7 +31898,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -31911,7 +31911,7 @@ exports[`next build works: node 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -31924,7 +31924,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -31937,7 +31937,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -31950,7 +31950,7 @@ exports[`next build works: node 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -31963,7 +31963,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -31976,7 +31976,7 @@ exports[`next build works: node 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -31989,7 +31989,7 @@ exports[`next build works: node 1`] = `
       "name": "ast-types",
       "npm": {
         "name": "ast-types",
-        "version": ">=0.13.4 <0.14.0",
+        "version": ">=0.13.4 <0.14.0-0",
       },
       "package_id": 141,
     },
@@ -32002,7 +32002,7 @@ exports[`next build works: node 1`] = `
       "name": "escodegen",
       "npm": {
         "name": "escodegen",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 215,
     },
@@ -32015,7 +32015,7 @@ exports[`next build works: node 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -32028,7 +32028,7 @@ exports[`next build works: node 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -32041,7 +32041,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -32054,7 +32054,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -32067,7 +32067,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -32080,7 +32080,7 @@ exports[`next build works: node 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -32093,7 +32093,7 @@ exports[`next build works: node 1`] = `
       "name": "is-arrayish",
       "npm": {
         "name": "is-arrayish",
-        "version": ">=0.2.1 <0.3.0",
+        "version": ">=0.2.1 <0.3.0-0",
       },
       "package_id": 284,
     },
@@ -32106,7 +32106,7 @@ exports[`next build works: node 1`] = `
       "name": "array-buffer-byte-length",
       "npm": {
         "name": "array-buffer-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 133,
     },
@@ -32119,7 +32119,7 @@ exports[`next build works: node 1`] = `
       "name": "arraybuffer.prototype.slice",
       "npm": {
         "name": "arraybuffer.prototype.slice",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 140,
     },
@@ -32132,7 +32132,7 @@ exports[`next build works: node 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -32145,7 +32145,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -32158,7 +32158,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -32171,7 +32171,7 @@ exports[`next build works: node 1`] = `
       "name": "data-view-buffer",
       "npm": {
         "name": "data-view-buffer",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 185,
     },
@@ -32184,7 +32184,7 @@ exports[`next build works: node 1`] = `
       "name": "data-view-byte-length",
       "npm": {
         "name": "data-view-byte-length",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 186,
     },
@@ -32197,7 +32197,7 @@ exports[`next build works: node 1`] = `
       "name": "data-view-byte-offset",
       "npm": {
         "name": "data-view-byte-offset",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 187,
     },
@@ -32210,7 +32210,7 @@ exports[`next build works: node 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -32223,7 +32223,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -32236,7 +32236,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -32249,7 +32249,7 @@ exports[`next build works: node 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -32262,7 +32262,7 @@ exports[`next build works: node 1`] = `
       "name": "es-to-primitive",
       "npm": {
         "name": "es-to-primitive",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 212,
     },
@@ -32275,7 +32275,7 @@ exports[`next build works: node 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.8 <2.0.0",
+        "version": ">=1.1.8 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -32288,7 +32288,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -32301,7 +32301,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -32314,7 +32314,7 @@ exports[`next build works: node 1`] = `
       "name": "get-symbol-description",
       "npm": {
         "name": "get-symbol-description",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 259,
     },
@@ -32327,7 +32327,7 @@ exports[`next build works: node 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -32340,7 +32340,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -32353,7 +32353,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -32366,7 +32366,7 @@ exports[`next build works: node 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -32379,7 +32379,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -32392,7 +32392,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -32405,7 +32405,7 @@ exports[`next build works: node 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -32418,7 +32418,7 @@ exports[`next build works: node 1`] = `
       "name": "is-array-buffer",
       "npm": {
         "name": "is-array-buffer",
-        "version": ">=3.0.5 <4.0.0",
+        "version": ">=3.0.5 <4.0.0-0",
       },
       "package_id": 283,
     },
@@ -32431,7 +32431,7 @@ exports[`next build works: node 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -32444,7 +32444,7 @@ exports[`next build works: node 1`] = `
       "name": "is-data-view",
       "npm": {
         "name": "is-data-view",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 292,
     },
@@ -32457,7 +32457,7 @@ exports[`next build works: node 1`] = `
       "name": "is-negative-zero",
       "npm": {
         "name": "is-negative-zero",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 300,
     },
@@ -32470,7 +32470,7 @@ exports[`next build works: node 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -32483,7 +32483,7 @@ exports[`next build works: node 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -32496,7 +32496,7 @@ exports[`next build works: node 1`] = `
       "name": "is-shared-array-buffer",
       "npm": {
         "name": "is-shared-array-buffer",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 305,
     },
@@ -32509,7 +32509,7 @@ exports[`next build works: node 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -32522,7 +32522,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -32535,7 +32535,7 @@ exports[`next build works: node 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -32548,7 +32548,7 @@ exports[`next build works: node 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -32561,7 +32561,7 @@ exports[`next build works: node 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.4 <2.0.0",
+        "version": ">=1.13.4 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -32574,7 +32574,7 @@ exports[`next build works: node 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -32587,7 +32587,7 @@ exports[`next build works: node 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.7 <5.0.0",
+        "version": ">=4.1.7 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -32600,7 +32600,7 @@ exports[`next build works: node 1`] = `
       "name": "own-keys",
       "npm": {
         "name": "own-keys",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 365,
     },
@@ -32613,7 +32613,7 @@ exports[`next build works: node 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.4 <2.0.0",
+        "version": ">=1.5.4 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -32626,7 +32626,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -32639,7 +32639,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -32652,7 +32652,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -32665,7 +32665,7 @@ exports[`next build works: node 1`] = `
       "name": "set-proto",
       "npm": {
         "name": "set-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 420,
     },
@@ -32678,7 +32678,7 @@ exports[`next build works: node 1`] = `
       "name": "stop-iteration-iterator",
       "npm": {
         "name": "stop-iteration-iterator",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 436,
     },
@@ -32691,7 +32691,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.trim",
       "npm": {
         "name": "string.prototype.trim",
-        "version": ">=1.2.10 <2.0.0",
+        "version": ">=1.2.10 <2.0.0-0",
       },
       "package_id": 442,
     },
@@ -32704,7 +32704,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -32717,7 +32717,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.trimstart",
       "npm": {
         "name": "string.prototype.trimstart",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 444,
     },
@@ -32730,7 +32730,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-array-buffer",
       "npm": {
         "name": "typed-array-buffer",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 465,
     },
@@ -32743,7 +32743,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-array-byte-length",
       "npm": {
         "name": "typed-array-byte-length",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 466,
     },
@@ -32756,7 +32756,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-array-byte-offset",
       "npm": {
         "name": "typed-array-byte-offset",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 467,
     },
@@ -32769,7 +32769,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-array-length",
       "npm": {
         "name": "typed-array-length",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 468,
     },
@@ -32782,7 +32782,7 @@ exports[`next build works: node 1`] = `
       "name": "unbox-primitive",
       "npm": {
         "name": "unbox-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 472,
     },
@@ -32795,7 +32795,7 @@ exports[`next build works: node 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.19 <2.0.0",
+        "version": ">=1.1.19 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -32808,7 +32808,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -32821,7 +32821,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -32834,7 +32834,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -32847,7 +32847,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -32860,7 +32860,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -32873,7 +32873,7 @@ exports[`next build works: node 1`] = `
       "name": "es-set-tostringtag",
       "npm": {
         "name": "es-set-tostringtag",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 210,
     },
@@ -32886,7 +32886,7 @@ exports[`next build works: node 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -32899,7 +32899,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -32912,7 +32912,7 @@ exports[`next build works: node 1`] = `
       "name": "globalthis",
       "npm": {
         "name": "globalthis",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 265,
     },
@@ -32925,7 +32925,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -32938,7 +32938,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -32951,7 +32951,7 @@ exports[`next build works: node 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -32964,7 +32964,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -32977,7 +32977,7 @@ exports[`next build works: node 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -32990,7 +32990,7 @@ exports[`next build works: node 1`] = `
       "name": "iterator.prototype",
       "npm": {
         "name": "iterator.prototype",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 314,
     },
@@ -33003,7 +33003,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-array-concat",
       "npm": {
         "name": "safe-array-concat",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 413,
     },
@@ -33016,7 +33016,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -33029,7 +33029,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -33042,7 +33042,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -33055,7 +33055,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -33068,7 +33068,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -33081,7 +33081,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -33094,7 +33094,7 @@ exports[`next build works: node 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -33107,7 +33107,7 @@ exports[`next build works: node 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.0.5 <2.0.0",
+        "version": ">=1.0.5 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -33120,7 +33120,7 @@ exports[`next build works: node 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -33133,7 +33133,7 @@ exports[`next build works: node 1`] = `
       "name": "source-map",
       "npm": {
         "name": "source-map",
-        "version": ">=0.6.1 <0.7.0",
+        "version": ">=0.6.1 <0.7.0-0",
       },
       "package_id": 432,
     },
@@ -33146,7 +33146,7 @@ exports[`next build works: node 1`] = `
       "name": "esprima",
       "npm": {
         "name": "esprima",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 228,
     },
@@ -33159,7 +33159,7 @@ exports[`next build works: node 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -33172,7 +33172,7 @@ exports[`next build works: node 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -33185,7 +33185,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint-community/eslint-utils",
       "npm": {
         "name": "@eslint-community/eslint-utils",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 21,
     },
@@ -33198,7 +33198,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint-community/regexpp",
       "npm": {
         "name": "@eslint-community/regexpp",
-        "version": ">=4.12.1 <5.0.0",
+        "version": ">=4.12.1 <5.0.0-0",
       },
       "package_id": 22,
     },
@@ -33211,7 +33211,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/config-array",
       "npm": {
         "name": "@eslint/config-array",
-        "version": ">=0.21.0 <0.22.0",
+        "version": ">=0.21.0 <0.22.0-0",
       },
       "package_id": 23,
     },
@@ -33224,7 +33224,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/config-helpers",
       "npm": {
         "name": "@eslint/config-helpers",
-        "version": ">=0.3.1 <0.4.0",
+        "version": ">=0.3.1 <0.4.0-0",
       },
       "package_id": 24,
     },
@@ -33237,7 +33237,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/core",
       "npm": {
         "name": "@eslint/core",
-        "version": ">=0.15.2 <0.16.0",
+        "version": ">=0.15.2 <0.16.0-0",
       },
       "package_id": 25,
     },
@@ -33250,7 +33250,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/eslintrc",
       "npm": {
         "name": "@eslint/eslintrc",
-        "version": ">=3.3.1 <4.0.0",
+        "version": ">=3.3.1 <4.0.0-0",
       },
       "package_id": 26,
     },
@@ -33276,7 +33276,7 @@ exports[`next build works: node 1`] = `
       "name": "@eslint/plugin-kit",
       "npm": {
         "name": "@eslint/plugin-kit",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 29,
     },
@@ -33289,7 +33289,7 @@ exports[`next build works: node 1`] = `
       "name": "@humanfs/node",
       "npm": {
         "name": "@humanfs/node",
-        "version": ">=0.16.6 <0.17.0",
+        "version": ">=0.16.6 <0.17.0-0",
       },
       "package_id": 31,
     },
@@ -33302,7 +33302,7 @@ exports[`next build works: node 1`] = `
       "name": "@humanwhocodes/module-importer",
       "npm": {
         "name": "@humanwhocodes/module-importer",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 32,
     },
@@ -33315,7 +33315,7 @@ exports[`next build works: node 1`] = `
       "name": "@humanwhocodes/retry",
       "npm": {
         "name": "@humanwhocodes/retry",
-        "version": ">=0.4.2 <0.5.0",
+        "version": ">=0.4.2 <0.5.0-0",
       },
       "package_id": 33,
     },
@@ -33328,7 +33328,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/estree",
       "npm": {
         "name": "@types/estree",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 86,
     },
@@ -33341,7 +33341,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/json-schema",
       "npm": {
         "name": "@types/json-schema",
-        "version": ">=7.0.15 <8.0.0",
+        "version": ">=7.0.15 <8.0.0-0",
       },
       "package_id": 87,
     },
@@ -33354,7 +33354,7 @@ exports[`next build works: node 1`] = `
       "name": "ajv",
       "npm": {
         "name": "ajv",
-        "version": ">=6.12.4 <7.0.0",
+        "version": ">=6.12.4 <7.0.0-0",
       },
       "package_id": 125,
     },
@@ -33367,7 +33367,7 @@ exports[`next build works: node 1`] = `
       "name": "chalk",
       "npm": {
         "name": "chalk",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 169,
     },
@@ -33380,7 +33380,7 @@ exports[`next build works: node 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -33393,7 +33393,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.2 <5.0.0",
+        "version": ">=4.3.2 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -33406,7 +33406,7 @@ exports[`next build works: node 1`] = `
       "name": "escape-string-regexp",
       "npm": {
         "name": "escape-string-regexp",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 214,
     },
@@ -33419,7 +33419,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-scope",
       "npm": {
         "name": "eslint-scope",
-        "version": ">=8.4.0 <9.0.0",
+        "version": ">=8.4.0 <9.0.0-0",
       },
       "package_id": 225,
     },
@@ -33432,7 +33432,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -33445,7 +33445,7 @@ exports[`next build works: node 1`] = `
       "name": "espree",
       "npm": {
         "name": "espree",
-        "version": ">=10.4.0 <11.0.0",
+        "version": ">=10.4.0 <11.0.0-0",
       },
       "package_id": 227,
     },
@@ -33458,7 +33458,7 @@ exports[`next build works: node 1`] = `
       "name": "esquery",
       "npm": {
         "name": "esquery",
-        "version": ">=1.5.0 <2.0.0",
+        "version": ">=1.5.0 <2.0.0-0",
       },
       "package_id": 229,
     },
@@ -33471,7 +33471,7 @@ exports[`next build works: node 1`] = `
       "name": "esutils",
       "npm": {
         "name": "esutils",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 232,
     },
@@ -33484,7 +33484,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-deep-equal",
       "npm": {
         "name": "fast-deep-equal",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 234,
     },
@@ -33497,7 +33497,7 @@ exports[`next build works: node 1`] = `
       "name": "file-entry-cache",
       "npm": {
         "name": "file-entry-cache",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 242,
     },
@@ -33510,7 +33510,7 @@ exports[`next build works: node 1`] = `
       "name": "find-up",
       "npm": {
         "name": "find-up",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 244,
     },
@@ -33523,7 +33523,7 @@ exports[`next build works: node 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -33536,7 +33536,7 @@ exports[`next build works: node 1`] = `
       "name": "ignore",
       "npm": {
         "name": "ignore",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 278,
     },
@@ -33549,7 +33549,7 @@ exports[`next build works: node 1`] = `
       "name": "imurmurhash",
       "npm": {
         "name": "imurmurhash",
-        "version": ">=0.1.4 <0.2.0",
+        "version": ">=0.1.4 <0.2.0-0",
       },
       "package_id": 280,
     },
@@ -33562,7 +33562,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -33575,7 +33575,7 @@ exports[`next build works: node 1`] = `
       "name": "json-stable-stringify-without-jsonify",
       "npm": {
         "name": "json-stable-stringify-without-jsonify",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 324,
     },
@@ -33588,7 +33588,7 @@ exports[`next build works: node 1`] = `
       "name": "lodash.merge",
       "npm": {
         "name": "lodash.merge",
-        "version": ">=4.6.2 <5.0.0",
+        "version": ">=4.6.2 <5.0.0-0",
       },
       "package_id": 334,
     },
@@ -33601,7 +33601,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -33614,7 +33614,7 @@ exports[`next build works: node 1`] = `
       "name": "natural-compare",
       "npm": {
         "name": "natural-compare",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 348,
     },
@@ -33627,7 +33627,7 @@ exports[`next build works: node 1`] = `
       "name": "optionator",
       "npm": {
         "name": "optionator",
-        "version": ">=0.9.3 <0.10.0",
+        "version": ">=0.9.3 <0.10.0-0",
       },
       "package_id": 364,
     },
@@ -33667,7 +33667,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.6 <0.4.0",
+        "version": ">=0.3.6 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -33680,7 +33680,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-import-resolver-typescript",
       "npm": {
         "name": "eslint-import-resolver-typescript",
-        "version": ">=3.5.2 <4.0.0",
+        "version": ">=3.5.2 <4.0.0-0",
       },
       "package_id": 219,
     },
@@ -33693,7 +33693,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-plugin-import",
       "npm": {
         "name": "eslint-plugin-import",
-        "version": ">=2.32.0 <3.0.0",
+        "version": ">=2.32.0 <3.0.0-0",
       },
       "package_id": 221,
     },
@@ -33706,7 +33706,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-plugin-jsx-a11y",
       "npm": {
         "name": "eslint-plugin-jsx-a11y",
-        "version": ">=6.10.0 <7.0.0",
+        "version": ">=6.10.0 <7.0.0-0",
       },
       "package_id": 222,
     },
@@ -33719,7 +33719,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-plugin-react",
       "npm": {
         "name": "eslint-plugin-react",
-        "version": ">=7.37.0 <8.0.0",
+        "version": ">=7.37.0 <8.0.0-0",
       },
       "package_id": 223,
     },
@@ -33732,7 +33732,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-plugin-react-hooks",
       "npm": {
         "name": "eslint-plugin-react-hooks",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 224,
     },
@@ -33758,7 +33758,7 @@ exports[`next build works: node 1`] = `
       "name": "typescript-eslint",
       "npm": {
         "name": "typescript-eslint",
-        "version": ">=8.46.0 <9.0.0",
+        "version": ">=8.46.0 <9.0.0-0",
       },
       "package_id": 471,
     },
@@ -33798,7 +33798,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -33811,7 +33811,7 @@ exports[`next build works: node 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -33824,7 +33824,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.4 <2.0.0",
+        "version": ">=1.22.4 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -33850,7 +33850,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.0 <5.0.0",
+        "version": ">=4.4.0 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -33863,7 +33863,7 @@ exports[`next build works: node 1`] = `
       "name": "get-tsconfig",
       "npm": {
         "name": "get-tsconfig",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 260,
     },
@@ -33876,7 +33876,7 @@ exports[`next build works: node 1`] = `
       "name": "is-bun-module",
       "npm": {
         "name": "is-bun-module",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 289,
     },
@@ -33889,7 +33889,7 @@ exports[`next build works: node 1`] = `
       "name": "stable-hash",
       "npm": {
         "name": "stable-hash",
-        "version": ">=0.0.5 <0.0.6",
+        "version": ">=0.0.5 <0.0.6-0",
       },
       "package_id": 435,
     },
@@ -33902,7 +33902,7 @@ exports[`next build works: node 1`] = `
       "name": "tinyglobby",
       "npm": {
         "name": "tinyglobby",
-        "version": ">=0.2.13 <0.3.0",
+        "version": ">=0.2.13 <0.3.0-0",
       },
       "package_id": 458,
     },
@@ -33915,7 +33915,7 @@ exports[`next build works: node 1`] = `
       "name": "unrs-resolver",
       "npm": {
         "name": "unrs-resolver",
-        "version": ">=1.6.2 <2.0.0",
+        "version": ">=1.6.2 <2.0.0-0",
       },
       "package_id": 474,
     },
@@ -33969,7 +33969,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -33982,7 +33982,7 @@ exports[`next build works: node 1`] = `
       "name": "@rtsao/scc",
       "npm": {
         "name": "@rtsao/scc",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 82,
     },
@@ -33995,7 +33995,7 @@ exports[`next build works: node 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.9 <4.0.0",
+        "version": ">=3.1.9 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -34008,7 +34008,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.findlastindex",
       "npm": {
         "name": "array.prototype.findlastindex",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 136,
     },
@@ -34021,7 +34021,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -34034,7 +34034,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -34047,7 +34047,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=3.2.7 <4.0.0",
+        "version": ">=3.2.7 <4.0.0-0",
       },
       "package_id": 517,
     },
@@ -34060,7 +34060,7 @@ exports[`next build works: node 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -34073,7 +34073,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-import-resolver-node",
       "npm": {
         "name": "eslint-import-resolver-node",
-        "version": ">=0.3.9 <0.4.0",
+        "version": ">=0.3.9 <0.4.0-0",
       },
       "package_id": 218,
     },
@@ -34086,7 +34086,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-module-utils",
       "npm": {
         "name": "eslint-module-utils",
-        "version": ">=2.12.1 <3.0.0",
+        "version": ">=2.12.1 <3.0.0-0",
       },
       "package_id": 220,
     },
@@ -34099,7 +34099,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -34112,7 +34112,7 @@ exports[`next build works: node 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.1 <3.0.0",
+        "version": ">=2.16.1 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -34125,7 +34125,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -34138,7 +34138,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -34151,7 +34151,7 @@ exports[`next build works: node 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -34164,7 +34164,7 @@ exports[`next build works: node 1`] = `
       "name": "object.groupby",
       "npm": {
         "name": "object.groupby",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 361,
     },
@@ -34177,7 +34177,7 @@ exports[`next build works: node 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -34190,7 +34190,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -34203,7 +34203,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.trimend",
       "npm": {
         "name": "string.prototype.trimend",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 443,
     },
@@ -34216,7 +34216,7 @@ exports[`next build works: node 1`] = `
       "name": "tsconfig-paths",
       "npm": {
         "name": "tsconfig-paths",
-        "version": ">=3.15.0 <4.0.0",
+        "version": ">=3.15.0 <4.0.0-0",
       },
       "package_id": 462,
     },
@@ -34229,7 +34229,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=2.0.0 <3.0.0 || >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.2.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=2.0.0 <3.0.0-0 || >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.2.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -34242,7 +34242,7 @@ exports[`next build works: node 1`] = `
       "name": "aria-query",
       "npm": {
         "name": "aria-query",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 132,
     },
@@ -34255,7 +34255,7 @@ exports[`next build works: node 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -34268,7 +34268,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -34281,7 +34281,7 @@ exports[`next build works: node 1`] = `
       "name": "ast-types-flow",
       "npm": {
         "name": "ast-types-flow",
-        "version": ">=0.0.8 <0.0.9",
+        "version": ">=0.0.8 <0.0.9-0",
       },
       "package_id": 142,
     },
@@ -34294,7 +34294,7 @@ exports[`next build works: node 1`] = `
       "name": "axe-core",
       "npm": {
         "name": "axe-core",
-        "version": ">=4.10.0 <5.0.0",
+        "version": ">=4.10.0 <5.0.0-0",
       },
       "package_id": 146,
     },
@@ -34307,7 +34307,7 @@ exports[`next build works: node 1`] = `
       "name": "axobject-query",
       "npm": {
         "name": "axobject-query",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 147,
     },
@@ -34320,7 +34320,7 @@ exports[`next build works: node 1`] = `
       "name": "damerau-levenshtein",
       "npm": {
         "name": "damerau-levenshtein",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 183,
     },
@@ -34333,7 +34333,7 @@ exports[`next build works: node 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -34346,7 +34346,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -34359,7 +34359,7 @@ exports[`next build works: node 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=3.3.5 <4.0.0",
+        "version": ">=3.3.5 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -34372,7 +34372,7 @@ exports[`next build works: node 1`] = `
       "name": "language-tags",
       "npm": {
         "name": "language-tags",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 329,
     },
@@ -34385,7 +34385,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -34398,7 +34398,7 @@ exports[`next build works: node 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -34411,7 +34411,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -34424,7 +34424,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.includes",
       "npm": {
         "name": "string.prototype.includes",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 439,
     },
@@ -34437,7 +34437,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -34450,7 +34450,7 @@ exports[`next build works: node 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.8 <4.0.0",
+        "version": ">=3.1.8 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -34463,7 +34463,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.findlast",
       "npm": {
         "name": "array.prototype.findlast",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 135,
     },
@@ -34476,7 +34476,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.flatmap",
       "npm": {
         "name": "array.prototype.flatmap",
-        "version": ">=1.3.3 <2.0.0",
+        "version": ">=1.3.3 <2.0.0-0",
       },
       "package_id": 138,
     },
@@ -34489,7 +34489,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.tosorted",
       "npm": {
         "name": "array.prototype.tosorted",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 139,
     },
@@ -34502,7 +34502,7 @@ exports[`next build works: node 1`] = `
       "name": "doctrine",
       "npm": {
         "name": "doctrine",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 197,
     },
@@ -34515,7 +34515,7 @@ exports[`next build works: node 1`] = `
       "name": "es-iterator-helpers",
       "npm": {
         "name": "es-iterator-helpers",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 208,
     },
@@ -34528,7 +34528,7 @@ exports[`next build works: node 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.3.0 <6.0.0",
+        "version": ">=5.3.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -34541,7 +34541,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -34554,7 +34554,7 @@ exports[`next build works: node 1`] = `
       "name": "jsx-ast-utils",
       "npm": {
         "name": "jsx-ast-utils",
-        "version": ">=2.4.1 <3.0.0 || >=3.0.0 <4.0.0 && >=3.0.0 <4.0.0",
+        "version": ">=2.4.1 <3.0.0-0 || >=3.0.0 <4.0.0-0 && >=3.0.0 <4.0.0-0",
       },
       "package_id": 326,
     },
@@ -34567,7 +34567,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 340,
     },
@@ -34580,7 +34580,7 @@ exports[`next build works: node 1`] = `
       "name": "object.entries",
       "npm": {
         "name": "object.entries",
-        "version": ">=1.1.9 <2.0.0",
+        "version": ">=1.1.9 <2.0.0-0",
       },
       "package_id": 359,
     },
@@ -34593,7 +34593,7 @@ exports[`next build works: node 1`] = `
       "name": "object.fromentries",
       "npm": {
         "name": "object.fromentries",
-        "version": ">=2.0.8 <3.0.0",
+        "version": ">=2.0.8 <3.0.0-0",
       },
       "package_id": 360,
     },
@@ -34606,7 +34606,7 @@ exports[`next build works: node 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -34619,7 +34619,7 @@ exports[`next build works: node 1`] = `
       "name": "prop-types",
       "npm": {
         "name": "prop-types",
-        "version": ">=15.8.1 <16.0.0",
+        "version": ">=15.8.1 <16.0.0-0",
       },
       "package_id": 392,
     },
@@ -34632,7 +34632,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=2.0.0-next.5 <3.0.0",
+        "version": ">=2.0.0-next.5 <3.0.0-0",
       },
       "package_id": 518,
     },
@@ -34645,7 +34645,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=6.3.1 <7.0.0",
+        "version": ">=6.3.1 <7.0.0-0",
       },
       "package_id": 417,
     },
@@ -34658,7 +34658,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.matchall",
       "npm": {
         "name": "string.prototype.matchall",
-        "version": ">=4.0.12 <5.0.0",
+        "version": ">=4.0.12 <5.0.0-0",
       },
       "package_id": 440,
     },
@@ -34671,7 +34671,7 @@ exports[`next build works: node 1`] = `
       "name": "string.prototype.repeat",
       "npm": {
         "name": "string.prototype.repeat",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 441,
     },
@@ -34684,7 +34684,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=8.0.0 <9.0.0 || >=9.7.0 <10.0.0 && >=9.7.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=8.0.0 <9.0.0-0 || >=9.7.0 <10.0.0-0 && >=9.7.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -34697,7 +34697,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/core",
       "npm": {
         "name": "@babel/core",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 4,
     },
@@ -34710,7 +34710,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/parser",
       "npm": {
         "name": "@babel/parser",
-        "version": ">=7.24.4 <8.0.0",
+        "version": ">=7.24.4 <8.0.0-0",
       },
       "package_id": 14,
     },
@@ -34723,7 +34723,7 @@ exports[`next build works: node 1`] = `
       "name": "hermes-parser",
       "npm": {
         "name": "hermes-parser",
-        "version": ">=0.25.1 <0.26.0",
+        "version": ">=0.25.1 <0.26.0-0",
       },
       "package_id": 275,
     },
@@ -34736,7 +34736,7 @@ exports[`next build works: node 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -34749,7 +34749,7 @@ exports[`next build works: node 1`] = `
       "name": "zod-validation-error",
       "npm": {
         "name": "zod-validation-error",
-        "version": ">=3.5.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.5.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 495,
     },
@@ -34762,7 +34762,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=7.0.0 <8.0.0 || >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=8.0.0-0 <9.0.0 || >=9.0.0 <10.0.0 && >=9.0.0 <10.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=4.0.0 <5.0.0-0 || >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=5.0.0 <6.0.0-0 || >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=7.0.0 <8.0.0-0 || >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=8.0.0-0 <9.0.0-0 || >=9.0.0 <10.0.0-0 && >=9.0.0 <10.0.0-0",
       },
       "package_id": 216,
     },
@@ -34775,7 +34775,7 @@ exports[`next build works: node 1`] = `
       "name": "esrecurse",
       "npm": {
         "name": "esrecurse",
-        "version": ">=4.3.0 <5.0.0",
+        "version": ">=4.3.0 <5.0.0-0",
       },
       "package_id": 230,
     },
@@ -34788,7 +34788,7 @@ exports[`next build works: node 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -34801,7 +34801,7 @@ exports[`next build works: node 1`] = `
       "name": "acorn",
       "npm": {
         "name": "acorn",
-        "version": ">=8.15.0 <9.0.0",
+        "version": ">=8.15.0 <9.0.0-0",
       },
       "package_id": 122,
     },
@@ -34814,7 +34814,7 @@ exports[`next build works: node 1`] = `
       "name": "acorn-jsx",
       "npm": {
         "name": "acorn-jsx",
-        "version": ">=5.3.2 <6.0.0",
+        "version": ">=5.3.2 <6.0.0-0",
       },
       "package_id": 123,
     },
@@ -34827,7 +34827,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=4.2.1 <5.0.0",
+        "version": ">=4.2.1 <5.0.0-0",
       },
       "package_id": 226,
     },
@@ -34840,7 +34840,7 @@ exports[`next build works: node 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -34853,7 +34853,7 @@ exports[`next build works: node 1`] = `
       "name": "estraverse",
       "npm": {
         "name": "estraverse",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 231,
     },
@@ -34866,7 +34866,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/yauzl",
       "npm": {
         "name": "@types/yauzl",
-        "version": ">=2.9.1 <3.0.0",
+        "version": ">=2.9.1 <3.0.0-0",
       },
       "package_id": 92,
     },
@@ -34879,7 +34879,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -34892,7 +34892,7 @@ exports[`next build works: node 1`] = `
       "name": "get-stream",
       "npm": {
         "name": "get-stream",
-        "version": ">=5.1.0 <6.0.0",
+        "version": ">=5.1.0 <6.0.0-0",
       },
       "package_id": 258,
     },
@@ -34905,7 +34905,7 @@ exports[`next build works: node 1`] = `
       "name": "yauzl",
       "npm": {
         "name": "yauzl",
-        "version": ">=2.10.0 <3.0.0",
+        "version": ">=2.10.0 <3.0.0-0",
       },
       "package_id": 492,
     },
@@ -34918,7 +34918,7 @@ exports[`next build works: node 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -34931,7 +34931,7 @@ exports[`next build works: node 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -34944,7 +34944,7 @@ exports[`next build works: node 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -34957,7 +34957,7 @@ exports[`next build works: node 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -34970,7 +34970,7 @@ exports[`next build works: node 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -34983,7 +34983,7 @@ exports[`next build works: node 1`] = `
       "name": "reusify",
       "npm": {
         "name": "reusify",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 411,
     },
@@ -34996,7 +34996,7 @@ exports[`next build works: node 1`] = `
       "name": "pend",
       "npm": {
         "name": "pend",
-        "version": ">=1.2.0 <1.3.0",
+        "version": ">=1.2.0 <1.3.0-0",
       },
       "package_id": 377,
     },
@@ -35010,7 +35010,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 379,
     },
@@ -35023,7 +35023,7 @@ exports[`next build works: node 1`] = `
       "name": "flat-cache",
       "npm": {
         "name": "flat-cache",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 245,
     },
@@ -35036,7 +35036,7 @@ exports[`next build works: node 1`] = `
       "name": "to-regex-range",
       "npm": {
         "name": "to-regex-range",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 459,
     },
@@ -35049,7 +35049,7 @@ exports[`next build works: node 1`] = `
       "name": "locate-path",
       "npm": {
         "name": "locate-path",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 333,
     },
@@ -35062,7 +35062,7 @@ exports[`next build works: node 1`] = `
       "name": "path-exists",
       "npm": {
         "name": "path-exists",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 373,
     },
@@ -35075,7 +35075,7 @@ exports[`next build works: node 1`] = `
       "name": "flatted",
       "npm": {
         "name": "flatted",
-        "version": ">=3.2.9 <4.0.0",
+        "version": ">=3.2.9 <4.0.0-0",
       },
       "package_id": 246,
     },
@@ -35088,7 +35088,7 @@ exports[`next build works: node 1`] = `
       "name": "keyv",
       "npm": {
         "name": "keyv",
-        "version": ">=4.5.4 <5.0.0",
+        "version": ">=4.5.4 <5.0.0-0",
       },
       "package_id": 327,
     },
@@ -35101,7 +35101,7 @@ exports[`next build works: node 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -35114,7 +35114,7 @@ exports[`next build works: node 1`] = `
       "name": "cross-spawn",
       "npm": {
         "name": "cross-spawn",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 180,
     },
@@ -35127,7 +35127,7 @@ exports[`next build works: node 1`] = `
       "name": "signal-exit",
       "npm": {
         "name": "signal-exit",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 428,
     },
@@ -35140,7 +35140,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -35153,7 +35153,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35166,7 +35166,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -35179,7 +35179,7 @@ exports[`next build works: node 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -35192,7 +35192,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -35205,7 +35205,7 @@ exports[`next build works: node 1`] = `
       "name": "is-callable",
       "npm": {
         "name": "is-callable",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 290,
     },
@@ -35218,7 +35218,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind-apply-helpers",
       "npm": {
         "name": "call-bind-apply-helpers",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 164,
     },
@@ -35231,7 +35231,7 @@ exports[`next build works: node 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -35244,7 +35244,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -35257,7 +35257,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -35270,7 +35270,7 @@ exports[`next build works: node 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -35283,7 +35283,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -35296,7 +35296,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -35309,7 +35309,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -35322,7 +35322,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -35335,7 +35335,7 @@ exports[`next build works: node 1`] = `
       "name": "math-intrinsics",
       "npm": {
         "name": "math-intrinsics",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 337,
     },
@@ -35348,7 +35348,7 @@ exports[`next build works: node 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -35361,7 +35361,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -35374,7 +35374,7 @@ exports[`next build works: node 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -35387,7 +35387,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35400,7 +35400,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -35413,7 +35413,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -35426,7 +35426,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve-pkg-maps",
       "npm": {
         "name": "resolve-pkg-maps",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 410,
     },
@@ -35439,7 +35439,7 @@ exports[`next build works: node 1`] = `
       "name": "basic-ftp",
       "npm": {
         "name": "basic-ftp",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 156,
     },
@@ -35452,7 +35452,7 @@ exports[`next build works: node 1`] = `
       "name": "data-uri-to-buffer",
       "npm": {
         "name": "data-uri-to-buffer",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 184,
     },
@@ -35465,7 +35465,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -35478,7 +35478,7 @@ exports[`next build works: node 1`] = `
       "name": "foreground-child",
       "npm": {
         "name": "foreground-child",
-        "version": ">=3.1.0 <4.0.0",
+        "version": ">=3.1.0 <4.0.0-0",
       },
       "package_id": 248,
     },
@@ -35491,7 +35491,7 @@ exports[`next build works: node 1`] = `
       "name": "jackspeak",
       "npm": {
         "name": "jackspeak",
-        "version": ">=3.1.2 <4.0.0",
+        "version": ">=3.1.2 <4.0.0-0",
       },
       "package_id": 315,
     },
@@ -35504,7 +35504,7 @@ exports[`next build works: node 1`] = `
       "name": "minimatch",
       "npm": {
         "name": "minimatch",
-        "version": ">=9.0.4 <10.0.0",
+        "version": ">=9.0.4 <10.0.0-0",
       },
       "package_id": 519,
     },
@@ -35517,7 +35517,7 @@ exports[`next build works: node 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -35530,7 +35530,7 @@ exports[`next build works: node 1`] = `
       "name": "package-json-from-dist",
       "npm": {
         "name": "package-json-from-dist",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 370,
     },
@@ -35543,7 +35543,7 @@ exports[`next build works: node 1`] = `
       "name": "path-scurry",
       "npm": {
         "name": "path-scurry",
-        "version": ">=1.11.1 <2.0.0",
+        "version": ">=1.11.1 <2.0.0-0",
       },
       "package_id": 376,
     },
@@ -35556,7 +35556,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -35569,7 +35569,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -35582,7 +35582,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -35595,7 +35595,7 @@ exports[`next build works: node 1`] = `
       "name": "es-define-property",
       "npm": {
         "name": "es-define-property",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 206,
     },
@@ -35608,7 +35608,7 @@ exports[`next build works: node 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -35621,7 +35621,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -35634,7 +35634,7 @@ exports[`next build works: node 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -35660,7 +35660,7 @@ exports[`next build works: node 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -35673,7 +35673,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -35686,7 +35686,7 @@ exports[`next build works: node 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -35699,7 +35699,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": "<5.0.0 >=4.0.0",
+        "version": "<5.0.0-0 >=4.0.0",
       },
       "package_id": 188,
     },
@@ -35712,7 +35712,7 @@ exports[`next build works: node 1`] = `
       "name": "parent-module",
       "npm": {
         "name": "parent-module",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 371,
     },
@@ -35725,7 +35725,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve-from",
       "npm": {
         "name": "resolve-from",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 409,
     },
@@ -35738,7 +35738,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -35751,7 +35751,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -35764,7 +35764,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -35790,7 +35790,7 @@ exports[`next build works: node 1`] = `
       "name": "sprintf-js",
       "npm": {
         "name": "sprintf-js",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 434,
     },
@@ -35803,7 +35803,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -35816,7 +35816,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35829,7 +35829,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -35842,7 +35842,7 @@ exports[`next build works: node 1`] = `
       "name": "async-function",
       "npm": {
         "name": "async-function",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 143,
     },
@@ -35855,7 +35855,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35868,7 +35868,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -35881,7 +35881,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -35894,7 +35894,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -35907,7 +35907,7 @@ exports[`next build works: node 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -35920,7 +35920,7 @@ exports[`next build works: node 1`] = `
       "name": "binary-extensions",
       "npm": {
         "name": "binary-extensions",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 157,
     },
@@ -35933,7 +35933,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35946,7 +35946,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -35959,7 +35959,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.1 <8.0.0",
+        "version": ">=7.7.1 <8.0.0-0",
       },
       "package_id": 506,
     },
@@ -35972,7 +35972,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -35985,7 +35985,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -35998,7 +35998,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -36011,7 +36011,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -36024,7 +36024,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36037,7 +36037,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -36050,7 +36050,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36063,7 +36063,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36076,7 +36076,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -36089,7 +36089,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -36102,7 +36102,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -36115,7 +36115,7 @@ exports[`next build works: node 1`] = `
       "name": "is-extglob",
       "npm": {
         "name": "is-extglob",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 294,
     },
@@ -36128,7 +36128,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36141,7 +36141,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -36154,7 +36154,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36167,7 +36167,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -36180,7 +36180,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -36193,7 +36193,7 @@ exports[`next build works: node 1`] = `
       "name": "hasown",
       "npm": {
         "name": "hasown",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 273,
     },
@@ -36206,7 +36206,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36219,7 +36219,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36232,7 +36232,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -36245,7 +36245,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36258,7 +36258,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -36271,7 +36271,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-regex-test",
       "npm": {
         "name": "safe-regex-test",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 415,
     },
@@ -36284,7 +36284,7 @@ exports[`next build works: node 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -36297,7 +36297,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36310,7 +36310,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36323,7 +36323,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -36336,7 +36336,7 @@ exports[`next build works: node 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -36349,7 +36349,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -36362,7 +36362,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -36375,7 +36375,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -36388,7 +36388,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -36401,7 +36401,7 @@ exports[`next build works: node 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -36414,7 +36414,7 @@ exports[`next build works: node 1`] = `
       "name": "@pkgjs/parseargs",
       "npm": {
         "name": "@pkgjs/parseargs",
-        "version": ">=0.11.0 <0.12.0",
+        "version": ">=0.11.0 <0.12.0-0",
       },
       "package_id": 80,
     },
@@ -36427,7 +36427,7 @@ exports[`next build works: node 1`] = `
       "name": "@isaacs/cliui",
       "npm": {
         "name": "@isaacs/cliui",
-        "version": ">=8.0.2 <9.0.0",
+        "version": ">=8.0.2 <9.0.0-0",
       },
       "package_id": 59,
     },
@@ -36440,7 +36440,7 @@ exports[`next build works: node 1`] = `
       "name": "argparse",
       "npm": {
         "name": "argparse",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 131,
     },
@@ -36453,7 +36453,7 @@ exports[`next build works: node 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -36466,7 +36466,7 @@ exports[`next build works: node 1`] = `
       "name": "array-includes",
       "npm": {
         "name": "array-includes",
-        "version": ">=3.1.6 <4.0.0",
+        "version": ">=3.1.6 <4.0.0-0",
       },
       "package_id": 134,
     },
@@ -36479,7 +36479,7 @@ exports[`next build works: node 1`] = `
       "name": "array.prototype.flat",
       "npm": {
         "name": "array.prototype.flat",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 137,
     },
@@ -36492,7 +36492,7 @@ exports[`next build works: node 1`] = `
       "name": "object.assign",
       "npm": {
         "name": "object.assign",
-        "version": ">=4.1.4 <5.0.0",
+        "version": ">=4.1.4 <5.0.0-0",
       },
       "package_id": 358,
     },
@@ -36505,7 +36505,7 @@ exports[`next build works: node 1`] = `
       "name": "object.values",
       "npm": {
         "name": "object.values",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 362,
     },
@@ -36531,7 +36531,7 @@ exports[`next build works: node 1`] = `
       "name": "language-subtag-registry",
       "npm": {
         "name": "language-subtag-registry",
-        "version": ">=0.3.20 <0.4.0",
+        "version": ">=0.3.20 <0.4.0-0",
       },
       "package_id": 328,
     },
@@ -36544,7 +36544,7 @@ exports[`next build works: node 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -36557,7 +36557,7 @@ exports[`next build works: node 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -36570,7 +36570,7 @@ exports[`next build works: node 1`] = `
       "name": "p-locate",
       "npm": {
         "name": "p-locate",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 367,
     },
@@ -36583,7 +36583,7 @@ exports[`next build works: node 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -36596,7 +36596,7 @@ exports[`next build works: node 1`] = `
       "name": "braces",
       "npm": {
         "name": "braces",
-        "version": ">=3.0.3 <4.0.0",
+        "version": ">=3.0.3 <4.0.0-0",
       },
       "package_id": 159,
     },
@@ -36609,7 +36609,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.3.1 <3.0.0",
+        "version": ">=2.3.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -36622,7 +36622,7 @@ exports[`next build works: node 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 158,
     },
@@ -36635,7 +36635,7 @@ exports[`next build works: node 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -36648,7 +36648,7 @@ exports[`next build works: node 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -36661,7 +36661,7 @@ exports[`next build works: node 1`] = `
       "name": "thenify-all",
       "npm": {
         "name": "thenify-all",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 457,
     },
@@ -36778,7 +36778,7 @@ exports[`next build works: node 1`] = `
       "name": "sharp",
       "npm": {
         "name": "sharp",
-        "version": ">=0.34.4 <0.35.0",
+        "version": ">=0.34.4 <0.35.0-0",
       },
       "package_id": 421,
     },
@@ -36817,7 +36817,7 @@ exports[`next build works: node 1`] = `
       "name": "baseline-browser-mapping",
       "npm": {
         "name": "baseline-browser-mapping",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 155,
     },
@@ -36830,7 +36830,7 @@ exports[`next build works: node 1`] = `
       "name": "caniuse-lite",
       "npm": {
         "name": "caniuse-lite",
-        "version": ">=1.0.30001579 <2.0.0",
+        "version": ">=1.0.30001579 <2.0.0-0",
       },
       "package_id": 168,
     },
@@ -36870,7 +36870,7 @@ exports[`next build works: node 1`] = `
       "name": "@opentelemetry/api",
       "npm": {
         "name": "@opentelemetry/api",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -36884,7 +36884,7 @@ exports[`next build works: node 1`] = `
       "name": "@playwright/test",
       "npm": {
         "name": "@playwright/test",
-        "version": ">=1.51.1 <2.0.0",
+        "version": ">=1.51.1 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -36911,7 +36911,7 @@ exports[`next build works: node 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -36924,7 +36924,7 @@ exports[`next build works: node 1`] = `
       "name": "react-dom",
       "npm": {
         "name": "react-dom",
-        "version": ">=18.2.0 <19.0.0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0 && >=19.0.0 <20.0.0",
+        "version": ">=18.2.0 <19.0.0-0 || ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && ==19.0.0-rc-de68d2f4-20241204 || >=19.0.0 <20.0.0-0 && >=19.0.0 <20.0.0-0",
       },
       "package_id": 401,
     },
@@ -36938,7 +36938,7 @@ exports[`next build works: node 1`] = `
       "name": "sass",
       "npm": {
         "name": "sass",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": null,
     },
@@ -36951,7 +36951,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -36964,7 +36964,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -36977,7 +36977,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -36990,7 +36990,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -37003,7 +37003,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -37016,7 +37016,7 @@ exports[`next build works: node 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -37029,7 +37029,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -37042,7 +37042,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -37055,7 +37055,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -37068,7 +37068,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -37081,7 +37081,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -37094,7 +37094,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -37107,7 +37107,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -37120,7 +37120,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -37133,7 +37133,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -37146,7 +37146,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -37159,7 +37159,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.2 <2.0.0",
+        "version": ">=1.23.2 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -37172,7 +37172,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -37185,7 +37185,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -37198,7 +37198,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -37211,7 +37211,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -37224,7 +37224,7 @@ exports[`next build works: node 1`] = `
       "name": "wrappy",
       "npm": {
         "name": "wrappy",
-        "version": "<2.0.0 >=1.0.0",
+        "version": "<2.0.0-0 >=1.0.0",
       },
       "package_id": 485,
     },
@@ -37237,7 +37237,7 @@ exports[`next build works: node 1`] = `
       "name": "deep-is",
       "npm": {
         "name": "deep-is",
-        "version": ">=0.1.3 <0.2.0",
+        "version": ">=0.1.3 <0.2.0-0",
       },
       "package_id": 189,
     },
@@ -37250,7 +37250,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-levenshtein",
       "npm": {
         "name": "fast-levenshtein",
-        "version": ">=2.0.6 <3.0.0",
+        "version": ">=2.0.6 <3.0.0-0",
       },
       "package_id": 238,
     },
@@ -37263,7 +37263,7 @@ exports[`next build works: node 1`] = `
       "name": "levn",
       "npm": {
         "name": "levn",
-        "version": ">=0.4.1 <0.5.0",
+        "version": ">=0.4.1 <0.5.0-0",
       },
       "package_id": 330,
     },
@@ -37276,7 +37276,7 @@ exports[`next build works: node 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -37289,7 +37289,7 @@ exports[`next build works: node 1`] = `
       "name": "type-check",
       "npm": {
         "name": "type-check",
-        "version": ">=0.4.0 <0.5.0",
+        "version": ">=0.4.0 <0.5.0-0",
       },
       "package_id": 464,
     },
@@ -37302,7 +37302,7 @@ exports[`next build works: node 1`] = `
       "name": "word-wrap",
       "npm": {
         "name": "word-wrap",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 483,
     },
@@ -37315,7 +37315,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -37328,7 +37328,7 @@ exports[`next build works: node 1`] = `
       "name": "object-keys",
       "npm": {
         "name": "object-keys",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 357,
     },
@@ -37341,7 +37341,7 @@ exports[`next build works: node 1`] = `
       "name": "safe-push-apply",
       "npm": {
         "name": "safe-push-apply",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 414,
     },
@@ -37354,7 +37354,7 @@ exports[`next build works: node 1`] = `
       "name": "yocto-queue",
       "npm": {
         "name": "yocto-queue",
-        "version": ">=0.1.0 <0.2.0",
+        "version": ">=0.1.0 <0.2.0-0",
       },
       "package_id": 493,
     },
@@ -37367,7 +37367,7 @@ exports[`next build works: node 1`] = `
       "name": "p-limit",
       "npm": {
         "name": "p-limit",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 366,
     },
@@ -37380,7 +37380,7 @@ exports[`next build works: node 1`] = `
       "name": "@tootallnate/quickjs-emscripten",
       "npm": {
         "name": "@tootallnate/quickjs-emscripten",
-        "version": ">=0.23.0 <0.24.0",
+        "version": ">=0.23.0 <0.24.0-0",
       },
       "package_id": 84,
     },
@@ -37393,7 +37393,7 @@ exports[`next build works: node 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -37406,7 +37406,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -37419,7 +37419,7 @@ exports[`next build works: node 1`] = `
       "name": "get-uri",
       "npm": {
         "name": "get-uri",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 261,
     },
@@ -37432,7 +37432,7 @@ exports[`next build works: node 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -37445,7 +37445,7 @@ exports[`next build works: node 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -37458,7 +37458,7 @@ exports[`next build works: node 1`] = `
       "name": "pac-resolver",
       "npm": {
         "name": "pac-resolver",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 369,
     },
@@ -37471,7 +37471,7 @@ exports[`next build works: node 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -37484,7 +37484,7 @@ exports[`next build works: node 1`] = `
       "name": "degenerator",
       "npm": {
         "name": "degenerator",
-        "version": ">=5.0.0 <6.0.0",
+        "version": ">=5.0.0 <6.0.0-0",
       },
       "package_id": 192,
     },
@@ -37497,7 +37497,7 @@ exports[`next build works: node 1`] = `
       "name": "netmask",
       "npm": {
         "name": "netmask",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 349,
     },
@@ -37510,7 +37510,7 @@ exports[`next build works: node 1`] = `
       "name": "callsites",
       "npm": {
         "name": "callsites",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 166,
     },
@@ -37523,7 +37523,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/code-frame",
       "npm": {
         "name": "@babel/code-frame",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 521,
     },
@@ -37536,7 +37536,7 @@ exports[`next build works: node 1`] = `
       "name": "error-ex",
       "npm": {
         "name": "error-ex",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 204,
     },
@@ -37549,7 +37549,7 @@ exports[`next build works: node 1`] = `
       "name": "json-parse-even-better-errors",
       "npm": {
         "name": "json-parse-even-better-errors",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 322,
     },
@@ -37562,7 +37562,7 @@ exports[`next build works: node 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -37575,7 +37575,7 @@ exports[`next build works: node 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=10.2.0 <11.0.0",
+        "version": ">=10.2.0 <11.0.0-0",
       },
       "package_id": 522,
     },
@@ -37588,7 +37588,7 @@ exports[`next build works: node 1`] = `
       "name": "minipass",
       "npm": {
         "name": "minipass",
-        "version": ">=5.0.0 <6.0.0 || >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=6.0.2 <7.0.0 || >=7.0.0 <8.0.0 && >=7.0.0 <8.0.0",
+        "version": ">=5.0.0 <6.0.0-0 || >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=6.0.2 <7.0.0-0 || >=7.0.0 <8.0.0-0 && >=7.0.0 <8.0.0-0",
       },
       "package_id": 342,
     },
@@ -37601,7 +37601,7 @@ exports[`next build works: node 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.11 <4.0.0",
+        "version": ">=3.3.11 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -37614,7 +37614,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -37627,7 +37627,7 @@ exports[`next build works: node 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -37640,7 +37640,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-value-parser",
       "npm": {
         "name": "postcss-value-parser",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 389,
     },
@@ -37653,7 +37653,7 @@ exports[`next build works: node 1`] = `
       "name": "read-cache",
       "npm": {
         "name": "read-cache",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 403,
     },
@@ -37666,7 +37666,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.1.7 <2.0.0",
+        "version": ">=1.1.7 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -37679,7 +37679,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -37692,7 +37692,7 @@ exports[`next build works: node 1`] = `
       "name": "camelcase-css",
       "npm": {
         "name": "camelcase-css",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 167,
     },
@@ -37705,7 +37705,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.21 <9.0.0",
+        "version": ">=8.4.21 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -37718,7 +37718,7 @@ exports[`next build works: node 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -37731,7 +37731,7 @@ exports[`next build works: node 1`] = `
       "name": "yaml",
       "npm": {
         "name": "yaml",
-        "version": ">=2.3.4 <3.0.0",
+        "version": ">=2.3.4 <3.0.0-0",
       },
       "package_id": 489,
     },
@@ -37772,7 +37772,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.1 <7.0.0",
+        "version": ">=6.1.1 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -37785,7 +37785,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.2.14 <9.0.0",
+        "version": ">=8.2.14 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -37798,7 +37798,7 @@ exports[`next build works: node 1`] = `
       "name": "cssesc",
       "npm": {
         "name": "cssesc",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 181,
     },
@@ -37811,7 +37811,7 @@ exports[`next build works: node 1`] = `
       "name": "util-deprecate",
       "npm": {
         "name": "util-deprecate",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 477,
     },
@@ -37824,7 +37824,7 @@ exports[`next build works: node 1`] = `
       "name": "loose-envify",
       "npm": {
         "name": "loose-envify",
-        "version": ">=1.4.0 <2.0.0",
+        "version": ">=1.4.0 <2.0.0-0",
       },
       "package_id": 335,
     },
@@ -37837,7 +37837,7 @@ exports[`next build works: node 1`] = `
       "name": "object-assign",
       "npm": {
         "name": "object-assign",
-        "version": ">=4.1.1 <5.0.0",
+        "version": ">=4.1.1 <5.0.0-0",
       },
       "package_id": 354,
     },
@@ -37850,7 +37850,7 @@ exports[`next build works: node 1`] = `
       "name": "react-is",
       "npm": {
         "name": "react-is",
-        "version": ">=16.13.1 <17.0.0",
+        "version": ">=16.13.1 <17.0.0-0",
       },
       "package_id": 402,
     },
@@ -37863,7 +37863,7 @@ exports[`next build works: node 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -37876,7 +37876,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -37889,7 +37889,7 @@ exports[`next build works: node 1`] = `
       "name": "http-proxy-agent",
       "npm": {
         "name": "http-proxy-agent",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 276,
     },
@@ -37902,7 +37902,7 @@ exports[`next build works: node 1`] = `
       "name": "https-proxy-agent",
       "npm": {
         "name": "https-proxy-agent",
-        "version": ">=7.0.6 <8.0.0",
+        "version": ">=7.0.6 <8.0.0-0",
       },
       "package_id": 277,
     },
@@ -37915,7 +37915,7 @@ exports[`next build works: node 1`] = `
       "name": "lru-cache",
       "npm": {
         "name": "lru-cache",
-        "version": ">=7.14.1 <8.0.0",
+        "version": ">=7.14.1 <8.0.0-0",
       },
       "package_id": 336,
     },
@@ -37928,7 +37928,7 @@ exports[`next build works: node 1`] = `
       "name": "pac-proxy-agent",
       "npm": {
         "name": "pac-proxy-agent",
-        "version": ">=7.1.0 <8.0.0",
+        "version": ">=7.1.0 <8.0.0-0",
       },
       "package_id": 368,
     },
@@ -37941,7 +37941,7 @@ exports[`next build works: node 1`] = `
       "name": "proxy-from-env",
       "npm": {
         "name": "proxy-from-env",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 394,
     },
@@ -37954,7 +37954,7 @@ exports[`next build works: node 1`] = `
       "name": "socks-proxy-agent",
       "npm": {
         "name": "socks-proxy-agent",
-        "version": ">=8.0.5 <9.0.0",
+        "version": ">=8.0.5 <9.0.0-0",
       },
       "package_id": 431,
     },
@@ -37967,7 +37967,7 @@ exports[`next build works: node 1`] = `
       "name": "end-of-stream",
       "npm": {
         "name": "end-of-stream",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 202,
     },
@@ -37980,7 +37980,7 @@ exports[`next build works: node 1`] = `
       "name": "once",
       "npm": {
         "name": "once",
-        "version": ">=1.3.1 <2.0.0",
+        "version": ">=1.3.1 <2.0.0-0",
       },
       "package_id": 363,
     },
@@ -38019,7 +38019,7 @@ exports[`next build works: node 1`] = `
       "name": "cosmiconfig",
       "npm": {
         "name": "cosmiconfig",
-        "version": ">=9.0.0 <10.0.0",
+        "version": ">=9.0.0 <10.0.0-0",
       },
       "package_id": 179,
     },
@@ -38058,7 +38058,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -38097,7 +38097,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.4.1 <5.0.0",
+        "version": ">=4.4.1 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -38123,7 +38123,7 @@ exports[`next build works: node 1`] = `
       "name": "typed-query-selector",
       "npm": {
         "name": "typed-query-selector",
-        "version": ">=2.12.0 <3.0.0",
+        "version": ">=2.12.0 <3.0.0-0",
       },
       "package_id": 469,
     },
@@ -38136,7 +38136,7 @@ exports[`next build works: node 1`] = `
       "name": "ws",
       "npm": {
         "name": "ws",
-        "version": ">=8.18.3 <9.0.0",
+        "version": ">=8.18.3 <9.0.0-0",
       },
       "package_id": 486,
     },
@@ -38149,7 +38149,7 @@ exports[`next build works: node 1`] = `
       "name": "scheduler",
       "npm": {
         "name": "scheduler",
-        "version": ">=0.27.0 <0.28.0",
+        "version": ">=0.27.0 <0.28.0-0",
       },
       "package_id": 416,
     },
@@ -38162,7 +38162,7 @@ exports[`next build works: node 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=19.2.4 <20.0.0",
+        "version": ">=19.2.4 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -38175,7 +38175,7 @@ exports[`next build works: node 1`] = `
       "name": "pify",
       "npm": {
         "name": "pify",
-        "version": ">=2.3.0 <3.0.0",
+        "version": ">=2.3.0 <3.0.0-0",
       },
       "package_id": 380,
     },
@@ -38188,7 +38188,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=2.2.1 <3.0.0",
+        "version": ">=2.2.1 <3.0.0-0",
       },
       "package_id": 379,
     },
@@ -38201,7 +38201,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -38214,7 +38214,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -38227,7 +38227,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.9 <2.0.0",
+        "version": ">=1.23.9 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -38240,7 +38240,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38253,7 +38253,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -38266,7 +38266,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.7 <2.0.0",
+        "version": ">=1.2.7 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -38279,7 +38279,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -38292,7 +38292,7 @@ exports[`next build works: node 1`] = `
       "name": "which-builtin-type",
       "npm": {
         "name": "which-builtin-type",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 480,
     },
@@ -38305,7 +38305,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -38318,7 +38318,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -38331,7 +38331,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38344,7 +38344,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -38357,7 +38357,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -38370,7 +38370,7 @@ exports[`next build works: node 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -38383,7 +38383,7 @@ exports[`next build works: node 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.16.0 <3.0.0",
+        "version": ">=2.16.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -38396,7 +38396,7 @@ exports[`next build works: node 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -38409,7 +38409,7 @@ exports[`next build works: node 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -38422,7 +38422,7 @@ exports[`next build works: node 1`] = `
       "name": "queue-microtask",
       "npm": {
         "name": "queue-microtask",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 399,
     },
@@ -38435,7 +38435,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -38448,7 +38448,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -38461,7 +38461,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -38474,7 +38474,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -38487,7 +38487,7 @@ exports[`next build works: node 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -38500,7 +38500,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38513,7 +38513,7 @@ exports[`next build works: node 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -38526,7 +38526,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -38539,7 +38539,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38552,7 +38552,7 @@ exports[`next build works: node 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -38565,7 +38565,7 @@ exports[`next build works: node 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -38578,7 +38578,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38591,7 +38591,7 @@ exports[`next build works: node 1`] = `
       "name": "function-bind",
       "npm": {
         "name": "function-bind",
-        "version": ">=1.1.2 <2.0.0",
+        "version": ">=1.1.2 <2.0.0-0",
       },
       "package_id": 251,
     },
@@ -38604,7 +38604,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.4 <2.0.0",
+        "version": ">=1.2.4 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -38617,7 +38617,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -38630,7 +38630,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -38643,7 +38643,7 @@ exports[`next build works: node 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -38656,7 +38656,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38669,7 +38669,7 @@ exports[`next build works: node 1`] = `
       "name": "functions-have-names",
       "npm": {
         "name": "functions-have-names",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 253,
     },
@@ -38682,7 +38682,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -38695,7 +38695,7 @@ exports[`next build works: node 1`] = `
       "name": "dunder-proto",
       "npm": {
         "name": "dunder-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 198,
     },
@@ -38708,7 +38708,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -38721,7 +38721,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -39046,7 +39046,7 @@ exports[`next build works: node 1`] = `
       "name": "@img/colour",
       "npm": {
         "name": "@img/colour",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 34,
     },
@@ -39059,7 +39059,7 @@ exports[`next build works: node 1`] = `
       "name": "detect-libc",
       "npm": {
         "name": "detect-libc",
-        "version": ">=2.1.2 <3.0.0",
+        "version": ">=2.1.2 <3.0.0-0",
       },
       "package_id": 193,
     },
@@ -39072,7 +39072,7 @@ exports[`next build works: node 1`] = `
       "name": "semver",
       "npm": {
         "name": "semver",
-        "version": ">=7.7.3 <8.0.0",
+        "version": ">=7.7.3 <8.0.0-0",
       },
       "package_id": 512,
     },
@@ -39085,7 +39085,7 @@ exports[`next build works: node 1`] = `
       "name": "shebang-regex",
       "npm": {
         "name": "shebang-regex",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 423,
     },
@@ -39098,7 +39098,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39111,7 +39111,7 @@ exports[`next build works: node 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -39124,7 +39124,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel-list",
       "npm": {
         "name": "side-channel-list",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 425,
     },
@@ -39137,7 +39137,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -39150,7 +39150,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel-weakmap",
       "npm": {
         "name": "side-channel-weakmap",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 427,
     },
@@ -39163,7 +39163,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39176,7 +39176,7 @@ exports[`next build works: node 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -39189,7 +39189,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -39202,7 +39202,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39215,7 +39215,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -39228,7 +39228,7 @@ exports[`next build works: node 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -39241,7 +39241,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -39254,7 +39254,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39267,7 +39267,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.5 <2.0.0",
+        "version": ">=1.2.5 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -39280,7 +39280,7 @@ exports[`next build works: node 1`] = `
       "name": "object-inspect",
       "npm": {
         "name": "object-inspect",
-        "version": ">=1.13.3 <2.0.0",
+        "version": ">=1.13.3 <2.0.0-0",
       },
       "package_id": 356,
     },
@@ -39293,7 +39293,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel-map",
       "npm": {
         "name": "side-channel-map",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 426,
     },
@@ -39306,7 +39306,7 @@ exports[`next build works: node 1`] = `
       "name": "ip-address",
       "npm": {
         "name": "ip-address",
-        "version": ">=9.0.5 <10.0.0",
+        "version": ">=9.0.5 <10.0.0-0",
       },
       "package_id": 282,
     },
@@ -39319,7 +39319,7 @@ exports[`next build works: node 1`] = `
       "name": "smart-buffer",
       "npm": {
         "name": "smart-buffer",
-        "version": ">=4.2.0 <5.0.0",
+        "version": ">=4.2.0 <5.0.0-0",
       },
       "package_id": 429,
     },
@@ -39332,7 +39332,7 @@ exports[`next build works: node 1`] = `
       "name": "agent-base",
       "npm": {
         "name": "agent-base",
-        "version": ">=7.1.2 <8.0.0",
+        "version": ">=7.1.2 <8.0.0-0",
       },
       "package_id": 124,
     },
@@ -39345,7 +39345,7 @@ exports[`next build works: node 1`] = `
       "name": "debug",
       "npm": {
         "name": "debug",
-        "version": ">=4.3.4 <5.0.0",
+        "version": ">=4.3.4 <5.0.0-0",
       },
       "package_id": 188,
     },
@@ -39358,7 +39358,7 @@ exports[`next build works: node 1`] = `
       "name": "socks",
       "npm": {
         "name": "socks",
-        "version": ">=2.8.3 <3.0.0",
+        "version": ">=2.8.3 <3.0.0-0",
       },
       "package_id": 430,
     },
@@ -39371,7 +39371,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39384,7 +39384,7 @@ exports[`next build works: node 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -39397,7 +39397,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-events",
       "npm": {
         "name": "bare-events",
-        "version": ">=2.2.0 <3.0.0",
+        "version": ">=2.2.0 <3.0.0-0",
       },
       "package_id": 150,
     },
@@ -39410,7 +39410,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.3.2 <2.0.0",
+        "version": ">=1.3.2 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -39423,7 +39423,7 @@ exports[`next build works: node 1`] = `
       "name": "text-decoder",
       "npm": {
         "name": "text-decoder",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 455,
     },
@@ -39436,7 +39436,7 @@ exports[`next build works: node 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": 523,
     },
@@ -39449,7 +39449,7 @@ exports[`next build works: node 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 296,
     },
@@ -39462,7 +39462,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -39475,7 +39475,7 @@ exports[`next build works: node 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=8.0.0 <9.0.0",
+        "version": ">=8.0.0 <9.0.0-0",
       },
       "package_id": null,
     },
@@ -39488,7 +39488,7 @@ exports[`next build works: node 1`] = `
       "name": "is-fullwidth-code-point",
       "npm": {
         "name": "is-fullwidth-code-point",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": null,
     },
@@ -39501,7 +39501,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -39514,7 +39514,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -39527,7 +39527,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39540,7 +39540,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.3 <2.0.0",
+        "version": ">=1.23.3 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -39553,7 +39553,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -39566,7 +39566,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -39579,7 +39579,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39592,7 +39592,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.6 <2.0.0",
+        "version": ">=1.23.6 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -39605,7 +39605,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -39618,7 +39618,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -39631,7 +39631,7 @@ exports[`next build works: node 1`] = `
       "name": "get-intrinsic",
       "npm": {
         "name": "get-intrinsic",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 256,
     },
@@ -39644,7 +39644,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -39657,7 +39657,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -39670,7 +39670,7 @@ exports[`next build works: node 1`] = `
       "name": "internal-slot",
       "npm": {
         "name": "internal-slot",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 281,
     },
@@ -39683,7 +39683,7 @@ exports[`next build works: node 1`] = `
       "name": "regexp.prototype.flags",
       "npm": {
         "name": "regexp.prototype.flags",
-        "version": ">=1.5.3 <2.0.0",
+        "version": ">=1.5.3 <2.0.0-0",
       },
       "package_id": 406,
     },
@@ -39696,7 +39696,7 @@ exports[`next build works: node 1`] = `
       "name": "set-function-name",
       "npm": {
         "name": "set-function-name",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 419,
     },
@@ -39709,7 +39709,7 @@ exports[`next build works: node 1`] = `
       "name": "side-channel",
       "npm": {
         "name": "side-channel",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 424,
     },
@@ -39722,7 +39722,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39735,7 +39735,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.17.5 <2.0.0",
+        "version": ">=1.17.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -39748,7 +39748,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -39761,7 +39761,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -39774,7 +39774,7 @@ exports[`next build works: node 1`] = `
       "name": "define-data-property",
       "npm": {
         "name": "define-data-property",
-        "version": ">=1.1.4 <2.0.0",
+        "version": ">=1.1.4 <2.0.0-0",
       },
       "package_id": 190,
     },
@@ -39787,7 +39787,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39800,7 +39800,7 @@ exports[`next build works: node 1`] = `
       "name": "es-abstract",
       "npm": {
         "name": "es-abstract",
-        "version": ">=1.23.5 <2.0.0",
+        "version": ">=1.23.5 <2.0.0-0",
       },
       "package_id": 205,
     },
@@ -39813,7 +39813,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -39826,7 +39826,7 @@ exports[`next build works: node 1`] = `
       "name": "has-property-descriptors",
       "npm": {
         "name": "has-property-descriptors",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 269,
     },
@@ -39839,7 +39839,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -39852,7 +39852,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -39865,7 +39865,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39878,7 +39878,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -39891,7 +39891,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -39904,7 +39904,7 @@ exports[`next build works: node 1`] = `
       "name": "define-properties",
       "npm": {
         "name": "define-properties",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 191,
     },
@@ -39917,7 +39917,7 @@ exports[`next build works: node 1`] = `
       "name": "es-object-atoms",
       "npm": {
         "name": "es-object-atoms",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 209,
     },
@@ -39930,7 +39930,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 126,
     },
@@ -39943,7 +39943,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": null,
     },
@@ -39969,7 +39969,7 @@ exports[`next build works: node 1`] = `
       "name": "react",
       "npm": {
         "name": "react",
-        "version": ">=16.8.0 || <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && <18.0.0 >=17.0.0 || >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=18.0.0-0 <19.0.0 || >=19.0.0-0 <20.0.0 && >=19.0.0-0 <20.0.0",
+        "version": ">=16.8.0 || <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && <18.0.0-0 >=17.0.0 || >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=18.0.0-0 <19.0.0-0 || >=19.0.0-0 <20.0.0-0 && >=19.0.0-0 <20.0.0-0",
       },
       "package_id": 400,
     },
@@ -39982,7 +39982,7 @@ exports[`next build works: node 1`] = `
       "name": "@jridgewell/gen-mapping",
       "npm": {
         "name": "@jridgewell/gen-mapping",
-        "version": ">=0.3.2 <0.4.0",
+        "version": ">=0.3.2 <0.4.0-0",
       },
       "package_id": 60,
     },
@@ -39995,7 +39995,7 @@ exports[`next build works: node 1`] = `
       "name": "commander",
       "npm": {
         "name": "commander",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 176,
     },
@@ -40008,7 +40008,7 @@ exports[`next build works: node 1`] = `
       "name": "glob",
       "npm": {
         "name": "glob",
-        "version": ">=10.3.10 <11.0.0",
+        "version": ">=10.3.10 <11.0.0-0",
       },
       "package_id": 262,
     },
@@ -40021,7 +40021,7 @@ exports[`next build works: node 1`] = `
       "name": "lines-and-columns",
       "npm": {
         "name": "lines-and-columns",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 332,
     },
@@ -40034,7 +40034,7 @@ exports[`next build works: node 1`] = `
       "name": "mz",
       "npm": {
         "name": "mz",
-        "version": ">=2.7.0 <3.0.0",
+        "version": ">=2.7.0 <3.0.0-0",
       },
       "package_id": 345,
     },
@@ -40047,7 +40047,7 @@ exports[`next build works: node 1`] = `
       "name": "pirates",
       "npm": {
         "name": "pirates",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 381,
     },
@@ -40060,7 +40060,7 @@ exports[`next build works: node 1`] = `
       "name": "ts-interface-checker",
       "npm": {
         "name": "ts-interface-checker",
-        "version": ">=0.1.9 <0.2.0",
+        "version": ">=0.1.9 <0.2.0-0",
       },
       "package_id": 461,
     },
@@ -40073,7 +40073,7 @@ exports[`next build works: node 1`] = `
       "name": "has-flag",
       "npm": {
         "name": "has-flag",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 268,
     },
@@ -40086,7 +40086,7 @@ exports[`next build works: node 1`] = `
       "name": "@alloc/quick-lru",
       "npm": {
         "name": "@alloc/quick-lru",
-        "version": ">=5.2.0 <6.0.0",
+        "version": ">=5.2.0 <6.0.0-0",
       },
       "package_id": 1,
     },
@@ -40099,7 +40099,7 @@ exports[`next build works: node 1`] = `
       "name": "arg",
       "npm": {
         "name": "arg",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 130,
     },
@@ -40112,7 +40112,7 @@ exports[`next build works: node 1`] = `
       "name": "chokidar",
       "npm": {
         "name": "chokidar",
-        "version": ">=3.6.0 <4.0.0",
+        "version": ">=3.6.0 <4.0.0-0",
       },
       "package_id": 170,
     },
@@ -40125,7 +40125,7 @@ exports[`next build works: node 1`] = `
       "name": "didyoumean",
       "npm": {
         "name": "didyoumean",
-        "version": ">=1.2.2 <2.0.0",
+        "version": ">=1.2.2 <2.0.0-0",
       },
       "package_id": 195,
     },
@@ -40138,7 +40138,7 @@ exports[`next build works: node 1`] = `
       "name": "dlv",
       "npm": {
         "name": "dlv",
-        "version": ">=1.1.3 <2.0.0",
+        "version": ">=1.1.3 <2.0.0-0",
       },
       "package_id": 196,
     },
@@ -40151,7 +40151,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-glob",
       "npm": {
         "name": "fast-glob",
-        "version": ">=3.3.2 <4.0.0",
+        "version": ">=3.3.2 <4.0.0-0",
       },
       "package_id": 236,
     },
@@ -40164,7 +40164,7 @@ exports[`next build works: node 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=6.0.2 <7.0.0",
+        "version": ">=6.0.2 <7.0.0-0",
       },
       "package_id": 263,
     },
@@ -40177,7 +40177,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -40190,7 +40190,7 @@ exports[`next build works: node 1`] = `
       "name": "jiti",
       "npm": {
         "name": "jiti",
-        "version": ">=1.21.6 <2.0.0",
+        "version": ">=1.21.6 <2.0.0-0",
       },
       "package_id": 316,
     },
@@ -40203,7 +40203,7 @@ exports[`next build works: node 1`] = `
       "name": "lilconfig",
       "npm": {
         "name": "lilconfig",
-        "version": ">=3.1.3 <4.0.0",
+        "version": ">=3.1.3 <4.0.0-0",
       },
       "package_id": 331,
     },
@@ -40216,7 +40216,7 @@ exports[`next build works: node 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.8 <5.0.0",
+        "version": ">=4.0.8 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -40229,7 +40229,7 @@ exports[`next build works: node 1`] = `
       "name": "normalize-path",
       "npm": {
         "name": "normalize-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 352,
     },
@@ -40242,7 +40242,7 @@ exports[`next build works: node 1`] = `
       "name": "object-hash",
       "npm": {
         "name": "object-hash",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 355,
     },
@@ -40255,7 +40255,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -40268,7 +40268,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss",
       "npm": {
         "name": "postcss",
-        "version": ">=8.4.47 <9.0.0",
+        "version": ">=8.4.47 <9.0.0-0",
       },
       "package_id": 383,
     },
@@ -40281,7 +40281,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-import",
       "npm": {
         "name": "postcss-import",
-        "version": ">=15.1.0 <16.0.0",
+        "version": ">=15.1.0 <16.0.0-0",
       },
       "package_id": 384,
     },
@@ -40294,7 +40294,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-js",
       "npm": {
         "name": "postcss-js",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 385,
     },
@@ -40307,7 +40307,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-load-config",
       "npm": {
         "name": "postcss-load-config",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 386,
     },
@@ -40320,7 +40320,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-nested",
       "npm": {
         "name": "postcss-nested",
-        "version": ">=6.2.0 <7.0.0",
+        "version": ">=6.2.0 <7.0.0-0",
       },
       "package_id": 387,
     },
@@ -40333,7 +40333,7 @@ exports[`next build works: node 1`] = `
       "name": "postcss-selector-parser",
       "npm": {
         "name": "postcss-selector-parser",
-        "version": ">=6.1.2 <7.0.0",
+        "version": ">=6.1.2 <7.0.0-0",
       },
       "package_id": 388,
     },
@@ -40346,7 +40346,7 @@ exports[`next build works: node 1`] = `
       "name": "resolve",
       "npm": {
         "name": "resolve",
-        "version": ">=1.22.8 <2.0.0",
+        "version": ">=1.22.8 <2.0.0-0",
       },
       "package_id": 408,
     },
@@ -40359,7 +40359,7 @@ exports[`next build works: node 1`] = `
       "name": "sucrase",
       "npm": {
         "name": "sucrase",
-        "version": ">=3.35.0 <4.0.0",
+        "version": ">=3.35.0 <4.0.0-0",
       },
       "package_id": 449,
     },
@@ -40372,7 +40372,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-fs",
       "npm": {
         "name": "bare-fs",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 151,
     },
@@ -40385,7 +40385,7 @@ exports[`next build works: node 1`] = `
       "name": "bare-path",
       "npm": {
         "name": "bare-path",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 153,
     },
@@ -40398,7 +40398,7 @@ exports[`next build works: node 1`] = `
       "name": "pump",
       "npm": {
         "name": "pump",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 395,
     },
@@ -40411,7 +40411,7 @@ exports[`next build works: node 1`] = `
       "name": "tar-stream",
       "npm": {
         "name": "tar-stream",
-        "version": ">=3.1.5 <4.0.0",
+        "version": ">=3.1.5 <4.0.0-0",
       },
       "package_id": 454,
     },
@@ -40424,7 +40424,7 @@ exports[`next build works: node 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -40437,7 +40437,7 @@ exports[`next build works: node 1`] = `
       "name": "fast-fifo",
       "npm": {
         "name": "fast-fifo",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 235,
     },
@@ -40450,7 +40450,7 @@ exports[`next build works: node 1`] = `
       "name": "streamx",
       "npm": {
         "name": "streamx",
-        "version": ">=2.15.0 <3.0.0",
+        "version": ">=2.15.0 <3.0.0-0",
       },
       "package_id": 437,
     },
@@ -40463,7 +40463,7 @@ exports[`next build works: node 1`] = `
       "name": "b4a",
       "npm": {
         "name": "b4a",
-        "version": ">=1.6.4 <2.0.0",
+        "version": ">=1.6.4 <2.0.0-0",
       },
       "package_id": 148,
     },
@@ -40476,7 +40476,7 @@ exports[`next build works: node 1`] = `
       "name": "any-promise",
       "npm": {
         "name": "any-promise",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 128,
     },
@@ -40489,7 +40489,7 @@ exports[`next build works: node 1`] = `
       "name": "thenify",
       "npm": {
         "name": "thenify",
-        "version": ">=3.1.0 && <4.0.0",
+        "version": ">=3.1.0 && <4.0.0-0",
       },
       "package_id": 456,
     },
@@ -40502,7 +40502,7 @@ exports[`next build works: node 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.4.4 <7.0.0",
+        "version": ">=6.4.4 <7.0.0-0",
       },
       "package_id": 241,
     },
@@ -40515,7 +40515,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -40528,7 +40528,7 @@ exports[`next build works: node 1`] = `
       "name": "is-number",
       "npm": {
         "name": "is-number",
-        "version": ">=7.0.0 <8.0.0",
+        "version": ">=7.0.0 <8.0.0-0",
       },
       "package_id": 301,
     },
@@ -40554,7 +40554,7 @@ exports[`next build works: node 1`] = `
       "name": "@types/json5",
       "npm": {
         "name": "@types/json5",
-        "version": ">=0.0.29 <0.0.30",
+        "version": ">=0.0.29 <0.0.30-0",
       },
       "package_id": 88,
     },
@@ -40567,7 +40567,7 @@ exports[`next build works: node 1`] = `
       "name": "json5",
       "npm": {
         "name": "json5",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 325,
     },
@@ -40580,7 +40580,7 @@ exports[`next build works: node 1`] = `
       "name": "minimist",
       "npm": {
         "name": "minimist",
-        "version": ">=1.2.6 <2.0.0",
+        "version": ">=1.2.6 <2.0.0-0",
       },
       "package_id": 341,
     },
@@ -40593,7 +40593,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-bom",
       "npm": {
         "name": "strip-bom",
-        "version": ">=3.0.0 <4.0.0",
+        "version": ">=3.0.0 <4.0.0-0",
       },
       "package_id": 446,
     },
@@ -40606,7 +40606,7 @@ exports[`next build works: node 1`] = `
       "name": "prelude-ls",
       "npm": {
         "name": "prelude-ls",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 390,
     },
@@ -40619,7 +40619,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -40632,7 +40632,7 @@ exports[`next build works: node 1`] = `
       "name": "es-errors",
       "npm": {
         "name": "es-errors",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 207,
     },
@@ -40645,7 +40645,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -40658,7 +40658,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -40671,7 +40671,7 @@ exports[`next build works: node 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -40684,7 +40684,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -40697,7 +40697,7 @@ exports[`next build works: node 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -40710,7 +40710,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.14 <2.0.0",
+        "version": ">=1.1.14 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -40723,7 +40723,7 @@ exports[`next build works: node 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -40736,7 +40736,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -40749,7 +40749,7 @@ exports[`next build works: node 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -40762,7 +40762,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -40775,7 +40775,7 @@ exports[`next build works: node 1`] = `
       "name": "has-proto",
       "npm": {
         "name": "has-proto",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 270,
     },
@@ -40788,7 +40788,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.15 <2.0.0",
+        "version": ">=1.1.15 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -40801,7 +40801,7 @@ exports[`next build works: node 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.9 <2.0.0",
+        "version": ">=1.0.9 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -40814,7 +40814,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -40827,7 +40827,7 @@ exports[`next build works: node 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.3 <0.4.0",
+        "version": ">=0.3.3 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -40840,7 +40840,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -40853,7 +40853,7 @@ exports[`next build works: node 1`] = `
       "name": "is-typed-array",
       "npm": {
         "name": "is-typed-array",
-        "version": ">=1.1.13 <2.0.0",
+        "version": ">=1.1.13 <2.0.0-0",
       },
       "package_id": 308,
     },
@@ -40866,7 +40866,7 @@ exports[`next build works: node 1`] = `
       "name": "possible-typed-array-names",
       "npm": {
         "name": "possible-typed-array-names",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 382,
     },
@@ -40879,7 +40879,7 @@ exports[`next build works: node 1`] = `
       "name": "reflect.getprototypeof",
       "npm": {
         "name": "reflect.getprototypeof",
-        "version": ">=1.0.6 <2.0.0",
+        "version": ">=1.0.6 <2.0.0-0",
       },
       "package_id": 405,
     },
@@ -40944,7 +40944,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=8.57.0 <9.0.0 || >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=9.0.0 <10.0.0 || >=10.0.0 <11.0.0 && >=10.0.0 <11.0.0",
+        "version": ">=8.57.0 <9.0.0-0 || >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=9.0.0 <10.0.0-0 || >=10.0.0 <11.0.0-0 && >=10.0.0 <11.0.0-0",
       },
       "package_id": 216,
     },
@@ -40970,7 +40970,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.3 <2.0.0",
+        "version": ">=1.0.3 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -40983,7 +40983,7 @@ exports[`next build works: node 1`] = `
       "name": "has-bigints",
       "npm": {
         "name": "has-bigints",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 267,
     },
@@ -40996,7 +40996,7 @@ exports[`next build works: node 1`] = `
       "name": "has-symbols",
       "npm": {
         "name": "has-symbols",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 271,
     },
@@ -41009,7 +41009,7 @@ exports[`next build works: node 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -41269,7 +41269,7 @@ exports[`next build works: node 1`] = `
       "name": "napi-postinstall",
       "npm": {
         "name": "napi-postinstall",
-        "version": ">=0.3.0 <0.4.0",
+        "version": ">=0.3.0 <0.4.0-0",
       },
       "package_id": 347,
     },
@@ -41282,7 +41282,7 @@ exports[`next build works: node 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.2.0 <4.0.0",
+        "version": ">=3.2.0 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -41295,7 +41295,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -41321,7 +41321,7 @@ exports[`next build works: node 1`] = `
       "name": "punycode",
       "npm": {
         "name": "punycode",
-        "version": ">=2.1.0 <3.0.0",
+        "version": ">=2.1.0 <3.0.0-0",
       },
       "package_id": 396,
     },
@@ -41334,7 +41334,7 @@ exports[`next build works: node 1`] = `
       "name": "isexe",
       "npm": {
         "name": "isexe",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 313,
     },
@@ -41347,7 +41347,7 @@ exports[`next build works: node 1`] = `
       "name": "is-bigint",
       "npm": {
         "name": "is-bigint",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 286,
     },
@@ -41360,7 +41360,7 @@ exports[`next build works: node 1`] = `
       "name": "is-boolean-object",
       "npm": {
         "name": "is-boolean-object",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 288,
     },
@@ -41373,7 +41373,7 @@ exports[`next build works: node 1`] = `
       "name": "is-number-object",
       "npm": {
         "name": "is-number-object",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 302,
     },
@@ -41386,7 +41386,7 @@ exports[`next build works: node 1`] = `
       "name": "is-string",
       "npm": {
         "name": "is-string",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 306,
     },
@@ -41399,7 +41399,7 @@ exports[`next build works: node 1`] = `
       "name": "is-symbol",
       "npm": {
         "name": "is-symbol",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 307,
     },
@@ -41412,7 +41412,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -41425,7 +41425,7 @@ exports[`next build works: node 1`] = `
       "name": "function.prototype.name",
       "npm": {
         "name": "function.prototype.name",
-        "version": ">=1.1.6 <2.0.0",
+        "version": ">=1.1.6 <2.0.0-0",
       },
       "package_id": 252,
     },
@@ -41438,7 +41438,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -41451,7 +41451,7 @@ exports[`next build works: node 1`] = `
       "name": "is-async-function",
       "npm": {
         "name": "is-async-function",
-        "version": ">=2.0.0 <3.0.0",
+        "version": ">=2.0.0 <3.0.0-0",
       },
       "package_id": 285,
     },
@@ -41464,7 +41464,7 @@ exports[`next build works: node 1`] = `
       "name": "is-date-object",
       "npm": {
         "name": "is-date-object",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 293,
     },
@@ -41477,7 +41477,7 @@ exports[`next build works: node 1`] = `
       "name": "is-finalizationregistry",
       "npm": {
         "name": "is-finalizationregistry",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 295,
     },
@@ -41490,7 +41490,7 @@ exports[`next build works: node 1`] = `
       "name": "is-generator-function",
       "npm": {
         "name": "is-generator-function",
-        "version": ">=1.0.10 <2.0.0",
+        "version": ">=1.0.10 <2.0.0-0",
       },
       "package_id": 297,
     },
@@ -41503,7 +41503,7 @@ exports[`next build works: node 1`] = `
       "name": "is-regex",
       "npm": {
         "name": "is-regex",
-        "version": ">=1.2.1 <2.0.0",
+        "version": ">=1.2.1 <2.0.0-0",
       },
       "package_id": 303,
     },
@@ -41516,7 +41516,7 @@ exports[`next build works: node 1`] = `
       "name": "is-weakref",
       "npm": {
         "name": "is-weakref",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 310,
     },
@@ -41529,7 +41529,7 @@ exports[`next build works: node 1`] = `
       "name": "isarray",
       "npm": {
         "name": "isarray",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 312,
     },
@@ -41542,7 +41542,7 @@ exports[`next build works: node 1`] = `
       "name": "which-boxed-primitive",
       "npm": {
         "name": "which-boxed-primitive",
-        "version": ">=1.1.0 <2.0.0",
+        "version": ">=1.1.0 <2.0.0-0",
       },
       "package_id": 479,
     },
@@ -41555,7 +41555,7 @@ exports[`next build works: node 1`] = `
       "name": "which-collection",
       "npm": {
         "name": "which-collection",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 481,
     },
@@ -41568,7 +41568,7 @@ exports[`next build works: node 1`] = `
       "name": "which-typed-array",
       "npm": {
         "name": "which-typed-array",
-        "version": ">=1.1.16 <2.0.0",
+        "version": ">=1.1.16 <2.0.0-0",
       },
       "package_id": 482,
     },
@@ -41581,7 +41581,7 @@ exports[`next build works: node 1`] = `
       "name": "is-map",
       "npm": {
         "name": "is-map",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 299,
     },
@@ -41594,7 +41594,7 @@ exports[`next build works: node 1`] = `
       "name": "is-set",
       "npm": {
         "name": "is-set",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 304,
     },
@@ -41607,7 +41607,7 @@ exports[`next build works: node 1`] = `
       "name": "is-weakmap",
       "npm": {
         "name": "is-weakmap",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 309,
     },
@@ -41620,7 +41620,7 @@ exports[`next build works: node 1`] = `
       "name": "is-weakset",
       "npm": {
         "name": "is-weakset",
-        "version": ">=2.0.3 <3.0.0",
+        "version": ">=2.0.3 <3.0.0-0",
       },
       "package_id": 311,
     },
@@ -41633,7 +41633,7 @@ exports[`next build works: node 1`] = `
       "name": "available-typed-arrays",
       "npm": {
         "name": "available-typed-arrays",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 145,
     },
@@ -41646,7 +41646,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bind",
       "npm": {
         "name": "call-bind",
-        "version": ">=1.0.8 <2.0.0",
+        "version": ">=1.0.8 <2.0.0-0",
       },
       "package_id": 163,
     },
@@ -41659,7 +41659,7 @@ exports[`next build works: node 1`] = `
       "name": "call-bound",
       "npm": {
         "name": "call-bound",
-        "version": ">=1.0.4 <2.0.0",
+        "version": ">=1.0.4 <2.0.0-0",
       },
       "package_id": 165,
     },
@@ -41672,7 +41672,7 @@ exports[`next build works: node 1`] = `
       "name": "for-each",
       "npm": {
         "name": "for-each",
-        "version": ">=0.3.5 <0.4.0",
+        "version": ">=0.3.5 <0.4.0-0",
       },
       "package_id": 247,
     },
@@ -41685,7 +41685,7 @@ exports[`next build works: node 1`] = `
       "name": "get-proto",
       "npm": {
         "name": "get-proto",
-        "version": ">=1.0.1 <2.0.0",
+        "version": ">=1.0.1 <2.0.0-0",
       },
       "package_id": 257,
     },
@@ -41698,7 +41698,7 @@ exports[`next build works: node 1`] = `
       "name": "gopd",
       "npm": {
         "name": "gopd",
-        "version": ">=1.2.0 <2.0.0",
+        "version": ">=1.2.0 <2.0.0-0",
       },
       "package_id": 266,
     },
@@ -41711,7 +41711,7 @@ exports[`next build works: node 1`] = `
       "name": "has-tostringtag",
       "npm": {
         "name": "has-tostringtag",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 272,
     },
@@ -41724,7 +41724,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 127,
     },
@@ -41737,7 +41737,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -41750,7 +41750,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": 445,
     },
@@ -41763,7 +41763,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -41776,7 +41776,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.1.0 <5.0.0",
+        "version": ">=4.1.0 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -41789,7 +41789,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=6.0.0 <7.0.0",
+        "version": ">=6.0.0 <7.0.0-0",
       },
       "package_id": null,
     },
@@ -41803,7 +41803,7 @@ exports[`next build works: node 1`] = `
       "name": "bufferutil",
       "npm": {
         "name": "bufferutil",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -41830,7 +41830,7 @@ exports[`next build works: node 1`] = `
       "name": "cliui",
       "npm": {
         "name": "cliui",
-        "version": ">=8.0.1 <9.0.0",
+        "version": ">=8.0.1 <9.0.0-0",
       },
       "package_id": 173,
     },
@@ -41843,7 +41843,7 @@ exports[`next build works: node 1`] = `
       "name": "escalade",
       "npm": {
         "name": "escalade",
-        "version": ">=3.1.1 <4.0.0",
+        "version": ">=3.1.1 <4.0.0-0",
       },
       "package_id": 213,
     },
@@ -41856,7 +41856,7 @@ exports[`next build works: node 1`] = `
       "name": "get-caller-file",
       "npm": {
         "name": "get-caller-file",
-        "version": ">=2.0.5 <3.0.0",
+        "version": ">=2.0.5 <3.0.0-0",
       },
       "package_id": 255,
     },
@@ -41869,7 +41869,7 @@ exports[`next build works: node 1`] = `
       "name": "require-directory",
       "npm": {
         "name": "require-directory",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 407,
     },
@@ -41882,7 +41882,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=4.2.3 <5.0.0",
+        "version": ">=4.2.3 <5.0.0-0",
       },
       "package_id": 438,
     },
@@ -41895,7 +41895,7 @@ exports[`next build works: node 1`] = `
       "name": "y18n",
       "npm": {
         "name": "y18n",
-        "version": ">=5.0.5 <6.0.0",
+        "version": ">=5.0.5 <6.0.0-0",
       },
       "package_id": 487,
     },
@@ -41908,7 +41908,7 @@ exports[`next build works: node 1`] = `
       "name": "yargs-parser",
       "npm": {
         "name": "yargs-parser",
-        "version": ">=21.1.1 <22.0.0",
+        "version": ">=21.1.1 <22.0.0-0",
       },
       "package_id": 491,
     },
@@ -41921,7 +41921,7 @@ exports[`next build works: node 1`] = `
       "name": "buffer-crc32",
       "npm": {
         "name": "buffer-crc32",
-        "version": ">=0.2.3 <0.3.0",
+        "version": ">=0.2.3 <0.3.0-0",
       },
       "package_id": 161,
     },
@@ -41934,7 +41934,7 @@ exports[`next build works: node 1`] = `
       "name": "fd-slicer",
       "npm": {
         "name": "fd-slicer",
-        "version": ">=1.1.0 <1.2.0",
+        "version": ">=1.1.0 <1.2.0-0",
       },
       "package_id": 240,
     },
@@ -41947,7 +41947,7 @@ exports[`next build works: node 1`] = `
       "name": "zod",
       "npm": {
         "name": "zod",
-        "version": ">=3.25.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.25.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 494,
     },
@@ -41960,7 +41960,7 @@ exports[`next build works: node 1`] = `
       "name": "yallist",
       "npm": {
         "name": "yallist",
-        "version": ">=3.0.2 <4.0.0",
+        "version": ">=3.0.2 <4.0.0-0",
       },
       "package_id": 488,
     },
@@ -41973,7 +41973,7 @@ exports[`next build works: node 1`] = `
       "name": "eastasianwidth",
       "npm": {
         "name": "eastasianwidth",
-        "version": ">=0.2.0 <0.3.0",
+        "version": ">=0.2.0 <0.3.0-0",
       },
       "package_id": 199,
     },
@@ -41986,7 +41986,7 @@ exports[`next build works: node 1`] = `
       "name": "emoji-regex",
       "npm": {
         "name": "emoji-regex",
-        "version": ">=9.2.2 <10.0.0",
+        "version": ">=9.2.2 <10.0.0-0",
       },
       "package_id": 201,
     },
@@ -41999,7 +41999,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -42012,7 +42012,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-regex",
       "npm": {
         "name": "ansi-regex",
-        "version": ">=6.0.1 <7.0.0",
+        "version": ">=6.0.1 <7.0.0-0",
       },
       "package_id": 525,
     },
@@ -42025,7 +42025,7 @@ exports[`next build works: node 1`] = `
       "name": "ansi-styles",
       "npm": {
         "name": "ansi-styles",
-        "version": ">=6.1.0 <7.0.0",
+        "version": ">=6.1.0 <7.0.0-0",
       },
       "package_id": 526,
     },
@@ -42038,7 +42038,7 @@ exports[`next build works: node 1`] = `
       "name": "string-width",
       "npm": {
         "name": "string-width",
-        "version": ">=5.0.1 <6.0.0",
+        "version": ">=5.0.1 <6.0.0-0",
       },
       "package_id": 501,
     },
@@ -42051,7 +42051,7 @@ exports[`next build works: node 1`] = `
       "name": "strip-ansi",
       "npm": {
         "name": "strip-ansi",
-        "version": ">=7.0.1 <8.0.0",
+        "version": ">=7.0.1 <8.0.0-0",
       },
       "package_id": 502,
     },
@@ -42064,7 +42064,7 @@ exports[`next build works: node 1`] = `
       "name": "tslib",
       "npm": {
         "name": "tslib",
-        "version": ">=2.4.0 <3.0.0",
+        "version": ">=2.4.0 <3.0.0-0",
       },
       "package_id": 463,
     },
@@ -42077,7 +42077,7 @@ exports[`next build works: node 1`] = `
       "name": "@nodelib/fs.stat",
       "npm": {
         "name": "@nodelib/fs.stat",
-        "version": ">=2.0.2 <3.0.0",
+        "version": ">=2.0.2 <3.0.0-0",
       },
       "package_id": 77,
     },
@@ -42090,7 +42090,7 @@ exports[`next build works: node 1`] = `
       "name": "@nodelib/fs.walk",
       "npm": {
         "name": "@nodelib/fs.walk",
-        "version": ">=1.2.3 <2.0.0",
+        "version": ">=1.2.3 <2.0.0-0",
       },
       "package_id": 78,
     },
@@ -42103,7 +42103,7 @@ exports[`next build works: node 1`] = `
       "name": "glob-parent",
       "npm": {
         "name": "glob-parent",
-        "version": ">=5.1.2 <6.0.0",
+        "version": ">=5.1.2 <6.0.0-0",
       },
       "package_id": 516,
     },
@@ -42116,7 +42116,7 @@ exports[`next build works: node 1`] = `
       "name": "merge2",
       "npm": {
         "name": "merge2",
-        "version": ">=1.3.0 <2.0.0",
+        "version": ">=1.3.0 <2.0.0-0",
       },
       "package_id": 338,
     },
@@ -42129,7 +42129,7 @@ exports[`next build works: node 1`] = `
       "name": "micromatch",
       "npm": {
         "name": "micromatch",
-        "version": ">=4.0.4 <5.0.0",
+        "version": ">=4.0.4 <5.0.0-0",
       },
       "package_id": 339,
     },
@@ -42142,7 +42142,7 @@ exports[`next build works: node 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": 527,
     },
@@ -42155,7 +42155,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -42168,7 +42168,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -42181,7 +42181,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -42194,7 +42194,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.3 <3.0.0",
+        "version": ">=2.1.3 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -42207,7 +42207,7 @@ exports[`next build works: node 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=5.0.2 <6.0.0",
+        "version": ">=5.0.2 <6.0.0-0",
       },
       "package_id": 528,
     },
@@ -42220,7 +42220,7 @@ exports[`next build works: node 1`] = `
       "name": "fdir",
       "npm": {
         "name": "fdir",
-        "version": ">=6.5.0 <7.0.0",
+        "version": ">=6.5.0 <7.0.0-0",
       },
       "package_id": 529,
     },
@@ -42233,7 +42233,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=4.0.3 <5.0.0",
+        "version": ">=4.0.3 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -42246,7 +42246,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint-visitor-keys",
       "npm": {
         "name": "eslint-visitor-keys",
-        "version": ">=3.4.3 <4.0.0",
+        "version": ">=3.4.3 <4.0.0-0",
       },
       "package_id": 498,
     },
@@ -42259,7 +42259,7 @@ exports[`next build works: node 1`] = `
       "name": "eslint",
       "npm": {
         "name": "eslint",
-        "version": ">=6.0.0 <7.0.0 || >=7.0.0 <8.0.0 || >=8.0.0 && >=7.0.0 <8.0.0 || >=8.0.0 && >=8.0.0",
+        "version": ">=6.0.0 <7.0.0-0 || >=7.0.0 <8.0.0-0 || >=8.0.0 && >=7.0.0 <8.0.0-0 || >=8.0.0 && >=8.0.0",
       },
       "package_id": 216,
     },
@@ -42272,7 +42272,7 @@ exports[`next build works: node 1`] = `
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.10.0 <7.11.0-0",
       },
       "package_id": null,
     },
@@ -42285,7 +42285,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": 298,
     },
@@ -42298,7 +42298,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": 344,
     },
@@ -42311,7 +42311,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -42324,7 +42324,7 @@ exports[`next build works: node 1`] = `
       "name": "ms",
       "npm": {
         "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
+        "version": ">=2.1.1 <3.0.0-0",
       },
       "package_id": null,
     },
@@ -42337,7 +42337,7 @@ exports[`next build works: node 1`] = `
       "name": "is-core-module",
       "npm": {
         "name": "is-core-module",
-        "version": ">=2.13.0 <3.0.0",
+        "version": ">=2.13.0 <3.0.0-0",
       },
       "package_id": 291,
     },
@@ -42350,7 +42350,7 @@ exports[`next build works: node 1`] = `
       "name": "path-parse",
       "npm": {
         "name": "path-parse",
-        "version": ">=1.0.7 <2.0.0",
+        "version": ">=1.0.7 <2.0.0-0",
       },
       "package_id": 375,
     },
@@ -42363,7 +42363,7 @@ exports[`next build works: node 1`] = `
       "name": "supports-preserve-symlinks-flag",
       "npm": {
         "name": "supports-preserve-symlinks-flag",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 451,
     },
@@ -42376,7 +42376,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -42389,7 +42389,7 @@ exports[`next build works: node 1`] = `
       "name": "brace-expansion",
       "npm": {
         "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "version": ">=2.0.1 <3.0.0-0",
       },
       "package_id": 530,
     },
@@ -42402,7 +42402,7 @@ exports[`next build works: node 1`] = `
       "name": "nanoid",
       "npm": {
         "name": "nanoid",
-        "version": ">=3.3.6 <4.0.0",
+        "version": ">=3.3.6 <4.0.0-0",
       },
       "package_id": 346,
     },
@@ -42415,7 +42415,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -42428,7 +42428,7 @@ exports[`next build works: node 1`] = `
       "name": "source-map-js",
       "npm": {
         "name": "source-map-js",
-        "version": ">=1.0.2 <2.0.0",
+        "version": ">=1.0.2 <2.0.0-0",
       },
       "package_id": 433,
     },
@@ -42441,7 +42441,7 @@ exports[`next build works: node 1`] = `
       "name": "@babel/helper-validator-identifier",
       "npm": {
         "name": "@babel/helper-validator-identifier",
-        "version": ">=7.27.1 <8.0.0",
+        "version": ">=7.27.1 <8.0.0-0",
       },
       "package_id": 531,
     },
@@ -42454,7 +42454,7 @@ exports[`next build works: node 1`] = `
       "name": "js-tokens",
       "npm": {
         "name": "js-tokens",
-        "version": ">=4.0.0 <5.0.0",
+        "version": ">=4.0.0 <5.0.0-0",
       },
       "package_id": 317,
     },
@@ -42467,7 +42467,7 @@ exports[`next build works: node 1`] = `
       "name": "picocolors",
       "npm": {
         "name": "picocolors",
-        "version": ">=1.1.1 <2.0.0",
+        "version": ">=1.1.1 <2.0.0-0",
       },
       "package_id": 378,
     },
@@ -42480,7 +42480,7 @@ exports[`next build works: node 1`] = `
       "name": "is-glob",
       "npm": {
         "name": "is-glob",
-        "version": ">=4.0.1 <5.0.0",
+        "version": ">=4.0.1 <5.0.0-0",
       },
       "package_id": null,
     },
@@ -42493,7 +42493,7 @@ exports[`next build works: node 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=4.0.2 <5.0.0",
+        "version": ">=4.0.2 <5.0.0-0",
       },
       "package_id": 532,
     },
@@ -42507,7 +42507,7 @@ exports[`next build works: node 1`] = `
       "name": "picomatch",
       "npm": {
         "name": "picomatch",
-        "version": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 && >=4.0.0 <5.0.0",
+        "version": ">=3.0.0 <4.0.0-0 || >=4.0.0 <5.0.0-0 && >=4.0.0 <5.0.0-0",
       },
       "package_id": 524,
     },
@@ -42520,7 +42520,7 @@ exports[`next build works: node 1`] = `
       "name": "balanced-match",
       "npm": {
         "name": "balanced-match",
-        "version": ">=1.0.0 <2.0.0",
+        "version": ">=1.0.0 <2.0.0-0",
       },
       "package_id": 149,
     },


### PR DESCRIPTION
## Problem

`Bun.semver.satisfies()` accepts prereleases that npm's `semver` rejects when range sugar (`^` / `~` / x-range / partial / hyphen) is AND-ed with a comparator naming a prerelease on the bound tuple:

```js
const npm = require("semver");
npm.satisfies("2.0.0-rc.1", ">=2.0.0-rc.0 ^1.2.3");         // false
Bun.semver.satisfies("2.0.0-rc.1", ">=2.0.0-rc.0 ^1.2.3");  // true  (wrong)

npm.satisfies("1.6.0-beta.2", "~1.5.0 >=1.6.0-beta");         // false
Bun.semver.satisfies("1.6.0-beta.2", "~1.5.0 >=1.6.0-beta");  // true  (wrong)
```

This is over-matching in the resolver `bun install` uses: a range whose npm meaning ends at `<2.0.0-0` accepts `2.0.0-rc.1` in bun.

## Cause

node-semver desugars `^1.2.3` to `>=1.2.3 <2.0.0-0` ([range.js#L306](https://github.com/npm/node-semver/blob/3a8a4309ae986c1967b3073ba88c9e69433d44cb/classes/range.js#L306)). The trailing `-0` is the lowest possible prerelease identifier, so `2.0.0-rc.1 < 2.0.0-0` is false (per SemVer §11, `rc.1 > 0`).

Bun was emitting `<2.0.0` with an empty prerelease tag in `Token::to_range` (caret/tilde arms), `Range::init_wildcard` (x-range/partial), and the hyphen-range arm of `parse()`. Since `2.0.0-rc.1 < 2.0.0` is true, the upper bound passed; the separate prerelease-tuple gate was then satisfied by the `>=2.0.0-rc.0` comparator in the same AND-group.

## Fix

Add `Tag::zero_pre()` (inline `"0"` prerelease, hashed the same way as a user-written `-0`) and apply it to every derived `Lt` upper bound:

- `^` (all major/minor/patch sub-cases)
- `~`
- bare `N.x` / `N.M.x` / `N` / `N.M`
- `<N.x` / `<N.M.x`
- `A - N` / `A - N.x` / `A - N.M.x`

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/semver.test.ts -t "desugared upper bounds"
(fail) Bun.semver.satisfies() > desugared upper bounds exclude prereleases of the bound tuple

$ bun bd test test/cli/install/semver.test.ts
 27 pass
 0 fail
```

The 13 over-match cases now return `false` matching npm `semver@7.7.4`; the regression-check cases (`^1.2.3` / `~1.2.3` / `^1.2.3-alpha` with release versions and same-tuple prereleases) are unchanged.