### PR TITLE
node:zlib: make deflate output independent of write() chunking

### DIFF
--- a/scripts/build/deps/zlib.ts
+++ b/scripts/build/deps/zlib.ts
@@ -143,6 +143,14 @@ export const zlib: Dependency = {
       // Gates the entire SIMD dispatch block in functable.c. Without it the
       // arch kernels compile but are never selected.
       WITH_OPTIM: true,
+      // zlib-ng's WITH_NEW_STRATEGIES=OFF. deflate_quick (level 1) and
+      // deflate_medium (levels 5/6) make block decisions at avail_in
+      // boundaries, so the bytes a createGzip() stream emits depend on
+      // upstream write() sizes and never match gzipSync(). deflate_fast/slow
+      // carry all match state in deflate_state and stay chunk-invariant (as
+      // cloudflare/zlib was). SIMD kernels above are unaffected.
+      NO_QUICK_STRATEGY: true,
+      NO_MEDIUM_STRATEGY: true,
       // zlib-ng 340f2f6e moved infback.c's distance-too-far-back check behind
       // INFLATE_STRICT (default OFF). Upstream zlib has it unconditional. Bun
       // doesn't call inflateBack(), but anything in-process linking the same

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -766,3 +766,51 @@ describe("crc32", () => {
     expect(zlib.crc32("abc")).toBe(891568578);
   });
 });
