### PR TITLE
node:vm: propagate termination from enclosing evaluation instead of asserting

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -256,6 +256,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // watchdog/SIGINT watcher. Leave the request in place and
             // propagate it; the enclosing frame converts it.
             status(Status::Errored);
+            m_evaluationException.set(vm, this, JSC::Exception::create(vm, jsNull()));
             scope.throwException(globalObject, vm.ensureTerminationException());
             return {};
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -255,6 +255,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // Termination fired while nested under an enclosing evaluation's
             // watchdog/SIGINT watcher. Leave the request in place and
             // propagate it; the enclosing frame converts it.
+            status(Status::Errored);
             scope.throwException(globalObject, vm.ensureTerminationException());
             return {};
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -105,6 +105,12 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+                if (!getSigintReceived() && timeout == 0) {
+                    // Termination belongs to an enclosing evaluation; leave
+                    // the request in place and propagate it.
+                    scope.throwException(globalObject, vm.ensureTerminationException());
+                    return {};
+                }
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
                 vm.clearHasTerminationRequest();
@@ -245,16 +251,21 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+        if (!getSigintReceived() && timeout == 0) {
+            // Termination fired while nested under an enclosing evaluation's
+            // watchdog/SIGINT watcher. Leave the request in place and
+            // propagate it; the enclosing frame converts it.
+            scope.throwException(globalObject, vm.ensureTerminationException());
+            return {};
+        }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -283,26 +283,31 @@ void NodeVMScript::destroy(JSCell* cell)
 
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
+    if (!vm.hasTerminationRequest())
+        return false;
+
+    if (!script->getSigintReceived() && !timeout) {
+        // Termination fired while nested under an enclosing evaluation's
+        // watchdog/SIGINT watcher. Leave the request in place and propagate
+        // it; the enclosing frame converts it to ERR_SCRIPT_EXECUTION_*.
+        scope.throwException(globalObject, vm.ensureTerminationException());
         return true;
     }
 
