### PR TITLE
url: preprocess host/hostname setter input so IDNA matches the constructor

### DIFF
--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -25,6 +25,7 @@
 
 #include "URLDecomposition.h"
 
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -104,8 +105,54 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
+static inline bool isASCIITabOrNewline(char32_t c)
+{
+    return c == 0x0009 || c == 0x000A || c == 0x000D;
+}
+
+// WTF::URL::setHost IDNA-encodes non-ASCII input without the spec's tab/newline strip or
+// percent-decode. Strip tab/newline and percent-encode non-ASCII so it takes the ASCII
+// passthrough and the full URLParser (which does both) runs on reparse.
+static String preprocessHostSetterValue(StringView value)
+{
+    bool needsWork = false;
+    for (auto codePoint : value.codePoints()) {
+        if (!isASCII(codePoint) || isASCIITabOrNewline(codePoint)) {
+            needsWork = true;
+            break;
+        }
+    }
+    if (!needsWork)
+        return { };
+
+    StringBuilder builder;
+    builder.reserveCapacity(value.length());
+    for (auto codePoint : value.codePoints()) {
+        if (isASCIITabOrNewline(codePoint))
+            continue;
+        if (isASCII(codePoint)) {
+            builder.append(static_cast<Latin1Character>(codePoint));
+            continue;
+        }
+        uint8_t utf8[U8_MAX_LENGTH];
+        unsigned utf8Length = 0;
+        // Input is IDLUSVString, so no unpaired surrogates.
+        U8_APPEND_UNSAFE(utf8, utf8Length, codePoint);
+        for (unsigned i = 0; i < utf8Length; ++i) {
+            builder.append('%');
+            builder.append(static_cast<Latin1Character>(upperNibbleToASCIIHexDigit(utf8[i])));
+            builder.append(static_cast<Latin1Character>(lowerNibbleToASCIIHexDigit(utf8[i])));
+        }
+    }
+    return builder.toString();
+}
+
 void URLDecomposition::setHost(StringView value)
 {
+    String preprocessed = preprocessHostSetterValue(value);
+    if (!preprocessed.isNull())
+        value = preprocessed;
+
     auto fullURL = this->fullURL();
     if (value.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
@@ -147,6 +194,10 @@ String URLDecomposition::hostname() const
 
 void URLDecomposition::setHostname(StringView host)
 {
+    String preprocessed = preprocessHostSetterValue(host);
+    if (!preprocessed.isNull())
+        host = preprocessed;
+
     auto fullURL = this->fullURL();
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -123,7 +123,7 @@ static String preprocessHostSetterValue(StringView value)
         }
     }
     if (!needsWork)
-        return { };
+        return {};
 
     StringBuilder builder;
     builder.reserveCapacity(value.length());

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -237,6 +237,62 @@ describe("url", () => {
     });
   });
 
