### PR TITLE
node:zlib: honour the `dictionary` option for BrotliCompress/BrotliDecompress

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -713,10 +713,19 @@ function Brotli(opts, mode) {
     });
   }
 
+  let dictionary = opts?.dictionary;
+  if (dictionary !== undefined && !isArrayBufferView(dictionary)) {
+    if (isAnyArrayBuffer(dictionary)) {
+      dictionary = Buffer.from(dictionary);
+    } else {
+      throw $ERR_INVALID_ARG_TYPE("options.dictionary", "Buffer, TypedArray, DataView, or ArrayBuffer", dictionary);
+    }
+  }
+
   const handle = new NativeBrotli(mode);
 
   this._writeState = new Uint32Array(2);
-  if (!handle.init(brotliInitParamsArray, this._writeState, processCallback)) {
+  if (!handle.init(brotliInitParamsArray, this._writeState, processCallback, dictionary)) {
     throw $ERR_ZLIB_INITIALIZATION_FAILED();
   }
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -472,6 +472,10 @@ mod _impl {
         }
 
         pub fn reset(&mut self) -> Error {
+            // Node's `Brotli{Encoder,Decoder}Context::ResetStream()` calls
+            // `Init()` with the default (empty) dictionary, so the attached
+            // dictionary is dropped on reset. Unlike zlib, this is Node's
+            // actual behaviour; match it.
             self.deinit_state();
             self.init(None)
         }

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -26,6 +26,14 @@ pub struct Context {
 
     pub last_result: LastResult,
     pub error_: c::BrotliDecoderErrorCode2,
+
+    /// Owned copy of the caller's `dictionary` option. The brotli encoder's
+    /// prepared dictionary and the decoder state both borrow these bytes for
+    /// their lifetime, so they must outlive `state`/`prepared_dictionary`.
+    pub dictionary: Vec<u8>,
+    /// Encoder only: the prepared dictionary attached to `state`. Destroyed
+    /// after the encoder state in `deinit_state`.
+    pub prepared_dictionary: Option<NonNull<c::BrotliEncoderPreparedDictionary>>,
 }
 
 impl Default for Context {
@@ -41,6 +49,8 @@ impl Default for Context {
             // SAFETY: all-zero is a valid LastResult (c_int 0 / enum 0).
             last_result: unsafe { bun_core::ffi::zeroed_unchecked() },
             error_: c::BrotliDecoderErrorCode2::NO_ERROR,
+            dictionary: Vec::new(),
+            prepared_dictionary: None,
         }
     }
 }
@@ -179,13 +189,13 @@ mod _impl {
             global_this: &JSGlobalObject,
             callframe: &CallFrame,
         ) -> JsResult<JSValue> {
-            let arguments = callframe.arguments_undef::<3>();
+            let arguments = callframe.arguments_undef::<4>();
             let this_value = callframe.this();
-            if arguments.len != 3 {
+            if arguments.len != 3 && arguments.len != 4 {
                 return Err(global_this
                     .err(
                         ErrorCode::MISSING_ARGS,
-                        format_args!("init(params, writeResult, writeCallback)"),
+                        format_args!("init(params, writeResult, writeCallback[, dictionary])"),
                     )
                     .throw());
             }
@@ -241,6 +251,26 @@ mod _impl {
                 ));
             }
 
