### PR TITLE
node:vm: route afterEvaluate promise jobs to the handler's realm

### DIFF
--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1178,13 +1178,16 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
   });
 });
 
-describe('microtaskMode: "afterEvaluate" promise reaction routing', () => {
-  // A PromiseReactionJob's realm is the handler's realm (HTML HostEnqueuePromiseJob),
-  // so the job must land on the handler's realm's microtask queue. For a handler
-  // from the host realm attached to a context promise, the reaction runs on the
-  // host queue (the event loop drains it). For a context-realm handler attached
-  // to a host promise, the reaction is stranded on the context's own queue until
-  // the next evaluation in that context drains it.
+// A PromiseReactionJob's realm is the handler's realm (HTML HostEnqueuePromiseJob),
+// so the job must land on the handler's realm's microtask queue. For a handler
+// from the host realm attached to a context promise, the reaction runs on the
+// host queue (the event loop drains it). For a context-realm handler attached
+// to a host promise, the reaction is stranded on the context's own queue until
+// the next evaluation in that context drains it.
+//
+// The fix is a JavaScriptCore change (oven-sh/WebKit#277). Marked todo until the
+// WEBKIT_VERSION bump lands; a passing .todo then forces these to be enabled.
+describe.todo('microtaskMode: "afterEvaluate" promise reaction routing', () => {
   async function run(fixture: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,78 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe('microtaskMode: "afterEvaluate" promise reaction routing', () => {
+  // A PromiseReactionJob's realm is the handler's realm (HTML HostEnqueuePromiseJob),
+  // so the job must land on the handler's realm's microtask queue. For a handler
+  // from the host realm attached to a context promise, the reaction runs on the
+  // host queue (the event loop drains it). For a context-realm handler attached
+  // to a host promise, the reaction is stranded on the context's own queue until
+  // the next evaluation in that context drains it.
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("host .then handler on a fulfilled context promise runs on the host queue", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      const c = vm.createContext({}, { microtaskMode: "afterEvaluate" });
+      const p = vm.runInContext("Promise.resolve('v')", c);
+      p.then(v => console.log("then:" + v));
+      setImmediate(() => console.log("done"));
+    `);
+    expect({ stdout, stderr }).toEqual({ stdout: "then:v\ndone\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("host .catch handler on a rejected context promise runs on the host queue", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      const c = vm.createContext({}, { microtaskMode: "afterEvaluate" });
+      const p = vm.runInContext("Promise.reject(new Error('boom'))", c);
+      p.catch(e => console.log("catch:" + e.message));
+      setImmediate(() => console.log("done"));
+    `);
+    expect({ stdout, stderr }).toEqual({ stdout: "catch:boom\ndone\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("host .then handler on a pending context promise runs once it settles from the host", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      const c = vm.createContext({ setImmediate }, { microtaskMode: "afterEvaluate" });
+      const p = vm.runInContext("new Promise(r => setImmediate(() => r('v2')))", c);
+      p.then(v => console.log("then:" + v));
+      setImmediate(() => setImmediate(() => console.log("done")));
+    `);
+    expect({ stdout, stderr }).toEqual({ stdout: "then:v2\ndone\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("context .then handler on a host promise is stranded until the context is drained", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      let resolve;
+      const hostPromise = new Promise(r => { resolve = r; });
+      const log = [];
+      const c = vm.createContext({ hostPromise, mark: () => log.push("mark") }, { microtaskMode: "afterEvaluate" });
+      vm.runInContext("hostPromise.then(() => mark())", c);
+      resolve("ok");
+      setImmediate(() => {
+        log.push("before-drain");
+        vm.runInContext("", c);
+        log.push("after-drain");
+        console.log(log.join(","));
+      });
+    `);
+    expect({ stdout, stderr }).toEqual({ stdout: "before-drain,mark,after-drain\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Depends on oven-sh/WebKit#277. This PR adds the regression tests; the fix itself is a JavaScriptCore change and lands via a `WEBKIT_VERSION` bump once that PR is released.

## Repro

```js
const vm = require('node:vm');
const c = vm.createContext({}, { microtaskMode: 'afterEvaluate' });
const p = vm.runInContext("Promise.resolve('v')", c);
p.then(v => console.log('then:', v));      // host-realm handler
setImmediate(() => console.log('done'));
// node v26.3.0:  then: v  /  done
// bun (before):  done          <- host handler never runs
```

## Cause

`performPromiseThen` enqueues the reaction on the `then` function's realm (the context) instead of the handler's realm. With `microtaskMode: "afterEvaluate"` the context has its own `MicrotaskQueue` that only drains inside the next evaluation of that context, so a reaction whose handler is host code is stranded forever. HTML's HostEnqueuePromiseJob says a PromiseReactionJob's realm is the handler's realm, and V8 already routes accordingly.

## Fix

oven-sh/WebKit#277 adds `globalObjectForPromiseJob` and applies it at the `PromiseReactionJob` / `PromiseResolveThenableJob*` enqueue sites, gated on a VM-level `mayHaveMultipleMicrotaskQueues()` flag so the common single-queue case is one predicted-not-taken branch. The thenable-job routing keeps `await contextPromise` behaving like Node (stalls until the context is next drained).

## Tests

Four new cases in `test/js/node/vm/vm.test.ts` spawn fresh processes so they observe real microtask scheduling:

- host `.then` on a fulfilled context promise runs on the host queue
- host `.catch` on a rejected context promise runs on the host queue
- host `.then` on a pending context promise runs once it settles from the host
- context `.then` on a host promise is stranded until the context is drained

All four fail on current main and on a `bun bd` build (prebuilt WebKit), and pass on a `bun run build:local` build that includes oven-sh/WebKit#277. The existing Node compat tests (`test-vm-{script,module}-after-evaluate.js`, `test-vm-timeout-escape-promise*`) and `test/js/node/async_hooks/` continue to pass with the WebKit change.

## Gate

The fix lives in `vendor/WebKit/` (outside `src/`), so the stash-based fail-before/pass-after proof cannot observe it; with the prebuilt WebKit both runs fail the same way. The fail-before evidence is the `USE_SYSTEM_BUN=1` run above; pass-after is the local-WebKit build. This PR should land together with the `WEBKIT_VERSION` bump that picks up oven-sh/WebKit#277.