### PR TITLE
glob: stop bracket expressions from matching path separators in match()

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -272,6 +272,11 @@ fn glob_match_impl(
                         }
                         b'[' => {
                             if (state.path_index as usize) < path.len() {
+                                // A bracket expression, like `?` and `*`, never matches a path
+                                // separator (POSIX fnmatch FNM_PATHNAME, git wildmatch).
+                                if is_separator(path[state.path_index as usize]) {
+                                    break 'fallthrough;
+                                }
                                 state.glob_index += 1;
 
                                 let mut negated = false;

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -83,6 +83,51 @@ describe("Glob.match", () => {
     expect(glob.match("src/foo/nice/bar/baz/lmao.ts")).toBeTrue();
   });
 
+  test("bracket expressions never match a path separator", () => {
+    // A `[...]` class matches exactly one character of a single path component,
+    // same as `?` — POSIX fnmatch(FNM_PATHNAME), git wildmatch, minimatch and
+    // node fs.glob all agree it never matches `/`. Without this, a single-segment
+    // pattern like `a[!b]c` would match the two-segment path `a/c`, and match()
+    // would accept paths that scan() on the same Glob refuses.
+
+    // negated class
+    expect(new Glob("[!a]").match("/")).toBeFalse();
+    expect(new Glob("[^a]").match("/")).toBeFalse();
+    expect(new Glob("a[!b]c").match("a/c")).toBeFalse();
+    expect(new Glob("a[^b]c").match("a/c")).toBeFalse();
+    // negated class after a wildcard (backtracking still refuses the separator)
+    expect(new Glob("*[!b]c").match("d1/c")).toBeFalse();
+    expect(new Glob("*[!x]").match("a/b")).toBeFalse();
+    // positive class whose range spans 0x2F
+    expect(new Glob("a[.-A]c").match("a/c")).toBeFalse();
+    expect(new Glob("a[--0]c").match("a/c")).toBeFalse();
+    // explicit `/` as a class member (git t3070 pathname-mode column)
+    expect(new Glob("foo[/]bar").match("foo/bar")).toBeFalse();
+    expect(new Glob("[/]").match("/")).toBeFalse();
+    // inside a brace branch
+    expect(new Glob("a{[!b],x}c").match("a/c")).toBeFalse();
+    expect(new Glob("a{[!b],x}c").match("axc")).toBeTrue();
+    // `**` still crosses separators as the only multi-segment wildcard
+    expect(new Glob("a/**/[!b]c").match("a/x/zc")).toBeTrue();
+
+    // non-separator characters are unaffected
+    expect(new Glob("[!a]").match("b")).toBeTrue();
+    expect(new Glob("a[!b]c").match("axc")).toBeTrue();
+    expect(new Glob("a[^b]c").match("axc")).toBeTrue();
+    expect(new Glob("a[.-A]c").match("a0c")).toBeTrue();
+    expect(new Glob("*[!b]c").match("d1c")).toBeTrue();
+
+    // On Windows `\` is also a path separator and must be refused the same way.
+    if (isWindows) {
+      expect(new Glob("a[!b]c").match("a\\c")).toBeFalse();
+      expect(new Glob("[!a]").match("\\")).toBeFalse();
+    }
+
+    // sibling wildcards already refuse the separator; kept as regression anchors
+    expect(new Glob("a?c").match("a/c")).toBeFalse();
+    expect(new Glob("a*c").match("a/c")).toBeFalse();
+  });
+
   test("comma inside a bracket class inside braces is not a branch separator", () => {
     // `[,]` is a single-character class containing a literal comma, so the
     // group has three branches: `ts`, `[,]foo`, and nothing after — not a
@@ -745,7 +790,8 @@ describe("Glob.match", () => {
       expect(new Glob("[a-y]*[^c]").match("bd")).toBeTrue();
       expect(new Glob("[a-y]*[^c]").match("bb")).toBeTrue();
       expect(new Glob("[a-y]*[^c]").match("bcd")).toBeTrue();
-      expect(new Glob("[a-y]*[^c]").match("bdir/")).toBeTrue();
+      // git t3070-wildmatch.sh: 0 0 1 1 — pathname mode (column 1) does not match.
+      expect(new Glob("[a-y]*[^c]").match("bdir/")).toBeFalse();
       expect(new Glob("[a-y]*[^c]").match("Beware")).toBeFalse();
       expect(new Glob("[a-y]*[^c]").match("c")).toBeFalse();
       expect(new Glob("[a-y]*[^c]").match("ca")).toBeTrue();
@@ -954,7 +1000,10 @@ describe("Glob.match", () => {
     });
 
     test("bash slashmatch", () => {
-      expect(new Glob("foo[/]bar").match("foo/bar")).toBeTrue();
+      // git t3070-wildmatch.sh: `match 0 0 1 1 'foo/bar' 'foo[/]bar'` — a bracket
+      // expression does not match `/` in pathname mode (column 1).
+      expect(new Glob("foo[/]bar").match("foo/bar")).toBeFalse();
+      expect(new Glob("f[^eiu][^eiu][^eiu][^eiu][^eiu]r").match("foo/bar")).toBeFalse();
       expect(new Glob("f[^eiu][^eiu][^eiu][^eiu][^eiu]r").match("foo-bar")).toBeTrue();
     });
 


### PR DESCRIPTION
## Problem

`Bun.Glob.match()` lets a bracket expression match the path separator `/`, so a single-segment pattern crosses directory boundaries:

```js
new Bun.Glob("[!a]").match("/");       // true, should be false
new Bun.Glob("a[!b]c").match("a/c");   // true, should be false (1-segment pattern, 2-segment path)
new Bun.Glob("a[^b]c").match("a/c");   // true, should be false
new Bun.Glob("a[.-A]c").match("a/c");  // true, should be false (range spanning 0x2F)
new Bun.Glob("foo[/]bar").match("foo/bar"); // true, should be false
// siblings already correct:
new Bun.Glob("a?c").match("a/c");      // false
new Bun.Glob("a*c").match("a/c");      // false
```

`scan()` on the same `Glob` object refuses these (the walker descends one directory per component), so `match()` and `scan()` disagree on the same pattern. Any code that pre-filters a candidate list with `match()`, or validates `scan()` output with `match()`, silently drops or invents entries. A "single-segment" pattern that crosses `/` is also a containment footgun: `uploads/[!.]*` is meant to be confined to `uploads/` but matches `uploads/../secret`.

POSIX `fnmatch(3)` with `FNM_PATHNAME`, git `wildmatch` in pathname mode (t3070, column 1), `minimatch`, and Node's `fs.glob` all agree a bracket expression never matches `/`:

```
fnmatch("a[!b]c", "a/c", FNM_PATHNAME)   => FNM_NOMATCH
fnmatch("a[.-A]c", "a/c", FNM_PATHNAME)  => FNM_NOMATCH
fnmatch("foo[/]bar", "foo/bar", FNM_PATHNAME) => FNM_NOMATCH
```

## Cause

In `src/glob/matcher.rs`, the `b'['` arm of `glob_match_impl` advances `path_index` on a class hit with no `is_separator()` check. The sibling `b'?'` arm immediately above and the `b'*'` arm both guard with `if !is_separator(path[path_index])`; the `[` arm alone is missing the path-side guard. Bun inherited this from the upstream `glob-match` crate.

## Fix

Add the same `is_separator` guard to the `[` arm: if the current path byte is a separator, fall through to backtracking (same as `?`). A bracket expression now matches exactly one character of a single path component.

Two existing assertions in the bash-derived test block were locking in the bug (they correspond to the non-pathname-mode columns of git t3070) and are updated to the pathname-mode result, with a comment citing the t3070 vector.

Not in this PR: the separate glob-side tokenizer hole where the class body scan does not stop at a `/` in the pattern (e.g. `[a/b]q`). That governs how the class is parsed, not what it matches, and is a distinct fix.

## Verification

New `bracket expressions never match a path separator` block in `test/js/bun/glob/match.test.ts` covers negated classes (`[!x]` and `[^x]`), a range spanning 0x2F, an explicit `/` class member, a negated class after `*` (backtracking), the brace-branch path, and the Windows `\\` separator. Positive controls confirm non-separator characters are unaffected.

```
bun bd test test/js/bun/glob/match.test.ts
# 27 pass, 0 fail

bun bd test test/js/bun/glob/scan.test.ts
# 194 pass, 0 fail

bun bd test test/js/node/path/matches-glob.test.ts
# 31 pass, 0 fail
```

`path.matchesGlob` delegates to the same matcher and inherits the fix.