-    return false;
+    vm.drainMicrotasksForGlobalObject(globalObject);
+    // The termination may have fired inside an afterEvaluate microtask
+    // checkpoint, leaving the termination exception pending; clear it so
+    // the ERR_SCRIPT_EXECUTION_* error below replaces it.
+    if (vm.hasPendingTerminationException())
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    vm.clearHasTerminationRequest();
+    if (script->getSigintReceived()) {
+        script->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    } else {
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
+    }
+    return true;
 }
 
 void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,115 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("node:vm nested evaluation under outer timeout/breakOnSigint", () => {
+  test("outer timeout fires while an inner untimed runInNewContext is running", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const inner = () => {
+        try {
+          return vm.runInNewContext(
+            "const t0 = Date.now(); while (Date.now() - t0 < 2000); 'inner-done'",
+            {},
+          );
+        } catch (e) {
+          return "inner-threw:" + (e && e.code);
+        }
+      };
+      try {
+        console.log("outer-ret:" + vm.runInNewContext("inner()", { inner }, { timeout: 70 }));
+      } catch (e) {
+        console.log("outer-threw:" + (e && e.code));
+      }
+      console.log("alive");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "outer-threw:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("outer timeout fires while an inner untimed runInThisContext is running", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      globalThis.__inner = () => {
+        try {
+          return new vm.Script(
+            "const t0 = Date.now(); while (Date.now() - t0 < 2000); 'inner-done'",
+          ).runInThisContext();
+        } catch (e) {
+          return "inner-threw:" + (e && e.code);
+        }
+      };
+      try {
+        console.log("outer-ret:" + new vm.Script("__inner()").runInThisContext({ timeout: 70 }));
+      } catch (e) {
+        console.log("outer-threw:" + (e && e.code));
+      }
+      delete globalThis.__inner;
+      console.log("alive");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "outer-threw:ERR_SCRIPT_EXECUTION_TIMEOUT\nalive",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "outer breakOnSigint fires while an inner evaluation without breakOnSigint is running",
+    async () => {
+      const fixture = `
+        const vm = require("node:vm");
+        const inner = () => {
+          try {
+            return vm.runInNewContext(
+              "kill(); const t0 = Date.now(); while (Date.now() - t0 < 5000); 'inner-done'",
+              { kill: () => process.kill(process.pid, "SIGINT") },
+            );
+          } catch (e) {
+            return "inner-threw:" + (e && e.code);
+          }
+        };
+        try {
+          console.log(
+            "outer-ret:" + vm.runInNewContext("inner()", { inner }, { breakOnSigint: true }),
+          );
+        } catch (e) {
+          console.log("outer-threw:" + (e && e.code));
+        }
+        console.log("alive");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        stdout: "outer-threw:ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive",
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+  );
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1288,4 +1288,42 @@ describe.concurrent("node:vm nested evaluation under outer timeout/breakOnSigint
       });
     },
   );
+
+  test("outer timeout fires while an inner untimed SourceTextModule.evaluate() is running", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const mod = new vm.SourceTextModule(
+        "const t0 = Date.now(); while (Date.now() - t0 < 2000);",
+        { identifier: "busy" },
+      );
+      await mod.link(() => {});
+      const host = () => { mod.evaluate(); };
+      try {
+        vm.runInNewContext("host()", { host }, { timeout: 70 });
+        console.log("outer-ret");
+      } catch (e) {
+        console.log("outer-threw:" + (e && e.code));
+      }
+      console.log("status:" + mod.status);
+      try {
+        console.log("error:" + String(mod.error));
+      } catch (e) {
+        console.log("error-threw:" + (e && e.code));
+      }
+      console.log("alive");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "outer-threw:ERR_SCRIPT_EXECUTION_TIMEOUT\nstatus:errored\nerror:null\nalive",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });


### PR DESCRIPTION
### Repro

```js
const vm = require("node:vm");
const inner = () => vm.runInNewContext(
  "const t0 = Date.now(); while (Date.now() - t0 < 300);", {});
try {
  vm.runInNewContext("inner()", { inner }, { timeout: 70 });
} catch (e) { console.log("outer-threw:" + e.code); }
console.log("alive");
```

Node: `outer-threw:ERR_SCRIPT_EXECUTION_TIMEOUT` then `alive`.
Bun 1.4.0 and main: whole-process SIGABRT:

```
ASSERTION FAILED: vm.Script terminated due neither to SIGINT nor to timeout
src/jsc/bindings/NodeVMScript.cpp(300) Bun::checkForTermination(...)
```

Same abort with outer `{ breakOnSigint: true }` and a SIGINT delivered while the inner evaluation is running. Any `node:vm` sandbox whose timed/interruptible evaluation calls a host helper that evaluates more guest code hits this.

### Cause

`checkForTermination` attributes the VM's termination request to the innermost evaluation: it clears `hasTerminationRequest()` and the pending termination exception, then tries to convert to `ERR_SCRIPT_EXECUTION_*` using the inner script's `sigintReceived` flag and `timeout` option. A nested evaluation with neither of those falls through to `RELEASE_ASSERT_NOT_REACHED`. The same pattern exists in `NodeVMModule::evaluate`.

### Fix

Attribute before clearing. When the termination request is set but this evaluation did not arm the watchdog (no `timeout`) and its script was not flagged by the SIGINT watcher, leave the VM termination state intact and re-throw the uncatchable termination exception so it propagates to the enclosing evaluation, which converts it to the appropriate `ERR_SCRIPT_EXECUTION_*` error. Applied to `checkForTermination` in `NodeVMScript.cpp` and both termination checks in `NodeVMModule::evaluate`.

### Verification

New tests in `test/js/node/vm/vm.test.ts` cover:
- outer `timeout` + inner `runInNewContext` with no timeout
- outer `timeout` + inner `runInThisContext` with no timeout
- outer `breakOnSigint` + inner eval with no `breakOnSigint`, self-`SIGINT` delivered while inner runs

All three abort with SIGABRT on an unfixed build (`USE_SYSTEM_BUN=1`) and pass with the fix, matching Node's output. Full `test/js/node/vm/vm.test.ts` (209 pass) and the `test-vm-timeout*`/`test-vm-sigint*` node-parallel suite still pass.

Note: #32773 (open) replaces the JSC Watchdog for the `timeout` option entirely and also removes this assert as part of that larger rework. This PR is the minimal targeted fix for the nested-evaluation abort.