### PR TITLE
readline/promises: reject instead of throwing synchronously from Interface#question

### DIFF
--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -2699,28 +2699,26 @@ var PromisesInterface = class Interface extends _Interface {
     super(input, output, completer, terminal);
   }
   question(query, options = kEmptyObject) {
-    var signal = options?.signal;
-    if (signal) {
-      validateAbortSignal(signal, "options.signal");
-      if (signal.aborted) {
-        return PromiseReject($makeAbortError(undefined, { cause: signal.reason }));
+    return new Promise((resolve, reject) => {
+      var cb = resolve;
+      var signal = options?.signal;
+      if (signal) {
+        validateAbortSignal(signal, "options.signal");
+        if (signal.aborted) {
+          return reject($makeAbortError(undefined, { cause: signal.reason }));
+        }
+        var onAbort = () => {
+          this[kQuestionCancel]();
+          reject($makeAbortError(undefined, { cause: signal.reason }));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        cb = answer => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(answer);
+        };
       }
-    }
-    const { promise, resolve, reject } = $newPromiseCapability(Promise);
-    var cb = resolve;
-    if (options?.signal) {
-      var onAbort = () => {
-        this[kQuestionCancel]();
-        reject($makeAbortError(undefined, { cause: signal.reason }));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-      cb = answer => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(answer);
-      };
-    }
-    this[kQuestion](query, cb);
-    return promise;
+      this[kQuestion](query, cb);
+    });
   }
 };
 

--- a/test/js/node/readline/readline_promises.node.test.ts
+++ b/test/js/node/readline/readline_promises.node.test.ts
@@ -1,6 +1,7 @@
 import { createTest } from "node-harness";
 import { EventEmitter } from "node:events";
 import readlinePromises from "node:readline/promises";
+import { PassThrough } from "node:stream";
 const { describe, it, expect, createDoneDotAll, createCallCheckCtx, assert } = createTest(import.meta.path);
 
 // ----------------------------------------------------------------------------
@@ -91,5 +92,53 @@ describe("readline/promises.createInterface()", () => {
 
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
+  });
+});
+
+describe("readline/promises.Interface.question()", () => {
+  it("returns a rejected promise (not a sync throw) on a closed interface", async () => {
+    const rl = readlinePromises.createInterface({ input: new PassThrough() });
+    rl.close();
+    const result = rl.question("q? ");
+    expect(result).toBeInstanceOf(Promise);
+    const err = await result.then(
+      () => null,
+      e => e,
+    );
+    expect({ name: err?.name, code: err?.code }).toEqual({ name: "Error", code: "ERR_USE_AFTER_CLOSE" });
+  });
+
+  it("returns a rejected promise (not a sync throw) for an invalid options.signal", async () => {
+    const rl = readlinePromises.createInterface({ input: new PassThrough() });
+    try {
+      const result = rl.question("q? ", { signal: 42 as any });
+      expect(result).toBeInstanceOf(Promise);
+      const err = await result.then(
+        () => null,
+        e => e,
+      );
+      expect({ name: err?.name, code: err?.code }).toEqual({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" });
+    } finally {
+      rl.close();
+    }
+  });
+
+  it("returns a rejected promise for an already-aborted signal", async () => {
+    const rl = readlinePromises.createInterface({ input: new PassThrough() });
+    try {
+      const result = rl.question("q? ", { signal: AbortSignal.abort("why") });
+      expect(result).toBeInstanceOf(Promise);
+      const err = await result.then(
+        () => null,
+        e => e,
+      );
+      expect({ name: err?.name, code: err?.code, cause: err?.cause }).toEqual({
+        name: "AbortError",
+        code: "ABORT_ERR",
+        cause: "why",
+      });
+    } finally {
+      rl.close();
+    }
   });
 });


### PR DESCRIPTION
### Repro

```js
import { createInterface } from "node:readline/promises";
import { PassThrough } from "node:stream";

const rl = createInterface({ input: new PassThrough() });
rl.close();
rl.question("q? ").catch(e => console.log("caught", e.code));
```

Node prints `caught ERR_USE_AFTER_CLOSE`. Bun throws synchronously before `.catch` is attached:

```
error: readline was closed
 code: "ERR_USE_AFTER_CLOSE"
```

Same for an invalid `options.signal` (`ERR_INVALID_ARG_TYPE`). `question()` is a promise API, so callers handle errors with `.catch()` or `try { await }` inside an async function that is usually not on the stack at the call site. Any caller racing a `close()` (a SIGINT handler, a `'line'` handler that closes the interface, an aborted `createInterface({ signal })`) gets an uncaught synchronous exception where Node delivers a handled rejection.

### Cause

Node evaluates the whole `question()` body inside `new Promise((resolve, reject) => { ... })`, so `validateAbortSignal()`'s throw and `[kQuestion]`'s `ERR_USE_AFTER_CLOSE` throw are converted to rejections by the executor. Bun's `PromisesInterface.question` built its capability with `$newPromiseCapability` and called `validateAbortSignal(signal, ...)` and `this[kQuestion](query, cb)` at the top level of the method, so both throws escaped synchronously.

### Fix

Match Node: wrap the whole body in the executor. This also routes the already-aborted fast path through `reject()` instead of the detached `PromiseReject` (that receiver bug is tracked more broadly in #33343, which also covers the `util.promisify(rl.question)` sibling and unrelated call sites).

### Verification

Three tests added to `test/js/node/readline/readline_promises.node.test.ts`: closed interface (`ERR_USE_AFTER_CLOSE`), invalid `options.signal` (`ERR_INVALID_ARG_TYPE`), and an already-aborted signal (`AbortError`/`ABORT_ERR` with `cause` preserved). All three fail on main (the first two with a synchronous throw, the third with `TypeError: |this| is not an object`) and pass with this change. The existing `readline.node.test.ts` suite (79 tests) continues to pass.