### PR TITLE
Avoid temp Vec for H2 WINDOW_UPDATE frames

### DIFF
--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -635,25 +635,24 @@ impl ClientSession {
             self.write_window_update(0, self.conn_unacked_bytes);
             self.conn_unacked_bytes = 0;
         }
-        // Collect (id, unacked) pairs before mutating self.
-        let mut updates: Vec<(u32, u32)> = Vec::new();
-        for &s in self.streams.values() {
-            let s = stream_mut(s);
-            if s.unacked_bytes < threshold || s.remote_closed() {
-                continue;
-            }
-            if s.client_ref()
-                .is_some_and(|c| c.signals.is_receive_paused())
-            {
-                continue;
-            }
-            updates.push((s.id, s.unacked_bytes));
-            s.unacked_bytes = 0;
-        }
-        for (id, unacked) in updates {
+        for i in 0..self.streams.count() {
+            let s = self.streams.values()[i];
+            let (id, unacked) = {
+                let s = stream_mut(s);
+                if s.unacked_bytes < threshold || s.remote_closed() {
+                    continue;
+                }
+                if s.client_ref()
+                    .is_some_and(|c| c.signals.is_receive_paused())
+                {
+                    continue;
+                }
+                let update = (s.id, s.unacked_bytes);
+                s.unacked_bytes = 0;
+                update
+            };
             self.write_window_update(id, unacked);
         }
-        // PERF: could iterate and write in one pass; profile if extra Vec matters.
     }
 
     pub fn flush(&mut self) -> Result<bool, Error> {


### PR DESCRIPTION
## Summary

Avoid the temporary `Vec<(u32, u32)>` in `ClientSession::replenish_window()` by queuing each eligible per-stream `WINDOW_UPDATE` frame immediately after copying `(stream_id, unacked_bytes)` and clearing the stream counter.

`write_window_update()` only appends frame bytes to the session write buffer, so this preserves the stream-map mutation boundary without a second pass.

## Performance

Removes one temporary Vec allocation/reallocation path per window replenishment. Isolated local benchmark of the old vs new loop shape (128 streams, 200k replenishments): old `72.6ms`, `1.2M` allocations / `403MB` requested; new `22.4ms`, `0` allocations.

## Validation

- `cargo check -p bun_http`
- `cargo fmt -p bun_http --check`
- `bun bd test test/js/web/fetch/fetch-http2-client.test.ts`
- `git diff --check`