### PR TITLE
node:vm: enforce timeout as a wall-clock deadline that interrupts Atomics.wait

### DIFF
--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -241,7 +241,8 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
     if (getSigintReceived() || didTimeOut) {
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
+        if (nodeVmGlobalObject)
+            vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         TimeoutWatchdog::clearTerminationState(vm);
         if (getSigintReceived()) {
             setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -8,9 +8,9 @@
 #include "JavaScriptCore/Exception.h"
 #include "JavaScriptCore/JSModuleRecord.h"
 #include "JavaScriptCore/JSPromise.h"
-#include "JavaScriptCore/Watchdog.h"
 
 #include "../vm/SigintWatcher.h"
+#include "../vm/TimeoutWatchdog.h"
 
 namespace Bun {
 
@@ -49,8 +49,6 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 
     return array;
 }
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -93,21 +91,21 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         NodeVMGlobalObject* nodeVmGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
         RETURN_IF_EXCEPTION(scope, {});
         if (nodeVmGlobalObject && nodeVmGlobalObject->hasOwnMicrotaskQueue()) {
-            std::optional<double> oldLimit;
-            if (timeout != 0)
-                setupWatchdog(vm, timeout, &oldLimit.emplace(), nullptr);
-            nodeVmGlobalObject->drainOwnMicrotasks();
-            if (timeout != 0)
-                vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+            bool didTimeOut = false;
+            {
+                TimeoutWatchdog watchdog(vm, timeout != 0 ? std::optional<int64_t>(timeout) : std::nullopt);
+                nodeVmGlobalObject->drainOwnMicrotasks();
+                watchdog.disarm();
+                didTimeOut = watchdog.didFire();
+            }
             // The drain may legitimately leave the termination exception
             // pending (watchdog fired mid-checkpoint); observe it so the
             // exception-check validator is satisfied before the TOP scope
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
-            if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+            if (getSigintReceived() || didTimeOut) {
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-                DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                vm.clearHasTerminationRequest();
+                TimeoutWatchdog::clearTerminationState(vm);
                 if (getSigintReceived()) {
                     setSigintReceived(false);
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
@@ -220,23 +218,21 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
 
     setSigintReceived(false);
 
-    std::optional<double> oldLimit, newLimit;
+    bool didTimeOut = false;
+    {
+        TimeoutWatchdog watchdog(vm, timeout != 0 ? std::optional<int64_t>(timeout) : std::nullopt);
 
-    if (timeout != 0) {
-        setupWatchdog(vm, timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
+        if (breakOnSigint) {
+            auto holder = SigintWatcher::hold(nodeVmGlobalObject, this);
+            run();
+            drainAfterEvaluate();
+        } else {
+            run();
+            drainAfterEvaluate();
+        }
 
-    if (breakOnSigint) {
-        auto holder = SigintWatcher::hold(nodeVmGlobalObject, this);
-        run();
-        drainAfterEvaluate();
-    } else {
-        run();
-        drainAfterEvaluate();
-    }
-
-    if (timeout != 0) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+        watchdog.disarm();
+        didTimeOut = watchdog.didFire();
     }
 
     // Evaluation (or the afterEvaluate drain) may leave an exception pending
@@ -244,17 +240,14 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // termination one is converted to ERR_SCRIPT_EXECUTION_* here. Observe it
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
-    if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+    if (getSigintReceived() || didTimeOut) {
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
+        TimeoutWatchdog::clearTerminationState(vm);
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -12,6 +12,7 @@
 
 #include "NodeVMScriptFetcher.h"
 #include "../vm/SigintWatcher.h"
+#include "../vm/TimeoutWatchdog.h"
 
 #include <bit>
 
@@ -281,51 +282,26 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
+static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<int64_t> timeout, bool didTimeOut)
 {
-    if (vm.hasTerminationRequest()) {
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
-        return true;
+    bool sigint = script->getSigintReceived();
+    if (!sigint && !didTimeOut) {
+        // A termination that this scope did not initiate (an enclosing
+        // node:vm timeout, or worker termination) propagates unchanged so the
+        // outer scope can translate it with its own timeout value.
+        return false;
     }
 
-    return false;
-}
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& dog = vm.ensureWatchdog();
-    dog.enteredVM();
-
-    Seconds oldLimit = dog.getTimeLimit();
-
-    if (oldTimeout) {
-        *oldTimeout = oldLimit.milliseconds();
-    }
-
-    if (oldLimit.isInfinity() || timeout < oldLimit.milliseconds()) {
-        dog.setTimeLimit(WTF::Seconds::fromMilliseconds(timeout));
+    vm.drainMicrotasksForGlobalObject(globalObject);
+    TimeoutWatchdog::clearTerminationState(vm);
+    if (sigint) {
+        script->setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
     } else {
-        timeout = oldLimit.milliseconds();
+        ASSERT(timeout);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
     }
-
-    if (newTimeout) {
-        *newTimeout = timeout;
-    }
+    return true;
 }
 
 static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVMScript* script, JSObject* contextifiedObject, JSValue optionsArg, bool allowStringInPlaceOfOptions = false)
@@ -354,12 +330,6 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
-
     script->setSigintReceived(false);
 
     // Node performs the afterEvaluate microtask checkpoint inside the
@@ -370,6 +340,8 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
             globalObject->drainOwnMicrotasks();
     };
 
+    TimeoutWatchdog watchdog(vm, options.timeout);
+
     if (options.breakOnSigint) {
         auto holder = SigintWatcher::hold(globalObject, script);
         run();
@@ -379,11 +351,9 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         drainAfterEvaluate();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
+    watchdog.disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, options.timeout, watchdog.didFire())) {
         return {};
     }
 
@@ -428,13 +398,9 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
-
     script->setSigintReceived(false);
+
+    TimeoutWatchdog watchdog(vm, options.timeout);
 
     if (options.breakOnSigint) {
         auto holder = SigintWatcher::hold(globalObject, script);
@@ -444,11 +410,9 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         run();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
+    watchdog.disarm();
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, options.timeout, watchdog.didFire())) {
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -286,13 +286,16 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
 {
     bool sigint = script->getSigintReceived();
     if (!sigint && !didTimeOut) {
-        // A termination that this scope did not initiate (an enclosing
-        // node:vm timeout, or worker termination) propagates unchanged so the
-        // outer scope can translate it with its own timeout value.
+        // A termination this scope did not initiate (an enclosing timeout or
+        // worker termination) propagates unchanged so the outer scope can
+        // translate it with its own timeout value.
         return false;
     }
 
-    vm.drainMicrotasksForGlobalObject(globalObject);
+    // Discard microtasks the terminated sandbox queued on the default queue;
+    // skip for runInThisContext so the caller's own jobs survive.
+    if (dynamicDowncast<NodeVMGlobalObject>(globalObject))
+        vm.drainMicrotasksForGlobalObject(globalObject);
     TimeoutWatchdog::clearTerminationState(vm);
     if (sigint) {
         script->setSigintReceived(false);

--- a/src/jsc/bindings/vm/TimeoutWatchdog.cpp
+++ b/src/jsc/bindings/vm/TimeoutWatchdog.cpp
@@ -26,12 +26,13 @@ TimeoutWatchdog::TimeoutWatchdog(JSC::VM& vm, std::optional<int64_t> timeoutMs)
             if (m_disarmed)
                 return;
             fire();
-            // Re-notify until disarmed: the first notify can be lost if it
-            // lands between the waiter's predicate check and parking.
+            // Re-assert until disarmed: a nested scope's clearTerminationState
+            // can wipe the request this watchdog installed, and a lost notify
+            // can land between the waiter's predicate check and parking.
             while (!m_disarmed) {
                 if (m_cond.waitUntil(m_lock, MonotonicTime::now() + 1_ms))
                     continue;
-                m_vm.syncWaiter()->condition().notifyOne();
+                fire();
             }
             return;
         }

--- a/src/jsc/bindings/vm/TimeoutWatchdog.cpp
+++ b/src/jsc/bindings/vm/TimeoutWatchdog.cpp
@@ -1,0 +1,91 @@
+#include "TimeoutWatchdog.h"
+
+#include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/VMTraps.h>
+#include <JavaScriptCore/WaiterListManager.h>
+#include <JavaScriptCore/ExceptionScope.h>
+
+namespace Bun {
+
+TimeoutWatchdog::TimeoutWatchdog(JSC::VM& vm, std::optional<int64_t> timeoutMs)
+    : m_vm(vm)
+{
+    if (!timeoutMs)
+        return;
+
+    // The worker thread requests termination via throwTerminationException()
+    // (reached from VMTraps::handleTraps / Atomics.wait Terminated). That
+    // path asserts the lazily-allocated termination exception exists, so
+    // create it now on the mutator thread.
+    vm.ensureTerminationException();
+
+    auto deadline = MonotonicTime::now() + Seconds::fromMilliseconds(static_cast<double>(*timeoutMs));
+    m_thread = WTF::Thread::create("node:vm timeout"_s, [this, deadline] {
+        Locker locker { m_lock };
+        while (!m_disarmed) {
+            if (m_cond.waitUntil(m_lock, deadline))
+                continue;
+            if (m_disarmed)
+                return;
+            fire();
+            // Keep nudging the sync waiter until the mutator disarms us:
+            // the first notify can be lost if it lands between the waiter
+            // evaluating its loop predicate and parking (we do not hold the
+            // waiter's list lock).
+            while (!m_disarmed) {
+                if (m_cond.waitUntil(m_lock, MonotonicTime::now() + 1_ms))
+                    continue;
+                m_vm.syncWaiter()->condition().notifyOne();
+            }
+            return;
+        }
+    });
+}
+
+TimeoutWatchdog::~TimeoutWatchdog()
+{
+    disarm();
+}
+
+void TimeoutWatchdog::disarm()
+{
+    if (!m_thread)
+        return;
+    {
+        Locker locker { m_lock };
+        m_disarmed = true;
+    }
+    m_cond.notifyOne();
+    m_thread->waitForCompletion();
+    m_thread = nullptr;
+}
+
+void TimeoutWatchdog::fire()
+{
+    m_fired.store(true, std::memory_order_release);
+    // Mark the VM as terminating so WaiterListManager::waitForSync's loop
+    // predicate (!vm.hasTerminationRequest()) falls through and a blocked
+    // Atomics.wait returns Terminated. m_hasTerminationRequest is a plain
+    // bool but the notify below is a full fence and the woken waiter
+    // reacquires its list lock (acquire), so the write is observable.
+    m_vm.setHasTerminationRequest();
+    // Raise NeedTermination so running JS exits at the next back-edge. This
+    // path also reaches requestThreadStopIfNeeded which notifies the sync
+    // waiter, but that notify is skipped when a thread-stop is already
+    // pending, so deliver one unconditionally here as well.
+    m_vm.notifyNeedTermination();
+    m_vm.syncWaiter()->condition().notifyOne();
+}
+
+void TimeoutWatchdog::clearTerminationState(JSC::VM& vm)
+{
+    if (vm.hasPendingTerminationException()) {
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        scope.clearException();
+    }
+    vm.clearHasTerminationRequest();
+    vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+    vm.traps().clearTrap(JSC::VMTraps::NeedWatchdogCheck);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/vm/TimeoutWatchdog.cpp
+++ b/src/jsc/bindings/vm/TimeoutWatchdog.cpp
@@ -13,10 +13,8 @@ TimeoutWatchdog::TimeoutWatchdog(JSC::VM& vm, std::optional<int64_t> timeoutMs)
     if (!timeoutMs)
         return;
 
-    // The worker thread requests termination via throwTerminationException()
-    // (reached from VMTraps::handleTraps / Atomics.wait Terminated). That
-    // path asserts the lazily-allocated termination exception exists, so
-    // create it now on the mutator thread.
+    // throwTerminationException() (reached via handleTraps / Atomics.wait
+    // Terminated) asserts this exists; allocate it on the mutator thread.
     vm.ensureTerminationException();
 
     auto deadline = MonotonicTime::now() + Seconds::fromMilliseconds(static_cast<double>(*timeoutMs));
@@ -28,10 +26,8 @@ TimeoutWatchdog::TimeoutWatchdog(JSC::VM& vm, std::optional<int64_t> timeoutMs)
             if (m_disarmed)
                 return;
             fire();
-            // Keep nudging the sync waiter until the mutator disarms us:
-            // the first notify can be lost if it lands between the waiter
-            // evaluating its loop predicate and parking (we do not hold the
-            // waiter's list lock).
+            // Re-notify until disarmed: the first notify can be lost if it
+            // lands between the waiter's predicate check and parking.
             while (!m_disarmed) {
                 if (m_cond.waitUntil(m_lock, MonotonicTime::now() + 1_ms))
                     continue;
@@ -63,16 +59,12 @@ void TimeoutWatchdog::disarm()
 void TimeoutWatchdog::fire()
 {
     m_fired.store(true, std::memory_order_release);
-    // Mark the VM as terminating so WaiterListManager::waitForSync's loop
-    // predicate (!vm.hasTerminationRequest()) falls through and a blocked
-    // Atomics.wait returns Terminated. m_hasTerminationRequest is a plain
-    // bool but the notify below is a full fence and the woken waiter
-    // reacquires its list lock (acquire), so the write is observable.
+    // waitForSync's loop predicate is !vm.hasTerminationRequest(); set it
+    // before the notify so a woken Atomics.wait returns Terminated.
     m_vm.setHasTerminationRequest();
-    // Raise NeedTermination so running JS exits at the next back-edge. This
-    // path also reaches requestThreadStopIfNeeded which notifies the sync
-    // waiter, but that notify is skipped when a thread-stop is already
-    // pending, so deliver one unconditionally here as well.
+    // Raise NeedTermination so running JS exits at the next back-edge, and
+    // notify the sync waiter unconditionally (requestThreadStopIfNeeded skips
+    // its own notify when a thread-stop is already pending).
     m_vm.notifyNeedTermination();
     m_vm.syncWaiter()->condition().notifyOne();
 }

--- a/src/jsc/bindings/vm/TimeoutWatchdog.h
+++ b/src/jsc/bindings/vm/TimeoutWatchdog.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "root.h"
+
+#include <wtf/Condition.h>
+#include <wtf/Lock.h>
+#include <wtf/Threading.h>
+
+namespace Bun {
+
+// Wall-clock watchdog for node:vm's `timeout` option. On fire it requests VM
+// termination and wakes a blocked Atomics.wait so the guest cannot sit out the
+// deadline in a futex. The destructor joins the worker thread, so the watchdog
+// is always armed on the stack bracketing JSC::evaluate.
+class TimeoutWatchdog {
+    WTF_MAKE_NONCOPYABLE(TimeoutWatchdog);
+
+public:
+    TimeoutWatchdog(JSC::VM& vm, std::optional<int64_t> timeoutMs);
+    ~TimeoutWatchdog();
+
+    void disarm();
+    bool didFire() const { return m_fired.load(std::memory_order_acquire); }
+
+    // Clears the VM's termination state (request flag + trap bits + pending
+    // exception) that this watchdog installed when it fired. Call from the
+    // mutator thread after evaluate returns.
+    static void clearTerminationState(JSC::VM&);
+
+private:
+    void fire();
+
+    JSC::VM& m_vm;
+    WTF::Lock m_lock;
+    WTF::Condition m_cond;
+    std::atomic<bool> m_fired { false };
+    bool m_disarmed WTF_GUARDED_BY_LOCK(m_lock) { false };
+    RefPtr<WTF::Thread> m_thread;
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/vm/TimeoutWatchdog.h
+++ b/src/jsc/bindings/vm/TimeoutWatchdog.h
@@ -8,10 +8,9 @@
 
 namespace Bun {
 
-// Wall-clock watchdog for node:vm's `timeout` option. On fire it requests VM
-// termination and wakes a blocked Atomics.wait so the guest cannot sit out the
-// deadline in a futex. The destructor joins the worker thread, so the watchdog
-// is always armed on the stack bracketing JSC::evaluate.
+// Wall-clock watchdog for node:vm's `timeout`. On fire it requests VM
+// termination and wakes a blocked Atomics.wait; the destructor joins the
+// worker, so instances are stack-allocated bracketing JSC::evaluate.
 class TimeoutWatchdog {
     WTF_MAKE_NONCOPYABLE(TimeoutWatchdog);
 
@@ -22,9 +21,8 @@ public:
     void disarm();
     bool didFire() const { return m_fired.load(std::memory_order_acquire); }
 
-    // Clears the VM's termination state (request flag + trap bits + pending
-    // exception) that this watchdog installed when it fired. Call from the
-    // mutator thread after evaluate returns.
+    // Clears request flag, trap bits, and pending termination exception.
+    // Call from the mutator thread after evaluate returns.
     static void clearTerminationState(JSC::VM&);
 
 private:

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1178,11 +1178,10 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
   });
 });
 
-describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
+describe.concurrent("timeout enforces a wall-clock deadline against Atomics.wait", () => {
   // Run in a subprocess so an unfixed build, which would sit in the wait for
-  // the full 30 s, fails the test by exceeding the test-file timeout rather
-  // than hanging the runner.
-  const run = async (label: string, source: string) => {
+  // the full 30 s, fails by exceeding the per-test timeout.
+  const run = async (source: string) => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", source],
       env: bunEnv,
@@ -1190,12 +1189,11 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { label, stdout: stdout.trim(), stderr, exitCode };
+    return { stdout: stdout.trim(), stderr, exitCode };
   };
 
   test("a single Atomics.wait spanning the deadline is interrupted", async () => {
     const { stdout, exitCode } = await run(
-      "single",
       `
       const vm = require("node:vm");
       const ia = new Int32Array(new SharedArrayBuffer(8));
@@ -1216,7 +1214,6 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
 
   test("chunked short waits are bounded by the wall-clock deadline", async () => {
     const { stdout, exitCode } = await run(
-      "chunked",
       `
       const vm = require("node:vm");
       const ia = new Int32Array(new SharedArrayBuffer(8));
@@ -1227,8 +1224,7 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
       } catch (e) { threw = e; }
       const dt = Date.now() - t0;
       if (!threw || threw.code !== "ERR_SCRIPT_EXECUTION_TIMEOUT") { console.log("bad result " + dt + "ms"); process.exit(1); }
-      // Before the fix this took ~150x the budget (many seconds); anything
-      // under 3 s is a pass for the wall-clock watchdog.
+      // Before the fix this took ~150x the budget; anything under 3 s passes.
       if (dt >= 3000) { console.log("late " + dt + "ms"); process.exit(1); }
       console.log("ok");
       `,
@@ -1238,11 +1234,15 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
 
   test("the next timed evaluation runs cleanly after a blocked deadline", async () => {
     const { stdout, exitCode } = await run(
-      "next",
       `
       const vm = require("node:vm");
       const ia = new Int32Array(new SharedArrayBuffer(8));
-      try { vm.runInNewContext("Atomics.wait(ia, 0, 0, 600)", { ia }, { timeout: 60 }); } catch {}
+      let first = null;
+      try { vm.runInNewContext("Atomics.wait(ia, 0, 0, 600)", { ia }, { timeout: 60 }); }
+      catch (e) { first = e; }
+      if (!first || first.code !== "ERR_SCRIPT_EXECUTION_TIMEOUT") {
+        console.log("precondition: " + (first && first.code)); process.exit(1);
+      }
       // On an assert-enabled build this call previously aborted with
       // ASSERTION FAILED: hasTimeLimit() in JSC::Watchdog::startTimer.
       const v = vm.runInNewContext("6 * 7", {}, { timeout: 5000 });
@@ -1252,12 +1252,12 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
     expect({ stdout, exitCode }).toEqual({ stdout: "ok 42", exitCode: 0 });
   });
 
-  test("runInThisContext enforces the deadline against Atomics.wait", async () => {
+  test("runInThisContext enforces the deadline and keeps caller microtasks", async () => {
     const { stdout, exitCode } = await run(
-      "thisContext",
       `
       const vm = require("node:vm");
       globalThis.ia = new Int32Array(new SharedArrayBuffer(8));
+      queueMicrotask(() => console.log("microtask"));
       let threw = null;
       try {
         vm.runInThisContext("Atomics.wait(ia, 0, 0, 30000)", { timeout: 100 });
@@ -1265,6 +1265,6 @@ describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
       console.log(threw && threw.code === "ERR_SCRIPT_EXECUTION_TIMEOUT" ? "ok" : "fail");
       `,
     );
-    expect({ stdout, exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+    expect({ stdout, exitCode }).toEqual({ stdout: "ok\nmicrotask", exitCode: 0 });
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,94 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("timeout enforces a wall-clock deadline against Atomics.wait", () => {
+  // Run in a subprocess so an unfixed build, which would sit in the wait for
+  // the full 30 s, fails the test by exceeding the test-file timeout rather
+  // than hanging the runner.
+  const run = async (label: string, source: string) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { label, stdout: stdout.trim(), stderr, exitCode };
+  };
+
+  test("a single Atomics.wait spanning the deadline is interrupted", async () => {
+    const { stdout, exitCode } = await run(
+      "single",
+      `
+      const vm = require("node:vm");
+      const ia = new Int32Array(new SharedArrayBuffer(8));
+      const t0 = Date.now();
+      let threw = null;
+      try {
+        vm.runInNewContext("Atomics.wait(ia, 0, 0, 30000)", { ia }, { timeout: 100 });
+      } catch (e) { threw = e; }
+      const dt = Date.now() - t0;
+      if (!threw) { console.log("returned after " + dt + "ms"); process.exit(1); }
+      if (threw.code !== "ERR_SCRIPT_EXECUTION_TIMEOUT") { console.log("code " + threw.code); process.exit(1); }
+      if (dt >= 30000) { console.log("late " + dt + "ms"); process.exit(1); }
+      console.log("ok " + threw.code);
+      `,
+    );
+    expect({ stdout, exitCode }).toEqual({ stdout: "ok ERR_SCRIPT_EXECUTION_TIMEOUT", exitCode: 0 });
+  });
+
+  test("chunked short waits are bounded by the wall-clock deadline", async () => {
+    const { stdout, exitCode } = await run(
+      "chunked",
+      `
+      const vm = require("node:vm");
+      const ia = new Int32Array(new SharedArrayBuffer(8));
+      const t0 = Date.now();
+      let threw = null;
+      try {
+        vm.runInNewContext("for (;;) Atomics.wait(ia, 0, 0, 10);", { ia }, { timeout: 100 });
+      } catch (e) { threw = e; }
+      const dt = Date.now() - t0;
+      if (!threw || threw.code !== "ERR_SCRIPT_EXECUTION_TIMEOUT") { console.log("bad result " + dt + "ms"); process.exit(1); }
+      // Before the fix this took ~150x the budget (many seconds); anything
+      // under 3 s is a pass for the wall-clock watchdog.
+      if (dt >= 3000) { console.log("late " + dt + "ms"); process.exit(1); }
+      console.log("ok");
+      `,
+    );
+    expect({ stdout, exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+  });
+
+  test("the next timed evaluation runs cleanly after a blocked deadline", async () => {
+    const { stdout, exitCode } = await run(
+      "next",
+      `
+      const vm = require("node:vm");
+      const ia = new Int32Array(new SharedArrayBuffer(8));
+      try { vm.runInNewContext("Atomics.wait(ia, 0, 0, 600)", { ia }, { timeout: 60 }); } catch {}
+      // On an assert-enabled build this call previously aborted with
+      // ASSERTION FAILED: hasTimeLimit() in JSC::Watchdog::startTimer.
+      const v = vm.runInNewContext("6 * 7", {}, { timeout: 5000 });
+      console.log("ok " + v);
+      `,
+    );
+    expect({ stdout, exitCode }).toEqual({ stdout: "ok 42", exitCode: 0 });
+  });
+
+  test("runInThisContext enforces the deadline against Atomics.wait", async () => {
+    const { stdout, exitCode } = await run(
+      "thisContext",
+      `
+      const vm = require("node:vm");
+      globalThis.ia = new Int32Array(new SharedArrayBuffer(8));
+      let threw = null;
+      try {
+        vm.runInThisContext("Atomics.wait(ia, 0, 0, 30000)", { timeout: 100 });
+      } catch (e) { threw = e; }
+      console.log(threw && threw.code === "ERR_SCRIPT_EXECUTION_TIMEOUT" ? "ok" : "fail");
+      `,
+    );
+    expect({ stdout, exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
### Problem

`node:vm`'s `timeout` option is not enforced against a guest blocked in `Atomics.wait`, and the missed deadline leaves JSC's Watchdog in an inconsistent state:

```js
const vm = require("node:vm");
const ia = new Int32Array(new SharedArrayBuffer(8));

let t = Date.now();
try { vm.runInNewContext("Atomics.wait(ia, 0, 0, 600)", { ia }, { timeout: 60 }); }
catch (e) { console.log(e.code, Date.now() - t); }
// node:  ERR_SCRIPT_EXECUTION_TIMEOUT ~65ms
// bun:   (no throw) returns "timed-out" after ~600ms

// On an assert-enabled build the next timed evaluation aborts:
//   ASSERTION FAILED: hasTimeLimit()
//   JavaScriptCore/runtime/Watchdog.cpp(133) JSC::Watchdog::startTimer
vm.runInNewContext("6*7", {}, { timeout: 5000 });

t = Date.now();
try { vm.runInNewContext("for(;;) Atomics.wait(ia, 0, 0, 10);", { ia }, { timeout: 80 }); }
catch (e) { console.log(e.code, Date.now() - t); }
// node:  ~81ms
// bun:   ~12000ms (150x past the budget)
```

`timeout` is the whole point of running untrusted code through `node:vm`, so a guest can currently evade the budget entirely with one `Atomics.wait`.

### Cause

`setupWatchdog` drove `timeout` through `JSC::Watchdog`, which is the wrong tool on two axes:

1. The Watchdog's timer only sets the `NeedWatchdogCheck` trap bit, which is polled at JS back-edges. A thread parked in `WaiterListManager::waitForSync` has no back-edge, so the fire is never observed while the wait runs; the script returns `"timed-out"` after the full wait.
2. `Watchdog::shouldTerminate` decides on CPU time (`m_cpuDeadline`), not wall-clock. A sleeping thread consumes ~zero CPU, so chunked short waits under an 80 ms budget only terminate once 80 ms of *CPU* has accumulated, ~150x later.

After the miss, `setTimeLimit(oldLimit)` resets `m_timeLimit` to infinity but `m_deadline` (wall-clock, now in the past) and the pending `NeedWatchdogCheck` trap bit remain. The next trap check calls `shouldTerminate`, finds `cpuTime < m_cpuDeadline`, and calls `startTimer(remaining)` with `hasTimeLimit()` false, tripping the assert.

### Fix

Replace the JSC Watchdog with a per-evaluation `TimeoutWatchdog` that spawns a worker thread parked on its own condvar until the wall-clock deadline. On fire it:

- sets `vm.setHasTerminationRequest()` so `waitForSync`'s loop predicate (`!vm.hasTerminationRequest()`) falls through and `Atomics.wait` returns `Terminated`,
- fires `vm.notifyNeedTermination()` so running JS terminates at the next back-edge,
- wakes `vm.syncWaiter()->condition()` (and keeps re-notifying at 1 ms until disarmed, covering the lost-wakeup window where the first notify lands between the waiter's predicate check and park).

Each scope only translates a termination it initiated (its own `didFire()` or a received SIGINT); a termination from an enclosing scope propagates unchanged. This matches Node's `Watchdog` semantics and keeps the nested-timeout tests reporting the correct (outer) limit.

`clearTerminationState` wipes the request flag, the pending termination exception, and the `NeedTermination`/`NeedWatchdogCheck` trap bits, so the next timed evaluation starts clean.

This is the same off-thread termination contract as #32802 (which does it for `worker.terminate()`), applied to `node:vm timeout`.

### Verification

```
# before
1: returned timed-out after 601ms
3: threw after 11907ms

# after
1: threw ERR_SCRIPT_EXECUTION_TIMEOUT after ~100ms
2: 42
3: threw after ~110ms
```

- New tests in `test/js/node/vm/vm.test.ts` cover: single long wait, chunked short waits, `runInThisContext`, and the follow-on timed evaluation. All four fail on the system bun (three by 5 s test timeout, one by subprocess abort on the assert build) and pass on this branch.
- All 98 `test/js/node/test/{parallel,sequential}/test-vm-*.js` pass, including `test-vm-timeout.js` (nested timeouts) and the three `test-vm-timeout-escape-promise-module*` variants.
- `BUN_JSC_validateExceptionChecks=1` clean on the repro and on `test-vm-timeout.js`.