### PR TITLE
node:test: run a root-level before() hook at registration time

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -728,11 +728,30 @@ function createDescribe(arg0: unknown, arg1: unknown, arg2: unknown) {
       ctx = originalContext;
     };
 
+    let result: unknown;
     try {
-      return fn(context);
-    } finally {
+      result = fn(context);
+    } catch (error) {
       endDescribe();
+      throw error;
     }
+    if (result instanceof Promise) {
+      // bun:test awaits an async describe body before collecting the next
+      // sibling; keep ctx set until it settles so before() inside the
+      // continuation is still recognised as suite-level.
+      return (result as Promise<unknown>).then(
+        value => {
+          endDescribe();
+          return value;
+        },
+        error => {
+          endDescribe();
+          throw error;
+        },
+      );
+    }
+    endDescribe();
+    return result;
   };
 
   return { name, options, fn: runDescribe };

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -598,8 +598,30 @@ test.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 };
 
 function before(arg0: unknown, arg1: unknown) {
-  const { fn } = createHook(arg0, arg1);
   const { beforeAll } = bunTest();
+  if (ctx === undefined) {
+    // Node's root test is already executing while the module body runs, so a
+    // root-level before() hook fires at registration time rather than after
+    // collection. Tests generated from state such a hook builds depend on this.
+    const { fn } = parseHookOptions(arg0, arg1);
+    let result: unknown;
+    try {
+      result = fn();
+    } catch (error) {
+      beforeAll(() => {
+        throw error;
+      });
+      return;
+    }
+    if (result instanceof Promise) {
+      const pending = result as Promise<unknown>;
+      // Surface rejection via beforeAll, not as an unhandled rejection.
+      pending.catch(() => {});
+      beforeAll(() => pending);
+    }
+    return;
+  }
+  const { fn } = createHook(arg0, arg1);
   beforeAll(fn);
 }
 

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -54,7 +54,7 @@ describe("node:test", () => {
   });
 });
 
