### PR TITLE
sql: drain queries awaited in the same tick as close()/end()

### DIFF
--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -128,35 +128,9 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   }
 
   async #runAsync() {
-    const { [_handler]: handler, [_queryStatus]: status } = this;
-
-    if (
-      status &
-      (SQLQueryStatus.executed | SQLQueryStatus.error | SQLQueryStatus.cancelled | SQLQueryStatus.invalidHandle)
-    ) {
-      return;
-    }
-
-    if (this[_flags] & SQLQueryFlags.notTagged) {
-      this.reject(this[_adapter].notTaggedCallError());
-      return;
-    }
-
-    this[_queryStatus] |= SQLQueryStatus.executed;
-    const handle = this.#getQueryHandle();
-
-    if (!handle) {
-      return this;
-    }
-
-    // Hand the query to the pool synchronously so a same-tick close() sees it
-    // as pending; the executed flag above guards re-entry from then()/finally().
-    try {
-      return handler(this, handle);
-    } catch (err) {
-      this[_queryStatus] |= SQLQueryStatus.error;
-      this.reject(err as Error);
-    }
+    // Enqueue synchronously (same as execute()) so a same-tick close() sees
+    // the query as pending; #run()'s executed-status guard handles re-entry.
+    return this.#run();
   }
 
   get active() {

--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -149,8 +149,8 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
       return this;
     }
 
-    await Promise.$resolve();
-
+    // Hand the query to the pool synchronously so a same-tick close() sees it
+    // as pending; the executed flag above guards re-entry from then()/finally().
     try {
       return handler(this, handle);
     } catch (err) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1304,6 +1304,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
     }
 
     let timeout = options?.timeout;
+    // Presence, not truthiness: `timeout: 0` means close now, undefined/null mean drain with no timer.
     const hasTimeout = timeout != null;
     if (hasTimeout) {
       timeout = Number(timeout);

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1304,7 +1304,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
     }
 
     let timeout = options?.timeout;
