### PR TITLE
sql(sqlite): detect SQLite's automatic ROLLBACK inside sql.begin()

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -607,15 +607,9 @@ const SQL: typeof Bun.SQL = function SQL(
       return queryFromTransaction(strings, values, pooledConnection, state.queries, preRunGuard);
     }
     transaction_sql.unsafe = (string, args = []) => {
-      if (needs_rollback && !transaction_still_open()) {
-        return Promise.$reject(transaction_aborted_error());
-      }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries, preRunGuard);
     };
     transaction_sql.file = async (path: string, args = []) => {
-      if (needs_rollback && !transaction_still_open()) {
-        throw transaction_aborted_error();
-      }
       const text = await Bun.file(path).text();
       return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries, preRunGuard);
     };

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -551,6 +551,20 @@ const SQL: typeof Bun.SQL = function SQL(
       pool.attachConnectionCloseHandler(pooledConnection, onClose);
     }
 
+    // Some databases (SQLite's ON CONFLICT ROLLBACK / OR ROLLBACK / RAISE(ROLLBACK)) can roll the
+    // transaction back on their own mid-callback. Once that happens the connection is in autocommit
+    // and any further COMMIT/ROLLBACK would fail with "no transaction is active".
+    let needs_rollback = false;
+    const isConnectionInTransaction = pool.isConnectionInTransaction?.bind(pool);
+    function transaction_still_open() {
+      return isConnectionInTransaction === undefined || isConnectionInTransaction(pooledConnection);
+    }
+    function transaction_aborted_error() {
+      return pool.invalidTransactionStateError(
+        "current transaction is aborted (the database already rolled it back), commands ignored until end of transaction",
+      );
+    }
+
     function run_internal_transaction_sql(string) {
       if (state.connectionState & ReservedConnectionState.closed) {
         return Promise.$reject(pool.connectionClosedError());
@@ -567,6 +581,9 @@ const SQL: typeof Bun.SQL = function SQL(
       ) {
         return Promise.$reject(pool.connectionClosedError());
       }
+      if (needs_rollback && !transaction_still_open()) {
+        return Promise.$reject(transaction_aborted_error());
+      }
       if ($isArray(strings)) {
         // detect if is tagged template
         if (!$isArray((strings as unknown as TemplateStringsArray).raw)) {
@@ -579,9 +596,15 @@ const SQL: typeof Bun.SQL = function SQL(
       return queryFromTransaction(strings, values, pooledConnection, state.queries);
     }
     transaction_sql.unsafe = (string, args = []) => {
+      if (needs_rollback && !transaction_still_open()) {
+        return Promise.$reject(transaction_aborted_error());
+      }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
     };
     transaction_sql.file = async (path: string, args = []) => {
+      if (needs_rollback && !transaction_still_open()) {
+        throw transaction_aborted_error();
+      }
       return await Bun.file(path)
         .text()
         .then(text => {
@@ -687,10 +710,13 @@ const SQL: typeof Bun.SQL = function SQL(
       for (const query of transactionQueries) {
         (query as Query<any, any>).cancel();
       }
-      if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
-        await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
+      if (transaction_still_open()) {
+        if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
+          await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
+        }
+        await run_internal_transaction_sql(ROLLBACK_COMMAND);
       }
-      await run_internal_transaction_sql(ROLLBACK_COMMAND);
+      needs_rollback = false;
       state.connectionState |= ReservedConnectionState.closed;
     };
     transaction_sql[Symbol.asyncDispose] = () => transaction_sql.close();
@@ -707,6 +733,9 @@ const SQL: typeof Bun.SQL = function SQL(
 
       try {
         let result = await savepoint_callback(transaction_sql);
+        if (needs_rollback && !transaction_still_open()) {
+          throw transaction_aborted_error();
+        }
         if (RELEASE_SAVEPOINT_COMMAND) {
           // mssql dont have release savepoint
           await run_internal_transaction_sql(`${RELEASE_SAVEPOINT_COMMAND} ${save_point_name}`);
@@ -716,8 +745,10 @@ const SQL: typeof Bun.SQL = function SQL(
         }
         return result;
       } catch (err) {
-        if (!(state.connectionState & ReservedConnectionState.closed)) {
-          await run_internal_transaction_sql(`${ROLLBACK_TO_SAVEPOINT_COMMAND} ${save_point_name}`);
+        if (!(state.connectionState & ReservedConnectionState.closed) && transaction_still_open()) {
+          try {
+            await run_internal_transaction_sql(`${ROLLBACK_TO_SAVEPOINT_COMMAND} ${save_point_name}`);
+          } catch {}
         }
         throw err;
       }
@@ -753,13 +784,15 @@ const SQL: typeof Bun.SQL = function SQL(
         return await promise.finally(onSavepointFinished.bind(null, promise));
       };
     }
-    let needs_rollback = false;
     try {
       await run_internal_transaction_sql(BEGIN_COMMAND);
       needs_rollback = true;
       let transaction_result = await callback(transaction_sql);
       if ($isArray(transaction_result)) {
         transaction_result = await Promise.all(transaction_result);
+      }
+      if (needs_rollback && !transaction_still_open()) {
+        throw transaction_aborted_error();
       }
       // at this point we dont need to rollback anymore
       needs_rollback = false;
@@ -770,15 +803,13 @@ const SQL: typeof Bun.SQL = function SQL(
       return resolve(transaction_result);
     } catch (err) {
       try {
-        if (!(state.connectionState & ReservedConnectionState.closed) && needs_rollback) {
+        if (!(state.connectionState & ReservedConnectionState.closed) && needs_rollback && transaction_still_open()) {
           if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
             await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
           }
           await run_internal_transaction_sql(ROLLBACK_COMMAND);
         }
-      } catch (err) {
-        return reject(err);
-      }
+      } catch {}
       return reject(err);
     } finally {
       state.connectionState |= ReservedConnectionState.closed;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -145,7 +145,7 @@ const SQL: typeof Bun.SQL = function SQL(
     transactionQueries.delete(query);
   }
 
-  function queryFromTransactionHandler(transactionQueries, query, handle, err) {
+  function queryFromTransactionHandler(transactionQueries, preRunGuard, query, handle, err) {
     const pooledConnection = this;
     if (err) {
       transactionQueries.delete(query);
@@ -156,6 +156,14 @@ const SQL: typeof Bun.SQL = function SQL(
     if (query.cancelled) {
       transactionQueries.delete(query);
       return query.reject(pool.queryCancelledError());
+    }
+
+    if (preRunGuard !== null) {
+      const guardErr = preRunGuard();
+      if (guardErr) {
+        transactionQueries.delete(query);
+        return query.reject(guardErr);
+      }
     }
 
     query.finally(onTransactionQueryDisconnected.bind(transactionQueries, query));
@@ -177,6 +185,7 @@ const SQL: typeof Bun.SQL = function SQL(
     values: any[],
     pooledConnection: PooledPostgresConnection,
     transactionQueries: Set<Query<any, any>>,
+    preRunGuard: (() => Error | null) | null = null,
   ) {
     try {
       const query = new Query(
@@ -185,7 +194,7 @@ const SQL: typeof Bun.SQL = function SQL(
         connectionInfo.bigint
           ? SQLQueryFlags.allowUnsafeTransaction | SQLQueryFlags.bigint
           : SQLQueryFlags.allowUnsafeTransaction,
-        queryFromTransactionHandler.bind(pooledConnection, transactionQueries),
+        queryFromTransactionHandler.bind(pooledConnection, transactionQueries, preRunGuard),
         pool,
       );
 
@@ -201,6 +210,7 @@ const SQL: typeof Bun.SQL = function SQL(
     values: any[],
     pooledConnection: PooledPostgresConnection,
     transactionQueries: Set<Query<any, any>>,
+    preRunGuard: (() => Error | null) | null = null,
   ) {
     try {
       let flags = connectionInfo.bigint
@@ -214,7 +224,7 @@ const SQL: typeof Bun.SQL = function SQL(
         strings,
         values,
         flags,
-        queryFromTransactionHandler.bind(pooledConnection, transactionQueries),
+        queryFromTransactionHandler.bind(pooledConnection, transactionQueries, preRunGuard),
         pool,
       );
       transactionQueries.add(query);
@@ -564,6 +574,10 @@ const SQL: typeof Bun.SQL = function SQL(
         "current transaction is aborted (the database already rolled it back), commands ignored until end of transaction",
       );
     }
+    const preRunGuard =
+      isConnectionInTransaction === undefined
+        ? null
+        : () => (needs_rollback && !transaction_still_open() ? transaction_aborted_error() : null);
 
     function run_internal_transaction_sql(string) {
       if (state.connectionState & ReservedConnectionState.closed) {
@@ -593,23 +607,20 @@ const SQL: typeof Bun.SQL = function SQL(
         return new SQLHelper([strings], values);
       }
 
-      return queryFromTransaction(strings, values, pooledConnection, state.queries);
+      return queryFromTransaction(strings, values, pooledConnection, state.queries, preRunGuard);
     }
     transaction_sql.unsafe = (string, args = []) => {
       if (needs_rollback && !transaction_still_open()) {
         return Promise.$reject(transaction_aborted_error());
       }
-      return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
+      return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries, preRunGuard);
     };
     transaction_sql.file = async (path: string, args = []) => {
       if (needs_rollback && !transaction_still_open()) {
         throw transaction_aborted_error();
       }
       const text = await Bun.file(path).text();
-      if (needs_rollback && !transaction_still_open()) {
-        throw transaction_aborted_error();
-      }
-      return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
+      return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries, preRunGuard);
     };
     // reserve is allowed to be called inside transaction connection but will return a new reserved connection from the pool and will not be part of the transaction
     // this matchs the behavior of the postgres package

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -579,11 +579,11 @@ const SQL: typeof Bun.SQL = function SQL(
         ? null
         : () => (needs_rollback && !transaction_still_open() ? transaction_aborted_error() : null);
 
-    function run_internal_transaction_sql(string) {
+    function run_internal_transaction_sql(string, guarded = false) {
       if (state.connectionState & ReservedConnectionState.closed) {
         return Promise.$reject(pool.connectionClosedError());
       }
-      return unsafeQueryFromTransaction(string, [], pooledConnection, state.queries);
+      return unsafeQueryFromTransaction(string, [], pooledConnection, state.queries, guarded ? preRunGuard : null);
     }
     function transaction_sql(
       strings: string | TemplateStringsArray | import("internal/sql/shared.ts").SQLHelper<any> | Query<any, any>,
@@ -743,7 +743,7 @@ const SQL: typeof Bun.SQL = function SQL(
       transactionSavepoints.delete(savepoint_promise);
     }
     async function run_internal_savepoint(save_point_name: string, savepoint_callback: TransactionCallback) {
-      await run_internal_transaction_sql(`${SAVEPOINT_COMMAND} ${save_point_name}`);
+      await run_internal_transaction_sql(`${SAVEPOINT_COMMAND} ${save_point_name}`, true);
 
       try {
         let result = await savepoint_callback(transaction_sql);

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -603,9 +603,6 @@ const SQL: typeof Bun.SQL = function SQL(
       } else if (typeof strings === "object" && !(strings instanceof Query) && !(strings instanceof SQLHelper)) {
         return new SQLHelper([strings], values);
       }
-      if (needs_rollback && !transaction_still_open()) {
-        return Promise.$reject(transaction_aborted_error());
-      }
 
       return queryFromTransaction(strings, values, pooledConnection, state.queries, preRunGuard);
     }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -692,10 +692,13 @@ const SQL: typeof Bun.SQL = function SQL(
             for (const query of transactionQueries) {
               (query as Query<any, any>).cancel();
             }
-            if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
-              await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
+            if (transaction_still_open()) {
+              if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
+                await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
+              }
+              await run_internal_transaction_sql(ROLLBACK_COMMAND);
             }
-            await run_internal_transaction_sql(ROLLBACK_COMMAND);
+            needs_rollback = false;
             state.connectionState |= ReservedConnectionState.closed;
             resolve();
           }, timeout * 1000);
@@ -733,15 +736,15 @@ const SQL: typeof Bun.SQL = function SQL(
 
       try {
         let result = await savepoint_callback(transaction_sql);
+        if ($isArray(result)) {
+          result = await Promise.all(result);
+        }
         if (needs_rollback && !transaction_still_open()) {
           throw transaction_aborted_error();
         }
         if (RELEASE_SAVEPOINT_COMMAND) {
           // mssql dont have release savepoint
           await run_internal_transaction_sql(`${RELEASE_SAVEPOINT_COMMAND} ${save_point_name}`);
-        }
-        if ($isArray(result)) {
-          result = await Promise.all(result);
         }
         return result;
       } catch (err) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -605,11 +605,11 @@ const SQL: typeof Bun.SQL = function SQL(
       if (needs_rollback && !transaction_still_open()) {
         throw transaction_aborted_error();
       }
-      return await Bun.file(path)
-        .text()
-        .then(text => {
-          return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
-        });
+      const text = await Bun.file(path).text();
+      if (needs_rollback && !transaction_still_open()) {
+        throw transaction_aborted_error();
+      }
+      return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
     };
     // reserve is allowed to be called inside transaction connection but will return a new reserved connection from the pool and will not be part of the transaction
     // this matchs the behavior of the postgres package
@@ -766,6 +766,9 @@ const SQL: typeof Bun.SQL = function SQL(
           !(state.connectionState & ReservedConnectionState.acceptQueries)
         ) {
           throw pool.connectionClosedError();
+        }
+        if (needs_rollback && !transaction_still_open()) {
+          throw transaction_aborted_error();
         }
 
         if ($isCallable(name)) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -595,9 +595,6 @@ const SQL: typeof Bun.SQL = function SQL(
       ) {
         return Promise.$reject(pool.connectionClosedError());
       }
-      if (needs_rollback && !transaction_still_open()) {
-        return Promise.$reject(transaction_aborted_error());
-      }
       if ($isArray(strings)) {
         // detect if is tagged template
         if (!$isArray((strings as unknown as TemplateStringsArray).raw)) {
@@ -605,6 +602,9 @@ const SQL: typeof Bun.SQL = function SQL(
         }
       } else if (typeof strings === "object" && !(strings instanceof Query) && !(strings instanceof SQLHelper)) {
         return new SQLHelper([strings], values);
+      }
+      if (needs_rollback && !transaction_still_open()) {
+        return Promise.$reject(transaction_aborted_error());
       }
 
       return queryFromTransaction(strings, values, pooledConnection, state.queries, preRunGuard);

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2123,6 +2123,7 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
 
   supportsReservedConnections?(): boolean;
   getConnectionForQuery?(pooledConnection: Connection): ConnectionHandle | null;
+  isConnectionInTransaction?(connection: Connection): boolean;
   attachConnectionCloseHandler?(connection: Connection, handler: () => void): void;
   detachConnectionCloseHandler?(connection: Connection, handler: () => void): void;
 

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -487,6 +487,9 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
   getConnectionForQuery(connection: BunSQLiteModule.Database): BunSQLiteModule.Database {
     return connection;
   }
+  isConnectionInTransaction(connection: BunSQLiteModule.Database): boolean {
+    return connection.inTransaction;
+  }
   array(_values: any[], _typeNameOrID?: number | ArrayType): SQLArrayParameter {
     throw new Error("SQLite doesn't support arrays");
   }

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, SQL } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { isDebug, tempDirWithFiles } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -2207,7 +2207,8 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    const iterations = 10000;
+    // debug+ASAN runs ~100x slower; 10k INSERTs there exceed the per-test timeout
+    const iterations = isDebug ? 1000 : 10000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1268,12 +1268,15 @@ describe("Transactions", () => {
 
     test("tx.savepoint after auto-rollback is refused and its body never runs", async () => {
       let bodyRan = false;
+      let conflictErr: any;
       let beginErr: any;
       try {
         await sql.begin(async tx => {
           try {
             await tx`INSERT INTO t VALUES ('dup')`;
-          } catch {}
+          } catch (e) {
+            conflictErr = e;
+          }
           await tx.savepoint(async sp => {
             bodyRan = true;
             await sp`INSERT INTO log VALUES ('from-savepoint')`;
@@ -1284,11 +1287,13 @@ describe("Transactions", () => {
       }
       expect({
         bodyRan,
-        code: beginErr?.code,
+        conflictErrCode: conflictErr?.code,
+        beginErrCode: beginErr?.code,
         durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
       }).toEqual({
         bodyRan: false,
-        code: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        conflictErrCode: "SQLITE_CONSTRAINT_PRIMARYKEY",
+        beginErrCode: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
         durable: [],
       });
     });

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1316,6 +1316,32 @@ describe("Transactions", () => {
       });
     });
 
+    test("tx.savepoint with a concurrent unawaited conflict is refused at SAVEPOINT execution time", async () => {
+      let bodyRan = false;
+      let beginErr: any;
+      await sql
+        .begin(async tx => {
+          // .catch() enqueues this query's execution microtask before SAVEPOINT's, without
+          // awaiting it; the conflict auto-rolls-back between the savepoint() call-time
+          // check and the SAVEPOINT command actually running.
+          tx`INSERT INTO t VALUES ('dup')`.catch(() => {});
+          await tx.savepoint(async sp => {
+            bodyRan = true;
+            await sp`INSERT INTO log VALUES ('from-savepoint')`;
+          });
+        })
+        .catch(e => (beginErr = e));
+      expect({
+        bodyRan,
+        code: beginErr?.code,
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        bodyRan: false,
+        code: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        durable: [],
+      });
+    });
+
     test("auto-rollback inside a savepoint propagates the original error and aborts the outer transaction", async () => {
       let caught: any;
       try {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1266,6 +1266,33 @@ describe("Transactions", () => {
       });
     });
 
+    test("tx.savepoint after auto-rollback is refused and its body never runs", async () => {
+      let bodyRan = false;
+      let beginErr: any;
+      try {
+        await sql.begin(async tx => {
+          try {
+            await tx`INSERT INTO t VALUES ('dup')`;
+          } catch {}
+          await tx.savepoint(async sp => {
+            bodyRan = true;
+            await sp`INSERT INTO log VALUES ('from-savepoint')`;
+          });
+        });
+      } catch (e) {
+        beginErr = e;
+      }
+      expect({
+        bodyRan,
+        code: beginErr?.code,
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        bodyRan: false,
+        code: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        durable: [],
+      });
+    });
+
     test("auto-rollback inside a savepoint propagates the original error and aborts the outer transaction", async () => {
       let caught: any;
       try {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1144,6 +1144,149 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT * FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1002);
   });
+
+  describe("SQLite automatic ROLLBACK (ON CONFLICT ROLLBACK / OR ROLLBACK / RAISE(ROLLBACK))", () => {
+    beforeEach(async () => {
+      await sql`CREATE TABLE t (v TEXT PRIMARY KEY ON CONFLICT ROLLBACK)`;
+      await sql`CREATE TABLE log (v TEXT)`;
+      await sql`INSERT INTO t VALUES ('dup')`;
+    });
+
+    test("uncaught conflict: begin() rejects with the original statement error, not 'cannot rollback'", async () => {
+      let caught: any;
+      try {
+        await sql.begin(async tx => {
+          await tx`INSERT INTO t VALUES ('dup')`;
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect({ code: caught?.code, message: String(caught) }).toEqual({
+        code: "SQLITE_CONSTRAINT_PRIMARYKEY",
+        message: "SQLiteError: UNIQUE constraint failed: t.v",
+      });
+    });
+
+    test("caught conflict: later statements are refused and nothing is committed", async () => {
+      let beginErr: any;
+      let stmtErr: any;
+      try {
+        await sql.begin(async tx => {
+          await tx`INSERT INTO log VALUES ('first')`;
+          try {
+            await tx`INSERT INTO t VALUES ('dup')`;
+          } catch {}
+          try {
+            await tx`INSERT INTO log VALUES ('after-auto-rollback')`;
+          } catch (e) {
+            stmtErr = e;
+            throw e;
+          }
+        });
+      } catch (e) {
+        beginErr = e;
+      }
+      const durable = (await sql`SELECT v FROM log`).map((r: any) => r.v);
+      expect({
+        stmtErrCode: stmtErr?.code,
+        beginErrCode: beginErr?.code,
+        durable,
+      }).toEqual({
+        stmtErrCode: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        beginErrCode: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        durable: [],
+      });
+      // the connection must remain usable for a fresh transaction afterwards
+      await sql.begin(async tx => {
+        await tx`INSERT INTO log VALUES ('next-tx')`;
+      });
+      expect((await sql`SELECT v FROM log`).map((r: any) => r.v)).toEqual(["next-tx"]);
+    });
+
+    test("caught conflict where callback swallows everything: begin() still rejects, COMMIT is not attempted", async () => {
+      let beginErr: any;
+      try {
+        await sql.begin(async tx => {
+          try {
+            await tx`INSERT INTO t VALUES ('dup')`;
+          } catch {}
+          // every subsequent statement keeps failing; swallowing one must not let the next through
+          try {
+            await tx`INSERT INTO log VALUES ('a')`;
+          } catch {}
+          try {
+            await tx`INSERT INTO log VALUES ('b')`;
+          } catch {}
+        });
+      } catch (e) {
+        beginErr = e;
+      }
+      expect({
+        code: beginErr?.code,
+        message: String(beginErr),
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        code: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        message:
+          "SQLiteError: current transaction is aborted (the database already rolled it back), commands ignored until end of transaction",
+        durable: [],
+      });
+    });
+
+    test("INSERT OR ROLLBACK (statement-level conflict clause) behaves the same", async () => {
+      await sql`CREATE TABLE t2 (v TEXT PRIMARY KEY)`;
+      await sql`INSERT INTO t2 VALUES ('dup')`;
+      let caught: any;
+      try {
+        await sql.begin(async tx => {
+          await tx`INSERT OR ROLLBACK INTO t2 VALUES ('dup')`;
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught?.code).toBe("SQLITE_CONSTRAINT_PRIMARYKEY");
+    });
+
+    test("tx.unsafe refuses to run after auto-rollback", async () => {
+      let stmtErr: any;
+      await sql
+        .begin(async tx => {
+          try {
+            await tx`INSERT INTO t VALUES ('dup')`;
+          } catch {}
+          await tx.unsafe("INSERT INTO log VALUES ('after-auto-rollback')");
+        })
+        .catch(e => (stmtErr = e));
+      expect({
+        code: stmtErr?.code,
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        code: "ERR_SQLITE_INVALID_TRANSACTION_STATE",
+        durable: [],
+      });
+    });
+
+    test("auto-rollback inside a savepoint propagates the original error and aborts the outer transaction", async () => {
+      let caught: any;
+      try {
+        await sql.begin(async tx => {
+          await tx`INSERT INTO log VALUES ('outer')`;
+          await tx.savepoint(async sp => {
+            await sp`INSERT INTO t VALUES ('dup')`;
+          });
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect({
+        code: caught?.code,
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        code: "SQLITE_CONSTRAINT_PRIMARYKEY",
+        durable: [],
+      });
+    });
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1233,6 +1233,24 @@ describe("Transactions", () => {
       });
     });
 
+    test("array-return form: queries created before the conflict are refused at execution time", async () => {
+      let beginErr: any;
+      await sql
+        .begin(tx => [
+          tx`INSERT INTO log VALUES ('before')`,
+          tx`INSERT INTO t VALUES ('dup')`,
+          tx`INSERT INTO log VALUES ('leaked')`,
+        ])
+        .catch(e => (beginErr = e));
+      expect({
+        code: beginErr?.code,
+        durable: (await sql`SELECT v FROM log`).map((r: any) => r.v),
+      }).toEqual({
+        code: "SQLITE_CONSTRAINT_PRIMARYKEY",
+        durable: [],
+      });
+    });
+
     test("INSERT OR ROLLBACK (statement-level conflict clause) behaves the same", async () => {
       await sql`CREATE TABLE t2 (v TEXT PRIMARY KEY)`;
       await sql`INSERT INTO t2 VALUES ('dup')`;


### PR DESCRIPTION
### Reproduction

```ts
const sql = new Bun.SQL({ adapter: "sqlite", filename: ":memory:" });
await sql`create table t (v text primary key on conflict rollback)`;
await sql`create table log (v text)`;
await sql`insert into t values ('dup')`;

// (A) callback tolerates the conflict
await sql.begin(async tx => {
  await tx`insert into log values ('first')`;
  try { await tx`insert into t values ('dup')`; } catch {}   // SQLite auto-ROLLBACK
  await tx`insert into log values ('kept')`;                  // runs in AUTOCOMMIT
}).catch(e => console.log("(A)", String(e)));
console.log((await sql`select v from log`).map(r => r.v));
// before: (A) SQLiteError: cannot commit - no transaction is active
//         [ "kept" ]   <- a REJECTED begin() committed a row

// (B) callback does not catch
await sql.begin(async tx => { await tx`insert into t values ('dup')`; })
  .catch(e => console.log("(B)", e.code, String(e)));
// before: (B) SQLITE_ERROR SQLiteError: cannot rollback - no transaction is active
//         <- real SQLITE_CONSTRAINT_PRIMARYKEY is gone
```

### Cause

`ON CONFLICT ROLLBACK`, `INSERT OR ROLLBACK`, and `RAISE(ROLLBACK)` make SQLite roll the whole transaction back from inside a statement. The adapter-generic runner in `onTransactionConnected` (`src/js/bun/sql.ts`) never checked the connection's real transaction state, so after an auto-rollback:

- **(B)** the runner issued `ROLLBACK`, which failed with "cannot rollback - no transaction is active"; that error then shadowed the callback's real error because the inner catch rebound `err`;
- **(A)** the rest of the callback ran in autocommit, each statement individually durable, and `COMMIT` then failed, so a rejected `sql.begin()` left committed rows behind.

`bun:sqlite`'s own `db.transaction()` already guards on `db.inTransaction` for exactly this case; the `Bun.SQL` runner did not.

### Fix

Add an optional `isConnectionInTransaction(connection)` hook to the adapter interface and implement it for SQLite via `db.inTransaction` (`sqlite3_get_autocommit`). In the runner:

- once `needs_rollback` is set and the adapter reports the transaction is gone, every further `tx\`...\`` / `tx.unsafe()` / `tx.file()` rejects with `ERR_SQLITE_INVALID_TRANSACTION_STATE` instead of executing in autocommit;
- the pre-`COMMIT` / pre-`RELEASE SAVEPOINT` paths make the same check so a callback that swallows everything still fails;
- `ROLLBACK` and `ROLLBACK TO SAVEPOINT` are skipped when the adapter says there is nothing to roll back;
- cleanup-SQL failures no longer replace the caller's original error.

The hook is optional; Postgres and MySQL don't implement it, so their behaviour is unchanged. Related but distinct from #33748 (COMMIT fails with `SQLITE_BUSY` and leaves the transaction open); the two fixes are complementary.

### Verification

```
bun bd test test/js/sql/sqlite-sql.test.ts -t "automatic ROLLBACK"
  6 pass / 0 fail
USE_SYSTEM_BUN=1 bun test test/js/sql/sqlite-sql.test.ts -t "automatic ROLLBACK"
  0 pass / 6 fail
```