+
+describe("deflate output is independent of write() chunking", () => {
+  // The compressed bytes must be a pure function of (input, options). Node's
+  // canonical zlib guarantees this; zlib-ng's deflate_quick/deflate_medium
+  // strategies do not, so they are disabled in Bun's build.
+  const input = Buffer.alloc(4096);
+  for (let i = 0; i < input.length; i++) input[i] = (i * i) & 0x3f;
+
+  const collect = (s, chunks) =>
+    new Promise((resolve, reject) => {
+      const out = [];
+      s.on("data", d => out.push(d));
+      s.on("end", () => resolve(Buffer.concat(out)));
+      s.on("error", reject);
+      stream.Readable.from(chunks).pipe(s);
+    });
+
+  const splits = [
+    ["single write", [input]],
+    ["two writes", [input.subarray(0, 2048), input.subarray(2048)]],
+    ["32 writes", Array.from({ length: 32 }, (_, i) => input.subarray(i * 128, i * 128 + 128))],
+  ];
+
+  describe.each([
+    ["gzip", zlib.gzipSync, zlib.gzip, zlib.createGzip, zlib.gunzipSync],
+    ["deflate", zlib.deflateSync, zlib.deflate, zlib.createDeflate, zlib.inflateSync],
+    ["deflateRaw", zlib.deflateRawSync, zlib.deflateRaw, zlib.createDeflateRaw, zlib.inflateRawSync],
+  ])("%s", (_name, sync, asyncFn, create, decode) => {
+    it.each([-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])("level %d", async level => {
+      const ref = sync(input, { level });
+      expect(decode(ref).equals(input)).toBe(true);
+
+      const asyncOut = await util.promisify(asyncFn)(input, { level });
+      const streamed = {};
+      for (const [label, chunks] of splits) {
+        streamed[label] = await collect(create({ level }), chunks);
+      }
+
+      expect({
+        async: asyncOut.toString("hex"),
+        ...Object.fromEntries(splits.map(([label]) => [label, streamed[label].toString("hex")])),
+      }).toEqual({
+        async: ref.toString("hex"),
+        ...Object.fromEntries(splits.map(([label]) => [label, ref.toString("hex")])),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Makes the bytes produced by `createGzip()` / `createDeflate()` / `createDeflateRaw()` (and the `gzip()` / `deflate()` / `deflateRaw()` convenience wrappers) independent of how the input was split across `write()` calls, so they always match `gzipSync()` / `deflateSync()` / `deflateRawSync()` on the same input and options.

## Reproduction

```js
import { createGzip, gzip, gzipSync, gunzipSync } from "node:zlib";
import { Readable } from "node:stream";

const P = Buffer.alloc(4096);
for (let i = 0; i < P.length; i++) P[i] = (i * i) & 0x3f;

const viaStream = chunks => new Promise(res => {
  const gz = createGzip(), out = [];
  gz.on("data", d => out.push(d)).on("end", () => res(Buffer.concat(out)));
  Readable.from(chunks).pipe(gz);
});

const sync = gzipSync(P);
const two  = await viaStream([P.subarray(0, 2048), P.subarray(2048)]);
const many = await viaStream(Array.from({ length: 32 }, (_, i) => P.subarray(i * 128, i * 128 + 128)));
console.log("2 writes == gzipSync:",  two.equals(sync));   // node: true, bun: false
console.log("32 writes == gzipSync:", many.equals(sync));  // node: true, bun: false

const s1 = gzipSync(P, { level: 1 });
const a1 = await new Promise(r => gzip(P, { level: 1 }, (_, x) => r(x)));
console.log("level 1: gzipSync == gzip():", s1.equals(a1)); // node: true, bun: false
```

Before (1.4.0 and `main`):

```
2 writes == gzipSync: false
32 writes == gzipSync: false
level 1: gzipSync == gzip(): false
```

All variants still round-trip correctly through `gunzipSync()`, so this is an output-determinism break, not corruption. But content hashes, ETags, dedup keys, and signed digests of stream-compressed artifacts become non-reproducible across code paths and chunk sizes, and test suites that assert `deflateSync(x).equals(streamed(x))` (true in Node at every level) fail under Bun at the default level.

## Cause

Bun links zlib-ng (since #29433) with its "new strategies" enabled. Two of them make block decisions at `avail_in` boundaries:

- `deflate_quick` (level 1) emits codes directly into the output bitstream without buffering symbols, so it writes the DEFLATE block header, including the `BFINAL` bit, before it knows whether more input will follow. A `Z_NO_FLUSH` write followed by `Z_FINISH` therefore closes the open block and opens a new last block, where a single `Z_FINISH` call would have produced one block.
- `deflate_medium` at levels 5 and 6 keeps its one-step lookahead match (`next_match`) in a stack local. When `avail_in` runs out and the function returns `need_more`, that state is discarded; the next call re-enters with `next_match.match_length == 0` and picks a different match at the boundary.

`deflate_fast` and `deflate_slow` buffer symbols in `sym_buf` and carry all match state in `deflate_state`, so their output is a pure function of the input bytes regardless of how they arrived. Node's canonical zlib (and the cloudflare/zlib Bun linked before #29433) use only those two.

## Fix

Build zlib-ng with `NO_QUICK_STRATEGY` and `NO_MEDIUM_STRATEGY` (what upstream's `WITH_NEW_STRATEGIES=OFF` sets). This maps level 1 to `deflate_fast` and levels 3-6 to `deflate_fast`/`deflate_slow` in `configuration_table`. The SIMD CRC32, adler32, hash, `longest_match`, and chunkset kernels remain enabled, and inflate is unchanged. `Bun.serve` response compression and `Bun.gzipSync` default to libdeflate, so they are unaffected.

The fix lives in `scripts/build/deps/zlib.ts` (a vendored-dependency build define), outside `src/`, so the automated fail-before stash of `src/` is a no-op for this change; the new test in `test/js/node/zlib/zlib.test.js` demonstrates the fix when run against the system Bun vs the PR build.

## Verification

```
# before
$ bun test test/js/node/zlib/zlib.test.js -t "independent of write"
 21 pass  12 fail   (levels -1, 1, 5, 6 for gzip/deflate/deflateRaw)

# after
$ bun bd test test/js/node/zlib/zlib.test.js -t "independent of write"
 33 pass   0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 12 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/zlib/zlib.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/zlib/zlib.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52aec2ade)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.24ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.20ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.44ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.90ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.55ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.33ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.33ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.35ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__ [0.51ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate [0.24ms]
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate [0.21ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype.__proto__.constructor.name should be Zlib [0.25ms]
(pass) prototype and name and constructor > Inflate > Inflate.prototype should be instanceof Inflate.__proto__ [0.39ms]
(pass) prototype and name and constructor > Inflate > Inflate.prototype.constructor should be Inflate [0.21ms]
(pass) prototype and name an
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/zlib.ts     |  8 +++++++
 test/js/node/zlib/zlib.test.js | 48 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 56 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
scripts/build/deps/zlib.ts          1      2      0
test/js/node/zlib/zlib.test.js      2      3      0
```

</details>

<!-- robobun:evidence:end -->