### PR TITLE
Bun.serve: survive aborted uploads when responding with a req.body.tee() branch

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -28,21 +28,21 @@ namespace WebCore {
 using namespace JSC;
 using namespace Bun::WebStreams;
 
-// A tee branch's controller slot usually still carries the kind its tee installed, but
-// Bun's native-sink pumps clear a consumed stream's controller slot in their finally step,
-// so these recover as null when the branch has been torn down.
-static JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* stream)
+// Null-safe tee-branch controller recovery: Bun's native-sink pumps clear a consumed
+// stream's controller slot in their finally step, so a tee reaction queued before that
+// teardown can see a branch with no controller. A torn-down branch is terminal; skip it.
+static JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch)
 {
-    if (stream->m_controllerKind != ControllerKind::Default)
+    if (branch->m_controllerKind != ControllerKind::Default)
         return nullptr;
-    return uncheckedDowncast<JSReadableStreamDefaultController>(stream->m_controller.get());
+    return uncheckedDowncast<JSReadableStreamDefaultController>(branch->m_controller.get());
 }
 
-static JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
+static JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch)
 {
-    if (stream->m_controllerKind != ControllerKind::Byte)
+    if (branch->m_controllerKind != ControllerKind::Byte)
         return nullptr;
-    return uncheckedDowncast<JSReadableByteStreamController>(stream->m_controller.get());
+    return uncheckedDowncast<JSReadableByteStreamController>(branch->m_controller.get());
 }
 
 // [reaction-convention] deferral: runs handler(value, context) as its own microtask,
