### PR TITLE
sql: reject tx.unsafe()/tx.file() on a settled transaction or released reserved handle

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -278,13 +278,31 @@ const SQL: typeof Bun.SQL = function SQL(
     }
 
     reserved_sql.unsafe = (string, args = []) => {
+      if (
+        state.connectionState & ReservedConnectionState.closed ||
+        !(state.connectionState & ReservedConnectionState.acceptQueries)
+      ) {
+        return Promise.$reject(pool.connectionClosedError());
+      }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
     };
 
     reserved_sql.file = async (path: string, args = []) => {
+      if (
+        state.connectionState & ReservedConnectionState.closed ||
+        !(state.connectionState & ReservedConnectionState.acceptQueries)
+      ) {
+        return Promise.$reject(pool.connectionClosedError());
+      }
       return await Bun.file(path)
         .text()
         .then(text => {
+          if (
+            state.connectionState & ReservedConnectionState.closed ||
+            !(state.connectionState & ReservedConnectionState.acceptQueries)
+          ) {
+            return Promise.$reject(pool.connectionClosedError());
+          }
           return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
         });
     };
@@ -579,12 +597,30 @@ const SQL: typeof Bun.SQL = function SQL(
       return queryFromTransaction(strings, values, pooledConnection, state.queries);
     }
     transaction_sql.unsafe = (string, args = []) => {
+      if (
+        state.connectionState & ReservedConnectionState.closed ||
+        !(state.connectionState & ReservedConnectionState.acceptQueries)
+      ) {
+        return Promise.$reject(pool.connectionClosedError());
+      }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
     };
     transaction_sql.file = async (path: string, args = []) => {
+      if (
+        state.connectionState & ReservedConnectionState.closed ||
+        !(state.connectionState & ReservedConnectionState.acceptQueries)
+      ) {
+        return Promise.$reject(pool.connectionClosedError());
+      }
       return await Bun.file(path)
         .text()
         .then(text => {
+          if (
+            state.connectionState & ReservedConnectionState.closed ||
+            !(state.connectionState & ReservedConnectionState.acceptQueries)
+          ) {
+            return Promise.$reject(pool.connectionClosedError());
+          }
           return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
         });
     };

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -27,6 +27,13 @@ interface TransactionState {
   queries: Set<Query<any, any>>;
 }
 
