### PR TITLE
Bun.write: drive a Response/Request ReadableStream body instead of hanging

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6067,7 +6067,8 @@ pub fn on_file_stream_resolve_request_stream(
     }
     // SAFETY: `sink` is the live +1 FileSink held for the wrapper's lifetime.
     let written = unsafe { (*this.sink).written.get() } as f64;
-    this.promise.resolve(global_this, JSValue::js_number(written))?;
+    this.promise
+        .resolve(global_this, JSValue::js_number(written))?;
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1704,21 +1704,25 @@ impl BlobExt for Blob {
                         return Ok(promise_value);
                     }
                     jsc::js_promise::Status::Fulfilled => {
+                        // SAFETY: `file_sink` is still our live +1 ref.
+                        let written = unsafe { (*file_sink).written.get() } as f64;
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.done(global_this);
                         return Ok(JSPromise::resolved_promise_value(
                             global_this,
-                            JSValue::js_number(0.0),
+                            JSValue::js_number(written),
                         ));
                     }
                     jsc::js_promise::Status::Rejected => {
+                        let err = promise.result(global_this.vm());
+                        promise.set_handled(global_this.vm());
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.cancel(global_this);
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
-                            promise.result(global_this.vm()),
+                            err,
                         ));
                     }
                 }
@@ -1734,12 +1738,14 @@ impl BlobExt for Blob {
                 );
             }
         }
+        // SAFETY: `file_sink` is still our live +1 ref.
+        let written = unsafe { (*file_sink).written.get() } as f64;
         // SAFETY: release our +1 ref on the sink.
         unsafe { webcore::FileSink::deref(file_sink) };
 
         Ok(JSPromise::resolved_promise_value(
             global_this,
-            JSValue::js_number(0.0),
+            JSValue::js_number(written),
         ))
     }
 
@@ -5273,6 +5279,45 @@ pub fn write_file_internal(
                                 "ReadableStream has already been used"
                             )));
                         }
