### PR TITLE
fetch: tee the body stream in clone() instead of detaching the cached .body

### DIFF
--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -97,6 +97,7 @@ JSObject* JSBunRequest::cookies() const
 }
 
 extern "C" void* Request__clone(void* internalZigRequestPointer, JSGlobalObject* globalObject);
+extern "C" void Request__syncClonedBodyStreamCaches(void* self, JSGlobalObject* globalObject, EncodedJSValue thisValue, void* cloned, EncodedJSValue jsWrapper);
 
 JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
 {
@@ -107,6 +108,7 @@ JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
     EXCEPTION_ASSERT(!!raw == !throwScope.exception());
     RETURN_IF_EXCEPTION(throwScope, nullptr);
     auto* clone = this->create(vm, structure, raw, nullptr);
+    Request__syncClonedBodyStreamCaches(this->wrapped(), globalObject, JSValue::encode(this), clone->wrapped(), JSValue::encode(clone));
 
     // Cookies and params are deep copied as they can be changed between the clone and original
     if (auto* params = this->params()) {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1746,19 +1746,33 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     }
 
     /// Shared `'brk:` block of `clone_into` / `clone_value`: clone the body
-    /// [`Value`], teeing through the JS-side cached stream if one exists.
+    /// [`Value`], teeing through the JS-side cached stream if one exists, then
+    /// repoint this owner's `body`/`stream` cache slots at the fresh first
+    /// branch now in `locked.readable` so the locked tee source is no longer
+    /// returned from `.body` / `get_body_readable_stream`.
     fn clone_body_value_via_cached_stream(&self, global_this: &JSGlobalObject) -> JsResult<Value> {
+        let cloned = 'brk: {
+            if let Some(js_ref) = self.js_ref() {
+                if let Some(stream) = Self::stream_get_cached(js_ref) {
+                    let mut readable = ReadableStream::from_js(stream, global_this)?;
+                    if let Some(r) = readable.as_mut() {
+                        break 'brk self
+                            .get_body_value()
+                            .clone_with_readable_stream(global_this, Some(r))?;
+                    }
+                }
+            }
+            self.get_body_value().clone(global_this)?
+        };
         if let Some(js_ref) = self.js_ref() {
-            if let Some(stream) = Self::stream_get_cached(js_ref) {
-                let mut readable = ReadableStream::from_js(stream, global_this)?;
-                if let Some(r) = readable.as_mut() {
-                    return self
-                        .get_body_value()
-                        .clone_with_readable_stream(global_this, Some(r));
+            if let Value::Locked(locked) = self.get_body_value() {
+                if let Some(readable) = locked.readable.get(global_this) {
+                    Self::body_set_cached(js_ref, global_this, readable.value);
                 }
             }
         }
-        self.get_body_value().clone(global_this)
+        self.check_body_stream_ref(global_this);
+        Ok(cloned)
     }
 
     fn get_text(&self, global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1745,11 +1745,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         self.check_body_stream_ref(global_this);
     }
 
-    /// Shared `'brk:` block of `clone_into` / `clone_value`: clone the body
-    /// [`Value`], teeing through the JS-side cached stream if one exists, then
-    /// repoint this owner's `body`/`stream` cache slots at the fresh first
-    /// branch now in `locked.readable` so the locked tee source is no longer
-    /// returned from `.body` / `get_body_readable_stream`.
+    /// Shared body-clone for `clone_into` / `clone_value`: tee through the
+    /// JS-side cached stream when present, then repoint this owner's
+    /// `body`/`stream` cache slots at the fresh branch in `locked.readable`.
     fn clone_body_value_via_cached_stream(&self, global_this: &JSGlobalObject) -> JsResult<Value> {
         let cloned = 'brk: {
             if let Some(js_ref) = self.js_ref() {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1588,11 +1588,14 @@ impl Value {
         global_this: &JSGlobalObject,
         readable: Option<&mut ReadableStream>,
     ) -> JsResult<Value> {
-        self.to_blob_if_possible();
-
+        // Tee a Locked body before any blob extraction: `to_blob_if_possible()`
+        // would `.done()` an already-materialized `.body` stream, leaving the
+        // user-visible cached stream empty instead of a live tee branch.
         if matches!(self, Value::Locked(_)) {
             return self.tee(global_this, readable);
         }
+
+        self.to_blob_if_possible();
 
         if let Value::InternalBlob(internal_blob) = self {
             let owned = internal_blob.to_owned_slice();

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -433,9 +433,13 @@ impl Request {
         js_wrapper: JSValue,
     ) {
         // `JSBunRequest::create` bypasses `to_js`, so `cloned.js_ref` is still
-        // empty; set it first so `check_body_stream_ref` can migrate the
-        // clone's teed `locked.readable` into its GC-traced `stream` slot.
-        cloned.js_ref.set(JsRef::init_weak(js_wrapper));
+        // the `JsRef::empty()` written by `clone_into`; seed it so
+        // `check_body_stream_ref` can migrate the clone's teed branch into its
+        // GC-traced `stream` slot. Guarded so a future caller that already
+        // populated it never has a Strong downgraded.
+        if cloned.js_ref.get().is_empty() {
+            cloned.js_ref.set(JsRef::init_weak(js_wrapper));
+        }
         cloned.check_body_stream_ref(global_this);
         self.sync_cloned_body_stream_caches(this_value, js_wrapper, global_this);
     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -432,6 +432,10 @@ impl Request {
         cloned: &Request,
         js_wrapper: JSValue,
     ) {
+        // `JSBunRequest::create` bypasses `to_js`, so `cloned.js_ref` is still
+        // empty; set it first so `check_body_stream_ref` can migrate the
+        // clone's teed `locked.readable` into its GC-traced `stream` slot.
+        cloned.js_ref.set(JsRef::init_weak(js_wrapper));
         cloned.check_body_stream_ref(global_this);
         self.sync_cloned_body_stream_caches(this_value, js_wrapper, global_this);
     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -432,11 +432,9 @@ impl Request {
         cloned: &Request,
         js_wrapper: JSValue,
     ) {
-        // `JSBunRequest::create` bypasses `to_js`, so `cloned.js_ref` is still
-        // the `JsRef::empty()` written by `clone_into`; seed it so
-        // `check_body_stream_ref` can migrate the clone's teed branch into its
-        // GC-traced `stream` slot. Guarded so a future caller that already
-        // populated it never has a Strong downgraded.
+        // `JSBunRequest::create` bypasses `to_js`, so seed the still-empty
+        // `js_ref` for `check_body_stream_ref`; guarded so a pre-populated
+        // Strong is never downgraded.
         if cloned.js_ref.get().is_empty() {
             cloned.js_ref.set(JsRef::init_weak(js_wrapper));
         }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1239,7 +1239,7 @@ impl Request {
                         match request.body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
-                                match request.body_value_mut().clone(global_this) {
+                                match request.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
                                     }
@@ -1288,11 +1288,10 @@ impl Request {
                     }
 
                     if !fields.contains(Fields::Body) {
-                        let body_value = response.get_body_value();
-                        match body_value {
+                        match response.get_body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
-                                match body_value.clone(global_this) {
+                                match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
                                     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -420,6 +420,21 @@ impl Request {
         self.throw_if_body_unusable(global_this).ok()?;
         self.clone(global_this).ok()
     }
+
+    /// `JSBunRequest::clone` tail: mirror [`Self::do_clone`]'s cache sync so a
+    /// `routes:` handler that observed `.body` before cloning gets a fresh tee
+    /// branch from the next `.body` read instead of the locked tee source.
+    #[bun_uws::uws_callback(export = "Request__syncClonedBodyStreamCaches")]
+    pub fn ffi_sync_cloned_body_stream_caches(
+        &self,
+        global_this: &JSGlobalObject,
+        this_value: JSValue,
+        cloned: &Request,
+        js_wrapper: JSValue,
+    ) {
+        cloned.check_body_stream_ref(global_this);
+        self.sync_cloned_body_stream_caches(this_value, js_wrapper, global_this);
+    }
 }
 
 // NOTE: `EventType` and `impl InternalJSEventCallback` are defined once below

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1019,7 +1019,9 @@ describe.concurrent("clone() after `.body` was observed returns a fresh tee bran
 // (migrated into the source wrapper's stream cache at construction) it must
 // consult that cache instead of teeing the now-empty native slot, or the
 // derived request's body is a branch of a disconnected stream and reads hang.
-test("new Request(src, init) with a user ReadableStream body: derived request's body carries the source's bytes", async () => {
+// After the tee, the source's cached stream must also be repointed to its own
+// branch so reading the source still works.
+test("new Request(src, init) with a user ReadableStream body: both derived and source read the bytes", async () => {
   const stream = () =>
     new ReadableStream({
       start(controller) {
@@ -1029,21 +1031,25 @@ test("new Request(src, init) with a user ReadableStream body: derived request's 
     });
   // @ts-expect-error duplex
   const make = () => new Request("http://example.com/", { method: "POST", body: stream(), duplex: "half" });
+  const bytes = async (r: Request | Response) => [...new Uint8Array(await r.arrayBuffer())];
 
-  const twoArg = new Request(make(), { headers: { "x-a": "1" } });
-  const oneArg = new Request(make());
+  const twoArgSrc = make();
+  const twoArg = new Request(twoArgSrc, { headers: { "x-a": "1" } });
+  const oneArgSrc = make();
+  const oneArg = new Request(oneArgSrc);
   // Bun extension: a Response as the second argument contributes its body via
   // the sibling Response-source branch in construct_into.
+  const responseSrc = new Response(stream());
   // @ts-expect-error Bun accepts a Response as init
-  const fromResponse = new Request("http://example.com/", new Response(stream()));
+  const fromResponse = new Request("http://example.com/", responseSrc);
   expect({
-    twoArg: new Uint8Array(await twoArg.arrayBuffer()),
-    oneArg: new Uint8Array(await oneArg.arrayBuffer()),
-    fromResponse: new Uint8Array(await fromResponse.arrayBuffer()),
+    twoArg: { derived: await bytes(twoArg), src: await bytes(twoArgSrc) },
+    oneArg: { derived: await bytes(oneArg), src: await bytes(oneArgSrc) },
+    fromResponse: { derived: await bytes(fromResponse), src: await bytes(responseSrc) },
   }).toEqual({
-    twoArg: new Uint8Array([1, 2, 3]),
-    oneArg: new Uint8Array([1, 2, 3]),
-    fromResponse: new Uint8Array([1, 2, 3]),
+    twoArg: { derived: [1, 2, 3], src: [1, 2, 3] },
+    oneArg: { derived: [1, 2, 3], src: [1, 2, 3] },
+    fromResponse: { derived: [1, 2, 3], src: [1, 2, 3] },
   });
 });
 

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -868,11 +868,34 @@ describe("clone() throws when the body is disturbed or locked", () => {
 // branch carrying every byte; the pre-clone stream object becomes the (now
 // locked) tee source. The `if (res.body) { cache.put(res.clone()); use
 // res.body }` middleware shape depends on this.
-describe("clone() after `.body` was observed returns a fresh tee branch for both sides", () => {
+describe.concurrent("clone() after `.body` was observed returns a fresh tee branch for both sides", () => {
   async function drain(stream: ReadableStream<Uint8Array>): Promise<number> {
     let n = 0;
     for await (const chunk of stream) n += chunk.byteLength;
     return n;
+  }
+
+  type Observed = { before: ReadableStream; after: ReadableStream; cloned: Request | Response };
+
+  function observeThenClone(target: Request | Response): Observed {
+    const before = target.body!;
+    expect(before.locked).toBe(false);
+    expect(target.bodyUsed).toBe(false);
+
+    const cloned = target.clone();
+    const after = target.body!;
+
+    // Spec: .body is a new tee branch; the pre-clone stream is the tee
+    // source and is now locked.
+    expect(after).not.toBe(before);
+    expect(before.locked).toBe(true);
+    expect(target.bodyUsed).toBe(false);
+    return { before, after, cloned };
+  }
+
+  async function checkBytes({ after, cloned }: Observed, n: number) {
+    const [origBytes, cloneBytes] = await Promise.all([drain(after), drain(cloned.body!)]);
+    expect({ origBytes, cloneBytes }).toEqual({ origBytes: n, cloneBytes: n });
   }
 
   // Each body type hits a different internal representation at clone() time:
@@ -940,22 +963,7 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
 
   for (const [label, make] of cases) {
     test(`${label}: reading .body after observe+clone yields the full payload on both sides`, async () => {
-      const target = await make();
-      const before = target.body!;
-      expect(before.locked).toBe(false);
-      expect(target.bodyUsed).toBe(false);
-
-      const cloned = target.clone();
-      const after = target.body!;
-
-      // Spec: .body is a new tee branch; the pre-clone stream is the tee
-      // source and is now locked.
-      expect(after).not.toBe(before);
-      expect(before.locked).toBe(true);
-      expect(target.bodyUsed).toBe(false);
-
-      const [origBytes, cloneBytes] = await Promise.all([drain(after), drain(cloned.body!)]);
-      expect({ origBytes, cloneBytes }).toEqual({ origBytes: N, cloneBytes: N });
+      await checkBytes(observeThenClone(await make()), N);
     });
 
     test(`${label}: .text() after observe+clone yields the full payload on both sides`, async () => {
@@ -967,6 +975,29 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
       expect(cloneText.length).toBe(N);
     });
   }
+
+  // `routes:` handlers receive a BunRequest subclass whose own `clone` is a
+  // separate native entry point (JSBunRequest::clone -> Request__clone); it
+  // must repoint the source's cached `.body` the same way.
+  test("Bun.serve routes: BunRequest observe+clone yields a fresh tee branch carrying the full payload", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/p/:id": async (req: Request) => {
+          try {
+            await checkBytes(observeThenClone(req), N);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+          return new Response("ok");
+        },
+      },
+    });
+    await fetch(new URL("/p/1", server.url), { method: "POST", body: payload });
+    await promise;
+  });
 
   test("fetch() Response: second clone after observe still yields full payload", async () => {
     await using server = Bun.serve({

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -894,20 +894,13 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
         // whole body has been received by then.
         await using server = Bun.serve({
           port: 0,
-          fetch: () =>
-            new Response(payload, { headers: { "content-length": String(N) } }),
+          fetch: () => new Response(payload, { headers: { "content-length": String(N) } }),
         });
         return await fetch(server.url);
       },
     ],
-    [
-      "Response with a string body",
-      async () => new Response(payload.toString("latin1")),
-    ],
-    [
-      "Response with a Uint8Array body",
-      async () => new Response(payload),
-    ],
+    ["Response with a string body", async () => new Response(payload.toString("latin1"))],
+    ["Response with a Uint8Array body", async () => new Response(payload)],
     [
       "Response with a user ReadableStream body",
       async () =>
@@ -961,10 +954,7 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
       expect(before.locked).toBe(true);
       expect(target.bodyUsed).toBe(false);
 
-      const [origBytes, cloneBytes] = await Promise.all([
-        drain(after),
-        drain(cloned.body!),
-      ]);
+      const [origBytes, cloneBytes] = await Promise.all([drain(after), drain(cloned.body!)]);
       expect({ origBytes, cloneBytes }).toEqual({ origBytes: N, cloneBytes: N });
     });
 
@@ -972,10 +962,7 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
       const target = await make();
       void target.body; // observe only; no reader, no lock
       const cloned = target.clone();
-      const [origText, cloneText] = await Promise.all([
-        target.text(),
-        cloned.text(),
-      ]);
+      const [origText, cloneText] = await Promise.all([target.text(), cloned.text()]);
       expect(origText.length).toBe(N);
       expect(cloneText.length).toBe(N);
     });
@@ -991,11 +978,7 @@ describe("clone() after `.body` was observed returns a fresh tee branch for both
     const c1 = response.clone();
     void response.body;
     const c2 = response.clone();
-    const [orig, b1, b2] = await Promise.all([
-      drain(response.body!),
-      drain(c1.body!),
-      drain(c2.body!),
-    ]);
+    const [orig, b1, b2] = await Promise.all([drain(response.body!), drain(c1.body!), drain(c2.body!)]);
     expect({ orig, b1, b2 }).toEqual({ orig: N, b1: N, b2: N });
   });
 });

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1014,6 +1014,31 @@ describe.concurrent("clone() after `.body` was observed returns a fresh tee bran
   });
 });
 
+// The two-arg `new Request(src, init)` constructor tees the source body via a
+// separate path from single-arg / .clone(); with a user ReadableStream body
+// (migrated into the source wrapper's stream cache at construction) it must
+// consult that cache instead of teeing the now-empty native slot, or the
+// derived request's body is a branch of a disconnected stream and reads hang.
+test("new Request(src, init) with a user ReadableStream body: derived request's body carries the source's bytes", async () => {
+  const make = () =>
+    new Request("http://example.com/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      }),
+      // @ts-expect-error duplex
+      duplex: "half",
+    });
+
+  const twoArg = new Request(make(), { headers: { "x-a": "1" } });
+  const oneArg = new Request(make());
+  expect(new Uint8Array(await twoArg.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+  expect(new Uint8Array(await oneArg.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+});
+
 test("Blob type from a consumed Response keeps the original content-type after clones with different content-types are consumed", async () => {
   // The Response and its clones share one underlying body store. Consuming a clone
   // with a different Content-Type must not change (or invalidate) the type of a Blob

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -862,6 +862,144 @@ describe("clone() throws when the body is disturbed or locked", () => {
   });
 });
 
+// https://fetch.spec.whatwg.org/#concept-body-clone: clone() tees the body
+// stream and *replaces* this's body stream with one tee branch. If `.body`
+// was observed before the clone, the original's `.body` must become a fresh
+// branch carrying every byte; the pre-clone stream object becomes the (now
+// locked) tee source. The `if (res.body) { cache.put(res.clone()); use
+// res.body }` middleware shape depends on this.
+describe("clone() after `.body` was observed returns a fresh tee branch for both sides", () => {
+  async function drain(stream: ReadableStream<Uint8Array>): Promise<number> {
+    let n = 0;
+    for await (const chunk of stream) n += chunk.byteLength;
+    return n;
+  }
+
+  // Each body type hits a different internal representation at clone() time:
+  //   - fetch() with the full body buffered → InternalBlob, then .body
+  //     materializes a Blob-backed stream (the reported bug)
+  //   - new Response(string) → WTFStringImpl, then .body materializes a
+  //     Blob-backed stream
+  //   - new Response(Uint8Array) → Blob, then .body materializes a
+  //     Blob-backed stream
+  //   - new Response(ReadableStream) → Locked with a user stream already
+  //     rooted in the JS-side stream slot
+  const N = 8192;
+  const payload = Buffer.alloc(N, "a");
+  const cases: Array<[string, () => Promise<Request | Response>]> = [
+    [
+      "fetch() Response with a buffered body",
+      async () => {
+        // `using` on the outer server closes it after fetch() returns; the
+        // whole body has been received by then.
+        await using server = Bun.serve({
+          port: 0,
+          fetch: () =>
+            new Response(payload, { headers: { "content-length": String(N) } }),
+        });
+        return await fetch(server.url);
+      },
+    ],
+    [
+      "Response with a string body",
+      async () => new Response(payload.toString("latin1")),
+    ],
+    [
+      "Response with a Uint8Array body",
+      async () => new Response(payload),
+    ],
+    [
+      "Response with a user ReadableStream body",
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(Uint8Array.from(payload));
+              controller.close();
+            },
+          }),
+        ),
+    ],
+    [
+      "Request with a string body",
+      async () =>
+        new Request("http://example.com/", {
+          method: "POST",
+          body: payload.toString("latin1"),
+        }),
+    ],
+    [
+      "Request with a user ReadableStream body",
+      async () =>
+        new Request("http://example.com/", {
+          method: "POST",
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(Uint8Array.from(payload));
+              controller.close();
+            },
+          }),
+          // @ts-expect-error duplex
+          duplex: "half",
+        }),
+    ],
+  ];
+
+  for (const [label, make] of cases) {
+    test(`${label}: reading .body after observe+clone yields the full payload on both sides`, async () => {
+      const target = await make();
+      const before = target.body!;
+      expect(before.locked).toBe(false);
+      expect(target.bodyUsed).toBe(false);
+
+      const cloned = target.clone();
+      const after = target.body!;
+
+      // Spec: .body is a new tee branch; the pre-clone stream is the tee
+      // source and is now locked.
+      expect(after).not.toBe(before);
+      expect(before.locked).toBe(true);
+      expect(target.bodyUsed).toBe(false);
+
+      const [origBytes, cloneBytes] = await Promise.all([
+        drain(after),
+        drain(cloned.body!),
+      ]);
+      expect({ origBytes, cloneBytes }).toEqual({ origBytes: N, cloneBytes: N });
+    });
+
+    test(`${label}: .text() after observe+clone yields the full payload on both sides`, async () => {
+      const target = await make();
+      void target.body; // observe only; no reader, no lock
+      const cloned = target.clone();
+      const [origText, cloneText] = await Promise.all([
+        target.text(),
+        cloned.text(),
+      ]);
+      expect(origText.length).toBe(N);
+      expect(cloneText.length).toBe(N);
+    });
+  }
+
+  test("fetch() Response: second clone after observe still yields full payload", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(payload),
+    });
+    const response = await fetch(server.url);
+    void response.body;
+    const c1 = response.clone();
+    void response.body;
+    const c2 = response.clone();
+    const [orig, b1, b2] = await Promise.all([
+      drain(response.body!),
+      drain(c1.body!),
+      drain(c2.body!),
+    ]);
+    expect({ orig, b1, b2 }).toEqual({ orig: N, b1: N, b2: N });
+  });
+});
+
 test("Blob type from a consumed Response keeps the original content-type after clones with different content-types are consumed", async () => {
   // The Response and its clones share one underlying body store. Consuming a clone
   // with a different Content-Type must not change (or invalidate) the type of a Blob

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1020,23 +1020,31 @@ describe.concurrent("clone() after `.body` was observed returns a fresh tee bran
 // consult that cache instead of teeing the now-empty native slot, or the
 // derived request's body is a branch of a disconnected stream and reads hang.
 test("new Request(src, init) with a user ReadableStream body: derived request's body carries the source's bytes", async () => {
-  const make = () =>
-    new Request("http://example.com/", {
-      method: "POST",
-      body: new ReadableStream({
-        start(controller) {
-          controller.enqueue(new Uint8Array([1, 2, 3]));
-          controller.close();
-        },
-      }),
-      // @ts-expect-error duplex
-      duplex: "half",
+  const stream = () =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
     });
+  // @ts-expect-error duplex
+  const make = () => new Request("http://example.com/", { method: "POST", body: stream(), duplex: "half" });
 
   const twoArg = new Request(make(), { headers: { "x-a": "1" } });
   const oneArg = new Request(make());
-  expect(new Uint8Array(await twoArg.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
-  expect(new Uint8Array(await oneArg.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+  // Bun extension: a Response as the second argument contributes its body via
+  // the sibling Response-source branch in construct_into.
+  // @ts-expect-error Bun accepts a Response as init
+  const fromResponse = new Request("http://example.com/", new Response(stream()));
+  expect({
+    twoArg: new Uint8Array(await twoArg.arrayBuffer()),
+    oneArg: new Uint8Array(await oneArg.arrayBuffer()),
+    fromResponse: new Uint8Array(await fromResponse.arrayBuffer()),
+  }).toEqual({
+    twoArg: new Uint8Array([1, 2, 3]),
+    oneArg: new Uint8Array([1, 2, 3]),
+    fromResponse: new Uint8Array([1, 2, 3]),
+  });
 });
 
 test("Blob type from a consumed Response keeps the original content-type after clones with different content-types are consumed", async () => {


### PR DESCRIPTION
## What

`Response.clone()` / `Request.clone()` silently emptied the original's `.body` stream when the `.body` getter had been observed (not read, not locked) before the clone. The common cache/proxy middleware shape hits this:

```js
if (res.body) {
  waitUntil(cache.put(req, res.clone()));
  return new Response(res.body, res); // <- 0 bytes
}
```

## Repro

```js
const r = await fetch(url); // small body, fully buffered
const before = r.body;       // observe only; no reader
const c = r.clone();
// before fix: r.body === before, before.locked === false, reading r.body yields 0 bytes
// after fix (matches Node/browsers): r.body !== before, before.locked === true, reading r.body yields full payload
```

## Cause

Accessing `.body` on a buffered response materializes a `ReadableStream` and caches it in the JS wrapper's `m_body` slot while also storing it in `locked.readable`. `Value::clone_with_readable_stream` then called `to_blob_if_possible()` first, which on a `Locked` value pulls the bytes out of `locked.readable`'s source and `.done()`s it, rebuilding the body as a `Blob`. The cached `m_body` stream the user already held was left with no source, and `sync_cloned_body_stream_caches` couldn't repoint it because the body was no longer `Locked`.

## Fix

Handle `Value::Locked` before the blob-extraction optimization so the existing `tee()` path runs. `sync_cloned_body_stream_caches` then sees `locked.readable` holding the first tee branch and repoints `m_body` to it. The pre-clone stream object becomes the locked tee source, per the [Fetch body-clone algorithm](https://fetch.spec.whatwg.org/#concept-body-clone).

Sibling entry points fixed for the same class while here:

- `BunRequest.prototype.clone` (the `Bun.serve` `routes:` subclass) goes through `JSBunRequest::clone` rather than `Request::do_clone` and was missing the post-clone `sync_cloned_body_stream_caches` step; wired in.
- Two-arg `new Request(src, init)` copied the source body via `Value::clone()` directly, bypassing the `m_stream` cache lookup. When `src` was built with a user `ReadableStream`, the derived request's body was a branch of a disconnected stream and reads hung forever; now routed through `clone_body_value_via_cached_stream` like the single-arg path.

## Verification

```
without src change: 55 pass, 7 fail   (test/js/web/fetch/body-clone.test.ts)
with    src change: 62 pass, 0 fail
```

Also re-ran `body.test.ts`, `response.test.ts`, `body-stream.test.ts`, `body-mixin-errors.test.ts`, `bun-serve-routes.test.ts` and the `clone`-filtered `fetch.test.ts` / `blob.test.ts` subsets with no new failures.
