### PR TITLE
util.parseArgs: look up declared 'no-*' options before stripping with allowNegative

### DIFF
--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -261,19 +261,6 @@ fn check_option_usage(
         match option.r#type {
             OptionValueType::String => {
                 if matches!(token.value, ValueRef::Jsvalue(v) if !v.is_string()) {
-                    if token.negative {
-                        // the option was found earlier because we trimmed 'no-' from the name, so we throw
-                        // the expected unknown option error.
-                        let raw_name = RawNameFormatter {
-                            token: *token,
-                            raw: token.raw.as_bun_string(global)?,
-                        };
-                        let err = global.to_type_error(
-                            bun_jsc::ErrorCode::PARSE_ARGS_UNKNOWN_OPTION,
-                            format_args!("Unknown option '{raw_name}'"),
-                        );
-                        return Err(global.throw_value(err));
-                    }
                     let err = global.to_type_error(
                         bun_jsc::ErrorCode::PARSE_ARGS_INVALID_OPTION_VALUE,
                         format_args!(
@@ -289,7 +276,7 @@ fn check_option_usage(
                             } else {
                                 ""
                             },
-                            token.name.as_bun_string(global)?,
+                            option.long_name,
                         ),
                     );
                     return Err(global.throw_value(err));
@@ -312,7 +299,7 @@ fn check_option_usage(
                             } else {
                                 ""
                             },
-                            token.name.as_bun_string(global)?,
+                            option.long_name,
                         ),
                     );
                     return Err(global.throw_value(err));
@@ -373,7 +360,12 @@ fn store_option(
         value
     };
 
-    let is_multiple = option_idx.is_some_and(|idx| options[idx].multiple);
+    let is_multiple = if negative {
+        // Node checks `multiple` on the stripped name after negation.
+        find_option_by_long_name(key, options).is_some_and(|idx| options[idx].multiple)
+    } else {
+        option_idx.is_some_and(|idx| options[idx].multiple)
+    };
     if is_multiple {
         // Always store value in array, including for boolean.
         // values[long_option] starts out not present,
@@ -697,31 +689,45 @@ fn tokenize_args(
 
             TokenSubtype::LoneLongOption => {
                 // e.g. '--foo'
-                let mut long_option = arg.substring(2);
+                let long_option = arg.substring(2);
 
-                let negative = if ctx.allow_negative && long_option.has_prefix_comptime(b"no-") {
-                    long_option = long_option.substring(3);
-                    true
-                } else {
-                    false
-                };
-
-                let option_idx = find_option_by_long_name(long_option, options);
+                let mut option_idx = find_option_by_long_name(long_option, options);
                 let option_type: OptionValueType =
                     option_idx.map_or(OptionValueType::Boolean, |idx| options[idx].r#type);
 
                 let mut value: Option<JSValue> = None;
-                if option_type == OptionValueType::String && index + 1 < num_args && !negative {
+                if option_type == OptionValueType::String && index + 1 < num_args {
                     // e.g. '--foo', "bar"
                     value = Some(args.get(global, index + 1)?);
                     bun_output::scoped_log!(parseArgs, "  (consuming next as value)");
                 }
 
+                // Node strips `no-` in storeOption only when the value is undefined.
+                let negative = ctx.allow_negative
+                    && value.is_none()
+                    && long_option.has_prefix_comptime(b"no-");
+
+                let name = if negative {
+                    let stripped = if long_option.length() > 3 {
+                        long_option.substring(3)
+                    } else {
+                        String::empty()
+                    };
+                    if option_idx.is_none() {
+                        // Strict mode accepts the stripped option only when it is boolean.
+                        option_idx = find_option_by_long_name(stripped, options)
+                            .filter(|&i| options[i].r#type == OptionValueType::Boolean);
+                    }
+                    stripped
+                } else {
+                    long_option
+                };
+
                 ctx.handle_token(&Token::Option(OptionToken {
                     index,
                     value: ValueRef::Jsvalue(value.unwrap_or(JSValue::UNDEFINED)),
                     inline_value: value.is_none(),
-                    name: ValueRef::Bunstr(long_option),
+                    name: ValueRef::Bunstr(name),
                     parse_type: OptionParseType::LoneLongOption,
                     raw: arg_ref,
                     option_idx,

--- a/test/js/node/util/parse_args/parse-args-allow-negative-declared.test.ts
+++ b/test/js/node/util/parse_args/parse-args-allow-negative-declared.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// allowNegative: an option literally declared as "no-X" must still be accepted.
+// Bun previously stripped the no- prefix before lookup, so the declared option
+// could never match and strict mode threw ERR_PARSE_ARGS_UNKNOWN_OPTION.
+test("parseArgs({ allowNegative: true }) accepts an option literally declared as 'no-X'", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { parseArgs } = require("node:util");
+        const r1 = parseArgs({
+          args: ["--no-color"],
+          options: { "no-color": { type: "boolean" } },
+          allowNegative: true,
+        });
+        console.log(JSON.stringify(r1));
+        const r2 = parseArgs({
+          args: ["--no-color", "val"],
+          options: { "no-color": { type: "string" } },
+          allowNegative: true,
+          allowPositionals: true,
+        });
+        console.log(JSON.stringify(r2));
+        const r3 = parseArgs({
+          args: ["--no-"],
+          options: { "no-": { type: "boolean" } },
+          allowNegative: true,
+        });
+        console.log(JSON.stringify(r3));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.split("\n").filter(Boolean), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: [
+      '{"values":{"color":false},"positionals":[]}',
+      '{"values":{"no-color":"val"},"positionals":[]}',
+      '{"values":{"":false},"positionals":[]}',
+    ],
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/node/util/parse_args/parse-args-allow-negative-declared.test.ts
+++ b/test/js/node/util/parse_args/parse-args-allow-negative-declared.test.ts
@@ -36,14 +36,13 @@ test("parseArgs({ allowNegative: true }) accepts an option literally declared as
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.split("\n").filter(Boolean), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.split("\n").filter(Boolean), exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: [
       '{"values":{"color":false},"positionals":[]}',
       '{"values":{"no-color":"val"},"positionals":[]}',
       '{"values":{"":false},"positionals":[]}',
     ],
-    stderr: "",
     exitCode: 0,
     signalCode: null,
   });

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -980,6 +980,152 @@ describe("parseArgs", () => {
 //
 
 describe("parseArgs extra tests", () => {
+  const expectToThrowErrorMatching = (fn, errorPattern) => {
+    let error = undefined;
+    try {
+      fn();
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toMatchObject(errorPattern);
+  };
+
+  describe("allowNegative with declared no-* options", () => {
+    test("boolean option literally declared as 'no-color' is accepted", () => {
+      const result = parseArgs({
+        args: ["--no-color"],
+        options: { "no-color": { type: "boolean" } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, color: false }, positionals: [] });
+    });
+
+    test("string option declared as 'no-color' consumes the next arg", () => {
+      const result = parseArgs({
+        args: ["--no-color", "val"],
+        options: { "no-color": { type: "string" } },
+        allowNegative: true,
+        allowPositionals: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, "no-color": "val" }, positionals: [] });
+    });
+
+    test("string option declared as 'no-color' with missing value throws INVALID_OPTION_VALUE", () => {
+      expectToThrowErrorMatching(
+        () =>
+          parseArgs({
+            args: ["--no-color"],
+            options: { "no-color": { type: "string", short: "n" } },
+            allowNegative: true,
+          }),
+        { code: "ERR_PARSE_ARGS_INVALID_OPTION_VALUE", message: "Option '-n, --no-color <value>' argument missing" },
+      );
+    });
+
+    test("multiple:true on the declared 'no-color' option is not applied to the stripped key", () => {
+      const result = parseArgs({
+        args: ["--no-color", "--no-color"],
+        options: { "no-color": { type: "boolean", multiple: true } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, color: false }, positionals: [] });
+    });
+
+    test("default on the declared 'no-color' option is applied since the stripped key is stored", () => {
+      const result = parseArgs({
+        args: ["--no-color"],
+        options: { "no-color": { type: "boolean", default: true } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, "color": false, "no-color": true }, positionals: [] });
+    });
+
+    test("tokens output has the stripped name", () => {
+      const result = parseArgs({
+        args: ["--no-color"],
+        options: { "no-color": { type: "boolean" } },
+        allowNegative: true,
+        tokens: true,
+      });
+      expect(result.tokens).toEqual([
+        { kind: "option", index: 0, name: "color", rawName: "--no-color", value: undefined, inlineValue: undefined },
+      ]);
+    });
+
+    test("declared 'no-color' string takes precedence over declared 'color' boolean for value consumption", () => {
+      const result = parseArgs({
+        args: ["--no-color", "val"],
+        options: { "no-color": { type: "string" }, "color": { type: "boolean", multiple: true } },
+        allowNegative: true,
+        allowPositionals: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, "no-color": "val" }, positionals: [] });
+    });
+
+    test("boolean option declared as 'no-foo' does not consume next arg as value", () => {
+      const result = parseArgs({
+        args: ["--no-foo", "val"],
+        options: { "no-foo": { type: "boolean" } },
+        allowNegative: true,
+        allowPositionals: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, foo: false }, positionals: ["val"] });
+    });
+
+    test("nested 'no-no-foo' strips one level", () => {
+      const result = parseArgs({
+        args: ["--no-no-foo"],
+        options: { "no-no-foo": { type: "boolean" } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, "no-foo": false }, positionals: [] });
+    });
+
+    test("option declared as bare 'no-' resolves to empty key", () => {
+      const result = parseArgs({
+        args: ["--no-"],
+        options: { "no-": { type: "boolean" } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, "": false }, positionals: [] });
+    });
+
+    test("bare '--no-' in non-strict mode stores empty key without crashing", () => {
+      const result = parseArgs({
+        args: ["--no-"],
+        options: {},
+        allowNegative: true,
+        strict: false,
+        tokens: true,
+      });
+      expect(result.values).toEqual({ __proto__: null, "": false });
+      expect(result.tokens).toEqual([
+        { kind: "option", index: 0, name: "", rawName: "--no-", value: undefined, inlineValue: undefined },
+      ]);
+    });
+
+    test("stripped name declared as string still throws UNKNOWN_OPTION in strict mode", () => {
+      expectToThrowErrorMatching(
+        () =>
+          parseArgs({
+            args: ["--no-color"],
+            options: { color: { type: "string" } },
+            allowNegative: true,
+          }),
+        { code: "ERR_PARSE_ARGS_UNKNOWN_OPTION" },
+      );
+    });
+
+    test("multiple:true on the stripped name is applied", () => {
+      const result = parseArgs({
+        args: ["--no-color", "--no-color"],
+        options: { color: { type: "boolean", multiple: true } },
+        allowNegative: true,
+      });
+      expect(result).toEqual({ values: { __proto__: null, color: [false, false] }, positionals: [] });
+    });
+  });
+
   test("accepts numeric options", () => {
     const result = parseArgs({
       allowPositionals: true,


### PR DESCRIPTION
## Reproduction

```js
import { parseArgs } from "node:util";

parseArgs({
  args: ["--no-color"],
  options: { "no-color": { type: "boolean" } },
  allowNegative: true,
});
```

Node 26 returns `{ values: { color: false }, positionals: [] }`. Bun throws `ERR_PARSE_ARGS_UNKNOWN_OPTION: Unknown option '--no-color'` even though `no-color` is exactly what the config declares.

## Cause

In `tokenize_args`, the `LoneLongOption` arm stripped the `no-` prefix before looking anything up whenever `allowNegative` was set, then resolved only the stripped name. A config entry literally named `no-X` could therefore never match, and when the stripped name was also undeclared strict mode rejected the flag.

Node does this differently: `argsToTokens` never handles `allowNegative` at all. Value consumption and `checkOptionUsage` use the full `no-X` name (falling back to the stripped name only when `no-X` is not declared), and `storeOption` strips `no-` only when the value is undefined.

## Fix

In `LoneLongOption`:
- Look up the full `no-X` name first to decide value consumption and set `option_idx` for strict validation.
- Compute `negative` only when `allowNegative` is set, the arg starts with `no-`, and no value was consumed.
- When `negative`, use the stripped name for the token (storage and tokens output). If the full name was not declared, fall back to the stripped name for `option_idx`, but only when that option is boolean (Node throws `ERR_PARSE_ARGS_UNKNOWN_OPTION` when the stripped option is string).
- Normalize the stripped name to `String::empty()` when it has zero length so `put_may_be_index` does not receive a zero-length `ZigString` (see also #33767 for a deeper fix in the bindings).

In `check_option_usage`, drop the now-unreachable `negative` special case and use the matched option's `long_name` in error messages so `Option '--no-color <value>' argument missing` names the declared option rather than the stripped key.

In `store_option`, when `negative` is set, look `multiple` up by the stripped name rather than `option_idx`, matching Node's `optionsGetOwn(options, longOption, 'multiple')` after the strip.

## Verification

Added an `allowNegative with declared no-* options` block to `test/js/node/util/parse_args/parse-args.test.mjs` covering the declared `no-X` boolean, string, `multiple`, `default`, tokens, nested `no-no-foo`, and bare `--no-` cases, plus regression guards for the existing stripped-name behaviour. All assertions were cross-checked against Node v26.3.0.

Fails with `USE_SYSTEM_BUN=1 bun test` (10 failures plus a segfault on the `--no-` case), passes with `bun bd test`. `test/js/node/test/parallel/test-parse-args.mjs` also passes.