### PR TITLE
node:vm: keep already-queued promise reactions after a timed-out evaluation

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -105,7 +105,6 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
                 vm.clearHasTerminationRequest();
                 if (getSigintReceived()) {
@@ -245,7 +244,6 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
         if (getSigintReceived()) {

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -284,7 +284,6 @@ void NodeVMScript::destroy(JSCell* cell)
 static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
     if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
         // The termination may have fired inside an afterEvaluate microtask
         // checkpoint, leaving the termination exception pending; clear it so
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,108 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("timeout termination preserves already-queued promise reactions", () => {
+  // default microtask mode: jobs the guest queued before expiry share the host's queue
+  // and must run at the next host checkpoint, so a host `.then` on the guest's promise settles.
+  test.concurrent("runInContext", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const c = vm.createContext({ o: [] });
+      let code;
+      try {
+        vm.runInContext(
+          "hostPromise = Promise.resolve().then(()=>{ o.push(1); return 'v' })" +
+          "                               .then((x)=>{ o.push(2); return x }); for(;;);",
+          c, { timeout: 80 });
+      } catch (e) { code = e.code; }
+      let hostSaw = "no";
+      c.hostPromise?.then(() => { hostSaw = "yes"; });
+      setTimeout(() => {
+        console.log("o=" + JSON.stringify(c.o) + " host=" + hostSaw + " code=" + code);
+      }, 0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "o=[1,2] host=yes code=ERR_SCRIPT_EXECUTION_TIMEOUT",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("runInThisContext", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      globalThis.o = [];
+      Promise.resolve().then(() => { o.push("host-before"); });
+      let code;
+      try {
+        vm.runInThisContext(
+          "globalThis.guestPromise = Promise.resolve().then(()=>{ o.push('guest'); }); for(;;);",
+          { timeout: 80 });
+      } catch (e) { code = e.code; }
+      let hostSaw = "no";
+      globalThis.guestPromise?.then(() => { hostSaw = "yes"; });
+      setTimeout(() => {
+        console.log("o=" + JSON.stringify(o) + " host=" + hostSaw + " code=" + code);
+      }, 0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: 'o=["host-before","guest"] host=yes code=ERR_SCRIPT_EXECUTION_TIMEOUT',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("SourceTextModule.evaluate", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const c = vm.createContext({ o: [] });
+      const mod = new vm.SourceTextModule(
+        "globalThis.hostPromise = Promise.resolve().then(()=>{ o.push(1); }); for(;;);",
+        { context: c });
+      await mod.link(() => { throw 0; });
+      let code;
+      try { await mod.evaluate({ timeout: 80 }); } catch (e) { code = e.code; }
+      let hostSaw = "no";
+      c.hostPromise?.then(() => { hostSaw = "yes"; });
+      setTimeout(() => {
+        console.log("o=" + JSON.stringify(c.o) + " host=" + hostSaw + " code=" + code);
+      }, 0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--input-type=module", "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "o=[1] host=yes code=ERR_SCRIPT_EXECUTION_TIMEOUT",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Repro

```js
import * as vm from "node:vm";

const c = vm.createContext({ o: [] });        // default microtaskMode: shares the host's queue
try {
  vm.runInContext(
    "hostPromise = Promise.resolve().then(()=>{ o.push(1); return 'v' })" +
    "                               .then((x)=>{ o.push(2); return x }); for(;;);",
    c, { timeout: 80 });
} catch (e) { /* ERR_SCRIPT_EXECUTION_TIMEOUT in both runtimes */ }

let hostSaw = "no";
c.hostPromise?.then(() => { hostSaw = "yes"; });
await new Promise(r => setTimeout(r, 20));
console.log(`o=${JSON.stringify(c.o)} | host .then ran=${hostSaw}`);

// node v26.3.0:  o=[1,2] | host .then ran=yes
// bun (before):  o=[]    | host .then ran=no    <- and it never will
```

The standard sandbox pattern is "give the guest a CPU budget, then await whatever promise it handed back". On bun, jobs that were already enqueued for already-settled promises were discarded with the terminated evaluation, so the host's `.then` on the guest's promise never settled and the host hung with no error. The `.catch` shape was worse: a rejection handler the guest attached before expiry never ran, and no `unhandledRejection` was reported either.

`runInThisContext` was affected even more directly: it passed the caller's global, so a timed-out evaluation also dropped the caller's own pending reactions queued before the vm call.

## Cause

`checkForTermination` (NodeVMScript.cpp) and the two termination branches in `NodeVMModule::evaluate` called `vm.drainMicrotasksForGlobalObject(globalObject)` before clearing the termination request and throwing `ERR_SCRIPT_EXECUTION_TIMEOUT`. Despite the name, that helper calls `MicrotaskQueue::clearForGlobalObject`, which removes every pending entry on the VM's default queue whose `globalObject()` matches. In default microtask mode the guest's reactions live on that shared queue, so they were dropped.

## Fix

Remove the three `drainMicrotasksForGlobalObject` calls. Terminating a timed evaluation only stops execution; jobs that were already enqueued stay on the queue and run at the next host checkpoint once the termination request is cleared, matching Node. `microtaskMode: "afterEvaluate"` is unaffected: those jobs live on the context's own queue, which the removed call never touched anyway.

## Verification

New tests in `test/js/node/vm/vm.test.ts` spawn a subprocess for each of `runInContext`, `runInThisContext`, and `SourceTextModule.evaluate`, queue a reaction on an already-resolved promise, spin into `{ timeout: 80 }`, and assert the reaction ran and a host `.then` on the guest's promise settled.

- `USE_SYSTEM_BUN=1 bun test test/js/node/vm/vm.test.ts -t "timeout termination preserves"`: 0 pass / 3 fail
- `bun bd test test/js/node/vm/vm.test.ts -t "timeout termination preserves"`: 3 pass / 0 fail
- Full `vm.test.ts`: 209 pass / 0 fail
- Node parallel `test-vm-timeout*.js` / `test-vm-module-*` suites: pass

Overlaps with #33411, which narrows the same call to the vm context's global for `runInThisContext`; this PR removes it outright so the guest's own reactions on the shared queue survive too.