-    const hasTimeout = !!timeout;
+    const hasTimeout = timeout != null;
     if (hasTimeout) {
       timeout = Number(timeout);
       if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -18,7 +18,21 @@
 
 import { SQL } from "bun";
 import { expect, mock, test } from "bun:test";
-import { listeningServer, neverAnsweringServer, pgAuthenticationOk, pgReadyForQuery } from "./wire-frames";
+import type { Server, Socket } from "node:net";
+import {
+  listeningServer,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlTextResultSet,
+  neverAnsweringServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
 
 const drivers = [
   ["postgres", "postgres://postgres@", "ERR_POSTGRES_CONNECTION_CLOSED"],
@@ -179,3 +193,125 @@ test("pool scans tolerate unassigned connection slots during pool start", async 
     server.close();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/32038
+//
+// close({ timeout }) used to be gated on `if (timeout)`, so the documented
+// `close({ timeout: 0 })` ("close now") fell into the graceful-drain branch and
+// waited for in-flight queries forever. The tests above sidestep that with the
+// truthy string "0"; these use the number. `timeout: null` must still mean
+// "no timeout" (drain), not "timeout of 0".
+//
+// Each mock completes the handshake and hands the first command it receives to
+// `onCommand`; by default it never answers, leaving the query in flight.
+
+type CommandMock = { port: number; server: Server; commandReceived: Promise<void> };
+
+async function pgReadyServer(onCommand?: (socket: Socket, type: number) => void): Promise<CommandMock> {
+  const received = Promise.withResolvers<void>();
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    let buffered = Buffer.alloc(0);
+    socket.on("data", chunk => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      buffered = pgReadFrontendMessages(Buffer.concat([buffered, chunk]), type => {
+        onCommand?.(socket, type);
+        received.resolve();
+      });
+    });
+    socket.on("error", () => {});
+  });
+  return { port, server, commandReceived: received.promise };
+}
+
+async function mysqlReadyServer(
+  onCommand?: (socket: Socket, seq: number, payload: Buffer) => void,
+): Promise<CommandMock> {
+  const received = Promise.withResolvers<void>();
+  const { port, server } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        onCommand?.(socket, seq, payload);
+        received.resolve();
+      });
+    });
+    socket.on("error", () => {});
+  });
+  return { port, server, commandReceived: received.promise };
+}
+
+// Answers a simple-protocol `select 1 as x` with one text row once `respond()` is called.
+const drainableMocks = {
+  async postgres() {
+    let respond!: () => void;
+    const mock = await pgReadyServer((socket, type) => {
+      if (type !== 0x51 /* Query */) return;
+      respond = () =>
+        socket.write(
+          Buffer.concat([
+            pgRowDescription([{ name: "x", typeOid: 25 }]),
+            pgDataRow([Buffer.from("1")]),
+            pgCommandComplete("SELECT 1"),
+            pgReadyForQuery(),
+          ]),
+        );
+    });
+    return { ...mock, respond: () => respond() };
+  },
+  async mysql() {
+    let respond!: () => void;
+    const mock = await mysqlReadyServer((socket, seq, payload) => {
+      if (payload[0] !== 0x03 /* COM_QUERY */) return;
+      respond = () => socket.write(mysqlTextResultSet(seq + 1, [{ name: "x", type: 0xfd }], [["1"]]));
+    });
+    return { ...mock, respond: () => respond() };
+  },
+} as const;
+
+const silentMocks = {
+  postgres: () => pgReadyServer(),
+  mysql: () => mysqlReadyServer(),
+} as const;
+
+for (const [name, scheme, closedCode] of drivers) {
+  test(`${name}: close({ timeout: 0 }) force-closes with a query in flight`, async () => {
+    const { port, server, commandReceived } = await silentMocks[name]();
+    try {
+      const sql = new SQL({ url: `${scheme}127.0.0.1:${port}/db`, max: 1 });
+      const queryError = sql`SELECT 1`.catch(e => e);
+      // the server has the query and will never answer it
+      await commandReceived;
+      await sql.close({ timeout: 0 });
+      expect((await queryError).code).toBe(closedCode);
+    } finally {
+      server.close();
+    }
+  });
+
+  test(`${name}: close({ timeout: null }) still waits for the query in flight`, async () => {
+    const { port, server, commandReceived, respond } = await drainableMocks[name]();
+    try {
+      const sql = new SQL({ url: `${scheme}127.0.0.1:${port}/db`, max: 1 });
+      const rows = sql`select 1 as x`.simple().then(r => r);
+      await commandReceived;
+      const closing = sql.close({ timeout: null });
+      respond();
+      expect(await rows).toEqual([{ x: "1" }]);
+      await closing;
+    } finally {
+      server.close();
+    }
+  });
+}

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -195,17 +195,15 @@ test("pool scans tolerate unassigned connection slots during pool start", async 
 });
 
 // https://github.com/oven-sh/bun/issues/32038
-//
-// close({ timeout }) used to be gated on `if (timeout)`, so the documented
-// `close({ timeout: 0 })` ("close now") fell into the graceful-drain branch and
-// waited for in-flight queries forever. The tests above sidestep that with the
-// truthy string "0"; these use the number. `timeout: null` must still mean
-// "no timeout" (drain), not "timeout of 0".
-//
-// Each mock completes the handshake and hands the first command it receives to
-// `onCommand`; by default it never answers, leaving the query in flight.
+// `timeout: null` is outside the declared option type; it must drain like an omitted timeout, not force-close like 0.
 
 type CommandMock = { port: number; server: Server; commandReceived: Promise<void> };
+
+// After the command arrives `received` is settled, so the reset caused by a forced close() is ignored.
+function failUntilCommand(socket: Socket, received: PromiseWithResolvers<void>) {
+  socket.on("error", received.reject);
+  socket.on("close", () => received.reject(new Error("the client disconnected before it sent a command")));
+}
 
 async function pgReadyServer(onCommand?: (socket: Socket, type: number) => void): Promise<CommandMock> {
   const received = Promise.withResolvers<void>();
@@ -223,7 +221,7 @@ async function pgReadyServer(onCommand?: (socket: Socket, type: number) => void)
         received.resolve();
       });
     });
-    socket.on("error", () => {});
+    failUntilCommand(socket, received);
   });
   return { port, server, commandReceived: received.promise };
 }
@@ -247,7 +245,7 @@ async function mysqlReadyServer(
         received.resolve();
       });
     });