+  // The host/hostname setter runs the basic URL parse with state override: it must strip
+  // ASCII tab/newline and percent-decode before domain-to-ASCII, exactly like the constructor.
+  describe("host/hostname setter matches constructor on IDNA input", () => {
+    const setHostname = (v: string) => {
+      const u = new URL("http://base9.example/a");
+      u.hostname = v;
+      return u.hostname;
+    };
+    const setHost = (v: string) => {
+      const u = new URL("http://base9.example/a");
+      u.host = v;
+      return u.host;
+    };
+    const ctor = (v: string) => new URL(`http://${v}/`).hostname;
+
+    it.each([
+      // tab/LF/CR in non-ASCII input must be stripped before IDNA, not punycode-encoded
+      ["\tß.de", "xn--zca.de"],
+      ["ü\t.de", "xn--tda.de"],
+      ["ß\n.de", "xn--zca.de"],
+      ["ß\r.de", "xn--zca.de"],
+      // pure-ASCII input was already stripped correctly
+      ["a\tb.com", "ab.com"],
+      // percent-escapes must be decoded before domain-to-ASCII
+      ["ü%41.de", "xn--a-dha.de"],
+      // mixed percent-escape and raw non-ASCII must not be silently dropped
+      ["%C3%BCü.de", "xn--tdaa.de"],
+      // astral plane (surrogate pair) code point with tab
+      ["\t\u{10348}.com", "xn--2c8c.com"],
+    ])("hostname/host setter with %j", (input, expected) => {
+      expect({
+        ctor: ctor(input),
+        hostname: setHostname(input),
+        host: setHost(input),
+      }).toEqual({ ctor: expected, hostname: expected, host: expected });
+    });
+
+    it("host setter with non-ASCII + port", () => {
+      const u = new URL("http://base9.example/a");
+      u.host = "\tß.de:8080";
+      expect({ hostname: u.hostname, port: u.port }).toEqual({ hostname: "xn--zca.de", port: "8080" });
+    });
+
+    it("host setter with non-ASCII + default port", () => {
+      const u = new URL("http://base9.example/a");
+      u.host = "ü%41.de:80";
+      expect({ hostname: u.hostname, port: u.port }).toEqual({ hostname: "xn--a-dha.de", port: "" });
+    });
+
+    it("hostname setter with only tab/newline leaves special-scheme host unchanged", () => {
+      const u = new URL("http://base9.example/a");
+      u.hostname = "\t\n\r";
+      expect(u.hostname).toBe("base9.example");
+    });
+  });
+
   // Web IDL record conversion interleaves Get with value conversion: mutations made by a
   // value's toString() are observed by the keys that follow it. Node agrees.
   it("URLSearchParams constructed from an object interleaves Get with value conversion", () => {


### PR DESCRIPTION
The URL `host`/`hostname` setter must run the basic URL parser with state override (https://url.spec.whatwg.org/#dom-url-host), which strips ASCII tab/newline from the input and then has the host parser UTF-8 percent-decode before domain-to-ASCII. `WTF::URL::setHost` instead hands any non-ASCII value straight to `uidna_nameToASCII` (via `appendEncodedHostname` in `WTF/wtf/URL.cpp`), so the tab/newline or the literal `%xx` is baked into the Punycode A-label and the setter disagrees with the constructor on the same input.

```js
const set  = v => { const u = new URL("http://base/"); u.hostname = v; return u.hostname; };
const ctor = v => new URL(`http://${v}/`).hostname;

set("\tß.de");      // bun: "xn---qfa.de" (A-label decodes to "\tß")   node/ctor: "xn--zca.de"
set("ü\t.de");      // bun: "xn---dha.de"                              node/ctor: "xn--tda.de"
set("ü%41.de");     // bun: "xn--a-goa.de" (literal "%41" in the label) node/ctor: "xn--a-dha.de"
set("%C3%BCü.de");  // bun: "base" (silently dropped)                  node/ctor: "xn--tdaa.de"

set("a\tb.com");    // bun: "ab.com", already correct: the pure-ASCII path
                    // in appendEncodedHostname passes through and the full parser runs
```

The first two inputs mint hostnames whose A-label decodes to an embedded control character, which no spec-conforming host parser can produce (the forbidden-host-code-point check runs on the already-encoded label and cannot see it), so a filter that validates `new URL(x)` and then assigns `u.hostname = x` validates a different host than it uses.

### Fix

`appendEncodedHostname` only diverges from the spec on non-ASCII input: for all-ASCII it appends the value as-is and the full `URLParser` then does the right thing on reparse. `URLDecomposition::setHost`/`setHostname` now strip ASCII tab/newline and UTF-8 percent-encode any non-ASCII code points before calling `WTF::URL::setHost`, which forces that ASCII passthrough and lets `URLParser::parseHostAndPort` do the spec's percent-decode + domain-to-ASCII exactly as the constructor does. For all-ASCII values with no tab/newline (the common case) the preprocessor is a no-op.

The upstream `appendEncodedHostname` itself lives in the prebuilt WebKit, so it is not touched here; the WHATWG setter semantics are owned by `URLDecomposition` in this repo.

### Verification

11 new cases in `test/js/web/url/url.test.ts` assert setter == constructor for tab/LF/CR + non-ASCII, `%xx` + non-ASCII, mixed, surrogate-pair code points, the `host` setter with a port, and a pure tab/newline value. Every expected value matches Node 26. 10 of the 11 fail on the released Bun (the one pass is the pure-ASCII control case); all 25 tests in the file pass with this change.

`test/js/node/url/url.test.ts` and `test/js/web/urlpattern/urlpattern.test.ts` (414 tests) pass with the fix.

### Relationship to open `URLDecomposition` PRs

#32826 (host/port split and origin), #33195 (empty-host guard), and #33206 (`domainToASCII`) touch the same file for adjacent bugs but none of them fixes this one: with each of those applied alone, `u.hostname = "\tß.de"` still yields `"xn---qfa.de"`. #33206's PR body notes this exact mechanism ("`setHost` applies IDNA to its raw argument before the parse removes them") but only works around it inside `domainToASCII`. These changes conflict textually on `URLDecomposition.cpp` and `url.test.ts`; whichever lands second gets a small rebase.
