### PR TITLE
child_process: report SIGSTKFLT instead of 'SIG16' on child exit

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -245,7 +245,7 @@ macro_rules! for_each_signal {
         $cb! {
             SIGHUP = 1, SIGINT = 2, SIGQUIT = 3, SIGILL = 4, SIGTRAP = 5, SIGABRT = 6,
             SIGBUS = 7, SIGFPE = 8, SIGKILL = 9, SIGUSR1 = 10, SIGSEGV = 11, SIGUSR2 = 12,
-            SIGPIPE = 13, SIGALRM = 14, SIGTERM = 15, SIG16 = 16, SIGCHLD = 17, SIGCONT = 18,
+            SIGPIPE = 13, SIGALRM = 14, SIGTERM = 15, SIGSTKFLT = 16, SIGCHLD = 17, SIGCONT = 18,
             SIGSTOP = 19, SIGTSTP = 20, SIGTTIN = 21, SIGTTOU = 22, SIGURG = 23, SIGXCPU = 24,
             SIGXFSZ = 25, SIGVTALRM = 26, SIGPROF = 27, SIGWINCH = 28, SIGIO = 29, SIGPWR = 30,
             SIGSYS = 31,

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
+import os from "node:os";
 import { promisify } from "node:util";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
@@ -540,6 +541,28 @@ it.if(!isWindows)("spawnSync correctly reports signal codes", () => {
   });
 
   expect(signal).toBe("SIGTRAP");
+});
+
+// SIGSTKFLT (signal 16 on Linux) used to be reported as the made-up name
+// "SIG16" on child exit, even though os.constants.signals and child.kill()
+// both spell it "SIGSTKFLT". Node reports "SIGSTKFLT".
+it.if(isLinux)("child killed by SIGSTKFLT reports 'SIGSTKFLT', not 'SIG16'", async () => {
+  expect(os.constants.signals.SIGSTKFLT).toBe(16);
+
+  const child = spawn("sleep", ["30"], { stdio: "ignore" });
+  const { promise, resolve, reject } = Promise.withResolvers<[number | null, string | null]>();
+  child.on("exit", (code, signal) => resolve([code, signal]));
+  child.on("error", reject);
+  await once(child, "spawn");
+
+  expect(child.kill("SIGSTKFLT")).toBe(true);
+  const [code, signal] = await promise;
+
+  expect({ code, signal, signalCode: child.signalCode }).toEqual({
+    code: null,
+    signal: "SIGSTKFLT",
+    signalCode: "SIGSTKFLT",
+  });
 });
 
 it("spawnSync(does-not-exist)", () => {


### PR DESCRIPTION
## Problem

On Linux, when a child process is killed by signal 16 (SIGSTKFLT), Bun reports the signal name as the invented string `"SIG16"` in the `exit`/`close` event argument and in `subprocess.signalCode`. Node.js reports `"SIGSTKFLT"`.

```js
import { spawn } from "node:child_process";
const c = spawn("/bin/sleep", ["5"], { stdio: "ignore" });
setTimeout(() => process.kill(c.pid, 16), 60);
c.on("exit", (code, signal) => console.log(JSON.stringify({ code, signal, signalCode: c.signalCode })));
// node:  {"code":null,"signal":"SIGSTKFLT","signalCode":"SIGSTKFLT"}
// bun:   {"code":null,"signal":"SIG16","signalCode":"SIG16"}
```

`"SIG16"` is not a real signal name. It appears nowhere in POSIX, Node's docs, or Bun's own `os.constants.signals` (which correctly has `SIGSTKFLT === 16`). Code that switches on documented signal names (process managers, lifecycle runners, signal-exit-style libraries) receives an impossible value and falls through.

It was also internally inconsistent: `child.kill("SIGSTKFLT")` accepts the name and delivers signal 16, then reports the resulting death as `"SIG16"`.

## Cause

The `for_each_signal!` X-macro in `src/bun_core/Global.rs`, which is the single source of truth for `SIGNAL_NAMES`, `SignalCode`, and `from_name`, had a placeholder entry `SIG16 = 16` instead of `SIGSTKFLT = 16`. No other numeric placeholders exist in the table, and nothing in the tree references `SignalCode::SIG16` by name.

## Fix

Rename the entry to `SIGSTKFLT`. All downstream consumers (exit-status naming, `subprocess.signalCode`, `bun_sys::SignalCode` associated consts, `from_name`) are generated from this macro.

## Verification

New test in `test/js/node/child_process/child_process.test.ts` (Linux-only; SIGSTKFLT is Linux-specific) asserts the round trip: `child.kill("SIGSTKFLT")` followed by `exit` event reporting `{signal: "SIGSTKFLT", signalCode: "SIGSTKFLT"}`.

<details>
<summary>Before / after</summary>

Before (bun 1.4.0):
```
expect(received).toEqual(expected)
  {
    code: null,
-   signal: "SIGSTKFLT",
-   signalCode: "SIGSTKFLT",
+   signal: "SIG16",
+   signalCode: "SIG16",
  }
```

After:
```
(pass) child killed by SIGSTKFLT reports 'SIGSTKFLT', not 'SIG16'
```
</details>