### PR TITLE
process: guard JSC's GC suspend signal against unsolicited SIGPWR on Linux

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1166,6 +1166,11 @@ bool isSignalName(WTF::String input)
 
 extern "C" void Bun__onSignalForJS(int signalNumber, Zig::GlobalObject* globalObject)
 {
+    // SigintWatcher::install() can prime the signal ring buffer without any process.on()
+    // ever running, in which case this map is still null and there is no listener to emit to.
+    if (!signalNumberToNameMap)
+        return;
+
     Process* process = globalObject->processObject();
 
     String signalName = signalNumberToNameMap->get(signalNumber);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1048,6 +1048,7 @@ static const NeverDestroyed<String>* getSignalNames()
         MAKE_STATIC_STRING_IMPL("SIGINFO"),
         MAKE_STATIC_STRING_IMPL("SIGSYS"),
         MAKE_STATIC_STRING_IMPL("SIGBREAK"),
+        MAKE_STATIC_STRING_IMPL("SIGPWR"),
     };
 
     return signalNames;
@@ -1149,6 +1150,9 @@ static void loadSignalNumberMap()
 #endif
 #ifdef SIGSYS
         signalNameToNumberMap->add(signalNames[30], SIGSYS);
+#endif
+#ifdef SIGPWR
+        signalNameToNumberMap->add(signalNames[32], SIGPWR);
 #endif
 #endif
     });
@@ -1384,6 +1388,38 @@ __attribute__((noinline)) static void forwardSignal(int signalNumber)
     Bun__onPosixSignal(signalNumber);
 }
 
+#if OS(LINUX)
+static struct sigaction s_jscSuspendResumeAction;
+static pid_t s_jscSuspendResumePid;
+
+static void Bun__sigThreadSuspendResumeGuard(int signalNumber, siginfo_t* info, void* ucontext)
+{
+    // JSC's GC suspend/resume always uses pthread_kill from this process (si_code == SI_TKILL,
+    // si_pid == us). Any other delivery is unsolicited and would null-deref targetThread in
+    // WTF::Thread::signalHandlerSuspendResume, so forward it to JS listeners instead.
+    if (info && info->si_code == SI_TKILL && info->si_pid == s_jscSuspendResumePid) [[likely]] {
+        s_jscSuspendResumeAction.sa_sigaction(signalNumber, info, ucontext);
+        return;
+    }
+    Bun__onPosixSignal(signalNumber);
+}
+
+extern "C" void Bun__installSigThreadSuspendResumeGuard()
+{
+    int signalNumber = g_wtfConfig.sigThreadSuspendResume;
+    if (!signalNumber)
+        return;
+    if (sigaction(signalNumber, nullptr, &s_jscSuspendResumeAction))
+        return;
+    if (!(s_jscSuspendResumeAction.sa_flags & SA_SIGINFO))
+        return;
+    s_jscSuspendResumePid = getpid();
+    struct sigaction action = s_jscSuspendResumeAction;
+    action.sa_sigaction = &Bun__sigThreadSuspendResumeGuard;
+    sigaction(signalNumber, &action, nullptr);
+}
+#endif
+
 extern "C" void Bun__MemoryPressure__install(JSC::JSGlobalObject* global);
 extern "C" void Bun__MemoryPressure__uninstall(JSC::JSGlobalObject* global);
 
@@ -1510,6 +1546,9 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #ifdef SIGBREAK
             signalNumberToNameMap->add(SIGBREAK, signalNames[31]);
 #endif