-    socket.on("error", () => {});
+    failUntilCommand(socket, received);
   });
   return { port, server, commandReceived: received.promise };
 }

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1002,6 +1002,16 @@ if (isDockerEnabled()) {
           return expect(await promise).toEqual([{ x: 0 }]);
         });
 
+        // Same contract as the .execute() case above, but via .then(): the query
+        // was handed to the pool one microtask late, so a same-tick end() ran
+        // first and rejected it with ERR_MYSQL_CONNECTION_CLOSED.
+        test("Connection end does not cancel a query awaited in the same tick", async () => {
+          const sql = new SQL({ ...getOptions(), max: 1 });
+          await sql`select 1 as x`;
+          const [rows] = await Promise.all([sql`select 1 as x`.then(r => r), sql.end()]);
+          expect(rows).toEqual([{ x: 1 }]);
+        });
+
         test("Connection destroyed", async () => {
           const sql = new SQL(getOptions());
           process.nextTick(() => sql.end({ timeout: 0 }));

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1002,9 +1002,7 @@ if (isDockerEnabled()) {
           return expect(await promise).toEqual([{ x: 0 }]);
         });
 
-        // Same contract as the .execute() case above, but via .then(): the query
-        // was handed to the pool one microtask late, so a same-tick end() ran
-        // first and rejected it with ERR_MYSQL_CONNECTION_CLOSED.
+        // https://github.com/oven-sh/bun/pull/33740
         test("Connection end does not cancel a query awaited in the same tick", async () => {
           const sql = new SQL({ ...getOptions(), max: 1 });
           await sql`select 1 as x`;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1825,9 +1825,7 @@ if (isDockerEnabled()) {
       return expect(await promise).toEqual([{ x: "" }]);
     });
 
-    // Same contract as the .execute() case above, but via .then(): the query
-    // was handed to the pool one microtask late, so a same-tick end() ran
-    // first and rejected it with ERR_POSTGRES_CONNECTION_CLOSED.
+    // https://github.com/oven-sh/bun/pull/33740
     test("Connection end does not cancel a query awaited in the same tick", async () => {
       const sql = postgres({ ...options, max: 1 });
       await sql`select 1 as x`;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1825,6 +1825,23 @@ if (isDockerEnabled()) {
       return expect(await promise).toEqual([{ x: "" }]);
     });
 
+    // Same contract as the .execute() case above, but via .then(): the query
+    // was handed to the pool one microtask late, so a same-tick end() ran
+    // first and rejected it with ERR_POSTGRES_CONNECTION_CLOSED.
+    test("Connection end does not cancel a query awaited in the same tick", async () => {
+      const sql = postgres({ ...options, max: 1 });
+      await sql`select 1 as x`;
+      const [rows] = await Promise.all([sql`select 1 as x`.then(r => r), sql.end()]);
+      expect(rows).toEqual([{ x: 1 }]);
+    });
+
+    test("Connection end with a timeout does not cancel a query awaited in the same tick", async () => {
+      const sql = postgres({ ...options, max: 1 });
+      await sql`select 1 as x`;
+      const [rows] = await Promise.all([sql`select 1 as x`.then(r => r), sql.end({ timeout: 5 })]);
+      expect(rows).toEqual([{ x: 1 }]);
+    });
+
     test("Connection destroyed", async () => {
       const sql = postgres(options);
       process.nextTick(() => sql.end({ timeout: 0 }));

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2053,9 +2053,7 @@ describe("Connection management", () => {
     }
   });
 
-  // Query.then() used to defer the pool hand-off by one microtask, so a
-  // close() in the same synchronous block ran first, saw zero pending
-  // queries, and rejected the already-awaited query with "Connection closed".
+  // https://github.com/oven-sh/bun/pull/33740
   test("close() drains a query awaited in the same tick", async () => {
     const sql = new SQL("sqlite://:memory:");
     await sql`SELECT 1 AS x`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2053,6 +2053,16 @@ describe("Connection management", () => {
     }
   });
 
+  // Query.then() used to defer the pool hand-off by one microtask, so a
+  // close() in the same synchronous block ran first, saw zero pending
+  // queries, and rejected the already-awaited query with "Connection closed".
+  test("close() drains a query awaited in the same tick", async () => {
+    const sql = new SQL("sqlite://:memory:");
+    await sql`SELECT 1 AS x`;
+    const [rows] = await Promise.all([sql`SELECT 42 AS x`.then(r => r), sql.close()]);
+    expect(rows).toEqual([{ x: 42 }]);
+  });
+
   test("reserve throws for SQLite", async () => {
     const sql = new SQL("sqlite://:memory:");
 


### PR DESCRIPTION
### Problem

A graceful `sql.close()` / `sql.end()` is documented to wait for pending queries, but a query created and awaited in the *same synchronous block* as the `close()` call is rejected with `ERR_*_CONNECTION_CLOSED` and never sent to the server, even with an explicit grace period (`close({ timeout: 5 })`).

```js
await using sql = new SQL(...);
await sql\`SELECT 1\`;                         // pool is warm and idle
const q = sql\`SELECT ...\`;
await Promise.all([q.then(r => r), sql.end()]); // q rejects: Connection closed
```

The same program with `q.execute()` before `end()`, or with `end()` one macrotask later, drains correctly. The contract depends on an internal microtask race the caller cannot observe.

### Cause

`Query.then()/catch()/finally()` route through `#runAsync()`, which did `await Promise.$resolve()` *before* calling the pool handler. So the pool enqueue landed one microtask after `.then()` returned. A same-tick `pool.close()` runs first, samples `hasPendingQueries()` (waiting queue empty, `totalQueries` 0), takes the close-immediately branch, and sets `closed = true`. The deferred enqueue then hits `connect(): if (this.closed) return onConnected(connectionClosedError(), null)`.

`Query.execute()` calls `#run()`, which invokes the handler synchronously, so `close()` sees the query as pending. That is why lane D worked.

### Fix

- `src/js/internal/sql/query.ts`: drop the `await Promise.$resolve()` from `#runAsync()` so `.then()/.catch()/.finally()` hand the query to the pool synchronously, the same way `.execute()` does. Re-entry (from `bindQuery`'s `query.finally()` and similar) is already guarded by the `SQLQueryStatus.executed` flag set immediately above.
- `src/js/internal/sql/shared.ts`: `BaseSQLAdapter.close()` checked `if (timeout)`, so the documented `{ timeout: 0 }` force-close fell through to the graceful-wait branch; it only rejected same-tick queries because nothing was enqueued yet. With queries now enqueued synchronously that accidental cover is gone, so check `timeout != null` to reach the existing `timeout === 0` fast-close path. This keeps the `Connection destroyed with query before` tests passing for the documented reason.

### Tests

- `test/js/sql/sqlite-sql.test.ts`: `close() drains a query awaited in the same tick` (SQLite, no container).
- `test/js/sql/sql.test.ts`: `Connection end does not cancel a query awaited in the same tick` and a `{ timeout: 5 }` variant, next to the existing `.execute()` case.
- `test/js/sql/sql-mysql.test.ts`: matching MySQL case.
- `test/js/sql/sql-close-pending-connection.test.ts`: `close({ timeout: 0 })` force-closes with a query in flight, and `close({ timeout: null })` still waits for it, for postgres and mysql against mock servers (the `timeout: 0` cases hang without the `shared.ts` change). These are the cases from #32039, which made the same `shared.ts` change on its own and is closed in favour of this PR.

Fail-before verified with `USE_SYSTEM_BUN=1` and with `src/` stashed under the debug build:

```
SQLiteError: Connection closed
  code: "ERR_SQLITE_CONNECTION_CLOSED"
```

All existing non-container `test/js/sql` suites pass with the fix (the one pre-existing debug-ASAN timeout in `properly finalizes prepared statements` also reproduces on `main`).

<details><summary>Rebase notes</summary>

Rebased onto main after #32089 and #39945 changed the same files. Two spots needed a manual resolution:

- `src/js/internal/sql/shared.ts`: #32089 rewrote the `close()` check as `const hasTimeout = !!timeout;`, which keeps the `timeout: 0` bug. It is now `const hasTimeout = timeout != null;`.
- `test/js/sql/sql-close-pending-connection.test.ts`: the import block is the union of the names #39945 added and the names the new mocks use. The new tests are appended after the #39945 tests.

The debug-build iteration shrink in `sqlite-sql.test.ts` landed on main on its own, so that commit was dropped. The net diff against main is otherwise unchanged. On top of main: `sql-close-pending-connection.test.ts` (12 pass), the full `test/js/sql/` directory (the 28 failures are the local MariaDB root login, the same as on main), and the `sql.test.ts` same-tick cases against a local Postgres, which still fail with the released bun.

</details>

Fixes #32038

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-close-pending-connection.test.ts test/js/sql/sql-mysql.test.ts test/js/sql/sql.test.ts test/js/sql/sqlite-sql.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [381.34ms]
(pass) postgres: close() does not fire onclose for slots that never connected [151.10ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [62.38ms]
(pass) mysql: forced close() resolves while a connection is mid-handshake [43.45ms]
(pass) mysql: close() does not fire onclose for slots that never connected [35.22ms]
(pass) mysql: forced close() resolves when called before the native handle is stored [16.00ms]
(pass) postgres: close() mid-reconnect does not fire onclose for the unfinished cycle [134.81ms]
(pass) pool scans tolerate unassigned connection slots during pool start [35.15ms]
(fail) postgres: close({ timeout: 0 }) force-closes with a query in flight [5007.23ms]
  ^ this test timed out after 50
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [7.24ms]
76 |       const queryError = sql`SELECT 1`.catch(e => e);
77 |       await accepted;
78 |       await sql.close({ timeout: "0" });
79 |       expect((await queryError).code).toBe(closedCode);
80 |       expect(onconnect).not.toHaveBeenCalled();
81 |       expect(onclose).not.toHaveBeenCalled();
                               ^
error: expect(received).not.toHaveBeenCalled()

Expected number of calls: 0
Received number of calls: 5

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-pending-connection.test.ts:81:27)
(fail) postgres: close() does not fire onclose for slots that never connected [2.74ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [1.60ms]
(pass) mysql: forced close() resolves while a connection is mid-handshake [1.65ms]
76 |       const queryError = sql`SELECT 1`.catch(e => e);
77 |       await accepted;
78 |       await sql.close({ timeout: "0" });
79 |       expect((await queryError).code).toBe(closedCode);
80 |       expect(onco
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-close-pending-connection.test.ts test/js/sql/sql-mysql.test.ts test/js/sql/sql.test.ts test/js/sql/sqlite-sql.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/sql-close-pending-connection.test.ts:
(pass) postgres: forced close() resolves while a connection is mid-handshake [364.45ms]
(pass) postgres: close() does not fire onclose for slots that never connected [142.16ms]
(pass) postgres: forced close() resolves when called before the native handle is stored [28.44ms]
(pass) mysql: forced close() resolves while a connection is mid-handshake [34.98ms]
(pass) mysql: close() does not fire onclose for slots that never connected [57.13ms]
(pass) mysql: forced close() resolves when called before the native handle is stored [14.87ms]
(pass) postgres: close() mid-reconnect does not fire onclose for the unfinished cycle [123.63ms]
(pass) pool scans tolerate unassigned connection slots during pool start [30.19ms]
(pass) postgres: close({ timeout: 0 }) force-closes with a query in flight [59.69ms]
(pass) postgres: close({ timeout: 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7603ms)
Bundle modules (53ms)
Postprocesss modules (28ms)
Bundle Functions (706ms)
Generate Code (25ms)

[8.44s] Bundled "src/js" for production
  2621 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_exe_format v0.0.0 (/workspace/bun/src/exe_format)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/query.ts                     |  32 +-----
 src/js/internal/sql/shared.ts                    |   3 +-
 test/js/sql/sql-close-pending-connection.test.ts | 136 ++++++++++++++++++++++-
 test/js/sql/sql-mysql.test.ts                    |   8 ++
 test/js/sql/sql.test.ts                          |  15 +++
 test/js/sql/sqlite-sql.test.ts                   |   8 ++
 6 files changed, 171 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js/internal/sql/query.ts                          1      0      0
src/js/internal/sql/shared.ts                         5      4      0
test/js/sql/sql-close-pending-connection.test.ts      3      4      0
test/js/sql/sql-mysql.test.ts                         1      1      0
test/js/sql/sql.test.ts                               1      2      0
test/js/sql/sqlite-sql.test.ts                        1      1      0
```

</details>

<!-- robobun:evidence:end -->
