### PR TITLE
TransformStream: survive controller API calls after a native sink tears down the readable

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -27,11 +27,14 @@ namespace WebStreams {
 
 using namespace JSC;
 
-// The transform's readable half always carries a default controller.
+// Null-safe: Bun's native-sink pumps clear a consumed stream's controller slot in their
+// finally step, so a transform reaction (or an async transform()/flush() resuming after
+// that teardown) can see a readable with no controller. A torn-down readable is terminal.
 static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
 {
     auto* readable = stream->m_readable.get();
-    ASSERT(readable && readable->m_controllerKind == ControllerKind::Default);
+    if (readable->m_controllerKind != ControllerKind::Default)
+        return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
 }
 
@@ -285,7 +288,10 @@ JSC_DEFINE_CUSTOM_GETTER(jsTransformStreamDefaultControllerPrototypeGetter_desir
     auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, globalObject, "TransformStreamDefaultController"_s);
-    std::optional<double> desiredSize = readableStreamDefaultControllerGetDesiredSize(transformReadableController(thisObject->m_stream.get()));
+    auto* readableController = transformReadableController(thisObject->m_stream.get());
+    if (!readableController)
+        return JSValue::encode(jsNull());
+    std::optional<double> desiredSize = readableStreamDefaultControllerGetDesiredSize(readableController);
     if (!desiredSize)
         return JSValue::encode(jsNull());
     return JSValue::encode(jsNumber(*desiredSize));
@@ -351,7 +357,7 @@ void transformStreamDefaultControllerEnqueue(JSGlobalObject* globalObject, JSTra
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = controller->m_stream.get();
     auto* readableController = transformReadableController(stream);
-    if (!readableStreamDefaultControllerCanCloseOrEnqueue(readableController)) {
+    if (!readableController || !readableStreamDefaultControllerCanCloseOrEnqueue(readableController)) {
         throwTypeError(globalObject, scope, "Cannot enqueue a chunk into a TransformStream whose readable side is closed or has already requested close"_s);
         return;
     }
@@ -407,8 +413,10 @@ void transformStreamDefaultControllerTerminate(JSGlobalObject* globalObject, JST
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = controller->m_stream.get();
-    readableStreamDefaultControllerClose(globalObject, transformReadableController(stream));
-    RETURN_IF_EXCEPTION(scope, void());
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerClose(globalObject, readableController);
+        RETURN_IF_EXCEPTION(scope, void());
+    }
     JSObject* error = createTypeError(globalObject, "The TransformStream has been terminated"_s);
     RELEASE_AND_RETURN(scope, transformStreamErrorWritableAndUnblockWrite(globalObject, stream, error));
 }

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -27,11 +27,14 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSStreamsRuntime;
 
-// The transform's readable half always carries a default controller.
+// Null-safe: Bun's native-sink pumps clear a consumed stream's controller slot in their
+// finally step, so a transform reaction (or an async transform()/flush() resuming after
+// that teardown) can see a readable with no controller. A torn-down readable is terminal.
 static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
 {
     auto* readable = stream->m_readable.get();
-    ASSERT(readable && readable->m_controllerKind == ControllerKind::Default);
+    if (readable->m_controllerKind != ControllerKind::Default)
+        return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
 }
 
@@ -145,8 +148,10 @@ void transformStreamError(JSGlobalObject* globalObject, JSTransformStream* strea
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    readableStreamDefaultControllerError(globalObject, transformReadableController(stream), error);
-    RETURN_IF_EXCEPTION(scope, void());
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerError(globalObject, readableController, error);
+        RETURN_IF_EXCEPTION(scope, void());
+    }
     RELEASE_AND_RETURN(scope, transformStreamErrorWritableAndUnblockWrite(globalObject, stream, error));
 }
 
@@ -336,8 +341,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkAbortCancelFulfilled, (JSGl
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
         return JSValue::encode(jsUndefined());
     }
-    readableStreamDefaultControllerError(globalObject, transformReadableController(stream), reason);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerError(globalObject, readableController, reason);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     resolvePromise(globalObject, finishPromise, jsUndefined());
     // Resolving with `undefined` performs no thenable lookup and cannot throw.
     scope.assertNoException();
@@ -352,8 +359,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkAbortCancelRejected, (JSGlo
     auto* stream = uncheckedDowncast<JSTransformStream>(uncheckedDowncast<InternalFieldTuple>(callFrame->argument(1))->getInternalField(0));
     auto* finishPromise = stream->m_controller->m_finishPromise.get();
 
-    readableStreamDefaultControllerError(globalObject, transformReadableController(stream), rejection);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerError(globalObject, readableController, rejection);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     rejectPromise(globalObject, finishPromise, rejection);
     return JSValue::encode(jsUndefined());
 }
@@ -370,8 +379,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkCloseFlushFulfilled, (JSGlo
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
         return JSValue::encode(jsUndefined());
     }
-    readableStreamDefaultControllerClose(globalObject, transformReadableController(stream));
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerClose(globalObject, readableController);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     resolvePromise(globalObject, finishPromise, jsUndefined());
     // Resolving with `undefined` performs no thenable lookup and cannot throw.
     scope.assertNoException();
@@ -386,8 +397,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkCloseFlushRejected, (JSGlob
     auto* stream = uncheckedDowncast<JSTransformStream>(callFrame->argument(1));
     auto* finishPromise = stream->m_controller->m_finishPromise.get();
 
-    readableStreamDefaultControllerError(globalObject, transformReadableController(stream), rejection);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* readableController = transformReadableController(stream)) {
+        readableStreamDefaultControllerError(globalObject, readableController, rejection);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     rejectPromise(globalObject, finishPromise, rejection);
     return JSValue::encode(jsUndefined());
 }

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2018,3 +2018,53 @@ it("pipeTo writes an already-dequeued chunk when the signal aborts mid-drain", a
   // Node 26 agrees byte-for-byte: every dequeued chunk is written before the abort finishes.
   expect({ outcome, written }).toEqual({ outcome: "rejected:stop", written: ["a", "b", "c"] });
 });
