### PR TITLE
sql: roll back when COMMIT itself fails (SQLite SQLITE_BUSY left tx open)

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -778,8 +778,9 @@ const SQL: typeof Bun.SQL = function SQL(
           }
           await run_internal_transaction_sql(ROLLBACK_COMMAND);
         }
-      } catch (err) {
-        return reject(err);
+      } catch {
+        // Best-effort cleanup; the adapter may have already torn the transaction
+        // down (SQLite SQLITE_FULL/IOERR, Postgres/MySQL on COMMIT failure).
       }
       return reject(err);
     } finally {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -761,12 +761,14 @@ const SQL: typeof Bun.SQL = function SQL(
       if ($isArray(transaction_result)) {
         transaction_result = await Promise.all(transaction_result);
       }
-      // at this point we dont need to rollback anymore
-      needs_rollback = false;
       if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
         await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
+        BEFORE_COMMIT_OR_ROLLBACK_COMMAND = null;
       }
       await run_internal_transaction_sql(COMMIT_COMMAND);
+      // COMMIT succeeded; only now is it safe to skip ROLLBACK on the error path.
+      // SQLite leaves the transaction OPEN when COMMIT fails (e.g. SQLITE_BUSY).
+      needs_rollback = false;
       return resolve(transaction_result);
     } catch (err) {
       try {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -717,7 +717,12 @@ const SQL: typeof Bun.SQL = function SQL(
         return result;
       } catch (err) {
         if (!(state.connectionState & ReservedConnectionState.closed)) {
-          await run_internal_transaction_sql(`${ROLLBACK_TO_SAVEPOINT_COMMAND} ${save_point_name}`);
+          try {
+            await run_internal_transaction_sql(`${ROLLBACK_TO_SAVEPOINT_COMMAND} ${save_point_name}`);
+          } catch {
+            // Best-effort; the savepoint may no longer exist if the engine
+            // already rolled the whole transaction back (SQLite SQLITE_FULL/IOERR).
+          }
         }
         throw err;
       }

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,4 +1,5 @@
 import { randomUUIDv7, SQL } from "bun";
+import { Database } from "bun:sqlite";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { tempDirWithFiles } from "harness";
 import { existsSync } from "node:fs";
@@ -1143,6 +1144,62 @@ describe("Transactions", () => {
 
     const accounts = await sql`SELECT * FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1002);
+  });
+
+  test("failed COMMIT (SQLITE_BUSY) rolls back instead of leaking an open transaction", async () => {
+    const dir = tempDirWithFiles("sqlite-commit-busy", {});
+    const dbPath = path.join(dir, "busy.db");
+
+    const fileSql = new SQL({ adapter: "sqlite", filename: dbPath });
+    try {
+      await fileSql`CREATE TABLE t (v TEXT)`;
+      await fileSql`INSERT INTO t VALUES ('seed')`;
+
+      // Hold a read lock from a second connection so COMMIT on the writer returns SQLITE_BUSY.
+      const reader = new Database(dbPath);
+      reader.run("BEGIN DEFERRED");
+      reader.prepare("SELECT COUNT(*) c FROM t").get();
+
+      const beginError = await fileSql
+        .begin(async tx => {
+          await tx`INSERT INTO t VALUES ('in-tx')`;
+        })
+        .then(
+          () => null,
+          e => e,
+        );
+      expect(String(beginError)).toContain("database is locked");
+
+      reader.run("ROLLBACK");
+      reader.close();
+
+      // The connection must no longer be inside the aborted transaction.
+      await fileSql`INSERT INTO t VALUES ('later-1')`;
+      await fileSql`INSERT INTO t VALUES ('later-2')`;
+
+      // A fresh connection must be able to read (no stale RESERVED lock).
+      const other = new Database(dbPath);
+      const rowsFromOther = other.prepare("SELECT v FROM t ORDER BY v").all() as { v: string }[];
+      other.close();
+      expect(rowsFromOther.map(r => r.v)).toEqual(["later-1", "later-2", "seed"]);
+
+      // A subsequent begin() on the same instance must work.
+      const second = await fileSql.begin(async tx => {
+        await tx`INSERT INTO t VALUES ('later-3')`;
+        return "ok";
+      });
+      expect(second).toBe("ok");
+
+      // All post-failure writes must be durable after close.
+      await fileSql.close();
+      const final = new Database(dbPath);
+      const finalRows = (final.prepare("SELECT v FROM t ORDER BY v").all() as { v: string }[]).map(r => r.v);
+      final.close();
+      expect(finalRows).toEqual(["later-1", "later-2", "later-3", "seed"]);
+    } finally {
+      await fileSql.close().catch(() => {});
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1155,33 +1155,34 @@ describe("Transactions", () => {
       await fileSql`CREATE TABLE t (v TEXT)`;
       await fileSql`INSERT INTO t VALUES ('seed')`;
 
-      // Hold a read lock from a second connection so COMMIT on the writer returns SQLITE_BUSY.
-      const reader = new Database(dbPath);
-      reader.run("BEGIN DEFERRED");
-      reader.prepare("SELECT COUNT(*) c FROM t").get();
+      {
+        // Hold a read lock from a second connection so COMMIT on the writer returns SQLITE_BUSY.
+        using reader = new Database(dbPath);
+        reader.run("BEGIN DEFERRED");
+        reader.query("SELECT COUNT(*) c FROM t").get();
 
-      const beginError = await fileSql
-        .begin(async tx => {
-          await tx`INSERT INTO t VALUES ('in-tx')`;
-        })
-        .then(
-          () => null,
-          e => e,
-        );
-      expect(String(beginError)).toContain("database is locked");
-
-      reader.run("ROLLBACK");
-      reader.close();
+        const beginError = await fileSql
+          .begin(async tx => {
+            await tx`INSERT INTO t VALUES ('in-tx')`;
+          })
+          .then(
+            () => null,
+            e => e,
+          );
+        expect(String(beginError)).toContain("database is locked");
+        reader.run("ROLLBACK");
+      }
 
       // The connection must no longer be inside the aborted transaction.
       await fileSql`INSERT INTO t VALUES ('later-1')`;
       await fileSql`INSERT INTO t VALUES ('later-2')`;
 
       // A fresh connection must be able to read (no stale RESERVED lock).
-      const other = new Database(dbPath);
-      const rowsFromOther = other.prepare("SELECT v FROM t ORDER BY v").all() as { v: string }[];
-      other.close();
-      expect(rowsFromOther.map(r => r.v)).toEqual(["later-1", "later-2", "seed"]);
+      {
+        using other = new Database(dbPath);
+        const rowsFromOther = other.query("SELECT v FROM t ORDER BY v").all() as { v: string }[];
+        expect(rowsFromOther.map(r => r.v)).toEqual(["later-1", "later-2", "seed"]);
+      }
 
       // A subsequent begin() on the same instance must work.
       const second = await fileSql.begin(async tx => {
@@ -1192,9 +1193,8 @@ describe("Transactions", () => {
 
       // All post-failure writes must be durable after close.
       await fileSql.close();
-      const final = new Database(dbPath);
-      const finalRows = (final.prepare("SELECT v FROM t ORDER BY v").all() as { v: string }[]).map(r => r.v);
-      final.close();
+      using final = new Database(dbPath);
+      const finalRows = (final.query("SELECT v FROM t ORDER BY v").all() as { v: string }[]).map(r => r.v);
       expect(finalRows).toEqual(["later-1", "later-2", "later-3", "seed"]);
     } finally {
       await fileSql.close().catch(() => {});

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,7 +1,7 @@
 import { randomUUIDv7, SQL } from "bun";
 import { Database } from "bun:sqlite";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { isDebug, tempDirWithFiles } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -2071,7 +2071,7 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    const iterations = 10000;
+    const iterations = isDebug ? 1000 : 10000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;


### PR DESCRIPTION
### Repro

```ts
import { Database } from "bun:sqlite";
const sql = new Bun.SQL({ adapter: "sqlite", filename: dbPath });
await sql`create table t (v text)`;
await sql`insert into t values ('seed')`;

// second connection holds a read lock so COMMIT on the writer returns SQLITE_BUSY
const reader = new Database(dbPath);
reader.run("BEGIN DEFERRED");
reader.prepare("select count(*) c from t").get();

await sql.begin(async tx => { await tx`insert into t values ('in-tx')`; })
  .catch(e => console.log(String(e)));  // SQLiteError: database is locked

reader.run("ROLLBACK"); reader.close();

await sql`insert into t values ('later')`;               // fulfills, but into the abandoned tx
new Database(dbPath).prepare("select * from t").all();   // SQLiteError: database is locked
await sql.begin(async tx => {});                         // SQLiteError: cannot start a transaction within a transaction
await sql.close();                                       // 'later' is gone
```

One SQLITE_BUSY collision at COMMIT time wedges the instance permanently: later writes on it fulfill but are never committed, every other connection to the file gets `database is locked`, and every later `sql.begin()` rejects. Reproduces on 1.4.0 and main with default options (`journal_mode=delete`, no `busy_timeout`).

### Cause

`onTransactionConnected` in `src/js/bun/sql.ts` cleared `needs_rollback = false` before awaiting COMMIT:

```ts
needs_rollback = false;            // cleared too early
if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) { ... }
await run_internal_transaction_sql(COMMIT_COMMAND);  // throws SQLITE_BUSY
```

so the catch path issued no ROLLBACK. Postgres and MySQL destroy the transaction server-side when COMMIT fails, so the missing ROLLBACK was a no-op there; SQLite keeps the transaction open on a busy COMMIT by design (so the caller can retry), and the pooled connection was returned still inside it. `bun:sqlite`'s own `db.transaction()` helper already handles this correctly (it checks `db.inTransaction` after a failure).

### Fix

- Clear `needs_rollback` only after COMMIT succeeds; null `BEFORE_COMMIT_OR_ROLLBACK_COMMAND` once it has run so the error path does not re-issue MySQL's `XA END` if `XA PREPARE` fails. ROLLBACK after a failed COMMIT is a no-op warning on Postgres/MySQL and the required cleanup on SQLite.
- The cleanup `ROLLBACK` (and the sibling `ROLLBACK TO SAVEPOINT` in `run_internal_savepoint`) are now best-effort: their own failure is swallowed so `sql.begin()` / `tx.savepoint()` always reject with the original error. Previously the inner catch shadowed it, so a COMMIT failure where SQLite had already auto-rolled-back (`SQLITE_FULL`/`IOERR`/`NOMEM`/`INTERRUPT`) would surface `cannot rollback - no transaction is active` instead of the real error.

### Verification

`test/js/sql/sqlite-sql.test.ts` gains a test that holds a read lock from a second `bun:sqlite` connection, forces `sql.begin()`'s COMMIT to fail with SQLITE_BUSY, releases the lock, then asserts:

- later writes on the same instance are visible from a fresh connection (no stale RESERVED lock)
- a subsequent `sql.begin()` succeeds
- all post-failure writes survive `sql.close()`

Fails on the unfixed build with `SQLiteError: database is locked` at the fresh-connection read; passes with the fix. Also reduced the unrelated `properly finalizes prepared statements` test to 1,000 iterations under debug builds (it was timing out under ASAN on main).
