### PR TITLE
node:url: run domainToUnicode regardless of string backing store

### DIFF
--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -117,11 +117,8 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject,
     )
         return JSC::JSValue::encode(jsEmptyString(vm));
 
-    if (!domain.is8Bit())
-        // this function is only for undoing punycode so its okay if utf-16 text makes it out unchanged.
-        return JSC::JSValue::encode(arg0);
-
-    domain.convertTo16Bit();
+    if (domain.is8Bit())
+        domain.convertTo16Bit();
 
     constexpr static int allowedNameToUnicodeErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
     constexpr static int hostnameBufferLength = 2048;

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -98,4 +98,34 @@ describe("url.domainToUnicode", () => {
       expect(url.domainToASCII(input)).toEqual(expected);
     });
   }
+
+  // The result must depend only on the string's value, not on whether JSC
+  // happened to back it with an 8-bit or 16-bit buffer.
+  test("does not depend on the string's internal representation", () => {
+    const eight = "xn--bcher-kva.de";
+    const sixteen = "xn--bcher-kva.de\u4e2d".slice(0, -1);
+    expect(sixteen).toBe(eight);
+    expect({
+      eight: url.domainToUnicode(eight),
+      sixteen: url.domainToUnicode(sixteen),
+    }).toEqual({
+      eight: "bücher.de",
+      sixteen: "bücher.de",
+    });
+  });
+
+  test("round-trips through domainToASCII", () => {
+    for (const [domain] of pairs) {
+      expect(url.domainToUnicode(url.domainToASCII(domain))).toBe(domain);
+    }
+  });
+
+  test("decodes A-labels that appear alongside non-Latin-1 labels", () => {
+    expect(url.domainToUnicode("中.xn--fiqs8s")).toBe("中.中国");
+    expect(url.domainToUnicode("пример.xn--p1ai")).toBe("пример.рф");
+  });
+
+  test("applies UTS #46 mapping to non-Latin-1 input", () => {
+    expect(url.domainToUnicode("\ufb00.COM")).toBe("ff.com");
+  });
 });


### PR DESCRIPTION
`url.domainToUnicode` returned its argument verbatim whenever the input `WTF::String` happened to be 16-bit backed, so the documented round trip never decoded and two `===` strings could produce different outputs.

## Repro

```js
import { domainToASCII, domainToUnicode } from "node:url";

domainToUnicode(domainToASCII("bücher.de"));
// bun: "xn--bcher-kva.de"   node: "bücher.de"

domainToUnicode("中.xn--fiqs8s");
// bun: "中.xn--fiqs8s"       node: "中.中国"

const a = "xn--bcher-kva.de";
const b = "xn--bcher-kva.de中".slice(0, -1);   // === a, 16-bit backed
console.log(a === b, domainToUnicode(a), domainToUnicode(b));
// bun: true "bücher.de" "xn--bcher-kva.de"
// node: true "bücher.de" "bücher.de"
```

## Cause

`jsDomainToUnicode` in `src/jsc/bindings/NodeURL.cpp` short-circuited on `!domain.is8Bit()`:

```cpp
if (!domain.is8Bit())
    // this function is only for undoing punycode so its okay if utf-16 text makes it out unchanged.
    return JSC::JSValue::encode(arg0);
```

`is8Bit()` is a representation property of `WTF::String`, not a value property. An all-ASCII punycode host can be stored in a 16-bit buffer: `domainToASCII` always returns one (it builds the result from a `char16_t[]`), and so do slices of any 16-bit rope and literals from a source file containing non-Latin-1 text. A 16-bit string can also contain `xn--` A-labels mixed with already-decoded labels (`"中.xn--fiqs8s"`), and UTS #46 ToUnicode is defined over all inputs, including mapping and case folding of code points above U+00FF.

## Fix

Drop the fast path and always call `uidna_nameToUnicode`, matching the structure `jsDomainToASCII` already uses for the 8-bit/16-bit split.

## Verification

`test/js/node/url/url-domain-ascii-unicode.test.js`: 134 pass. The four new tests fail on released Bun and pass with this change; the 130 pre-existing tests are unchanged.

#33206 is a broader rewrite of both `domainToASCII` and `domainToUnicode` through the WHATWG host parser that also removes this fast path; this PR is the minimal targeted fix for the representation-dependent result and conflicts only on the three lines it deletes.