+                        // If the body already exposes a ReadableStream (a JS
+                        // stream passed to `new Response`, or one cached on
+                        // the wrapper), drive it into a FileSink now; nothing
+                        // else will pump it.
+                        let readable_opt = get_stream(global_this).or_else(|| {
+                            // SAFETY: re-borrow after `get_stream`.
+                            let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                                return None;
+                            };
+                            locked.readable.get(global_this)
+                        });
+                        if let Some(readable) = readable_opt {
+                            if readable.is_disturbed(global_this) {
+                                destination_blob.detach();
+                                return Err(global_this.throw_invalid_arguments(format_args!(
+                                    "ReadableStream has already been used"
+                                )));
+                            }
+                            return Ok(ControlFlow::Break(
+                                destination_blob.pipe_readable_stream_to_blob(
+                                    global_this,
+                                    readable,
+                                    options.extra_options,
+                                )?,
+                            ));
+                        }
+                        // No stream attached: a native producer (fetch, server
+                        // request, HTMLRewriter) owns `locked.task` and will
+                        // `resolve()` the body later. Kick its buffering hook
+                        // with that original task pointer before we overwrite
+                        // `locked.task` with our own below.
+                        // SAFETY: re-borrow after `get_stream`.
+                        if let BodyValue::Locked(locked) = unsafe { &mut *body_value } {
+                            if let (Some(on_start_buffering), Some(producer_task)) =
+                                (locked.on_start_buffering.take(), locked.task)
+                            {
+                                on_start_buffering(producer_task);
+                            }
+                        }
                         let task =
                             bun_core::heap::into_raw(Box::new(WriteFileWaitFromLockedValueTask {
                                 global_this: bun_ptr::BackRef::new(global_this),
@@ -6020,7 +6065,9 @@ pub fn on_file_stream_resolve_request_stream(
     if let Some(stream) = strong.get(global_this) {
         stream.done(global_this);
     }
-    this.promise.resolve(global_this, JSValue::js_number(0.0))?;
+    // SAFETY: `sink` is the live +1 FileSink held for the wrapper's lifetime.
+    let written = unsafe { (*this.sink).written.get() } as f64;
+    this.promise.resolve(global_this, JSValue::js_number(written))?;
     Ok(JSValue::UNDEFINED)
 }
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -288,6 +288,169 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await gcTick();
   });
 
+  // The pre-fix behavior is a hard hang (promise never settles and holds an
+  // event-loop ref), so these run in a subprocess with a watchdog timer.
+  it("Bun.write(path, Response) with a JS ReadableStream body", async () => {
+    using dir = tempDir("bun-write-response-stream", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dst = process.argv[1] + "/out.bin";
+        const timer = setTimeout(() => process.exit(1), 10000);
+        const response = new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new Uint8Array(10).fill(3));
+              c.enqueue(new Uint8Array(6).fill(9));
+              c.close();
+            },
+          }),
+        );
+        const n = await Bun.write(dst, response);
+        clearTimeout(timer);
+        const bytes = await Bun.file(dst).bytes();
+        console.log(JSON.stringify({ n, bytes: Array.from(bytes), used: response.bodyUsed }));
+        `,
+        String(dir),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ n: 16, bytes: [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 9, 9, 9, 9, 9, 9], used: true }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("Bun.write(path, Request) with a JS ReadableStream body", async () => {
+    using dir = tempDir("bun-write-request-stream", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dst = process.argv[1] + "/out.bin";
+        const timer = setTimeout(() => process.exit(1), 10000);
+        const request = new Request("http://example.com/", {
+          method: "POST",
+          body: new ReadableStream({
+            start(c) {
+              c.enqueue(new Uint8Array([1, 2, 3, 4, 5]));
+              c.close();
+            },
+          }),
+        });
+        const n = await Bun.write(dst, request);
+        clearTimeout(timer);
+        const bytes = await Bun.file(dst).bytes();
+        console.log(JSON.stringify({ n, bytes: Array.from(bytes) }));
+        `,
+        String(dir),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ n: 5, bytes: [1, 2, 3, 4, 5] }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("Bun.write(path, Response) with an erroring ReadableStream body rejects", async () => {
+    using dir = tempDir("bun-write-response-stream-err", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dst = process.argv[1] + "/out.bin";
+        const timer = setTimeout(() => process.exit(1), 10000);
+        const response = new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new Uint8Array(4));
+              c.error(new Error("stream boom"));
+            },
+          }),
+        );
+        try {
+          await Bun.write(dst, response);
+          console.log("resolved");
+        } catch (e) {
+          console.log("rejected:" + e.message);
+        }
+        clearTimeout(timer);
+        `,
+        String(dir),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("rejected:stream boom");
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.write(path, await fetch(url)) from a chunked origin", async () => {
+    using dir = tempDir("bun-write-fetch-chunked", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dst = process.argv[1] + "/out.bin";
+        const total = 256 * 1024;
+        await using server = Bun.serve({
+          port: 0,
+          async fetch() {
+            let o = 0;
+            return new Response(
+              new ReadableStream({
+                async pull(c) {
+                  if (o >= total) return c.close();
+                  c.enqueue(new Uint8Array(16384).fill(7));
+                  o += 16384;
+                  await Bun.sleep(0);
+                },
+              }),
+            );
+          },
+        });
+        const timer = setTimeout(() => process.exit(1), 10000);
+        const res = await fetch(server.url);
+        const n = await Bun.write(dst, res);
+        clearTimeout(timer);
+        const bytes = await Bun.file(dst).bytes();
+        console.log(JSON.stringify({
+          cl: res.headers.get("content-length"),
+          n,
+          len: bytes.length,
+          allSeven: bytes.every(b => b === 7),
+        }));
+        `,
+        String(dir),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ cl: null, n: 262144, len: 262144, allSeven: true }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("Response -> Bun.file -> Response -> text", async () => {
     await gcTick();
     const file = path.join(import.meta.dir, "fetch.js.txt");


### PR DESCRIPTION
## Reproduction

```js
// hangs forever on main
await Bun.write("/tmp/out.bin", new Response(new ReadableStream({
  start(c) { c.enqueue(new Uint8Array(10)); c.close(); },
})));
```

and the documented download idiom, against any chunked / no-`Content-Length` origin:

```js
await Bun.write("/tmp/out.bin", await fetch(url)); // never resolves
```

## Cause

`write_file_internal`'s `BodyValue::Locked` arm registers an `on_receive_value` callback and returns, but nothing drives the body:

- For a JS `ReadableStream` body, `locked.readable` holds the stream and nobody reads from it.
- For a fetch body still in flight, the FetchTasklet's `on_start_buffering` hook is never invoked (and `locked.task` is overwritten with the write-file task pointer), so the tasklet never switches to buffer-all mode and never calls `resolve()`.

Either way `on_receive_value` is never reached and the `Bun.write` promise never settles.

## Fix

In the non-S3 `Locked` arm:

- If the body already exposes a `ReadableStream` (from `new Response(stream)` or cached on the wrapper), pump it through the existing `pipe_readable_stream_to_blob` FileSink path, the same machinery already used for S3 sources.
- Otherwise, call the producer's `on_start_buffering` with its original `task` pointer before overwriting it, so the producer actually delivers bytes and eventually `resolve()`s the body into the existing `WriteFileWaitFromLockedValueTask` path.

Producers that set neither (HTMLRewriter) keep the existing wait-for-resolve behaviour unchanged.

Also fixed in `pipe_readable_stream_to_blob`: resolve with the FileSink's `written` count instead of a hardcoded `0`, and mark the inner `assign_to_stream` promise handled on the synchronous reject path so the stream error is not also surfaced as an unhandled rejection.

## Verification

New tests in `test/js/bun/io/bun-write.test.js` cover a Response JS-stream body, a Request JS-stream body, a fetch from a chunked origin, and an erroring stream body. All four hang and time out on `main`; all pass with this change. `test/js/workerd/html-rewriter.test.js` and `test/js/web/fetch/body.test.ts` still pass.