+function cannotAcceptQueries(state: TransactionState) {
+  return (
+    state.connectionState & ReservedConnectionState.closed ||
+    !(state.connectionState & ReservedConnectionState.acceptQueries)
+  );
+}
+
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
   switch (options.adapter) {
     case "postgres":
@@ -259,10 +266,7 @@ const SQL: typeof Bun.SQL = function SQL(
     }
 
     function reserved_sql(strings: string | TemplateStringsArray | SQLHelper<any> | Query<any, any>, ...values: any[]) {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       if ($isArray(strings)) {
@@ -278,29 +282,20 @@ const SQL: typeof Bun.SQL = function SQL(
     }
 
     reserved_sql.unsafe = (string, args = []) => {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
     };
 
     reserved_sql.file = async (path: string, args = []) => {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       return await Bun.file(path)
         .text()
         .then(text => {
-          if (
-            state.connectionState & ReservedConnectionState.closed ||
-            !(state.connectionState & ReservedConnectionState.acceptQueries)
-          ) {
+          if (cannotAcceptQueries(state)) {
             return Promise.$reject(pool.connectionClosedError());
           }
           return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
@@ -361,10 +356,7 @@ const SQL: typeof Bun.SQL = function SQL(
     };
     reserved_sql.begin = (options_or_fn: string | TransactionCallback, fn?: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       let callback = fn;
@@ -398,10 +390,7 @@ const SQL: typeof Bun.SQL = function SQL(
     };
     reserved_sql.close = async (options?: { timeout?: number }) => {
       const reserveQueries = state.queries;
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$resolve(undefined);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
@@ -444,10 +433,7 @@ const SQL: typeof Bun.SQL = function SQL(
       return Promise.$resolve(undefined);
     };
     reserved_sql.release = () => {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       // just release the connection back to the pool
@@ -579,10 +565,7 @@ const SQL: typeof Bun.SQL = function SQL(
       strings: string | TemplateStringsArray | import("internal/sql/shared.ts").SQLHelper<any> | Query<any, any>,
       ...values: any[]
     ) {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       if ($isArray(strings)) {
@@ -597,28 +580,19 @@ const SQL: typeof Bun.SQL = function SQL(
       return queryFromTransaction(strings, values, pooledConnection, state.queries);
     }
     transaction_sql.unsafe = (string, args = []) => {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       return unsafeQueryFromTransaction(string, args, pooledConnection, state.queries);
     };
     transaction_sql.file = async (path: string, args = []) => {
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$reject(pool.connectionClosedError());
       }
       return await Bun.file(path)
         .text()
         .then(text => {
-          if (
-            state.connectionState & ReservedConnectionState.closed ||
-            !(state.connectionState & ReservedConnectionState.acceptQueries)
-          ) {
+          if (cannotAcceptQueries(state)) {
             return Promise.$reject(pool.connectionClosedError());
           }
           return unsafeQueryFromTransaction(text, args, pooledConnection, state.queries);
@@ -681,10 +655,7 @@ const SQL: typeof Bun.SQL = function SQL(
     };
     transaction_sql.close = async function (options?: { timeout?: number }) {
       // we dont actually close the connection here, we just set the state to closed and rollback the transaction
-      if (
-        state.connectionState & ReservedConnectionState.closed ||
-        !(state.connectionState & ReservedConnectionState.acceptQueries)
-      ) {
+      if (cannotAcceptQueries(state)) {
         return Promise.$resolve(undefined);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
@@ -766,10 +737,7 @@ const SQL: typeof Bun.SQL = function SQL(
       transaction_sql.savepoint = async (fn: TransactionCallback, name?: string): Promise<any> => {
         let savepoint_callback = fn;
 
-        if (
-          state.connectionState & ReservedConnectionState.closed ||
-          !(state.connectionState & ReservedConnectionState.acceptQueries)
-        ) {
+        if (cannotAcceptQueries(state)) {
           throw pool.connectionClosedError();
         }
 

--- a/test/js/sql/sql-transaction-closed-handle.test.ts
+++ b/test/js/sql/sql-transaction-closed-handle.test.ts
@@ -1,0 +1,42 @@
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
+import { join } from "node:path";
+
+// tx.unsafe()/tx.file() must reject once sql.begin() has settled, the same way the
+// tagged-template call and tx.savepoint() already do. Before the fix they reached the
+// pooled connection the handle no longer owns and the write was durable.
+test("tx.unsafe() and tx.file() reject after begin() settles", async () => {
+  const dir = tempDirWithFiles("sql-tx-closed", {
+    "q.sql": `INSERT INTO accounts VALUES (98, 0)`,
+  });
+  const sql = new SQL("sqlite://:memory:");
+  try {
+    await sql`CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance REAL)`;
+    let leaked: any;
+    await sql.begin(async tx => {
+      leaked = tx;
+      await tx.unsafe(`INSERT INTO accounts VALUES (10, 0)`);
+    });
+    const outcome = async (p: Promise<any>) =>
+      p.then(
+        () => "fulfilled",
+        (e: any) => `rejected: ${e.message}`,
+      );
+    expect({
+      template: await outcome(leaked`SELECT 1`),
+      savepoint: await outcome(Promise.resolve().then(() => leaked.savepoint(async () => {}))),
+      unsafe: await outcome(leaked.unsafe(`INSERT INTO accounts VALUES (99, 0)`)),
+      file: await outcome(leaked.file(join(dir, "q.sql"))),
+    }).toEqual({
+      template: "rejected: Connection closed",
+      savepoint: "rejected: Connection closed",
+      unsafe: "rejected: Connection closed",
+      file: "rejected: Connection closed",
+    });
+    const rows = await sql`SELECT id FROM accounts ORDER BY id`;
+    expect(rows).toEqual([{ id: 10 }]);
+  } finally {
+    await sql.close();
+  }
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -4001,7 +4001,11 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
       const reserved = await sql.reserve();
       await reserved.release();
-      const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.code}`);
+      const outcome = async (p: Promise<any>) =>
+        p.then(
+          () => "fulfilled",
+          (e: any) => `rejected: ${e.code}`,
+        );
       expect({
         template: await outcome(reserved`select 1 as x`),
         unsafe: await outcome(reserved.unsafe("select 1 as x")),
@@ -4020,7 +4024,11 @@ CREATE TABLE ${table_name} (
         leaked = tx;
         await tx.unsafe("select 1 as x");
       });
-      const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.code}`);
+      const outcome = async (p: Promise<any>) =>
+        p.then(
+          () => "fulfilled",
+          (e: any) => `rejected: ${e.code}`,
+        );
       expect({
         template: await outcome(leaked`select 1 as x`),
         unsafe: await outcome(leaked.unsafe("select 1 as x")),

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -3997,6 +3997,41 @@ CREATE TABLE ${table_name} (
       expect(xs.map(x => x.x).join("")).toBe("123");
     });
 
+    test("reserved.unsafe() and reserved.file() reject after release()", async () => {
+      await using sql = postgres({ ...options, max: 1 });
+      const reserved = await sql.reserve();
+      await reserved.release();
+      const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.code}`);
+      expect({
+        template: await outcome(reserved`select 1 as x`),
+        unsafe: await outcome(reserved.unsafe("select 1 as x")),
+        file: await outcome(reserved.file(rel("select.sql"))),
+      }).toEqual({
+        template: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+        unsafe: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+        file: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+      });
+    });
+
+    test("tx.unsafe() and tx.file() reject after begin() settles", async () => {
+      await using sql = postgres({ ...options, max: 1 });
+      let leaked: any;
+      await sql.begin(async tx => {
+        leaked = tx;
+        await tx.unsafe("select 1 as x");
+      });
+      const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.code}`);
+      expect({
+        template: await outcome(leaked`select 1 as x`),
+        unsafe: await outcome(leaked.unsafe("select 1 as x")),
+        file: await outcome(leaked.file(rel("select.sql"))),
+      }).toEqual({
+        template: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+        unsafe: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+        file: "rejected: ERR_POSTGRES_CONNECTION_CLOSED",
+      });
+    });
+
     test("keeps process alive when it should", async () => {
       const file = path.posix.join(__dirname, "sql-fixture-ref.ts");
       const result = await $`DATABASE_URL=${process.env.DATABASE_URL} ${bunExe()} ${file}`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1144,35 +1144,6 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT * FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1002);
   });
-
-  test("tx.unsafe() and tx.file() reject after begin() settles", async () => {
-    const dir = tempDirWithFiles("sql-tx-closed", {
-      "q.sql": `INSERT INTO accounts VALUES (98, 0)`,
-    });
-    let leaked: any;
-    await sql.begin(async tx => {
-      leaked = tx;
-      await tx.unsafe(`INSERT INTO accounts VALUES (10, 0)`);
-    });
-    const outcome = async (p: Promise<any>) =>
-      p.then(
-        () => "fulfilled",
-        (e: any) => `rejected: ${e.message}`,
-      );
-    expect({
-      template: await outcome(leaked`SELECT 1`),
-      savepoint: await outcome(Promise.resolve().then(() => leaked.savepoint(async () => {}))),
-      unsafe: await outcome(leaked.unsafe(`INSERT INTO accounts VALUES (99, 0)`)),
-      file: await outcome(leaked.file(join(dir, "q.sql"))),
-    }).toEqual({
-      template: "rejected: Connection closed",
-      savepoint: "rejected: Connection closed",
-      unsafe: "rejected: Connection closed",
-      file: "rejected: Connection closed",
-    });
-    const rows = await sql`SELECT id FROM accounts WHERE id >= 10 ORDER BY id`;
-    expect(rows).toEqual([{ id: 10 }]);
-  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1144,6 +1144,31 @@ describe("Transactions", () => {
     const accounts = await sql`SELECT * FROM accounts WHERE id = 1`;
     expect(accounts[0].balance).toBe(1002);
   });
+
+  test("tx.unsafe() and tx.file() reject after begin() settles", async () => {
+    const dir = tempDirWithFiles("sql-tx-closed", {
+      "q.sql": `INSERT INTO accounts VALUES (98, 0)`,
+    });
+    let leaked: any;
+    await sql.begin(async tx => {
+      leaked = tx;
+      await tx.unsafe(`INSERT INTO accounts VALUES (10, 0)`);
+    });
+    const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.message}`);
+    expect({
+      template: await outcome(leaked`SELECT 1`),
+      savepoint: await outcome(Promise.resolve().then(() => leaked.savepoint(async () => {}))),
+      unsafe: await outcome(leaked.unsafe(`INSERT INTO accounts VALUES (99, 0)`)),
+      file: await outcome(leaked.file(join(dir, "q.sql"))),
+    }).toEqual({
+      template: "rejected: Connection closed",
+      savepoint: "rejected: Connection closed",
+      unsafe: "rejected: Connection closed",
+      file: "rejected: Connection closed",
+    });
+    const rows = await sql`SELECT id FROM accounts WHERE id >= 10 ORDER BY id`;
+    expect(rows).toEqual([{ id: 10 }]);
+  });
 });
 
 describe("SQLite-specific features", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1154,7 +1154,11 @@ describe("Transactions", () => {
       leaked = tx;
       await tx.unsafe(`INSERT INTO accounts VALUES (10, 0)`);
     });
-    const outcome = async (p: Promise<any>) => p.then(() => "fulfilled", (e: any) => `rejected: ${e.message}`);
+    const outcome = async (p: Promise<any>) =>
+      p.then(
+        () => "fulfilled",
+        (e: any) => `rejected: ${e.message}`,
+      );
     expect({
       template: await outcome(leaked`SELECT 1`),
       savepoint: await outcome(Promise.resolve().then(() => leaked.savepoint(async () => {}))),


### PR DESCRIPTION
Every other entry point on a transaction/reserved handle (the tagged template, `savepoint()`, `connect()`, `flush()`, `begin()`, and the runner's own internal SQL) checks `state.connectionState` and rejects with `Connection closed` once `sql.begin()` has settled or the reserved connection has been released. `unsafe()` and `file()` on the same handle did not, so a `tx` reference retained past the callback silently executes on a pooled connection the handle no longer owns.

## Reproduction

```ts
import { SQL } from "bun";
import { Database } from "bun:sqlite";
import { mkdtempSync } from "node:fs"; import { tmpdir } from "node:os";

const path = mkdtempSync(tmpdir() + "/esc-") + "/a.db";
const sql = new SQL(`sqlite://${path}`);
await sql`create table w (v text)`;
let leaked;
await sql.begin(async tx => { leaked = tx; await tx.unsafe("insert into w (v) values ('inside')"); });
console.log(await leaked`select 1`.then(() => "ok", e => "rejected: " + e));
// rejected: SQLiteError: Connection closed
console.log(await leaked.unsafe("insert into w (v) values ('escaped')").then(() => "ok", e => "rejected: " + e));
// ok   <-- should reject
await sql.close();
console.log(new Database(path, { readonly: true }).query("select v from w").all());
// [{ v: "inside" }, { v: "escaped" }]   <-- escaped write is durable, ran in autocommit
```

On a Postgres/MySQL pool the leaked statement reaches whatever the released connection is doing next, which may be another caller's open transaction.

## Fix

Add the same `closed`/`acceptQueries` guard that `transaction_sql()` already has to `transaction_sql.unsafe`, `transaction_sql.file`, `reserved_sql.unsafe`, and `reserved_sql.file`. `file()` re-checks after the async read so a handle closed while the file is being read still rejects.

## Verification

`test/js/sql/sqlite-sql.test.ts` gains a test that retains `tx` past `begin()`, asserts all four entry points now reject `Connection closed`, and asserts no escaped rows landed. `test/js/sql/sql.test.ts` gains the same for a released `reserved` handle and a settled `tx` on Postgres. Before the fix the sqlite test shows `unsafe: "fulfilled"` / `file: "fulfilled"`; after, all reject.