### PR TITLE
node:http2: surface the session error on streams torn down by a nonzero GOAWAY

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3178,6 +3178,10 @@ function rejectNoPayloadContentLengthNT(req) {
   req.rstCode = constants.NGHTTP2_PROTOCOL_ERROR;
   req.destroy(streamErrorFromCode(constants.NGHTTP2_PROTOCOL_ERROR));
 }
+function closeUnreadRespondedStreamNT(stream) {
+  if (stream.destroyed || stream.closed) return;
+  stream.close();
+}
 // node's Http2Stream[kMaybeDestroy]: once a server stream's response has finished, if user code
 // never read the request (didRead false, flowing null) and no trailers are pending, node closes
 // the stream gracefully instead of leaving it open until the request side ends.
@@ -3190,7 +3194,9 @@ function onServerStreamFinishMaybeClose(this: ServerHttp2Stream) {
     !this[kDidRead] &&
     this.readableFlowing === null
   ) {
-    this.close();
+    // node defers with setImmediate so pushStreams issued around the response finish still make
+    // it out before the stream officially closes (core.js kMaybeDestroy).
+    setImmediate(closeUnreadRespondedStreamNT, this);
   }
 }
 function emitStreamErrorFromCodeNT(stream, rstCode) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3178,10 +3178,6 @@ function rejectNoPayloadContentLengthNT(req) {
   req.rstCode = constants.NGHTTP2_PROTOCOL_ERROR;
   req.destroy(streamErrorFromCode(constants.NGHTTP2_PROTOCOL_ERROR));
 }
-function closeUnreadRespondedStreamNT(stream) {
-  if (stream.destroyed || stream.closed) return;
-  stream.close();
-}
 // node's Http2Stream[kMaybeDestroy]: once a server stream's response has finished, if user code
 // never read the request (didRead false, flowing null) and no trailers are pending, node closes
 // the stream gracefully instead of leaving it open until the request side ends.
@@ -3194,7 +3190,7 @@ function onServerStreamFinishMaybeClose(this: ServerHttp2Stream) {
     !this[kDidRead] &&
     this.readableFlowing === null
   ) {
-    setImmediate(closeUnreadRespondedStreamNT, this);
+    this.close();
   }
 }
 function emitStreamErrorFromCodeNT(stream, rstCode) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3184,18 +3184,25 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
       if (error !== 0 && !stream.rstCode) stream.rstCode = error;
       error = self[kSessionDestroyError];
     }
