### PR TITLE
node:test: make mock.fn() a transparent Proxy over the original

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -16,7 +16,11 @@ function run() {
 // Port of Node.js lib/internal/test_runner/mock/mock.js (v26.3.0):
 //   https://github.com/nodejs/node/blob/50c35fea9e64d50ab3bb5f359e8523de89d6c798/lib/internal/test_runner/mock/mock.js
 // API reference: https://nodejs.org/api/test.html#class-mocktracker
-let trackMockCall: (ctx: MockFunctionContext, thisArg: unknown, args: unknown[], target: unknown) => unknown;
+const ReflectConstruct = Reflect.construct;
+const ReflectGet = Reflect.get;
+
+let nextMockImpl: (ctx: MockFunctionContext) => Function;
+let pushMockCall: (ctx: MockFunctionContext, call: unknown) => void;
 
 class MockFunctionContext {
   #calls: unknown[];
@@ -84,12 +88,7 @@ class MockFunctionContext {
   }
 
   static {
-    trackMockCall = function trackMockCall(
-      ctx: MockFunctionContext,
-      thisArg: unknown,
-      args: unknown[],
-      target: unknown,
-    ) {
+    nextMockImpl = function nextMockImpl(ctx: MockFunctionContext) {
       const callIndex = ctx.#calls.length;
       let implementation = ctx.#onceImplementations.get(callIndex);
       if (implementation !== undefined) {
@@ -103,30 +102,10 @@ class MockFunctionContext {
       if (callIndex + 1 === ctx.#times) {
         ctx.restore();
       }
-      // node records the call in a finally *after* invoking, so a reentrant
-      // implementation observes callCount() === N (not N+1), recursive calls
-      // record in completion order, and the stack is captured post-invoke.
-      let result: unknown;
-      let error: unknown;
-      try {
-        result =
-          target === undefined
-            ? (implementation as Function).$apply(thisArg, args)
-            : Reflect.construct(implementation as Function, args, target as Function);
-        return result;
-      } catch (e) {
-        error = e;
-        throw e;
-      } finally {
-        ctx.#calls.push({
-          arguments: args,
-          error,
-          result,
-          stack: new Error(),
-          target,
-          this: thisArg,
-        });
-      }
+      return implementation;
+    };
+    pushMockCall = function pushMockCall(ctx: MockFunctionContext, call: unknown) {
+      ctx.#calls.push(call);
     };
   }
 }
@@ -139,23 +118,60 @@ function createMockFunction(
 ) {
   const context = new MockFunctionContext(original, implementation, restore, times);
   kMockContexts.push(context);
-  function mockFunction(this: unknown, ...args: unknown[]) {
-    return trackMockCall(context, this, args, new.target);
-  }
-  Object.defineProperty(mockFunction, "mock", {
-    value: context,
-    writable: false,
-    enumerable: false,
-  });
-  Object.defineProperty(mockFunction, "length", {
-    value: original.length,
-    configurable: true,
-  });
-  Object.defineProperty(mockFunction, "name", {
-    value: original.name,
-    configurable: true,
-  });
-  return mockFunction;
+  // Node returns a Proxy over the original so .prototype, statics, name,
+  // length and constructability pass through unchanged; see #setupMock in
+  // lib/internal/test_runner/mock/mock.js.
+  return new Proxy(original, {
+    __proto__: null,
+    apply(_fn: Function, thisArg: unknown, argList: unknown[]) {
+      const fn = nextMockImpl(context);
+      let result: unknown;
+      let error: unknown;
+      try {
+        result = fn.$apply(thisArg, argList);
+      } catch (err) {
+        error = err;
+        throw err;
+      } finally {
+        pushMockCall(context, {
+          arguments: argList,
+          error,
+          result,
+          stack: new Error(),
+          target: undefined,
+          this: thisArg,
+        });
+      }
+      return result;
+    },
+    construct(target: Function, argList: unknown[], newTarget: Function) {
+      const realTarget = nextMockImpl(context);
+      let result: unknown;
+      let error: unknown;
+      try {
+        result = ReflectConstruct(realTarget, argList, newTarget);
+      } catch (err) {
+        error = err;
+        throw err;
+      } finally {
+        pushMockCall(context, {
+          arguments: argList,
+          error,
+          result,
+          stack: new Error(),
+          target,
+          this: result,
+        });
+      }
+      return result;
+    },
+    get(target: Function, property: PropertyKey, receiver: unknown) {
+      if (property === "mock") {
+        return context;
+      }
+      return ReflectGet(target, property, receiver);
+    },
+  } as ProxyHandler<Function>);
 }
 
 const kMockContexts: MockFunctionContext[] = [];

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
@@ -217,6 +217,10 @@ describe("node:test mock tracker semantics", () => {
 describe("node:test mock.fn is a transparent Proxy", () => {
   const { mock } = require("node:test");
 
+  afterEach(() => {
+    mock.reset();
+  });
+
   class Service {
     url: string;
     static kind = "svc";
@@ -246,7 +250,6 @@ describe("node:test mock.fn is a transparent Proxy", () => {
       staticKind: "svc",
       callCount: 1,
     });
-    mock.reset();
   });
 
   test("construct call record has target=original and this=result, like node", () => {
@@ -264,7 +267,6 @@ describe("node:test mock.fn is a transparent Proxy", () => {
       resultIsInstance: true,
       args: ["http://y"],
     });
-    mock.reset();
   });
 
   test("name and length pass through from the original", () => {
@@ -277,7 +279,6 @@ describe("node:test mock.fn is a transparent Proxy", () => {
       length: 3,
       proto: "object",
     });
-    mock.reset();
   });
 
   test("a mocked arrow function is not constructible and records no call", () => {
@@ -288,7 +289,6 @@ describe("node:test mock.fn is a transparent Proxy", () => {
     expect(m.mock.callCount()).toBe(0);
     expect(m(1, 2)).toBe(3);
     expect(m.mock.callCount()).toBe(1);
-    mock.reset();
   });
 
   test("properties pass through to the original function", () => {
@@ -296,7 +296,6 @@ describe("node:test mock.fn is a transparent Proxy", () => {
     const m = mock.fn(original);
     (original as any).custom = 42;
     expect((m as any).custom).toBe(42);
-    mock.reset();
   });
 });
 

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -214,6 +214,92 @@ describe("node:test mock tracker semantics", () => {
   });
 });
 
+describe("node:test mock.fn is a transparent Proxy", () => {
+  const { mock } = require("node:test");
+
+  class Service {
+    url: string;
+    static kind = "svc";
+    constructor(url: string) {
+      this.url = url;
+    }
+    fetch() {
+      return "real:" + this.url;
+    }
+  }
+
+  test("mocking a constructor preserves prototype, statics and instanceof", () => {
+    const MockedService = mock.fn(Service);
+    const s = new MockedService("http://x");
+    expect({
+      instanceOf: s instanceof Service,
+      protoMethod: typeof s.fetch,
+      fetchResult: s.fetch(),
+      prototypeIdentity: MockedService.prototype === Service.prototype,
+      staticKind: MockedService.kind,
+      callCount: MockedService.mock.callCount(),
+    }).toEqual({
+      instanceOf: true,
+      protoMethod: "function",
+      fetchResult: "real:http://x",
+      prototypeIdentity: true,
+      staticKind: "svc",
+      callCount: 1,
+    });
+    mock.reset();
+  });
+
+  test("construct call record has target=original and this=result, like node", () => {
+    const MockedService = mock.fn(Service);
+    const s = new MockedService("http://y");
+    const call = MockedService.mock.calls[0];
+    expect({
+      targetIsOriginal: call.target === Service,
+      thisIsResult: call.this === s,
+      resultIsInstance: call.result === s,
+      args: call.arguments,
+    }).toEqual({
+      targetIsOriginal: true,
+      thisIsResult: true,
+      resultIsInstance: true,
+      args: ["http://y"],
+    });
+    mock.reset();
+  });
+
+  test("name and length pass through from the original", () => {
+    function orig(a: number, b: number, c: number) {
+      return a + b + c;
+    }
+    const m = mock.fn(orig);
+    expect({ name: m.name, length: m.length, proto: typeof m.prototype }).toEqual({
+      name: "orig",
+      length: 3,
+      proto: "object",
+    });
+    mock.reset();
+  });
+
+  test("a mocked arrow function is not constructible and records no call", () => {
+    const arrow = (a: number, b: number) => a + b;
+    const m = mock.fn(arrow);
+    expect(typeof m.prototype).toBe("undefined");
+    expect(() => new (m as any)(1, 2)).toThrow(TypeError);
+    expect(m.mock.callCount()).toBe(0);
+    expect(m(1, 2)).toBe(3);
+    expect(m.mock.callCount()).toBe(1);
+    mock.reset();
+  });
+
+  test("properties pass through to the original function", () => {
+    function original() {}
+    const m = mock.fn(original);
+    (original as any).custom = 42;
+    expect((m as any).custom).toBe(42);
+    mock.reset();
+  });
+});
+
 test("the call record is pushed after the implementation runs, like node", () => {
   const { mock } = require("node:test");
   let inside = -1;


### PR DESCRIPTION
## What does this PR do?

`mock.fn(original)` from `node:test` previously returned a fresh wrapper function. That meant the mock had its own `.prototype`, none of the original's static properties, and `new (mock.fn(C))()` produced an object that was not `instanceof C` and had none of `C`'s prototype methods. A mocked arrow function was also incorrectly constructible (and recorded a call before throwing).

Node's `MockTracker.prototype.fn` returns `new Proxy(original, {apply, construct, get})` (see [`#setupMock` in `lib/internal/test_runner/mock/mock.js`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/test_runner/mock/mock.js)). Because the Proxy target is the original function, `.prototype`, statics, `name`, `length`, constructability and `new.target` all pass through unchanged, and `.mock` is surfaced via the `get` trap rather than as an own property.

This PR switches `createMockFunction` to return a Proxy with `apply`/`construct`/`get` traps, matching Node. It also aligns the construct call record with Node: `target` is the original function (the Proxy target) and `this` is the constructed result.

## Repro

```js
import { test, mock } from 'node:test';
import assert from 'node:assert';

class Service {
  constructor(url) { this.url = url; }
  fetch() { return 'real:' + this.url; }
  static kind = 'svc';
}

test('mocked constructor still constructs Service instances', () => {
  const MockedService = mock.fn(Service);
  const s = new MockedService('http://x');
  assert.ok(s instanceof Service);                       // was false
  assert.strictEqual(typeof s.fetch, 'function');        // was undefined
  assert.ok(MockedService.prototype === Service.prototype); // was false
  assert.strictEqual(MockedService.kind, 'svc');         // was undefined
});
```

## How did you verify your code works?

New tests in `test/js/node/test_runner/node-test.test.ts` cover:
- `instanceof`, prototype identity, statics and prototype methods survive mocking a class
- construct call record: `target === original`, `this === result`
- `name`/`length`/`prototype` pass through from the original
- a mocked arrow function is not constructible and records no call on `new`
- properties set on the original are visible through the mock

All 5 fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The 18 pre-existing `node:test` mock tests continue to pass.