@@ -150,8 +150,8 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
     case ReadRequestKind::DefaultTee: {
         auto* teeState = uncheckedDowncast<JSStreamTeeState>(m_context.get());
         teeState->m_reading = false;
-        auto* controller1 = defaultControllerOf(teeState->m_branch1.get());
-        auto* controller2 = defaultControllerOf(teeState->m_branch2.get());
+        auto* controller1 = teeBranchDefaultController(teeState->m_branch1.get());
+        auto* controller2 = teeBranchDefaultController(teeState->m_branch2.get());
         if (!teeState->m_canceled1 && controller1) {
             readableStreamDefaultControllerClose(globalObject, controller1);
             RETURN_IF_EXCEPTION(scope, void());
@@ -167,8 +167,8 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
     case ReadRequestKind::ByteTee: {
         auto* teeState = uncheckedDowncast<JSStreamTeeState>(m_context.get());
         teeState->m_reading = false;
-        auto* controller1 = byteControllerOf(teeState->m_branch1.get());
-        auto* controller2 = byteControllerOf(teeState->m_branch2.get());
+        auto* controller1 = teeBranchByteController(teeState->m_branch1.get());
+        auto* controller2 = teeBranchByteController(teeState->m_branch2.get());
         if (!teeState->m_canceled1 && controller1) {
             readableByteStreamControllerClose(globalObject, controller1);
             RETURN_IF_EXCEPTION(scope, void());
@@ -315,8 +315,8 @@ void JSReadIntoRequest::closeSteps(JSGlobalObject* globalObject, JSArrayBufferVi
         teeState->m_reading = false;
         auto* byobBranch = forBranch2 ? teeState->m_branch2.get() : teeState->m_branch1.get();
         auto* otherBranch = forBranch2 ? teeState->m_branch1.get() : teeState->m_branch2.get();
-        auto* byobController = byteControllerOf(byobBranch);
-        auto* otherController = byteControllerOf(otherBranch);
+        auto* byobController = teeBranchByteController(byobBranch);
+        auto* otherController = teeBranchByteController(otherBranch);
         bool byobCanceled = forBranch2 ? teeState->m_canceled2 : teeState->m_canceled1;
         bool otherCanceled = forBranch2 ? teeState->m_canceled1 : teeState->m_canceled2;
         if (!byobCanceled && byobController) {

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -28,16 +28,20 @@ namespace WebCore {
 using namespace JSC;
 using namespace Bun::WebStreams;
 
-// The tee state's branches always carry the controller kind their tee installed.
+// A tee branch's controller slot usually still carries the kind its tee installed, but
+// Bun's native-sink pumps clear a consumed stream's controller slot in their finally step,
+// so these recover as null when the branch has been torn down.
 static JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* stream)
 {
-    ASSERT(stream->m_controllerKind == ControllerKind::Default);
+    if (stream->m_controllerKind != ControllerKind::Default)
+        return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(stream->m_controller.get());
 }
 
 static JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
 {
-    ASSERT(stream->m_controllerKind == ControllerKind::Byte);
+    if (stream->m_controllerKind != ControllerKind::Byte)
+        return nullptr;
     return uncheckedDowncast<JSReadableByteStreamController>(stream->m_controller.get());
 }
 
@@ -146,12 +150,14 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
     case ReadRequestKind::DefaultTee: {
         auto* teeState = uncheckedDowncast<JSStreamTeeState>(m_context.get());
         teeState->m_reading = false;
-        if (!teeState->m_canceled1) {
-            readableStreamDefaultControllerClose(globalObject, defaultControllerOf(teeState->m_branch1.get()));
+        auto* controller1 = defaultControllerOf(teeState->m_branch1.get());
+        auto* controller2 = defaultControllerOf(teeState->m_branch2.get());
+        if (!teeState->m_canceled1 && controller1) {
+            readableStreamDefaultControllerClose(globalObject, controller1);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        if (!teeState->m_canceled2) {
-            readableStreamDefaultControllerClose(globalObject, defaultControllerOf(teeState->m_branch2.get()));
+        if (!teeState->m_canceled2 && controller2) {
+            readableStreamDefaultControllerClose(globalObject, controller2);
             RETURN_IF_EXCEPTION(scope, void());
         }
         if (!teeState->m_canceled1 || !teeState->m_canceled2)
@@ -161,20 +167,22 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
     case ReadRequestKind::ByteTee: {
         auto* teeState = uncheckedDowncast<JSStreamTeeState>(m_context.get());
         teeState->m_reading = false;
-        if (!teeState->m_canceled1) {
-            readableByteStreamControllerClose(globalObject, byteControllerOf(teeState->m_branch1.get()));
+        auto* controller1 = byteControllerOf(teeState->m_branch1.get());
+        auto* controller2 = byteControllerOf(teeState->m_branch2.get());
+        if (!teeState->m_canceled1 && controller1) {
+            readableByteStreamControllerClose(globalObject, controller1);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        if (!teeState->m_canceled2) {
-            readableByteStreamControllerClose(globalObject, byteControllerOf(teeState->m_branch2.get()));
+        if (!teeState->m_canceled2 && controller2) {
+            readableByteStreamControllerClose(globalObject, controller2);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        if (!byteControllerOf(teeState->m_branch1.get())->m_pendingPullIntos.isEmpty()) {
-            readableByteStreamControllerRespond(globalObject, byteControllerOf(teeState->m_branch1.get()), 0);
+        if (controller1 && !controller1->m_pendingPullIntos.isEmpty()) {
+            readableByteStreamControllerRespond(globalObject, controller1, 0);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        if (!byteControllerOf(teeState->m_branch2.get())->m_pendingPullIntos.isEmpty()) {
-            readableByteStreamControllerRespond(globalObject, byteControllerOf(teeState->m_branch2.get()), 0);
+        if (controller2 && !controller2->m_pendingPullIntos.isEmpty()) {
+            readableByteStreamControllerRespond(globalObject, controller2, 0);
             RETURN_IF_EXCEPTION(scope, void());
         }
         if (!teeState->m_canceled1 || !teeState->m_canceled2)
@@ -307,24 +315,26 @@ void JSReadIntoRequest::closeSteps(JSGlobalObject* globalObject, JSArrayBufferVi
         teeState->m_reading = false;
         auto* byobBranch = forBranch2 ? teeState->m_branch2.get() : teeState->m_branch1.get();
         auto* otherBranch = forBranch2 ? teeState->m_branch1.get() : teeState->m_branch2.get();
+        auto* byobController = byteControllerOf(byobBranch);
+        auto* otherController = byteControllerOf(otherBranch);
         bool byobCanceled = forBranch2 ? teeState->m_canceled2 : teeState->m_canceled1;
         bool otherCanceled = forBranch2 ? teeState->m_canceled1 : teeState->m_canceled2;
-        if (!byobCanceled) {
-            readableByteStreamControllerClose(globalObject, byteControllerOf(byobBranch));
+        if (!byobCanceled && byobController) {
+            readableByteStreamControllerClose(globalObject, byobController);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        if (!otherCanceled) {
-            readableByteStreamControllerClose(globalObject, byteControllerOf(otherBranch));
+        if (!otherCanceled && otherController) {
+            readableByteStreamControllerClose(globalObject, otherController);
             RETURN_IF_EXCEPTION(scope, void());
         }
         if (chunkOrNull) {
             ASSERT(!chunkOrNull->byteLength());
-            if (!byobCanceled) {
-                readableByteStreamControllerRespondWithNewView(globalObject, byteControllerOf(byobBranch), chunkOrNull);
+            if (!byobCanceled && byobController) {
+                readableByteStreamControllerRespondWithNewView(globalObject, byobController, chunkOrNull);
                 RETURN_IF_EXCEPTION(scope, void());
             }
-            if (!otherCanceled && !byteControllerOf(otherBranch)->m_pendingPullIntos.isEmpty()) {
-                readableByteStreamControllerRespond(globalObject, byteControllerOf(otherBranch), 0);
+            if (!otherCanceled && otherController && !otherController->m_pendingPullIntos.isEmpty()) {
+                readableByteStreamControllerRespond(globalObject, otherController, 0);
                 RETURN_IF_EXCEPTION(scope, void());
             }
         }

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -71,6 +71,23 @@ static JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream
     return nullptr;
 }
 
+// Null-safe tee-branch controller recovery: Bun's native-sink pumps clear a consumed
+// stream's controller slot in their finally step, so a tee reaction queued before that
+// teardown can see a branch with no controller. A torn-down branch is terminal; skip it.
+static JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch)
+{
+    if (branch->m_controllerKind != ControllerKind::Default)
+        return nullptr;
+    return uncheckedDowncast<JSReadableStreamDefaultController>(branch->m_controller.get());
+}
+
+static JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch)
+{
+    if (branch->m_controllerKind != ControllerKind::Byte)
+        return nullptr;
+    return uncheckedDowncast<JSReadableByteStreamController>(branch->m_controller.get());
+}
+
 // The byte tee's mutable reader slot is erased to JSCell; recover the non-polymorphic
 // reader base through the two concrete classes.
 static JSReadableStreamReaderBase* teeReader(JSStreamTeeState* teeState)
@@ -977,6 +994,8 @@ static EncodedJSValue defaultTeeChunkStepsMicrotask(JSGlobalObject* globalObject
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     teeState->m_readAgain1 = false;
+    auto* controller1 = teeBranchDefaultController(teeState->m_branch1.get());
+    auto* controller2 = teeBranchDefaultController(teeState->m_branch2.get());
     JSValue chunk1 = chunk;
     JSValue chunk2 = chunk;
     if (!teeState->m_canceled2 && teeState->m_shouldClone) {
@@ -988,10 +1007,14 @@ static EncodedJSValue defaultTeeChunkStepsMicrotask(JSGlobalObject* globalObject
                 JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
                 if (thrown.isEmpty())
                     return {};
-                readableStreamDefaultControllerError(globalObject, defaultControllerOf(teeState->m_branch1.get()), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
-                readableStreamDefaultControllerError(globalObject, defaultControllerOf(teeState->m_branch2.get()), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
+                if (controller1) {
+                    readableStreamDefaultControllerError(globalObject, controller1, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+                if (controller2) {
+                    readableStreamDefaultControllerError(globalObject, controller2, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
                 auto* cancelResult = readableStreamCancel(globalObject, teeState->m_stream.get(), thrown);
                 RETURN_IF_EXCEPTION(scope, {});
                 resolvePromise(globalObject, teeState->m_cancelPromise.get(), cancelResult);
@@ -1001,12 +1024,12 @@ static EncodedJSValue defaultTeeChunkStepsMicrotask(JSGlobalObject* globalObject
         }
         chunk2 = cloneResult;
     }
-    if (!teeState->m_canceled1) {
-        readableStreamDefaultControllerEnqueue(globalObject, defaultControllerOf(teeState->m_branch1.get()), chunk1);
+    if (!teeState->m_canceled1 && controller1) {
+        readableStreamDefaultControllerEnqueue(globalObject, controller1, chunk1);
         RETURN_IF_EXCEPTION(scope, {});
     }
-    if (!teeState->m_canceled2) {
-        readableStreamDefaultControllerEnqueue(globalObject, defaultControllerOf(teeState->m_branch2.get()), chunk2);
+    if (!teeState->m_canceled2 && controller2) {
+        readableStreamDefaultControllerEnqueue(globalObject, controller2, chunk2);
         RETURN_IF_EXCEPTION(scope, {});
     }
     teeState->m_reading = false;
@@ -1022,10 +1045,14 @@ static EncodedJSValue defaultTeeReaderClosedRejected(JSGlobalObject* globalObjec
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    readableStreamDefaultControllerError(globalObject, defaultControllerOf(teeState->m_branch1.get()), reason);
-    RETURN_IF_EXCEPTION(scope, {});
-    readableStreamDefaultControllerError(globalObject, defaultControllerOf(teeState->m_branch2.get()), reason);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* controller1 = teeBranchDefaultController(teeState->m_branch1.get())) {
+        readableStreamDefaultControllerError(globalObject, controller1, reason);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    if (auto* controller2 = teeBranchDefaultController(teeState->m_branch2.get())) {
+        readableStreamDefaultControllerError(globalObject, controller2, reason);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     if (!teeState->m_canceled1 || !teeState->m_canceled2) {
         resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
@@ -1158,6 +1185,8 @@ static EncodedJSValue byteTeeChunkStepsMicrotask(JSGlobalObject* globalObject, J
     auto scope = DECLARE_THROW_SCOPE(vm);
     teeState->m_readAgain1 = false;
     teeState->m_readAgain2 = false;
+    auto* controller1 = teeBranchByteController(teeState->m_branch1.get());
+    auto* controller2 = teeBranchByteController(teeState->m_branch2.get());
     auto* chunk1 = uncheckedDowncast<JSArrayBufferView>(chunk);
     JSArrayBufferView* chunk2 = chunk1;
     if (!teeState->m_canceled1 && !teeState->m_canceled2) {
@@ -1169,10 +1198,14 @@ static EncodedJSValue byteTeeChunkStepsMicrotask(JSGlobalObject* globalObject, J
                 JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
                 if (thrown.isEmpty())
                     return {};
-                readableByteStreamControllerError(globalObject, byteControllerOf(teeState->m_branch1.get()), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
-                readableByteStreamControllerError(globalObject, byteControllerOf(teeState->m_branch2.get()), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
+                if (controller1) {
+                    readableByteStreamControllerError(globalObject, controller1, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+                if (controller2) {
+                    readableByteStreamControllerError(globalObject, controller2, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
                 auto* cancelResult = readableStreamCancel(globalObject, teeState->m_stream.get(), thrown);
                 RETURN_IF_EXCEPTION(scope, {});
                 resolvePromise(globalObject, teeState->m_cancelPromise.get(), cancelResult);
@@ -1182,12 +1215,12 @@ static EncodedJSValue byteTeeChunkStepsMicrotask(JSGlobalObject* globalObject, J
         }
         chunk2 = cloneResult;
     }
-    if (!teeState->m_canceled1) {
-        readableByteStreamControllerEnqueue(globalObject, byteControllerOf(teeState->m_branch1.get()), chunk1);
+    if (!teeState->m_canceled1 && controller1) {
+        readableByteStreamControllerEnqueue(globalObject, controller1, chunk1);
         RETURN_IF_EXCEPTION(scope, {});
     }
-    if (!teeState->m_canceled2) {
-        readableByteStreamControllerEnqueue(globalObject, byteControllerOf(teeState->m_branch2.get()), chunk2);
+    if (!teeState->m_canceled2 && controller2) {
+        readableByteStreamControllerEnqueue(globalObject, controller2, chunk2);
         RETURN_IF_EXCEPTION(scope, {});
     }
     teeState->m_reading = false;
@@ -1214,6 +1247,8 @@ static EncodedJSValue byteTeeReadIntoChunkStepsMicrotask(JSGlobalObject* globalO
     teeState->m_readAgain2 = false;
     auto* byobBranch = forBranch2 ? teeState->m_branch2.get() : teeState->m_branch1.get();
     auto* otherBranch = forBranch2 ? teeState->m_branch1.get() : teeState->m_branch2.get();
+    auto* byobController = teeBranchByteController(byobBranch);
+    auto* otherController = teeBranchByteController(otherBranch);
     bool byobCanceled = forBranch2 ? teeState->m_canceled2 : teeState->m_canceled1;
     bool otherCanceled = forBranch2 ? teeState->m_canceled1 : teeState->m_canceled2;
 
@@ -1226,10 +1261,14 @@ static EncodedJSValue byteTeeReadIntoChunkStepsMicrotask(JSGlobalObject* globalO
                 JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
                 if (thrown.isEmpty())
                     return {};
-                readableByteStreamControllerError(globalObject, byteControllerOf(byobBranch), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
-                readableByteStreamControllerError(globalObject, byteControllerOf(otherBranch), thrown);
-                RETURN_IF_EXCEPTION(scope, {});
+                if (byobController) {
+                    readableByteStreamControllerError(globalObject, byobController, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+                if (otherController) {
+                    readableByteStreamControllerError(globalObject, otherController, thrown);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
                 auto* cancelResult = readableStreamCancel(globalObject, teeState->m_stream.get(), thrown);
                 RETURN_IF_EXCEPTION(scope, {});
                 resolvePromise(globalObject, teeState->m_cancelPromise.get(), cancelResult);
@@ -1237,14 +1276,16 @@ static EncodedJSValue byteTeeReadIntoChunkStepsMicrotask(JSGlobalObject* globalO
                 return JSValue::encode(jsUndefined());
             }
         }
-        if (!byobCanceled) {
-            readableByteStreamControllerRespondWithNewView(globalObject, byteControllerOf(byobBranch), chunk);
+        if (!byobCanceled && byobController) {
+            readableByteStreamControllerRespondWithNewView(globalObject, byobController, chunk);
             RETURN_IF_EXCEPTION(scope, {});
         }
-        readableByteStreamControllerEnqueue(globalObject, byteControllerOf(otherBranch), clonedChunk);
-        RETURN_IF_EXCEPTION(scope, {});
-    } else if (!byobCanceled) {
-        readableByteStreamControllerRespondWithNewView(globalObject, byteControllerOf(byobBranch), chunk);
+        if (otherController) {
+            readableByteStreamControllerEnqueue(globalObject, otherController, clonedChunk);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    } else if (!byobCanceled && byobController) {
+        readableByteStreamControllerRespondWithNewView(globalObject, byobController, chunk);
         RETURN_IF_EXCEPTION(scope, {});
     }
     teeState->m_reading = false;
@@ -1266,10 +1307,14 @@ static EncodedJSValue byteTeeReaderClosedRejected(JSGlobalObject* globalObject, 
     auto* teeState = uncheckedDowncast<JSStreamTeeState>(context->getInternalField(0));
     if (context->getInternalField(1) != teeState->m_reader.get())
         return JSValue::encode(jsUndefined());
-    readableByteStreamControllerError(globalObject, byteControllerOf(teeState->m_branch1.get()), reason);
-    RETURN_IF_EXCEPTION(scope, {});
-    readableByteStreamControllerError(globalObject, byteControllerOf(teeState->m_branch2.get()), reason);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* controller1 = teeBranchByteController(teeState->m_branch1.get())) {
+        readableByteStreamControllerError(globalObject, controller1, reason);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    if (auto* controller2 = teeBranchByteController(teeState->m_branch2.get())) {
+        readableByteStreamControllerError(globalObject, controller2, reason);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     if (!teeState->m_canceled1 || !teeState->m_canceled2) {
         resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3187,22 +3187,21 @@ it("type: direct stream — small write queued under backpressure is delivered i
   }
 });
 
-// `const [a,b] = req.body.tee(); return new Response(a)`: when the client aborts the
-// upload, the response-side sink pump tears down branch `a`'s controller slot, then
-// the tee's queued closed-rejected / chunk reactions run against a branch that no
-// longer carries a default controller. That used to hit a RELEASE_ASSERT in
-// defaultControllerOf() and SIGABRT the whole server process.
+// Aborting an upload mid-body while a req.body.tee() branch is the in-flight
+// response body must not crash the server process.
 it("survives aborted uploads while responding with a tee()d request-body branch", async () => {
   const script = `
     const net = require("node:net");
     const readAll = async rs => { const rd = rs.getReader(); for (;;) { if ((await rd.read()).done) return; } };
+    let seen = 0, settled = 0, notify = () => {};
     const srv = Bun.serve({
       hostname: "127.0.0.1", port: 0, idleTimeout: 0,
       error() { return new Response("err"); },
       async fetch(req) {
         if (!req.body) return new Response("nobody");
+        seen++;
         const [a, b] = req.body.tee();
-        readAll(b).catch(() => {});
+        readAll(b).catch(() => {}).finally(() => { settled++; notify(); });
         return new Response(a);
       },
     });
@@ -3223,8 +3222,12 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
         s.on("error", () => done());
       });
     }
-    await new Promise(r => setTimeout(r, 20));
-    console.log("SURVIVED", it);
+    // One clean request so every aborted connection's header has reached fetch().
+    await fetch(srv.url).then(r => r.text());
+    // readAll(b) settles only after the tee's source-error reaction has errored branch b,
+    // so settled == seen proves every tee reaction for every handled request has run.
+    while (settled < seen) await new Promise(r => { notify = r; });
+    console.log("SURVIVED", it, seen === settled);
     srv.stop(true);
   `;
 
@@ -3237,7 +3240,7 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-    stdout: "SURVIVED 40",
+    stdout: "SURVIVED 40 true",
     stderr: "",
     exitCode: 0,
     signalCode: null,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3186,3 +3186,60 @@ it("type: direct stream — small write queued under backpressure is delivered i
     socket.destroy();
   }
 });
+
+// `const [a,b] = req.body.tee(); return new Response(a)`: when the client aborts the
+// upload, the response-side sink pump tears down branch `a`'s controller slot, then
+// the tee's queued closed-rejected / chunk reactions run against a branch that no
+// longer carries a default controller. That used to hit a RELEASE_ASSERT in
+// defaultControllerOf() and SIGABRT the whole server process.
+it("survives aborted uploads while responding with a tee()d request-body branch", async () => {
+  const script = `
+    const net = require("node:net");
+    const readAll = async rs => { const rd = rs.getReader(); for (;;) { if ((await rd.read()).done) return; } };
+    const srv = Bun.serve({
+      hostname: "127.0.0.1", port: 0, idleTimeout: 0,
+      error() { return new Response("err"); },
+      async fetch(req) {
+        if (!req.body) return new Response("nobody");
+        const [a, b] = req.body.tee();
+        readAll(b).catch(() => {});
+        return new Response(a);
+      },
+    });
+    const chunk = Buffer.alloc(8192, 66);
+    let it = 0;
+    for (; it < 40; it++) {
+      await new Promise(done => {
+        const s = net.connect(srv.port, "127.0.0.1", () => {
+          s.write("POST / HTTP/1.1\\r\\nhost: x\\r\\ncontent-length: 262144\\r\\n\\r\\n");
+          setImmediate(() => {
+            s.write(chunk);
+            s.write(chunk);
+            s.write(chunk);
+            setImmediate(() => { s.destroy(); done(); });
+          });
+        });
+        s.on("data", () => {});
+        s.on("error", () => done());
+      });
+    }
+    await new Promise(r => setTimeout(r, 20));
+    console.log("SURVIVED", it);
+    srv.stop(true);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "SURVIVED 40",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -741,6 +741,52 @@ describe("spawn stdin ReadableStream", () => {
     expect(await proc.exited).toBe(0);
   });
 
+  // The native-sink pump's finally step clears the consumed tee branch's controller slot;
+  // a tee reaction queued for the source's later error/close must skip that branch instead
+  // of RELEASE_ASSERT'ing on the mismatched controller kind.
+  test.each([
+    { streamType: "bytes", finish: "error", result: "rejected upstream failed" },
+    { streamType: "bytes", finish: "close", result: "resolved done=true" },
+    { streamType: "default", finish: "error", result: "rejected upstream failed" },
+  ] as const)(
+    "tee()d $streamType stream: source $finish after stdin consumer exits does not crash",
+    async ({ streamType, finish, result }) => {
+      const script = `
+        let ctrl;
+        const src = new ReadableStream({
+          ${streamType === "bytes" ? 'type: "bytes",' : ""}
+          start(c) { ctrl = c; },
+        });
+        const [a, b] = src.tee();
+        const bRead = b.getReader().read();
+        bRead.catch(() => {});
+        const child = Bun.spawn({ cmd: [process.execPath, "-e", ""], stdin: a, stdout: "ignore", stderr: "ignore" });
+        await child.exited;
+        ${finish === "error" ? 'ctrl.error(new Error("upstream failed"));' : "ctrl.close();"}
+        const settled = await bRead.then(
+          v => "resolved done=" + v.done,
+          e => "rejected " + e.message,
+        );
+        console.log("SURVIVED", ${JSON.stringify(streamType)}, ${JSON.stringify(finish)}, settled);
+      `;
+
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        stdout: `SURVIVED ${streamType} ${finish} ${result}`,
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+  );
+
   test("ReadableStream object type count", async () => {
     const iterations = isASAN
       ? // With ASAN, entire process gets killed. Likely an OOM or out of file


### PR DESCRIPTION
### What

`const [a, b] = req.body.tee(); return new Response(a)` followed by the client aborting the upload (closed tab, `curl` ^C, lost network) SIGABRTs the whole server process.

### Repro

```js
const srv = Bun.serve({
  port: 0, idleTimeout: 0,
  async fetch(req) {
    if (!req.body) return new Response("nobody");
    const [a, b] = req.body.tee();
    b.getReader().read().catch(() => {});
    return new Response(a);
  },
});
// POST a few chunks of a content-length body, destroy the socket mid-upload.
// Within a few dozen aborts: SIGABRT.
```

Assert build:

```
SHOULD NEVER BE REACHED
src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp(55)
Bun::WebStreams::defaultControllerOf(JSReadableStream *)
```

### Cause

`readableStreamDefaultTee` creates two branch streams, each with a `ControllerKind::Default` controller, and registers the `onDefaultTeeReaderClosedRejected` / `onDefaultTeeReadChunkMicrotask` reactions on the source reader.

When the server sends branch `a` as the response body, `readStreamIntoSink` pumps it into the HTTP response sink. That pump's finally step (`rsisFinally`, and `resumableReleaseReader` for the resumable-sink pump) calls `clearStreamControllerSlots(branch)`, which sets `branch->m_controllerKind = ControllerKind::None` and clears `branch->m_controller`.

When the client then aborts the upload mid-body, the request-body source stream errors, rejecting the tee reader's `closedPromise`. The queued `defaultTeeReaderClosedRejected` reaction runs and calls `defaultControllerOf(teeState->m_branch1.get())`, which `RELEASE_ASSERT`s on a non-`Default` controller kind. The same race exists for the tee's chunk microtask and read-request `closeSteps`, and for the byte-tee equivalents.

### Fix

Add null-safe branch-controller recovery (`teeBranchDefaultController` / `teeBranchByteController`) and use it in every tee reaction that operates on `teeState->m_branch{1,2}`. A branch whose controller has been torn down by a Bun consumer is terminal; the spec AOs (`ReadableStreamDefaultControllerError/Close/Enqueue` and byte equivalents) would no-op on it anyway, so the reaction simply skips that branch.

### Verification

- New test in `test/js/bun/http/serve.test.ts` spawns a server that returns a `req.body.tee()` branch and hits it with 40 aborted uploads. Without the fix: SIGABRT (exit 134) 5/5 on the debug build within the first few iterations. With the fix: exits 0 with empty stderr, 3/3.
- `test/js/third_party/wpt-streams/wpt-streams.test.ts`: 1175 pass / 0 fail.
- `test/js/web/streams/streams.test.js`: no new failures (2 pre-existing timeouts also present on main).
- `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts` (uses tee): 25 pass / 0 fail.