### PR TITLE
util: restore outer format after nested styleText

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -213,6 +213,32 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
+const StringPrototypeIndexOf = String.prototype.indexOf;
+const StringPrototypeSlice = String.prototype.slice;
+
+function replaceCloseCode(str, closeSeq, openSeq, keepClose) {
+  const closeLen = closeSeq.length;
+  let index = StringPrototypeIndexOf.$call(str, closeSeq);
+  if (index === -1) return str;
+
+  let result = "";
+  let lastIndex = 0;
+  const replacement = keepClose ? closeSeq + openSeq : openSeq;
+
+  do {
+    const afterClose = index + closeLen;
+    if (afterClose < str.length) {
+      result += StringPrototypeSlice.$call(str, lastIndex, index) + replacement;
+      lastIndex = afterClose;
+    } else {
+      break;
+    }
+    index = StringPrototypeIndexOf.$call(str, closeSeq, lastIndex);
+  } while (index !== -1);
+
+  return result + StringPrototypeSlice.$call(str, lastIndex);
+}
+
 function styleText(format, text) {
   validateString(text, "text");
 
@@ -220,23 +246,33 @@ function styleText(format, text) {
     let left = "";
     let right = "";
     for (const key of format) {
+      if (key === "none") continue;
       const formatCodes = inspect.colors[key];
       if (formatCodes == null) {
         validateOneOf(key, "format", ObjectKeys(inspect.colors));
       }
-      left += `\u001b[${formatCodes[0]}m`;
-      right = `\u001b[${formatCodes[1]}m${right}`;
+      const openNum = formatCodes[0];
+      const openSeq = `\u001b[${openNum}m`;
+      const closeSeq = `\u001b[${formatCodes[1]}m`;
+      left += openSeq;
+      right = `${closeSeq}${right}`;
+      text = replaceCloseCode(text, closeSeq, openSeq, openNum === 1 || openNum === 2);
     }
 
     return `${left}${text}${right}`;
   }
 
-  let formatCodes = inspect.colors[format];
+  if (format === "none") return text;
 
+  const formatCodes = inspect.colors[format];
   if (formatCodes == null) {
     validateOneOf(format, "format", ObjectKeys(inspect.colors));
   }
-  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+  const openNum = formatCodes[0];
+  const openSeq = `\u001b[${openNum}m`;
+  const closeSeq = `\u001b[${formatCodes[1]}m`;
+  text = replaceCloseCode(text, closeSeq, openSeq, openNum === 1 || openNum === 2);
+  return `${openSeq}${text}${closeSeq}`;
 }
 
 function getSystemErrorName(err: any) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -347,6 +347,25 @@ describe("util", () => {
     expect(util.styleText("red", "test")).toBe("\u001b[31mtest\u001b[39m");
   });
 
+  it("styleText restores outer format after nested styleText", () => {
+    expect(util.styleText("red", "a" + util.styleText("blue", "b") + "c")).toBe(
+      "\u001b[31ma\u001b[34mb\u001b[31mc\u001b[39m",
+    );
+    expect(util.styleText(["bold", "red"], "a" + util.styleText("green", "b") + "c")).toBe(
+      "\u001b[1m\u001b[31ma\u001b[32mb\u001b[31mc\u001b[39m\u001b[22m",
+    );
+    expect(util.styleText("red", "a" + util.styleText("green", "b" + util.styleText("blue", "c") + "d") + "e")).toBe(
+      "\u001b[31ma\u001b[32mb\u001b[34mc\u001b[32md\u001b[31me\u001b[39m",
+    );
+    expect(util.styleText("bold", "a" + util.styleText("dim", "b") + "c")).toBe(
+      "\u001b[1ma\u001b[2mb\u001b[22m\u001b[1mc\u001b[22m",
+    );
+    expect(util.styleText("red", "X\u001b[39m")).toBe("\u001b[31mX\u001b[39m\u001b[39m");
+    expect(util.styleText("red", "X\u001b[39mY\u001b[39m")).toBe("\u001b[31mX\u001b[31mY\u001b[39m\u001b[39m");
+    expect(util.styleText("none", "test")).toBe("test");
+    expect(util.styleText(["red", "none"], "test")).toBe("\u001b[31mtest\u001b[39m");
+  });
+
   it("styleText", () => {
     [undefined, null, false, 5n, 5, Symbol(), () => {}, {}].forEach(invalidOption => {
       assert.throws(


### PR DESCRIPTION
## Problem

Composing `util.styleText` calls drops the outer format after the inner call closes:

```js
import { styleText } from "node:util";
// node: "\u001b[31ma\u001b[34mb\u001b[31mc\u001b[39m"   -> 'c' is RED again
// bun : "\u001b[31ma\u001b[34mb\u001b[39mc\u001b[39m"   -> inner [39m leaks; 'c' is UNSTYLED
console.log(JSON.stringify(styleText("red", "a" + styleText("blue", "b") + "c")));
```

This is the normal way `styleText` is composed in a CLI (an error line in red containing a differently-colored token), so on bun the tail of every such message silently reverts to the terminal default.

## Cause

Bun's `styleText` only concatenates `open + text + close`. Node additionally rewrites any occurrence of the enclosing format's close sequence inside the text to its open sequence before wrapping (nodejs/node#55572), so an inner style's close becomes a re-open of the outer style. For `bold` and `dim`, which share close code `[22m`, Node keeps the close and inserts the open after it so the inner modifier is still terminated.

## Fix

Port Node's `replaceCloseCode` into `src/js/node/util.ts` and apply it per format (for both the single-string and array forms). A trailing close sequence is left untouched to match Node's output byte-for-byte. Also accept `"none"` as a no-op format, matching Node.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/util/util.test.js -t "restores outer"   # fails
bun bd test test/js/node/util/util.test.js                                       # 193 pass
bun bd test/js/node/test/parallel/test-util-styletext.js                         # exit 0
```

20 composed/edge cases (nesting, three levels, bold/dim, bg colors, trailing close, `none`) produce byte-identical output to Node v26.3.0.