+            // Bind the ArrayBuffer view to a local so the borrowed byte_slice()
+            // outlives the call to `stream.init` below.
+            let dictionary_buf;
+            let dictionary = if arguments.ptr[3].is_undefined() {
+                None
+            } else {
+                let dictionary_value = arguments.ptr[3];
+                dictionary_buf = match dictionary_value.as_array_buffer(global_this) {
+                    Some(buf) => buf,
+                    None => {
+                        return Err(global_this.throw_invalid_argument_type_value(
+                            "dictionary",
+                            "Buffer, TypedArray, or DataView",
+                            dictionary_value,
+                        ));
+                    }
+                };
+                Some(dictionary_buf.byte_slice())
+            };
+
             js::write_result_set_cached(this_value, global_this, write_result_value);
 
             js::write_callback_set_cached(
@@ -249,7 +279,7 @@ mod _impl {
                 write_callback.with_async_context_if_needed(global_this),
             );
 
-            let mut err = self.stream.with_mut(|s| s.init());
+            let mut err = self.stream.with_mut(|s| s.init(dictionary));
             if err.is_error() {
                 CompressionStream::<Self>::emit_error(self, global_this, this_value, err);
                 return Ok(JSValue::FALSE);
@@ -316,11 +346,15 @@ mod _impl {
     }
 
     impl Context {
-        pub fn init(&mut self) -> Error {
+        pub fn init(&mut self, dictionary: Option<&[u8]>) -> Error {
+            let alloc = bun_brotli::BrotliAllocator::alloc;
+            let free = bun_brotli::BrotliAllocator::free;
+            self.dictionary = match dictionary {
+                Some(d) if !d.is_empty() => d.to_vec(),
+                _ => Vec::new(),
+            };
             match self.mode {
                 bun_zlib::NodeMode::BROTLI_ENCODE => {
-                    let alloc = bun_brotli::BrotliAllocator::alloc;
-                    let free = bun_brotli::BrotliAllocator::free;
                     // SAFETY: FFI — alloc/free are valid fn ptrs, opaque arg unused.
                     let state = unsafe {
                         c::BrotliEncoderCreateInstance(Some(alloc), Some(free), ptr::null_mut())
@@ -333,11 +367,46 @@ mod _impl {
                         );
                     }
                     self.state = NonNull::new(state.cast::<c_void>());
+                    if !self.dictionary.is_empty() {
+                        // SAFETY: FFI — `self.dictionary` bytes outlive the prepared
+                        // dictionary (freed in `deinit_state` / on Context drop).
+                        let prepared = unsafe {
+                            c::BrotliEncoderPrepareDictionary(
+                                c::BROTLI_SHARED_DICTIONARY_RAW as c::BrotliSharedDictionaryType,
+                                self.dictionary.len(),
+                                self.dictionary.as_ptr(),
+                                c::BROTLI_MAX_QUALITY,
+                                Some(alloc),
+                                Some(free),
+                                ptr::null_mut(),
+                            )
+                        };
+                        let Some(prepared) = NonNull::new(prepared) else {
+                            self.deinit_state();
+                            return Error::init(
+                                c"Failed to prepare brotli dictionary".as_ptr(),
+                                -1,
+                                c"ERR_ZLIB_DICTIONARY_LOAD_FAILED".as_ptr(),
+                            );
+                        };
+                        self.prepared_dictionary = Some(prepared);
+                        // SAFETY: FFI — `state` is a freshly created encoder; `prepared`
+                        // outlives it (destroyed after the encoder in `deinit_state`).
+                        let ok = unsafe {
+                            c::BrotliEncoderAttachPreparedDictionary(state, prepared.as_ptr())
+                        };
+                        if ok == 0 {
+                            self.deinit_state();
+                            return Error::init(
+                                c"Failed to attach brotli dictionary".as_ptr(),
+                                -1,
+                                c"ERR_ZLIB_DICTIONARY_LOAD_FAILED".as_ptr(),
+                            );
+                        }
+                    }
                     Error::ok()
                 }
                 bun_zlib::NodeMode::BROTLI_DECODE => {
-                    let alloc = bun_brotli::BrotliAllocator::alloc;
-                    let free = bun_brotli::BrotliAllocator::free;
                     // SAFETY: FFI — alloc/free are valid fn ptrs, opaque arg unused.
                     let state = unsafe {
                         c::BrotliDecoderCreateInstance(Some(alloc), Some(free), ptr::null_mut())
@@ -350,6 +419,26 @@ mod _impl {
                         );
                     }
                     self.state = NonNull::new(state.cast::<c_void>());
+                    if !self.dictionary.is_empty() {
+                        // SAFETY: FFI — `state` is a freshly created decoder;
+                        // `self.dictionary` bytes outlive it.
+                        let ok = unsafe {
+                            c::BrotliDecoderAttachDictionary(
+                                state,
+                                c::BROTLI_SHARED_DICTIONARY_RAW as c::BrotliSharedDictionaryType,
+                                self.dictionary.len(),
+                                self.dictionary.as_ptr(),
+                            )
+                        };
+                        if ok == 0 {
+                            self.deinit_state();
+                            return Error::init(
+                                c"Failed to attach brotli dictionary".as_ptr(),
+                                -1,
+                                c"ERR_ZLIB_DICTIONARY_LOAD_FAILED".as_ptr(),
+                            );
+                        }
+                    }
                     Error::ok()
                 }
                 _ => unreachable!(),
@@ -383,25 +472,30 @@ mod _impl {
         }
 
         pub fn reset(&mut self) -> Error {
-            if self.state.is_some() {
-                self.deinit_state();
-            }
-            self.init()
+            self.deinit_state();
+            self.init(None)
         }
 
         /// Frees the Brotli encoder/decoder state without changing mode.
         /// Use close() for full cleanup that also sets mode to NONE.
         fn deinit_state(&mut self) {
-            match self.mode {
-                bun_zlib::NodeMode::BROTLI_ENCODE => {
-                    c::BrotliEncoder::destroy_instance(self.encoder_mut())
+            if self.state.is_some() {
+                match self.mode {
+                    bun_zlib::NodeMode::BROTLI_ENCODE => {
+                        c::BrotliEncoder::destroy_instance(self.encoder_mut())
+                    }
+                    bun_zlib::NodeMode::BROTLI_DECODE => {
+                        c::BrotliDecoder::destroy_instance(self.decoder_mut())
+                    }
+                    _ => unreachable!(),
                 }
-                bun_zlib::NodeMode::BROTLI_DECODE => {
-                    c::BrotliDecoder::destroy_instance(self.decoder_mut())
-                }
-                _ => unreachable!(),
+                self.state = None;
             }
-            self.state = None;
+            if let Some(prepared) = self.prepared_dictionary.take() {
+                // SAFETY: FFI — allocated by `BrotliEncoderPrepareDictionary`; the
+                // encoder state that borrowed it was destroyed above.
+                unsafe { c::BrotliEncoderDestroyPreparedDictionary(prepared.as_ptr()) };
+            }
         }
 
         pub fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>) {
@@ -534,9 +628,8 @@ mod _impl {
         pub fn close(&mut self) {
             // Idempotent: a handle that was never (successfully) initialized,
             // or that was already closed, has no encoder/decoder to free.
-            if self.state.is_some() {
-                self.deinit_state();
-            }
+            self.deinit_state();
+            self.dictionary = Vec::new();
             self.mode = bun_zlib::NodeMode::NONE;
         }
 

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -736,10 +736,7 @@ describe("brotli dictionary", () => {
   // Bytes produced by node's `brotliCompressSync(input, { dictionary: dict })`
   // for the `dict`/`input` above, so decoding this frame without attaching the
   // dictionary fails with ERR__ERROR_FORMAT_DICTIONARY.
-  const nodeDictFrame = Buffer.from(
-    "1b1c01c0c56dec3bce77185582d4830cb3ce6e8a145317f5e300c63a0f1df52d38",
-    "hex",
-  );
+  const nodeDictFrame = Buffer.from("1b1c01c0c56dec3bce77185582d4830cb3ce6e8a145317f5e300c63a0f1df52d38", "hex");
 
   it("brotliCompressSync honours the dictionary option", () => {
     const noDict = zlib.brotliCompressSync(input);

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -728,3 +728,106 @@ describe("dictionary buffer lifetime", () => {
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
   });
 });
+
+describe("brotli dictionary", () => {
+  const dict = Buffer.alloc(2000).fill("the quick brown fox dictdictdict alpha beta gamma ");
+  const input = Buffer.alloc(285).fill("the quick brown fox jumps alpha beta gamma delta epsilon\n");
+
+  // Bytes produced by node's `brotliCompressSync(input, { dictionary: dict })`
+  // for the `dict`/`input` above, so decoding this frame without attaching the
+  // dictionary fails with ERR__ERROR_FORMAT_DICTIONARY.
+  const nodeDictFrame = Buffer.from(
+    "1b1c01c0c56dec3bce77185582d4830cb3ce6e8a145317f5e300c63a0f1df52d38",
+    "hex",
+  );
+
+  it("brotliCompressSync honours the dictionary option", () => {
+    const noDict = zlib.brotliCompressSync(input);
+    const withDict = zlib.brotliCompressSync(input, { dictionary: dict });
+    expect(withDict.equals(noDict)).toBe(false);
+    expect(withDict.length).toBeLessThan(noDict.length);
+    expect(zlib.brotliDecompressSync(withDict, { dictionary: dict }).equals(input)).toBe(true);
+    expect(() => zlib.brotliDecompressSync(withDict)).toThrow(
+      expect.objectContaining({ code: "ERR__ERROR_FORMAT_DICTIONARY" }),
+    );
+  });
+
+  it("brotliDecompressSync honours the dictionary option (decodes node output)", () => {
+    expect(() => zlib.brotliDecompressSync(nodeDictFrame)).toThrow(
+      expect.objectContaining({ code: "ERR__ERROR_FORMAT_DICTIONARY" }),
+    );
+    const out = zlib.brotliDecompressSync(nodeDictFrame, { dictionary: dict });
+    expect(out.equals(input)).toBe(true);
+  });
+
+  it("brotliCompress / brotliDecompress honour the dictionary option", async () => {
+    const compressed = await util.promisify(zlib.brotliCompress)(input, { dictionary: dict });
+    expect(compressed.equals(zlib.brotliCompressSync(input))).toBe(false);
+    const roundtrip = await util.promisify(zlib.brotliDecompress)(compressed, { dictionary: dict });
+    expect(roundtrip.equals(input)).toBe(true);
+  });
+
+  it("createBrotliCompress / createBrotliDecompress honour the dictionary option", async () => {
+    const enc = zlib.createBrotliCompress({ dictionary: dict });
+    const encChunks = [];
+    {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      enc.on("data", c => encChunks.push(c));
+      enc.on("end", resolve);
+      enc.on("error", reject);
+      enc.end(input);
+      await promise;
+    }
+    const compressed = Buffer.concat(encChunks);
+    expect(compressed.equals(zlib.brotliCompressSync(input))).toBe(false);
+
+    const dec = zlib.createBrotliDecompress({ dictionary: dict });
+    const decChunks = [];
+    {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      dec.on("data", c => decChunks.push(c));
+      dec.on("end", resolve);
+      dec.on("error", reject);
+      dec.end(compressed);
+      await promise;
+    }
+    expect(Buffer.concat(decChunks).equals(input)).toBe(true);
+  });
+
+  it("createBrotliDecompress({ dictionary }) decodes node output", async () => {
+    const dec = zlib.createBrotliDecompress({ dictionary: dict });
+    const chunks = [];
+    const { promise, resolve, reject } = Promise.withResolvers();
+    dec.on("data", c => chunks.push(c));
+    dec.on("end", resolve);
+    dec.on("error", reject);
+    dec.end(nodeDictFrame);
+    await promise;
+    expect(Buffer.concat(chunks).equals(input)).toBe(true);
+  });
+
+  it("accepts an ArrayBuffer dictionary", () => {
+    const ab = new ArrayBuffer(dict.length);
+    new Uint8Array(ab).set(dict);
+    const out = zlib.brotliDecompressSync(nodeDictFrame, { dictionary: ab });
+    expect(out.equals(input)).toBe(true);
+  });
+
+  it("ignores an empty dictionary", () => {
+    const noDict = zlib.brotliCompressSync(input);
+    const emptyDict = zlib.brotliCompressSync(input, { dictionary: Buffer.alloc(0) });
+    expect(emptyDict.equals(noDict)).toBe(true);
+    expect(zlib.brotliDecompressSync(emptyDict).equals(input)).toBe(true);
+  });
+
+  it("rejects an invalid dictionary type", () => {
+    for (const bad of ["string", 42, {}]) {
+      expect(() => zlib.createBrotliCompress({ dictionary: bad })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => zlib.createBrotliDecompress({ dictionary: bad })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    }
+  });
+});


### PR DESCRIPTION
The `dictionary` option on `BrotliCompress`/`BrotliDecompress` was validated but never forwarded to the native brotli handle, so it was a silent no-op on both sides:

```js
import * as zlib from "node:zlib";

const dict = Buffer.from("the quick brown fox dictdictdict alpha beta gamma ".repeat(40));
const P = Buffer.from("the quick brown fox jumps alpha beta gamma delta epsilon\n".repeat(5));

const noDict   = zlib.brotliCompressSync(P);
const withDict = zlib.brotliCompressSync(P, { dictionary: dict });
console.log(noDict.length, withDict.length, !withDict.equals(noDict));
// node: 55 33 true     bun (before): 55 55 false

// Frame produced by node with {dictionary: dict}:
const nodeFrame = Buffer.from(
  "1b1c01c0c56dec3bce77185582d4830cb3ce6e8a145317f5e300c63a0f1df52d38", "hex");
zlib.brotliDecompressSync(nodeFrame, { dictionary: dict });
// node: returns P     bun (before): throws ERR__ERROR_FORMAT_DICTIONARY
```

The decompress side is an interop break: any Node service, `brotli -D` pipeline, or libbrotli producer that ships brotli shared-dictionary payloads (RFC 9842 / `Content-Encoding: dcb`-style delta compression) produces data a Bun consumer cannot read, even when the caller supplies the correct `dictionary`.

## Cause

`Brotli()` in `src/js/node/zlib.ts` never read `opts.dictionary`, and the native `NativeBrotli.init()` signature had no dictionary parameter. The `Zlib` base constructor that brotli inherits from does read and type-check `opts.dictionary`, but only forwards it to `NativeZlib.init()`, which the brotli classes do not use.

## Fix

Plumb the option through, matching Node's `node_zlib.cc`:

- `Brotli()` reads and validates `opts.dictionary` and passes it as a fourth argument to `handle.init()`.
- `NativeBrotli::init()` accepts it, copies the bytes into the `Context`, and attaches them to the freshly created encoder/decoder state via `BrotliEncoderPrepareDictionary` + `BrotliEncoderAttachPreparedDictionary` (encoder) / `BrotliDecoderAttachDictionary` (decoder), using `BROTLI_SHARED_DICTIONARY_RAW`.
- The prepared-dictionary handle is stored on the `Context` and destroyed after the encoder state in `deinit_state()`; `close()` releases the owned dictionary bytes.

## Verification

New tests in `test/js/node/zlib/zlib.test.js` cover sync and async compress/decompress, the stream classes, round-tripping a Node-produced dictionary frame, `ArrayBuffer` input, empty-dictionary no-op, and invalid-type rejection. 7 of the 8 new tests fail on the released binary and all pass with this change.


Addresses the Brotli half of #28033 (`dcb`); the Zstd dictionary path is unchanged.
