### PR TITLE
semver: collapse a || union containing a match-all branch to * before the prerelease rule

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -980,6 +980,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
         }
 
         if !skip_round {
+            let has_real_operand = matches!(input.get(i), Some(b'0'..=b'9' | b'x' | b'X' | b'*'));
             let parse_result = Version::parse(sliced.sub(&input[i..]));
             let version = parse_result.version.min();
             if version.tag.has_build() {
@@ -1124,10 +1125,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 list.or_version(version)?;
             } else {
                 let range = token.to_range(&parse_result.version);
-                // A bare operator with no operand (`^`, `~`, `>=` at end of
-                // branch) parses len==0 and node-semver loose mode drops it
-                // before the collapse step, so it is not the ANY comparator.
-                if !range.is_match_all() || parse_result.len == 0 {
+                // An operator whose operand is not a real version or wildcard
+                // char (`^`, `~`, `>=`, `^v`, `vv`, ...) is dropped by
+                // node-semver loose mode before the collapse step.
+                if !range.is_match_all() || !has_real_operand {
                     branch_has_non_any = true;
                 }
                 if count == 0 && token.tag == TokenTag::Version {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1122,7 +1122,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 list.or_version(version)?;
             } else {
                 let range = token.to_range(&parse_result.version);
-                if !range.is_match_all() {
+                // A bare operator with no operand (`^`, `~`, `>=` at end of
+                // branch) parses len==0 and node-semver loose mode drops it
+                // before the collapse step, so it is not the ANY comparator.
+                if !range.is_match_all() || parse_result.len == 0 {
                     branch_has_non_any = true;
                 }
                 if count == 0 && token.tag == TokenTag::Version {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -350,6 +350,10 @@ pub struct Flags;
 impl Flags {
     pub const PRE: usize = 1;
     pub const BUILD: usize = 0;
+    /// Set when an explicit `||` union contains a branch that is entirely the
+    /// ANY comparator (`*`, `x`, `>=0.0.0`, ...). node-semver collapses such a
+    /// range to `*` before applying the prerelease rule.
+    pub const MATCH_ALL_BRANCH: usize = 2;
 }
 
 pub struct Group {
@@ -462,6 +466,7 @@ impl Group {
         let range = &self.head.head.range;
         if self.head.next.is_none()
             && self.head.head.next.is_none()
+            && !self.flags.is_set(Flags::MATCH_ALL_BRANCH)
             && range.has_left()
             && range.left.op == RangeOp::Eql
             && !range.has_right()
@@ -578,6 +583,11 @@ impl Group {
     #[inline]
     pub fn satisfies(&self, version: Version, group_buf: &[u8], version_buf: &[u8]) -> bool {
         if version.tag.has_pre() {
+            // node-semver collapses a `||`-union containing a match-all branch
+            // to `*`, which then rejects every prerelease (see range.js L57-67).
+            if self.flags.is_set(Flags::MATCH_ALL_BRANCH) {
+                return false;
+            }
             self.head.satisfies_pre(version, group_buf, version_buf)
         } else {
             self.head.satisfies(version, group_buf, version_buf)
@@ -855,6 +865,8 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut count: u32 = 0;
     let mut skip_round;
     let mut is_or = false;
+    let mut saw_or_separator = false;
+    let mut branch_has_non_any = false;
 
     while i < input.len() {
         skip_round = false;
@@ -926,6 +938,11 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
                 }
+                if !branch_has_non_any {
+                    list.flags.set_value(Flags::MATCH_ALL_BRANCH, true);
+                }
+                saw_or_separator = true;
+                branch_has_non_any = false;
                 is_or = true;
                 token.tag = TokenTag::None;
                 skip_round = true;
@@ -1074,6 +1091,9 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                     },
                 };
 
+                if !range.is_match_all() {
+                    branch_has_non_any = true;
+                }
                 if is_or {
                     list.or_range(&range)?;
                 } else {
@@ -1090,27 +1110,36 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 // tag, like "1 || - foo".
                 token.wildcard = Wildcard::None;
                 continue;
-            } else if count == 0 && token.tag == TokenTag::Version {
-                match parse_result.wildcard {
-                    Wildcard::None => {
-                        list.or_version(version)?;
-                    }
-                    _ => {
-                        list.or_range(&token.to_range(&parse_result.version))?;
-                    }
-                }
-            } else if count == 0 {
-                list.and_range(&token.to_range(&parse_result.version))?;
-            } else if is_or {
-                list.or_range(&token.to_range(&parse_result.version))?;
+            } else if count == 0
+                && token.tag == TokenTag::Version
+                && parse_result.wildcard == Wildcard::None
+            {
+                branch_has_non_any = true;
+                list.or_version(version)?;
             } else {
-                list.and_range(&token.to_range(&parse_result.version))?;
+                let range = token.to_range(&parse_result.version);
+                if !range.is_match_all() {
+                    branch_has_non_any = true;
+                }
+                if count == 0 && token.tag == TokenTag::Version {
+                    list.or_range(&range)?;
+                } else if count == 0 {
+                    list.and_range(&range)?;
+                } else if is_or {
+                    list.or_range(&range)?;
+                } else {
+                    list.and_range(&range)?;
+                }
             }
 
             is_or = false;
             count += 1;
             token.wildcard = Wildcard::None;
         }
+    }
+
+    if saw_or_separator && !branch_has_non_any {
+        list.flags.set_value(Flags::MATCH_ALL_BRANCH, true);
     }
 
     Ok(list)

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1104,7 +1104,11 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                     },
                 };
 
-                if !range.is_match_all() {
+                // npm's hyphen-range grammar only accepts a `[v=\s]*` prefix;
+                // an operator-prefixed left side is not a hyphen range there.
+                if !range.is_match_all()
+                    || !matches!(token.tag, TokenTag::Version | TokenTag::Gte)
+                {
                     branch_has_non_any = true;
                 }
                 if is_or {
@@ -1135,7 +1139,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 // An operator whose operand is not a real version or wildcard
                 // char (`^`, `~`, `>=`, `^v`, `vv`, ...) is dropped by
                 // node-semver loose mode before the collapse step.
-                if !range.is_match_all() || !has_real_operand {
+                if !range.is_match_all() || !has_real_operand || !parse_result.valid {
                     branch_has_non_any = true;
                 }
                 if count == 0 && token.tag == TokenTag::Version {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -934,17 +934,24 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
             b'|' => {
                 i += 1;
 
+                let is_double = i < input.len() && input[i] == b'|';
                 while i < input.len() && input[i] == b'|' {
                     i += 1;
                 }
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
                 }
-                if !branch_has_non_any {
-                    list.flags.set_value(Flags::MATCH_ALL_BRANCH, true);
+                // node-semver only splits on `||`; a lone `|` is loose-mode
+                // garbage dropped before the collapse step, not a separator.
+                if is_double {
+                    if !branch_has_non_any {
+                        list.flags.set_value(Flags::MATCH_ALL_BRANCH, true);
+                    }
+                    saw_or_separator = true;
+                    branch_has_non_any = false;
+                } else {
+                    branch_has_non_any = true;
                 }
-                saw_or_separator = true;
-                branch_has_non_any = false;
                 is_or = true;
                 token.tag = TokenTag::None;
                 skip_round = true;

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1106,8 +1106,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
 
                 // npm's hyphen-range grammar only accepts a `[v=\s]*` prefix;
                 // an operator-prefixed left side is not a hyphen range there.
-                if !range.is_match_all()
-                    || !matches!(token.tag, TokenTag::Version | TokenTag::Gte)
+                if !range.is_match_all() || !matches!(token.tag, TokenTag::Version | TokenTag::Gte)
                 {
                     branch_has_non_any = true;
                 }

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -520,7 +520,8 @@ impl Group {
 
     #[inline]
     pub fn eql(&self, rhs: &Group) -> bool {
-        self.head.eql(&rhs.head)
+        self.flags.is_set(Flags::MATCH_ALL_BRANCH) == rhs.flags.is_set(Flags::MATCH_ALL_BRANCH)
+            && self.head.eql(&rhs.head)
     }
 
     pub fn to_version(&self) -> Version {
@@ -1112,6 +1113,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 // covers a leading "--foo" (treat "--foo" the same as "-foo", example:
                 // foo/bar@1.2.3@--canary.24) as well as a dangling "-" after a skipped
                 // tag, like "1 || - foo".
+                branch_has_non_any = true;
                 token.wildcard = Wildcard::None;
                 continue;
             } else if count == 0

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -503,6 +503,7 @@ impl Group {
     pub fn is_exact(&self) -> bool {
         self.head.next.is_none()
             && self.head.head.next.is_none()
+            && !self.flags.is_set(Flags::MATCH_ALL_BRANCH)
             && !self.head.head.range.has_right()
             && self.head.head.range.left.op == RangeOp::Eql
     }
@@ -970,6 +971,9 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 while i < input.len() && input[i] != b' ' && input[i] != b'|' {
                     i += 1;
                 }
+                // node-semver loose mode drops these tokens via `.filter(c => c.length)`
+                // before the collapse-to-`*` step, so a garbage-only branch is not ANY.
+                branch_has_non_any = true;
                 skip_round = true;
             }
         }

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -131,6 +131,19 @@ impl Range {
         self.right.op != Op::Unset
     }
 
+    /// True when this range is node-semver's ANY comparator (`*` / `x` /
+    /// `>=0.0.0`): it accepts every release version and, under the default
+    /// prerelease rule, no prerelease.
+    pub fn is_match_all(self) -> bool {
+        if !self.has_left() {
+            return true;
+        }
+        self.left.op == Op::Gte
+            && self.left.version.is_zero()
+            && !self.left.version.tag.has_pre()
+            && !self.has_right()
+    }
+
     /// Is the Range equal to another Range
     /// This does not evaluate the range.
     #[inline]

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -391,6 +391,11 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("1.2.3-alpha.1 || latest", "1.2.3-alpha.1", true);
     testSatisfies("latest || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("boop || * || 1.2.3-alpha.1", "1.2.3-alpha.1", false);
+    // A bare operator with no operand is likewise dropped, not treated as `*`.
+    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v"]) {
+      testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
+      testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);
+    }
 
     const notPassing = [
       "0.1.0",

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -357,6 +357,34 @@ describe("Bun.semver.satisfies()", () => {
 
     testSatisfies("^3.0.0-next.0||^3.0.0", "3.0.0-next.2", true);
 
+    // node-semver collapses a `||`-union containing a match-all branch to `*`
+    // before applying the prerelease rule, so the prerelease is rejected even
+    // though a sibling branch names it explicitly.
+    for (const any of ["*", "x", "X", "x.x", "x.x.x", ">=0.0.0", ">=0.0.0+build", "* *", "0.0.0 - x", "^*", "~*", ""]) {
+      testSatisfies(`${any} || 1.2.3-alpha.1`, "1.2.3-alpha.1", false);
+      testSatisfies(`1.2.3-alpha.1 || ${any}`, "1.2.3-alpha.1", false);
+      testSatisfies(`${any} || ^1.2.3-alpha`, "1.2.3-alpha.1", false);
+      testSatisfies(`${any} || 1.2.3-alpha.1 || ${any}`, "1.2.3-alpha.1", false);
+    }
+    for (const any of ["*", "x", "X", "x.x", "x.x.x", ">=0.0.0", ">=0.0.0+build", "* *", "0.0.0 - x"]) {
+      // A release version still satisfies the collapsed `*`.
+      testSatisfies(`${any} || 1.2.3-alpha.1`, "1.2.4", true);
+    }
+    testSatisfies("|| 1.2.3-alpha.1", "1.2.3-alpha.1", false);
+    testSatisfies("1.2.3-alpha.1 ||", "1.2.3-alpha.1", false);
+    // A non-match-all first branch keeps union semantics.
+    testSatisfies("1.x || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies(">0.0.0 || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies(">=1.0.0 || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    // `>=0.0.0-0` has a prerelease tag so it is not the ANY comparator.
+    testSatisfies(">=0.0.0-0 || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    // `*` alongside a narrower comparator in the same `||`-branch is not a
+    // match-all branch: node-semver drops the `*` and keeps the narrower one.
+    testSatisfies("* 2.0.0 || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("2.0.0 * || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("2.0.0 || * 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("* 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+
     const notPassing = [
       "0.1.0",
       "0.10.0",

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -427,6 +427,10 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("| 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("1.2.3-alpha.1 |", "1.2.3-alpha.1", true);
     testSatisfies("* | 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("1.2.3-alpha.1 ||| 2.0.0", "1.2.3-alpha.1", true);
+    testSatisfies("1.2.3-alpha.1 ||| *", "1.2.3-alpha.1", false);
+    testSatisfies("||| 1.2.3-alpha.1", "1.2.3-alpha.1", false);
+    testSatisfies("1.2.3-alpha.1 ||||", "1.2.3-alpha.1", false);
 
     const notPassing = [
       "0.1.0",

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -392,7 +392,25 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("latest || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("boop || * || 1.2.3-alpha.1", "1.2.3-alpha.1", false);
     // A bare operator with no operand is likewise dropped, not treated as `*`.
-    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v", "-", "- -", "- boop", "vv", "==", "^v", "~=", ">=v", "^\t"]) {
+    for (const op of [
+      "^",
+      "~",
+      ">=",
+      ">",
+      "<",
+      "<=",
+      "=",
+      "v",
+      "-",
+      "- -",
+      "- boop",
+      "vv",
+      "==",
+      "^v",
+      "~=",
+      ">=v",
+      "^\t",
+    ]) {
       testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
       testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);
     }

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -414,6 +414,10 @@ describe("Bun.semver.satisfies()", () => {
       testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
       testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);
     }
+    // A lone `|` is not the `||` separator and is dropped in loose mode.
+    testSatisfies("| 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("1.2.3-alpha.1 |", "1.2.3-alpha.1", true);
+    testSatisfies("* | 1.2.3-alpha.1", "1.2.3-alpha.1", true);
 
     const notPassing = [
       "0.1.0",

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -410,6 +410,15 @@ describe("Bun.semver.satisfies()", () => {
       "~=",
       ">=v",
       "^\t",
+      "xy",
+      "*a",
+      "^xy",
+      "xoop",
+      "^0.0.0 - x",
+      "~0.0.0 - x",
+      ">0.0.0 - x",
+      "<0.0.0 - x",
+      "<=0.0.0 - x",
     ]) {
       testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
       testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -392,7 +392,7 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("latest || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("boop || * || 1.2.3-alpha.1", "1.2.3-alpha.1", false);
     // A bare operator with no operand is likewise dropped, not treated as `*`.
-    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v", "-", "- -", "- boop"]) {
+    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v", "-", "- -", "- boop", "vv", "==", "^v", "~=", ">=v", "^\t"]) {
       testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
       testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);
     }

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -392,7 +392,7 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("latest || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("boop || * || 1.2.3-alpha.1", "1.2.3-alpha.1", false);
     // A bare operator with no operand is likewise dropped, not treated as `*`.
-    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v"]) {
+    for (const op of ["^", "~", ">=", ">", "<", "<=", "=", "v", "-", "- -", "- boop"]) {
       testSatisfies(`1.2.3-alpha.1 || ${op}`, "1.2.3-alpha.1", true);
       testSatisfies(`${op} || 1.2.3-alpha.1`, "1.2.3-alpha.1", true);
     }

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -384,6 +384,13 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("2.0.0 * || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("2.0.0 || * 1.2.3-alpha.1", "1.2.3-alpha.1", true);
     testSatisfies("* 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    // A dist-tag/garbage branch is dropped by node-semver loose mode before
+    // the collapse-to-`*` step, so it is not a match-all branch.
+    testSatisfies("1.2.3-alpha.1 || boop", "1.2.3-alpha.1", true);
+    testSatisfies("boop || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("1.2.3-alpha.1 || latest", "1.2.3-alpha.1", true);
+    testSatisfies("latest || 1.2.3-alpha.1", "1.2.3-alpha.1", true);
+    testSatisfies("boop || * || 1.2.3-alpha.1", "1.2.3-alpha.1", false);
 
     const notPassing = [
       "0.1.0",


### PR DESCRIPTION
## Problem

`Bun.semver.satisfies()` diverges from npm's `semver` when a `||`-union contains a match-all branch (`*`, `x`, `X`, `>=0.0.0`) next to a branch that allows a prerelease: npm collapses the whole range to `*` and rejects the prerelease, Bun evaluated each branch and accepted it.

```js
const npm = require("semver");
npm.validRange("x || 1.2.3-alpha.1");                         // "*"
npm.satisfies("1.2.3-alpha.1", "x || 1.2.3-alpha.1");         // false
Bun.semver.satisfies("1.2.3-alpha.1", "x || 1.2.3-alpha.1");  // true   (before)

npm.satisfies("1.2.3-alpha.1", "* || ^1.2.3-alpha");          // false
Bun.semver.satisfies("1.2.3-alpha.1", "* || ^1.2.3-alpha");   // true   (before)

// controls: agree in both
npm.satisfies("1.2.3-alpha.1", "1.x || 1.2.3-alpha.1");       // true
npm.satisfies("1.2.4", "* || ^1.2.3-alpha");                  // true
```

This is the range parser behind `bun install`, so a `package.json` that resolves one way under npm resolves differently under Bun.

## Cause

node-semver's `Range` constructor has a post-parse simplification: if any `||`-alternative is the ANY comparator set (`value === ""`, produced by `*`, `x`, `>=0.0.0`, etc.), the whole range becomes `[["*"]]` ([range.js#L57-L67](https://github.com/npm/node-semver/blob/ac9b35769ab0ddfefd5a3af4a3ecaf3da2012352/classes/range.js#L57-L67)). `*` then rejects every prerelease under the default prerelease rule, so the prerelease-allowing sibling branch is discarded before it is ever tested.

Bun's `List::satisfies_pre` iterated each `||`-branch independently, so the sibling branch matched.

## Fix

Track during parse whether any explicit `||`-delimited branch is entirely a match-all comparator. A new `Range::is_match_all()` predicate recognizes the internal shapes that `*` / `x` / `X` / `x.x` / `>=0.0.0` / `^*` / `~*` / `0.0.0 - x` parse to (unset, or `>=0.0.0` with no prerelease and no right side). When a `||` closes such a branch, or the final branch after a `||` is match-all, set `Flags::MATCH_ALL_BRANCH` on the `Group`.

`Group::satisfies` then returns `false` for any prerelease version when the flag is set, matching the npm collapse. Release versions are unaffected (the flag is only consulted on the prerelease path). `get_exact_version()` also returns `None` when the flag is set, since a range with a match-all branch is semantically `*`, not an exact version.

The flag is keyed to explicit `||` separators, so it does not interact with the separate space-separated-comparators question (#32993) and `"* 1.2.3-alpha.1"` (no `||`) is unchanged.

## Verification

New cases in `test/cli/install/semver.test.ts` covering every match-all spelling in both `||` positions, the release-version control, non-match-all siblings (`1.x`, `>0.0.0`, `>=1.0.0`, `>=0.0.0-0`), and `*` alongside a narrower comparator in the same branch.

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/semver.test.ts -t ranges
(fail) Bun.semver.satisfies() > ranges

$ bun bd test test/cli/install/semver.test.ts
 26 pass
 0 fail
 2038 expect() calls
```

Differential against `semver@7.7.4` over 174 version x range pairs (wildcards, prereleases, `||` unions, controls): 7 mismatches before, 0 after.
