### PR TITLE
Bun.Glob: preserve leading `**` as globstar under `!` negation

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -147,10 +147,13 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
 
     let mut brace_stack = BraceStack::default();
     let mut brace_budget = BRACE_BRANCH_BUDGET;
+    // glob_start must point past the consumed `!` prefix so that a pattern-initial
+    // `**` is still recognized as being at the start of a path segment.
+    let glob_start = state.glob_index;
     let matched = glob_match_impl(
         &mut state,
         glob,
-        0,
+        glob_start,
         path,
         &mut brace_stack,
         &mut brace_budget,

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -1555,7 +1555,7 @@ describe("Glob.match", () => {
       expect(new Glob("!f*b").match("foo")).toBeTrue();
       expect(new Glob("!.md").match(".md")).toBeFalse();
       expect(new Glob("!**/*.md").match("a.js")).toBeTrue();
-      // try expect(!match("!**/*.md", "b.md"));
+      expect(new Glob("!**/*.md").match("b.md")).toBeFalse();
       expect(new Glob("!**/*.md").match("c.txt")).toBeTrue();
       expect(new Glob("!*.md").match("a.js")).toBeTrue();
       expect(new Glob("!*.md").match("b.md")).toBeFalse();
@@ -1585,9 +1585,9 @@ describe("Glob.match", () => {
       expect(new Glob("!*.md").match("a.js")).toBeTrue();
       expect(new Glob("!*.md").match("b.txt")).toBeTrue();
       expect(new Glob("!*.md").match("c.md")).toBeFalse();
-      // try expect(!match("!**/a.js", "a/a/a.js"));
-      // try expect(!match("!**/a.js", "a/b/a.js"));
-      // try expect(!match("!**/a.js", "a/c/a.js"));
+      expect(new Glob("!**/a.js").match("a/a/a.js")).toBeFalse();
+      expect(new Glob("!**/a.js").match("a/b/a.js")).toBeFalse();
+      expect(new Glob("!**/a.js").match("a/c/a.js")).toBeFalse();
       expect(new Glob("!**/a.js").match("a/a/b.js")).toBeTrue();
       expect(new Glob("!a/**/a.js").match("a/a/a/a.js")).toBeFalse();
       expect(new Glob("!a/**/a.js").match("b/a/b/a.js")).toBeTrue();
@@ -1595,7 +1595,7 @@ describe("Glob.match", () => {
       expect(new Glob("!**/*.md").match("a/b.js")).toBeTrue();
       expect(new Glob("!**/*.md").match("a.js")).toBeTrue();
       expect(new Glob("!**/*.md").match("a/b.md")).toBeFalse();
-      // try expect(!match("!**/*.md", "a.md"));
+      expect(new Glob("!**/*.md").match("a.md")).toBeFalse();
       expect(new Glob("**/*.md").match("a/b.js")).toBeFalse();
       expect(new Glob("**/*.md").match("a.js")).toBeFalse();
       expect(new Glob("**/*.md").match("a/b.md")).toBeTrue();
@@ -1603,14 +1603,52 @@ describe("Glob.match", () => {
       expect(new Glob("!**/*.md").match("a/b.js")).toBeTrue();
       expect(new Glob("!**/*.md").match("a.js")).toBeTrue();
       expect(new Glob("!**/*.md").match("a/b.md")).toBeFalse();
-      // try expect(!match("!**/*.md", "a.md"));
+      expect(new Glob("!**/*.md").match("a.md")).toBeFalse();
       expect(new Glob("!*.md").match("a/b.js")).toBeTrue();
       expect(new Glob("!*.md").match("a.js")).toBeTrue();
       expect(new Glob("!*.md").match("a/b.md")).toBeTrue();
       expect(new Glob("!*.md").match("a.md")).toBeFalse();
       expect(new Glob("!**/*.md").match("a.js")).toBeTrue();
-      // try expect(!match("!**/*.md", "b.md"));
+      expect(new Glob("!**/*.md").match("b.md")).toBeFalse();
       expect(new Glob("!**/*.md").match("c.txt")).toBeTrue();
+    });
+
+    test("negation with leading globstar", () => {
+      // `!p` must be the exact complement of `p`, including when `p` starts with `**`.
+      expect(new Glob("**/a").match("a")).toBeTrue();
+      expect(new Glob("**/a").match("x/y/a")).toBeTrue();
+      expect(new Glob("!**/a").match("a")).toBeFalse();
+      expect(new Glob("!**/a").match("x/y/a")).toBeFalse();
+      expect(new Glob("!**/a").match("zzz")).toBeTrue();
+      expect(new Glob("!**/a").match("x/y/b")).toBeTrue();
+
+      // trailing globstar
+      expect(new Glob("!**").match("a")).toBeFalse();
+      expect(new Glob("!**").match("a/b/c")).toBeFalse();
+
+      // `!!p` must equal `p` (involution)
+      expect(new Glob("!!**/a").match("a")).toBeTrue();
+      expect(new Glob("!!**/a").match("x/y/a")).toBeTrue();
+      expect(new Glob("!!**/a").match("zzz")).toBeFalse();
+      expect(new Glob("!!!**/a").match("a")).toBeFalse();
+      expect(new Glob("!!!**/a").match("x/y/a")).toBeFalse();
+
+      // canonical negated ignore glob
+      expect(new Glob("**/node_modules/**").match("node_modules/pkg/index.js")).toBeTrue();
+      expect(new Glob("!**/node_modules/**").match("node_modules/pkg/index.js")).toBeFalse();
+      expect(new Glob("!**/node_modules/**").match("a/b/node_modules/pkg/index.js")).toBeFalse();
+      expect(new Glob("!**/node_modules/**").match("src/index.js")).toBeTrue();
+
+      // control: `**` not at pattern start was already correct
+      expect(new Glob("!x/**/a").match("x/a")).toBeFalse();
+      expect(new Glob("!x/**/a").match("x/y/a")).toBeFalse();
+      expect(new Glob("!x/**/a").match("y/a")).toBeTrue();
+
+      // negation combined with braces containing a leading globstar
+      expect(new Glob("!{**/a,**/b}").match("a")).toBeFalse();
+      expect(new Glob("!{**/a,**/b}").match("x/y/a")).toBeFalse();
+      expect(new Glob("!{**/a,**/b}").match("x/y/b")).toBeFalse();
+      expect(new Glob("!{**/a,**/b}").match("x/y/c")).toBeTrue();
     });
 
     test("question_mark", () => {


### PR DESCRIPTION
## What

A leading `!` on a glob pattern silently degraded a pattern-initial `**` to a single-segment `*` before applying negation. `!p` was therefore not the complement of `p` when `p` started with `**`:

```js
new Glob("**/a").match("a")        // true
new Glob("!**/a").match("a")       // true   (should be false)
new Glob("!**/a").match("x/y/a")   // true   (should be false)
new Glob("!!**/a").match("a")      // false  (should be true; !!p must equal p)
new Glob("!**/node_modules/**").match("node_modules/pkg/index.js")  // true (should be false)
```

## Why

`r#match` in `src/glob/matcher.rs` consumes leading `!`s by advancing `state.glob_index`, then calls `glob_match_impl(..., glob_start = 0, ...)`. The globstar promotion check in the `*` arm is:

```rust
state.glob_index.saturating_sub(glob_start) < 3 || glob[state.glob_index - 3] == b'/'
```

For `!**/a`, after stepping past `**` `glob_index` is 3, so the left side is `3 - 0 < 3` (false) and the right side reads `glob[0] == '!'` (not `/`). The `**` is never recognized as being at the start of a path segment and falls back to single-`*` semantics.

## Fix

Pass the post-`!` offset as `glob_start` so a pattern-initial `**` is recognized as segment-initial. A `**` that follows a `/` (e.g. `!x/**/a`) was already handled by the `glob[... - 3] == '/'` branch and is unchanged.

## Tests

Added `negation with leading globstar` to `test/js/bun/glob/match.test.ts` covering zero-segment/deep matches, the `!!` involution, `!**/node_modules/**`, bare `!**`, the `!x/**/a` control, and `!{**/a,**/b}`. Also enabled seven previously commented-out `!**/...` assertions in the existing `negation` test that this bug had been blocking.

`bun bd test test/js/bun/glob/match.test.ts`: 27 pass / 0 fail. `scan.test.ts` and `stress.test.ts` pass unchanged.