-    // The resolved error is passed to stream.destroy() unconditionally: node surfaces the same
-    // error whether or not an 'error' listener is attached (absent a listener it becomes an
-    // uncaught exception, like any Duplex). Gating on listenerCount here dropped the resolved
-    // session error and let _destroy synthesize a misleading ERR_HTTP2_STREAM_ERROR from rstCode.
+    // Pass the resolved error to stream.destroy() unconditionally: node surfaces the same error
+    // whether or not an 'error' listener is attached (absent one it becomes an uncaught exception,
+    // like any Duplex); do not gate on listenerCount.
     let error_instance: Error | undefined;
     if (typeof error === "number") {
       stream.rstCode = error;
-      if (error != 0 && !stream[kNeverAnnounced]) {
+      // NO_ERROR and CANCEL close without an 'error' event (node semantics); _destroy mirrors
+      // this exclusion when it synthesizes from rstCode.
+      if (error != 0 && error != NGHTTP2_CANCEL && !stream[kNeverAnnounced]) {
         error_instance = streamErrorFromCode(error);
       }
-    } else if (!stream[kNeverAnnounced]) {
-      error_instance = error;
+    } else if (error != null && !stream[kNeverAnnounced]) {
+      // A session destroyed without an error synthesizes ERR_HTTP2_STREAM_CANCEL for its open
+      // streams; node only surfaces that on streams that never became active, otherwise the close
+      // is silent. Bun does not yet track that distinction, so this one code stays listener-gated
+      // rather than becoming an uncaught exception on active streams.
+      if (error.code !== "ERR_HTTP2_STREAM_CANCEL" || stream.listenerCount("error") > 0) {
+        error_instance = error;
+      }
     }
     if (stream.readable) {
       stream.resume(); // we have a error we consume and close
@@ -3485,10 +3492,10 @@ class ServerHttp2Session extends Http2Session {
       self.#connections++;
       if (stream_id % 2 === 1) self.#peerInitiatedStreams++;
       const stream = new ServerHttp2Stream(stream_id, self, null);
-      // Until the request HEADERS are accepted and the 'stream' event fires, user code has no
-      // reference to this object and cannot attach an 'error' listener; node never surfaces a
-      // JS stream for a request it rejects at the header layer.
-      stream[kNeverAnnounced] = true;
+      // Until an incoming request's HEADERS are accepted and the 'stream' event fires, user code
+      // has no reference to this object; node never surfaces a JS stream for a request it rejects
+      // at the header layer. Even ids are server-initiated pushes (handed out via pushStream).
+      if (stream_id % 2 === 1) stream[kNeverAnnounced] = true;
       // Returned to the native caller, which stores it as the stream context — no
       // setStreamContext host call needed.
       return stream;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -370,6 +370,8 @@ let priorityDeprecationWarned = false;
 // Marks a client stream created from a received PUSH_PROMISE: its response HEADERS fire 'push'.
 const kPush = Symbol("pushStream");
 const kNeverAnnounced = Symbol("neverAnnounced");
+// node's Http2Stream[kState].didRead: set by the first _read() attempt, not by data arrival.
+const kDidRead = Symbol("didRead");
 const kReceivedGoaway = Symbol("receivedGoaway");
 // The error code carried by a received GOAWAY; like Node's state.goawayCode it
 // takes precedence over the destroy code when streams are torn down.
@@ -2466,6 +2468,7 @@ class Http2Stream extends Duplex {
 
   _read(_size) {
     // we always use the internal stream queue now
+    if (!this[kDidRead]) this[kDidRead] = true;
   }
 
   end(chunk, encoding, callback) {
@@ -2708,6 +2711,7 @@ class ServerHttp2Stream extends Http2Stream {
   headersSent = false;
   constructor(streamId, session, headers) {
     super(streamId, session, headers);
+    this.once("finish", onServerStreamFinishMaybeClose);
   }
   // Node sends the implicit response headers (:status 200) when the stream is written to before
   // respond() was called; without this the DATA frames would go out with no preceding HEADERS.
@@ -3173,6 +3177,25 @@ function settingsCallbackNT(self, callback, start) {
 function rejectNoPayloadContentLengthNT(req) {
   req.rstCode = constants.NGHTTP2_PROTOCOL_ERROR;
   req.destroy(streamErrorFromCode(constants.NGHTTP2_PROTOCOL_ERROR));
+}
+function closeUnreadRespondedStreamNT(stream) {
+  if (stream.destroyed || stream.closed) return;
+  stream.close();
+}
+// node's Http2Stream[kMaybeDestroy]: once a server stream's response has finished, if user code
+// never read the request (didRead false, flowing null) and no trailers are pending, node closes
+// the stream gracefully instead of leaving it open until the request side ends.
+function onServerStreamFinishMaybeClose(this: ServerHttp2Stream) {
+  if (
+    this.headersSent &&
+    !this.destroyed &&
+    !this.closed &&
+    (this[bunHTTP2StreamStatus] & StreamState.WantTrailer) === 0 &&
+    !this[kDidRead] &&
+    this.readableFlowing === null
+  ) {
+    setImmediate(closeUnreadRespondedStreamNT, this);
+  }
 }
 function emitStreamErrorFromCodeNT(stream, rstCode) {
   stream.emit("error", streamErrorFromCode(rstCode));

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2210,6 +2210,9 @@ class Http2Stream extends Duplex {
       this.#sentTrailers = undefined;
       throw error;
     }
+    // node re-runs [kMaybeDestroy] once the trailers are out (finishSendTrailers): a server
+    // stream whose response is now complete and whose request was never read closes gracefully.
+    if (this instanceof ServerHttp2Stream) maybeCloseUnreadRespondedStream(this);
   }
 
   setTimeout(timeout, callback) {
@@ -3184,20 +3187,25 @@ function closeUnreadRespondedStreamNT(stream) {
 }
 // node's Http2Stream[kMaybeDestroy]: once a server stream's response has finished, if user code
 // never read the request (didRead false, flowing null) and no trailers are pending, node closes
-// the stream gracefully instead of leaving it open until the request side ends.
-function onServerStreamFinishMaybeClose(this: ServerHttp2Stream) {
+// the stream gracefully instead of leaving it open until the request side ends. Trailers defer
+// the close until they are sent (node re-runs the check from finishSendTrailers).
+function maybeCloseUnreadRespondedStream(stream) {
   if (
-    this.headersSent &&
-    !this.destroyed &&
-    !this.closed &&
-    (this[bunHTTP2StreamStatus] & StreamState.WantTrailer) === 0 &&
-    !this[kDidRead] &&
-    this.readableFlowing === null
+    stream.headersSent &&
+    stream.writableFinished &&
+    !stream.destroyed &&
+    !stream.closed &&
+    ((stream[bunHTTP2StreamStatus] & StreamState.WantTrailer) === 0 || stream.sentTrailers !== undefined) &&
+    !stream[kDidRead] &&
+    stream.readableFlowing === null
   ) {
     // node defers with setImmediate so pushStreams issued around the response finish still make
     // it out before the stream officially closes (core.js kMaybeDestroy).
-    setImmediate(closeUnreadRespondedStreamNT, this);
+    setImmediate(closeUnreadRespondedStreamNT, stream);
   }
+}
+function onServerStreamFinishMaybeClose(this: ServerHttp2Stream) {
+  maybeCloseUnreadRespondedStream(this);
 }
 function emitStreamErrorFromCodeNT(stream, rstCode) {
   stream.emit("error", streamErrorFromCode(rstCode));

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3180,6 +3180,12 @@ function emitStreamErrorFromCodeNT(stream, rstCode) {
 
 function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
+    // node only tears down live streams (closeSession skips streams already gone from its set);
+    // re-destroying a destroyed Duplex with an error would re-emit it as an uncaught exception.
+    if (stream.destroyed) {
+      if (destroy_self) self.destroy();
+      return;
+    }
     // node destroys a stream torn down by a session error with that same session error, and a
     // stream closed by a raw code with no error at all - _destroy synthesizes the
     // ERR_HTTP2_STREAM_ERROR from rstCode (never for NGHTTP2_NO_ERROR / NGHTTP2_CANCEL).

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2373,7 +2373,7 @@ class Http2Stream extends Duplex {
     // RST code 8 not emitted as an error as its used by clients to signify
     // abort and is already covered by aborted event, also allows more
     // seamless compatibility with http1
-    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL)
+    if (err == null && rstCode !== NGHTTP2_NO_ERROR && rstCode !== NGHTTP2_CANCEL && !this[kNeverAnnounced])
       err = $ERR_HTTP2_STREAM_ERROR(nameForErrorCode[rstCode] || rstCode);
 
     this[bunHTTP2Session] = null;
@@ -3184,16 +3184,18 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
       if (error !== 0 && !stream.rstCode) stream.rstCode = error;
       error = self[kSessionDestroyError];
     }
-    let error_instance: Error | number | undefined = undefined;
-    if (stream.listenerCount("error") > 0) {
-      if (typeof error === "number") {
-        stream.rstCode = error;
-        if (error != 0) {
-          error_instance = streamErrorFromCode(error);
-        }
-      } else {
-        error_instance = error;
+    // The resolved error is passed to stream.destroy() unconditionally: node surfaces the same
+    // error whether or not an 'error' listener is attached (absent a listener it becomes an
+    // uncaught exception, like any Duplex). Gating on listenerCount here dropped the resolved
+    // session error and let _destroy synthesize a misleading ERR_HTTP2_STREAM_ERROR from rstCode.
+    let error_instance: Error | undefined;
+    if (typeof error === "number") {
+      stream.rstCode = error;
+      if (error != 0 && !stream[kNeverAnnounced]) {
+        error_instance = streamErrorFromCode(error);
       }
+    } else if (!stream[kNeverAnnounced]) {
+      error_instance = error;
     }
     if (stream.readable) {
       stream.resume(); // we have a error we consume and close
@@ -3483,6 +3485,10 @@ class ServerHttp2Session extends Http2Session {
       self.#connections++;
       if (stream_id % 2 === 1) self.#peerInitiatedStreams++;
       const stream = new ServerHttp2Stream(stream_id, self, null);
+      // Until the request HEADERS are accepted and the 'stream' event fires, user code has no
+      // reference to this object and cannot attach an 'error' listener; node never surfaces a
+      // JS stream for a request it rejects at the header layer.
+      stream[kNeverAnnounced] = true;
       // Returned to the native caller, which stores it as the stream context — no
       // setStreamContext host call needed.
       return stream;
@@ -3589,6 +3595,7 @@ class ServerHttp2Session extends Http2Session {
         // user handler — in particular, losing WantTrailer/FinalCalled breaks
         // any later `sendTrailers()` with ERR_HTTP2_TRAILERS_NOT_READY.
         stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded;
+        stream[kNeverAnnounced] = false;
         if (onServerStreamCreatedChannel.hasSubscribers) {
           onServerStreamCreatedChannel.publish({ stream, headers });
         }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3213,9 +3213,10 @@ function emitStreamErrorFromCodeNT(stream, rstCode) {
 
 function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
-    // node only tears down live streams (closeSession skips streams already gone from its set);
-    // re-destroying a destroyed Duplex with an error would re-emit it as an uncaught exception.
-    if (stream.destroyed) {
+    // node only tears down live streams (closeSession skips streams already gone from its set). A
+    // stream already closed (close() ran; destroy is a setImmediate behind) has also committed to
+    // its rstCode, so a late session error has nothing to add and would race the pending destroy.
+    if (stream.destroyed || stream.closed) {
       if (destroy_self) self.destroy();
       return;
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3197,9 +3197,8 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
       }
     } else if (error != null && !stream[kNeverAnnounced]) {
       // A session destroyed without an error synthesizes ERR_HTTP2_STREAM_CANCEL for its open
-      // streams; node only surfaces that on streams that never became active, otherwise the close
-      // is silent. Bun does not yet track that distinction, so this one code stays listener-gated
-      // rather than becoming an uncaught exception on active streams.
+      // streams; node only surfaces that on streams that never became active. Bun does not yet
+      // track that distinction, so this one code stays listener-gated to avoid uncaught exceptions.
       if (error.code !== "ERR_HTTP2_STREAM_CANCEL" || stream.listenerCount("error") > 0) {
         error_instance = error;
       }
@@ -5212,10 +5211,23 @@ class ClientHttp2Session extends Http2Session {
         onClientStreamCreatedChannel.publish({ stream: req, headers });
       }
       const wireHeaders = rawHeadersList !== null ? rawHeadersList : headers;
+      // Native rejects an oversized/invalid header block synchronously via run_callback, which can
+      // drain the deferring nextTick before this call returns (event-loop enter count 0); the
+      // caller has no reference to req yet, so keep it never-announced for the native call.
+      req[kNeverAnnounced] = true;
       if (typeof options === "undefined") {
         this.#parser.request(stream_id, req, wireHeaders, sensitiveNames);
       } else {
         this.#parser.request(stream_id, req, wireHeaders, sensitiveNames, options);
+      }
+      req[kNeverAnnounced] = false;
+      if (req.destroyed) {
+        // Synchronous rejection: surface the error after the caller has attached listeners.
+        const rstCode = req.rstCode;
+        if (rstCode && rstCode !== NGHTTP2_CANCEL) {
+          process.nextTick(emitEventNT, req, "error", streamErrorFromCode(rstCode));
+        }
+        return req;
       }
       if (onClientStreamStartChannel.hasSubscribers) {
         onClientStreamStartChannel.publish({ stream: req, headers });

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3174,6 +3174,9 @@ function rejectNoPayloadContentLengthNT(req) {
   req.rstCode = constants.NGHTTP2_PROTOCOL_ERROR;
   req.destroy(streamErrorFromCode(constants.NGHTTP2_PROTOCOL_ERROR));
 }
+function emitStreamErrorFromCodeNT(stream, rstCode) {
+  stream.emit("error", streamErrorFromCode(rstCode));
+}
 
 function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
@@ -5211,10 +5214,11 @@ class ClientHttp2Session extends Http2Session {
       }
       req[kNeverAnnounced] = false;
       if (req.destroyed) {
-        // Synchronous rejection: surface the error after the caller has attached listeners.
+        // Synchronous rejection: surface the error once the caller has had a chance to attach
+        // listeners. Not listener-gated: absent one it becomes an uncaught exception, like node.
         const rstCode = req.rstCode;
         if (rstCode && rstCode !== NGHTTP2_CANCEL) {
-          process.nextTick(emitEventNT, req, "error", streamErrorFromCode(rstCode));
+          process.nextTick(emitStreamErrorFromCodeNT, req, rstCode);
         }
         return req;
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3177,32 +3177,18 @@ function rejectNoPayloadContentLengthNT(req) {
 
 function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
-    if (typeof error === "number" && self != null && self[kSessionDestroyError] != null) {
-      // The stream is being torn down because its session was destroyed with an error: surface
-      // that session error on the stream (node semantics) instead of a generic stream error. The
-      // numeric code still becomes the stream's rstCode (node uses the session's destroy code).
-      if (error !== 0 && !stream.rstCode) stream.rstCode = error;
-      error = self[kSessionDestroyError];
-    }
-    // Pass the resolved error to stream.destroy() unconditionally: node surfaces the same error
-    // whether or not an 'error' listener is attached (absent one it becomes an uncaught exception,
-    // like any Duplex); do not gate on listenerCount.
+    // node destroys a stream torn down by a session error with that same session error, and a
+    // stream closed by a raw code with no error at all - _destroy synthesizes the
+    // ERR_HTTP2_STREAM_ERROR from rstCode (never for NGHTTP2_NO_ERROR / NGHTTP2_CANCEL).
     let error_instance: Error | undefined;
     if (typeof error === "number") {
-      stream.rstCode = error;
-      // NO_ERROR and CANCEL close without an 'error' event (node semantics); _destroy mirrors
-      // this exclusion when it synthesizes from rstCode.
-      if (error != 0 && error != NGHTTP2_CANCEL && !stream[kNeverAnnounced]) {
-        error_instance = streamErrorFromCode(error);
-      }
-    } else if (error != null && !stream[kNeverAnnounced]) {
-      // A session destroyed without an error synthesizes ERR_HTTP2_STREAM_CANCEL for its open
-      // streams; node only surfaces that on streams that never became active. Bun does not yet
-      // track that distinction, so this one code stays listener-gated to avoid uncaught exceptions.
-      if (error.code !== "ERR_HTTP2_STREAM_CANCEL" || stream.listenerCount("error") > 0) {
-        error_instance = error;
-      }
+      if (error !== 0 && !stream.rstCode) stream.rstCode = error;
+      error_instance = self != null ? self[kSessionDestroyError] : undefined;
+    } else {
+      error_instance = error;
     }
+    // A stream user code never received cannot have an 'error' listener; node never surfaces it.
+    if (stream[kNeverAnnounced]) error_instance = undefined;
     if (stream.readable) {
       stream.resume(); // we have a error we consume and close
       pushToStream(stream, null);
@@ -4182,6 +4168,9 @@ class ClientHttp2Session extends Http2Session {
         // A pushed (even-id) stream announced by the server: its context object must be a stream,
         // not a session. Returned to the native caller, which stores it as the stream context.
         const stream = new ClientHttp2Stream(stream_id, self, null);
+        // Placeholder until streamPush announces the real pushed stream on the 'stream' event;
+        // user code can never observe this object, so nothing may surface errors on it.
+        stream[kNeverAnnounced] = true;
         return stream;
       }
     },
@@ -4530,11 +4519,10 @@ class ClientHttp2Session extends Http2Session {
       return;
     }
     if (this.listenerCount("error") === 0 && (error as NodeJS.ErrnoException)?.code === "ECONNRESET") {
-      // A transport teardown on a session nobody observes (an idle pooled
-      // connection dropped by the peer): shut down quietly - the destroy
-      // still errors any remaining streams. Anything else (handshake
-      // failure, ECONNREFUSED, ...) keeps Node's EventEmitter contract and
-      // surfaces when unobserved.
+      // A transport teardown on a session nobody observes (an idle pooled connection dropped by
+      // the peer): the session shuts down quietly, but remaining streams still surface the real
+      // socket error like node's. Anything else keeps Node's EventEmitter contract.
+      this[kSessionDestroyError] = error;
       this.destroy();
       return;
     }
@@ -4852,6 +4840,10 @@ class ClientHttp2Session extends Http2Session {
       // Streams torn down by this destroy surface the same session error (node semantics).
       this[kSessionDestroyError] = error;
     }
+    // node only cancels *pending* streams (never connected / not submitted) with
+    // ERR_HTTP2_STREAM_CANCEL; streams already open on a connected session are destroyed with
+    // the session error, or silently when the session is destroyed without one.
+    const streamsArePending = !this.#connected;
     this.#closed = true;
     this.#connected = false;
     {
@@ -4880,13 +4872,10 @@ class ClientHttp2Session extends Http2Session {
     }
     const parser = this.#parser;
     if (parser) {
-      // node cancels streams still open when their session is destroyed: each gets
-      // ERR_HTTP2_STREAM_CANCEL (or the session error when one was provided), with the CANCEL
-      // rst code.
-      if (this[kSessionDestroyError] == null && error == null) {
-        // ERR_HTTP2_STREAM_CANCEL is not in the native error-code registry (the registry is
-        // positional and shared across Rust/C++/the JS bundle, so additions need a coordinated
-        // regeneration); construct the node-shaped error directly.
+      // A session that never connected only has pending streams: node cancels each of them with
+      // ERR_HTTP2_STREAM_CANCEL. (The error is built inline: it is not in the native error-code
+      // registry, which is positional and shared across Rust/C++/the JS bundle.)
+      if (this[kSessionDestroyError] == null && error == null && streamsArePending) {
         const cancelError = new Error("The pending stream has been canceled");
         cancelError.name = "Error";
         cancelError.code = "ERR_HTTP2_STREAM_CANCEL";

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -817,7 +817,6 @@ describe("inbound stream lifecycle", () => {
       toString:start
       toString:end
       sendTrailers:returned
-      req error ERR_HTTP2_STREAM_CANCEL
       req close"
     `);
     expect(proc.signalCode).toBeNull();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3364,3 +3364,58 @@ describe.concurrent("http2 server: pushed stream error surfacing", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("http2 server: finished response with an unread request", () => {
+  // node (Http2Stream[kMaybeDestroy]): a server stream whose response finished while user code
+  // never read the request closes gracefully (rstCode 0) instead of waiting for the client's
+  // half; a later session.destroy(code) then has nothing to error (grpc-js forceShutdown shape).
+  it("closes the stream and survives a later session.destroy(code)", async () => {
+    const fixture = `
+      const http2 = require("node:http2");
+      process.on("uncaughtException", e => {
+        console.log("UNCAUGHT " + e.code);
+        process.exit(42);
+      });
+      const server = http2.createServer();
+      let ssession;
+      server.on("session", s => (ssession = s));
+      server.on("stream", stream => {
+        stream.on("close", () => {
+          console.log("server stream close rstCode=" + stream.rstCode);
+          // The uncaught (if any) is delivered before the session's own 'close' completes.
+          ssession.on("close", () => {
+            setImmediate(() => {
+              console.log("DONE");
+              process.exit(0);
+            });
+          });
+          ssession.destroy(http2.constants.NGHTTP2_CANCEL);
+        });
+        stream.respond({ ":status": 200, "grpc-status": "12" }, { endStream: true });
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        // The GOAWAY from the server-session teardown reaches this same process's client session;
+        // it is not what this test observes (the server stream lifecycle is).
+        client.on("error", () => {});
+        const req = client.request({ ":path": "/Sum", ":method": "POST" }); // client half stays open
+        req.on("error", () => {});
+        req.resume();
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("server stream close rstCode=0"),
+      stderr: "",
+    });
+    expect(stdout).toContain("DONE");
+    expect(stdout).not.toContain("UNCAUGHT");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3188,11 +3188,9 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
 });
 
 describe.concurrent("http2 client: stream error identity when the peer closes with a nonzero code", () => {
-  // Raw h2c server that completes the SETTINGS handshake and, on the first HEADERS, sends the
-  // requested frame (GOAWAY or RST_STREAM) with ENHANCE_YOUR_CALM. The client opens one request;
-  // with no 'error' listener on the stream, node surfaces the error as an uncaught exception with
-  // a code that identifies WHAT closed (session vs. stream). An 'error' listener observes the same
-  // error and the stream's rstCode is stamped from the frame's code either way.
+  // Raw h2c server: after the SETTINGS handshake it answers the first HEADERS with the requested
+  // frame (GOAWAY or RST_STREAM) carrying ENHANCE_YOUR_CALM. Node surfaces the error (uncaught
+  // without a stream 'error' listener) with a code identifying what closed: session vs stream.
   function fixture({ mode, withListener }) {
     const reply =
       mode === "goaway"
@@ -3306,6 +3304,61 @@ describe.concurrent("http2 client: stream error identity when the peer closes wi
       stderr: "",
     });
     expect(stdout).toContain("req close rstCode=11");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("http2 server: pushed stream error surfacing", () => {
+  // A pushed stream is handed to user code through the pushStream() callback (it has no 'stream'
+  // event), so a peer reset must reach its 'error' listener like node: ERR_HTTP2_STREAM_ERROR with
+  // the RST_STREAM code stamped as rstCode (verified against node v26.3.0).
+  it("a pushed stream refused by the peer emits ERR_HTTP2_STREAM_ERROR with the peer's code", async () => {
+    const fixture = `
+      const http2 = require("node:http2");
+      process.on("uncaughtException", e => {
+        console.log("UNCAUGHT " + e.code);
+        process.exit(42);
+      });
+      const server = http2.createServer();
+      server.on("stream", (stream, headers) => {
+        stream.respond({ ":status": 200 });
+        stream.pushStream({ ":path": "/push" }, (err, pushStream) => {
+          if (err) {
+            console.log("pushErr " + err.code);
+            process.exit(43);
+          }
+          pushStream.on("error", e => console.log("push error: " + e.code + " " + e.message));
+          pushStream.on("close", () => {
+            console.log("push close rstCode=" + pushStream.rstCode);
+            process.exit(0);
+          });
+          pushStream.respond({ ":status": 200 });
+          pushStream.write("pushed");
+        });
+        stream.end("main");
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        client.on("stream", pushed => {
+          pushed.on("error", () => {});
+          pushed.close(http2.constants.NGHTTP2_REFUSED_STREAM);
+        });
+        const req = client.request({ ":path": "/" });
+        req.resume();
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("push error: ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_REFUSED_STREAM"),
+      stderr: "",
+    });
+    expect(stdout).toContain("push close rstCode=7");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3418,4 +3418,48 @@ describe.concurrent("http2 server: finished response with an unread request", ()
     expect(stdout).not.toContain("UNCAUGHT");
     expect(exitCode).toBe(0);
   });
+
+  // Same rule via the trailers path: node re-runs [kMaybeDestroy] from finishSendTrailers, so a
+  // response that ends with trailers (grpc-js status) also closes an unread stream.
+  it("closes the stream after trailers when the request was never read", async () => {
+    const fixture = `
+      const http2 = require("node:http2");
+      process.on("uncaughtException", e => {
+        console.log("UNCAUGHT " + e.code);
+        process.exit(42);
+      });
+      const server = http2.createServer();
+      server.on("stream", stream => {
+        stream.on("close", () => {
+          console.log("server stream close rstCode=" + stream.rstCode);
+          process.exit(0);
+        });
+        stream.on("wantTrailers", () => {
+          stream.sendTrailers({ "grpc-status": "12", "grpc-message": "unimplemented" });
+        });
+        stream.respond({ ":status": 200, "content-type": "application/grpc" }, { waitForTrailers: true });
+        stream.end();
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        client.on("error", () => {});
+        const req = client.request({ ":path": "/Sum", ":method": "POST" }); // client half stays open
+        req.on("error", () => {});
+        req.resume();
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("server stream close rstCode=0"),
+      stderr: "",
+    });
+    expect(stdout).not.toContain("UNCAUGHT");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3186,3 +3186,126 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
     server.close();
   }
 });
+
+describe.concurrent("http2 client: stream error identity when the peer closes with a nonzero code", () => {
+  // Raw h2c server that completes the SETTINGS handshake and, on the first HEADERS, sends the
+  // requested frame (GOAWAY or RST_STREAM) with ENHANCE_YOUR_CALM. The client opens one request;
+  // with no 'error' listener on the stream, node surfaces the error as an uncaught exception with
+  // a code that identifies WHAT closed (session vs. stream). An 'error' listener observes the same
+  // error and the stream's rstCode is stamped from the frame's code either way.
+  function fixture({ mode, withListener }) {
+    const reply =
+      mode === "goaway"
+        ? `
+          const goaway = Buffer.alloc(8);
+          goaway.writeUInt32BE(1, 0);
+          goaway.writeUInt32BE(0xb, 4);
+          socket.write(frame(0x7, 0, 0, goaway));`
+        : `
+          const rst = Buffer.alloc(4);
+          rst.writeUInt32BE(0xb, 0);
+          socket.write(frame(0x3, 0, 1, rst));
+          setImmediate(() => socket.end());`;
+    return `
+      const http2 = require("node:http2");
+      const net = require("node:net");
+      function frame(type, flags, streamId, payload = Buffer.alloc(0)) {
+        const header = Buffer.alloc(9);
+        header.writeUIntBE(payload.length, 0, 3);
+        header.writeUInt8(type, 3);
+        header.writeUInt8(flags, 4);
+        header.writeUInt32BE(streamId, 5);
+        return Buffer.concat([header, payload]);
+      }
+      const server = net.createServer(socket => {
+        socket.write(frame(0x4, 0, 0));
+        let buf = Buffer.alloc(0), sawPreface = false, done = false;
+        socket.on("data", chunk => {
+          if (done) return;
+          buf = Buffer.concat([buf, chunk]);
+          if (!sawPreface) {
+            if (buf.length < 24) return;
+            buf = buf.subarray(24);
+            sawPreface = true;
+          }
+          let off = 0;
+          while (buf.length - off >= 9) {
+            const len = buf.readUIntBE(off, 3), type = buf.readUInt8(off + 3);
+            if (buf.length - off < 9 + len) break;
+            if (type === 0x4 && (buf.readUInt8(off + 4) & 0x1) === 0) socket.write(frame(0x4, 0x1, 0));
+            if (type === 0x1) {
+              done = true;${reply}
+              return;
+            }
+            off += 9 + len;
+          }
+          buf = buf.subarray(off);
+        });
+      });
+      process.on("uncaughtException", e => {
+        console.log("UNCAUGHT " + e.code + ": " + e.message);
+        process.exit(42);
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const session = http2.connect("http://127.0.0.1:" + server.address().port);
+        session.on("error", e => console.log("session error: " + e.code));
+        session.on("close", () => { console.log("session close"); server.close(); });
+        const req = session.request({ ":path": "/" });
+        ${withListener ? `req.on("error", e => console.log("req error: " + e.code + " rstCode=" + req.rstCode));` : ``}
+        req.on("close", () => console.log("req close rstCode=" + req.rstCode));
+      });
+    `;
+  }
+
+  async function run(opts) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(opts)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("GOAWAY without a stream 'error' listener raises uncaught ERR_HTTP2_SESSION_ERROR", async () => {
+    const { stdout, stderr, exitCode } = await run({ mode: "goaway", withListener: false });
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("UNCAUGHT ERR_HTTP2_SESSION_ERROR: Session closed with error code 11"),
+      stderr: "",
+    });
+    expect(stdout).not.toContain("ERR_HTTP2_STREAM_ERROR");
+    expect(exitCode).toBe(42);
+  });
+
+  it("GOAWAY with a stream 'error' listener delivers ERR_HTTP2_SESSION_ERROR and stamps rstCode", async () => {
+    const { stdout, stderr, exitCode } = await run({ mode: "goaway", withListener: true });
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("req error: ERR_HTTP2_SESSION_ERROR rstCode=11"),
+      stderr: "",
+    });
+    expect(stdout).toContain("req close rstCode=11");
+    expect(exitCode).toBe(0);
+  });
+
+  it("RST_STREAM without a stream 'error' listener raises uncaught ERR_HTTP2_STREAM_ERROR", async () => {
+    const { stdout, stderr, exitCode } = await run({ mode: "rst", withListener: false });
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining(
+        "UNCAUGHT ERR_HTTP2_STREAM_ERROR: Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM",
+      ),
+      stderr: "",
+    });
+    expect(exitCode).toBe(42);
+  });
+
+  it("RST_STREAM with a stream 'error' listener delivers ERR_HTTP2_STREAM_ERROR and stamps rstCode", async () => {
+    const { stdout, stderr, exitCode } = await run({ mode: "rst", withListener: true });
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("req error: ERR_HTTP2_STREAM_ERROR rstCode=11"),
+      stderr: "",
+    });
+    expect(stdout).toContain("req close rstCode=11");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3355,7 +3355,9 @@ describe.concurrent("http2 server: pushed stream error surfacing", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr }).toEqual({
-      stdout: expect.stringContaining("push error: ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_REFUSED_STREAM"),
+      stdout: expect.stringContaining(
+        "push error: ERR_HTTP2_STREAM_ERROR Stream closed with error code NGHTTP2_REFUSED_STREAM",
+      ),
       stderr: "",
     });
     expect(stdout).toContain("push close rstCode=7");


### PR DESCRIPTION
### What

When a peer sends `GOAWAY` with a nonzero error code and a client stream has no `error` listener, the uncaught exception is now `ERR_HTTP2_SESSION_ERROR` (identifying the session as the thing that closed) instead of a synthesized `ERR_HTTP2_STREAM_ERROR`. A direct `RST_STREAM` with a nonzero code on a listener-less stream is likewise surfaced as uncaught `ERR_HTTP2_STREAM_ERROR` (node semantics) instead of being swallowed with `rstCode = 0`.

```js
// Raw h2c server: SETTINGS, then GOAWAY(ENHANCE_YOUR_CALM, lastStreamId=1) once the
// client's HEADERS arrives. Client opens one request with NO 'error' listener.
const session = http2.connect(url);
session.on("error", e => console.log("session error:", e.code));
const req = session.request({ ":path": "/" });
// no req.on("error")
```

| | no stream `error` listener | with stream `error` listener |
|---|---|---|
| bun 1.3.14 | silent, rstCode=0 | `error` = `ERR_HTTP2_STREAM_ERROR` |
| bun main | uncaught `ERR_HTTP2_STREAM_ERROR`: "Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM" | `error` = `ERR_HTTP2_SESSION_ERROR`, rstCode=11 |
| node v22 / v25 / v26.3 | uncaught `ERR_HTTP2_SESSION_ERROR`: "Session closed with error code 11" | `error` = `ERR_HTTP2_SESSION_ERROR`, rstCode=11 |
| **this PR** | uncaught `ERR_HTTP2_SESSION_ERROR`: "Session closed with error code 11" | `error` = `ERR_HTTP2_SESSION_ERROR`, rstCode=11 |

HTTP/2 servers shed load with exactly this frame (`GOAWAY(ENHANCE_YOUR_CALM)`), so it shows up under real-world throttling. A session-level `error` listener does not protect the process (node behaves the same way there), and one `GOAWAY` produces one uncaught exception per bare stream: a multiplexed client takes N process-killing throws from a single frame. The synthesized error also misattributed the failure as a stream-level `RST_STREAM` when the stream was actually torn down by session destruction, so the real cause (the `GOAWAY` and its code) was invisible in crash logs.

### Cause

`emitStreamErrorNT` already resolves the session's destroy error and stamps the stream's `rstCode` from the `GOAWAY` code. The resolved error was then dropped by a `stream.listenerCount("error") > 0` gate: with no listener, `stream.destroy(undefined, rstCode)` ran and `_destroy` manufactured `ERR_HTTP2_STREAM_ERROR` from the stamped `rstCode`. For a direct `RST_STREAM`, the gate also skipped the `stream.rstCode = error` assignment, so the stream was destroyed with `rstCode = 0` and no error at all.

### Fix

`emitStreamErrorNT` passes the resolved error to `stream.destroy()` regardless of listener count. Node surfaces the same error in both listener states; absent a listener it becomes an uncaught exception like any Duplex.

Server-side streams native rejects before the `'stream'` event fires are now marked `kNeverAnnounced` so their teardown stays silent: user code never received a reference to the stream and cannot attach a listener, and node never creates a JS stream object for a request rejected at the header layer (oversized header list, connection-specific headers, malformed values). Without this, removing the gate would surface those as uncaught on the server.

### Verification

Four new tests in `test/js/node/http2/node-http2.test.js` spawn a raw h2c server that replies with either `GOAWAY(ENHANCE_YOUR_CALM)` or `RST_STREAM(ENHANCE_YOUR_CALM)` to the first request and assert the uncaught exception code (no-listener case) or the delivered error and `rstCode` (with-listener case). The two no-listener tests fail on `main` (wrong error identity / silent) and pass with this change; the two with-listener tests pass on both and guard the existing correct behavior. Verified against node v26.3.0.

`bun bd test test/js/node/http2/node-http2.test.js`: 298 pass / 0 fail (2 runs).

### Known follow-up: grpc-js `forceShutdown` surfaces `ERR_HTTP2_SESSION_ERROR`

`test/js/third_party/grpc-js/test-server.test.ts` logs two "Unhandled error between tests" with this change. grpc's `forceShutdown` calls `session.destroy(NGHTTP2_CANCEL)`; node converts a nonzero numeric code to `ERR_HTTP2_SESSION_ERROR` and surfaces it on every open stream (verified against node v26.3.0: a server stream with no `error` listener receives an uncaught exception there too). This PR makes Bun match that. The test passed on `main` only because the removed `listenerCount` gate suppressed the node-correct error. The actual divergence from node is that Bun's server stream has not reached `CLOSED` by the time `forceShutdown` runs in `afterEach`, so `emitErrorToAllStreams` still finds it; under node the stream is already closed and the session destroy is a no-op on it. That close-timing gap is pre-existing and tracked separately (the test already has ASAN and Windows entries in `test/expectations.txt`).

---

### Update: teardown error semantics matched to node exactly (fixes the 10 CI test regressions)

Removing the `listenerCount` gate exposed two places where bun manufactured errors node never creates; with the gate gone they became uncaught exceptions across 10 ported node http2 tests (`test-http2-compat-*`, `test-http2-server-*`, `test-http2-cancel-while-client-reading`, `test-http2-client-request-options-errors`):

1. `emitStreamErrorNT` built an `ERR_HTTP2_STREAM_ERROR` out of **any** nonzero close code — including `NGHTTP2_CANCEL`. Node never creates the stream error at that layer: it stamps `rstCode`, destroys with no error, and `Http2Stream._destroy` synthesizes `ERR_HTTP2_STREAM_ERROR` from `rstCode` (never for `NO_ERROR`/`CANCEL`). Bun's `_destroy` already implements that rule, so the notification layer now only stamps `rstCode` and lets `_destroy` synthesize — one synthesis site, identical messages, and the CANCEL/NO_ERROR exclusion holds everywhere instead of being special-cased per call site.
2. `ClientHttp2Session#destroy()` **without** an error fabricated an `ERR_HTTP2_STREAM_CANCEL` and handed it to every open stream. Node reserves that error for *pending* streams (`closeSession`: pending → `ERR_HTTP2_STREAM_CANCEL`, open → the session error, or nothing). The fabrication is now limited to sessions that never connected; `client.destroy()` on a connected session tears open streams down silently, exactly like node.

Also in this update:
- `#onError`'s unobserved-`ECONNRESET` path stashes the socket error as the session teardown error, so live streams still surface the real error (node hands them the socket error) while the session itself stays quiet.
- The client-side even-id placeholder stream created by `streamStart` before `streamPush` announces the real pushed stream is marked never-announced — user code can never observe it, so nothing may raise errors on it (node has no JS object at that point).
- The `h2-conformance` sendTrailers snapshot drops its `req error ERR_HTTP2_STREAM_CANCEL` line: node v26.3.0 prints no error for that fixture (the line encoded the fabricated cancel).
- New regression test: a pushed stream refused by the peer emits `ERR_HTTP2_STREAM_ERROR NGHTTP2_REFUSED_STREAM` with `rstCode = 7` on the server side.

Every behavior above was verified against real `node v26.3.0` with standalone client/server scripts before being encoded in tests. Locally: the 10 previously-failing node parallel tests pass (and pass on node), `node-http2.test.js` 299/299, `h2-conformance` 37/37.


### Update 2: close server streams whose finished response never read the request

The un-gating also exposed that bun keeps a server stream open after a trailers-only response (`respond(..., { endStream: true })`) until the client's request half ends. Node does not: `Http2Stream[kMaybeDestroy]` closes a server stream whose response finished when user code never attempted to read the request (`didRead` false, `readableFlowing === null`, no trailers pending). grpc-js answers unimplemented client-streaming/bidi calls exactly this way, so those streams lingered until `forceShutdown()` destroyed the session and (correctly, per node) surfaced the session error on them — as uncaught exceptions, since grpc's default handlers attach no `error` listener. With node's close rule ported (and `didRead` tracked like node's, on the first `_read()` attempt), those streams are gone long before the session is torn down, exactly as on node. Regression test included (verified against node v26.3.0).

Follow-up worth its own change (pre-existing): bun never clears its `WantTrailer` flag, so this close rule does not yet cover responses that carry trailers (`waitForTrailers`, including the http1-compat `res.end(body)` path); node closes those too once trailers are sent.
