### PR TITLE
process: accept SIGSTKFLT/SIGPOLL/SIGPWR by name and fire aliased signal listeners

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1593,17 +1593,29 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                     }
                 } else {
                     if (signalToContextIdsMap->find(signalNumber) != signalToContextIdsMap->end() && eventEmitter.listenerCount(eventName) == 0) {
-
-#if !OS(WINDOWS)
-                        if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
-                            // Don't uninstall the old handler if it's not the one we installed.
-                            signal(signalNumber, oldHandler);
+                        // A single signal number can be registered under multiple names
+                        // (SIGABRT/SIGIOT, SIGIO/SIGPOLL). Only restore the default
+                        // disposition once no alias has a listener left.
+                        auto& vm = JSC::getVM(eventEmitter.scriptExecutionContext()->jsGlobalObject());
+                        bool anyAliasRemaining = false;
+                        for (auto& entry : *signalNameToNumberMap) {
+                            if (entry.value == signalNumber && eventEmitter.listenerCount(Identifier::fromString(vm, entry.key)) > 0) {
+                                anyAliasRemaining = true;
+                                break;
+                            }
                         }
+                        if (!anyAliasRemaining) {
+#if !OS(WINDOWS)
+                            if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
+                                // Don't uninstall the old handler if it's not the one we installed.
+                                signal(signalNumber, oldHandler);
+                            }
 #else
-                        SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);
-                        Bun__UVSignalHandle__close(signal_handle.handle);
+                            SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);
+                            Bun__UVSignalHandle__close(signal_handle.handle);
 #endif
-                        signalToContextIdsMap->remove(signalNumber);
+                            signalToContextIdsMap->remove(signalNumber);
+                        }
                     }
                 }
             }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1051,6 +1051,8 @@ static const NeverDestroyed<String>* getSignalNames()
         MAKE_STATIC_STRING_IMPL("SIGSTKFLT"),
         MAKE_STATIC_STRING_IMPL("SIGPOLL"),
         MAKE_STATIC_STRING_IMPL("SIGPWR"),
+        MAKE_STATIC_STRING_IMPL("SIGUNUSED"),
+        MAKE_STATIC_STRING_IMPL("SIGLOST"),
     };
 
     return signalNames;
@@ -1161,6 +1163,12 @@ static void loadSignalNumberMap()
 #endif
 #ifdef SIGPWR
         signalNameToNumberMap->add(signalNames[34], SIGPWR);
+#endif
+#ifdef SIGUNUSED
+        signalNameToNumberMap->add(signalNames[35], SIGUNUSED);
+#endif
+#ifdef SIGLOST
+        signalNameToNumberMap->add(signalNames[36], SIGLOST);
 #endif
 #endif
     });
@@ -1536,6 +1544,12 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #endif
 #ifdef SIGPWR
             signalNumberToNameMap->add(SIGPWR, signalNames[34]);
+#endif
+#ifdef SIGUNUSED
+            signalNumberToNameMap->add(SIGUNUSED, signalNames[35]);
+#endif
+#ifdef SIGLOST
+            signalNumberToNameMap->add(SIGLOST, signalNames[36]);
 #endif
         });
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1048,6 +1048,9 @@ static const NeverDestroyed<String>* getSignalNames()
         MAKE_STATIC_STRING_IMPL("SIGINFO"),
         MAKE_STATIC_STRING_IMPL("SIGSYS"),
         MAKE_STATIC_STRING_IMPL("SIGBREAK"),
+        MAKE_STATIC_STRING_IMPL("SIGSTKFLT"),
+        MAKE_STATIC_STRING_IMPL("SIGPOLL"),
+        MAKE_STATIC_STRING_IMPL("SIGPWR"),
     };
 
     return signalNames;
@@ -1060,7 +1063,7 @@ static void loadSignalNumberMap()
     std::call_once(signalNameToNumberMapOnceFlag, [] {
         auto signalNames = getSignalNames();
         signalNameToNumberMap = new HashMap<String, int>();
-        signalNameToNumberMap->reserveInitialCapacity(31);
+        signalNameToNumberMap->reserveInitialCapacity(35);
 #if OS(WINDOWS)
         // libuv-supported console-control signals on Windows:
         // CTRL_C_EVENT → SIGINT, CTRL_BREAK_EVENT → SIGBREAK,
@@ -1150,6 +1153,15 @@ static void loadSignalNumberMap()
 #ifdef SIGSYS
         signalNameToNumberMap->add(signalNames[30], SIGSYS);
 #endif
+#ifdef SIGSTKFLT
+        signalNameToNumberMap->add(signalNames[32], SIGSTKFLT);
+#endif
+#ifdef SIGPOLL
+        signalNameToNumberMap->add(signalNames[33], SIGPOLL);
+#endif
+#ifdef SIGPWR
+        signalNameToNumberMap->add(signalNames[34], SIGPWR);
+#endif
 #endif
     });
 }
