### PR TITLE
node:crypto: default to SHA256 for EC keys in one-shot sign/verify with null algorithm

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -388,22 +388,26 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
         //              return 0;
         //      }
         //
+        //    EC and DSA providers do the same thing:
+        //    - providers/implementations/keymgmt/ec_kmgmt.c returns "SHA256"
+        //    - providers/implementations/keymgmt/dsa_kmgmt.c returns DSA_DEFAULT_MD ("SHA256")
+        //
         // BoringSSL Difference:
         // =====================
         // BoringSSL (used by Bun) does not have this automatic default mechanism.
-        // When NULL is passed as the digest to EVP_DigestVerifyInit for RSA keys,
+        // When NULL is passed as the digest to EVP_DigestVerifyInit for RSA/EC/DSA keys,
         // BoringSSL returns error 0x06000077 (NO_DEFAULT_DIGEST).
         //
         // This Fix:
         // =========
         // To achieve Node.js/OpenSSL compatibility, we explicitly set SHA256 as the
-        // default digest for RSA keys when no algorithm is specified, matching the
-        // OpenSSL behavior documented above.
+        // default digest for RSA, EC, and DSA keys when no algorithm is specified,
+        // matching the OpenSSL behavior documented above.
         //
         // For Ed25519/Ed448 keys (one-shot variants), we intentionally leave digest
         // as null since these algorithms perform their own hashing internally and
         // don't require a separate digest algorithm.
-        if (keyObject.asymmetricKey().isRsaVariant()) {
+        if (keyObject.asymmetricKey().isRsaVariant() || keyObject.asymmetricKey().isSigVariant()) {
             digest = Digest::FromName("SHA256"_s);
         }
     }

--- a/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
+++ b/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import crypto from "crypto";
+import { promisify } from "util";
 
 // Regression test for issue #11029
 // crypto.verify() should support null/undefined algorithm parameter
@@ -105,6 +106,43 @@ test("crypto.verify cross-verification between null and explicit SHA256", () => 
   // Should be able to verify with explicit SHA256
   const isVerifiedWithSHA256 = crypto.verify("SHA256", data, publicKey, signatureNull);
   expect(isVerifiedWithSHA256).toBe(true);
+});
+
+describe.each(["prime256v1", "secp384r1", "secp521r1"])("crypto.sign/verify with null algorithm for EC (%s)", curve => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: curve });
+  const data = Buffer.from("test data");
+
+  test.each([null, undefined])("sync sign(%p)", algorithm => {
+    const signature = crypto.sign(algorithm, data, privateKey);
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(crypto.verify(algorithm, data, publicKey, signature)).toBe(true);
+    expect(crypto.verify(algorithm, Buffer.from("wrong data"), publicKey, signature)).toBe(false);
+  });
+
+  test("async sign(null)", async () => {
+    const signature = await promisify(crypto.sign)(null, data, privateKey);
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(await promisify(crypto.verify)(null, data, publicKey, signature)).toBe(true);
+  });
+
+  test("null defaults to SHA256 (cross-verification)", () => {
+    // Node.js/OpenSSL default the digest to SHA256 for EC keys when algorithm is null.
+    const signedWithSha256 = crypto.sign("sha256", data, privateKey);
+    expect(crypto.verify(null, data, publicKey, signedWithSha256)).toBe(true);
+
+    const signedWithNull = crypto.sign(null, data, privateKey);
+    expect(crypto.verify("sha256", data, publicKey, signedWithNull)).toBe(true);
+  });
+
+  test("sign(null) with ieee-p1363 encoding", () => {
+    const signature = crypto.sign(null, data, { key: privateKey, dsaEncoding: "ieee-p1363" });
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(crypto.verify(null, data, { key: publicKey, dsaEncoding: "ieee-p1363" }, signature)).toBe(true);
+  });
+
+  test("verify(null) returns false for a bad signature instead of throwing", () => {
+    expect(crypto.verify(null, data, publicKey, Buffer.alloc(70))).toBe(false);
+  });
 });
 
 test("crypto.createVerify should also work with RSA keys", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes `crypto.sign(null, data, ecKey)` and `crypto.verify(null, data, ecKey, sig)` throwing `ERR_OSSL_NO_DEFAULT_DIGEST` instead of defaulting to SHA256 like Node.js.

## Reproduction

```js
import crypto from "node:crypto";
const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
const data = Buffer.from("payload");

const sig = crypto.sign(null, data, privateKey);
console.log(crypto.verify(null, data, publicKey, sig));
```

Node v26.3.0 prints `true`. Bun throws:

```
error:06000077:public key routines:OPENSSL_internal:NO_DEFAULT_DIGEST
```

The same happens for `undefined`, for all EC curves (P-256/384/521), for the async callback variants, and for `crypto.verify(null, ..., <bad sig>)` which should return `false` but throws.

## Cause

When `algorithm` is `null`/`undefined`, Node passes a NULL digest to `EVP_DigestSignInit`. OpenSSL v3 then queries the key's `OSSL_PKEY_PARAM_DEFAULT_DIGEST` and receives `"SHA256"` from the EC keymgmt provider (`providers/implementations/keymgmt/ec_kmgmt.c`), same as it does for RSA and DSA.

BoringSSL has no default-digest mechanism: `do_sigver_init` in `crypto/fipsmodule/digestsign/digestsign.cc.inc` fails with `EVP_R_NO_DEFAULT_DIGEST` whenever `type == NULL` and the key uses a prehash method (EC, RSA, DSA).

Bun already compensates for RSA by explicitly selecting SHA256 when the algorithm argument is nullish. EC and DSA were missing from that branch.

## Fix

Extend the existing SHA256 default in `SignJobCtx::fromJS` to cover `isSigVariant()` (EC and DSA) in addition to `isRsaVariant()`. This matches OpenSSL v3 behaviour exactly: verified that in Node, `crypto.sign(null, data, ecKey)` cross-verifies with `crypto.verify("sha256", data, ecKey, sig)` and vice versa.

## Verification

Added EC coverage (P-256/384/521, sync + async, DER + ieee-p1363, bad-signature-returns-false) to `test/regression/issue/11029-crypto-verify-null-algorithm.test.ts` alongside the existing RSA/Ed25519 cases.

- `USE_SYSTEM_BUN=1 bun test`: 18 new EC tests fail with `ERR_OSSL_NO_DEFAULT_DIGEST`, 5 existing tests pass
- `bun bd test`: 23/23 pass
- `test/js/node/test/parallel/test-crypto-sign-verify.js` and related crypto sign tests still pass