### PR TITLE
util.parseArgs: fix segfault with allowNegative and bare "--no-"

### DIFF
--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -923,7 +923,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue newValue = JSC::JSValue::decode(encodedValue);
     auto& vm = global->vm();
-    WTF::String str = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
+    WTF::String str = key->isEmpty() ? WTF::emptyString() : key->toWTFString();
     Identifier id = Identifier::fromString(vm, str);
     auto existingValue = target->getIfPropertyExists(global, id);
     RETURN_IF_EXCEPTION(scope, {});
@@ -958,7 +958,7 @@ extern "C" void JSC__JSValue__putBunString(
     JSC::JSObject* target = JSC::JSValue::decode(encodedTarget).getObject();
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);
     auto& vm = global->vm();
-    WTF::String str = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
+    WTF::String str = key->isEmpty() ? WTF::emptyString() : key->toWTFString();
     Identifier id = Identifier::fromString(vm, str);
     target->putDirect(vm, id, value, 0);
 }

--- a/src/jsc/bindings/JSWrappingFunction.cpp
+++ b/src/jsc/bindings/JSWrappingFunction.cpp
@@ -27,7 +27,7 @@ JS_EXPORT_PRIVATE JSWrappingFunction* JSWrappingFunction::create(
     JSC::JSObject* wrappedFn = wrappedFnValue.getObject();
     ASSERT(wrappedFn != nullptr);
 
-    auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::emptyString() : symbolName->toWTFString();
+    auto nameStr = symbolName->isEmpty() ? WTF::emptyString() : symbolName->toWTFString();
     auto name = Identifier::fromString(vm, nameStr);
     // Pass callHostFunctionAsConstructor so `new` on the wrapper throws a
     // TypeError instead of jumping to a null native constructor.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3899,7 +3899,7 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__putMayBeIndex(JSC::Enco
     auto& vm = JSC::getVM(globalObject);
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
-    WTF::String keyStr = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
+    WTF::String keyStr = key->isEmpty() ? WTF::emptyString() : key->toWTFString();
     JSC::Identifier identifier = JSC::Identifier::fromString(vm, keyStr);
 
     JSC::JSObject* object = JSC::JSValue::decode(target).asCell()->getObject();
@@ -4290,7 +4290,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwn(JSC::EncodedJSValue JSValue0
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = JSC::JSValue::decode(JSValue0);
-    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::emptyString() : propertyName->toWTFString(BunString::ZeroCopy);
+    WTF::String propertyNameString = propertyName->isEmpty() ? WTF::emptyString() : propertyName->toWTFString(BunString::ZeroCopy);
     auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
     auto property = JSC::PropertyName(identifier);
     PropertySlot slot(value, PropertySlot::InternalMethodType::GetOwnProperty);

--- a/test/js/node/util/parse_args/parse-args-allow-negative.test.ts
+++ b/test/js/node/util/parse_args/parse-args-allow-negative.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// allowNegative strips the "no-" prefix; a bare "--no-" leaves an empty option
+// name. The resulting BunString (ZigString tag, len 0) used to reach
+// Identifier::fromString with a null WTF::String and segfault the process.
+test("parseArgs({ allowNegative: true }) with bare '--no-' does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { parseArgs } = require("node:util");
+        const r1 = parseArgs({ args: ["--no-"], allowNegative: true, strict: false });
+        console.log(JSON.stringify(r1));
+        try {
+          parseArgs({ args: ["--no-"], allowNegative: true, strict: true });
+          console.log("no throw");
+        } catch (e) {
+          console.log(e.code);
+        }
+        const r2 = parseArgs({
+          args: ["--no-", "--no-"],
+          allowNegative: true,
+          strict: false,
+          options: { "": { type: "boolean", multiple: true } },
+        });
+        console.log(JSON.stringify(r2));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.split("\n").filter(Boolean), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: [
+      '{"values":{"":false},"positionals":[]}',
+      "ERR_PARSE_ARGS_UNKNOWN_OPTION",
+      '{"values":{"":[false,false]},"positionals":[]}',
+    ],
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -1129,4 +1129,50 @@ describe("parseArgs extra tests", () => {
     expect(parseArgs({ allowPositionals: undefined })).toEqual({ values: { __proto__: null }, positionals: [] });
     expect(parseArgs({ allowPositionals: null })).toEqual({ values: { __proto__: null }, positionals: [] });
   });
+
+  describe("allowNegative", () => {
+    test("--no-foo stores foo=false", () => {
+      const result = parseArgs({ args: ["--no-foo"], allowNegative: true, strict: false });
+      expect(result).toEqual({ values: { __proto__: null, foo: false }, positionals: [] });
+    });
+
+    test("bare --no- with strict:false stores empty-name key as false", () => {
+      const result = parseArgs({ args: ["--no-"], allowNegative: true, strict: false });
+      expect(result).toEqual({ values: { __proto__: null, "": false }, positionals: [] });
+    });
+
+    test("bare --no- with strict:true throws unknown option", () => {
+      let error;
+      try {
+        parseArgs({ args: ["--no-"], allowNegative: true, strict: true });
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toMatchObject({ code: "ERR_PARSE_ARGS_UNKNOWN_OPTION", message: "Unknown option '--no-'" });
+    });
+
+    test("bare --no- with tokens:true produces empty-name token", () => {
+      const result = parseArgs({ args: ["--no-"], allowNegative: true, strict: false, tokens: true });
+      expect(result).toEqual({
+        values: { __proto__: null, "": false },
+        positionals: [],
+        tokens: [{ kind: "option", index: 0, name: "", rawName: "--no-", value: undefined, inlineValue: undefined }],
+      });
+    });
+
+    test("bare --no- with multiple:true on empty-name option appends to array", () => {
+      const result = parseArgs({
+        args: ["--no-", "--no-"],
+        allowNegative: true,
+        strict: false,
+        options: { "": { type: "boolean", multiple: true } },
+      });
+      expect(result).toEqual({ values: { __proto__: null, "": [false, false] }, positionals: [] });
+    });
+
+    test("--no- with allowNegative:false stores 'no-' as key", () => {
+      const result = parseArgs({ args: ["--no-"], allowNegative: false, strict: false });
+      expect(result).toEqual({ values: { __proto__: null, "no-": true }, positionals: [] });
+    });
+  });
 });


### PR DESCRIPTION
## Reproduction

```js
import { parseArgs } from "node:util";
console.log(JSON.stringify(parseArgs({ args: ["--no-"], allowNegative: true, strict: false })));
```

```
panic(main thread): Segmentation fault at address 0x0
```

Under a debug/ASAN build:

```
ASSERTION FAILED: m_ptr
wtf/RefPtr.h(126) : T &WTF::RefPtr<WTF::AtomStringImpl>::operator*()
```

Node.js returns `{"values":{"":false},"positionals":[]}`.

## Cause

When `allowNegative` is true, the `LoneLongOption` path in `parse_args.rs` strips `no-` from the option name. For the bare token `--no-`, `arg.substring(2)` is `"no-"` and `.substring(3)` yields an empty name. That empty name is a `bun_core::String` with `tag == ZigString` and `len == 0`, not `tag == Empty`.

`JSC__JSValue__putMayBeIndex` (and the sibling `getOwn`, `putBunString`, `upsertBunStringArray`, and `JSWrappingFunction::create` sites) guarded empty keys with `key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString()`. The zero-length ZigString falls through to `toWTFString()`, which returns a null `WTF::String` for `len == 0`. `Identifier::fromString(vm, nullStr)` then builds an identifier with a null `AtomStringImpl`, and `putDirectMayBeIndex` dereferences it.

## Fix

Replace the tag-only check with `key->isEmpty()` at all five binding sites. `BunString::isEmpty()` already handles every tag variant (`ZigString`/`StaticZigString` with `len == 0`, `WTFStringImpl` with `isEmpty()`, and `Empty`/`Dead`).

No change to `parse_args.rs` is needed: once the empty-key store works, the existing logic produces Node-compatible output (`values[""] = false` in non-strict mode, `ERR_PARSE_ARGS_UNKNOWN_OPTION` in strict mode, and a token with `name: ""` when `tokens: true`).

## Verification

Added `allowNegative` tests to `test/js/node/util/parse_args/parse-args.test.mjs` covering non-strict, strict, `tokens: true`, and `multiple: true` (which exercises the `getOwn` path). All crash under `bun bd` without the binding change and pass with it.