### PR TITLE
diagnostics_channel: hold channels strongly while they have subscribers

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -29,7 +29,7 @@ class WeakReference<T extends WeakKey> {
   }
 
   get() {
-    return this.#weak.deref();
+    return this.#strong ?? this.#weak.deref();
   }
 
   incRef() {

--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -4,6 +4,7 @@
 const { validateFunction } = require("internal/validators");
 
 const SafeMap = Map;
+const SafeWeakRef = WeakRef;
 const SafeFinalizationRegistry = FinalizationRegistry;
 
 const ArrayPrototypeAt = Array.prototype.at;
@@ -16,20 +17,38 @@ const PromiseResolve = Promise.$resolve.bind(Promise);
 const PromiseReject = Promise.$reject.bind(Promise);
 const PromisePrototypeThen = (promise, onFulfilled, onRejected) => promise.then(onFulfilled, onRejected);
 
-// TODO: https://github.com/nodejs/node/blob/fb47afc335ef78a8cef7eac52b8ee7f045300696/src/node_util.h#L13
-class WeakReference<T extends WeakKey> extends WeakRef<T> {
-  #refs = 0;
+// Mirrors Node's internal/util.js WeakReference: the referent is pinned strongly
+// while the ref count is positive so a subscribed channel is not collectable.
+class WeakReference<T extends WeakKey> {
+  #weak: WeakRef<T>;
+  #strong: T | undefined = undefined;
+  #refCount = 0;
+
+  constructor(object: T) {
+    this.#weak = new SafeWeakRef(object);
+  }
 
   get() {
-    return this.deref();
+    return this.#weak.deref();
   }
 
   incRef() {
-    return ++this.#refs;
+    this.#refCount++;
+    if (this.#refCount === 1) {
+      const derefed = this.#weak.deref();
+      if (derefed !== undefined) {
+        this.#strong = derefed;
+      }
+    }
+    return this.#refCount;
   }
 
   decRef() {
-    return --this.#refs;
+    this.#refCount--;
+    if (this.#refCount === 0) {
+      this.#strong = undefined;
+    }
+    return this.#refCount;
   }
 }
 

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -1,5 +1,6 @@
 import { gc } from "bun";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { channel, Channel, hasSubscribers, subscribe, unsubscribe } from "node:diagnostics_channel";
 
@@ -319,6 +320,72 @@ describe("Channel", () => {
     calledRunStores = true;
 
     checkCalls();
+  });
+
+  // https://github.com/oven-sh/bun/issues/26536
+  // A channel with a live subscriber must not be garbage-collected. Node keeps the
+  // registry entry strong while the ref count is positive; previously Bun only bumped
+  // a counter on a WeakRef, so the first full GC dropped every subscriber.
+  test("subscribe() keeps the channel alive across GC", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      const hits = [];
+      dc.subscribe("gc.subscribe.evt", m => hits.push(m));
+      dc.channel("gc.subscribe.evt").publish(1);
+      for (let i = 0; i < 10; i++) { Bun.gc(true); await Bun.sleep(0); }
+      const before = dc.channel("gc.subscribe.evt");
+      dc.channel("gc.subscribe.evt").publish(2);
+      const sameInstance = dc.channel("gc.subscribe.evt") === before;
+      console.log(JSON.stringify({
+        hasSubscribers: dc.hasSubscribers("gc.subscribe.evt"),
+        hits,
+        sameInstance,
+      }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ hasSubscribers: true, hits: [1, 2], sameInstance: true });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  });
+
+  test("bindStore() keeps the channel alive across GC", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      const { AsyncLocalStorage } = require("node:async_hooks");
+      const als = new AsyncLocalStorage();
+      dc.channel("gc.bindstore.evt").bindStore(als);
+      for (let i = 0; i < 10; i++) { Bun.gc(true); await Bun.sleep(0); }
+      let seen = "not-run";
+      dc.channel("gc.bindstore.evt").runStores({ v: 42 }, () => { seen = als.getStore(); });
+      console.log(JSON.stringify({
+        hasSubscribers: dc.hasSubscribers("gc.bindstore.evt"),
+        seen,
+      }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ hasSubscribers: true, seen: { v: 42 } });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  });
+
+  test("channel is collectable again after the last unsubscribe()", async () => {
+    const script = `
+      const dc = require("node:diagnostics_channel");
+      const noop = () => {};
+      dc.subscribe("gc.unsubscribe.evt", noop);
+      for (let i = 0; i < 10; i++) { Bun.gc(true); await Bun.sleep(0); }
+      const hadBefore = dc.hasSubscribers("gc.unsubscribe.evt");
+      dc.unsubscribe("gc.unsubscribe.evt", noop);
+      const ref = new WeakRef(dc.channel("gc.unsubscribe.evt"));
+      // The deref in the loop condition keeps the target alive for the rest of that job,
+      // so let the pin expire before each collection instead of after.
+      for (let i = 0; i < 20 && ref.deref() !== undefined; i++) { await Bun.sleep(0); Bun.gc(true); }
+      console.log(JSON.stringify({ hadBefore, collected: ref.deref() === undefined }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ hadBefore: true, collected: true });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
   });
 
   // test-diagnostics-channel-memory-leak.js


### PR DESCRIPTION
Fixes #26536. Supersedes #26537 (auto-closed for inactivity).

## Repro

```js
import dc from "node:diagnostics_channel";
const hits = [];
dc.subscribe("app.evt", m => hits.push(m));   // no reference to the Channel kept

dc.channel("app.evt").publish(1);
for (let i = 0; i < 5; i++) { Bun.gc(true); await new Promise(r => setTimeout(r, 5)); }

console.log("hasSubscribers after gc:", dc.hasSubscribers("app.evt"));
dc.channel("app.evt").publish(2);
console.log("delivered:", JSON.stringify(hits));
```

```
node v26.3.0:           hasSubscribers after gc: true    delivered: [1,2]
bun 1.4.0 / main:       hasSubscribers after gc: false   delivered: [1]
```

`dc.subscribe(name, fn)` without a retained `Channel` reference is exactly how dd-trace, OpenTelemetry, Next.js and undici instrumentation subscribe, so every dc-based APM integration was one full GC away from silently going blind. `channel.bindStore(als)` was lost through the same path, so ALS context propagation via `runStores` degraded too.

## Cause

`WeakReference` in `src/js/node/diagnostics_channel.ts` extended `WeakRef` and kept a private `#refs` counter, but `incRef()` only incremented the counter and never held the referent strongly. Node's `WeakReference` (lib/internal/util.js, backed by `node_util.cc` `WeakReference::IncRef`) promotes the reference to strong while the count is positive, which is what makes the `channels.incRef(name)` calls in `ActiveChannel.subscribe` / `bindStore` actually pin the registry entry.

## Fix

Replace the `WeakRef` subclass with Node's composition: a `#weak: WeakRef<T>` plus a `#strong: T | undefined` that is set on the `0 -> 1` transition in `incRef()` and cleared on the `1 -> 0` transition in `decRef()`. `WeakRef` is captured at module load as `SafeWeakRef` alongside the existing `SafeFinalizationRegistry`.

## Verification

Three subprocess tests added to `test/js/node/diagnostics_channel/diagnostics_channel.test.ts`:

- `subscribe()` with no retained reference survives 10 full GCs: `hasSubscribers` stays true, both publishes deliver, and `channel(name)` keeps returning the same instance.
- `bindStore()` with no retained reference survives GC: `runStores` still enters the ALS context afterward.
- After the last `unsubscribe()`, the channel survives GC while subscribed and becomes collectable again once the ref count returns to zero, so the fix does not leak.

All three fail on `main` and pass with this change. The existing `references are not leaked` heap test and the vendored `test/js/node/test/parallel/test-diagnostics-channel-*` suite still pass.