@@ -1163,14 +1175,20 @@ bool isSignalName(WTF::String input)
 extern "C" void Bun__onSignalForJS(int signalNumber, Zig::GlobalObject* globalObject)
 {
     Process* process = globalObject->processObject();
+    auto& vm = JSC::getVM(globalObject);
 
-    String signalName = signalNumberToNameMap->get(signalNumber);
-    Identifier signalNameIdentifier = Identifier::fromString(JSC::getVM(globalObject), signalName);
-    MarkedArgumentBuffer args;
-    args.append(jsString(JSC::getVM(globalObject), signalNameIdentifier.string()));
-    args.append(jsNumber(signalNumber));
-
-    process->wrapped().emitForBindings(signalNameIdentifier, args);
+    // A single signal number can map to multiple names (SIGABRT/SIGIOT, SIGIO/SIGPOLL).
+    // Emit the event for every name that resolves to this number so listeners registered
+    // under either alias fire, matching Node.js.
+    for (auto& entry : *signalNameToNumberMap) {
+        if (entry.value != signalNumber)
+            continue;
+        Identifier signalNameIdentifier = Identifier::fromString(vm, entry.key);
+        MarkedArgumentBuffer args;
+        args.append(jsString(vm, signalNameIdentifier.string()));
+        args.append(jsNumber(signalNumber));
+        process->wrapped().emitForBindings(signalNameIdentifier, args);
+    }
 }
 
 #if OS(WINDOWS)
