### PR TITLE
webstreams: stop clearing the controller slot in the native-sink pump teardown

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -969,9 +969,9 @@ static void rsisFinally(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamI
     auto* stream = op->m_stream.get();
     if (!stream)
         return;
-    ReadableStreamState state = stream->m_state;
-    clearStreamControllerSlots(stream);
-    if (!op->m_didThrow && state != ReadableStreamState::Closed && state != ReadableStreamState::Errored) {
+    // The pump never installed this stream's controller; the TransformStream and tee machinery
+    // reach it through the stream for the stream's lifetime, so it is not ours to clear.
+    if (!op->m_didThrow && stream->m_state != ReadableStreamState::Closed && stream->m_state != ReadableStreamState::Errored) {
         readableStreamCloseIfPossible(globalObject, stream);
         RETURN_IF_EXCEPTION(scope, );
     }
@@ -1297,11 +1297,11 @@ static void resumableReleaseReader(JSC::VM& vm, JSGlobalObject* globalObject, JS
     auto* stream = op->m_stream.get();
     if (!stream)
         return;
-    ReadableStreamState state = stream->m_state;
-    clearStreamControllerSlots(stream);
+    // The pump never installed this stream's controller; the TransformStream and tee machinery
+    // reach it through the stream for the stream's lifetime, so it is not ours to clear.
     JSValue error = op->m_error.get();
     bool hasTruthyError = !error.isEmpty() && error.toBoolean(globalObject);
-    if (!hasTruthyError && state != ReadableStreamState::Closed && state != ReadableStreamState::Errored) {
+    if (!hasTruthyError && stream->m_state != ReadableStreamState::Closed && stream->m_state != ReadableStreamState::Errored) {
         readableStreamCloseIfPossible(globalObject, stream);
         RETURN_IF_EXCEPTION(scope, );
     }

--- a/test/js/web/streams/transform-stream-sink-abort.test.ts
+++ b/test/js/web/streams/transform-stream-sink-abort.test.ts
@@ -1,0 +1,130 @@
+// When the readable half of a TransformStream is consumed by a Bun native sink
+// (Bun.serve response body, Bun.spawn stdin) and that sink aborts, the pump
+// teardown used to null the stream's controller slot. A still-pending async
+// transform() then called controller.enqueue() and dereferenced a null
+// controller: a debug ASSERT / release segfault.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test.concurrent("Bun.serve: client abort while async transform() is pending does not crash", async () => {
+  using dir = tempDir("transform-sink-abort-serve", {
+    "index.ts": `
+      import net from "node:net";
+      import { once } from "node:events";
+      let resolveGate: () => void;
+      const gate = new Promise<void>(r => (resolveGate = r));
+      let enqueueResult = "not reached";
+      let readable: ReadableStream | undefined;
+      const srv = Bun.serve({
+        hostname: "127.0.0.1", port: 0, idleTimeout: 0,
+        async fetch(req) {
+          if (!req.body) return new Response("nobody");
+          const ts = new TransformStream({
+            async transform(ch, c) {
+              await gate;
+              try {
+                c.enqueue(ch);
+                enqueueResult = "ok";
+              } catch (e) {
+                enqueueResult = "threw " + (e as Error)?.constructor?.name;
+              }
+            },
+          });
+          readable = req.body.pipeThrough(ts);
+          return new Response(readable);
+        },
+        error() { return new Response("error"); },
+      });
+      const s = net.connect(srv.port, "127.0.0.1");
+      await once(s, "connect");
+      s.write("POST / HTTP/1.1\\r\\nhost: x\\r\\ncontent-length: 100000\\r\\n\\r\\n");
+      s.write(Buffer.alloc(1024, 66));
+      s.on("data", () => {});
+      s.on("error", () => {});
+      // Wait for the server to start pumping the response body (locks ts.readable).
+      while (!readable || !readable.locked) await new Promise(r => setImmediate(r));
+      s.destroy();
+      // Wait for the pump to tear down ts.readable (it releases the reader).
+      while (readable.locked) await new Promise(r => setImmediate(r));
+      resolveGate!();
+      await Promise.resolve();
+      await Promise.resolve();
+      srv.stop(true);
+      console.log("SURVIVED", enqueueResult);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  // The readable is closed by the pump teardown, so enqueue must throw a TypeError.
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "SURVIVED threw TypeError",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.concurrent("Bun.spawn stdin: child exit while async transform() is pending does not crash", async () => {
+  using dir = tempDir("transform-sink-abort-spawn", {
+    "index.ts": `
+      let resolvePending: () => void;
+      const pending = new Promise<void>(r => (resolvePending = r));
+      let enqueueResult = "not reached";
+      const ts = new TransformStream({
+        async transform(chunk, controller) {
+          await pending;
+          try {
+            controller.enqueue(chunk);
+            enqueueResult = "ok";
+          } catch (e) {
+            enqueueResult = "threw " + (e as Error)?.constructor?.name;
+          }
+        },
+      });
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", ""],
+        stdin: ts.readable,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      const writer = ts.writable.getWriter();
+      writer.write(new Uint8Array(1024)).catch(() => {});
+      await proc.exited;
+      // Wait for the pump to tear down ts.readable (it releases the reader).
+      while (ts.readable.locked) await new Promise(r => setImmediate(r));
+      resolvePending!();
+      await Promise.resolve();
+      await Promise.resolve();
+      console.log("SURVIVED", enqueueResult);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  // The readable is closed by the pump teardown, so enqueue must throw a TypeError.
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "SURVIVED threw TypeError",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/web/streams/transform-stream-sink-abort.test.ts
+++ b/test/js/web/streams/transform-stream-sink-abort.test.ts
@@ -60,11 +60,7 @@ test.concurrent("Bun.serve: client abort while async transform() is pending does
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // The readable is closed by the pump teardown, so enqueue must throw a TypeError.
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: "SURVIVED threw TypeError",
@@ -115,11 +111,7 @@ test.concurrent("Bun.spawn stdin: child exit while async transform() is pending 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // The readable is closed by the pump teardown, so enqueue must throw a TypeError.
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: "SURVIVED threw TypeError",


### PR DESCRIPTION
## What does this PR do?

Fixes a segfault in `Bun.serve` (and `Bun.spawn({stdin})`) when the readable side of a `TransformStream` is consumed by a native sink and that sink aborts while an async `transform()` is still pending.

### Reproduction

```js
// Any remote client that aborts mid-upload kills the server process.
Bun.serve({
  port: 0,
  async fetch(req) {
    return new Response(req.body.pipeThrough(new TransformStream({
      async transform(ch, c) { await new Promise(r => setTimeout(r, 2)); c.enqueue(ch); },
    })));
  },
});
```

Release build:
```
panic(main thread): Segmentation fault at address 0x9B
```

Debug build:
```
ASSERTION FAILED: readable && readable->m_controllerKind == ControllerKind::Default
src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp(34)
JSReadableStreamDefaultController *Bun::WebStreams::transformReadableController(JSTransformStream *)
```

### Cause

`rsisFinally` (the `readStreamIntoSink` pump teardown, used by `Bun.serve` response bodies) and `resumableReleaseReader` (the `assignStreamIntoResumableSink` pump teardown, used by `Bun.spawn` stdin) both called `clearStreamControllerSlots(stream)`, which nulls `m_controller` and flips `m_controllerKind` to `None`. When that stream is a `TransformStream`'s readable half, the `TransformStream` still holds it via `m_readable` and reaches its controller through the slot. A pending async `transform()` that resumes and calls `controller.enqueue()` then walks `transformReadableController()`, whose `uncheckedDowncast` dereferences the now-null controller.

The clear was a GC hint carried over from the old JS builtins (where it surfaced as an uncaught `TypeError: null is not an object`). These two pumps never installed the controller; releasing the reader is the only teardown a consumer owes.

### Fix

Drop the `clearStreamControllerSlots` call from both pump teardowns. The stream is already moved to `Closed` by the pump's `readableStreamCancel` / `readableStreamCloseIfPossible`, so a late `enqueue()` now hits `readableStreamDefaultControllerCanCloseOrEnqueue` returning `false` and throws the spec `TypeError` instead of crashing. The remaining `clearStreamControllerSlots` call in `readDirectStreamCloseImpl` is unchanged: that path operates on a `ControllerKind::NativeSink` that `readDirectStream` itself installed.

### How did you verify your code works?

New tests in `test/js/web/streams/transform-stream-sink-abort.test.ts` exercise both pump paths deterministically (single request each, condition-based waits). Both abort with the `ASSERTION FAILED` above on an unpatched build and pass with this change. `wpt-streams.test.ts` (1175 tests) is unchanged.