### PR TITLE
node:crypto: validate EC JWK private scalar matches public point in createPrivateKey

### DIFF
--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -931,9 +931,14 @@ KeyObject KeyObject::getKeyObjectHandleFromJwk(JSGlobalObject* globalObject, Thr
 
         if (keyType != CryptoKeyType::Public) {
             auto* dBuf = decodeJwkString(globalObject, scope, dView, "key.d"_s);
+            RETURN_IF_EXCEPTION(scope, {});
             auto dBufSpan = dBuf->span();
             BignumPointer dBn = BignumPointer(dBufSpan.data(), dBufSpan.size());
             if (!ec.setPrivateKey(dBn)) {
+                ERR::CRYPTO_INVALID_JWK(scope, globalObject, "Invalid JWK EC key"_s);
+                return {};
+            }
+            if (!ec.checkKey()) {
                 ERR::CRYPTO_INVALID_JWK(scope, globalObject, "Invalid JWK EC key"_s);
                 return {};
             }

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -610,6 +610,41 @@ describe("crypto.KeyObjects", () => {
     });
   });
 
+  describe("createPrivateKey rejects inconsistent EC JWK", () => {
+    for (const namedCurve of ["prime256v1", "secp384r1", "secp521r1"]) {
+      test(namedCurve, () => {
+        const a = generateKeyPairSync("ec", { namedCurve }).privateKey.export({ format: "jwk" });
+        const b = generateKeyPairSync("ec", { namedCurve }).privateKey.export({ format: "jwk" });
+
+        // valid key still imports and self-verifies
+        const good = createPrivateKey({ key: a, format: "jwk" });
+        const msg = Buffer.from("message");
+        expect(verify("sha256", msg, createPublicKey(good), sign("sha256", msg, good))).toBe(true);
+
+        // d from a different keypair on the same curve
+        expect(() => createPrivateKey({ key: { ...a, d: b.d }, format: "jwk" })).toThrow(
+          expect.objectContaining({ code: "ERR_CRYPTO_INVALID_JWK" }),
+        );
+
+        // d truncated by one byte
+        const dBuf = Buffer.from(a.d, "base64url");
+        expect(() =>
+          createPrivateKey({
+            key: { ...a, d: dBuf.subarray(0, dBuf.length - 1).toString("base64url") },
+            format: "jwk",
+          }),
+        ).toThrow(expect.objectContaining({ code: "ERR_CRYPTO_INVALID_JWK" }));
+
+        // d with a leading zero byte is accepted by Node (same scalar value)
+        const padded = createPrivateKey({
+          key: { ...a, d: Buffer.concat([Buffer.alloc(1), dBuf]).toString("base64url") },
+          format: "jwk",
+        });
+        expect(padded.export({ format: "jwk" })).toEqual(a);
+      });
+    }
+  });
+
   test("private encrypted should work", async () => {
     // Reading an encrypted key without a passphrase should fail.
     expect(() => createPrivateKey(privateEncryptedPem)).toThrow();


### PR DESCRIPTION
### What does this PR do?

`crypto.createPrivateKey({format: "jwk"})` currently accepts an EC private JWK whose `d` does not correspond to its `(x, y)`, producing a KeyObject whose derived public key cannot verify its own signatures:

```js
const crypto = require("node:crypto");
const A = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" }).privateKey.export({ format: "jwk" });
const B = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" }).privateKey.export({ format: "jwk" });
const k = crypto.createPrivateKey({ key: { ...A, d: B.d }, format: "jwk" });
const m = Buffer.from("msg");
crypto.verify("sha256", m, crypto.createPublicKey(k), crypto.sign("sha256", m, k));
// Node v26:  throws ERR_CRYPTO_INVALID_JWK at createPrivateKey
// Bun:       returns false (key accepted, self-verify fails)
```

A truncated `d` is similarly accepted and re-exports as a different scalar. Bun's own `crypto.subtle.importKey("jwk", ...)` already rejects both inputs in the same process, so the two JWK importers disagreed with each other.

The cause is that `KeyObject::getKeyObjectHandleFromJwk` sets the public point via `EC_KEY_set_public_key_affine_coordinates` (which validates the point is on the curve) and the private scalar via `EC_KEY_set_private_key` (which does not cross-check against the public point), then wraps the result without ever calling `EC_KEY_check_key`. Node [performs that check](https://github.com/nodejs/node/blob/main/src/crypto/crypto_ec.cc) after setting the private key, as does Bun's WebCrypto `CryptoKeyEC::platformImportJWKPrivate`.

This PR calls `ec.checkKey()` (the existing `ECKeyPointer` wrapper around `EC_KEY_check_key`) after `setPrivateKey` and throws `ERR_CRYPTO_INVALID_JWK` on failure, matching Node. It also adds the missing `RETURN_IF_EXCEPTION` after base64-decoding `d`.

Sibling of #32910, which makes the analogous fix for OKP private JWKs in the same function.

### How did you verify your code works?

New tests in `test/js/node/crypto/crypto.key-objects.test.ts` cover mismatched `d`, truncated `d`, and leading-zero-padded `d` (which Node accepts, since the scalar value is unchanged) for P-256/P-384/P-521. They fail on current `main` (`USE_SYSTEM_BUN=1 bun test`) and pass with `bun bd test`; the rest of the file (88 tests) is unaffected. Also verified the test expectations match Node v26.3.0 for all three curves.