+#ifdef SIGPWR
+            signalNumberToNameMap->add(SIGPWR, signalNames[32]);
+#endif
         });
 
         if (!signalToContextIdsMap) {
@@ -1517,11 +1556,7 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
         }
 
         if (auto signalNumber = signalNameToNumberMap->get(eventName.string())) {
-#if OS(LINUX)
-            // SIGKILL and SIGSTOP cannot be handled, and JSC needs its own signal handler to
-            // suspend and resume the JS thread which we must not override.
-            if (signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume) {
-#elif OS(DARWIN) || OS(FREEBSD)
+#if OS(LINUX) || OS(DARWIN) || OS(FREEBSD)
             // these signals cannot be handled
             if (signalNumber != SIGKILL && signalNumber != SIGSTOP) {
 #elif OS(WINDOWS)
@@ -1540,18 +1575,26 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                         };
 #if !OS(WINDOWS)
                         Bun__ensureSignalHandler();
-                        struct sigaction action;
-                        memset(&action, 0, sizeof(struct sigaction));
+#if OS(LINUX)
+                        // JSC owns the handler for its GC suspend/resume signal; our wrapper
+                        // (Bun__installSigThreadSuspendResumeGuard) already forwards unsolicited
+                        // deliveries into Bun__onPosixSignal, so we must not replace it here.
+                        if (signalNumber != g_wtfConfig.sigThreadSuspendResume)
+#endif
+                        {
+                            struct sigaction action;
+                            memset(&action, 0, sizeof(struct sigaction));
 
-                        // Set the handler in the action struct
-                        action.sa_handler = forwardSignal;
+                            // Set the handler in the action struct
+                            action.sa_handler = forwardSignal;
 
-                        // Clear the sa_mask
-                        sigemptyset(&action.sa_mask);
-                        sigaddset(&action.sa_mask, signalNumber);
-                        action.sa_flags = SA_RESTART;
+                            // Clear the sa_mask
+                            sigemptyset(&action.sa_mask);
+                            sigaddset(&action.sa_mask, signalNumber);
+                            action.sa_flags = SA_RESTART;
 
-                        sigaction(signalNumber, &action, nullptr);
+                            sigaction(signalNumber, &action, nullptr);
+                        }
 #else
                         signal_handle.handle = Bun__UVSignalHandle__init(
                             eventEmitter.scriptExecutionContext()->jsGlobalObject(),
@@ -1568,6 +1611,9 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                     if (signalToContextIdsMap->find(signalNumber) != signalToContextIdsMap->end() && eventEmitter.listenerCount(eventName) == 0) {
 
 #if !OS(WINDOWS)
+#if OS(LINUX)
+                        if (signalNumber != g_wtfConfig.sigThreadSuspendResume)
+#endif
                         if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
                             // Don't uninstall the old handler if it's not the one we installed.
                             signal(signalNumber, oldHandler);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1614,10 +1614,10 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #if OS(LINUX)
                         if (signalNumber != g_wtfConfig.sigThreadSuspendResume)
 #endif
-                        if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
-                            // Don't uninstall the old handler if it's not the one we installed.
-                            signal(signalNumber, oldHandler);
-                        }
+                            if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
+                                // Don't uninstall the old handler if it's not the one we installed.
+                                signal(signalNumber, oldHandler);
+                            }
 #else
                         SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);
                         Bun__UVSignalHandle__close(signal_handle.handle);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1390,14 +1390,13 @@ __attribute__((noinline)) static void forwardSignal(int signalNumber)
 
 #if OS(LINUX)
 static struct sigaction s_jscSuspendResumeAction;
-static pid_t s_jscSuspendResumePid;
 
 static void Bun__sigThreadSuspendResumeGuard(int signalNumber, siginfo_t* info, void* ucontext)
 {
     // JSC's GC suspend/resume always uses pthread_kill from this process (si_code == SI_TKILL,
     // si_pid == us). Any other delivery is unsolicited and would null-deref targetThread in
     // WTF::Thread::signalHandlerSuspendResume, so forward it to JS listeners instead.
-    if (info && info->si_code == SI_TKILL && info->si_pid == s_jscSuspendResumePid) [[likely]] {
+    if (info && info->si_code == SI_TKILL && info->si_pid == getpid()) [[likely]] {
         s_jscSuspendResumeAction.sa_sigaction(signalNumber, info, ucontext);
         return;
     }
@@ -1413,7 +1412,6 @@ extern "C" void Bun__installSigThreadSuspendResumeGuard()
         return;
     if (!(s_jscSuspendResumeAction.sa_flags & SA_SIGINFO))
         return;
-    s_jscSuspendResumePid = getpid();
     struct sigaction action = s_jscSuspendResumeAction;
     action.sa_sigaction = &Bun__sigThreadSuspendResumeGuard;
     sigaction(signalNumber, &action, nullptr);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -274,6 +274,10 @@ extern "C" unsigned getJSCBytecodeCacheVersion()
 extern "C" void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject*);
 #endif
 
+#if OS(LINUX)
+extern "C" void Bun__installSigThreadSuspendResumeGuard();
+#endif
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup)
 {
     static std::once_flag jsc_init_flag;
@@ -283,6 +287,10 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
 
         std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
         WTF::initializeMainThread();
+
+#if OS(LINUX)
+        Bun__installSigThreadSuspendResumeGuard();
+#endif
 
         // Use JSC::initialize with a callback to set Options during initialization.
         // The callback runs BEFORE IPInt::initialize() so we can configure WASM options early.

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -111,7 +111,10 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
       let handled = 0;
       process.on("SIGPWR", () => { handled++; });
       const w = new Worker("data:text/javascript,postMessage(0);setInterval(()=>{},1e6)");
-      await new Promise(r => w.addEventListener("message", r, { once: true }));
+      await new Promise((resolve, reject) => {
+        w.addEventListener("message", resolve, { once: true });
+        w.addEventListener("error", reject, { once: true });
+      });
       for (let i = 0; i < ${iterations}; i++) {
         const junk = [];
         for (let j = 0; j < 200; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -102,13 +102,16 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
     expect(await runScript(script)).toEqual(ok("survived\n"));
   });
 
-  // GC stress: make JSC actually use its SIGPWR suspend/resume machinery alongside an
-  // external SIGPWR, to prove the si_code gate lets the GC path through unmolested.
+  // A Worker gives MachineThreads a second entry so Bun.gc(true) actually has a thread to
+  // suspend via pthread_kill(SIGPWR), proving the SI_TKILL gate still lets JSC's own
+  // suspend/resume through while an external SIGPWR is routed to the JS listener.
   test.concurrent("GC suspend/resume still works with the SIGPWR guard installed", async () => {
     const iterations = isDebug ? 10 : 50;
     const script = /*js*/ `
       let handled = 0;
       process.on("SIGPWR", () => { handled++; });
+      const w = new Worker("data:text/javascript,postMessage(0);setInterval(()=>{},1e6)");
+      await new Promise(r => w.addEventListener("message", r, { once: true }));
       for (let i = 0; i < ${iterations}; i++) {
         const junk = [];
         for (let j = 0; j < 200; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });
@@ -116,6 +119,7 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
         process.kill(process.pid, 30);
         await new Promise(r => setImmediate(r));
       }
+      await w.terminate();
       console.log(JSON.stringify({ handled }));
     `;
 

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -8,10 +8,10 @@ import { bunEnv, bunExe, isDebug, isLinux } from "harness";
 // registered via process.on("SIGPWR", ...) actually fires.
 
 describe.skipIf(!isLinux)("SIGPWR", () => {
-  async function runScript(script: string) {
+  async function runScript(script: string, extraEnv: Record<string, string> = {}) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
-      env: bunEnv,
+      env: { ...bunEnv, ...extraEnv },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -102,19 +102,14 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
     expect(await runScript(script)).toEqual(ok("survived\n"));
   });
 
-  // A Worker gives MachineThreads a second entry so Bun.gc(true) actually has a thread to
-  // suspend via pthread_kill(SIGPWR), proving the SI_TKILL gate still lets JSC's own
-  // suspend/resume through while an external SIGPWR is routed to the JS listener.
+  // collectContinuously runs a dedicated collector thread in the same VM that suspends the
+  // main mutator via pthread_kill(SIGPWR); a broken SI_TKILL passthrough would hang here.
+  // The exact `handled` count also proves internal deliveries are not misrouted to JS.
   test.concurrent("GC suspend/resume still works with the SIGPWR guard installed", async () => {
     const iterations = isDebug ? 10 : 50;
     const script = /*js*/ `
       let handled = 0;
       process.on("SIGPWR", () => { handled++; });
-      const w = new Worker("data:text/javascript,postMessage(0);setInterval(()=>{},1e6)");
-      await new Promise((resolve, reject) => {
-        w.addEventListener("message", resolve, { once: true });
-        w.addEventListener("error", reject, { once: true });
-      });
       for (let i = 0; i < ${iterations}; i++) {
         const junk = [];
         for (let j = 0; j < 200; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });
@@ -122,11 +117,10 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
         process.kill(process.pid, 30);
         await new Promise(r => setImmediate(r));
       }
-      await w.terminate();
       console.log(JSON.stringify({ handled }));
     `;
 
-    const { stdout, stderr, exitCode, signalCode } = await runScript(script);
+    const { stdout, stderr, exitCode, signalCode } = await runScript(script, { BUN_JSC_collectContinuously: "1" });
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({ handled: iterations });
     expect(exitCode).toBe(0);

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// JSC uses SIGPWR on Linux to suspend/resume the JS thread for conservative stack scanning.
+// An unsolicited SIGPWR (from process.kill, Bun.spawn().kill, or an external `kill -PWR`)
+// used to reach WTF::Thread::signalHandlerSuspendResume with targetThread == nullptr and
+// segfault at offset 0x58. These tests prove the process now survives and that a JS listener
+// registered via process.on("SIGPWR", ...) actually fires.
+
+describe.skipIf(!isLinux)("SIGPWR", () => {
+  test.concurrent("process.kill(self, 30) runs the SIGPWR listener instead of crashing", async () => {
+    const script = /*js*/ `
+      const { promise, resolve } = Promise.withResolvers();
+      process.on("SIGPWR", (name, num) => {
+        console.log("handler", name, num);
+        resolve();
+      });
+      process.kill(process.pid, 30);
+      await promise;
+      console.log("survived");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "handler SIGPWR 30\nsurvived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent('process.kill(self, "SIGPWR") runs the listener', async () => {
+    const script = /*js*/ `
+      const { promise, resolve } = Promise.withResolvers();
+      process.on("SIGPWR", () => { console.log("handler ran"); resolve(); });
+      process.kill(process.pid, "SIGPWR");
+      await promise;
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "handler ran\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  async function spawnAndSignalAfterReady(deliver: (proc: import("bun").Subprocess<"ignore", "pipe", "pipe">) => void) {
+    const script = /*js*/ `
+      const { promise, resolve } = Promise.withResolvers();
+      process.on("SIGPWR", () => { console.log("handler ran"); resolve(); });
+      console.log("ready");
+      await promise;
+      console.log("survived");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let stdout = "";
+    let sent = false;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (value) stdout += decoder.decode(value, { stream: true });
+      if (!sent && stdout.includes("ready\n")) {
+        sent = true;
+        deliver(proc);
+      }
+      if (done) break;
+    }
+    stdout += decoder.decode();
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  test.concurrent("SIGPWR delivered from outside the process runs the listener", async () => {
+    const result = await spawnAndSignalAfterReady(proc => process.kill(proc.pid!, "SIGPWR"));
+    expect(result).toEqual({
+      stdout: "ready\nhandler ran\nsurvived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("subprocess.kill('SIGPWR') runs the listener in the child", async () => {
+    const result = await spawnAndSignalAfterReady(proc => proc.kill("SIGPWR"));
+    expect(result).toEqual({
+      stdout: "ready\nhandler ran\nsurvived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("unsolicited SIGPWR with no listener does not crash the process", async () => {
+    const script = /*js*/ `
+      process.kill(process.pid, 30);
+      await new Promise(r => setImmediate(r));
+      console.log("survived");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "survived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  // GC stress: make JSC actually use its SIGPWR suspend/resume machinery alongside an
+  // external SIGPWR, to prove the si_code gate lets the GC path through unmolested.
+  test.concurrent("GC suspend/resume still works with the SIGPWR guard installed", async () => {
+    const script = /*js*/ `
+      let handled = 0;
+      process.on("SIGPWR", () => { handled++; });
+      for (let i = 0; i < 50; i++) {
+        const junk = [];
+        for (let j = 0; j < 1000; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });
+        Bun.gc(true);
+        process.kill(process.pid, 30);
+        await new Promise(r => setImmediate(r));
+      }
+      console.log(JSON.stringify({ handled }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ handled: 50 });
+    expect(exitCode).toBe(0);
+    expect(proc.signalCode).toBe(null);
+  });
+
+  test.concurrent("removing all SIGPWR listeners does not reset the disposition to SIG_DFL", async () => {
+    const script = /*js*/ `
+      const fn = () => {};
+      process.on("SIGPWR", fn);
+      process.off("SIGPWR", fn);
+      Bun.gc(true);
+      process.kill(process.pid, 30);
+      await new Promise(r => setImmediate(r));
+      console.log("survived");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "survived\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux } from "harness";
 
 // JSC uses SIGPWR on Linux to suspend/resume the JS thread for conservative stack scanning.
 // An unsolicited SIGPWR (from process.kill, Bun.spawn().kill, or an external `kill -PWR`)
@@ -8,59 +8,16 @@ import { bunEnv, bunExe, isLinux } from "harness";
 // registered via process.on("SIGPWR", ...) actually fires.
 
 describe.skipIf(!isLinux)("SIGPWR", () => {
-  test.concurrent("process.kill(self, 30) runs the SIGPWR listener instead of crashing", async () => {
-    const script = /*js*/ `
-      const { promise, resolve } = Promise.withResolvers();
-      process.on("SIGPWR", (name, num) => {
-        console.log("handler", name, num);
-        resolve();
-      });
-      process.kill(process.pid, 30);
-      await promise;
-      console.log("survived");
-    `;
-
+  async function runScript(script: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "handler SIGPWR 30\nsurvived\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent('process.kill(self, "SIGPWR") runs the listener', async () => {
-    const script = /*js*/ `
-      const { promise, resolve } = Promise.withResolvers();
-      process.on("SIGPWR", () => { console.log("handler ran"); resolve(); });
-      process.kill(process.pid, "SIGPWR");
-      await promise;
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "handler ran\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
 
   async function spawnAndSignalAfterReady(deliver: (proc: import("bun").Subprocess<"ignore", "pipe", "pipe">) => void) {
     const script = /*js*/ `
@@ -78,6 +35,7 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
       stderr: "pipe",
     });
 
+    const stderrPromise = proc.stderr.text();
     const reader = proc.stdout.getReader();
     const decoder = new TextDecoder();
     let stdout = "";
@@ -93,28 +51,46 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
     }
     stdout += decoder.decode();
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([stderrPromise, proc.exited]);
     return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
+  const ok = (stdout: string) => ({ stdout, stderr: "", exitCode: 0, signalCode: null });
+
+  // The literal 30 is intentional: this exercises the numeric-signal path from the repro,
+  // which hands the raw number straight to kill(2) without name-table lookup.
+  test.concurrent("process.kill(self, 30) runs the SIGPWR listener instead of crashing", async () => {
+    const script = /*js*/ `
+      const { promise, resolve } = Promise.withResolvers();
+      process.on("SIGPWR", (name, num) => {
+        console.log("handler", name, num);
+        resolve();
+      });
+      process.kill(process.pid, 30);
+      await promise;
+      console.log("survived");
+    `;
+    expect(await runScript(script)).toEqual(ok("handler SIGPWR 30\nsurvived\n"));
+  });
+
+  test.concurrent('process.kill(self, "SIGPWR") runs the listener', async () => {
+    const script = /*js*/ `
+      const { promise, resolve } = Promise.withResolvers();
+      process.on("SIGPWR", () => { console.log("handler ran"); resolve(); });
+      process.kill(process.pid, "SIGPWR");
+      await promise;
+    `;
+    expect(await runScript(script)).toEqual(ok("handler ran\n"));
+  });
+
   test.concurrent("SIGPWR delivered from outside the process runs the listener", async () => {
     const result = await spawnAndSignalAfterReady(proc => process.kill(proc.pid!, "SIGPWR"));
-    expect(result).toEqual({
-      stdout: "ready\nhandler ran\nsurvived\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect(result).toEqual(ok("ready\nhandler ran\nsurvived\n"));
   });
 
   test.concurrent("subprocess.kill('SIGPWR') runs the listener in the child", async () => {
     const result = await spawnAndSignalAfterReady(proc => proc.kill("SIGPWR"));
-    expect(result).toEqual({
-      stdout: "ready\nhandler ran\nsurvived\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect(result).toEqual(ok("ready\nhandler ran\nsurvived\n"));
   });
 
   test.concurrent("unsolicited SIGPWR with no listener does not crash the process", async () => {
@@ -123,33 +99,19 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
       await new Promise(r => setImmediate(r));
       console.log("survived");
     `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "survived\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect(await runScript(script)).toEqual(ok("survived\n"));
   });
 
   // GC stress: make JSC actually use its SIGPWR suspend/resume machinery alongside an
   // external SIGPWR, to prove the si_code gate lets the GC path through unmolested.
   test.concurrent("GC suspend/resume still works with the SIGPWR guard installed", async () => {
+    const iterations = isDebug ? 10 : 50;
     const script = /*js*/ `
       let handled = 0;
       process.on("SIGPWR", () => { handled++; });
-      for (let i = 0; i < 50; i++) {
+      for (let i = 0; i < ${iterations}; i++) {
         const junk = [];
-        for (let j = 0; j < 1000; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });
+        for (let j = 0; j < 200; j++) junk.push({ a: j, b: Buffer.alloc(64, 65).toString() });
         Bun.gc(true);
         process.kill(process.pid, 30);
         await new Promise(r => setImmediate(r));
@@ -157,19 +119,11 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
       console.log(JSON.stringify({ handled }));
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
+    const { stdout, stderr, exitCode, signalCode } = await runScript(script);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ handled: 50 });
+    expect(JSON.parse(stdout.trim())).toEqual({ handled: iterations });
     expect(exitCode).toBe(0);
-    expect(proc.signalCode).toBe(null);
+    expect(signalCode).toBe(null);
   });
 
   test.concurrent("removing all SIGPWR listeners does not reset the disposition to SIG_DFL", async () => {
@@ -182,21 +136,6 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
       await new Promise(r => setImmediate(r));
       console.log("survived");
     `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "survived\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    expect(await runScript(script)).toEqual(ok("survived\n"));
   });
 });

--- a/test/js/node/process/process-sigpwr.test.ts
+++ b/test/js/node/process/process-sigpwr.test.ts
@@ -102,6 +102,16 @@ describe.skipIf(!isLinux)("SIGPWR", () => {
     expect(await runScript(script)).toEqual(ok("survived\n"));
   });
 
+  test.concurrent("unsolicited SIGPWR after breakOnSigint primed the signal ring does not crash", async () => {
+    const script = /*js*/ `
+      require("node:vm").runInNewContext("1", {}, { breakOnSigint: true });
+      process.kill(process.pid, 30);
+      await new Promise(r => setImmediate(r));
+      console.log("survived");
+    `;
+    expect(await runScript(script)).toEqual(ok("survived\n"));
+  });
+
   // collectContinuously runs a dedicated collector thread in the same VM that suspends the
   // main mutator via pthread_kill(SIGPWR); a broken SI_TKILL passthrough would hang here.
   // The exact `handled` count also proves internal deliveries are not misrouted to JS.


### PR DESCRIPTION
## What

Delivering SIGPWR (signal 30) to a Bun process on Linux segfaults the whole runtime:

```js
process.on("SIGPWR", () => console.log("SIGPWR handler ran"));
process.kill(process.pid, 30);
setTimeout(() => console.log("survived"), 150);
```

```
panic(main thread): Segmentation fault at address 0x58
AddressSanitizer: SEGV on unknown address 0x000000000058 ... pc = WTF::Thread::signalHandlerSuspendResume (wtf/posix/ThreadingPOSIX.cpp:123)
```

Reachable three ways: `process.kill(pid, 30)`, `subprocess.kill("SIGPWR")`, or `kill -PWR <pid>` from outside the process. The last one matters because container managers (lxc stop, systemd) send SIGPWR to PID 1 on power events, so a Bun server running as PID 1 segfaults instead of shutting down cleanly. Under Node the same code runs the listener and exits 0.

## Cause

On Linux JSC uses SIGPWR to suspend and resume JS threads for conservative stack scanning. `WTF::Thread::signalHandlerSuspendResume` loads a file-static `targetThread` pointer and immediately dereferences `thread->m_suspendCount`. `targetThread` is only set by JSC's own `Thread::suspend()`/`resume()` right before they `pthread_kill` the target, so any SIGPWR delivered from outside that path sees `targetThread == nullptr` and reads offset 0x58 of null.

`src/jsc/bindings/c-bindings.cpp` already documents that SIGPWR is reserved for JSC's GC, but nothing protects the delivery path.

## Fix

Install a thin wrapper over WTF's handler immediately after `WTF::initializeMainThread()`. JSC's suspend/resume always delivers via `pthread_kill` from our own process, which the kernel reports as `si_code == SI_TKILL` with `si_pid == getpid()`; that path is passed through unchanged. Anything else (all three repros above use `kill(2)`, which is `SI_USER`) is forwarded into the JS signal queue instead of reaching WTF.

Alongside that:
- `SIGPWR` is added to the process signal name tables so `process.kill(pid, "SIGPWR")` and `process.on("SIGPWR", fn)` are wired up.
- The listener add/remove path in `onDidChangeListeners` no longer touches the `sigaction` for `g_wtfConfig.sigThreadSuspendResume`; the wrapper is permanent and already feeds `Bun__onPosixSignal`.

The one intentional divergence from Node: with no listener registered, an unsolicited SIGPWR is ignored rather than terminating the process, because JSC still owns the disposition.

## Verification

```
bun bd test test/js/node/process/process-sigpwr.test.ts
  7 pass / 0 fail
```

Covers self-kill by number and by name, external `process.kill` on a child, `subprocess.kill("SIGPWR")`, no-listener survival, listener add/remove not resetting the disposition, and a GC stress loop (`Bun.gc(true)` interleaved with `process.kill(pid, 30)`) to prove the `SI_TKILL` gate still lets JSC's suspend/resume through.