+
+// When a Bun native sink (spawn stdin, Bun.serve response body) consumes a TransformStream's
+// readable and then tears it down on abort, the transform controller API must not segfault.
+it("TransformStreamDefaultController survives after a native sink tears down its readable", async () => {
+  const script = `
+    process.on("unhandledRejection", () => {});
+    const actions = {
+      desiredSize: c => c.desiredSize,
+      enqueue: c => c.enqueue(new Uint8Array([1])),
+      terminate: c => c.terminate(),
+      error: c => c.error(new Error("bad payload")),
+    };
+    for (const [name, fn] of Object.entries(actions)) {
+      let ctrl;
+      const ts = new TransformStream({ start(c) { ctrl = c; } });
+      const child = Bun.spawn({
+        cmd: [process.execPath, "-e", "setInterval(()=>{},1e5)"],
+        stdin: ts.readable, stdout: "ignore", stderr: "ignore",
+      });
+      child.kill();
+      await child.exited;
+      // The stdin sink's finally step releases its reader and clears the readable's
+      // controller slot; unlocked is the observable post-teardown condition.
+      while (ts.readable.locked) await new Promise(r => setImmediate(r));
+      let outcome;
+      try { outcome = "returned:" + fn(ctrl); } catch (e) { outcome = "threw:" + e?.constructor?.name; }
+      console.log(name, outcome);
+    }
+    console.log("SURVIVED");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  void stderr;
+  expect({ stdout: stdout.trim().split("\n"), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: [
+      "desiredSize returned:null",
+      "enqueue threw:TypeError",
+      "terminate returned:undefined",
+      "error returned:undefined",
+      "SURVIVED",
+    ],
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
### What

`Bun.serve` responding with `req.body.pipeThrough(transform)` where the transformer's async `transform()` calls `controller.error()` (a streaming validator rejecting a payload) segfaults the whole server process when the client aborts the upload mid-body. The same applies to `controller.enqueue()`, `controller.terminate()` and `controller.desiredSize`.

### Repro

```js
const srv = Bun.serve({
  port: 0, idleTimeout: 0,
  async fetch(req) {
    if (!req.body) return new Response("nobody");
    return new Response(req.body.pipeThrough(new TransformStream({
      async transform(_ch, c) { await new Promise(r => setTimeout(r, 2)); c.error(new Error("bad payload")); },
    })));
  },
});
// POST a few chunks of a content-length body, destroy the socket mid-upload. Within a few
// dozen aborts: SIGSEGV (release) / SIGABRT (asserts on).
```

Assert build:

```
ASSERTION FAILED: readable && readable->m_controllerKind == ControllerKind::Default
src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp(34)
JSReadableStreamDefaultController *Bun::WebStreams::transformReadableController(JSTransformStream *)
```

Release build: `Segmentation fault at address 0x88`.

### Cause

When a Bun native sink (`Bun.serve` response body, `Bun.spawn` stdin) consumes a `TransformStream`'s readable side and the consumer aborts, the sink pump's finally step (`rsisFinally` / `resumableReleaseReader` / `readDirectStreamCloseImpl` in `BunStreamSource.cpp`) runs `clearStreamControllerSlots()` on the readable, setting `m_controllerKind = None` and clearing `m_controller`. The `TransformStream` still holds that readable via `m_readable`, so a later controller method call (from an async `transform()`/`flush()` that resumed after the abort, or from a queued sink reaction) walks `transformReadableController()`, which asserts `ControllerKind::Default` and then `uncheckedDowncast`s a null slot. Every caller immediately dereferences the result.

This is the TransformStream sibling of the tee-branch crash addressed in #33778.

### Fix

Make both `transformReadableController()` copies null-safe (return `nullptr` when the readable's controller slot has been cleared) and make every call site skip the readable-side abstract operation on null: `transformStreamError`, `transformStreamDefaultControllerEnqueue`/`Terminate`, the `desiredSize` getter, and the four sink abort/close reaction handlers. The spec AOs (`ReadableStreamDefaultControllerError`/`Close`/`Enqueue`) would no-op on a non-`Readable` stream anyway; the writable-side error/unblock still runs. This mirrors the `teeBranch*Controller` approach from #33778.

### Verification

New test in `test/js/web/streams/streams.test.js` passes `ts.readable` as stdin to a child process, kills the child, awaits the sink teardown (`ts.readable.locked === false`), then exercises all four controller members.

Without the fix: SIGABRT on the first action, 3/3 on the debug build.
With the fix: `desiredSize` returns `null`, `enqueue()` throws `TypeError`, `terminate()` and `error()` return normally; exit 0, 3/3.

- `test/js/third_party/wpt-streams/wpt-streams.test.ts`: 1175 pass / 0 fail.
- `test/js/web/streams/streams.test.js`: no new failures (2 pre-existing timeouts also present on main).
- `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`: 25 pass / 0 fail.
- `test/js/web/streams/transform-stream-leak.test.ts`: 3 pass / 0 fail.
- Original Bun.serve + `node:net` client-abort loop (400 iterations): survives.