### PR TITLE
glob: stop decoding \b/\n/\r/\t as C escapes in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -591,14 +591,7 @@ fn unescape(c: &mut u8, glob: &[u8], glob_index: &mut u32) -> bool {
             return false; // Invalid pattern!
         }
 
-        *c = match glob[*glob_index as usize] {
-            b'a' => b'\x61',
-            b'b' => b'\x08',
-            b'n' => b'\n',
-            b'r' => b'\r',
-            b't' => b'\t',
-            cc => cc,
-        };
+        *c = glob[*glob_index as usize];
     }
 
     true
@@ -636,18 +629,9 @@ fn get_unicode(c: &mut u32, clen: &mut u8, glob: &[u8], glob_index: &mut u32) ->
                 return false; // Invalid pattern!
             }
 
-            *c = match glob[*glob_index as usize] {
-                b'a' => b'\x61' as u32,
-                b'b' => b'\x08' as u32,
-                b'n' => b'\n' as u32,
-                b'r' => b'\r' as u32,
-                b't' => b'\t' as u32,
-                _ => 'brk: {
-                    let (cp, len) = decode_wtf8_rune_at(glob, *glob_index as usize);
-                    *clen = len;
-                    break 'brk cp;
-                }
-            };
+            let (cp, len) = decode_wtf8_rune_at(glob, *glob_index as usize);
+            *clen = len;
+            *c = cp;
         }
         // multi-byte sequences
         _ => {

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -432,6 +432,36 @@ describe("Glob.match", () => {
     expect(glob.match("runtime.node.pre.out.js")).toBeTrue();
   });
 
+  test("backslash escapes the following character literally, not as a C escape", () => {
+    // `\X` in a glob pattern means the literal character X (POSIX 2.13.1),
+    // it is not a C-style escape sequence. `\n` is the letter 'n', not LF.
+    for (const letter of ["b", "n", "r", "t"]) {
+      const ctrl = { b: "\b", n: "\n", r: "\r", t: "\t" }[letter]!;
+      expect({ letter, match: new Glob(`x\\${letter}y`).match(`x${letter}y`) }).toEqual({ letter, match: true });
+      expect({ letter, match: new Glob(`x\\${letter}y`).match(`x${ctrl}y`) }).toEqual({ letter, match: false });
+      expect({ letter, match: new Glob(`x[\\${letter}]y`).match(`x${letter}y`) }).toEqual({ letter, match: true });
+      expect({ letter, match: new Glob(`x[\\${letter}]y`).match(`x${ctrl}y`) }).toEqual({ letter, match: false });
+    }
+
+    // `\a` was already the letter 'a' (the old table mapped it to 0x61 == 'a')
+    // and must stay that way.
+    expect(new Glob("x\\ay").match("xay")).toBeTrue();
+    expect(new Glob("x\\ay").match("x\x07y")).toBeFalse();
+    expect(new Glob("x[\\a]y").match("xay")).toBeTrue();
+
+    // Escaped letter as a character-class range endpoint.
+    expect(new Glob("x[\\n-\\r]y").match("xpy")).toBeTrue();
+    expect(new Glob("x[\\n-\\r]y").match("x\ny")).toBeFalse();
+
+    // Windows-style path used as a pattern: `\t` must not become TAB.
+    expect(new Glob("src\\test\\a.ts").match("srctesta.ts")).toBeTrue();
+    expect(new Glob("src\\test\\a.ts").match("src\testa.ts")).toBeFalse();
+
+    // Escaping a non-ASCII codepoint still matches that codepoint.
+    expect(new Glob("\\ñ").match("ñ")).toBeTrue();
+    expect(new Glob("[\\ñ]").match("ñ")).toBeTrue();
+  });
+
   /**
    * These tests are ported from micromatch, glob-match, globlin
    */
@@ -840,7 +870,7 @@ describe("Glob.match", () => {
       expect(new Glob("a[\\b]c").match("\\*")).toBeFalse();
       expect(new Glob("a[\\b]c").match("a")).toBeFalse();
       expect(new Glob("a[\\b]c").match("a/*")).toBeFalse();
-      expect(new Glob("a[\\b]c").match("abc")).toBeFalse();
+      expect(new Glob("a[\\b]c").match("abc")).toBeTrue();
       expect(new Glob("a[\\b]c").match("abd")).toBeFalse();
       expect(new Glob("a[\\b]c").match("abe")).toBeFalse();
       expect(new Glob("a[\\b]c").match("b")).toBeFalse();


### PR DESCRIPTION
## Problem

A backslash in a glob pattern quotes the following character literally (POSIX 2.13.1, bash, minimatch, and Bun's own docs: "\\ escapes any of the special characters above"). `Glob.match()` instead decoded exactly four letters, `\b` `\n` `\r` `\t`, as C escape sequences (backspace, LF, CR, TAB) while every other `\X` was the literal `X`:

```js
new Glob("x\\ny").match("xny")    // false (wrong; should be true: \\n = literal 'n')
new Glob("x\\ny").match("x\ny")  // true  (wrong; it matched a raw LF)
new Glob("x[\\t]y").match("xty")  // false (wrong; same bug inside a class)
new Glob("x\\ay").match("xay")    // true  (every other letter is already identity)
```

The real-world failure is a backslash-separated path handed to `Glob`: `new Glob("src\\test\\a.ts")` silently turns its `\t` into TAB, matches nothing on disk, and does match names containing a raw TAB.

## Cause

`unescape()` and `get_unicode()` in `src/glob/matcher.rs` each carried a hard-coded C-style escape table, inherited from the upstream `glob-match` crate:

```rust
b'a' => b'\x61',   // 0x61 is 'a'; this BEL row was a typo that accidentally did the right thing
b'b' => b'\x08',
b'n' => b'\n',
b'r' => b'\r',
b't' => b'\t',
cc   => cc,
```

Only these four bytes were remapped; everything else was already identity, so the current behaviour was not even internally consistent.

## Fix

Make both `unescape()` and `get_unicode()` decode `\X` as `X` unconditionally (the `get_unicode` branch now simply decodes the WTF-8 rune following the backslash, matching the existing default arm).

One existing assertion ported from micromatch (`new Glob("a[\\b]c").match("abc")` expected `false`) encoded the control-character interpretation of `\b` and is updated to `true`, matching bash/minimatch and Bun's documented semantics.

## Verification

```
bun bd test test/js/bun/glob/match.test.ts
# 27 pass, 0 fail

# fail-before proof
git stash push -- src/ && bun bd test test/js/bun/glob/match.test.ts
# Glob.match > backslash escapes the following character literally, not as a C escape: FAIL
# Glob.match > ported ... > bash classes: FAIL
```