@@ -1433,7 +1451,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
         std::call_once(signalNumberToNameMapOnceFlag, [] {
             auto signalNames = getSignalNames();
             signalNumberToNameMap = new HashMap<int, String>();
-            signalNumberToNameMap->reserveInitialCapacity(31);
+            signalNumberToNameMap->reserveInitialCapacity(35);
             signalNumberToNameMap->add(SIGHUP, signalNames[0]);
             signalNumberToNameMap->add(SIGINT, signalNames[1]);
             signalNumberToNameMap->add(SIGQUIT, signalNames[2]);
@@ -1509,6 +1527,15 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #endif
 #ifdef SIGBREAK
             signalNumberToNameMap->add(SIGBREAK, signalNames[31]);
+#endif
+#ifdef SIGSTKFLT
+            signalNumberToNameMap->add(SIGSTKFLT, signalNames[32]);
+#endif
+#ifdef SIGPOLL
+            signalNumberToNameMap->add(SIGPOLL, signalNames[33]);
+#endif
+#ifdef SIGPWR
+            signalNumberToNameMap->add(SIGPWR, signalNames[34]);
 #endif
         });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1013,10 +1013,8 @@ describe.concurrent(() => {
 
     // Removing the listener for one alias must not uninstall the OS handler
     // while another alias of the same signal number still has a listener.
-    it.skipIf(isWindows)(
-      "removing one alias's listener keeps the handler installed for the other alias",
-      async () => {
-        const script = /*js*/ `
+    it.skipIf(isWindows)("removing one alias's listener keeps the handler installed for the other alias", async () => {
+      const script = /*js*/ `
           const { promise, resolve } = Promise.withResolvers();
           function a() { console.log("SIGABRT handler (removed) fired"); }
           function b(name, num) { console.log("SIGIOT handler", name, num); resolve(); }
@@ -1027,21 +1025,20 @@ describe.concurrent(() => {
           await promise;
           console.log("survived");
         `;
-        await using child = Bun.spawn({
-          cmd: [bunExe(), "-e", script],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
-        expect({ stdout, stderr, signalCode: child.signalCode }).toEqual({
-          stdout: "SIGIOT handler SIGIOT 6\nsurvived\n",
-          stderr: "",
-          signalCode: null,
-        });
-        expect(exitCode).toBe(0);
-      },
-    );
+      await using child = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+      expect({ stdout, stderr, signalCode: child.signalCode }).toEqual({
+        stdout: "SIGIOT handler SIGIOT 6\nsurvived\n",
+        stderr: "",
+        signalCode: null,
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 
   const undefinedStubs = [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1010,6 +1010,38 @@ describe.concurrent(() => {
         expect(exitCode).toBe(0);
       },
     );
+
+    // Removing the listener for one alias must not uninstall the OS handler
+    // while another alias of the same signal number still has a listener.
+    it.skipIf(isWindows)(
+      "removing one alias's listener keeps the handler installed for the other alias",
+      async () => {
+        const script = /*js*/ `
+          const { promise, resolve } = Promise.withResolvers();
+          function a() { console.log("SIGABRT handler (removed) fired"); }
+          function b(name, num) { console.log("SIGIOT handler", name, num); resolve(); }
+          process.on("SIGABRT", a);
+          process.on("SIGIOT", b);
+          process.removeListener("SIGABRT", a);
+          process.kill(process.pid, "SIGABRT");
+          await promise;
+          console.log("survived");
+        `;
+        await using child = Bun.spawn({
+          cmd: [bunExe(), "-e", script],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+        expect({ stdout, stderr, signalCode: child.signalCode }).toEqual({
+          stdout: "SIGIOT handler SIGIOT 6\nsurvived\n",
+          stderr: "",
+          signalCode: null,
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
   });
 
   const undefinedStubs = [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2,6 +2,7 @@ import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import os from "node:os";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -918,6 +919,97 @@ describe.concurrent(() => {
       expect(() => process.kill(2147483640, "SIGPOOP")).toThrow();
       expect(() => process.kill(2147483640, 456)).toThrow();
     });
+
+    // SIGSTKFLT, SIGPOLL and SIGPWR are Linux-only signals that are in
+    // os.constants.signals but were missing from the process.kill name table.
+    it.skipIf(process.platform !== "linux")(
+      "process.kill accepts every signal name in os.constants.signals",
+      async () => {
+        const results = {};
+        for (const name of Object.keys(os.constants.signals)) {
+          try {
+            process.kill(0x7fffffff, name);
+            results[name] = "sent";
+          } catch (e) {
+            results[name] = e.code;
+          }
+        }
+        // Every name in os.constants.signals must be resolved as a signal name,
+        // so the only error we should ever see is ESRCH from kill(2) for the
+        // nonexistent pid, never ERR_UNKNOWN_SIGNAL from the name lookup.
+        const unknown = Object.entries(results).filter(([, v]) => v === "ERR_UNKNOWN_SIGNAL");
+        expect(unknown).toEqual([]);
+      },
+    );
+
+    it.skipIf(process.platform !== "linux")(
+      "process.on('SIGSTKFLT') installs a real handler and the listener runs",
+      async () => {
+        const script = /*js*/ `
+          const { promise, resolve } = Promise.withResolvers();
+          process.on("SIGSTKFLT", (name, num) => {
+            console.log("handler", name, num);
+            resolve();
+          });
+          process.kill(process.pid, "SIGSTKFLT");
+          await promise;
+          console.log("survived");
+        `;
+        await using child = Bun.spawn({
+          cmd: [bunExe(), "-e", script],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+        expect({ stdout, stderr, signalCode: child.signalCode }).toEqual({
+          stdout: "handler SIGSTKFLT 16\nsurvived\n",
+          stderr: "",
+          signalCode: null,
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    // SIGPOLL is an alias for SIGIO on Linux. Node.js emits both event names
+    // when the signal arrives; the listener registered under each alias must
+    // fire with its own name.
+    it.skipIf(process.platform !== "linux")(
+      "process.on fires listeners for every alias of a signal number",
+      async () => {
+        const script = /*js*/ `
+          const fired = [];
+          const { promise, resolve } = Promise.withResolvers();
+          process.on("SIGPOLL", (name, num) => {
+            fired.push(["SIGPOLL", name, num]);
+            if (fired.length === 2) resolve();
+          });
+          process.on("SIGIO", (name, num) => {
+            fired.push(["SIGIO", name, num]);
+            if (fired.length === 2) resolve();
+          });
+          process.kill(process.pid, "SIGPOLL");
+          await promise;
+          console.log(JSON.stringify(fired.sort((a, b) => a[0].localeCompare(b[0]))));
+        `;
+        await using child = Bun.spawn({
+          cmd: [bunExe(), "-e", script],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+        expect({ stdout: stdout.trim(), stderr, signalCode: child.signalCode }).toEqual({
+          stdout: JSON.stringify([
+            ["SIGIO", "SIGIO", 29],
+            ["SIGPOLL", "SIGPOLL", 29],
+          ]),
+          stderr: "",
+          signalCode: null,
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
   });
 
   const undefinedStubs = [


### PR DESCRIPTION
## What's wrong

Bun keeps three disagreeing signal-name tables. `os.constants.signals` and the `subprocess.kill(name)` path know `SIGSTKFLT`, `SIGPOLL` and `SIGPWR`, but `signalNameToNumberMap` in `BunProcess.cpp` (used by `process.kill(pid, name)` and the `process.on(name)` → `sigaction` wiring) does not. On Linux:

```js
import { spawn } from "node:child_process";
const c = spawn("/bin/sleep", ["5"]);
process.kill(c.pid, "SIGSTKFLT"); // throws ERR_UNKNOWN_SIGNAL
c.kill("SIGSTKFLT");              // delivers signal 16
```

The dangerous half is the listener side: `process.on("SIGSTKFLT", fn)` succeeds, `listenerCount` returns 1, but no `sigaction` is ever installed (the `SigCgt` bit in `/proc/self/status` stays clear), so the first delivery of that signal kills the process to its default disposition with a JS handler attached:

```
listener child: {"status":null,"signal":"SIG16","stdout":"listeners: 1"}   // DIED, handler never ran
```

Node v26 accepts all three names from both APIs and the listener runs.

## Cause

`getSignalNames()` / `loadSignalNumberMap()` in `BunProcess.cpp` never had entries for `SIGSTKFLT`, `SIGPOLL` or `SIGPWR`, so `signalNameToNumberMap->get(eventName)` returned 0 for those names and the handler-install branch never executed, and `process.kill`'s name lookup fell through to `ERR_UNKNOWN_SIGNAL`.

Two related bugs in the same code for aliased signal numbers (`SIGABRT`/`SIGIOT` share 6, `SIGIO`/`SIGPOLL` share 29):

- `Bun__onSignalForJS` looked up one canonical name per signal number from `signalNumberToNameMap` and emitted only that event, so a listener registered under the alias name never fired even though the `sigaction` was installed. Node emits both.
- `onDidChangeListeners` keyed the OS handler on the signal number but decided whether to uninstall it based only on the listener count of the event name being removed. `process.on('SIGABRT', a); process.on('SIGIOT', b); process.removeListener('SIGABRT', a)` restored `SIG_DFL` for signal 6 while `b` was still registered, so the next delivery killed the process.

## Fix

- Add `SIGSTKFLT`, `SIGPOLL`, `SIGPWR` to the `signalNames` array and to both `signalNameToNumberMap` and `signalNumberToNameMap`, each under `#ifdef` so macOS/Windows are unaffected.
- `Bun__onSignalForJS` now iterates `signalNameToNumberMap` and emits the event for every name that resolves to the delivered signal number, so listeners registered under either alias fire with their own name as the first argument.
- The uninstall branch in `onDidChangeListeners` now checks the listener count of every name that resolves to the same signal number before restoring the default disposition.
- `process.on("SIGPWR", fn)` resolves the name but still does not replace JSC's thread-suspend handler on Linux: the existing `signalNumber != g_wtfConfig.sigThreadSuspendResume` guard in `onDidChangeListeners` already covers that.

## Verification

Four new tests in `test/js/node/process/process.test.js`, each failing against base `src/` and passing with the fix:

- `process.kill accepts every signal name in os.constants.signals` (Linux) sends every name in `os.constants.signals` to a nonexistent pid and asserts no `ERR_UNKNOWN_SIGNAL`. On `main` it fails for exactly `SIGSTKFLT`, `SIGPOLL`, `SIGPWR`.
- `process.on('SIGSTKFLT') installs a real handler and the listener runs` (Linux) spawns a child that registers the listener, self-signals, and asserts the handler ran and the child exited 0.
- `process.on fires listeners for every alias of a signal number` (Linux) registers listeners for both `SIGPOLL` and `SIGIO`, self-signals once, and asserts both fired with the correct name/number pair.
- `removing one alias's listener keeps the handler installed for the other alias` (POSIX) registers `SIGABRT` and `SIGIOT` listeners, removes the `SIGABRT` one, self-signals, and asserts the `SIGIOT` listener still runs and the child exits 0. On `main` the child dies with `signalCode: SIGABRT`.

Also checked: `test/js/node/process/process-signal-listener-count.test.ts`, `test/js/node/process/process-on.test.ts`, `test/js/node/test/parallel/test-process-kill-pid.js`, removing all aliases still restores `SIG_DFL`, and `BUN_JSC_validateExceptionChecks=1` over both code paths.