-describe("node:test root before() timing", () => {
+describe.concurrent("node:test root before() timing", () => {
   // In Node a root-level before() hook runs synchronously at the call site
   // because the root test is already executing while the module body runs.
   // Suite-level before() (inside a describe) is deferred in both runtimes.

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -186,6 +186,43 @@ describe.concurrent("node:test root before() timing", () => {
       exitCode: 0,
     });
   });
+
+  test("a suite-level before() after an await in an async describe() is still deferred", async () => {
+    using dir = tempDir("node-test-async-suite-before", {
+      "asyncsuite.test.mjs": `
+        import assert from 'node:assert';
+        import { test, describe, before } from 'node:test';
+        let g;
+        describe('A', async () => {
+          await 0;
+          before(() => { g = 'A'; });
+          test('a', () => { console.log('LOG:test-a g=' + g); assert.strictEqual(g, 'A'); });
+        });
+        describe('B', async () => {
+          await 0;
+          before(() => { g = 'B'; });
+          test('b', () => { console.log('LOG:test-b g=' + g); assert.strictEqual(g, 'B'); });
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "asyncsuite.test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const logs = stdout
+      .split("\n")
+      .filter(l => l.startsWith("LOG:"))
+      .join("\n");
+    expect({ logs, stderr, exitCode }).toMatchObject({
+      logs: "LOG:test-a g=A\nLOG:test-b g=B",
+      stderr: expect.stringContaining("2 pass"),
+      exitCode: 0,
+    });
+  });
 });
 
 async function runTests(filenames: string[]) {

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("node:test", () => {
@@ -50,6 +50,140 @@ describe("node:test", () => {
     expect({ exitCode, stderr }).toMatchObject({
       exitCode: 0,
       stderr: expect.stringContaining("0 fail"),
+    });
+  });
+});
+
+describe("node:test root before() timing", () => {
+  // In Node a root-level before() hook runs synchronously at the call site
+  // because the root test is already executing while the module body runs.
+  // Suite-level before() (inside a describe) is deferred in both runtimes.
+  test("runs a root before() synchronously so generated tests are registered", async () => {
+    using dir = tempDir("node-test-root-before", {
+      "rootbefore.test.mjs": `
+        import { test, describe, before } from 'node:test';
+
+        let cases = null;
+        before(() => { cases = ['a', 'b']; console.log('LOG:before-ran'); });
+        console.log('LOG:module-continues cases=' + JSON.stringify(cases));
+
+        describe('generated', () => {
+          console.log('LOG:describe-body cases=' + JSON.stringify(cases));
+          for (const c of (cases ?? [])) test('case ' + c, () => {});
+        });
+
+        test('control', () => {});
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "rootbefore.test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const logs = stdout
+      .split("\n")
+      .filter(l => l.startsWith("LOG:"))
+      .join("\n");
+    expect({ logs, stderr, exitCode }).toMatchObject({
+      logs: ['LOG:before-ran', 'LOG:module-continues cases=["a","b"]', 'LOG:describe-body cases=["a","b"]'].join("\n"),
+      stderr: expect.stringContaining("3 pass"),
+      exitCode: 0,
+    });
+  });
+
+  test("a throwing root before() fails the run but does not abort module evaluation", async () => {
+    using dir = tempDir("node-test-root-before-throw", {
+      "rootbefore.test.mjs": `
+        import { test, before } from 'node:test';
+        before(() => { console.log('LOG:before-ran'); throw new Error('before failed'); });
+        console.log('LOG:module-continues');
+        test('control', () => {});
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "rootbefore.test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const logs = stdout
+      .split("\n")
+      .filter(l => l.startsWith("LOG:"))
+      .join("\n");
+    expect({ logs, stderr, exitCode }).toMatchObject({
+      logs: "LOG:before-ran\nLOG:module-continues",
+      stderr: expect.stringContaining("before failed"),
+      exitCode: 1,
+    });
+  });
+
+  test("an async root before() runs its sync prefix now and tests await its completion", async () => {
+    using dir = tempDir("node-test-root-before-async", {
+      "rootbefore.test.mjs": `
+        import assert from 'node:assert';
+        import { test, before } from 'node:test';
+        let x = 0;
+        before(async () => {
+          x = 1;
+          await new Promise(r => setImmediate(r));
+          x = 2;
+        });
+        console.log('LOG:module-continues x=' + x);
+        test('control', () => { console.log('LOG:test x=' + x); assert.strictEqual(x, 2); });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "rootbefore.test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const logs = stdout
+      .split("\n")
+      .filter(l => l.startsWith("LOG:"))
+      .join("\n");
+    expect({ logs, stderr, exitCode }).toMatchObject({
+      logs: "LOG:module-continues x=1\nLOG:test x=2",
+      stderr: expect.stringContaining("1 pass"),
+      exitCode: 0,
+    });
+  });
+
+  test("a suite-level before() inside describe() is still deferred", async () => {
+    using dir = tempDir("node-test-suite-before", {
+      "suitebefore.test.mjs": `
+        import { test, describe, before } from 'node:test';
+        describe('suite', () => {
+          let x = 0;
+          before(() => { x = 1; console.log('LOG:suite-before-ran'); });
+          console.log('LOG:describe-body x=' + x);
+          test('t', () => { console.log('LOG:test x=' + x); });
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "suitebefore.test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const logs = stdout
+      .split("\n")
+      .filter(l => l.startsWith("LOG:"))
+      .join("\n");
+    expect({ logs, stderr, exitCode }).toMatchObject({
+      logs: "LOG:describe-body x=0\nLOG:suite-before-ran\nLOG:test x=1",
+      stderr: expect.stringContaining("1 pass"),
+      exitCode: 0,
     });
   });
 });

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -88,7 +88,7 @@ describe("node:test root before() timing", () => {
       .filter(l => l.startsWith("LOG:"))
       .join("\n");
     expect({ logs, stderr, exitCode }).toMatchObject({
-      logs: ['LOG:before-ran', 'LOG:module-continues cases=["a","b"]', 'LOG:describe-body cases=["a","b"]'].join("\n"),
+      logs: ["LOG:before-ran", 'LOG:module-continues cases=["a","b"]', 'LOG:describe-body cases=["a","b"]'].join("\n"),
       stderr: expect.stringContaining("3 pass"),
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem

In Node the root test is already executing while the test file's module body runs, so a `before()` hook registered at the top level fires synchronously at the call site. That makes this a supported idiom for generating tests from fixtures:

```js
import { test, describe, before } from 'node:test';

let cases = null;
before(() => { cases = ['a', 'b']; console.log('LOG:before-ran'); });
console.log('LOG:module-continues cases=' + JSON.stringify(cases));

describe('generated', () => {
  for (const c of (cases ?? [])) test('case ' + c, () => {});
});
test('control', () => {});
```

`node --test` prints `LOG:before-ran` first, then `cases=["a","b"]`, and runs 3 tests. Bun printed the lines in the opposite order with `cases=null` and ran only the control test. The generated tests were silently never registered and the run still exited 0.

### Cause

`src/js/node/test.ts` mapped every `before()` to bun:test's `beforeAll`, which runs after collection. The root hook's side effects were never visible to module-level code or describe bodies.

### Fix

A root-level `before()` (registered while no describe/test context is active) now invokes the hook immediately. A synchronous throw is caught and re-raised from `beforeAll` so the run fails without aborting module evaluation, and a returned promise is awaited from `beforeAll` so tests still wait for async setup and see its rejection. Suite-level `before()` inside a `describe` is unchanged; it is deferred in both runtimes.

The root-level check keys on the module-level `ctx` the shim already maintains. `runDescribe` previously restored `ctx` in a synchronous `try/finally`, so a `before()` called after an `await` in an async `describe()` body would have observed `ctx === undefined` and taken the root-level branch. `runDescribe` now restores `ctx` only after an async body's promise settles, the same way `runTest` already does; bun:test collects sibling async describe bodies sequentially, so `ctx` stays correct across the await.

### Verification

Five new cases in `test/js/node/test_runner/node-test.test.ts`, verified against Node v26.3.0:

- the repro above registers 3 tests with the hook running before module evaluation continues
- a throwing root `before()` fails the run (exit 1) but module evaluation continues
- an async root `before()` runs its synchronous prefix immediately and tests await the promise
- a suite-level `before()` inside a `describe` stays deferred (regression guard)
- a suite-level `before()` after an `await` in an async `describe()` body stays deferred (regression guard for the `ctx` restore)

The existing `02-hooks.js` hook-ordering fixture still passes.

```
bun bd test test/js/node/test_runner/node-test.test.ts   # 23 pass, 0 fail
```

Without the fix, 3 of the 5 new cases fail (the two suite-level guards pass on both).
