### PR TITLE
uws: compile-time-split node:http state via template<bool NODE_HTTP>

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -747,13 +747,13 @@ public:
     }
     void setOnSocketData(typename HttpContextData<SSL, NODE_HTTP>::OnSocketDataCallback onData) {
         if constexpr (NODE_HTTP) {
-            httpContext->getSocketContextData()->onSocketData = onData;
+            httpContext->getSocketContextData()->nodeCompat.onSocketData = onData;
         }
     }
 
     void setOnClientError(typename HttpContextData<SSL, NODE_HTTP>::OnClientErrorCallback onClientError) {
         if constexpr (NODE_HTTP) {
-            httpContext->getSocketContextData()->onClientError = std::move(onClientError);
+            httpContext->getSocketContextData()->nodeCompat.onClientError = std::move(onClientError);
         }
     }
 

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -91,11 +91,11 @@ namespace uWS {
 
     static_assert(sizeof(struct us_bun_socket_context_options_t) == sizeof(SocketContextOptions), "Mismatching uSockets/uWebSockets ABI");
 
-template <bool SSL>
+template <bool SSL, bool NODE_HTTP = false>
 struct TemplatedApp {
 private:
     /* The app always owns at least one http context, but creates websocket contexts on demand */
-    HttpContext<SSL> *httpContext;
+    HttpContext<SSL, NODE_HTTP> *httpContext;
     /* Shared SSL_CTX for every accepted socket. nullptr for plain HTTP. Built
      * once in the constructor; the listener up_ref's it; SSL_CTX_free in dtor. */
     struct ssl_ctx_st *sslCtx = nullptr;
@@ -104,7 +104,7 @@ private:
     struct PendingServerName {
         std::string hostname;
         struct ssl_ctx_st *ctx;
-        HttpRouter<typename HttpContextData<SSL>::RouterData> *router;
+        HttpRouter<typename HttpContextData<SSL, NODE_HTTP>::RouterData> *router;
     };
     std::vector<PendingServerName> pendingServerNames;
     /* No raw us_listen_socket_t* cache here. src/runtime/server/mod.rs's non-abrupt stop calls
@@ -139,7 +139,7 @@ public:
                 if (success) *success = false;
                 return std::move(*this);
             }
-            auto *domainRouter = new HttpRouter<typename HttpContextData<SSL>::RouterData>();
+            auto *domainRouter = new HttpRouter<typename HttpContextData<SSL, NODE_HTTP>::RouterData>();
             int result = 0;
             forEachListenSocket([&](us_listen_socket_t *ls) {
                 result |= us_listen_socket_add_server_name(ls, hostname_pattern.c_str(), domainCtx, domainRouter);
@@ -201,7 +201,7 @@ public:
     }
 
     /* Attaches a "filter" function to track socket connections/disconnections */
-    TemplatedApp &&filter(MoveOnlyFunction<void(HttpResponse<SSL> *, int)> &&filterHandler) {
+    TemplatedApp &&filter(MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, int)> &&filterHandler) {
         httpContext->filter(std::move(filterHandler));
 
         return std::move(*this);
@@ -313,7 +313,7 @@ private:
          * default serve the request - it never aborts or suspends the handshake. */
         (void) abort_handshake;
         (void) socket;
-        auto *httpContext = (HttpContext<SSL> *) us_socket_group_ext(us_listen_socket_group(ls));
+        auto *httpContext = (HttpContext<SSL, NODE_HTTP> *) us_socket_group_ext(us_listen_socket_group(ls));
         httpContext->getSocketContextData()->missingServerNameHandler(hostname);
         /* The handler is expected to have registered the name via
          * addServerName(); hand the newly-registered context back so the
@@ -329,12 +329,12 @@ private:
             sslCtx = us_ssl_ctx_from_options(options, &err);
             if (!sslCtx) { httpContext = nullptr; return; }
         }
-        httpContext = HttpContext<SSL>::create(Loop::get(), options.request_cert, options.reject_unauthorized);
+        httpContext = HttpContext<SSL, NODE_HTTP>::create(Loop::get(), options.request_cert, options.reject_unauthorized);
     }
 public:
 
-    static TemplatedApp<SSL>* create(SocketContextOptions options = {}) {
-        auto *app = new TemplatedApp<SSL>(options);
+    static TemplatedApp* create(SocketContextOptions options = {}) {
+        auto *app = new TemplatedApp(options);
         if (app->constructorFailed()) {
             delete app;
             return nullptr;
@@ -363,7 +363,7 @@ public:
         bool sendPingsAutomatically = true;
         /* Maximum socket lifetime in minutes before forced closure (defaults to disabled) */
         unsigned short maxLifetime = 0;
-        MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *, WebSocketContext<SSL, true, UserData> *)> upgrade = nullptr;
+        MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *, WebSocketContext<SSL, true, UserData> *)> upgrade = nullptr;
         MoveOnlyFunction<void(WebSocket<SSL, true, UserData> *)> open = nullptr;
         MoveOnlyFunction<void(WebSocket<SSL, true, UserData> *, std::string_view, OpCode)> message = nullptr;
         MoveOnlyFunction<void(WebSocket<SSL, true, UserData> *)> drain = nullptr;
@@ -584,7 +584,7 @@ public:
 
     /* Browse to a server name, changing the router to this domain */
     TemplatedApp &&domain(const std::string &serverName) {
-        HttpContextData<SSL> *httpContextData = httpContext->getSocketContextData();
+        HttpContextData<SSL, NODE_HTTP> *httpContextData = httpContext->getSocketContextData();
 
         void *domainRouter = nullptr;
         for (auto &p : pendingServerNames) {
@@ -599,42 +599,42 @@ public:
         return std::move(*this);
     }
 
-    TemplatedApp &&get(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&get(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("GET", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&post(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&post(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("POST", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&options(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&options(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("OPTIONS", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&del(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&del(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("DELETE", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&patch(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&patch(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("PATCH", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&put(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&put(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("PUT", pattern, std::move(handler));
         }
@@ -648,21 +648,21 @@ public:
     }
 
 
-    TemplatedApp &&head(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&head(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("HEAD", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&connect(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&connect(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("CONNECT", pattern, std::move(handler));
         }
         return std::move(*this);
     }
 
-    TemplatedApp &&trace(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&trace(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("TRACE", pattern, std::move(handler));
         }
@@ -670,7 +670,7 @@ public:
     }
 
     /* This one catches any method */
-    TemplatedApp &&any(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler) {
+    TemplatedApp &&any(std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler) {
         if (httpContext) {
             httpContext->onHttp("*", pattern, std::move(handler));
         }
@@ -739,29 +739,31 @@ public:
         return std::move(*this);
     }
 
-    void setOnSocketClosed(HttpContextData<SSL>::OnSocketClosedCallback onClose) {
+    void setOnSocketClosed(typename HttpContextData<SSL, NODE_HTTP>::OnSocketClosedCallback onClose) {
         httpContext->getSocketContextData()->onSocketClosed = onClose;
     }
-    void setOnSocketDrain(HttpContextData<SSL>::OnSocketDrainCallback onDrain) {
+    void setOnSocketDrain(typename HttpContextData<SSL, NODE_HTTP>::OnSocketDrainCallback onDrain) {
         httpContext->getSocketContextData()->onSocketDrain = onDrain;
     }
-    void setOnSocketData(HttpContextData<SSL>::OnSocketDataCallback onData) {
-        httpContext->getSocketContextData()->onSocketData = onData;
+    void setOnSocketData(typename HttpContextData<SSL, NODE_HTTP>::OnSocketDataCallback onData) {
+        if constexpr (NODE_HTTP) {
+            httpContext->getSocketContextData()->onSocketData = onData;
+        }
     }
 
-    void setOnClientError(HttpContextData<SSL>::OnClientErrorCallback onClientError) {
-        httpContext->getSocketContextData()->onClientError = std::move(onClientError);
+    void setOnClientError(typename HttpContextData<SSL, NODE_HTTP>::OnClientErrorCallback onClientError) {
+        if constexpr (NODE_HTTP) {
+            httpContext->getSocketContextData()->onClientError = std::move(onClientError);
+        }
     }
 
-    void setOnSocketUpgraded(HttpContextData<SSL>::OnSocketUpgradedCallback onUpgraded) {
+    void setOnSocketUpgraded(typename HttpContextData<SSL, NODE_HTTP>::OnSocketUpgradedCallback onUpgraded) {
         httpContext->getSocketContextData()->onSocketUpgraded = onUpgraded;
     }
 
-    /* Marks this app as backing a node:http server, enabling the per-socket
-     * request timing used by headersTimeout/requestTimeout. */
-    void setUsingNodeHttpCompat(bool value) {
-        httpContext->getSocketContextData()->flags.usingNodeHttpCompat = value;
-    }
+    /* NODE_HTTP is now the compile-time flag; runtime setter kept as a no-op
+     * so existing CAPI callers keep compiling until migrated. */
+    void setUsingNodeHttpCompat(bool /*value*/) {}
 
     TemplatedApp &&run() {
         uWS::run();
@@ -788,7 +790,9 @@ public:
 
 };
 
-typedef TemplatedApp<false> App;
-typedef TemplatedApp<true> SSLApp;
+typedef TemplatedApp<false, false> App;
+typedef TemplatedApp<true, false> SSLApp;
+typedef TemplatedApp<false, true> NodeHttpApp;
+typedef TemplatedApp<true, true> NodeHttpSSLApp;
 
 }

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -746,24 +746,22 @@ public:
         httpContext->getSocketContextData()->onSocketDrain = onDrain;
     }
     void setOnSocketData(typename HttpContextData<SSL, NODE_HTTP>::OnSocketDataCallback onData) {
-        if constexpr (NODE_HTTP) {
-            httpContext->getSocketContextData()->nodeCompat.onSocketData = onData;
-        }
+        static_assert(NODE_HTTP, "setOnSocketData is node:http-only; use NodeHttpApp/NodeHttpSSLApp");
+        httpContext->getSocketContextData()->nodeCompat.onSocketData = onData;
     }
 
     void setOnClientError(typename HttpContextData<SSL, NODE_HTTP>::OnClientErrorCallback onClientError) {
-        if constexpr (NODE_HTTP) {
-            httpContext->getSocketContextData()->nodeCompat.onClientError = std::move(onClientError);
-        }
+        static_assert(NODE_HTTP, "setOnClientError is node:http-only; use NodeHttpApp/NodeHttpSSLApp");
+        httpContext->getSocketContextData()->nodeCompat.onClientError = std::move(onClientError);
     }
 
     void setOnSocketUpgraded(typename HttpContextData<SSL, NODE_HTTP>::OnSocketUpgradedCallback onUpgraded) {
         httpContext->getSocketContextData()->onSocketUpgraded = onUpgraded;
     }
 
-    /* NODE_HTTP is now the compile-time flag; runtime setter kept as a no-op
-     * so existing CAPI callers keep compiling until migrated. */
-    void setUsingNodeHttpCompat(bool /*value*/) {}
+    void setUsingNodeHttpCompat(bool /*value*/) {
+        static_assert(NODE_HTTP, "setUsingNodeHttpCompat is obsolete; use NodeHttpApp/NodeHttpSSLApp");
+    }
 
     TemplatedApp &&run() {
         uWS::run();

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -50,12 +50,12 @@ namespace uWS {
 template <bool SSL>
 struct AsyncSocket {
     /* This guy is promiscuous */
-    template <bool> friend struct HttpContext;
+    template <bool, bool> friend struct HttpContext;
     template <bool, bool, typename> friend struct WebSocketContext;
-    template <bool> friend struct TemplatedApp;
+    template <bool, bool> friend struct TemplatedApp;
     template <bool, typename> friend struct WebSocketContextData;
     template <typename, typename> friend struct TopicTree;
-    template <bool> friend struct HttpResponse;
+    template <bool, bool> friend struct HttpResponse;
 
 
 public:

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -90,23 +90,23 @@ static constexpr auto supportedHttpMethods = makeArray<std::string_view>(
 
 } // namespace detail
 
-template<bool> struct HttpResponse;
+template<bool, bool> struct HttpResponse;
 
 /* Real heap-allocated owner of one HTTP server's socket group + router state.
  * Replaces the old reinterpret_cast over us_socket_context_t — `group.ext`
  * points back to `this` so socket handlers recover the typed context via
- * `(HttpContext<SSL>*) us_socket_group_ext(us_socket_group(s))`. */
-template <bool SSL>
+ * `(HttpContext<SSL, NODE_HTTP>*) us_socket_group_ext(us_socket_group(s))`. */
+template <bool SSL, bool NODE_HTTP>
 struct HttpContext {
-    template<bool> friend struct TemplatedApp;
-    template<bool> friend struct HttpResponse;
+    template<bool, bool> friend struct TemplatedApp;
+    template<bool, bool> friend struct HttpResponse;
 private:
     HttpContext() = default;
 
     /* Embedded list-head for accepted sockets. The vtable is `httpVTable` below;
      * SSL_CTX comes from the listener, not from here. */
     us_socket_group_t group{};
-    HttpContextData<SSL> data;
+    HttpContextData<SSL, NODE_HTTP> data;
 
     /* fromSocket() / getSocketContextDataS() cast group.ext back to
      * HttpContext*; nothing else relies on offsetof(data), but pin group at 0
@@ -134,15 +134,15 @@ public:
         return &group;
     }
 
-    HttpContextData<SSL> *getSocketContextData() {
+    HttpContextData<SSL, NODE_HTTP> *getSocketContextData() {
         return &data;
     }
 
-    static HttpContext<SSL> *fromSocket(us_socket_t *s) {
-        return (HttpContext<SSL> *) us_socket_group_ext(us_socket_group(s));
+    static HttpContext<SSL, NODE_HTTP> *fromSocket(us_socket_t *s) {
+        return (HttpContext<SSL, NODE_HTTP> *) us_socket_group_ext(us_socket_group(s));
     }
 
-    static HttpContextData<SSL> *getSocketContextDataS(us_socket_t *s) {
+    static HttpContextData<SSL, NODE_HTTP> *getSocketContextDataS(us_socket_t *s) {
         return &fromSocket(s)->data;
     }
 
@@ -152,9 +152,9 @@ private:
     static void onHandshake(us_socket_t *s, int success, struct us_bun_verify_error_t verify_error, void * /*custom_data*/) {
         // if we are closing or already closed, we don't need to do anything
         if (!us_socket_is_closed(s)) {
-            HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+            HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
             // Set per-socket authorization status
-            auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
+            auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL, NODE_HTTP> *>(us_socket_ext(s));
             if(httpContextData->flags.rejectUnauthorized) {
                 if(!success || verify_error.error != 0) {
                     // we failed to handshake, close the socket
@@ -173,28 +173,28 @@ private:
             httpResponseData->isAuthorized = success;
 
             /* Any connected socket should timeout until it has a request */
-            ((HttpResponse<SSL> *) s)->resetTimeout();
+            ((HttpResponse<SSL, NODE_HTTP> *) s)->resetTimeout();
 
             /* Call filter */
             for (auto &f : httpContextData->filterHandlers) {
-                f((HttpResponse<SSL> *) s, 1);
+                f((HttpResponse<SSL, NODE_HTTP> *) s, 1);
             }
         }
     }
 
     static us_socket_t *onOpen(us_socket_t *s, int /*is_client*/, char * /*ip*/, int /*ip_length*/) {
         /* Init socket ext */
-        new (us_socket_ext(s)) HttpResponseData<SSL>;
+        new (us_socket_ext(s)) HttpResponseData<SSL, NODE_HTTP>;
           /* Any connected socket should timeout until it has a request */
-        ((HttpResponse<SSL> *) s)->resetTimeout();
+        ((HttpResponse<SSL, NODE_HTTP> *) s)->resetTimeout();
 
-        HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+        [[maybe_unused]] HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
 
         /* node:http compat: the headers/request timeout window opens at accept
          * (mirrors the parser-initialize timestamp in Node's ConnectionsList),
          * so a client that connects and never sends anything still expires. */
-        if (httpContextData->flags.usingNodeHttpCompat) {
-            ((HttpResponseData<SSL> *) us_socket_ext(s))->lastMessageStartMs = nodeCompatMonotonicMs();
+        if constexpr (NODE_HTTP) {
+            ((HttpResponseData<SSL, NODE_HTTP> *) us_socket_ext(s))->nodeCompat.lastMessageStartMs = nodeCompatMonotonicMs();
             /* A peer FIN must not tear the connection down at the loop level:
              * onEnd() below decides whether to close right away (idle) or to
              * keep writing the responses that are still in flight / pipelined
@@ -211,7 +211,7 @@ private:
         if(!SSL) {
             /* Call filter */
             for (auto &f : httpContextData->filterHandlers) {
-                f((HttpResponse<SSL> *) s, 1);
+                f((HttpResponse<SSL, NODE_HTTP> *) s, 1);
             }
         }
 
@@ -222,38 +222,42 @@ private:
         ((AsyncSocket<SSL> *)s)->uncorkWithoutSending();
 
         /* Get socket ext */
-        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
+        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL, NODE_HTTP> *>(us_socket_ext(s));
 
 
         /* Call filter */
-        HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+        HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
 
-        if(httpResponseData && (httpResponseData->isConnectRequest || httpResponseData->nodeHttpTunnelAfterBody)) {
-            if (httpResponseData->socketData && httpContextData->onSocketData) {
-                httpContextData->onSocketData(httpResponseData->socketData, SSL, s, "", 0, true);
-            }
-            if(httpResponseData->inStream) {
-                httpResponseData->inStream(reinterpret_cast<HttpResponse<SSL> *>(s), "", 0, true, httpResponseData->userData);
-                httpResponseData->inStream = nullptr;
+        if constexpr (NODE_HTTP) {
+            if(httpResponseData && (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody)) {
+                if (httpResponseData->nodeCompat.socketData && httpContextData->onSocketData) {
+                    httpContextData->onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
+                }
+                if(httpResponseData->inStream) {
+                    httpResponseData->inStream(reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(s), "", 0, true, httpResponseData->userData);
+                    httpResponseData->inStream = nullptr;
+                }
             }
         }
 
 
         for (auto &f : httpContextData->filterHandlers) {
-            f((HttpResponse<SSL> *) s, -1);
+            f((HttpResponse<SSL, NODE_HTTP> *) s, -1);
         }
 
-        if (httpResponseData->socketData && httpContextData->onSocketClosed) {
-            httpContextData->onSocketClosed(httpResponseData->socketData, SSL, s);
+        if constexpr (NODE_HTTP) {
+            if (httpResponseData->nodeCompat.socketData && httpContextData->onSocketClosed) {
+                httpContextData->onSocketClosed(httpResponseData->nodeCompat.socketData, SSL, s);
+            }
         }
         /* Signal broken HTTP request only if we have a pending request */
         if (httpResponseData->onAborted != nullptr && httpResponseData->userData != nullptr) {
-            httpResponseData->onAborted((HttpResponse<SSL> *)s, httpResponseData->userData);
+            httpResponseData->onAborted((HttpResponse<SSL, NODE_HTTP> *)s, httpResponseData->userData);
         }
 
 
         /* Destruct socket ext */
-        httpResponseData->~HttpResponseData<SSL>();
+        httpResponseData->~HttpResponseData<SSL, NODE_HTTP>();
 
         return s;
     }
@@ -268,7 +272,7 @@ private:
         // ~190k req/sec is with http parsing
         // ~180k - 190k req/sec is with varying routing
 
-        HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+        HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
 
         /* Do not accept any data while in shutdown state */
         if (us_socket_is_shut_down((us_socket_t *) s)) {
@@ -278,16 +282,18 @@ private:
             return s;
         }
 
-        HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = (HttpResponseData<SSL, NODE_HTTP> *) us_socket_ext(s);
 
         /* node:http compat: HTTP parsing stopped on this connection (a parse error
          * was already delivered to 'clientError', or the JS layer freed the
          * parser); ignore further request bytes. CONNECT/Upgrade tunnels are not
          * parsed as HTTP and keep flowing below. */
-        if (httpContextData->flags.usingNodeHttpCompat && httpResponseData->nodeHttpParsingStopped
-            && !httpResponseData->isConnectRequest) {
-            us_socket_unref(s);
-            return s;
+        if constexpr (NODE_HTTP) {
+            if (httpResponseData->nodeCompat.nodeHttpParsingStopped
+                && !httpResponseData->nodeCompat.isConnectRequest) {
+                us_socket_unref(s);
+                return s;
+            }
         }
 
         /* Cork this socket */
@@ -297,10 +303,6 @@ private:
         httpContextData->flags.isParsingHttp = true;
         httpResponseData->isIdle = false;
 
-        /* node:http compat: maintain the headers/request timeout window (see
-         * the requestHandler/dataHandler hooks and the post-parse check). */
-        const bool trackNodeHttpTimings = httpContextData->flags.usingNodeHttpCompat && !httpResponseData->isConnectRequest;
-
         // clients need to know the cursor after http parse, not servers!
         // how far did we read then? we need to know to continue with websocket parsing data? or?
 
@@ -309,75 +311,86 @@ private:
         proxyParser = &httpResponseData->proxyParser;
 #endif
 
+        /* CONNECT-tunnel state lives in nodeCompat (a bitfield, so not
+         * addressable). The parser mutates a local via bool&; sync it back to
+         * nodeCompat after the parse so onClose/onEnd/next-onData see it. */
+        bool isConnectRequest = false;
+        if constexpr (NODE_HTTP) {
+            isConnectRequest = httpResponseData->nodeCompat.isConnectRequest;
+        }
+
         /* The return value is entirely up to us to interpret. The HttpParser cares only for whether the returned value is DIFFERENT from passed user */
 
-        auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.usingNodeHttpCompat, httpContextData->flags.useInsecureHTTPParser, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+        auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
             /* For every request we reset the timeout and hang until user makes action */
             /* Warning: if we are in shutdown state, resetting the timer is a security issue! */
             us_socket_timeout((us_socket_t *) s, 0);
 
-            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
+            HttpResponseData<SSL, NODE_HTTP> *httpResponseData = (HttpResponseData<SSL, NODE_HTTP> *) us_socket_ext((us_socket_t *) s);
 
-            /* node:http compat: the JS layer stopped HTTP processing on this
-             * connection (the user emitted 'close' on the socket - Node frees
-             * the parser there); abandon the rest of the buffer. */
-            if (httpContextData->flags.usingNodeHttpCompat && httpResponseData->nodeHttpParsingStopped) {
-                return nullptr;
-            }
-
-            /* node:http compat: the request head has been fully parsed, so only
-             * requestTimeout (not headersTimeout) applies from here on. A
-             * pipelined request whose head sits mid-buffer never went through
-             * onData with an idle connection, so open its window here too. */
-            if (httpContextData->flags.usingNodeHttpCompat) {
-                if (httpResponseData->lastMessageStartMs == 0) {
-                    httpResponseData->lastMessageStartMs = nodeCompatMonotonicMs();
+            if constexpr (NODE_HTTP) {
+                /* node:http compat: the JS layer stopped HTTP processing on this
+                 * connection (the user emitted 'close' on the socket - Node frees
+                 * the parser there); abandon the rest of the buffer. */
+                if (httpResponseData->nodeCompat.nodeHttpParsingStopped) {
+                    return nullptr;
                 }
-                httpResponseData->headersCompleted = true;
+
+                /* node:http compat: the request head has been fully parsed, so only
+                 * requestTimeout (not headersTimeout) applies from here on. A
+                 * pipelined request whose head sits mid-buffer never went through
+                 * onData with an idle connection, so open its window here too. */
+                if (httpResponseData->nodeCompat.lastMessageStartMs == 0) {
+                    httpResponseData->nodeCompat.lastMessageStartMs = nodeCompatMonotonicMs();
+                }
+                httpResponseData->nodeCompat.headersCompleted = true;
             }
 
             /* Are we not ready for another request yet? Terminate the connection.
              * Important for denying async pipelining until, if ever, we want to support it.
              * Otherwise requests can get mixed up on the same connection. We still support sync pipelining. */
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING)
-                || httpResponseData->nodeHttpQueuedPipelinedCount > 0) {
-                if (!httpContextData->flags.usingNodeHttpCompat) {
+            bool responseStillPending = httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING;
+            if constexpr (NODE_HTTP) {
+                responseStillPending = responseStillPending || httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount > 0;
+            }
+            if (responseStillPending) {
+                if constexpr (!NODE_HTTP) {
                     us_socket_close((us_socket_t *) s, 0, nullptr);
                     return nullptr;
-                }
-
-                /* node:http supports async pipelining: the request is dispatched
-                 * while the previous response is still in flight and the JS layer
-                 * queues its response (res.socket === null until it becomes the
-                 * connection's current response). The per-response state reset is
-                 * skipped here - it still belongs to the in-flight response - and
-                 * is applied by JSNodeHTTPServerSocket::startPipelinedResponse()
-                 * when the queued response is activated. Node keeps reading and
-                 * dispatching pipelined requests while responses are queued (its
-                 * parserOnIncoming only pauses the socket once the outgoing data
-                 * backs up), so reads are paused only when this connection already
-                 * has unsent outgoing backpressure; they resume once the pipeline
-                 * drains and the backpressure flushes (startPipelinedResponse /
-                 * onWritable). */
-                httpResponseData->isNodeHttpPipelinedDispatch = true;
-                httpResponseData->nodeHttpQueuedPipelinedCount++;
-                if (((AsyncSocket<SSL> *) s)->getBufferedAmount() > 0) {
-                    httpResponseData->nodeHttpReadsPaused = true;
-                    ((HttpResponse<SSL> *) s)->pause();
+                } else {
+                    /* node:http supports async pipelining: the request is dispatched
+                     * while the previous response is still in flight and the JS layer
+                     * queues its response (res.socket === null until it becomes the
+                     * connection's current response). The per-response state reset is
+                     * skipped here - it still belongs to the in-flight response - and
+                     * is applied by JSNodeHTTPServerSocket::startPipelinedResponse()
+                     * when the queued response is activated. Node keeps reading and
+                     * dispatching pipelined requests while responses are queued (its
+                     * parserOnIncoming only pauses the socket once the outgoing data
+                     * backs up), so reads are paused only when this connection already
+                     * has unsent outgoing backpressure; they resume once the pipeline
+                     * drains and the backpressure flushes (startPipelinedResponse /
+                     * onWritable). */
+                    httpResponseData->nodeCompat.isNodeHttpPipelinedDispatch = true;
+                    httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount++;
+                    if (((AsyncSocket<SSL> *) s)->getBufferedAmount() > 0) {
+                        httpResponseData->nodeCompat.nodeHttpReadsPaused = true;
+                        ((HttpResponse<SSL, NODE_HTTP> *) s)->pause();
+                    }
                 }
             } else {
                 /* Reset httpResponse */
                 httpResponseData->offset = 0;
 
                 /* Mark pending request and emit it */
-                httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
+                httpResponseData->state = HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING;
 
 
                 /* Mark this response as connectionClose if ancient or connection: close */
                 if (httpRequest->isAncient() || httpRequest->getHeader("connection").length() == 5) {
-                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                    httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_CONNECTION_CLOSE;
                 }
 
                 httpResponseData->fromAncientRequest = httpRequest->isAncient();
@@ -390,7 +403,9 @@ private:
                 httpResponseData->closeDelimited = false;
                 /* Per-response trailer fields must not leak into the next response
                  * on this keep-alive connection. */
-                httpResponseData->nodeHttpResponseTrailers.clear();
+                if constexpr (NODE_HTTP) {
+                    httpResponseData->nodeCompat.nodeHttpResponseTrailers.clear();
+                }
             }
 
             /* Select the router based on SNI (only possible for SSL) */
@@ -403,7 +418,7 @@ private:
             }
 
             /* Route the method and URL */
-            selectedRouter->getUserData() = {(HttpResponse<SSL> *) s, httpRequest};
+            selectedRouter->getUserData() = {(HttpResponse<SSL, NODE_HTTP> *) s, httpRequest};
             if (!selectedRouter->route(httpRequest->getCaseSensitiveMethod(), httpRequest->getUrlForRouting())) {
                 /* We have to force close this socket as we have no handler for it */
                 us_socket_close((us_socket_t *) s, 0, nullptr);
@@ -428,51 +443,60 @@ private:
 
             /* node:http compat: the pipelined-dispatch marker is only meaningful
              * while this dispatch is on the stack. */
-            if (httpContextData->flags.usingNodeHttpCompat) {
-                httpResponseData->isNodeHttpPipelinedDispatch = false;
+            if constexpr (NODE_HTTP) {
+                httpResponseData->nodeCompat.isNodeHttpPipelinedDispatch = false;
             }
 
             /* Returning from a request handler without responding or attaching an onAborted handler is ill-use */
-            if (!((HttpResponse<SSL> *) s)->hasResponded() && !httpResponseData->onAborted && !httpResponseData->socketData) {
+            bool hasSocketData = false;
+            if constexpr (NODE_HTTP) {
+                hasSocketData = httpResponseData->nodeCompat.socketData != nullptr;
+            }
+            if (!((HttpResponse<SSL, NODE_HTTP> *) s)->hasResponded() && !httpResponseData->onAborted && !hasSocketData) {
                 /* Throw exception here? */
                 std::cerr << "Error: Returning from a request handler without responding or attaching an abort handler is forbidden!" << std::endl;
                 std::terminate();
             }
 
             /* If we have not responded and we have a data handler, we need to timeout to enfore client sending the data */
-            if (!((HttpResponse<SSL> *) s)->hasResponded() && httpResponseData->inStream) {
-                ((HttpResponse<SSL> *) s)->resetTimeout();
+            if (!((HttpResponse<SSL, NODE_HTTP> *) s)->hasResponded() && httpResponseData->inStream) {
+                ((HttpResponse<SSL, NODE_HTTP> *) s)->resetTimeout();
             }
 
             /* Continue parsing */
             return s;
 
-        }, [httpResponseData, httpContextData](void *user, std::string_view data, bool fin) -> void * {
+        }, [httpResponseData, httpContextData, &isConnectRequest](void *user, std::string_view data, bool fin) -> void * {
+            (void) httpContextData;
+            (void) isConnectRequest;
 
-            /* node:http compat: an accepted Upgrade request's body just completed -
-             * after this fin chunk has been delivered to the request body stream
-             * below, the connection switches into tunnel mode so every byte after
-             * the end of the message reaches the 'upgrade' listener's socket as
-             * opaque data. Deferred so the fin itself is not routed to the
-             * raw-socket data path. */
-            const bool switchToTunnelAfterThisChunk = fin && httpContextData->flags.usingNodeHttpCompat
-                && !httpResponseData->isConnectRequest && httpResponseData->nodeHttpTunnelAfterBody;
+            if constexpr (NODE_HTTP) {
+                /* node:http compat: an accepted Upgrade request's body just completed -
+                 * after this fin chunk has been delivered to the request body stream
+                 * below, the connection switches into tunnel mode so every byte after
+                 * the end of the message reaches the 'upgrade' listener's socket as
+                 * opaque data. Deferred so the fin itself is not routed to the
+                 * raw-socket data path. */
+                const bool switchToTunnelAfterThisChunk = fin
+                    && !isConnectRequest && httpResponseData->nodeCompat.nodeHttpTunnelAfterBody;
 
-            /* node:http compat: the request message (head + body) has been fully
-             * received - the connection is idle for the headers/request timeout
-             * sweeps until the next message starts. */
-            if (fin && httpContextData->flags.usingNodeHttpCompat && !httpResponseData->isConnectRequest) {
-                httpResponseData->lastMessageStartMs = 0;
-                httpResponseData->headersCompleted = false;
-            }
+                /* node:http compat: the request message (head + body) has been fully
+                 * received - the connection is idle for the headers/request timeout
+                 * sweeps until the next message starts. */
+                if (fin && !isConnectRequest) {
+                    httpResponseData->nodeCompat.lastMessageStartMs = 0;
+                    httpResponseData->nodeCompat.headersCompleted = false;
+                }
 
-            if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketData) {
-                httpContextData->onSocketData(httpResponseData->socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
-            }
+                if (isConnectRequest && httpResponseData->nodeCompat.socketData && httpContextData->nodeCompat.onSocketData) {
+                    httpContextData->nodeCompat.onSocketData(httpResponseData->nodeCompat.socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
+                }
 
-            if (switchToTunnelAfterThisChunk) {
-                httpResponseData->nodeHttpTunnelAfterBody = false;
-                httpResponseData->isConnectRequest = true;
+                if (switchToTunnelAfterThisChunk) {
+                    httpResponseData->nodeCompat.nodeHttpTunnelAfterBody = false;
+                    httpResponseData->nodeCompat.isConnectRequest = true;
+                    isConnectRequest = true;
+                }
             }
             /* We always get an empty chunk even if there is no data */
             if (httpResponseData->inStream) {
@@ -486,13 +510,13 @@ private:
                     /* Only reset timeout if we got enough bytes (16kb/sec) since last time we reset here */
                     httpResponseData->received_bytes_per_timeout += (unsigned int) data.length();
                     if (httpResponseData->received_bytes_per_timeout >= HTTP_RECEIVE_THROUGHPUT_BYTES * httpResponseData->idleTimeout) {
-                        ((HttpResponse<SSL> *) user)->resetTimeout();
+                        ((HttpResponse<SSL, NODE_HTTP> *) user)->resetTimeout();
                         httpResponseData->received_bytes_per_timeout = 0;
                     }
                 }
 
                 /* We might respond in the handler, so do not change timeout after this */
-                httpResponseData->inStream(static_cast<HttpResponse<SSL>*>(user), data.data(), data.length(), fin, httpResponseData->userData);
+                httpResponseData->inStream(static_cast<HttpResponse<SSL, NODE_HTTP>*>(user), data.data(), data.length(), fin, httpResponseData->userData);
 
                 /* Was the socket closed? */
                 if (us_socket_is_closed((struct us_socket_t *) user)) {
@@ -513,32 +537,39 @@ private:
             return user;
         });
 
+        if constexpr (NODE_HTTP) {
+            httpResponseData->nodeCompat.isConnectRequest = isConnectRequest;
+        }
+
         auto httpErrorStatusCode = result.httpErrorStatusCode();
 
         /* Mark that we are no longer parsing Http */
         httpContextData->flags.isParsingHttp = false;
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
-            /* node:http compat: parse errors surface as the server's 'clientError'
-             * event and the JS layer (the user's listener or the default handler)
-             * decides whether to write an error response and when to tear the
-             * connection down, exactly like Node. The native layer only stops
-             * parsing further requests on this connection. */
-            if (httpContextData->flags.usingNodeHttpCompat && httpContextData->onClientError) {
-                httpResponseData->nodeHttpParsingStopped = true;
-                httpContextData->onClientError(SSL, s, result.parserError, data, length);
-                if (!us_socket_is_closed(s)) {
-                    /* Balance the parsing ref taken at the top of onData (the
-                     * success path does this through returnedData). */
-                    us_socket_unref(s);
+            if constexpr (NODE_HTTP) {
+                /* node:http compat: parse errors surface as the server's 'clientError'
+                 * event and the JS layer (the user's listener or the default handler)
+                 * decides whether to write an error response and when to tear the
+                 * connection down, exactly like Node. The native layer only stops
+                 * parsing further requests on this connection. */
+                if (httpContextData->onClientError) {
+                    httpResponseData->nodeCompat.nodeHttpParsingStopped = true;
+                    httpContextData->onClientError(SSL, s, result.parserError, data, length);
+                    if (!us_socket_is_closed(s)) {
+                        /* Balance the parsing ref taken at the top of onData (the
+                         * success path does this through returnedData). */
+                        us_socket_unref(s);
+                    }
+                    /* Flush anything the 'clientError' handler wrote (uncorking a
+                     * closed socket is a no-op). */
+                    ((AsyncSocket<SSL> *) s)->uncork();
+                    return s;
                 }
-                /* Flush anything the 'clientError' handler wrote (uncorking a
-                 * closed socket is a no-op). */
-                ((AsyncSocket<SSL> *) s)->uncork();
-                return s;
-            }
-            if(httpContextData->onClientError) {
-                httpContextData->onClientError(SSL, s, result.parserError, data, length);
+            } else {
+                if(httpContextData->onClientError) {
+                    httpContextData->onClientError(SSL, s, result.parserError, data, length);
+                }
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
             us_socket_write(s, httpErrorResponses[httpErrorStatusCode].data(), (int) httpErrorResponses[httpErrorStatusCode].length());
@@ -557,22 +588,24 @@ private:
              * buffer by this read (either fresh bytes on an idle connection or a
              * pipelined request after the previous message completed) - its
              * headers timeout window opens now. */
-            if (trackNodeHttpTimings && httpResponseData->lastMessageStartMs == 0
-                && httpResponseData->hasBufferedPartialRequestHeaders()) {
-                httpResponseData->lastMessageStartMs = nodeCompatMonotonicMs();
-                httpResponseData->headersCompleted = false;
+            if constexpr (NODE_HTTP) {
+                if (!httpResponseData->nodeCompat.isConnectRequest && httpResponseData->nodeCompat.lastMessageStartMs == 0
+                    && httpResponseData->hasBufferedPartialRequestHeaders()) {
+                    httpResponseData->nodeCompat.lastMessageStartMs = nodeCompatMonotonicMs();
+                    httpResponseData->nodeCompat.headersCompleted = false;
+                }
             }
 
             /* Timeout on uncork failure */
             auto [written, failed] = ((AsyncSocket<SSL> *) returnedData)->uncork();
             if (written > 0 || failed) {
                 /* All Http sockets timeout by this, and this behavior match the one in HttpResponse::cork */
-                ((HttpResponse<SSL> *) s)->resetTimeout();
+                ((HttpResponse<SSL, NODE_HTTP> *) s)->resetTimeout();
             }
 
             /* We need to check if we should close this socket here now */
             if (httpResponseData->shouldCloseConnection()) {
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING) == 0) {
                     if (((AsyncSocket<SSL> *) s)->getBufferedAmount() == 0) {
                         ((AsyncSocket<SSL> *) s)->shutdown();
                         /* We need to force close after sending FIN since we want to hinder
@@ -617,7 +650,7 @@ private:
 
     static us_socket_t *onWritable(us_socket_t *s) {
         auto *asyncSocket = reinterpret_cast<AsyncSocket<SSL> *>(s);
-        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(asyncSocket->getAsyncSocketData());
+        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL, NODE_HTTP> *>(asyncSocket->getAsyncSocketData());
 
         /* Attempt to drain the socket buffer before triggering onWritable callback */
         size_t bufferedAmount = asyncSocket->getBufferedAmount();
@@ -631,7 +664,7 @@ private:
                 * - This allows time for another writable event or new request
                 * - Return the socket to indicate we're still processing
                 */
-                reinterpret_cast<HttpResponse<SSL> *>(s)->resetTimeout();
+                reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(s)->resetTimeout();
                 return s;
             }
             /* If bufferedAmount is now 0, we've successfully flushed everything
@@ -639,11 +672,13 @@ private:
             */
         }
 
-        auto *httpContextData = getSocketContextDataS(s);
+        [[maybe_unused]] auto *httpContextData = getSocketContextDataS(s);
 
 
-        if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketDrain) {
-            httpContextData->onSocketDrain(httpResponseData->socketData, SSL, (struct us_socket_t *) s);
+        if constexpr (NODE_HTTP) {
+            if (httpResponseData->nodeCompat.isConnectRequest && httpResponseData->nodeCompat.socketData && httpContextData->onSocketDrain) {
+                httpContextData->onSocketDrain(httpResponseData->nodeCompat.socketData, SSL, (struct us_socket_t *) s);
+            }
         }
         /* Ask the developer to write data and return success (true) or failure (false), OR skip sending anything and return success (true). */
         if (httpResponseData->onWritable) {
@@ -652,7 +687,7 @@ private:
 
             /* We expect the developer to return whether or not write was successful (true).
              * If write was never called, the developer should still return true so that we may drain. */
-            bool success = httpResponseData->callOnWritable(reinterpret_cast<HttpResponse<SSL> *>(asyncSocket), httpResponseData->offset);
+            bool success = httpResponseData->callOnWritable(reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(asyncSocket), httpResponseData->offset);
 
             /* The developer indicated that their onWritable failed. */
             if (!success) {
@@ -670,16 +705,18 @@ private:
          * queued and stayed paused because the socket still had outgoing
          * backpressure when the queue drained; now that it has flushed, read
          * new requests again. */
-        if (httpContextData->flags.usingNodeHttpCompat && httpResponseData->nodeHttpReadsPaused
-            && httpResponseData->nodeHttpQueuedPipelinedCount == 0
-            && asyncSocket->getBufferedAmount() == 0) {
-            httpResponseData->nodeHttpReadsPaused = false;
-            reinterpret_cast<HttpResponse<SSL> *>(s)->resume();
+        if constexpr (NODE_HTTP) {
+            if (httpResponseData->nodeCompat.nodeHttpReadsPaused
+                && httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount == 0
+                && asyncSocket->getBufferedAmount() == 0) {
+                httpResponseData->nodeCompat.nodeHttpReadsPaused = false;
+                reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(s)->resume();
+            }
         }
 
         /* Should we close this connection after a response - and is this response really done? */
         if (httpResponseData->shouldCloseConnection()) {
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+            if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING) == 0) {
                 if (asyncSocket->getBufferedAmount() == 0) {
 
                     asyncSocket->shutdown();
@@ -691,7 +728,7 @@ private:
         }
 
         /* Expect another writable event, or another request within the timeout */
-        reinterpret_cast<HttpResponse<SSL> *>(s)->resetTimeout();
+        reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(s)->resetTimeout();
 
         return s;
     }
@@ -703,9 +740,9 @@ private:
          * Node calls parser.finish() when the socket ends and surfaces it as
          * HPE_INVALID_EOF_STATE through 'clientError'; the JS layer decides what
          * (if anything) to write and when to destroy the connection. */
-        HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
-        if (httpContextData->flags.usingNodeHttpCompat) {
-            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
+        if constexpr (NODE_HTTP) {
+            HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
+            HttpResponseData<SSL, NODE_HTTP> *httpResponseData = (HttpResponseData<SSL, NODE_HTTP> *) us_socket_ext(s);
 
             /* CONNECT/Upgrade tunnels allow half-open: the peer finishing its
              * writable side ends the JS socket's readable side ('end' event) but
@@ -713,17 +750,17 @@ private:
              * Node's http server (allowHalfOpen: true). This includes an accepted
              * Upgrade whose body never completed (nodeHttpTunnelAfterBody): the
              * EOF ends the upgrade socket, exactly like Node's UpgradeStream. */
-            if (httpResponseData->isConnectRequest || httpResponseData->nodeHttpTunnelAfterBody) {
-                if (httpResponseData->socketData && httpContextData->onSocketData) {
-                    httpContextData->onSocketData(httpResponseData->socketData, SSL, s, "", 0, true);
+            if (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody) {
+                if (httpResponseData->nodeCompat.socketData && httpContextData->onSocketData) {
+                    httpContextData->onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
                 }
                 return s;
             }
 
-            if (httpContextData->onClientError && !httpResponseData->nodeHttpParsingStopped
+            if (httpContextData->onClientError && !httpResponseData->nodeCompat.nodeHttpParsingStopped
                 && (httpResponseData->hasBufferedPartialRequestHeaders()
                     || httpResponseData->hasIncompleteRequestBody())) {
-                httpResponseData->nodeHttpParsingStopped = true;
+                httpResponseData->nodeCompat.nodeHttpParsingStopped = true;
                 httpContextData->onClientError(SSL, s, HTTP_PARSER_ERROR_INVALID_EOF, nullptr, 0);
                 if (us_socket_is_closed(s)) {
                     return s;
@@ -737,9 +774,9 @@ private:
              * written; it is shut down once the pipeline has drained (the
              * shouldCloseConnection() checks on response completion). */
             if (httpContextData->flags.httpAllowHalfOpen
-                && (httpResponseData->nodeHttpQueuedPipelinedCount > 0
-                    || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING))) {
-                httpResponseData->nodeHttpReceivedFIN = true;
+                && (httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount > 0
+                    || (httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING))) {
+                httpResponseData->nodeCompat.nodeHttpReceivedFIN = true;
                 return s;
             }
         }
@@ -754,10 +791,10 @@ private:
         /* Force close rather than gracefully shutdown and risk confusing the client with a complete download */
         AsyncSocket<SSL> *asyncSocket = reinterpret_cast<AsyncSocket<SSL> *>(s);
         // Node.js by default closes the connection but they emit the timeout event before that
-        HttpResponseData<SSL> *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(asyncSocket->getAsyncSocketData());
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = reinterpret_cast<HttpResponseData<SSL, NODE_HTTP> *>(asyncSocket->getAsyncSocketData());
 
         if (httpResponseData->onTimeout) {
-            httpResponseData->onTimeout((HttpResponse<SSL> *)s, httpResponseData->userData);
+            httpResponseData->onTimeout((HttpResponse<SSL, NODE_HTTP> *)s, httpResponseData->userData);
         }
         return asyncSocket->close();
     }
@@ -795,13 +832,13 @@ public:
         delete this;
     }
 
-    void filter(MoveOnlyFunction<void(HttpResponse<SSL> *, int)> &&filterHandler) {
+    void filter(MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, int)> &&filterHandler) {
         getSocketContextData()->filterHandlers.emplace_back(std::move(filterHandler));
     }
 
     /* Register an HTTP route handler acording to URL pattern */
-    void onHttp(std::string_view method, std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL> *, HttpRequest *)> &&handler, bool upgrade = false) {
-        HttpContextData<SSL> *httpContextData = getSocketContextData();
+    void onHttp(std::string_view method, std::string_view pattern, MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, HttpRequest *)> &&handler, bool upgrade = false) {
+        HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextData();
 
         std::span<const std::string_view> methods;
         std::string method_buffer;
@@ -871,7 +908,7 @@ public:
         int error = 0;
         /* HTTP clients always send first (the request, or ClientHello for TLS), so defer
          * accept() until data arrives and dispatch the read immediately after accept. */
-        auto socket = us_socket_group_listen(&group, socketKind(), sslCtx, host, port, options | LIBUS_LISTEN_DEFER_ACCEPT, sizeof(HttpResponseData<SSL>), &error);
+        auto socket = us_socket_group_listen(&group, socketKind(), sslCtx, host, port, options | LIBUS_LISTEN_DEFER_ACCEPT, sizeof(HttpResponseData<SSL, NODE_HTTP>), &error);
         // we dont depend on libuv ref for keeping it alive
         if (socket) {
           us_socket_unref(&socket->s);
@@ -882,7 +919,7 @@ public:
     /* Listen to unix domain socket using this HttpContext */
     us_listen_socket_t *listen_unix(struct ssl_ctx_st *sslCtx, const char *path, size_t pathlen, int options) {
         int error = 0;
-        auto* socket = us_socket_group_listen_unix(&group, socketKind(), sslCtx, path, pathlen, options, sizeof(HttpResponseData<SSL>), &error);
+        auto* socket = us_socket_group_listen_unix(&group, socketKind(), sslCtx, path, pathlen, options, sizeof(HttpResponseData<SSL, NODE_HTTP>), &error);
         // we dont depend on libuv ref for keeping it alive
         if (socket) {
             us_socket_unref(&socket->s);

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -229,7 +229,7 @@ private:
         HttpContextData<SSL, NODE_HTTP> *httpContextData = getSocketContextDataS(s);
 
         if constexpr (NODE_HTTP) {
-            if(httpResponseData && (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody)) {
+            if(httpResponseData && (httpResponseData->isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody)) {
                 if (httpResponseData->nodeCompat.socketData && httpContextData->nodeCompat.onSocketData) {
                     httpContextData->nodeCompat.onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
                 }
@@ -290,7 +290,7 @@ private:
          * parsed as HTTP and keep flowing below. */
         if constexpr (NODE_HTTP) {
             if (httpResponseData->nodeCompat.nodeHttpParsingStopped
-                && !httpResponseData->nodeCompat.isConnectRequest) {
+                && !httpResponseData->isConnectRequest) {
                 us_socket_unref(s);
                 return s;
             }
@@ -311,13 +311,11 @@ private:
         proxyParser = &httpResponseData->proxyParser;
 #endif
 
-        /* CONNECT-tunnel state lives in nodeCompat (a bitfield, so not
-         * addressable). The parser mutates a local via bool&; sync it back to
-         * nodeCompat after the parse so onClose/onEnd/next-onData see it. */
-        bool isConnectRequest = false;
-        if constexpr (NODE_HTTP) {
-            isConnectRequest = httpResponseData->nodeCompat.isConnectRequest;
-        }
+        /* CONNECT-tunnel state is coupled with the parser's persisted
+         * remainingStreamingBytes across onData calls, so it must round-trip
+         * through the response data for both instantiations. The parser mutates
+         * a local via bool&; sync it back after the parse. */
+        bool isConnectRequest = httpResponseData->isConnectRequest;
 
         /* The return value is entirely up to us to interpret. The HttpParser cares only for whether the returned value is DIFFERENT from passed user */
 
@@ -494,7 +492,7 @@ private:
 
                 if (switchToTunnelAfterThisChunk) {
                     httpResponseData->nodeCompat.nodeHttpTunnelAfterBody = false;
-                    httpResponseData->nodeCompat.isConnectRequest = true;
+                    httpResponseData->isConnectRequest = true;
                     isConnectRequest = true;
                 }
             }
@@ -537,10 +535,8 @@ private:
             return user;
         });
 
-        if constexpr (NODE_HTTP) {
-            if (!us_socket_is_closed(s) && !httpContextData->upgradedWebSocket) {
-                httpResponseData->nodeCompat.isConnectRequest = isConnectRequest;
-            }
+        if (!us_socket_is_closed(s) && !httpContextData->upgradedWebSocket) {
+            httpResponseData->isConnectRequest = isConnectRequest;
         }
 
         auto httpErrorStatusCode = result.httpErrorStatusCode();
@@ -587,7 +583,7 @@ private:
              * pipelined request after the previous message completed) - its
              * headers timeout window opens now. */
             if constexpr (NODE_HTTP) {
-                if (!httpResponseData->nodeCompat.isConnectRequest && httpResponseData->nodeCompat.lastMessageStartMs == 0
+                if (!httpResponseData->isConnectRequest && httpResponseData->nodeCompat.lastMessageStartMs == 0
                     && httpResponseData->hasBufferedPartialRequestHeaders()) {
                     httpResponseData->nodeCompat.lastMessageStartMs = nodeCompatMonotonicMs();
                     httpResponseData->nodeCompat.headersCompleted = false;
@@ -674,7 +670,7 @@ private:
 
 
         if constexpr (NODE_HTTP) {
-            if (httpResponseData->nodeCompat.isConnectRequest && httpResponseData->nodeCompat.socketData && httpContextData->onSocketDrain) {
+            if (httpResponseData->isConnectRequest && httpResponseData->nodeCompat.socketData && httpContextData->onSocketDrain) {
                 httpContextData->onSocketDrain(httpResponseData->nodeCompat.socketData, SSL, (struct us_socket_t *) s);
             }
         }
@@ -748,7 +744,7 @@ private:
              * Node's http server (allowHalfOpen: true). This includes an accepted
              * Upgrade whose body never completed (nodeHttpTunnelAfterBody): the
              * EOF ends the upgrade socket, exactly like Node's UpgradeStream. */
-            if (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody) {
+            if (httpResponseData->isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody) {
                 if (httpResponseData->nodeCompat.socketData && httpContextData->nodeCompat.onSocketData) {
                     httpContextData->nodeCompat.onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
                 }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -230,8 +230,8 @@ private:
 
         if constexpr (NODE_HTTP) {
             if(httpResponseData && (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody)) {
-                if (httpResponseData->nodeCompat.socketData && httpContextData->onSocketData) {
-                    httpContextData->onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
+                if (httpResponseData->nodeCompat.socketData && httpContextData->nodeCompat.onSocketData) {
+                    httpContextData->nodeCompat.onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
                 }
                 if(httpResponseData->inStream) {
                     httpResponseData->inStream(reinterpret_cast<HttpResponse<SSL, NODE_HTTP> *>(s), "", 0, true, httpResponseData->userData);
@@ -538,7 +538,9 @@ private:
         });
 
         if constexpr (NODE_HTTP) {
-            httpResponseData->nodeCompat.isConnectRequest = isConnectRequest;
+            if (!us_socket_is_closed(s) && !httpContextData->upgradedWebSocket) {
+                httpResponseData->nodeCompat.isConnectRequest = isConnectRequest;
+            }
         }
 
         auto httpErrorStatusCode = result.httpErrorStatusCode();
@@ -553,9 +555,9 @@ private:
                  * decides whether to write an error response and when to tear the
                  * connection down, exactly like Node. The native layer only stops
                  * parsing further requests on this connection. */
-                if (httpContextData->onClientError) {
+                if (httpContextData->nodeCompat.onClientError) {
                     httpResponseData->nodeCompat.nodeHttpParsingStopped = true;
-                    httpContextData->onClientError(SSL, s, result.parserError, data, length);
+                    httpContextData->nodeCompat.onClientError(SSL, s, result.parserError, data, length);
                     if (!us_socket_is_closed(s)) {
                         /* Balance the parsing ref taken at the top of onData (the
                          * success path does this through returnedData). */
@@ -565,10 +567,6 @@ private:
                      * closed socket is a no-op). */
                     ((AsyncSocket<SSL> *) s)->uncork();
                     return s;
-                }
-            } else {
-                if(httpContextData->onClientError) {
-                    httpContextData->onClientError(SSL, s, result.parserError, data, length);
                 }
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
@@ -751,17 +749,17 @@ private:
              * Upgrade whose body never completed (nodeHttpTunnelAfterBody): the
              * EOF ends the upgrade socket, exactly like Node's UpgradeStream. */
             if (httpResponseData->nodeCompat.isConnectRequest || httpResponseData->nodeCompat.nodeHttpTunnelAfterBody) {
-                if (httpResponseData->nodeCompat.socketData && httpContextData->onSocketData) {
-                    httpContextData->onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
+                if (httpResponseData->nodeCompat.socketData && httpContextData->nodeCompat.onSocketData) {
+                    httpContextData->nodeCompat.onSocketData(httpResponseData->nodeCompat.socketData, SSL, s, "", 0, true);
                 }
                 return s;
             }
 
-            if (httpContextData->onClientError && !httpResponseData->nodeCompat.nodeHttpParsingStopped
+            if (httpContextData->nodeCompat.onClientError && !httpResponseData->nodeCompat.nodeHttpParsingStopped
                 && (httpResponseData->hasBufferedPartialRequestHeaders()
                     || httpResponseData->hasIncompleteRequestBody())) {
                 httpResponseData->nodeCompat.nodeHttpParsingStopped = true;
-                httpContextData->onClientError(SSL, s, HTTP_PARSER_ERROR_INVALID_EOF, nullptr, 0);
+                httpContextData->nodeCompat.onClientError(SSL, s, HTTP_PARSER_ERROR_INVALID_EOF, nullptr, 0);
                 if (us_socket_is_closed(s)) {
                     return s;
                 }
@@ -799,7 +797,7 @@ private:
         return asyncSocket->close();
     }
 
-    /* Static .rodata vtable — one per SSL value, shared by every HttpContext. */
+    /* Static .rodata vtable — one per (SSL, NODE_HTTP) pair. */
     static inline const us_socket_vtable_t httpVTable = {
         /* on_open */         &onOpen,
         /* on_data */         &onData,

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -21,10 +21,11 @@
 #include "HttpRouter.h"
 
 #include <vector>
+#include <type_traits>
 #include "MoveOnlyFunction.h"
 #include "HttpParser.h"
 namespace uWS {
-template<bool> struct HttpResponse;
+template<bool, bool> struct HttpResponse;
 struct HttpRequest;
 
 struct HttpFlags {
@@ -40,33 +41,31 @@ struct HttpFlags {
      * in field values); TE+CL conflict, chunked-size/CRLF strictness, version
      * and header-token checks are still enforced. */
     bool useInsecureHTTPParser: 1 = false;
-    /* Set for node:http compatibility servers: per-socket request timing
-     * (lastMessageStartMs / headersCompleted on HttpResponseData) is only
-     * maintained when this is set, so plain Bun.serve pays nothing for it. */
-    bool usingNodeHttpCompat: 1 = false;
     /* node:http server.httpAllowHalfOpen: when true, a peer FIN with in-flight
      * or queued responses keeps the connection open until they drain (Node's
      * socketOnEnd); when false (the default), the connection ends right away. */
     bool httpAllowHalfOpen: 1 = false;
 };
 
-template <bool SSL>
+template <bool SSL, bool NODE_HTTP>
 struct alignas(16) HttpContextData {
-    template <bool> friend struct HttpContext;
-    template <bool> friend struct HttpResponse;
-    template <bool> friend struct TemplatedApp;
-private:
-    std::vector<MoveOnlyFunction<void(HttpResponse<SSL> *, int)>> filterHandlers;
+    template <bool, bool> friend struct HttpContext;
+    template <bool, bool> friend struct HttpResponse;
+    template <bool, bool> friend struct TemplatedApp;
+public:
     using OnSocketDataCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, const char *data, int length, bool last);
     using OnSocketDrainCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnSocketUpgradedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnClientErrorCallback = MoveOnlyFunction<void(int is_ssl, struct us_socket_t *rawSocket, uWS::HttpParserError errorCode, char *rawPacket, int rawPacketLength)>;
     using OnSocketClosedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
 
+private:
+    std::vector<MoveOnlyFunction<void(HttpResponse<SSL, NODE_HTTP> *, int)>> filterHandlers;
+
     MoveOnlyFunction<void(const char *hostname)> missingServerNameHandler;
 
     struct RouterData {
-        HttpResponse<SSL> *httpResponse;
+        HttpResponse<SSL, NODE_HTTP> *httpResponse;
         HttpRequest *httpRequest;
     };
 
@@ -79,9 +78,16 @@ private:
     /* Used to simulate Node.js socket events. */
     OnSocketClosedCallback onSocketClosed = nullptr;
     OnSocketDrainCallback onSocketDrain = nullptr;
-    OnSocketDataCallback onSocketData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
-    OnClientErrorCallback onClientError = nullptr;
+
+    /* node:http-only callback slots. Compiled out for the Bun.serve
+     * instantiation so per-context storage stays minimal. */
+    struct NodeHttpContextFields {
+        OnSocketDataCallback onSocketData = nullptr;
+        OnClientErrorCallback onClientError = nullptr;
+    };
+    struct EmptyNodeHttpContext {};
+    [[no_unique_address]] std::conditional_t<NODE_HTTP, NodeHttpContextFields, EmptyNodeHttpContext> nodeCompat;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 
@@ -93,7 +99,7 @@ private:
     }
 
 public:
-    
+
     HttpFlags flags;
 };
 

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -33,6 +33,7 @@
 #include <string_view>
 #include <span>
 #include <map>
+#include <type_traits>
 #include "MoveOnlyFunction.h"
 #include "ChunkedEncoding.h"
 
@@ -172,7 +173,7 @@ namespace uWS
     struct HttpRequest
     {
 
-        friend struct HttpParser;
+        template <bool> friend struct HttpParser;
 
     private:
         struct Header
@@ -437,9 +438,31 @@ namespace uWS
         }
     };
 
+    /* node:http compat parser state, present only in the NODE_HTTP=true
+     * instantiation via [[no_unique_address]] std::conditional_t below. */
+    struct NodeHttpParserFields {
+        /* Raw bytes of the trailer section received after the final 0-size chunk
+         * of the current request's chunked body, including its terminating CRLF.
+         * Cleared when a new chunked body starts; consumed by the JS layer when
+         * the request reaches EOF (req.trailers/rawTrailers). */
+        std::string nodeHttpRequestTrailers;
+
+        /* Bytes of chunk extensions consumed on the current chunk-size line,
+         * matching llhttp/Node which resets the counter in on_chunk_header
+         * (per chunk, not per message). consumeHexNumber resets it at each
+         * fresh line. */
+        uint64_t chunkedExtensionsByteCount = 0;
+    };
+    struct EmptyNodeHttpParserFields {};
+
+    template <bool NODE_HTTP>
     struct HttpParser
     {
     public:
+        /* node:http compat parser state (trailers, chunk-extension counter).
+         * Zero-size in the Bun.serve (NODE_HTTP=false) instantiation. */
+        [[no_unique_address]] std::conditional_t<NODE_HTTP, NodeHttpParserFields, EmptyNodeHttpParserFields> nodeCompat;
+
         /* node:http server compat: whether a partial request head is sitting in
          * the fallback buffer waiting for more bytes (used by the
          * headersTimeout/requestTimeout tracking in HttpContext::onData).
@@ -461,12 +484,6 @@ namespace uWS
         bool hasIncompleteRequestBody() const {
             return remainingStreamingBytes != 0;
         }
-
-        /* node:http server compat: raw bytes of the trailer section received after
-         * the final 0-size chunk of the current request's chunked body, including
-         * its terminating CRLF. Cleared when a new chunked body starts; consumed by
-         * the JS layer when the request reaches EOF (req.trailers/rawTrailers). */
-        std::string nodeHttpRequestTrailers;
 
         /* Maximum number of trailer fields surfaced to JS (the section size cap
          * already bounds memory; this matches the regular-header count cap). */
@@ -538,12 +555,6 @@ namespace uWS
         std::string fallback;
          /* This guy really has only 30 bits since we reserve two highest bits to chunked encoding parsing state */
         uint64_t remainingStreamingBytes = 0;
-
-        /* node:http compat: bytes of chunk extensions consumed on the current
-         * chunk-size line, matching llhttp/Node which resets the counter in
-         * on_chunk_header (per chunk, not per message). Only counted under
-         * node compat; consumeHexNumber resets it at each fresh line. */
-        uint64_t chunkedExtensionsByteCount = 0;
 
         const size_t MAX_FALLBACK_SIZE = BUN_DEFAULT_MAX_HTTP_HEADER_SIZE;
 
@@ -1029,7 +1040,7 @@ namespace uWS
 
     /* This is the only caller of getHeaders and is thus the deepest part of the parser. */
     template <bool ConsumeMinimally>
-    HttpParserResult fenceAndConsumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool usingNodeHttpCompat, bool useInsecureHTTPParser, char *data, unsigned int length, void *user, void *reserved, HttpRequest *req, MoveOnlyFunction<void *(void *, HttpRequest *)> &requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &dataHandler) {
+    HttpParserResult fenceAndConsumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool useInsecureHTTPParser, char *data, unsigned int length, void *user, void *reserved, HttpRequest *req, MoveOnlyFunction<void *(void *, HttpRequest *)> &requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &dataHandler) {
 
         /* How much data we CONSUMED (to throw away) */
         unsigned int consumedTotal = 0;
@@ -1045,10 +1056,12 @@ namespace uWS
              * handler set isConnectRequest when it saw the body fin). Everything
              * after the end of that message is opaque data for the 'upgrade'
              * listener's socket, never a pipelined HTTP request. */
-            if (usingNodeHttpCompat && isConnectRequest) [[unlikely]] {
-                void *returnedUser = dataHandler(user, std::string_view(data, length), false);
-                consumedTotal += length;
-                return HttpParserResult::success(consumedTotal, returnedUser);
+            if constexpr (NODE_HTTP) {
+                if (isConnectRequest) [[unlikely]] {
+                    void *returnedUser = dataHandler(user, std::string_view(data, length), false);
+                    consumedTotal += length;
+                    return HttpParserResult::success(consumedTotal, returnedUser);
+                }
             }
             /* RFC 9112 2.2: ignore empty lines (CRLF) received prior to the
              * request-line, like Node/llhttp - e.g. a stray "\r\n" sent on an
@@ -1126,8 +1139,11 @@ namespace uWS
              * the request head completes - Node dispatches the 'request' first and the
              * error then surfaces through 'clientError'. The error is deferred until
              * after the request handler below; no body data is ever emitted. */
-            bool deferredTransferEncodingError = usingNodeHttpCompat && transferEncoding.has
-                && !transferEncoding.invalid && !transferEncoding.chunked && !contentLengthStringLen;
+            bool deferredTransferEncodingError = false;
+            if constexpr (NODE_HTTP) {
+                deferredTransferEncodingError = transferEncoding.has
+                    && !transferEncoding.invalid && !transferEncoding.chunked && !contentLengthStringLen;
+            }
 
             transferEncoding.invalid = transferEncoding.invalid || (transferEncoding.has && (contentLengthStringLen || !transferEncoding.chunked));
 
@@ -1186,8 +1202,8 @@ namespace uWS
              * every dispatched request (not only chunked ones) so a pipelined GET
              * cannot read the previous chunked request's trailers via
              * takeRequestTrailers() on this same connection. */
-            if (usingNodeHttpCompat) {
-                nodeHttpRequestTrailers.clear();
+            if constexpr (NODE_HTTP) {
+                nodeCompat.nodeHttpRequestTrailers.clear();
             }
 
             /* The rules at play here according to RFC 9112 for requests are essentially:
@@ -1210,18 +1226,26 @@ namespace uWS
             } else if (transferEncoding.has) {
                 /* We already validated that chunked is last if present, before calling the handler */
                 remainingStreamingBytes = STATE_IS_CHUNKED;
-                if (usingNodeHttpCompat) {
-                    chunkedExtensionsByteCount = 0;
+                if constexpr (NODE_HTTP) {
+                    nodeCompat.chunkedExtensionsByteCount = 0;
                 }
                 /* If consume minimally, we do not want to consume anything but we want to mark this as being chunked */
                 if constexpr (!ConsumeMinimally) {
                     /* Go ahead and parse it (todo: better heuristics for emitting FIN to the app level) */
                     std::string_view dataToConsume(data, length);
-                    for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, usingNodeHttpCompat ? &chunkedExtensionsByteCount : nullptr, usingNodeHttpCompat ? &nodeHttpRequestTrailers : nullptr, maxBufferedHeaderSize)) {
+                    uint64_t *extBytes = nullptr;
+                    std::string *trailers = nullptr;
+                    if constexpr (NODE_HTTP) {
+                        extBytes = &nodeCompat.chunkedExtensionsByteCount;
+                        trailers = &nodeCompat.nodeHttpRequestTrailers;
+                    }
+                    for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, extBytes, trailers, maxBufferedHeaderSize)) {
                         /* llhttp errors at the offending extension byte, before any body bytes from
                          * that chunk reach the application; check before every dispatch. */
-                        if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                            return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                        if constexpr (NODE_HTTP) {
+                            if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                                return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                            }
                         }
                         void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                         if (returnedUser != user) {
@@ -1230,8 +1254,10 @@ namespace uWS
                             return HttpParserResult::success(consumedTotal, returnedUser);
                         }
                     }
-                    if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                        return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                    if constexpr (NODE_HTTP) {
+                        if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                            return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                        }
                     }
                     if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) [[unlikely]] {
                         // TODO: what happen if we already responded?
@@ -1277,7 +1303,7 @@ namespace uWS
     }
 
 public:
-    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool usingNodeHttpCompat, bool useInsecureHTTPParser, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
+    HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool useInsecureHTTPParser, char *data, unsigned int length, void *user, void *reserved, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
         /* The fallback buffer may not exceed the configured per-request header
          * limit (per-server maxHeaderSize can raise it above the default). */
         const size_t maxFallbackSize = maxHeaderSize ? (size_t) maxHeaderSize : MAX_FALLBACK_SIZE;
@@ -1291,17 +1317,27 @@ public:
             } else if (isParsingChunkedEncoding(remainingStreamingBytes)) {
                  /* It's either chunked or with a content-length */
                 std::string_view dataToConsume(data, length);
-                for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, usingNodeHttpCompat ? &chunkedExtensionsByteCount : nullptr, usingNodeHttpCompat ? &nodeHttpRequestTrailers : nullptr, maxFallbackSize)) {
-                    if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                        return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                uint64_t *extBytes = nullptr;
+                std::string *trailers = nullptr;
+                if constexpr (NODE_HTTP) {
+                    extBytes = &nodeCompat.chunkedExtensionsByteCount;
+                    trailers = &nodeCompat.nodeHttpRequestTrailers;
+                }
+                for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, extBytes, trailers, maxFallbackSize)) {
+                    if constexpr (NODE_HTTP) {
+                        if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                            return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                        }
                     }
                     void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                     if (returnedUser != user) {
                         return HttpParserResult::success(0, returnedUser);
                     }
                 }
-                if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                    return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                if constexpr (NODE_HTTP) {
+                    if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                        return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                    }
                 }
                 if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {
                     if (isTrailerOverflow(remainingStreamingBytes)) {
@@ -1343,7 +1379,7 @@ public:
             fallback.append(data, maxCopyDistance);
 
             // break here on break
-            HttpParserResult consumed = fenceAndConsumePostPadded<true>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, usingNodeHttpCompat, useInsecureHTTPParser, fallback.data(), (unsigned int) fallback.length(), user, reserved, &req, requestHandler, dataHandler);
+            HttpParserResult consumed = fenceAndConsumePostPadded<true>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, useInsecureHTTPParser, fallback.data(), (unsigned int) fallback.length(), user, reserved, &req, requestHandler, dataHandler);
             /* Return data will be different than user if we are upgraded to WebSocket or have an error */
             if (consumed.returnedData != user) {
                 return consumed;
@@ -1366,17 +1402,27 @@ public:
                     } else if (isParsingChunkedEncoding(remainingStreamingBytes)) {
                         /* It's either chunked or with a content-length */
                         std::string_view dataToConsume(data, length);
-                        for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, usingNodeHttpCompat ? &chunkedExtensionsByteCount : nullptr, usingNodeHttpCompat ? &nodeHttpRequestTrailers : nullptr, maxFallbackSize)) {
-                            if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                                return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                        uint64_t *extBytes = nullptr;
+                        std::string *trailers = nullptr;
+                        if constexpr (NODE_HTTP) {
+                            extBytes = &nodeCompat.chunkedExtensionsByteCount;
+                            trailers = &nodeCompat.nodeHttpRequestTrailers;
+                        }
+                        for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, extBytes, trailers, maxFallbackSize)) {
+                            if constexpr (NODE_HTTP) {
+                                if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                                    return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                                }
                             }
                             void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                             if (returnedUser != user) {
                                 return HttpParserResult::success(0, returnedUser);
                             }
                         }
-                        if (usingNodeHttpCompat && chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
-                            return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                        if constexpr (NODE_HTTP) {
+                            if (nodeCompat.chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                                return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
+                            }
                         }
                         if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {
                             if (isTrailerOverflow(remainingStreamingBytes)) {
@@ -1415,7 +1461,7 @@ public:
             }
         }
 
-        HttpParserResult consumed = fenceAndConsumePostPadded<false>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, usingNodeHttpCompat, useInsecureHTTPParser, data, length, user, reserved, &req, requestHandler, dataHandler);
+        HttpParserResult consumed = fenceAndConsumePostPadded<false>(maxHeaderSize, isConnectRequest, requireHostHeader, useStrictMethodValidation, useInsecureHTTPParser, data, length, user, reserved, &req, requestHandler, dataHandler);
         /* Return data will be different than user if we are upgraded to WebSocket or have an error */
         if (consumed.returnedData != user) {
             return consumed;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -42,19 +42,19 @@ template <bool, bool, typename> struct WebSocketContext;
 /* Some pre-defined status constants to use with writeStatus */
 static const char *HTTP_200_OK = "200 OK";
 
-template <bool SSL>
+template <bool SSL, bool NODE_HTTP>
 struct HttpResponse : public AsyncSocket<SSL> {
     /* Solely used for getHttpResponseData() */
-    template <bool> friend struct TemplatedApp;
+    template <bool, bool> friend struct TemplatedApp;
     typedef AsyncSocket<SSL> Super;
 public:
 
-    HttpResponseData<SSL> *getHttpResponseData() {
-        return (HttpResponseData<SSL> *) Super::getAsyncSocketData();
+    HttpResponseData<SSL, NODE_HTTP> *getHttpResponseData() {
+        return (HttpResponseData<SSL, NODE_HTTP> *) Super::getAsyncSocketData();
     }
 
-    static HttpResponseData<SSL> *getHttpResponseDataS(us_socket_t *s) {
-        return (HttpResponseData<SSL> *) us_socket_ext(s);
+    static HttpResponseData<SSL, NODE_HTTP> *getHttpResponseDataS(us_socket_t *s) {
+        return (HttpResponseData<SSL, NODE_HTTP> *) us_socket_ext(s);
     }
 
     void setTimeout(uint8_t seconds) {
@@ -88,12 +88,12 @@ public:
 
     /* Called only once per request */
     void writeMark() {
-        if (getHttpResponseData()->state & HttpResponseData<SSL>::HTTP_WROTE_DATE_HEADER) {
+        if (getHttpResponseData()->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_DATE_HEADER) {
             return;
         }
         /* Date is always written */
         writeHeader("Date", std::string_view(((LoopData *) us_loop_ext(us_socket_group_loop(us_socket_group((us_socket_t *) this))))->date, 29));
-        getHttpResponseData()->state |= HttpResponseData<SSL>::HTTP_WROTE_DATE_HEADER;
+        getHttpResponseData()->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_DATE_HEADER;
     }
 
     /* Returns true on success, indicating that it might be feasible to write more data.
@@ -110,7 +110,7 @@ public:
             totalSize = data.length();
         }
 
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         /* A no-body status carries no Content-Length (RFC 9110 8.6) and no body
          * bytes (RFC 9112 6.3 terminates it at the blank line). end() already
@@ -124,37 +124,41 @@ public:
         /* In some cases, such as when refusing huge data we want to close the connection when drained */
         if (closeConnection) {
             /* We can only write the header once */
-            if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
+            if (!(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_END_CALLED))) {
 
                 /* HTTP 1.1 must send this back unless the client already sent it to us.
                 * It is a connection close when either of the two parties say so but the
                 * one party must tell the other one so.
                 *
                 * This check also serves to limit writing the header only once. */
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0 && !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
+                if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_CONNECTION_CLOSE) == 0 && !(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED))) {
                     writeHeader("Connection", "close");
                 }
 
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_CONNECTION_CLOSE;
             }
         }
 
         /* if write was called and there was previously no Content-Length header set.
          * node:http compat: pending response trailers (addTrailers) also force chunked
          * framing, since trailer fields can only be sent on a chunked body. */
-        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED || !httpResponseData->nodeHttpResponseTrailers.empty()) && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited && !httpResponseData->noBodyStatus) {
+        bool hasTrailers = false;
+        if constexpr (NODE_HTTP) {
+            hasTrailers = !httpResponseData->nodeCompat.nodeHttpResponseTrailers.empty();
+        }
+        if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED || hasTrailers) && !(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited && !httpResponseData->noBodyStatus) {
 
             /* We do not have tryWrite-like functionalities, so ignore optional in this path */
 
             /* Trailers-only end with no body chunk: write() below would early-return on
              * empty data, so terminate the header section and enter chunked mode here. */
-            if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED) && data.empty()) [[unlikely]] {
+            if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED) && data.empty()) [[unlikely]] {
                 writeMark();
-                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
                     writeHeader("Transfer-Encoding", "chunked");
                 }
                 Super::write("\r\n", 2);
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+                httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
             }
 
             /* Write the chunked data if there is any (this will not send zero chunks) */
@@ -163,11 +167,15 @@ public:
 
             /* Terminating 0 chunk; node:http response trailers (RFC 9112 7.1.2) sit
              * between it and the final CRLF. */
-            if (!httpResponseData->nodeHttpResponseTrailers.empty()) [[unlikely]] {
-                Super::write("0\r\n", 3);
-                Super::write(httpResponseData->nodeHttpResponseTrailers.data(), (int) httpResponseData->nodeHttpResponseTrailers.length());
-                Super::write("\r\n", 2);
-                httpResponseData->nodeHttpResponseTrailers.clear();
+            if constexpr (NODE_HTTP) {
+                if (!httpResponseData->nodeCompat.nodeHttpResponseTrailers.empty()) [[unlikely]] {
+                    Super::write("0\r\n", 3);
+                    Super::write(httpResponseData->nodeCompat.nodeHttpResponseTrailers.data(), (int) httpResponseData->nodeCompat.nodeHttpResponseTrailers.length());
+                    Super::write("\r\n", 2);
+                    httpResponseData->nodeCompat.nodeHttpResponseTrailers.clear();
+                } else {
+                    Super::write("0\r\n\r\n", 5);
+                }
             } else {
                 Super::write("0\r\n\r\n", 5);
             }
@@ -176,7 +184,7 @@ public:
             /* We need to check if we should close this socket here now */
             if (!Super::isCorked()) {
                 if (httpResponseData->shouldCloseConnection()) {
-                    if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                    if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING) == 0) {
                         if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
                             ((AsyncSocket<SSL> *) this)->shutdown();
                             /* We need to force close after sending FIN since we want to hinder
@@ -195,7 +203,7 @@ public:
             return true;
         } else {
             /* Write content-length on first call */
-            if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
+            if (!(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_END_CALLED))) {
                 /* Write mark, this propagates to WebSockets too */
                 writeMark();
 
@@ -205,13 +213,13 @@ public:
                     Super::write("Content-Length: ", 16);
                     writeUnsigned64(totalSize);
                     Super::write("\r\n\r\n", 4);
-                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
-                } else if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
+                    httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+                } else if (!(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED))) {
                     Super::write("\r\n", 2);
                 }
 
                 /* Mark end called */
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_END_CALLED;
+                httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_END_CALLED;
             }
 
             /* Even if we supply no new data to write, its failed boolean is useful to know
@@ -242,7 +250,7 @@ public:
                 /* We need to check if we should close this socket here now */
                 if (!Super::isCorked()) {
                     if (httpResponseData->shouldCloseConnection()) {
-                        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                        if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING) == 0) {
                             if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
                                 ((AsyncSocket<SSL> *) this)->shutdown();
                                 /* We need to force close after sending FIN since we want to hinder
@@ -351,14 +359,17 @@ public:
         internalEnd({nullptr, 0}, 0, false, false, false, true);
 
         /* Grab the httpContext from res */
-        HttpContext<SSL> *httpContext = HttpContext<SSL>::fromSocket((struct us_socket_t *) this);
+        HttpContext<SSL, NODE_HTTP> *httpContext = HttpContext<SSL, NODE_HTTP>::fromSocket((struct us_socket_t *) this);
 
         /* Move any backpressure out of HttpResponse */
         auto* responseData = getHttpResponseData();
         BackPressure backpressure(std::move(((AsyncSocketData<SSL> *) responseData)->buffer));
 
-        auto* socketData = responseData->socketData;
-        HttpContextData<SSL> *httpContextData = httpContext->getSocketContextData();
+        void* socketData = nullptr;
+        if constexpr (NODE_HTTP) {
+            socketData = responseData->nodeCompat.socketData;
+        }
+        HttpContextData<SSL, NODE_HTTP> *httpContextData = httpContext->getSocketContextData();
 
         /* Destroy HttpResponseData */
         responseData->~HttpResponseData();
@@ -371,7 +382,7 @@ public:
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
         us_socket_t *usSocket = us_socket_adopt((us_socket_t *) this, webSocketContext->getSocketGroup(),
             WebSocketContext<SSL, true, UserData>::socketKind(),
-            sizeof(HttpResponseData<SSL>), sizeof(WebSocketData) + sizeof(UserData));
+            sizeof(HttpResponseData<SSL, NODE_HTTP>), sizeof(WebSocketData) + sizeof(UserData));
         WebSocket<SSL, true, UserData> *webSocket = (WebSocket<SSL, true, UserData> *) usSocket;
 
         /* For whatever reason we were corked, update cork to the new socket */
@@ -440,18 +451,21 @@ public:
 
     /* Write a caller-built 1xx informational response line + headers. Shares
      * the AsyncSocket write path (and buffer) writeStatus/end use, so a
-     * pipelined replay stays ordered ahead of the final response bytes. */
+     * pipelined replay stays ordered ahead of the final response bytes.
+     * node:http compat only (writeEarlyHints, writeProcessing). */
     HttpResponse *writeRawInformational(std::string_view data) {
-        Super::write(data.data(), (int) data.length());
+        if constexpr (NODE_HTTP) {
+            Super::write(data.data(), (int) data.length());
+        }
         return this;
     }
 
     /* Write the HTTP status */
     HttpResponse *writeStatus(std::string_view status) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         /* Do not allow writing more than one status */
-        if (httpResponseData->state & HttpResponseData<SSL>::HTTP_STATUS_CALLED) {
+        if (httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_STATUS_CALLED) {
             return this;
         }
 
@@ -464,7 +478,7 @@ public:
         }
 
         /* Update status */
-        httpResponseData->state |= HttpResponseData<SSL>::HTTP_STATUS_CALLED;
+        httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_STATUS_CALLED;
 
         Super::write("HTTP/1.1 ", 9);
         Super::write(status.data(), (int) status.length());
@@ -511,7 +525,7 @@ public:
 
     /* End the response with an optional data chunk. Always starts a timeout. */
     void end(std::string_view data = {}, bool closeConnection = false) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         /* 204/304 responses carry no body framing at all: no Content-Length,
          * no chunked framing and no terminating chunk, even when an explicit
@@ -527,7 +541,7 @@ public:
          * CONNECTION_CLOSE state is set directly so internalEnd() closes the
          * socket without adding a Connection: close header the user removed. */
         if (httpResponseData->closeDelimited) {
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+            httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_CONNECTION_CLOSE;
             internalEnd(data, data.length(), false, false, false);
             return;
         }
@@ -536,19 +550,19 @@ public:
          * streaming writes (a one-shot end), the body must still be chunk-framed.
          * Terminate the headers and enter chunked mode so internalEnd() takes the
          * chunked path instead of writing the raw body after the headers. */
-        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER) &&
-            !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) &&
+        if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER) &&
+            !(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED | HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) &&
             !httpResponseData->fromAncientRequest && !httpResponseData->noBodyStatus) {
             writeStatus(HTTP_200_OK);
             writeMark();
             Super::write("\r\n", 2);
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+            httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
         }
 
         /* Do not auto-write a Content-Length header when the user already wrote
          * a Content-Length or an explicit Transfer-Encoding header (a message
          * must not carry both, see RFC 9112 §6.2). */
-        internalEnd(data, data.length(), false, !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER | HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)), closeConnection);
+        internalEnd(data, data.length(), false, !(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER | HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)), closeConnection);
     }
 
     /* Try and end the response. Returns [true, true] on success.
@@ -561,16 +575,16 @@ public:
     /* Write the end of chunked encoded stream */
     bool sendTerminatingChunk(bool closeConnection = false) {
         writeStatus(HTTP_200_OK);
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-        if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER))) {
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
+        if (!(httpResponseData->state & (HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED | HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER))) {
             /* Write mark on first call to write */
             writeMark();
 
-            if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+            if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
                 writeHeader("Transfer-Encoding", "chunked");
             }
             Super::write("\r\n", 2);
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+            httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
         }
 
         /* This will be sent always when state is HTTP_WRITE_CALLED inside internalEnd, so no need to write the terminating 0 chunk here */
@@ -583,26 +597,26 @@ public:
 
         writeStatus(HTTP_200_OK);
 
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         /* Close-delimited responses must not re-add the Transfer-Encoding
          * header the user removed; their body is raw, so take the else path. */
-        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited && !httpResponseData->noBodyStatus) {
-            if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+        if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited && !httpResponseData->noBodyStatus) {
+            if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED)) {
                 /* Write mark on first call to write */
                 writeMark();
 
-                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
                     writeHeader("Transfer-Encoding", "chunked");
                 }
                 Super::write("\r\n", 2);
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+                httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
             }
 
-         } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+         } else if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED)) {
             writeMark();
             Super::write("\r\n", 2);
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+            httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
         }
         if (flushImmediately) {
             /* Uncork the socket to send data to the client immediately */
@@ -656,28 +670,28 @@ public:
         }
 
 
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         /* Close-delimited responses (the user removed the framing headers)
          * write raw bytes with no chunk framing, like the else path. */
-        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited) {
-            if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+        if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited) {
+            if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED)) {
                 /* Write mark on first call to write */
                 writeMark();
 
-                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
                     writeHeader("Transfer-Encoding", "chunked");
                 }
                 Super::write("\r\n", 2);
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+                httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
             }
 
             writeUnsignedHex((unsigned int) data.length());
             Super::write("\r\n", 2);
-        } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
+        } else if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED)) {
             writeMark();
             Super::write("\r\n", 2);
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
+            httpResponseData->state |= HttpResponseData<SSL, NODE_HTTP>::HTTP_WRITE_CALLED;
         }
         size_t total_written = 0;
         bool has_failed = false;
@@ -702,7 +716,7 @@ public:
 
         /* Close-delimited bodies are raw; the chunk-terminating CRLF would be
          * injected into the body bytes. */
-        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited) {
+        if (!(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest && !httpResponseData->closeDelimited) {
             // Write End of Chunked Encoding after data has been written
             Super::write("\r\n", 2);
         }
@@ -719,23 +733,23 @@ public:
 
     /* Get the current byte write offset for this Http response */
     uint64_t getWriteOffset() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         return httpResponseData->offset;
     }
 
     /* If you are messing around with sendfile you might want to override the offset. */
     void overrideWriteOffset(uint64_t offset) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->offset = offset;
     }
 
     /* Checking if we have fully responded and are ready for another request */
     bool hasResponded() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
-        return !(httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);
+        return !(httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING);
     }
 
      /* Corks the response if possible. Leaves already corked socket be. */
@@ -766,9 +780,9 @@ public:
             }
 
             /* If we have no backbuffer and we are connection close and we responded fully then close */
-            HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+            HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
             if (httpResponseData->shouldCloseConnection()) {
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                if ((httpResponseData->state & HttpResponseData<SSL, NODE_HTTP>::HTTP_RESPONSE_PENDING) == 0) {
                     if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
                         ((AsyncSocket<SSL> *) this)->shutdown();
                         /* We need to force close after sending FIN since we want to hinder
@@ -786,8 +800,8 @@ public:
     }
 
     /* Attach handler for writable HTTP response */
-    HttpResponse *onWritable(void* userData, HttpResponseData<SSL>::OnWritableCallback handler) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+    HttpResponse *onWritable(void* userData, HttpResponseData<SSL, NODE_HTTP>::OnWritableCallback handler) {
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->writableUserData = userData;
         httpResponseData->onWritable = handler;
@@ -796,7 +810,7 @@ public:
 
     /* Remove handler for writable HTTP response */
     HttpResponse *clearOnWritable() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
         httpResponseData->writableUserData = nullptr;
@@ -804,16 +818,16 @@ public:
     }
 
     /* Attach handler for aborted HTTP request */
-    HttpResponse *onAborted(void* userData,  HttpResponseData<SSL>::OnAbortedCallback handler) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+    HttpResponse *onAborted(void* userData,  HttpResponseData<SSL, NODE_HTTP>::OnAbortedCallback handler) {
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->userData = userData;
         httpResponseData->onAborted = handler;
         return this;
     }
 
-    HttpResponse *onTimeout(void* userData,  HttpResponseData<SSL>::OnTimeoutCallback handler) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+    HttpResponse *onTimeout(void* userData,  HttpResponseData<SSL, NODE_HTTP>::OnTimeoutCallback handler) {
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->userData = userData;
         httpResponseData->onTimeout = handler;
@@ -821,7 +835,7 @@ public:
     }
 
     HttpResponse* clearOnWritableAndAborted() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
         httpResponseData->writableUserData = nullptr;
@@ -832,21 +846,21 @@ public:
     }
 
     HttpResponse* clearOnAborted() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onAborted = nullptr;
         return this;
     }
 
     HttpResponse* clearOnTimeout() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onTimeout = nullptr;
         return this;
     }
     /* Attach a read handler for data sent. Will be called with FIN set true if last segment. */
-    void onData(void* userData, HttpResponseData<SSL>::OnDataCallback handler) {
-        HttpResponseData<SSL> *data = getHttpResponseData();
+    void onData(void* userData, HttpResponseData<SSL, NODE_HTTP>::OnDataCallback handler) {
+        HttpResponseData<SSL, NODE_HTTP> *data = getHttpResponseData();
         data->userData = userData;
         data->inStream = handler;
 
@@ -855,17 +869,20 @@ public:
     }
 
     void* getSocketData() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-
-        return httpResponseData->socketData;
+        if constexpr (NODE_HTTP) {
+            return getHttpResponseData()->nodeCompat.socketData;
+        }
+        return nullptr;
     }
     bool isConnectRequest() {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-        return httpResponseData->isConnectRequest;
+        if constexpr (NODE_HTTP) {
+            return getHttpResponseData()->nodeCompat.isConnectRequest;
+        }
+        return false;
     }
 
     void setWriteOffset(uint64_t offset) {
-        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        HttpResponseData<SSL, NODE_HTTP> *httpResponseData = getHttpResponseData();
 
         httpResponseData->offset = offset;
     }

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -454,9 +454,8 @@ public:
      * pipelined replay stays ordered ahead of the final response bytes.
      * node:http compat only (writeEarlyHints, writeProcessing). */
     HttpResponse *writeRawInformational(std::string_view data) {
-        if constexpr (NODE_HTTP) {
-            Super::write(data.data(), (int) data.length());
-        }
+        static_assert(NODE_HTTP, "writeRawInformational is node:http-only; call via the <SSL,true> instantiation");
+        Super::write(data.data(), (int) data.length());
         return this;
     }
 
@@ -875,10 +874,7 @@ public:
         return nullptr;
     }
     bool isConnectRequest() {
-        if constexpr (NODE_HTTP) {
-            return getHttpResponseData()->nodeCompat.isConnectRequest;
-        }
-        return false;
+        return getHttpResponseData()->isConnectRequest;
     }
 
     void setWriteOffset(uint64_t offset) {

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -26,23 +26,90 @@
 
 #include "MoveOnlyFunction.h"
 
+#include <type_traits>
+
 namespace uWS {
 
-template <bool SSL>
+template <bool, bool>
 struct HttpContext;
 
-template <bool SSL>
-struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
-    template <bool> friend struct HttpResponse;
-    template <bool> friend struct HttpContext;
+template <bool, bool>
+struct HttpResponse;
+
+/* Per-connection state that only node:http compatibility servers use. Compiled
+ * out entirely (via std::conditional_t + [[no_unique_address]]) for Bun.serve
+ * so that instantiation carries none of these bytes and none of the branches
+ * that read them. */
+struct NodeHttpResponseFields {
+    /* lastMessageStartMs: when the request currently being received started
+     * arriving (or when the connection was accepted, before its first
+     * request); 0 once the message has been fully received (idle). Mirrors
+     * last_message_start_ in Node's http parser ConnectionsList, which backs
+     * server.headersTimeout / requestTimeout. */
+    uint64_t lastMessageStartMs = 0;
+    /* Opaque JS-side per-socket handle (JSNodeHTTPServerSocket). */
+    void* socketData = nullptr;
+    /* Trailer fields set via response.addTrailers(), pre-rendered as
+     * "name: value\r\n" lines. Written between the terminating 0 chunk and the
+     * final CRLF of a chunked response (RFC 9112 7.1.2); non-empty also forces
+     * chunked framing for the response body. */
+    std::string nodeHttpResponseTrailers;
+    /* Number of pipelined responses dispatched to JS that have not yet become
+     * this connection's current response. While non-zero, newly parsed
+     * requests keep being queued (preserving response order) and socket reads
+     * stay paused (bounding memory under a pipeline flood). */
+    uint32_t nodeHttpQueuedPipelinedCount = 0;
+    /* Whether the currently-being-received request's head has been fully
+     * parsed. Mirrors headers_completed_ in Node's ConnectionsList. */
+    uint8_t headersCompleted : 1 = false;
+    /* The request currently being routed arrived while an earlier response on
+     * this connection is still in flight (HTTP/1.1 pipelining). NodeHTTP.cpp
+     * queues it on the server socket instead of making it the connection's
+     * current response; the per-response state reset is applied later by
+     * JSNodeHTTPServerSocket::startPipelinedResponse(). Only meaningful while
+     * the request handler dispatch is on the stack. */
+    uint8_t isNodeHttpPipelinedDispatch : 1 = false;
+    /* The JS layer stopped HTTP processing on this connection (Node frees the
+     * parser when 'close' is emitted on the socket); any further request data
+     * in the buffer is not parsed. */
+    uint8_t nodeHttpParsingStopped : 1 = false;
+    /* Socket reads were paused because pipelined responses are (or were)
+     * queued. Reads resume once the queue has drained AND the socket has no
+     * outgoing backpressure left (Node's flood prevention pauses the socket
+     * while responses back up). */
+    uint8_t nodeHttpReadsPaused : 1 = false;
+    /* An accepted Upgrade request with a body. The body is parsed and
+     * delivered through the request as usual; once it completes, the
+     * connection switches into CONNECT-style tunnel mode (isConnectRequest)
+     * and everything after the end of the message is opaque data for the
+     * 'upgrade' listener's socket. */
+    uint8_t nodeHttpTunnelAfterBody : 1 = false;
+    /* The peer half-closed (FIN) while pipelined responses were still queued
+     * behind the in-flight one. Like Node's http server, the connection stays
+     * open so those responses can still be written; it is shut down once the
+     * pipeline has drained (see shouldCloseConnection()). */
+    uint8_t nodeHttpReceivedFIN : 1 = false;
+    /* CONNECT-method request (or a completed Upgrade tunnel): everything on
+     * the wire is opaque data for JS's socket, not HTTP. */
+    uint8_t isConnectRequest : 1 = false;
+};
+
+/* Empty stand-in selected when NODE_HTTP is false. With
+ * [[no_unique_address]] this occupies zero bytes in HttpResponseData. */
+struct EmptyNodeHttp {};
+
+template <bool SSL, bool NODE_HTTP = false>
+struct HttpResponseData : AsyncSocketData<SSL>, HttpParser<NODE_HTTP> {
+    template <bool, bool> friend struct HttpResponse;
+    template <bool, bool> friend struct HttpContext;
     public:
-    using OnWritableCallback = bool (*)(uWS::HttpResponse<SSL>*, uint64_t, void*);
-    using OnAbortedCallback = void (*)(uWS::HttpResponse<SSL>*, void*);
-    using OnTimeoutCallback = void (*)(uWS::HttpResponse<SSL>*, void*);
-    using OnDataCallback = void (*)(uWS::HttpResponse<SSL>* response, const char* chunk, size_t chunk_length, bool, void*);
+    using OnWritableCallback = bool (*)(uWS::HttpResponse<SSL, NODE_HTTP>*, uint64_t, void*);
+    using OnAbortedCallback = void (*)(uWS::HttpResponse<SSL, NODE_HTTP>*, void*);
+    using OnTimeoutCallback = void (*)(uWS::HttpResponse<SSL, NODE_HTTP>*, void*);
+    using OnDataCallback = void (*)(uWS::HttpResponse<SSL, NODE_HTTP>* response, const char* chunk, size_t chunk_length, bool, void*);
 
     /* When we are done with a response we mark it like so */
-    void markDone(uWS::HttpResponse<SSL> *uwsRes) {
+    void markDone(uWS::HttpResponse<SSL, NODE_HTTP> *uwsRes) {
         onAborted = nullptr;
         /* Also remove onWritable so that we do not emit when draining behind the scenes. */
         onWritable = nullptr;
@@ -54,19 +121,19 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         onTimeout = nullptr;
 
         /* We are done with this request */
-        this->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
+        this->state &= ~HttpResponseData::HTTP_RESPONSE_PENDING;
 
-        HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
+        HttpResponseData *httpResponseData = uwsRes->getHttpResponseData();
         httpResponseData->isIdle = true;
     }
 
     /* Caller of onWritable. It is possible onWritable calls markDone so we need to borrow it. */
-    bool callOnWritable(uWS::HttpResponse<SSL>* response, uint64_t offset) {
+    bool callOnWritable(uWS::HttpResponse<SSL, NODE_HTTP>* response, uint64_t offset) {
         /* Borrow real onWritable */
         auto* borrowedOnWritable = std::move(onWritable);
 
         /* Set onWritable to placeholder */
-        onWritable = [](uWS::HttpResponse<SSL>*, uint64_t, void*) {return true;};
+        onWritable = [](uWS::HttpResponse<SSL, NODE_HTTP>*, uint64_t, void*) {return true;};
 
         /* Run borrowed onWritable */
         bool ret = borrowedOnWritable(response, offset, writableUserData);
@@ -100,7 +167,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * pointer in its own slot so arming it does not redirect the other
      * callbacks to the wrong object. Mirrors Http3ResponseData. */
     void* writableUserData = nullptr;
-    void* socketData = nullptr;
 
     /* Per socket event handlers */
     OnWritableCallback onWritable = nullptr;
@@ -117,7 +183,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     uint8_t state = 0;
     uint8_t idleTimeout = 10; // default HTTP_TIMEOUT 10 seconds
     bool fromAncientRequest = false;
-    bool isConnectRequest = false;
     /* When set, the response carries no body framing at all: no Content-Length,
      * no chunked encoding, no terminating chunk. writeStatus() sets it for 1xx
      * and 204 (RFC 9110 8.6); node:http additionally sets it for 304. */
@@ -127,62 +192,20 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * when the user removed the framing headers. */
     bool closeDelimited = false;
 
-    /* node:http server compat (HttpFlags::usingNodeHttpCompat only).
-     * lastMessageStartMs: when the request currently being received started
-     * arriving (or when the connection was accepted, before its first
-     * request); 0 once the message has been fully received (idle).
-     * headersCompleted: whether that request's head has been fully parsed.
-     * Mirrors last_message_start_/headers_completed_ in Node's http parser
-     * ConnectionsList, which back server.headersTimeout/requestTimeout. */
-    uint64_t lastMessageStartMs = 0;
-    bool headersCompleted = false;
-
-    /* node:http server compat: the request currently being routed arrived
-     * while an earlier response on this connection is still in flight
-     * (HTTP/1.1 pipelining). NodeHTTP.cpp queues it on the server socket
-     * instead of making it the connection's current response; the per-response
-     * state reset is applied later by
-     * JSNodeHTTPServerSocket::startPipelinedResponse(). Only meaningful while
-     * the request handler dispatch is on the stack. */
-    bool isNodeHttpPipelinedDispatch = false;
-    /* node:http server compat: the JS layer stopped HTTP processing on this
-     * connection (Node frees the parser when 'close' is emitted on the
-     * socket); any further request data in the buffer is not parsed. */
-    bool nodeHttpParsingStopped = false;
-    /* node:http server compat: number of pipelined responses dispatched to JS
-     * that have not yet become this connection's current response. While
-     * non-zero, newly parsed requests keep being queued (preserving response
-     * order) and socket reads stay paused (bounding memory under a pipeline
-     * flood). */
-    uint32_t nodeHttpQueuedPipelinedCount = 0;
-    /* node:http server compat: socket reads were paused because pipelined
-     * responses are (or were) queued. Reads resume once the queue has drained
-     * AND the socket has no outgoing backpressure left (Node's flood
-     * prevention pauses the socket while responses back up). */
-    bool nodeHttpReadsPaused = false;
-    /* node:http server compat: an accepted Upgrade request with a body. The
-     * body is parsed and delivered through the request as usual; once it
-     * completes, the connection switches into CONNECT-style tunnel mode
-     * (isConnectRequest) and everything after the end of the message is
-     * opaque data for the 'upgrade' listener's socket. */
-    bool nodeHttpTunnelAfterBody = false;
-    /* node:http server compat: trailer fields set via response.addTrailers(),
-     * pre-rendered as "name: value\r\n" lines. Written between the terminating
-     * 0 chunk and the final CRLF of a chunked response (RFC 9112 7.1.2);
-     * non-empty also forces chunked framing for the response body. */
-    std::string nodeHttpResponseTrailers;
-    /* node:http server compat: the peer half-closed (FIN) while pipelined
-     * responses were still queued behind the in-flight one. Like Node's http
-     * server, the connection stays open so those responses can still be
-     * written; it is shut down once the pipeline has drained (see
-     * shouldCloseConnection()). */
-    bool nodeHttpReceivedFIN = false;
+    /* node:http server compat state. When NODE_HTTP is false this is
+     * EmptyNodeHttp (zero bytes via [[no_unique_address]]) and every access is
+     * gated behind `if constexpr (NODE_HTTP)`, so Bun.serve pays nothing. */
+    [[no_unique_address]] std::conditional_t<NODE_HTTP, NodeHttpResponseFields, EmptyNodeHttp> nodeCompat;
 
     /* Whether the connection should be torn down once the in-flight response (if
      * any) has completed and all buffered outgoing data has been flushed. */
     bool shouldCloseConnection() const {
-        return (state & HTTP_CONNECTION_CLOSE)
-            || (nodeHttpReceivedFIN && nodeHttpQueuedPipelinedCount == 0);
+        if constexpr (!NODE_HTTP) {
+            return state & HTTP_CONNECTION_CLOSE;
+        } else {
+            return (state & HTTP_CONNECTION_CLOSE)
+                || (nodeCompat.nodeHttpReceivedFIN && nodeCompat.nodeHttpQueuedPipelinedCount == 0);
+        }
     }
 
 #ifdef UWS_WITH_PROXY

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -213,4 +213,10 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser<NODE_HTTP> {
 #endif
 };
 
+/* Bun.serve's per-socket allocation must not exceed what it was on main before
+ * the node:http compat state landed. Bound is main's measured layout expressed
+ * relative to sizeof(std::string) so it holds across libc++ and libstdc++. */
+static_assert(sizeof(HttpResponseData<false, false>) <= 112 + 2 * sizeof(std::string),
+    "HttpResponseData<SSL, NODE_HTTP=false> grew past its size on main; the Bun.serve per-socket allocation regressed");
+
 }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -89,9 +89,6 @@ struct NodeHttpResponseFields {
      * open so those responses can still be written; it is shut down once the
      * pipeline has drained (see shouldCloseConnection()). */
     uint8_t nodeHttpReceivedFIN : 1 = false;
-    /* CONNECT-method request (or a completed Upgrade tunnel): everything on
-     * the wire is opaque data for JS's socket, not HTTP. */
-    uint8_t isConnectRequest : 1 = false;
 };
 
 /* Empty stand-in selected when NODE_HTTP is false. With
@@ -191,6 +188,11 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser<NODE_HTTP> {
      * no Content-Length and no chunked framing, then close. Used by node:http
      * when the user removed the framing headers. */
     bool closeDelimited = false;
+    /* CONNECT-method request (or a completed Upgrade tunnel): everything on
+     * the wire is opaque data, not HTTP. Coupled with HttpParser's persisted
+     * remainingStreamingBytes across onData calls, so it must persist for both
+     * NODE_HTTP instantiations (not in nodeCompat). */
+    bool isConnectRequest = false;
 
     /* node:http server compat state. When NODE_HTTP is false this is
      * EmptyNodeHttp (zero bytes via [[no_unique_address]]) and every access is

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -29,8 +29,8 @@ namespace uWS {
 
 template <bool SSL, bool isServer, typename USERDATA>
 struct WebSocket : AsyncSocket<SSL> {
-    template <bool> friend struct TemplatedApp;
-    template <bool> friend struct HttpResponse;
+    template <bool, bool> friend struct TemplatedApp;
+    template <bool, bool> friend struct HttpResponse;
 private:
     typedef AsyncSocket<SSL> Super;
 

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -28,7 +28,7 @@ namespace uWS {
 
 template <bool SSL, bool isServer, typename USERDATA>
 struct WebSocketContext {
-    template <bool> friend struct TemplatedApp;
+    template <bool, bool> friend struct TemplatedApp;
     template <bool, typename> friend struct WebSocketProtocol;
 private:
     /* Real heap-allocated owner; group.ext = this. Replaces the old

--- a/packages/bun-uws/src/WebSocketData.h
+++ b/packages/bun-uws/src/WebSocketData.h
@@ -32,7 +32,7 @@ struct WebSocketData : AsyncSocketData<false>, WebSocketState<true> {
     template <bool, bool, typename> friend struct WebSocketContext;
     template <bool, typename> friend struct WebSocketContextData;
     template <bool, bool, typename> friend struct WebSocket;
-    template <bool> friend struct HttpContext;
+    template <bool, bool> friend struct HttpContext;
 private:
     std::string fragmentBuffer;
     unsigned int controlTipLength = 0;

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -32,6 +32,12 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
     case UWSResponseKind::SSL:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<true, false>*>(arg2));
         break;
+    case UWSResponseKind::TCPNode:
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<false, true>*>(arg2));
+        break;
+    case UWSResponseKind::SSLNode:
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<true, true>*>(arg2));
+        break;
     case UWSResponseKind::H3:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -27,10 +27,10 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
 {
     switch (kind) {
     case UWSResponseKind::TCP:
-        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<false>*>(arg2));
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<false, false>*>(arg2));
         break;
     case UWSResponseKind::SSL:
-        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<true>*>(arg2));
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<true, false>*>(arg2));
         break;
     case UWSResponseKind::H3:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -454,9 +454,8 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
 }
 
 template<bool isSSL>
-static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL>* app)
+static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL, true>* app)
 {
-    app->setUsingNodeHttpCompat(true);
     app->setOnSocketClosed([](void* socketData, int is_ssl, struct us_socket_t* rawSocket) -> void {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);
         ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
@@ -483,18 +482,18 @@ static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL>* app)
 extern "C" void NodeHTTP_assignOnNodeJSCompat(bool is_ssl, void* uws_app)
 {
     if (is_ssl) {
-        assignOnNodeJSCompat<true>(reinterpret_cast<uWS::TemplatedApp<true>*>(uws_app));
+        assignOnNodeJSCompat<true>(reinterpret_cast<uWS::NodeHttpSSLApp*>(uws_app));
     } else {
-        assignOnNodeJSCompat<false>(reinterpret_cast<uWS::TemplatedApp<false>*>(uws_app));
+        assignOnNodeJSCompat<false>(reinterpret_cast<uWS::NodeHttpApp*>(uws_app));
     }
 }
 
 extern "C" void NodeHTTP_setUsingCustomExpectHandler(bool is_ssl, void* uws_app, bool value)
 {
     if (is_ssl) {
-        reinterpret_cast<uWS::TemplatedApp<true>*>(uws_app)->setUsingCustomExpectHandler(value);
+        reinterpret_cast<uWS::NodeHttpSSLApp*>(uws_app)->setUsingCustomExpectHandler(value);
     } else {
-        reinterpret_cast<uWS::TemplatedApp<false>*>(uws_app)->setUsingCustomExpectHandler(value);
+        reinterpret_cast<uWS::NodeHttpApp*>(uws_app)->setUsingCustomExpectHandler(value);
     }
 }
 
@@ -508,7 +507,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     JSValue callback,
     JSValue methodString,
     uWS::HttpRequest* request,
-    uWS::HttpResponse<isSSL>* response,
+    uWS::HttpResponse<isSSL, true>* response,
     void* upgrade_ctx,
     void** nodeHttpResponsePtr)
 {
@@ -532,8 +531,8 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     // HTTP/1.1 pipelining: this request arrived while an earlier response on
     // the connection is still in flight. It is queued on the server socket
     // (and in JS) instead of becoming the connection's current response.
-    const bool isPipelinedDispatch = httpResponseData->isNodeHttpPipelinedDispatch;
-    auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(httpResponseData->socketData);
+    const bool isPipelinedDispatch = httpResponseData->nodeCompat.isNodeHttpPipelinedDispatch;
+    auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(httpResponseData->nodeCompat.socketData);
 
     if (currentSocketDataPtr) {
         auto* thisSocket = uncheckedDowncast<JSNodeHTTPServerSocket>(currentSocketDataPtr);
@@ -554,7 +553,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
 
         socket->strongThis.set(vm, socket);
 
-        response->getHttpResponseData()->socketData = socket;
+        response->getHttpResponseData()->nodeCompat.socketData = socket;
 
         args.append(socket);
         args.append(jsBoolean(true));
@@ -579,8 +578,8 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     return JSValue::encode(returnValue);
 }
 
-template<bool isSSL>
-static void writeResponseHeader(uWS::HttpResponse<isSSL>* res, const WTF::StringView& name, const WTF::StringView& value)
+template<bool isSSL, bool isNodeHttp>
+static void writeResponseHeader(uWS::HttpResponse<isSSL, isNodeHttp>* res, const WTF::StringView& name, const WTF::StringView& value)
 {
     WTF::CString nameStr;
     WTF::CString valueStr;
@@ -625,8 +624,8 @@ static bool connectionValueHasClose(const WTF::String& value)
     return false;
 }
 
-template<bool isSSL>
-static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL>* res)
+template<bool isSSL, bool isNodeHttp>
+static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL, isNodeHttp>* res)
 {
     auto& internalHeaders = headers.internalHeaders();
 
@@ -667,20 +666,20 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         // <
         //
         if (header.key == WebCore::HTTPHeaderName::ContentLength) {
-            if (!(data->state & uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
-                data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+            if (!(data->state & uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                data->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                 res->writeMark();
             }
         }
 
         // Prevent automatic Date header insertion when user provides one
         if (header.key == WebCore::HTTPHeaderName::Date) {
-            data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
+            data->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_DATE_HEADER;
         }
 
         // Prevent automatic Transfer-Encoding: chunked insertion when user provides one
         if (header.key == WebCore::HTTPHeaderName::TransferEncoding) {
-            data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
+            data->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
         }
 
         // RFC 9112 §9.6: a server that sends the "close" connection option MUST
@@ -688,16 +687,16 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         // end()/tryEnd() shut the socket down instead of returning it to the
         // keep-alive pool.
         if (header.key == WebCore::HTTPHeaderName::Connection && connectionValueHasClose(value)) {
-            data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
+            data->state |= uWS::HttpResponseData<isSSL, true>::HTTP_CONNECTION_CLOSE;
         }
-        writeResponseHeader<isSSL>(res, name, value);
+        writeResponseHeader<isSSL, isNodeHttp>(res, name, value);
     }
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
         const auto& name = header.key;
         const auto& value = header.value;
 
-        writeResponseHeader<isSSL>(res, name, value);
+        writeResponseHeader<isSSL, isNodeHttp>(res, name, value);
     }
 }
 
@@ -707,7 +706,7 @@ static void NodeHTTPServer__writeHead(
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
-    uWS::HttpResponse<isSSL>* response)
+    uWS::HttpResponse<isSSL, true>* response)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -721,7 +720,7 @@ static void NodeHTTPServer__writeHead(
     // node:http's ServerResponse owns the Date header entirely (it honors
     // res.sendDate / removeHeader("date") in JS), so never let uWS write its
     // own Date header for these responses.
-    response->getHttpResponseData()->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
+    response->getHttpResponseData()->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_DATE_HEADER;
 
     // 204/304 responses must not carry any body framing, even when the user
     // explicitly set a Transfer-Encoding header (Node.js suppresses the
@@ -733,7 +732,7 @@ static void NodeHTTPServer__writeHead(
 
     if (headersObject) {
         if (auto* fetchHeaders = dynamicDowncast<WebCore::JSFetchHeaders>(headersObject)) {
-            writeFetchHeadersToUWSResponse<isSSL>(fetchHeaders->wrapped(), response);
+            writeFetchHeadersToUWSResponse<isSSL, true>(fetchHeaders->wrapped(), response);
             return;
         }
 
@@ -771,18 +770,18 @@ static void NodeHTTPServer__writeHead(
                 WebCore::HTTPHeaderName headerName;
                 if (WebCore::findHTTPHeaderName(StringView(name), headerName)) {
                     if (headerName == WebCore::HTTPHeaderName::ContentLength) {
-                        if (!(httpResponseData->state & uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
-                            httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+                        if (!(httpResponseData->state & uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                            httpResponseData->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                             response->writeMark();
                         }
                     } else if (headerName == WebCore::HTTPHeaderName::Date) {
-                        httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
+                        httpResponseData->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_DATE_HEADER;
                     } else if (headerName == WebCore::HTTPHeaderName::TransferEncoding) {
-                        httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
+                        httpResponseData->state |= uWS::HttpResponseData<isSSL, true>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
                     }
                 }
 
-                writeResponseHeader<isSSL>(response, name, value);
+                writeResponseHeader<isSSL, true>(response, name, value);
             }
             return;
         }
@@ -806,7 +805,7 @@ static void NodeHTTPServer__writeHead(
                 String value = headerValue.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, false);
 
-                writeResponseHeader<isSSL>(response, key, value);
+                writeResponseHeader<isSSL, true>(response, key, value);
 
                 return true;
             });
@@ -826,7 +825,7 @@ static void NodeHTTPServer__writeHead(
                 String value = headerValue.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, void());
 
-                writeResponseHeader<isSSL>(response, key, value);
+                writeResponseHeader<isSSL, true>(response, key, value);
             }
         }
     }
@@ -839,7 +838,7 @@ extern "C" void NodeHTTPServer__writeHead_http(
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
-    uWS::HttpResponse<false>* response)
+    uWS::HttpResponse<false, true>* response)
 {
     return NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, response);
 }
@@ -849,7 +848,7 @@ extern "C" void NodeHTTPServer__writeHead_https(
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
-    uWS::HttpResponse<true>* response)
+    uWS::HttpResponse<true, true>* response)
 {
     return NodeHTTPServer__writeHead<true>(globalObject, statusMessage, statusMessageLength, headersObjectValue, response);
 }
@@ -861,7 +860,7 @@ extern "C" EncodedJSValue NodeHTTPServer__onRequest_http(
     EncodedJSValue callback,
     EncodedJSValue methodString,
     uWS::HttpRequest* request,
-    uWS::HttpResponse<false>* response,
+    uWS::HttpResponse<false, true>* response,
     void* upgrade_ctx,
     void** nodeHttpResponsePtr)
 {
@@ -884,7 +883,7 @@ extern "C" EncodedJSValue NodeHTTPServer__onRequest_https(
     EncodedJSValue callback,
     EncodedJSValue methodString,
     uWS::HttpRequest* request,
-    uWS::HttpResponse<true>* response,
+    uWS::HttpResponse<true, true>* response,
     void* upgrade_ctx,
     void** nodeHttpResponsePtr)
 {
@@ -1324,10 +1323,10 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
 {
     switch (kind) {
     case UWSResponseKind::TCP:
-        writeFetchHeadersToUWSResponse<false>(*arg0, reinterpret_cast<uWS::HttpResponse<false>*>(arg2));
+        writeFetchHeadersToUWSResponse<false, false>(*arg0, reinterpret_cast<uWS::HttpResponse<false, false>*>(arg2));
         break;
     case UWSResponseKind::SSL:
-        writeFetchHeadersToUWSResponse<true>(*arg0, reinterpret_cast<uWS::HttpResponse<true>*>(arg2));
+        writeFetchHeadersToUWSResponse<true, false>(*arg0, reinterpret_cast<uWS::HttpResponse<true, false>*>(arg2));
         break;
     case UWSResponseKind::H3:
         writeFetchHeadersToH3Response(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -1328,6 +1328,12 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
     case UWSResponseKind::SSL:
         writeFetchHeadersToUWSResponse<true, false>(*arg0, reinterpret_cast<uWS::HttpResponse<true, false>*>(arg2));
         break;
+    case UWSResponseKind::TCPNode:
+        writeFetchHeadersToUWSResponse<false, true>(*arg0, reinterpret_cast<uWS::HttpResponse<false, true>*>(arg2));
+        break;
+    case UWSResponseKind::SSLNode:
+        writeFetchHeadersToUWSResponse<true, true>(*arg0, reinterpret_cast<uWS::HttpResponse<true, true>*>(arg2));
+        break;
     case UWSResponseKind::H3:
         writeFetchHeadersToH3Response(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -52,6 +52,8 @@ enum class UWSResponseKind : int32_t {
     TCP = 0,
     SSL = 1,
     H3 = 2,
+    TCPNode = 3, // HttpResponse<false, true> (node:http compat layout)
+    SSLNode = 4, // HttpResponse<true,  true> (node:https compat layout)
 };
 #endif
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -53,22 +53,22 @@ void JSNodeHTTPServerSocket::clearSocketData(bool upgraded, us_socket_t* socket)
         auto* webSocket = (uWS::WebSocketData*)us_socket_ext(socket);
         webSocket->socketData = nullptr;
     } else {
-        auto* httpResponseData = (uWS::HttpResponseData<SSL>*)us_socket_ext(socket);
-        httpResponseData->socketData = nullptr;
+        auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
+        httpResponseData->nodeCompat.socketData = nullptr;
     }
 }
 
 template<bool SSL>
 static void flushPartialResponseBeforeClose(us_socket_t* socket)
 {
-    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
+    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL, true>*>(us_socket_ext(socket));
     // Only flush when an in-flight response wrote part of its body but never
     // ended: Node has already handed those res.write() bytes to the kernel by
     // the time destroy() runs, so they reach the client there. Ended
     // responses (including the synthetic terminator written by abort()) keep
     // the old behavior of being discarded with the close.
-    if ((httpResponseData->state & uWS::HttpResponseData<SSL>::HTTP_WRITE_CALLED)
-        && !(httpResponseData->state & uWS::HttpResponseData<SSL>::HTTP_END_CALLED)) {
+    if ((httpResponseData->state & uWS::HttpResponseData<SSL, true>::HTTP_WRITE_CALLED)
+        && !(httpResponseData->state & uWS::HttpResponseData<SSL, true>::HTTP_END_CALLED)) {
         reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->uncork();
     }
 }
@@ -90,12 +90,12 @@ void JSNodeHTTPServerSocket::close()
 template<bool SSL>
 static void upgradeToTunnelModeImpl(us_socket_t* socket, bool afterBody)
 {
-    auto* httpResponseData = (uWS::HttpResponseData<SSL>*)us_socket_ext(socket);
+    auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
     if (afterBody) {
         /* The Upgrade request carries a body: keep parsing it as HTTP and only
          * switch into tunnel mode once the message completes (Node 26 delivers
          * the body through the request before raw data starts flowing). */
-        httpResponseData->nodeHttpTunnelAfterBody = true;
+        httpResponseData->nodeCompat.nodeHttpTunnelAfterBody = true;
     } else {
         httpResponseData->isConnectRequest = true;
     }
@@ -124,7 +124,9 @@ template<bool SSL>
 static std::string* requestTrailersFor(us_socket_t* socket)
 {
     auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
-    return &httpResponseData->uWS::HttpParser<true>::nodeCompat.nodeHttpRequestTrailers;
+    /* Both HttpResponseData and its HttpParser base have a nodeCompat member;
+     * cast to the base to reach the parser's request-trailer buffer. */
+    return &static_cast<uWS::HttpParser<true>*>(httpResponseData)->nodeCompat.nodeHttpRequestTrailers;
 }
 
 /* Move the connection's captured trailer section out, returning its (ptr, length)
@@ -193,8 +195,8 @@ extern "C" JSC::EncodedJSValue Bun__NodeHTTP__parseRequestTrailers(JSC::JSGlobal
 template<bool SSL>
 static std::string& responseTrailersFor(us_socket_t* socket)
 {
-    auto* httpResponseData = (uWS::HttpResponseData<SSL>*)us_socket_ext(socket);
-    return httpResponseData->nodeHttpResponseTrailers;
+    auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
+    return httpResponseData->nodeCompat.nodeHttpResponseTrailers;
 }
 
 void JSNodeHTTPServerSocket::setResponseTrailers(WTF::StringView trailers)
@@ -232,8 +234,8 @@ static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
     /* HttpContext<SSL>::onWritable shuts the socket down once the buffered
      * response data has flushed and HTTP_CONNECTION_CLOSE is set, so the FIN
      * is sequenced after the response bytes (like Node's destroySoon). */
-    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
-    httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL, true>*>(us_socket_ext(socket));
+    httpResponseData->state |= uWS::HttpResponseData<SSL, true>::HTTP_CONNECTION_CLOSE;
     return true;
 }
 
@@ -251,20 +253,20 @@ bool JSNodeHTTPServerSocket::shutdownAfterResponseDrains()
 template<bool SSL>
 static bool isRequestTimedOutImpl(us_socket_t* socket, uint64_t headersTimeoutMs, uint64_t requestTimeoutMs)
 {
-    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
+    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL, true>*>(us_socket_ext(socket));
     if (httpResponseData->isConnectRequest) {
         // CONNECT/Upgrade tunnels are detached from the HTTP request machinery,
         // like Node freeing the parser for upgraded connections.
         return false;
     }
-    uint64_t start = httpResponseData->lastMessageStartMs;
+    uint64_t start = httpResponseData->nodeCompat.lastMessageStartMs;
     if (start == 0) {
         // Idle: no request message is currently being received.
         return false;
     }
     uint64_t now = uWS::nodeCompatMonotonicMs();
     uint64_t elapsed = now > start ? now - start : 0;
-    if (headersTimeoutMs > 0 && !httpResponseData->headersCompleted && elapsed > headersTimeoutMs) {
+    if (headersTimeoutMs > 0 && !httpResponseData->nodeCompat.headersCompleted && elapsed > headersTimeoutMs) {
         return true;
     }
     return requestTimeoutMs > 0 && elapsed > requestTimeoutMs;
@@ -290,7 +292,7 @@ bool JSNodeHTTPServerSocket::isAuthorized() const
     // Check if the handshake callback has fired. If so, use the isAuthorized flag
     // which reflects the actual certificate verification result.
     if (us_socket_ssl_handshake_callback_has_fired(socket)) {
-        auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<true>*>(us_socket_ext(socket));
+        auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<true, true>*>(us_socket_ext(socket));
         if (!httpResponseData)
             return false;
         return httpResponseData->isAuthorized;
@@ -368,32 +370,32 @@ void JSNodeHTTPServerSocket::appendPipelinedResponse(JSC::VM& vm, WebCore::JSNod
 template<bool SSL>
 static bool startPipelinedResponseImpl(us_socket_t* socket, bool isAncient, bool connectionClose, bool hasMoreQueued)
 {
-    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
+    auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL, true>*>(us_socket_ext(socket));
 
     // The previous response on this connection has finished; this queued
     // response now owns the per-response state the request handler normally
     // resets per parsed request.
     httpResponseData->offset = 0;
-    httpResponseData->state = uWS::HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
+    httpResponseData->state = uWS::HttpResponseData<SSL, true>::HTTP_RESPONSE_PENDING;
     if (connectionClose) {
-        httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+        httpResponseData->state |= uWS::HttpResponseData<SSL, true>::HTTP_CONNECTION_CLOSE;
     }
     httpResponseData->fromAncientRequest = isAncient;
     httpResponseData->noBodyStatus = false;
     httpResponseData->closeDelimited = false;
-    httpResponseData->nodeHttpResponseTrailers.clear();
+    httpResponseData->nodeCompat.nodeHttpResponseTrailers.clear();
 
-    if (httpResponseData->nodeHttpQueuedPipelinedCount > 0) {
-        httpResponseData->nodeHttpQueuedPipelinedCount--;
+    if (httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount > 0) {
+        httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount--;
     }
-    if (!hasMoreQueued && httpResponseData->nodeHttpQueuedPipelinedCount == 0 && httpResponseData->nodeHttpReadsPaused) {
+    if (!hasMoreQueued && httpResponseData->nodeCompat.nodeHttpQueuedPipelinedCount == 0 && httpResponseData->nodeCompat.nodeHttpReadsPaused) {
         // The pipeline backlog drained. Resume reading new requests only once
         // the socket has no outgoing backpressure left (Node's flood
         // prevention keeps the socket paused while responses back up);
         // otherwise HttpContext::onWritable resumes after the drain.
         if (reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->getBufferedAmount() == 0) {
-            httpResponseData->nodeHttpReadsPaused = false;
-            reinterpret_cast<uWS::HttpResponse<SSL>*>(socket)->resume();
+            httpResponseData->nodeCompat.nodeHttpReadsPaused = false;
+            reinterpret_cast<uWS::HttpResponse<SSL, true>*>(socket)->resume();
         }
     }
     return true;
@@ -430,9 +432,9 @@ void JSNodeHTTPServerSocket::stopHTTPParsing()
         return;
     }
     if (is_ssl) {
-        reinterpret_cast<uWS::HttpResponseData<true>*>(us_socket_ext(socket))->nodeHttpParsingStopped = true;
+        reinterpret_cast<uWS::HttpResponseData<true, true>*>(us_socket_ext(socket))->nodeCompat.nodeHttpParsingStopped = true;
     } else {
-        reinterpret_cast<uWS::HttpResponseData<false>*>(us_socket_ext(socket))->nodeHttpParsingStopped = true;
+        reinterpret_cast<uWS::HttpResponseData<false, true>*>(us_socket_ext(socket))->nodeCompat.nodeHttpParsingStopped = true;
     }
 }
 
@@ -667,8 +669,8 @@ DEFINE_VISIT_CHILDREN(JSNodeHTTPServerSocket);
 template<bool SSL>
 static JSNodeHTTPServerSocket* getNodeHTTPServerSocket(us_socket_t* socket)
 {
-    auto* httpResponseData = (uWS::HttpResponseData<SSL>*)us_socket_ext(socket);
-    return reinterpret_cast<JSNodeHTTPServerSocket*>(httpResponseData->socketData);
+    auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
+    return reinterpret_cast<JSNodeHTTPServerSocket*>(httpResponseData->nodeCompat.socketData);
 }
 
 template<bool SSL>
@@ -708,14 +710,14 @@ extern "C" JSC::EncodedJSValue Bun__getOrCreateNodeHTTPServerSocket(bool isSSL, 
     RETURN_IF_EXCEPTION(scope, {});
 
     if (isSSL) {
-        uWS::HttpResponse<true>* response = reinterpret_cast<uWS::HttpResponse<true>*>(us_socket);
-        auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(response->getHttpResponseData()->socketData);
+        uWS::HttpResponse<true, true>* response = reinterpret_cast<uWS::HttpResponse<true, true>*>(us_socket);
+        auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(response->getHttpResponseData()->nodeCompat.socketData);
         if (currentSocketDataPtr) {
             return JSValue::encode(currentSocketDataPtr);
         }
     } else {
-        uWS::HttpResponse<false>* response = reinterpret_cast<uWS::HttpResponse<false>*>(us_socket);
-        auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(response->getHttpResponseData()->socketData);
+        uWS::HttpResponse<false, true>* response = reinterpret_cast<uWS::HttpResponse<false, true>*>(us_socket);
+        auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(response->getHttpResponseData()->nodeCompat.socketData);
         if (currentSocketDataPtr) {
             return JSValue::encode(currentSocketDataPtr);
         }
@@ -727,11 +729,11 @@ extern "C" JSC::EncodedJSValue Bun__getOrCreateNodeHTTPServerSocket(bool isSSL, 
         us_socket,
         isSSL, nullptr);
     if (isSSL) {
-        uWS::HttpResponse<true>* response = reinterpret_cast<uWS::HttpResponse<true>*>(us_socket);
-        response->getHttpResponseData()->socketData = socket;
+        uWS::HttpResponse<true, true>* response = reinterpret_cast<uWS::HttpResponse<true, true>*>(us_socket);
+        response->getHttpResponseData()->nodeCompat.socketData = socket;
     } else {
-        uWS::HttpResponse<false>* response = reinterpret_cast<uWS::HttpResponse<false>*>(us_socket);
-        response->getHttpResponseData()->socketData = socket;
+        uWS::HttpResponse<false, true>* response = reinterpret_cast<uWS::HttpResponse<false, true>*>(us_socket);
+        response->getHttpResponseData()->nodeCompat.socketData = socket;
     }
     RETURN_IF_EXCEPTION(scope, {});
     if (socket) {

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -123,8 +123,8 @@ void JSNodeHTTPServerSocket::upgradeToTunnelMode(bool afterBody)
 template<bool SSL>
 static std::string* requestTrailersFor(us_socket_t* socket)
 {
-    auto* httpResponseData = (uWS::HttpResponseData<SSL>*)us_socket_ext(socket);
-    return &httpResponseData->nodeHttpRequestTrailers;
+    auto* httpResponseData = (uWS::HttpResponseData<SSL, true>*)us_socket_ext(socket);
+    return &httpResponseData->uWS::HttpParser<true>::nodeCompat.nodeHttpRequestTrailers;
 }
 
 /* Move the connection's captured trailer section out, returning its (ptr, length)
@@ -160,8 +160,8 @@ extern "C" JSC::EncodedJSValue Bun__NodeHTTP__parseRequestTrailers(JSC::JSGlobal
 
     /* Parse with the same field-line primitives the request-header parser uses
      * (uWS::HttpParser::consumeFieldName / tryConsumeFieldValue / OWS-trim). */
-    std::pair<std::string_view, std::string_view> fields[uWS::HttpParser::MAX_TRAILER_FIELDS];
-    unsigned count = uWS::HttpParser::parseTrailerFields(section, fields);
+    std::pair<std::string_view, std::string_view> fields[uWS::HttpParser<true>::MAX_TRAILER_FIELDS];
+    unsigned count = uWS::HttpParser<true>::parseTrailerFields(section, fields);
     if (count == 0) {
         return JSC::JSValue::encode(JSC::jsUndefined());
     }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -30,7 +30,7 @@ struct us_socket_t;
 }
 
 namespace uWS {
-template<bool SSL>
+template<bool SSL, bool NODE_HTTP>
 struct HttpResponseData;
 struct WebSocketData;
 }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1359,9 +1359,11 @@ impl DevServer {
         // shim parameterized on the handler type `H` (which is zero-sized for
         // a fn-item), so each `tramp::<H, SSL>` lowers to a distinct C
         // function pointer with the handler baked in.
+        // bake dev server is never a node:http-compat server.
+        let nh = server.config.is_node_http;
         macro_rules! route {
             ($method:ident, $pattern:expr, $id:expr) => {{
-                app.$method($pattern, Some(dev_route_tramp::<SSL, { $id }>), dev);
+                app.$method(nh, $pattern, Some(dev_route_tramp::<SSL, { $id }>), dev);
             }};
         }
 
@@ -1393,6 +1395,7 @@ impl DevServer {
         route!(any, INTERNAL_PREFIX.as_bytes(), DevHandlerId::NotFound);
 
         app.ws(
+            nh,
             const_format::concatcp!(INTERNAL_PREFIX, "/hmr").as_bytes(),
             dev,
             0,
@@ -1612,27 +1615,27 @@ extern "C" fn dev_route_tramp<const SSL: bool, const ID: DevHandlerId>(
 
 fn on_report_error_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
     use bun_uws_sys::thunk::OpaqueHandle as _;
-    match resp {
-        AnyResponse::SSL(r) => {
+    match resp.kind() {
+        uws::AnyResponseKind::SSL(r) => {
             ErrorReportRequest::run(dev, req, bun_uws_sys::response::TLSResponse::as_handle(r))
         }
-        AnyResponse::TCP(r) => {
+        uws::AnyResponseKind::TCP(r) => {
             ErrorReportRequest::run(dev, req, bun_uws_sys::response::TCPResponse::as_handle(r))
         }
-        AnyResponse::H3(_) => not_found(resp),
+        uws::AnyResponseKind::H3(_) => not_found(resp),
     }
 }
 
 fn on_unref_source_map_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
     use bun_uws_sys::thunk::OpaqueHandle as _;
-    match resp {
-        AnyResponse::SSL(r) => {
+    match resp.kind() {
+        uws::AnyResponseKind::SSL(r) => {
             UnrefSourceMapRequest::run(dev, req, bun_uws_sys::response::TLSResponse::as_handle(r))
         }
-        AnyResponse::TCP(r) => {
+        uws::AnyResponseKind::TCP(r) => {
             UnrefSourceMapRequest::run(dev, req, bun_uws_sys::response::TCPResponse::as_handle(r))
         }
-        AnyResponse::H3(_) => not_found(resp),
+        uws::AnyResponseKind::H3(_) => not_found(resp),
     }
 }
 

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -603,7 +603,7 @@ fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> 
     {
         // sendfile() needs a real socket fd; SSL writes go through BIO and H3
         // through lsquic stream frames — neither has one.
-        if !matches!(resp, AnyResponse::TCP(_)) {
+        if !resp.is_tcp() {
             return false;
         }
         if file_type != FileType::File {

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -220,8 +220,8 @@ impl FileRoute {
 
         debug_assert_eq!(names.len(), values.len());
         // S008: variant payloads are ZST opaques — safe `*mut → &mut` deref.
-        match resp {
-            AnyResponse::SSL(s) => {
+        match resp.kind() {
+            bun_uws::AnyResponseKind::SSL(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
@@ -232,7 +232,7 @@ impl FileRoute {
                     }
                 }
             }
-            AnyResponse::TCP(s) => {
+            bun_uws::AnyResponseKind::TCP(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
@@ -243,7 +243,7 @@ impl FileRoute {
                     }
                 }
             }
-            AnyResponse::H3(s) => {
+            bun_uws::AnyResponseKind::H3(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
@@ -268,10 +268,10 @@ impl FileRoute {
     }
 
     fn write_status_code(&self, status: u16, resp: AnyResponse) {
-        match resp {
-            AnyResponse::SSL(r) => write_status::<true>(r, status),
-            AnyResponse::TCP(r) => write_status::<false>(r, status),
-            AnyResponse::H3(r) => {
+        match resp.kind() {
+            bun_uws::AnyResponseKind::SSL(r) => write_status::<true>(r, status),
+            bun_uws::AnyResponseKind::TCP(r) => write_status::<false>(r, status),
+            bun_uws::AnyResponseKind::H3(r) => {
                 let mut b = bun_core::fmt::ItoaBuf::new();
                 let s = bun_core::fmt::itoa(&mut b, status);
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -255,10 +255,10 @@ fn err_throw<T>(global: &JSGlobalObject, code: ErrorCode, msg: &'static str) -> 
     Err(err_throw_cold(global, code, msg))
 }
 
-/// AnyResponse `is_ssl()` shim (upstream lacks this accessor).
+/// AnyResponse `is_ssl()` shim.
 #[inline]
 fn any_response_is_ssl(r: &uws::AnyResponse) -> bool {
-    matches!(r, uws::AnyResponse::SSL(_))
+    r.is_ssl()
 }
 
 // uSockets callback adapters: AnyResponse::on_data/on_timeout/on_writable expect
@@ -904,22 +904,22 @@ fn write_head_internal(
         "writeHeadInternal({})",
         BStr::new(status_message)
     );
-    match response {
-        uws::AnyResponse::TCP(tcp) => NodeHTTPServer__writeHead_http(
+    match response.kind() {
+        uws::AnyResponseKind::TCP(tcp) => NodeHTTPServer__writeHead_http(
             global_object,
             status_message.as_ptr(),
             status_message.len(),
             headers,
-            (*tcp).cast::<c_void>(),
+            tcp.cast::<c_void>(),
         ),
-        uws::AnyResponse::SSL(ssl) => NodeHTTPServer__writeHead_https(
+        uws::AnyResponseKind::SSL(ssl) => NodeHTTPServer__writeHead_https(
             global_object,
             status_message.as_ptr(),
             status_message.len(),
             headers,
-            (*ssl).cast::<c_void>(),
+            ssl.cast::<c_void>(),
         ),
-        uws::AnyResponse::H3(_) => {
+        uws::AnyResponseKind::H3(_) => {
             bun_core::Output::panic(format_args!("node:http does not support HTTP/3 responses"));
         }
     }
@@ -2202,10 +2202,11 @@ pub unsafe extern "C" fn NodeHTTPResponse__createForJS(
         *has_body = req_len > 0 || request_ref.header(b"transfer-encoding").is_some();
     }
 
+    // NodeHTTPResponse is always backed by the NODE_HTTP=true C++ instantiation.
     let raw_response = if is_ssl != 0 {
-        uws::AnyResponse::SSL(response_ptr.cast())
+        uws::AnyResponse::SSL_node(response_ptr.cast())
     } else {
-        uws::AnyResponse::TCP(response_ptr.cast())
+        uws::AnyResponse::TCP_node(response_ptr.cast())
     };
 
     let response = bun_core::heap::into_raw(Box::new(NodeHTTPResponse {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -49,46 +49,11 @@ impl AdditionalOnAbortCallback {
 pub type Req<const SSL_ENABLED: bool, const HTTP3: bool> = c_void;
 pub type Resp<const SSL_ENABLED: bool, const HTTP3: bool> = c_void;
 
-// Surface gaps `AnyResponse` doesn't expose yet — hand-dispatched here so the
-// state machine can call them without touching `bun_uws_sys`.
-pub trait AnyResponseExt {
-    fn has_responded(self) -> bool;
-    fn override_write_offset(self, offset: u64);
-}
-
 /// Extract the raw FFI pointer from an `AnyResponse` for C-ABI shims that
 /// take `*mut c_void` (e.g. `FetchHeaders::to_uws_response`, `CookieMap::write`).
 #[inline]
 fn any_response_as_ptr(r: uws::AnyResponse) -> *mut c_void {
     r.as_raw_ptr()
-}
-
-impl AnyResponseExt for uws::AnyResponse {
-    #[inline]
-    fn has_responded(self) -> bool {
-        // S012: variant payloads are ZST opaques (`Response<SSL>` / `H3Response`);
-        // route the `*mut → &mut` deref through the const-asserted
-        // `bun_opaque::opaque_deref_mut` so dispatch is `unsafe`-free.
-        match self.kind() {
-            uws::AnyResponseKind::SSL(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-            uws::AnyResponseKind::TCP(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-            uws::AnyResponseKind::H3(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-        }
-    }
-    #[inline]
-    fn override_write_offset(self, offset: u64) {
-        match self.kind() {
-            uws::AnyResponseKind::SSL(p) => {
-                bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
-            }
-            uws::AnyResponseKind::TCP(p) => {
-                bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
-            }
-            uws::AnyResponseKind::H3(p) => {
-                bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
-            }
-        }
-    }
 }
 
 /// Back-reference to a stack-local "should this RequestContext defer its
@@ -547,7 +512,7 @@ impl<ThisServer, const SSL_ENABLED: bool, const DEBUG_MODE: bool, const HTTP3: b
 where
     ThisServer: ServerLike + 'static,
 {
-    const RESP_KIND: uws::ResponseKind = uws::ResponseKind::from(SSL_ENABLED, HTTP3);
+    const RESP_KIND: uws::ResponseKind = uws::ResponseKind::from(SSL_ENABLED, HTTP3, false);
 
     /// Reborrow the owning server. `server` is a BACKREF (LIFETIMES.tsv): set
     /// at construction in `init()` from the `NewServer` that owns the request

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -60,11 +60,7 @@ pub trait AnyResponseExt {
 /// take `*mut c_void` (e.g. `FetchHeaders::to_uws_response`, `CookieMap::write`).
 #[inline]
 fn any_response_as_ptr(r: uws::AnyResponse) -> *mut c_void {
-    match r {
-        uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
-        uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
-        uws::AnyResponse::H3(p) => p.cast::<c_void>(),
-    }
+    r.as_raw_ptr()
 }
 
 impl AnyResponseExt for uws::AnyResponse {
@@ -73,22 +69,22 @@ impl AnyResponseExt for uws::AnyResponse {
         // S012: variant payloads are ZST opaques (`Response<SSL>` / `H3Response`);
         // route the `*mut → &mut` deref through the const-asserted
         // `bun_opaque::opaque_deref_mut` so dispatch is `unsafe`-free.
-        match self {
-            uws::AnyResponse::SSL(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-            uws::AnyResponse::TCP(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-            uws::AnyResponse::H3(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
+        match self.kind() {
+            uws::AnyResponseKind::SSL(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
+            uws::AnyResponseKind::TCP(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
+            uws::AnyResponseKind::H3(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
         }
     }
     #[inline]
     fn override_write_offset(self, offset: u64) {
-        match self {
-            uws::AnyResponse::SSL(p) => {
+        match self.kind() {
+            uws::AnyResponseKind::SSL(p) => {
                 bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
             }
-            uws::AnyResponse::TCP(p) => {
+            uws::AnyResponseKind::TCP(p) => {
                 bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
             }
-            uws::AnyResponse::H3(p) => {
+            uws::AnyResponseKind::H3(p) => {
                 bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
             }
         }
@@ -2017,11 +2013,7 @@ where
 
         // `HTTPServerWritable::res` stores the type-erased uws response handle;
         // `any_res()` reconstructs the variant from the const generics.
-        let raw_res: *mut c_void = match resp {
-            uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
-            uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
-            uws::AnyResponse::H3(p) => p.cast::<c_void>(),
-        };
+        let raw_res: *mut c_void = resp.as_raw_ptr();
 
         let response_stream_box = Box::new(ResponseStreamJSSink::<SSL_ENABLED, HTTP3> {
             sink: ResponseStream::<SSL_ENABLED, HTTP3> {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -326,6 +326,7 @@ impl ServerConfig {
 pub(crate) fn apply_static_route<const SSL: bool, T>(
     server: AnyServer,
     app: &mut uws::NewApp<SSL>,
+    node_http: bool,
     entry: *mut T,
     path: &[u8],
     method: http_method::Optional,
@@ -385,16 +386,16 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
     // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
     // handler route: uWS keeps the last registration for the same method and path.
     if !path_has_user_head_route && serves_head(&method) {
-        app.head(path, Some(head::<SSL, T>), user_data);
+        app.head(node_http, path, Some(head::<SSL, T>), user_data);
     }
     match method {
         http_method::Optional::Any => {
-            app.any(path, Some(handler::<SSL, T>), user_data);
+            app.any(node_http, path, Some(handler::<SSL, T>), user_data);
         }
         http_method::Optional::Method(m) => {
             let mut iter = m.iter();
             while let Some(method_) = iter.next() {
-                app.method(method_, path, Some(handler::<SSL, T>), user_data);
+                app.method(node_http, method_, path, Some(handler::<SSL, T>), user_data);
             }
         }
     }
@@ -1328,6 +1329,7 @@ impl ServerConfig {
             }
             let on_request = on_request_.with_async_context_if_needed(global);
             args.on_node_http_request = Some(Strong::create(on_request, global));
+            args.is_node_http = true;
         }
 
         if let Some(on_request_) = arg.get_truthy(global, "fetch")? {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -338,9 +338,22 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
     unsafe { T::set_server(entry, server) };
 
     // Trampolines: uWS hands us an opaque `uws_res*`, a live `Request*`, and the
-    // user_data pointer (= `entry`). Cast back to the typed `Response<SSL>` /
-    // `T` and dispatch into the trait. Monomorphized per `<SSL, T>`.
-    extern "C" fn handler<const SSL: bool, T: StaticRouteLike<SSL>>(
+    // user_data pointer (= `entry`). Cast back to the typed response / `T` and
+    // dispatch into the trait. Monomorphized per `<SSL, NODE_HTTP, T>` so the
+    // constructed `AnyResponse` carries the C++ template discriminant.
+    #[inline(always)]
+    fn wrap_resp<const SSL: bool, const NODE_HTTP: bool>(
+        resp: *mut uws::uws_res,
+    ) -> bun_uws_sys::AnyResponse {
+        match (SSL, NODE_HTTP) {
+            (true, true) => bun_uws_sys::AnyResponse::SSL_node(resp.cast()),
+            (true, false) => bun_uws_sys::AnyResponse::SSL(resp.cast()),
+            (false, true) => bun_uws_sys::AnyResponse::TCP_node(resp.cast()),
+            (false, false) => bun_uws_sys::AnyResponse::TCP(resp.cast()),
+        }
+    }
+
+    extern "C" fn handler<const SSL: bool, const NODE_HTTP: bool, T: StaticRouteLike<SSL>>(
         resp: *mut uws::uws_res,
         req: *mut uws::Request,
         user_data: *mut core::ffi::c_void,
@@ -349,53 +362,47 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
         // of the callback; `user_data` is the `entry` pointer registered below,
         // kept alive by the route table for the lifetime of the app.
         let route = user_data.cast::<T>();
-        let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
-        // `Response<SSL>` is a `#[repr(C)]` opaque over `uws_res`; pointer cast
-        // selects the matching `AnyResponse` variant for the const-generic SSL flag.
-        let any_resp = if SSL {
-            bun_uws_sys::AnyResponse::SSL(resp.cast())
-        } else {
-            bun_uws_sys::AnyResponse::TCP(resp.cast())
-        };
+        let any_resp = wrap_resp::<SSL, NODE_HTTP>(resp);
         // SAFETY: `route`, `req`, and `resp` are non-null and valid for the
         // duration of this uWS callback (see invariants established above);
         // `on_request` only dereferences them while this frame is live.
         unsafe { T::on_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
     }
 
-    extern "C" fn head<const SSL: bool, T: StaticRouteLike<SSL>>(
+    extern "C" fn head<const SSL: bool, const NODE_HTTP: bool, T: StaticRouteLike<SSL>>(
         resp: *mut uws::uws_res,
         req: *mut uws::Request,
         user_data: *mut core::ffi::c_void,
     ) {
         // SAFETY: see `handler` above.
         let route = user_data.cast::<T>();
-        let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
-        let any_resp = if SSL {
-            bun_uws_sys::AnyResponse::SSL(resp.cast())
-        } else {
-            bun_uws_sys::AnyResponse::TCP(resp.cast())
-        };
+        let any_resp = wrap_resp::<SSL, NODE_HTTP>(resp);
         // SAFETY: `route`, `req`, and `resp` validity is guaranteed by uWS for
         // the callback's duration — same invariants as `handler` above.
         unsafe { T::on_head_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
     }
 
+    type RouteFn = extern "C" fn(*mut uws::uws_res, *mut uws::Request, *mut core::ffi::c_void);
     let user_data = entry.cast::<core::ffi::c_void>();
+    let (head_fn, handler_fn): (RouteFn, RouteFn) = if node_http {
+        (head::<SSL, true, T>, handler::<SSL, true, T>)
+    } else {
+        (head::<SSL, false, T>, handler::<SSL, false, T>)
+    };
     // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
     // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
     // handler route: uWS keeps the last registration for the same method and path.
     if !path_has_user_head_route && serves_head(&method) {
-        app.head(node_http, path, Some(head::<SSL, T>), user_data);
+        app.head(node_http, path, Some(head_fn), user_data);
     }
     match method {
         http_method::Optional::Any => {
-            app.any(node_http, path, Some(handler::<SSL, T>), user_data);
+            app.any(node_http, path, Some(handler_fn), user_data);
         }
         http_method::Optional::Method(m) => {
             let mut iter = m.iter();
             while let Some(method_) = iter.next() {
-                app.method(node_http, method_, path, Some(handler::<SSL, T>), user_data);
+                app.method(node_http, method_, path, Some(handler_fn), user_data);
             }
         }
     }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -233,13 +233,14 @@ impl ServerWebSocket {
     /// log + `0` return is the caller's responsibility (it varies in nothing,
     /// but keeping it inline preserves the per-method `scoped_log!` callsite).
     #[inline]
-    fn publish_ctx(&self) -> Option<(*mut c_void, bool, bool)> {
+    fn publish_ctx(&self) -> Option<(*mut c_void, bool, bool, bool)> {
         let handler = self.handler();
         let app = handler.app?;
         let flags = handler.flags;
         Some((
             app,
             flags.contains(HandlerFlags::SSL),
+            flags.contains(HandlerFlags::NODE_HTTP),
             flags.contains(HandlerFlags::PUBLISH_TO_SELF),
         ))
     }
@@ -271,6 +272,7 @@ impl ServerWebSocket {
     fn do_publish(
         &self,
         ssl: bool,
+        node_http: bool,
         app: *mut c_void,
         publish_to_self: bool,
         topic: &[u8],
@@ -281,7 +283,7 @@ impl ServerWebSocket {
         let status = if !publish_to_self && !self.is_closed() {
             self.websocket().publish(topic, buffer, opcode, compress)
         } else {
-            AnyWebSocket::publish_with_options(ssl, app, topic, buffer, opcode, compress)
+            AnyWebSocket::publish_with_options(ssl, node_http, app, topic, buffer, opcode, compress)
         };
         send_status_to_js(status, buffer.len(), "publish", "bytes")
     }
@@ -765,7 +767,7 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some((app, ssl, node_http, publish_to_self)) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -794,6 +796,7 @@ impl ServerWebSocket {
             let buffer = array_buffer.slice();
             return Ok(self.do_publish(
                 ssl,
+                node_http,
                 app,
                 publish_to_self,
                 topic_slice.slice(),
@@ -810,6 +813,7 @@ impl ServerWebSocket {
 
             let ret = self.do_publish(
                 ssl,
+                node_http,
                 app,
                 publish_to_self,
                 topic_slice.slice(),
@@ -835,7 +839,7 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some((app, ssl, node_http, publish_to_self)) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -864,6 +868,7 @@ impl ServerWebSocket {
 
         let ret = self.do_publish(
             ssl,
+            node_http,
             app,
             publish_to_self,
             topic_slice.slice(),
@@ -890,7 +895,7 @@ impl ServerWebSocket {
             );
         }
 
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some((app, ssl, node_http, publish_to_self)) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -923,6 +928,7 @@ impl ServerWebSocket {
 
         Ok(self.do_publish(
             ssl,
+            node_http,
             app,
             publish_to_self,
             topic_slice.slice(),
@@ -938,7 +944,7 @@ impl ServerWebSocket {
         topic_str: &JSString,
         array: &mut JSUint8Array,
     ) -> JsResult<JSValue> {
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some((app, ssl, node_http, publish_to_self)) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -955,6 +961,7 @@ impl ServerWebSocket {
 
         Ok(self.do_publish(
             ssl,
+            node_http,
             app,
             publish_to_self,
             topic_slice.slice(),
@@ -970,7 +977,7 @@ impl ServerWebSocket {
         topic_str: &JSString,
         str: &JSString,
     ) -> JsResult<JSValue> {
-        let Some((app, ssl, publish_to_self)) = self.publish_ctx() else {
+        let Some((app, ssl, node_http, publish_to_self)) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
@@ -989,6 +996,7 @@ impl ServerWebSocket {
 
         Ok(self.do_publish(
             ssl,
+            node_http,
             app,
             publish_to_self,
             topic_slice.slice(),

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -469,10 +469,10 @@ impl StaticRoute {
     }
 
     fn do_write_status(&self, status: u16, resp: AnyResponse) {
-        match resp {
-            AnyResponse::SSL(r) => write_status::<true>(r, status),
-            AnyResponse::TCP(r) => write_status::<false>(r, status),
-            AnyResponse::H3(r) => {
+        match resp.kind() {
+            bun_uws::AnyResponseKind::SSL(r) => write_status::<true>(r, status),
+            bun_uws::AnyResponseKind::TCP(r) => write_status::<false>(r, status),
+            bun_uws::AnyResponseKind::H3(r) => {
                 let mut b = bun_core::fmt::ItoaBuf::new();
                 let s = bun_core::fmt::itoa(&mut b, status);
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.
@@ -495,7 +495,7 @@ impl StaticRoute {
                 &buf[value.offset as usize..][..value.length as usize],
             );
         }
-        if !matches!(resp, AnyResponse::H3(_)) {
+        if !resp.is_h3() {
             if let Some(srv) = self.server.get() {
                 if let Some(alt) = srv.h3_alt_svc() {
                     resp.write_header(b"alt-svc", alt);

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -49,7 +49,8 @@ bitflags::bitflags! {
     pub struct HandlerFlags: u8 {
         const SSL             = 1 << 0;
         const PUBLISH_TO_SELF = 1 << 1;
-        // remaining 6 bits: padding
+        const NODE_HTTP       = 1 << 2;
+        // remaining 5 bits: padding
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1476,6 +1476,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if let Some(app) = self.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
             bun_opaque::opaque_deref_mut(app).set_flags(
+                self.config.is_node_http,
                 require_host_header,
                 use_strict_method_validation,
                 use_insecure_http_parser,
@@ -1487,7 +1488,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub fn set_max_http_header_size(&mut self, max_header_size: u64) {
         if let Some(app) = self.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(app).set_max_http_header_size(max_header_size);
+            bun_opaque::opaque_deref_mut(app)
+                .set_max_http_header_size(self.config.is_node_http, max_header_size);
         }
     }
 
@@ -1574,7 +1576,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             self.flags.insert(ServerFlags::TERMINATED);
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(self.app.unwrap()).close();
+            bun_opaque::opaque_deref_mut(self.app.unwrap()).close(self.config.is_node_http);
         }
     }
 
@@ -1671,7 +1673,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             if let Some(dev) = self.dev_server.take() {
                 if let Some(app) = self.app {
                     // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).clear_routes();
+                    bun_opaque::opaque_deref_mut(app).clear_routes(self.config.is_node_http);
                 }
                 drop(dev); // dev.deinit()
             }
@@ -1701,11 +1703,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // Therefore, we split it into two tasks.
             self.flags.insert(ServerFlags::TERMINATED);
             let app = self.app.unwrap();
-            vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(app, |app| {
+            // ManagedTask::new takes a fn item; select the NODE_HTTP arm here.
+            fn close_app<const SSL: bool, const NH: bool>(
+                app: *mut uws_sys::NewApp<SSL>,
+            ) -> bun_event_loop::JsResult<()> {
                 // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).close();
+                bun_opaque::opaque_deref_mut(app).close(NH);
                 Ok(())
-            }));
+            }
+            let close = if self.config.is_node_http {
+                close_app::<SSL, true>
+            } else {
+                close_app::<SSL, false>
+            };
+            vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(app, close));
         }
 
         vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
@@ -1873,7 +1884,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
         if let Some(app) = this_ref.app.take() {
             // SAFETY: live uws App handle owned by this server.
-            unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
+            unsafe { uws_sys::NewApp::<SSL>::destroy(app, this_ref.config.is_node_http) };
         }
 
         // SAFETY: paired with heap::alloc in `init()`.
@@ -2002,6 +2013,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
         // set_routes is only called after `self.app = Some(..)` in listen().
         let app = bun_opaque::opaque_deref_mut(self.app.unwrap());
+        let nh = self.config.is_node_http;
         let self_ptr: *mut Self = self;
         let any_server = AnyServer::from(self_ptr.cast_const());
         // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;
@@ -2062,6 +2074,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 .handler
                 .flags
                 .set(web_socket_server_context::HandlerFlags::SSL, SSL);
+            websocket
+                .handler
+                .flags
+                .set(web_socket_server_context::HandlerFlags::NODE_HTTP, nh);
         }
 
         // --- 3. Register compiled user routes & track "/*" coverage ---
@@ -2096,6 +2112,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             match user_route.route.method {
                 server_config::RouteMethod::Any => {
                     app.any(
+                        nh,
                         path,
                         Some(trampoline::on_user_route_request::<SSL, DEBUG>),
                         ud,
@@ -2118,6 +2135,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             has_any_ws_route_for_star_path = true;
                         }
                         app.ws(
+                            nh,
                             path,
                             ud,
                             1, // id 1 means is a user route
@@ -2127,6 +2145,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 }
                 server_config::RouteMethod::Specific(method_val) => {
                     app.method(
+                        nh,
                         method_val,
                         path,
                         Some(trampoline::on_user_route_request::<SSL, DEBUG>),
@@ -2151,6 +2170,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         // Websocket upgrade is a GET request
                         if method_val == http_method::Method::GET {
                             app.ws(
+                                nh,
                                 path,
                                 ud,
                                 1, // id 1 means is a user route
@@ -2166,11 +2186,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         for route_path in self.config.negative_routes.iter() {
             let p = route_path.as_bytes();
             app.head(
+                nh,
                 p,
                 Some(trampoline::on_request::<SSL, DEBUG>),
                 self_ptr.cast(),
             );
             app.any(
+                nh,
                 p,
                 Some(trampoline::on_request::<SSL, DEBUG>),
                 self_ptr.cast(),
@@ -2229,6 +2251,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, StaticRoute>(
                         any_server,
                         app,
+                        nh,
                         p.as_ptr(),
                         &entry.path,
                         entry.method,
@@ -2252,6 +2275,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, FileRoute>(
                         any_server,
                         app,
+                        nh,
                         p.as_ptr(),
                         &entry.path,
                         entry.method,
@@ -2275,6 +2299,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, html_bundle::Route>(
                         any_server,
                         app,
+                        nh,
                         r.as_ptr(),
                         &entry.path,
                         entry.method,
@@ -2333,6 +2358,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // --- 7. Debug-mode specific routes ---
         if DEBUG {
             app.get(
+                nh,
                 b"/bun:info",
                 Some(trampoline::on_bun_info_request::<SSL, DEBUG>),
                 self_ptr.cast(),
@@ -2364,6 +2390,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if !has_any_ws_route_for_star_path {
             if let Some(websocket) = websocket_ptr {
                 app.ws(
+                    nh,
                     b"/*",
                     self_ptr.cast(),
                     0, // id 0 means is a fallback route and ctx is the server
@@ -2388,6 +2415,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             for method_to_cover in !star_methods_covered_by_user {
                 if has_node_http {
                     app.method(
+                        nh,
                         method_to_cover,
                         b"/*",
                         Some(trampoline::on_node_http_request::<SSL, DEBUG>),
@@ -2395,6 +2423,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     );
                 } else if has_on_request {
                     app.method(
+                        nh,
                         method_to_cover,
                         b"/*",
                         Some(trampoline::on_request::<SSL, DEBUG>),
@@ -2402,6 +2431,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     );
                 } else {
                     app.method(
+                        nh,
                         method_to_cover,
                         b"/*",
                         Some(trampoline::on_404::<SSL, DEBUG>),
@@ -2411,14 +2441,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         } else if has_node_http {
             app.any(
+                nh,
                 b"/*",
                 Some(trampoline::on_node_http_request::<SSL, DEBUG>),
                 ud,
             );
         } else if has_on_request {
-            app.any(b"/*", Some(trampoline::on_request::<SSL, DEBUG>), ud);
+            app.any(nh, b"/*", Some(trampoline::on_request::<SSL, DEBUG>), ud);
         } else {
-            app.any(b"/*", Some(trampoline::on_404::<SSL, DEBUG>), ud);
+            app.any(nh, b"/*", Some(trampoline::on_404::<SSL, DEBUG>), ud);
         }
 
         // H3 fallback — same three-way as H1 above, but driven by user/static
@@ -2447,6 +2478,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if should_add_chrome_devtools_json_route {
             app.get(
+                nh,
                 CHROME_DEVTOOLS_ROUTE,
                 Some(trampoline::on_chrome_devtools_json_request::<SSL, DEBUG>),
                 ud,
@@ -2515,7 +2547,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 return JSValue::ZERO;
             };
 
-            app = match uws_sys::NewApp::<SSL>::create(&ssl_options) {
+            app = match uws_sys::NewApp::<SSL>::create(&ssl_options, this_ref.config.is_node_http) {
                 Some(a) => a,
                 None => {
                     if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
@@ -2573,7 +2605,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let server_name = unsafe { bun_core::ffi::cstr(name_ptr) };
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 if bun_opaque::opaque_deref_mut(app)
-                    .add_server_name_with_options(server_name, &ssl_options)
+                    .add_server_name_with_options(this_ref.config.is_node_http, server_name, &ssl_options)
                     .is_err()
                 {
                     if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
@@ -2595,7 +2627,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // SAFETY: server_name is a CStr; ZStr::from_raw upholds the NUL invariant.
                 let z = unsafe { bun_core::ZStr::from_raw(name_ptr.cast(), name_len) };
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                bun_opaque::opaque_deref_mut(app).domain(this_ref.config.is_node_http, z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
                     Self::deinit(this);
@@ -2655,7 +2687,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 }
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 if bun_opaque::opaque_deref_mut(app)
-                    .add_server_name_with_options(sni_name, &sni_opts)
+                    .add_server_name_with_options(this_ref.config.is_node_http, sni_name, &sni_opts)
                     .is_err()
                 {
                     if !global.has_exception() && !throw_ssl_error_if_necessary(global) {
@@ -2669,7 +2701,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     return JSValue::ZERO;
                 }
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                bun_opaque::opaque_deref_mut(app).domain(this_ref.config.is_node_http, z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
                     Self::deinit(this);
@@ -2679,8 +2711,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let _ = unsafe { &mut *this }.set_routes();
             }
         } else {
-            app = match uws_sys::NewApp::<SSL>::create(&uws_sys::BunSocketContextOptions::default())
-            {
+            app = match uws_sys::NewApp::<SSL>::create(
+                &uws_sys::BunSocketContextOptions::default(),
+                this_ref.config.is_node_http,
+            ) {
                 Some(a) => a,
                 None => {
                     if !global.has_exception() {
@@ -2767,6 +2801,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         // `&mut *this` is the sole borrow while it runs.
                         unsafe {
                             (*app).listen_with_config(
+                                this_ref.config.is_node_http,
                                 Some(trampoline::on_listen::<SSL, DEBUG>),
                                 this.cast::<c_void>(),
                                 uws_app_c::uws_app_listen_config_t {
@@ -2854,6 +2889,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // `&*this` is live across this call.
                 unsafe {
                     (*app).listen_on_unix_socket(
+                        this_ref.config.is_node_http,
                         trampoline::on_listen_unix::<SSL, DEBUG>,
                         this.cast::<c_void>(),
                         z,
@@ -3534,7 +3570,8 @@ impl AnyServer {
         any_server_dispatch!(self, |s| match s.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
             // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) => bun_opaque::opaque_deref_mut(app).num_subscribers(topic),
+            Some(app) =>
+                bun_opaque::opaque_deref_mut(app).num_subscribers(s.config.is_node_http, topic),
             // Defensive 0
             // here for the post-stop window; assert in debug to catch misuse.
             None => {
@@ -3554,8 +3591,8 @@ impl AnyServer {
         any_server_dispatch!(self, |s| match s.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
             // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) =>
-                bun_opaque::opaque_deref_mut(app).publish(topic, message, opcode, compress),
+            Some(app) => bun_opaque::opaque_deref_mut(app)
+                .publish(s.config.is_node_http, topic, message, opcode, compress),
             // Defensive for the post-stop window; assert in debug to catch misuse.
             None => {
                 debug_assert!(false, "publish on server with no app");

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1121,7 +1121,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub fn on_node_http_request(
         this: *mut Self,
         req: &mut uws_sys::Request,
-        resp: &mut uws_sys::NewAppResponse<SSL>,
+        resp: &mut uws_sys::NodeAppResponse<SSL>,
     ) {
         jsc::mark_binding!();
         // `upgrade_ctx` null is valid (no upgrade).
@@ -1146,7 +1146,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub(crate) fn on_node_http_request_with_upgrade_ctx(
         this: *mut Self,
         req: &mut uws_sys::Request,
-        resp: &mut uws_sys::NewAppResponse<SSL>,
+        resp: &mut uws_sys::NodeAppResponse<SSL>,
         upgrade_ctx: *mut uws_sys::WebSocketUpgradeContext,
     ) {
         use bun_http_jsc::method_jsc::MethodJsc as _;
@@ -1220,7 +1220,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 callback,
                 method_string,
                 req,
-                std::ptr::from_mut::<uws_sys::NewAppResponse<SSL>>(resp).cast(),
+                std::ptr::from_mut::<uws_sys::NodeAppResponse<SSL>>(resp).cast(),
                 upgrade_ctx.cast(),
                 &mut node_http_response,
             )
@@ -3020,11 +3020,13 @@ mod trampoline {
         user_data: *mut c_void,
     ) {
         // user_data is the `*mut NewServer<..>` registered in set_routes.
-        // S008: `Request` / `Response<SSL>` are ZST opaques — safe deref.
+        // S008: `Request` / `Response<SSL, true>` are ZST opaques — safe deref.
+        // node:http path is only registered on a NODE_HTTP=true app, so the C++
+        // object is always `HttpResponse<SSL, true>`.
         NewServer::<SSL, DEBUG>::on_node_http_request(
             user_data.cast(),
             bun_opaque::opaque_deref_mut(req),
-            bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NewAppResponse<SSL>>()),
+            bun_opaque::opaque_deref_mut(res.cast::<uws_sys::NodeAppResponse<SSL>>()),
         );
     }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1468,7 +1468,8 @@ where
         }
 
         Ok(JSValue::js_number(f64::from(
-            self.app_mut().num_subscribers(topic.slice()),
+            self.app_mut()
+                .num_subscribers(self.config.is_node_http, topic.slice()),
         )))
     }
 
@@ -1682,6 +1683,7 @@ where
         if let Some(buffer) = message_value.as_array_buffer(global) {
             let status = AnyWebSocket::publish_with_options(
                 SSL,
+                self.config.is_node_http,
                 app,
                 topic_slice.slice(),
                 buffer.slice(),
@@ -1708,6 +1710,7 @@ where
             let buffer = slice.slice();
             let status = AnyWebSocket::publish_with_options(
                 SSL,
+                self.config.is_node_http,
                 app,
                 topic_slice.slice(),
                 buffer,
@@ -2155,7 +2158,7 @@ where
 
         // SAFETY: `on_reload` is only reachable while the server is running
         // (`self.app` set in `listen()`).
-        self.app_mut().clear_routes();
+        self.app_mut().clear_routes(self.config.is_node_http);
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2192,6 +2195,10 @@ where
             ws.handler
                 .flags
                 .set(super::web_socket_server_context::HandlerFlags::SSL, SSL);
+            ws.handler.flags.set(
+                super::web_socket_server_context::HandlerFlags::NODE_HTTP,
+                self.config.is_node_http,
+            );
             if !ws.handler.on_message.is_empty() || !ws.handler.on_open.is_empty() {
                 if let Some(old_ws) = self.config.websocket.as_ref() {
                     old_ws.unprotect();
@@ -2249,7 +2256,7 @@ where
             return Ok(false);
         }
         self.config = self.config.clone_for_reloading_static_routes()?;
-        self.app_mut().clear_routes();
+        self.app_mut().clear_routes(self.config.is_node_http);
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2495,7 +2502,8 @@ where
         if self.app.is_none() {
             return Ok(JSValue::UNDEFINED);
         }
-        self.app_mut().close_idle_connections();
+        self.app_mut()
+            .close_idle_connections(self.config.is_node_http);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -3751,8 +3759,11 @@ pub(super) fn server_set_on_connection_(
                         this.on_connection_callback(socket.cast::<c_void>());
                     }
                     // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app)
-                        .filter(thunk, core::ptr::from_mut::<$T>(this).cast::<c_void>());
+                    bun_opaque::opaque_deref_mut(app).filter(
+                        this.config.is_node_http,
+                        thunk,
+                        core::ptr::from_mut::<$T>(this).cast::<c_void>(),
+                    );
                 }
                 return Ok(JSValue::UNDEFINED);
             }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1865,7 +1865,7 @@ where
                             // we must write the status first so that 200 OK isn't written
                             raw_response.write_status(b"101 Switching Protocols");
                             fetch_headers_to_use.to_uws_response(
-                                ResponseKind::from(SSL, false),
+                                ResponseKind::from_any(raw_response),
                                 raw_response.socket().cast::<c_void>(),
                             );
                         }
@@ -2092,14 +2092,14 @@ where
             if let Some(h) = fetch_headers_to_use {
                 // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                 bun_opaque::opaque_deref_mut(h).to_uws_response(
-                    ResponseKind::from(SSL, false),
+                    ResponseKind::from_any(resp),
                     resp.socket().cast::<c_void>(),
                 );
             }
             if let Some(c) = cookies_to_write.as_mut() {
                 c.write(
                     global,
-                    ResponseKind::from(SSL, false),
+                    ResponseKind::from_any(resp),
                     resp.socket().cast::<c_void>(),
                 )?;
             }
@@ -3278,6 +3278,12 @@ where
         if this.config.on_node_http_request.is_some() {
             // NOTE: receiver is `*mut Self` (mod.rs) — the callee re-enters
             // JS, so a long-lived `&mut self` here would alias on callback.
+            // node:http registered `app.ws(nh=true, ..)`, so the underlying
+            // C++ object is `HttpResponse<SSL, true>`; both `Response<SSL, N>`
+            // are ZST opaques over the same pointer, so re-type via cast.
+            let resp = bun_opaque::opaque_deref_mut(
+                std::ptr::from_mut(resp).cast::<uws_sys::NodeAppResponse<SSL>>(),
+            );
             Self::on_node_http_request_with_upgrade_ctx(self_ptr, req, resp, upgrade_ctx);
             return;
         }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -53,17 +53,27 @@ pub enum ResponseKind {
     Tcp = 0,
     Ssl = 1,
     H3 = 2,
+    /// `HttpResponse<false, true>` — node:http compat layout.
+    TcpNode = 3,
+    /// `HttpResponse<true, true>` — node:https compat layout.
+    SslNode = 4,
 }
 
 impl ResponseKind {
-    pub const fn from(ssl: bool, http3: bool) -> ResponseKind {
+    pub const fn from(ssl: bool, http3: bool, node_http: bool) -> ResponseKind {
         if http3 {
             ResponseKind::H3
+        } else if node_http {
+            if ssl { ResponseKind::SslNode } else { ResponseKind::TcpNode }
         } else if ssl {
             ResponseKind::Ssl
         } else {
             ResponseKind::Tcp
         }
+    }
+
+    pub fn from_any(r: bun_uws_sys::AnyResponse) -> ResponseKind {
+        Self::from(r.is_ssl(), r.is_h3(), r.is_node_http())
     }
 }
 

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1440,5 +1440,6 @@ pub type Response<const SSL: bool> = bun_uws_sys::response::Response<SSL>;
 /// Variants: `SSL(*mut Response<true>)`, `TCP(*mut Response<false>)`,
 /// `H3(*mut H3::Response)`.
 pub use bun_uws_sys::AnyResponse;
+pub use bun_uws_sys::AnyResponseKind;
 
 pub use bun_uws_sys::response::WriteResult;

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -46,7 +46,11 @@ use crate::{
 // The C layer handles the impedance mismatch between Rust and C++, while the
 // Rust layer provides idiomatic APIs for Rust developers.
 
-/// Opaque handle to a uWS::TemplatedApp<SSL>. Always used via `*mut App<SSL>`.
+/// Opaque handle to a `uWS::TemplatedApp<SSL, NODE_HTTP>`. Always used via
+/// `*mut App<SSL>`. `NODE_HTTP` is threaded as a runtime flag on every method
+/// (the owning server picks it once at create time from `config.is_node_http`
+/// and passes it thereafter); the same opaque pointer type covers both C++
+/// instantiations.
 #[repr(C)]
 pub struct App<const SSL: bool> {
     _p: core::cell::UnsafeCell<[u8; 0]>,
@@ -56,14 +60,15 @@ pub struct App<const SSL: bool> {
 /// Legacy name alias.
 pub type NewApp<const SSL: bool> = App<SSL>;
 
-/// Stamps one `pub fn $name(&mut self, pattern, handler, user_data)` per HTTP
-/// verb. Bodies are byte-identical modulo the C symbol — see `uws_app_get` &co
-/// in capi.rs. uWS copies `pattern` internally, so the slice need only live for
-/// the call.
+/// Stamps one `pub fn $name(&mut self, node_http, pattern, handler, user_data)`
+/// per HTTP verb. Bodies are byte-identical modulo the C symbol — see
+/// `uws_app_get` &co in capi.rs. uWS copies `pattern` internally, so the slice
+/// need only live for the call.
 macro_rules! uws_app_route_methods {
     ($($name:ident => $cfn:ident),* $(,)?) => {$(
         pub fn $name(
             &mut self,
+            node_http: bool,
             pattern: &[u8],
             handler: c::uws_method_handler,
             user_data: *mut c_void,
@@ -72,6 +77,7 @@ macro_rules! uws_app_route_methods {
             unsafe {
                 c::$cfn(
                     Self::SSL_FLAG,
+                    node_http as i32,
                     std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                     pattern.as_ptr(),
                     pattern.len(),
@@ -97,17 +103,26 @@ impl<const SSL: bool> App<SSL> {
         unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<uws_app_s>() }
     }
 
-    pub fn close(&mut self) {
-        c::uws_app_close(Self::SSL_FLAG, self.as_raw())
+    pub fn close(&mut self, node_http: bool) {
+        c::uws_app_close(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
-    pub fn close_idle_connections(&mut self) {
-        c::uws_app_close_idle(Self::SSL_FLAG, self.as_raw())
+    pub fn close_idle_connections(&mut self, node_http: bool) {
+        c::uws_app_close_idle(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
-    pub fn create(opts: &BunSocketContextOptions) -> Option<*mut Self> {
-        // SAFETY: FFI call; uws_create_app returns null on failure.
-        let app = unsafe { c::uws_create_app(Self::SSL_FLAG, *opts) };
+    /// Create a `TemplatedApp<SSL, NODE_HTTP>`. `node_http` picks the C++
+    /// template instantiation: `false` for Bun.serve (no per-socket node-compat
+    /// state), `true` for the node:http compat server.
+    pub fn create(opts: &BunSocketContextOptions, node_http: bool) -> Option<*mut Self> {
+        // SAFETY: FFI call; both return null on failure.
+        let app = unsafe {
+            if node_http {
+                c::uws_create_app_node_http(Self::SSL_FLAG, *opts)
+            } else {
+                c::uws_create_app(Self::SSL_FLAG, *opts)
+            }
+        };
         if app.is_null() {
             None
         } else {
@@ -117,14 +132,22 @@ impl<const SSL: bool> App<SSL> {
 
     /// # Safety
     /// `this` must be a live app handle from [`App::create`]. Caller must not use it after.
+    /// `node_http` must match the value passed to `create`.
     /// (FFI destroy on an opaque C-owned handle — intentionally not `Drop`.)
-    pub unsafe fn destroy(this: *mut Self) {
-        // SAFETY: caller contract — `this` is a valid *mut uws_app_s; ssl flag matches construction.
-        unsafe { c::uws_app_destroy(Self::SSL_FLAG, this.cast::<uws_app_t>()) }
+    pub unsafe fn destroy(this: *mut Self, node_http: bool) {
+        // SAFETY: caller contract — `this` is a valid *mut uws_app_s; ssl/node_http flags match construction.
+        unsafe {
+            if node_http {
+                c::uws_app_destroy_node_http(Self::SSL_FLAG, this.cast::<uws_app_t>())
+            } else {
+                c::uws_app_destroy(Self::SSL_FLAG, this.cast::<uws_app_t>())
+            }
+        }
     }
 
     pub fn set_flags(
         &mut self,
+        node_http: bool,
         require_host_header: bool,
         use_strict_method_validation: bool,
         use_insecure_http_parser: bool,
@@ -132,6 +155,7 @@ impl<const SSL: bool> App<SSL> {
     ) {
         c::uws_app_set_flags(
             Self::SSL_FLAG,
+            node_http as i32,
             self.as_raw(),
             require_host_header,
             use_strict_method_validation,
@@ -140,16 +164,22 @@ impl<const SSL: bool> App<SSL> {
         )
     }
 
-    pub fn set_max_http_header_size(&mut self, max_header_size: u64) {
-        c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
+    pub fn set_max_http_header_size(&mut self, node_http: bool, max_header_size: u64) {
+        c::uws_app_set_max_http_header_size(
+            Self::SSL_FLAG,
+            node_http as i32,
+            self.as_raw(),
+            max_header_size,
+        )
     }
 
-    pub fn clear_routes(&mut self) {
-        c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
+    pub fn clear_routes(&mut self, node_http: bool) {
+        c::uws_app_clear_routes(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
     pub fn publish_with_options(
         &mut self,
+        node_http: bool,
         topic: &[u8],
         message: &[u8],
         opcode: Opcode,
@@ -159,6 +189,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe {
             c::uws_publish(
                 SSL as i32,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 topic.as_ptr(),
                 topic.len(),
@@ -204,48 +235,57 @@ impl<const SSL: bool> App<SSL> {
     /// Alias matching uWS C++ `del()` naming (Rust `delete` is not reserved, but callers
     /// porting from uWS expect `del`).
     #[inline]
-    pub fn del(&mut self, pattern: &[u8], handler: c::uws_method_handler, user_data: *mut c_void) {
-        self.delete(pattern, handler, user_data)
+    pub fn del(
+        &mut self,
+        node_http: bool,
+        pattern: &[u8],
+        handler: c::uws_method_handler,
+        user_data: *mut c_void,
+    ) {
+        self.delete(node_http, pattern, handler, user_data)
     }
 
     pub fn method(
         &mut self,
+        node_http: bool,
         method_: Method,
         pattern: &[u8],
         handler: c::uws_method_handler,
         user_data: *mut c_void,
     ) {
         match method_ {
-            Method::GET => self.get(pattern, handler, user_data),
-            Method::POST => self.post(pattern, handler, user_data),
-            Method::PUT => self.put(pattern, handler, user_data),
-            Method::DELETE => self.delete(pattern, handler, user_data),
-            Method::PATCH => self.patch(pattern, handler, user_data),
-            Method::OPTIONS => self.options(pattern, handler, user_data),
-            Method::HEAD => self.head(pattern, handler, user_data),
-            Method::CONNECT => self.connect(pattern, handler, user_data),
-            Method::TRACE => self.trace(pattern, handler, user_data),
+            Method::GET => self.get(node_http, pattern, handler, user_data),
+            Method::POST => self.post(node_http, pattern, handler, user_data),
+            Method::PUT => self.put(node_http, pattern, handler, user_data),
+            Method::DELETE => self.delete(node_http, pattern, handler, user_data),
+            Method::PATCH => self.patch(node_http, pattern, handler, user_data),
+            Method::OPTIONS => self.options(node_http, pattern, handler, user_data),
+            Method::HEAD => self.head(node_http, pattern, handler, user_data),
+            Method::CONNECT => self.connect(node_http, pattern, handler, user_data),
+            Method::TRACE => self.trace(node_http, pattern, handler, user_data),
             _ => {}
         }
     }
 
-    pub fn domain(&mut self, pattern: &ZStr) {
+    pub fn domain(&mut self, node_http: bool, pattern: &ZStr) {
         // SAFETY: pattern is NUL-terminated; self is a valid app.
         unsafe {
             c::uws_app_domain(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 pattern.as_ptr().cast(),
             )
         }
     }
 
-    pub fn run(&mut self) {
-        c::uws_app_run(Self::SSL_FLAG, self.as_raw())
+    pub fn run(&mut self, node_http: bool) {
+        c::uws_app_run(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
     pub fn listen(
         &mut self,
+        node_http: bool,
         port: i32,
         handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
         user_data: *mut c_void,
@@ -253,6 +293,7 @@ impl<const SSL: bool> App<SSL> {
         // Callers supply the C-ABI shim directly (see the RouteHandler note above).
         c::uws_app_listen(
             Self::SSL_FLAG,
+            node_http as i32,
             self.as_raw(),
             port,
             Some(handler),
@@ -271,6 +312,7 @@ impl<const SSL: bool> App<SSL> {
 
     pub fn listen_with_config(
         &mut self,
+        node_http: bool,
         handler: c::uws_listen_handler,
         user_data: *mut c_void,
         config: c::uws_app_listen_config_t,
@@ -280,6 +322,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe {
             c::uws_app_listen_with_config(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 config.host,
                 u16::try_from(config.port).expect("int cast"),
@@ -292,6 +335,7 @@ impl<const SSL: bool> App<SSL> {
 
     pub fn listen_on_unix_socket(
         &mut self,
+        node_http: bool,
         handler: extern "C" fn(*mut UwsListenSocket, *const c_char, i32, *mut c_void),
         user_data: *mut c_void,
         domain_name: &ZStr,
@@ -302,6 +346,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe {
             c::uws_app_listen_domain_with_options(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 domain_name.as_ptr().cast(),
                 domain_name.len(),
@@ -312,15 +357,16 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    pub fn constructor_failed(&mut self) -> bool {
-        c::uws_constructor_failed(Self::SSL_FLAG, self.as_raw())
+    pub fn constructor_failed(&mut self, node_http: bool) -> bool {
+        c::uws_constructor_failed(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
-    pub fn num_subscribers(&mut self, topic: &[u8]) -> u32 {
+    pub fn num_subscribers(&mut self, node_http: bool, topic: &[u8]) -> u32 {
         // SAFETY: self is a valid app; topic valid for the call.
         unsafe {
             c::uws_num_subscribers(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 topic.as_ptr(),
                 topic.len(),
@@ -330,6 +376,7 @@ impl<const SSL: bool> App<SSL> {
 
     pub fn publish(
         &mut self,
+        node_http: bool,
         topic: &[u8],
         message: &[u8],
         opcode: Opcode,
@@ -339,6 +386,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe {
             c::uws_publish(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 topic.as_ptr(),
                 topic.len(),
@@ -350,26 +398,28 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    pub fn get_native_handle(&mut self) -> *mut c_void {
-        c::uws_get_native_handle(Self::SSL_FLAG, self.as_raw())
+    pub fn get_native_handle(&mut self, node_http: bool) -> *mut c_void {
+        c::uws_get_native_handle(Self::SSL_FLAG, node_http as i32, self.as_raw())
     }
 
-    pub fn remove_server_name(&mut self, hostname_pattern: &core::ffi::CStr) {
+    pub fn remove_server_name(&mut self, node_http: bool, hostname_pattern: &core::ffi::CStr) {
         // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
         unsafe {
             c::uws_remove_server_name(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 hostname_pattern.as_ptr(),
             )
         }
     }
 
-    pub fn add_server_name(&mut self, hostname_pattern: &core::ffi::CStr) {
+    pub fn add_server_name(&mut self, node_http: bool, hostname_pattern: &core::ffi::CStr) {
         // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
         unsafe {
             c::uws_add_server_name(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 hostname_pattern.as_ptr(),
             )
@@ -378,6 +428,7 @@ impl<const SSL: bool> App<SSL> {
 
     pub fn add_server_name_with_options(
         &mut self,
+        node_http: bool,
         hostname_pattern: &core::ffi::CStr,
         opts: &BunSocketContextOptions,
     ) -> Result<(), AddServerNameError> {
@@ -385,6 +436,7 @@ impl<const SSL: bool> App<SSL> {
         let rc = unsafe {
             c::uws_add_server_name_with_options(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 hostname_pattern.as_ptr(),
                 *opts,
@@ -398,10 +450,17 @@ impl<const SSL: bool> App<SSL> {
 
     pub fn missing_server_name(
         &mut self,
+        node_http: bool,
         handler: c::uws_missing_server_handler,
         user_data: *mut c_void,
     ) {
-        c::uws_missing_server_name(Self::SSL_FLAG, self.as_raw(), handler, user_data)
+        c::uws_missing_server_name(
+            Self::SSL_FLAG,
+            node_http as i32,
+            self.as_raw(),
+            handler,
+            user_data,
+        )
     }
 
     /// Register a connection filter: `handler` is invoked with the raw
@@ -409,14 +468,22 @@ impl<const SSL: bool> App<SSL> {
     /// its handshake completes) and `-1` when it closes.
     pub fn filter(
         &mut self,
+        node_http: bool,
         handler: extern "C" fn(*mut us_socket_t, i32, *mut c_void),
         user_data: *mut c_void,
     ) {
-        c::uws_filter(Self::SSL_FLAG, self.as_raw(), Some(handler), user_data)
+        c::uws_filter(
+            Self::SSL_FLAG,
+            node_http as i32,
+            self.as_raw(),
+            Some(handler),
+            user_data,
+        )
     }
 
     pub fn ws(
         &mut self,
+        node_http: bool,
         pattern: &[u8],
         ctx: *mut c_void,
         id: usize,
@@ -427,6 +494,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe {
             uws_ws(
                 Self::SSL_FLAG,
+                node_http as i32,
                 std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
                 ctx,
                 pattern.as_ptr(),
@@ -513,11 +581,12 @@ pub mod c {
     pub(crate) type uws_missing_server_handler = Option<extern "C" fn(*const c_char, *mut c_void)>;
 
     unsafe extern "C" {
-        pub(crate) safe fn uws_app_close(ssl: i32, app: &mut uws_app_s);
-        pub(crate) safe fn uws_app_close_idle(ssl: i32, app: &mut uws_app_s);
+        pub(crate) safe fn uws_app_close(ssl: i32, node_http: i32, app: &mut uws_app_s);
+        pub(crate) safe fn uws_app_close_idle(ssl: i32, node_http: i32, app: &mut uws_app_s);
         // safe: `&mut uws_app_s` is ABI-identical to a non-null `*mut`;
         // `handler`/`user_data` are stored opaquely (never dereferenced by the
-        // C++ shim itself) — no preconditions on this call.
+        // C++ shim itself) — no preconditions on this call. node:http-only —
+        // C shim hardcodes NODE_HTTP=true.
         pub(crate) safe fn uws_app_set_on_clienterror(
             ssl: c_int,
             app: &mut uws_app_s,
@@ -525,9 +594,15 @@ pub mod c {
             user_data: *mut c_void,
         );
         pub(crate) fn uws_create_app(ssl: i32, options: BunSocketContextOptions) -> *mut uws_app_t;
+        pub(crate) fn uws_create_app_node_http(
+            ssl: i32,
+            options: BunSocketContextOptions,
+        ) -> *mut uws_app_t;
         pub(crate) fn uws_app_destroy(ssl: i32, app: *mut uws_app_t);
+        pub(crate) fn uws_app_destroy_node_http(ssl: i32, app: *mut uws_app_t);
         pub(crate) safe fn uws_app_set_flags(
             ssl: i32,
+            node_http: i32,
             app: &mut uws_app_t,
             require_host_header: bool,
             use_strict_method_validation: bool,
@@ -536,11 +611,13 @@ pub mod c {
         );
         pub(crate) safe fn uws_app_set_max_http_header_size(
             ssl: i32,
+            node_http: i32,
             app: &mut uws_app_t,
             max_header_size: u64,
         );
         pub(crate) fn uws_app_get(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -549,6 +626,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_post(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -557,6 +635,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_options(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -565,6 +644,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_delete(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -573,6 +653,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_patch(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -581,6 +662,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_put(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -589,6 +671,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_head(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -597,6 +680,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_connect(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -605,6 +689,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_trace(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
@@ -613,18 +698,25 @@ pub mod c {
         );
         pub(crate) fn uws_app_any(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
             user_data: *mut c_void,
         );
-        pub(crate) safe fn uws_app_run(ssl: i32, app: &mut uws_app_t);
-        pub(crate) fn uws_app_domain(ssl: i32, app: *mut uws_app_t, domain: *const c_char);
+        pub(crate) safe fn uws_app_run(ssl: i32, node_http: i32, app: &mut uws_app_t);
+        pub(crate) fn uws_app_domain(
+            ssl: i32,
+            node_http: i32,
+            app: *mut uws_app_t,
+            domain: *const c_char,
+        );
         // safe: handle-only + value `port`; `handler`/`user_data` are stored
         // opaquely — no preconditions on this call.
         pub(crate) safe fn uws_app_listen(
             ssl: i32,
+            node_http: i32,
             app: &mut uws_app_t,
             port: i32,
             handler: uws_listen_handler,
@@ -632,6 +724,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_listen_with_config(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             host: *const c_char,
             port: u16,
@@ -639,15 +732,21 @@ pub mod c {
             handler: uws_listen_handler,
             user_data: *mut c_void,
         );
-        pub(crate) safe fn uws_constructor_failed(ssl: i32, app: &mut uws_app_t) -> bool;
+        pub(crate) safe fn uws_constructor_failed(
+            ssl: i32,
+            node_http: i32,
+            app: &mut uws_app_t,
+        ) -> bool;
         pub(crate) fn uws_num_subscribers(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             topic: *const u8,
             topic_length: usize,
         ) -> c_uint;
         pub(crate) fn uws_publish(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             topic: *const u8,
             topic_length: usize,
@@ -660,31 +759,40 @@ pub mod c {
         // `&mut uws_app_s` is ABI-identical to the C `uws_app_t*` (non-null,
         // no `noalias`/`readonly`). The C++ body only reads `app->getNativeHandle()`
         // — no preconditions beyond a live handle.
-        pub(crate) safe fn uws_get_native_handle(ssl: i32, app: &mut uws_app_s) -> *mut c_void;
+        pub(crate) safe fn uws_get_native_handle(
+            ssl: i32,
+            node_http: i32,
+            app: &mut uws_app_s,
+        ) -> *mut c_void;
         pub(crate) fn uws_remove_server_name(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             hostname_pattern: *const c_char,
         );
         pub(crate) fn uws_add_server_name(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             hostname_pattern: *const c_char,
         );
         pub(crate) fn uws_add_server_name_with_options(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             hostname_pattern: *const c_char,
             options: BunSocketContextOptions,
         ) -> i32;
         pub(crate) safe fn uws_missing_server_name(
             ssl: i32,
+            node_http: i32,
             app: &mut uws_app_t,
             handler: uws_missing_server_handler,
             user_data: *mut c_void,
         );
         pub(crate) safe fn uws_filter(
             ssl: i32,
+            node_http: i32,
             app: &mut uws_app_t,
             handler: uws_filter_handler,
             user_data: *mut c_void,
@@ -692,6 +800,7 @@ pub mod c {
 
         pub(crate) fn uws_app_listen_domain_with_options(
             ssl_flag: c_int,
+            node_http: c_int,
             app: *mut uws_app_t,
             domain: *const c_char,
             pathlen: usize,
@@ -700,7 +809,7 @@ pub mod c {
             user_data: *mut c_void,
         );
 
-        pub(crate) safe fn uws_app_clear_routes(ssl_flag: c_int, app: &mut uws_app_t);
+        pub(crate) safe fn uws_app_clear_routes(ssl_flag: c_int, node_http: c_int, app: &mut uws_app_t);
     }
 
     #[repr(C)]

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -960,11 +960,21 @@ impl AnyResponse {
     }
 
     pub fn get_native_handle(self) -> Fd {
-        match self.kind {
-            AnyResponseKind::H3(_) => bun_core::Fd::INVALID,
-            AnyResponseKind::SSL(ptr) => TLSResponse::as_handle(ptr).get_native_handle(),
-            AnyResponseKind::TCP(ptr) => TCPResponse::as_handle(ptr).get_native_handle(),
+        match (self.kind, self.is_node_http) {
+            (AnyResponseKind::H3(_), _) => bun_core::Fd::INVALID,
+            (AnyResponseKind::SSL(ptr), false) => TLSResponse::as_handle(ptr).get_native_handle(),
+            (AnyResponseKind::SSL(ptr), true) => {
+                TLSNodeResponse::as_handle(ptr.cast()).get_native_handle()
+            }
+            (AnyResponseKind::TCP(ptr), false) => TCPResponse::as_handle(ptr).get_native_handle(),
+            (AnyResponseKind::TCP(ptr), true) => {
+                TCPNodeResponse::as_handle(ptr.cast()).get_native_handle()
+            }
         }
+    }
+
+    pub fn override_write_offset(self, offset: u64) {
+        any_dispatch!(self, |r| r.override_write_offset(offset))
     }
 
     pub fn prepare_for_sendfile(self) {

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -68,25 +68,32 @@ bun_opaque::opaque_ffi! {
     pub struct WebSocketUpgradeContext;
 }
 
-/// Opaque handle for `uws::Response<SSL>`.
+/// Opaque handle for `uws::HttpResponse<SSL, NODE_HTTP>`.
 ///
-/// The SSL flag is modeled as a `const SSL: bool` parameter on an opaque
-/// extern type (Nomicon pattern).
+/// Both flags are const parameters on an opaque extern type. `NODE_HTTP`
+/// selects the C++ `HttpResponseData<SSL, true>` node:http-compat layout vs
+/// the leaner `<SSL, false>` Bun.serve layout; the default keeps existing
+/// `Response<SSL>` uses at NODE_HTTP=false.
 #[repr(C)]
-pub struct Response<const SSL: bool> {
+pub struct Response<const SSL: bool, const NODE_HTTP: bool = false> {
     _p: core::cell::UnsafeCell<[u8; 0]>,
     _m: PhantomData<(*mut u8, PhantomPinned)>,
 }
 
-impl<const SSL: bool> Response<SSL> {
+impl<const SSL: bool, const NODE_HTTP: bool> Response<SSL, NODE_HTTP> {
     #[inline(always)]
     const fn ssl_flag() -> i32 {
         SSL as i32
     }
 
+    #[inline(always)]
+    const fn node_http_flag() -> i32 {
+        NODE_HTTP as i32
+    }
+
     #[inline]
-    pub fn cast_res(res: *mut c::uws_res) -> *mut Response<SSL> {
-        res.cast::<Response<SSL>>()
+    pub fn cast_res(res: *mut c::uws_res) -> *mut Response<SSL, NODE_HTTP> {
+        res.cast::<Response<SSL, NODE_HTTP>>()
     }
 
     #[inline]
@@ -115,6 +122,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_end(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 data.as_ptr(),
                 data.len(),
@@ -128,6 +136,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_try_end(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 data.as_ptr(),
                 data.len(),
@@ -146,19 +155,21 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn flush_headers(&mut self, flush_immediately: bool) {
-        c::uws_res_flush_headers(Self::ssl_flag(), self.as_raw(), flush_immediately)
+        c::uws_res_flush_headers(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), flush_immediately)
     }
 
     pub fn is_corked(&mut self) -> bool {
-        c::uws_res_is_corked(Self::ssl_flag(), self.as_raw())
+        c::uws_res_is_corked(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn state(&self) -> State {
         // SAFETY: `Response<SSL>` and `c::uws_res` are layout-identical opaque
         // ZSTs (both `UnsafeCell<[u8; 0]>`); the reborrow is a no-op cast.
-        c::uws_res_state(Self::ssl_flag() as c_int, unsafe {
-            &*std::ptr::from_ref::<Self>(self).cast::<c::uws_res>()
-        })
+        c::uws_res_state(
+            Self::ssl_flag() as c_int,
+            Self::node_http_flag() as c_int,
+            unsafe { &*std::ptr::from_ref::<Self>(self).cast::<c::uws_res>() },
+        )
     }
 
     pub fn should_close_connection(&self) -> bool {
@@ -166,23 +177,23 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn prepare_for_sendfile(&mut self) {
-        c::uws_res_prepare_for_sendfile(Self::ssl_flag(), self.as_raw())
+        c::uws_res_prepare_for_sendfile(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn uncork(&mut self) {
-        c::uws_res_uncork(Self::ssl_flag(), self.as_raw())
+        c::uws_res_uncork(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn pause(&mut self) {
-        c::uws_res_pause(Self::ssl_flag(), self.as_raw())
+        c::uws_res_pause(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn resume_(&mut self) {
-        c::uws_res_resume(Self::ssl_flag(), self.as_raw())
+        c::uws_res_resume(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn write_continue(&mut self) {
-        c::uws_res_write_continue(Self::ssl_flag(), self.as_raw())
+        c::uws_res_write_continue(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn write_informational(&mut self, data: &[u8]) {
@@ -202,6 +213,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_write_status(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 status.as_ptr(),
                 status.len(),
@@ -214,6 +226,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_write_header(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 key.as_ptr(),
                 key.len(),
@@ -228,6 +241,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_write_header_int(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 key.as_ptr(),
                 key.len(),
@@ -237,12 +251,13 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn end_without_body(&mut self, close_connection: bool) {
-        c::uws_res_end_without_body(Self::ssl_flag(), self.as_raw(), close_connection)
+        c::uws_res_end_without_body(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), close_connection)
     }
 
     pub fn end_send_file(&mut self, write_offset: u64, close_connection: bool) {
         c::uws_res_end_sendfile(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
             write_offset,
             close_connection,
@@ -250,15 +265,15 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn timeout(&mut self, seconds: u8) {
-        c::uws_res_timeout(Self::ssl_flag(), self.as_raw(), seconds)
+        c::uws_res_timeout(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), seconds)
     }
 
     pub fn reset_timeout(&mut self) {
-        c::uws_res_reset_timeout(Self::ssl_flag(), self.as_raw())
+        c::uws_res_reset_timeout(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn get_buffered_amount(&mut self) -> u64 {
-        c::uws_res_get_buffered_amount(Self::ssl_flag(), self.as_raw())
+        c::uws_res_get_buffered_amount(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn write(&mut self, data: &[u8]) -> WriteResult {
@@ -267,6 +282,7 @@ impl<const SSL: bool> Response<SSL> {
         match unsafe {
             c::uws_res_write(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 data.as_ptr(),
                 &raw mut len,
@@ -278,7 +294,7 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn get_write_offset(&mut self) -> u64 {
-        c::uws_res_get_write_offset(Self::ssl_flag(), self.as_raw())
+        c::uws_res_get_write_offset(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn override_write_offset<T>(&mut self, offset: T)
@@ -288,21 +304,22 @@ impl<const SSL: bool> Response<SSL> {
     {
         c::uws_res_override_write_offset(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
             u64::try_from(offset).expect("int cast"),
         )
     }
 
     pub fn has_responded(&mut self) -> bool {
-        c::uws_res_has_responded(Self::ssl_flag(), self.as_raw())
+        c::uws_res_has_responded(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn mark_wrote_content_length_header(&mut self) {
-        c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
+        c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn write_mark(&mut self) {
-        c::uws_res_write_mark(Self::ssl_flag(), self.as_raw())
+        c::uws_res_write_mark(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     pub fn get_native_handle(&mut self) -> Fd {
@@ -312,7 +329,7 @@ impl<const SSL: bool> Response<SSL> {
             // value; tag kind=system via `from_system` (masks bit 63) so
             // `INVALID_SOCKET` (~0) doesn't decode as kind=uv.
             return Fd::from_system(
-                c::uws_res_get_native_handle(Self::ssl_flag(), self.as_raw())
+                c::uws_res_get_native_handle(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
                     as *mut core::ffi::c_void,
             );
         }
@@ -320,7 +337,7 @@ impl<const SSL: bool> Response<SSL> {
         {
             Fd::from_native(
                 c_int::try_from(
-                    c::uws_res_get_native_handle(Self::ssl_flag(), self.as_raw()) as usize,
+                    c::uws_res_get_native_handle(Self::ssl_flag(), Self::node_http_flag(), self.as_raw()) as usize,
                 )
                 .unwrap(),
             )
@@ -329,7 +346,7 @@ impl<const SSL: bool> Response<SSL> {
 
     pub fn get_remote_address_as_text(&mut self) -> Option<&[u8]> {
         let mut buf: *const u8 = core::ptr::null();
-        let size = c::uws_res_get_remote_address_as_text(Self::ssl_flag(), self.as_raw(), &mut buf);
+        let size = c::uws_res_get_remote_address_as_text(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), &mut buf);
         if size > 0 {
             // SAFETY: uws populated `buf` with `size` bytes valid while the response lives.
             Some(unsafe { bun_core::ffi::slice(buf, size) })
@@ -368,17 +385,17 @@ impl<const SSL: bool> Response<SSL> {
     /// handler is baked in with no runtime storage.
     pub fn on_writable<U, H>(&mut self, _handler: H, user_data: *mut U)
     where
-        H: Fn(*mut U, u64, &mut Response<SSL>) -> bool + Copy + 'static,
+        H: Fn(*mut U, u64, &mut Response<SSL, NODE_HTTP>) -> bool + Copy + 'static,
     {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
         // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn handle<U, H, const SSL: bool>(
+        extern "C" fn handle<U, H, const SSL: bool, const NODE_HTTP: bool>(
             this: *mut c::uws_res,
             amount: u64,
             data: *mut c_void,
         ) -> bool
         where
-            H: Fn(*mut U, u64, &mut Response<SSL>) -> bool + Copy + 'static,
+            H: Fn(*mut U, u64, &mut Response<SSL, NODE_HTTP>) -> bool + Copy + 'static,
         {
             // null user-data is always a no-op.
             if data.is_null() {
@@ -390,20 +407,21 @@ impl<const SSL: bool> Response<SSL> {
                 thunk::zst::<H>()(
                     data.cast::<U>(),
                     amount,
-                    thunk::handle_mut(Response::<SSL>::cast_res(this)),
+                    thunk::handle_mut(Response::<SSL, NODE_HTTP>::cast_res(this)),
                 )
             }
         }
         c::uws_res_on_writable(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
-            Some(handle::<U, H, SSL>),
+            Some(handle::<U, H, SSL, NODE_HTTP>),
             user_data.cast(),
         );
     }
 
     pub fn clear_on_writable(&mut self) {
-        c::uws_res_clear_on_writable(Self::ssl_flag(), self.as_raw())
+        c::uws_res_clear_on_writable(Self::ssl_flag(), Self::node_http_flag(), self.as_raw())
     }
 
     #[inline]
@@ -415,13 +433,15 @@ impl<const SSL: bool> Response<SSL> {
 
     pub fn on_aborted<U, H>(&mut self, _handler: H, optional_data: *mut U)
     where
-        H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
+        H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>) + Copy + 'static,
     {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
         // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn handle<U, H, const SSL: bool>(this: *mut c::uws_res, user_data: *mut c_void)
-        where
-            H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
+        extern "C" fn handle<U, H, const SSL: bool, const NODE_HTTP: bool>(
+            this: *mut c::uws_res,
+            user_data: *mut c_void,
+        ) where
+            H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>) + Copy + 'static,
         {
             // null user-data is always a no-op.
             if user_data.is_null() {
@@ -432,31 +452,34 @@ impl<const SSL: bool> Response<SSL> {
             unsafe {
                 thunk::zst::<H>()(
                     user_data.cast::<U>(),
-                    thunk::handle_mut(Response::<SSL>::cast_res(this)),
+                    thunk::handle_mut(Response::<SSL, NODE_HTTP>::cast_res(this)),
                 )
             }
         }
         c::uws_res_on_aborted(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
-            Some(handle::<U, H, SSL>),
+            Some(handle::<U, H, SSL, NODE_HTTP>),
             optional_data.cast(),
         );
     }
 
     pub fn clear_aborted(&mut self) {
-        c::uws_res_on_aborted(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
+        c::uws_res_on_aborted(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
     pub fn on_timeout<U, H>(&mut self, _handler: H, optional_data: *mut U)
     where
-        H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
+        H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>) + Copy + 'static,
     {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
         // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn handle<U, H, const SSL: bool>(this: *mut c::uws_res, user_data: *mut c_void)
-        where
-            H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
+        extern "C" fn handle<U, H, const SSL: bool, const NODE_HTTP: bool>(
+            this: *mut c::uws_res,
+            user_data: *mut c_void,
+        ) where
+            H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>) + Copy + 'static,
         {
             // null user-data is always a no-op.
             if user_data.is_null() {
@@ -467,40 +490,41 @@ impl<const SSL: bool> Response<SSL> {
             unsafe {
                 thunk::zst::<H>()(
                     user_data.cast::<U>(),
-                    thunk::handle_mut(Response::<SSL>::cast_res(this)),
+                    thunk::handle_mut(Response::<SSL, NODE_HTTP>::cast_res(this)),
                 )
             }
         }
         c::uws_res_on_timeout(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
-            Some(handle::<U, H, SSL>),
+            Some(handle::<U, H, SSL, NODE_HTTP>),
             optional_data.cast(),
         );
     }
 
     pub fn clear_timeout(&mut self) {
-        c::uws_res_on_timeout(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
+        c::uws_res_on_timeout(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
     pub fn clear_on_data(&mut self) {
-        c::uws_res_on_data(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
+        c::uws_res_on_data(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
     pub fn on_data<U, H>(&mut self, _handler: H, optional_data: *mut U)
     where
-        H: Fn(*mut U, &mut Response<SSL>, &[u8], bool) + Copy + 'static,
+        H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>, &[u8], bool) + Copy + 'static,
     {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
         // fn-pointer type passed to C; body wraps its raw-ptr ops explicitly.
-        extern "C" fn handle<U, H, const SSL: bool>(
+        extern "C" fn handle<U, H, const SSL: bool, const NODE_HTTP: bool>(
             this: *mut c::uws_res,
             chunk_ptr: *const u8,
             len: usize,
             last: bool,
             user_data: *mut c_void,
         ) where
-            H: Fn(*mut U, &mut Response<SSL>, &[u8], bool) + Copy + 'static,
+            H: Fn(*mut U, &mut Response<SSL, NODE_HTTP>, &[u8], bool) + Copy + 'static,
         {
             // null user-data is always a no-op.
             if user_data.is_null() {
@@ -511,7 +535,7 @@ impl<const SSL: bool> Response<SSL> {
             unsafe {
                 thunk::zst::<H>()(
                     user_data.cast::<U>(),
-                    thunk::handle_mut(Response::<SSL>::cast_res(this)),
+                    thunk::handle_mut(Response::<SSL, NODE_HTTP>::cast_res(this)),
                     thunk::c_slice(chunk_ptr, len),
                     last,
                 )
@@ -519,14 +543,15 @@ impl<const SSL: bool> Response<SSL> {
         }
         c::uws_res_on_data(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
-            Some(handle::<U, H, SSL>),
+            Some(handle::<U, H, SSL, NODE_HTTP>),
             optional_data.cast(),
         );
     }
 
     pub fn end_stream(&mut self, close_connection: bool) {
-        c::uws_res_end_stream(Self::ssl_flag(), self.as_raw(), close_connection)
+        c::uws_res_end_stream(Self::ssl_flag(), Self::node_http_flag(), self.as_raw(), close_connection)
     }
 
     /// Run `handler` while the response is corked.
@@ -542,6 +567,7 @@ impl<const SSL: bool> Response<SSL> {
         // cork is synchronous so the stack-allocated closure outlives the FFI call.
         c::uws_res_cork(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
             (&raw mut *f).cast::<c_void>(),
             handle::<F>,
@@ -563,6 +589,7 @@ impl<const SSL: bool> Response<SSL> {
         // cork is synchronous so the stack-allocated ctx outlives the FFI call.
         c::uws_res_cork(
             Self::ssl_flag(),
+            Self::node_http_flag(),
             self.as_raw(),
             (&raw mut ctx).cast::<c_void>(),
             handle::<U>,
@@ -581,6 +608,7 @@ impl<const SSL: bool> Response<SSL> {
         unsafe {
             c::uws_res_upgrade(
                 Self::ssl_flag(),
+                Self::node_http_flag(),
                 self.downcast(),
                 data.cast::<c_void>(),
                 sec_web_socket_key.as_ptr(),
@@ -597,19 +625,34 @@ impl<const SSL: bool> Response<SSL> {
 
 pub type TCPResponse = Response<false>;
 pub type TLSResponse = Response<true>;
+pub type TCPNodeResponse = Response<false, true>;
+pub type TLSNodeResponse = Response<true, true>;
 
-// SAFETY: `Response<SSL>` is a `#[repr(C)]` ZST (`UnsafeCell<[u8; 0]>`) with
-// align 1; C++ owns the real bytes.
-unsafe impl<const SSL: bool> OpaqueHandle for Response<SSL> {}
+// SAFETY: `Response<SSL, NODE_HTTP>` is a `#[repr(C)]` ZST
+// (`UnsafeCell<[u8; 0]>`) with align 1; C++ owns the real bytes.
+unsafe impl<const SSL: bool, const NODE_HTTP: bool> OpaqueHandle for Response<SSL, NODE_HTTP> {}
 // SAFETY: `h3::Response` is a `#[repr(C)]` ZST (`UnsafeCell<[u8; 0]>`) with
 // align 1; C++ owns the real bytes.
 unsafe impl OpaqueHandle for H3Response {}
 
+/// The transport axis of an [`AnyResponse`]. Match on `.kind()` when the typed
+/// pointer is needed; otherwise use the accessors on `AnyResponse` directly.
 #[derive(Clone, Copy)]
-pub enum AnyResponse {
+pub enum AnyResponseKind {
     SSL(*mut TLSResponse),
     TCP(*mut TCPResponse),
     H3(*mut H3Response),
+}
+
+/// Type-erased uWS response handle carrying both the transport (`kind`) and the
+/// C++ `NODE_HTTP` template discriminant. `is_node_http` selects the
+/// `HttpResponseData<SSL, true>` instantiation (node:http compat layer) vs
+/// `<SSL, false>` (Bun.serve). H3 has no node:http path so its flag is always
+/// false.
+#[derive(Clone, Copy)]
+pub struct AnyResponse {
+    kind: AnyResponseKind,
+    is_node_http: bool,
 }
 
 // Helper: dispatch to the underlying response, calling the same-named method on each
@@ -620,16 +663,24 @@ pub enum AnyResponse {
 // construction and needs no `unsafe` at the dispatch site.
 macro_rules! any_dispatch {
     ($self:expr, |$r:ident| $body:expr) => {
-        match $self {
-            AnyResponse::SSL(ptr) => {
+        match ($self.kind, $self.is_node_http) {
+            (AnyResponseKind::SSL(ptr), false) => {
                 let $r = TLSResponse::as_handle(ptr);
                 $body
             }
-            AnyResponse::TCP(ptr) => {
+            (AnyResponseKind::SSL(ptr), true) => {
+                let $r = TLSNodeResponse::as_handle(ptr.cast());
+                $body
+            }
+            (AnyResponseKind::TCP(ptr), false) => {
                 let $r = TCPResponse::as_handle(ptr);
                 $body
             }
-            AnyResponse::H3(ptr) => {
+            (AnyResponseKind::TCP(ptr), true) => {
+                let $r = TCPNodeResponse::as_handle(ptr.cast());
+                $body
+            }
+            (AnyResponseKind::H3(ptr), _) => {
                 let $r = H3Response::as_handle(ptr);
                 $body
             }
@@ -661,41 +712,107 @@ macro_rules! any_response_register_cb {
         { $($body:tt)* }
     ) => {{
         const { assert!(core::mem::size_of::<$H>() == 0, "handler must be a fn item or capture-less closure") };
-        fn ssl<$U, $H: $($bound)*>($u: *mut $U $(, $pre: $pre_ty)*, $r: &mut TLSResponse $(, $post: $post_ty)*) -> $ret {
-            let $any = AnyResponse::SSL(std::ptr::from_mut($r));
+        fn ssl<$U, $H: $($bound)*, const N: bool>($u: *mut $U $(, $pre: $pre_ty)*, $r: &mut Response<true, N> $(, $post: $post_ty)*) -> $ret {
+            let $any = AnyResponse { kind: AnyResponseKind::SSL(std::ptr::from_mut($r).cast()), is_node_http: N };
             $($body)*
         }
-        fn tcp<$U, $H: $($bound)*>($u: *mut $U $(, $pre: $pre_ty)*, $r: &mut TCPResponse $(, $post: $post_ty)*) -> $ret {
-            let $any = AnyResponse::TCP(std::ptr::from_mut($r));
+        fn tcp<$U, $H: $($bound)*, const N: bool>($u: *mut $U $(, $pre: $pre_ty)*, $r: &mut Response<false, N> $(, $post: $post_ty)*) -> $ret {
+            let $any = AnyResponse { kind: AnyResponseKind::TCP(std::ptr::from_mut($r).cast()), is_node_http: N };
             $($body)*
         }
         fn h3<$U, $H: $($bound)*>($u: &mut $U $(, $pre: $pre_ty)*, $r: &mut H3Response $(, $post: $post_ty)*) -> $ret {
             let $u = std::ptr::from_mut::<$U>($u);
-            let $any = AnyResponse::H3(std::ptr::from_mut($r));
+            let $any = AnyResponse { kind: AnyResponseKind::H3(std::ptr::from_mut($r)), is_node_http: false };
             $($body)*
         }
-        match $self {
-            AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).$method(ssl::<$U, $H>, $opt_data),
-            AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).$method(tcp::<$U, $H>, $opt_data),
-            AnyResponse::H3(ptr) => H3Response::as_handle(ptr).$method(h3::<$U, $H>, $opt_data),
+        match ($self.kind, $self.is_node_http) {
+            (AnyResponseKind::SSL(ptr), true) => TLSNodeResponse::as_handle(ptr.cast()).$method(ssl::<$U, $H, true>, $opt_data),
+            (AnyResponseKind::SSL(ptr), false) => TLSResponse::as_handle(ptr).$method(ssl::<$U, $H, false>, $opt_data),
+            (AnyResponseKind::TCP(ptr), true) => TCPNodeResponse::as_handle(ptr.cast()).$method(tcp::<$U, $H, true>, $opt_data),
+            (AnyResponseKind::TCP(ptr), false) => TCPResponse::as_handle(ptr).$method(tcp::<$U, $H, false>, $opt_data),
+            (AnyResponseKind::H3(ptr), _) => H3Response::as_handle(ptr).$method(h3::<$U, $H>, $opt_data),
         }
     }};
 }
 
+#[allow(non_snake_case)]
 impl AnyResponse {
+    // ── constructors ────────────────────────────────────────────────────────
+    // Named to match the old enum variants so existing construction sites
+    // (`AnyResponse::SSL(ptr)` etc.) keep compiling. Bun.serve paths use these
+    // and get `is_node_http = false`.
+    #[inline]
+    pub const fn SSL(ptr: *mut TLSResponse) -> Self {
+        Self { kind: AnyResponseKind::SSL(ptr), is_node_http: false }
+    }
+    #[inline]
+    pub const fn TCP(ptr: *mut TCPResponse) -> Self {
+        Self { kind: AnyResponseKind::TCP(ptr), is_node_http: false }
+    }
+    #[inline]
+    pub const fn H3(ptr: *mut H3Response) -> Self {
+        Self { kind: AnyResponseKind::H3(ptr), is_node_http: false }
+    }
+    /// node:http compat: response backed by `HttpResponseData<true, true>`.
+    #[inline]
+    pub const fn SSL_node(ptr: *mut TLSResponse) -> Self {
+        Self { kind: AnyResponseKind::SSL(ptr), is_node_http: true }
+    }
+    /// node:http compat: response backed by `HttpResponseData<false, true>`.
+    #[inline]
+    pub const fn TCP_node(ptr: *mut TCPResponse) -> Self {
+        Self { kind: AnyResponseKind::TCP(ptr), is_node_http: true }
+    }
+
+    // ── accessors ───────────────────────────────────────────────────────────
+    #[inline]
+    pub const fn kind(self) -> AnyResponseKind {
+        self.kind
+    }
+    #[inline]
+    pub const fn is_node_http(self) -> bool {
+        self.is_node_http
+    }
+    #[inline]
+    pub const fn node_http_flag(self) -> i32 {
+        self.is_node_http as i32
+    }
+    #[inline]
+    pub const fn is_ssl(self) -> bool {
+        matches!(self.kind, AnyResponseKind::SSL(_))
+    }
+    #[inline]
+    pub const fn is_tcp(self) -> bool {
+        matches!(self.kind, AnyResponseKind::TCP(_))
+    }
+    #[inline]
+    pub const fn is_h3(self) -> bool {
+        matches!(self.kind, AnyResponseKind::H3(_))
+    }
+    /// Untyped uWS response handle (all three variants are the same C++
+    /// pointer under the cast).
+    #[inline]
+    pub fn as_raw_ptr(self) -> *mut c_void {
+        match self.kind {
+            AnyResponseKind::SSL(p) => p.cast::<c_void>(),
+            AnyResponseKind::TCP(p) => p.cast::<c_void>(),
+            AnyResponseKind::H3(p) => p.cast::<c_void>(),
+        }
+    }
+
     pub fn assert_ssl(self) -> *mut TLSResponse {
-        match self {
-            AnyResponse::SSL(resp) => resp,
-            AnyResponse::TCP(_) => panic!("Expected SSL response, got TCP response"),
-            AnyResponse::H3(_) => panic!("Expected SSL response, got H3 response"),
+        match self.kind {
+            AnyResponseKind::SSL(resp) => resp,
+            AnyResponseKind::TCP(_) => panic!("Expected SSL response, got TCP response"),
+            AnyResponseKind::H3(_) => panic!("Expected SSL response, got H3 response"),
         }
     }
 
     pub fn assert_no_ssl(self) -> *mut TCPResponse {
-        match self {
-            AnyResponse::SSL(_) => panic!("Expected TCP response, got SSL response"),
-            AnyResponse::TCP(resp) => resp,
-            AnyResponse::H3(_) => panic!("Expected TCP response, got H3 response"),
+        match self.kind {
+            AnyResponseKind::SSL(_) => panic!("Expected TCP response, got SSL response"),
+            AnyResponseKind::TCP(resp) => resp,
+            AnyResponseKind::H3(_) => panic!("Expected TCP response, got H3 response"),
         }
     }
 
@@ -716,10 +833,10 @@ impl AnyResponse {
     }
 
     pub fn socket(self) -> *mut c::uws_res {
-        match self {
-            AnyResponse::H3(_) => panic!("socket() is not available for HTTP/3 responses"),
-            AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).downcast(),
-            AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).downcast(),
+        match self.kind {
+            AnyResponseKind::H3(_) => panic!("socket() is not available for HTTP/3 responses"),
+            AnyResponseKind::SSL(ptr) => TLSResponse::as_handle(ptr).downcast(),
+            AnyResponseKind::TCP(ptr) => TCPResponse::as_handle(ptr).downcast(),
         }
     }
 
@@ -828,25 +945,25 @@ impl AnyResponse {
     }
 
     pub fn force_close(self) {
-        match self {
-            AnyResponse::SSL(ptr) => {
+        match self.kind {
+            AnyResponseKind::SSL(ptr) => {
                 // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
                 us_socket_t::opaque_mut(TLSResponse::as_handle(ptr).downcast_socket())
                     .close(crate::us_socket::CloseCode::failure);
             }
-            AnyResponse::TCP(ptr) => {
+            AnyResponseKind::TCP(ptr) => {
                 us_socket_t::opaque_mut(TCPResponse::as_handle(ptr).downcast_socket())
                     .close(crate::us_socket::CloseCode::failure);
             }
-            AnyResponse::H3(ptr) => H3Response::as_handle(ptr).force_close(),
+            AnyResponseKind::H3(ptr) => H3Response::as_handle(ptr).force_close(),
         }
     }
 
     pub fn get_native_handle(self) -> Fd {
-        match self {
-            AnyResponse::H3(_) => bun_core::Fd::INVALID,
-            AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).get_native_handle(),
-            AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).get_native_handle(),
+        match self.kind {
+            AnyResponseKind::H3(_) => bun_core::Fd::INVALID,
+            AnyResponseKind::SSL(ptr) => TLSResponse::as_handle(ptr).get_native_handle(),
+            AnyResponseKind::TCP(ptr) => TCPResponse::as_handle(ptr).get_native_handle(),
         }
     }
 
@@ -935,19 +1052,33 @@ impl AnyResponse {
         sec_web_socket_extensions: &[u8],
         ctx: Option<&mut WebSocketUpgradeContext>,
     ) -> *mut Socket {
-        match self {
+        match (self.kind, self.is_node_http) {
             // server.upgrade() returns false before reaching here for H3
             // (request_context.get(RequestContext) is null — the H3 ctx is a
             // different type and upgrade_context is never set).
-            AnyResponse::H3(_) => unreachable!(),
-            AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).upgrade(
+            (AnyResponseKind::H3(_), _) => unreachable!(),
+            (AnyResponseKind::SSL(ptr), false) => TLSResponse::as_handle(ptr).upgrade(
                 data,
                 sec_web_socket_key,
                 sec_web_socket_protocol,
                 sec_web_socket_extensions,
                 ctx,
             ),
-            AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).upgrade(
+            (AnyResponseKind::SSL(ptr), true) => TLSNodeResponse::as_handle(ptr.cast()).upgrade(
+                data,
+                sec_web_socket_key,
+                sec_web_socket_protocol,
+                sec_web_socket_extensions,
+                ctx,
+            ),
+            (AnyResponseKind::TCP(ptr), false) => TCPResponse::as_handle(ptr).upgrade(
+                data,
+                sec_web_socket_key,
+                sec_web_socket_protocol,
+                sec_web_socket_extensions,
+                ctx,
+            ),
+            (AnyResponseKind::TCP(ptr), true) => TCPNodeResponse::as_handle(ptr.cast()).upgrade(
                 data,
                 sec_web_socket_key,
                 sec_web_socket_protocol,
@@ -1047,10 +1178,15 @@ pub mod c {
     // shims are `safe fn`; (ptr,len), nullable raw, *mut c_void ctx stay
     // unsafe.
     unsafe extern "C" {
-        pub(crate) safe fn uws_res_mark_wrote_content_length_header(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn uws_res_write_mark(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_mark_wrote_content_length_header(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+        );
+        pub(crate) safe fn uws_res_write_mark(ssl: i32, node_http: i32, res: &mut uws_res);
         pub(crate) safe fn us_socket_mark_needs_more_not_ssl(socket: &mut uws_res);
-        pub(crate) safe fn uws_res_state(ssl: c_int, res: &uws_res) -> State;
+        pub(crate) safe fn uws_res_state(ssl: c_int, node_http: c_int, res: &uws_res) -> State;
+        // node:http-only — C shim hardcodes NODE_HTTP=true.
         pub(crate) safe fn uws_res_is_connect_request(ssl: i32, res: &mut uws_res) -> bool;
         // Out-params are `&mut` (non-null, valid for write); the C shim only
         // stores into them and returns a length — no read-through precondition.
@@ -1060,9 +1196,10 @@ pub mod c {
             port: &mut i32,
             is_ipv6: &mut bool,
         ) -> usize;
-        pub(crate) safe fn uws_res_uncork(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_uncork(ssl: i32, node_http: i32, res: &mut uws_res);
         pub(crate) fn uws_res_end(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             data: *const u8,
             length: usize,
@@ -1070,14 +1207,17 @@ pub mod c {
         );
         pub(crate) safe fn uws_res_flush_headers(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             flush_immediately: bool,
         );
-        pub(crate) safe fn uws_res_is_corked(ssl: i32, res: &mut uws_res) -> bool;
+        pub(crate) safe fn uws_res_is_corked(ssl: i32, node_http: i32, res: &mut uws_res) -> bool;
+        // node:http-only — C shim hardcodes NODE_HTTP=true.
         pub(crate) safe fn uws_res_get_socket_data(ssl: i32, res: &mut uws_res) -> *mut SocketData;
-        pub(crate) safe fn uws_res_pause(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn uws_res_resume(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn uws_res_write_continue(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_pause(ssl: i32, node_http: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_resume(ssl: i32, node_http: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_write_continue(ssl: i32, node_http: i32, res: &mut uws_res);
+        // node:http-only — C shim hardcodes NODE_HTTP=true.
         pub(crate) fn uws_res_write_informational(
             ssl: i32,
             res: *mut uws_res,
@@ -1086,12 +1226,14 @@ pub mod c {
         );
         pub(crate) fn uws_res_write_status(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             status: *const u8,
             length: usize,
         );
         pub(crate) fn uws_res_write_header(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             key: *const u8,
             key_length: usize,
@@ -1100,6 +1242,7 @@ pub mod c {
         );
         pub(crate) fn uws_res_write_header_int(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             key: *const u8,
             key_length: usize,
@@ -1107,67 +1250,102 @@ pub mod c {
         );
         pub(crate) safe fn uws_res_end_without_body(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             close_connection: bool,
         );
         pub(crate) safe fn uws_res_end_sendfile(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             write_offset: u64,
             close_connection: bool,
         );
-        pub(crate) safe fn uws_res_timeout(ssl: i32, res: &mut uws_res, timeout: u8);
-        pub(crate) safe fn uws_res_reset_timeout(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn uws_res_get_buffered_amount(ssl: i32, res: &mut uws_res) -> u64;
+        pub(crate) safe fn uws_res_timeout(ssl: i32, node_http: i32, res: &mut uws_res, timeout: u8);
+        pub(crate) safe fn uws_res_reset_timeout(ssl: i32, node_http: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_get_buffered_amount(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+        ) -> u64;
         pub(crate) fn uws_res_write(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             data: *const u8,
             length: *mut usize,
         ) -> bool;
-        pub(crate) safe fn uws_res_get_write_offset(ssl: i32, res: &mut uws_res) -> u64;
-        pub(crate) safe fn uws_res_override_write_offset(ssl: i32, res: &mut uws_res, offset: u64);
-        pub(crate) safe fn uws_res_has_responded(ssl: i32, res: &mut uws_res) -> bool;
+        pub(crate) safe fn uws_res_get_write_offset(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+        ) -> u64;
+        pub(crate) safe fn uws_res_override_write_offset(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+            offset: u64,
+        );
+        pub(crate) safe fn uws_res_has_responded(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+        ) -> bool;
         // safe: `&mut uws_res` is ABI-identical to a non-null `*mut uws_res`;
         // `handler`/`user_data` are stored opaquely (never dereferenced by the
         // C++ shim itself) — no preconditions on this call.
         pub(crate) safe fn uws_res_on_writable(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             handler: Option<unsafe extern "C" fn(*mut uws_res, u64, *mut c_void) -> bool>,
             user_data: *mut c_void,
         );
-        pub(crate) safe fn uws_res_clear_on_writable(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_clear_on_writable(ssl: i32, node_http: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_on_aborted(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             handler: Option<unsafe extern "C" fn(*mut uws_res, *mut c_void)>,
             optional_data: *mut c_void,
         );
         pub(crate) safe fn uws_res_on_timeout(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             handler: Option<unsafe extern "C" fn(*mut uws_res, *mut c_void)>,
             optional_data: *mut c_void,
         );
         pub(crate) fn uws_res_try_end(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             data: *const u8,
             length: usize,
             total: usize,
             close: bool,
         ) -> bool;
-        pub(crate) safe fn uws_res_end_stream(ssl: i32, res: &mut uws_res, close_connection: bool);
-        pub(crate) safe fn uws_res_prepare_for_sendfile(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn uws_res_get_native_handle(ssl: i32, res: &mut uws_res) -> *mut Socket;
+        pub(crate) safe fn uws_res_end_stream(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+            close_connection: bool,
+        );
+        pub(crate) safe fn uws_res_prepare_for_sendfile(ssl: i32, node_http: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_get_native_handle(
+            ssl: i32,
+            node_http: i32,
+            res: &mut uws_res,
+        ) -> *mut Socket;
         pub(crate) safe fn uws_res_get_remote_address_as_text(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             dest: &mut *const u8,
         ) -> usize;
         pub(crate) safe fn uws_res_on_data(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             handler: Option<
                 unsafe extern "C" fn(*mut uws_res, *const u8, usize, bool, *mut c_void),
@@ -1176,6 +1354,7 @@ pub mod c {
         );
         pub(crate) fn uws_res_upgrade(
             ssl: i32,
+            node_http: i32,
             res: *mut uws_res,
             data: *mut c_void,
             sec_web_socket_key: *const u8,
@@ -1191,6 +1370,7 @@ pub mod c {
         // call has no preconditions beyond the live opaque handle.
         pub(crate) safe fn uws_res_cork(
             ssl: i32,
+            node_http: i32,
             res: &mut uws_res,
             ctx: *mut c_void,
             corker: unsafe extern "C" fn(*mut c_void),

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -382,6 +382,7 @@ impl AnyWebSocket {
 
     pub fn publish_with_options(
         ssl: bool,
+        node_http: bool,
         app: *mut c_void,
         topic: &[u8],
         message: &[u8],
@@ -395,6 +396,7 @@ impl AnyWebSocket {
         if ssl {
             uws::NewApp::<true>::publish_with_options(
                 bun_opaque::opaque_deref_mut(app.cast::<uws::NewApp<true>>()),
+                node_http,
                 topic,
                 message,
                 opcode,
@@ -403,6 +405,7 @@ impl AnyWebSocket {
         } else {
             uws::NewApp::<false>::publish_with_options(
                 bun_opaque::opaque_deref_mut(app.cast::<uws::NewApp<false>>()),
+                node_http,
                 topic,
                 message,
                 opcode,
@@ -725,6 +728,7 @@ pub mod c {
         pub(crate) safe fn uws_ws_memory_cost(ssl: i32, ws: &mut RawWebSocket) -> usize;
         pub(crate) fn uws_ws(
             ssl: i32,
+            node_http: i32,
             app: *mut uws_app_t,
             ctx: *mut c_void,
             pattern: *const u8,

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -463,5 +463,7 @@ pub use web_socket::{AnyWebSocket, RawWebSocket, WebSocketBehavior};
 /// Legacy aliases for `App<SSL>` / `Response<SSL>`.
 pub type NewApp<const SSL: bool> = app::App<SSL>;
 pub type NewAppResponse<const SSL: bool> = response::Response<SSL>;
+/// node:http compat: response backed by `HttpResponseData<SSL, true>`.
+pub type NodeAppResponse<const SSL: bool> = response::Response<SSL, true>;
 pub type Socket = us_socket::us_socket_t;
 pub type SocketContext = us_socket_context_t;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -453,7 +453,7 @@ pub use connecting_socket::ConnectingSocket;
 pub use listen_socket::ListenSocket;
 pub use request::{AnyRequest, Request};
 pub use response::c::uws_res;
-pub use response::{AnyResponse, SocketAddress, WebSocketUpgradeContext};
+pub use response::{AnyResponse, AnyResponseKind, SocketAddress, WebSocketUpgradeContext};
 pub use socket_context::BunSocketContextOptions;
 pub use socket_group::ConnectResult;
 pub use socket_group::SocketGroup;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -5,6 +5,7 @@
 #include <bun-uws/src/AsyncSocket.h>
 #include <bun-usockets/src/internal/internal.h>
 #include <string_view>
+#include <type_traits>
 
 extern "C" const char* ares_inet_ntop(int af, const char *src, char *dst, size_t size);
 
@@ -19,6 +20,47 @@ static inline std::string_view stringViewFromC(const char* message, size_t lengt
 }
 using TLSWebSocket = uWS::WebSocket<true, true, void *>;
 using TCPWebSocket = uWS::WebSocket<false, true, void *>;
+
+// 4-way dispatch on (ssl, node_http) into the matching HttpResponse<SSL,
+// NODE_HTTP> instantiation. NODE_HTTP compiles the node:http compat state
+// (nodeCompat) in/out of HttpResponseData; the wrong instantiation reads a
+// different ext-data layout, so every uws_res_* wrapper must dispatch on both
+// flags. Generic-lambda body sees `auto* uwsRes` typed correctly.
+template<typename F>
+static inline auto uws_res_dispatch(int ssl, int node_http, uws_res_t* res, F&& f) {
+    if (ssl) {
+        if (node_http) return f((uWS::HttpResponse<true, true>*)res);
+        return f((uWS::HttpResponse<true, false>*)res);
+    }
+    if (node_http) return f((uWS::HttpResponse<false, true>*)res);
+    return f((uWS::HttpResponse<false, false>*)res);
+}
+
+// Same 4-way dispatch for TemplatedApp<SSL, NODE_HTTP>.
+template<typename F>
+static inline auto uws_app_dispatch(int ssl, int node_http, uws_app_t* app, F&& f) {
+    if (ssl) {
+        if (node_http) return f((uWS::NodeHttpSSLApp*)app);
+        return f((uWS::SSLApp*)app);
+    }
+    if (node_http) return f((uWS::NodeHttpApp*)app);
+    return f((uWS::App*)app);
+}
+
+// node:http-only functions are only ever invoked against a NODE_HTTP=true
+// app/response (their C++ impl is `if constexpr (NODE_HTTP)`), so they
+// hardcode the second template arg and dispatch on ssl only.
+template<typename F>
+static inline auto uws_res_dispatch_node(int ssl, uws_res_t* res, F&& f) {
+    if (ssl) return f((uWS::HttpResponse<true, true>*)res);
+    return f((uWS::HttpResponse<false, true>*)res);
+}
+
+template<typename F>
+static inline auto uws_app_dispatch_node(int ssl, uws_app_t* app, F&& f) {
+    if (ssl) return f((uWS::NodeHttpSSLApp*)app);
+    return f((uWS::NodeHttpApp*)app);
+}
 
 extern "C"
 {
@@ -48,26 +90,31 @@ extern "C"
     return (uws_app_t *)uWS::App::create(socket_context_options);
   }
 
-  void uws_app_clear_routes(int ssl, uws_app_t *app)
+  // node:http compat instantiation (TemplatedApp<SSL, /*NODE_HTTP=*/true>).
+  // Separate symbol so the Rust side selects at create time; the template
+  // arg gates per-socket node-compat state.
+  uws_app_t *uws_create_app_node_http(int ssl, struct us_bun_socket_context_options_t options)
   {
+    uWS::SocketContextOptions socket_context_options;
+    memcpy(&socket_context_options, &options,
+           sizeof(uWS::SocketContextOptions));
     if (ssl)
     {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->clearRoutes();
+      return (uws_app_t *)uWS::NodeHttpSSLApp::create(socket_context_options);
     }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->clearRoutes();
-    }
+
+    return (uws_app_t *)uWS::NodeHttpApp::create(socket_context_options);
   }
 
-  void uws_app_get(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_clear_routes(int ssl, int node_http, uws_app_t *app)
+  {
+    uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) { uwsApp->clearRoutes(); });
+  }
+
+  void uws_app_get(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->get(pattern, nullptr);
@@ -75,26 +122,13 @@ extern "C"
       }
       uwsApp->get(pattern, [handler, user_data](auto *res, auto *req)
                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->get(pattern, nullptr);
-        return;
-      }
-      uwsApp->get(pattern, [handler, user_data](auto *res, auto *req)
-                  { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_post(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_post(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->post(pattern, nullptr);
@@ -102,26 +136,13 @@ extern "C"
       }
       uwsApp->post(pattern, [handler, user_data](auto *res, auto *req)
                    { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->post(pattern, nullptr);
-        return;
-      }
-      uwsApp->post(pattern, [handler, user_data](auto *res, auto *req)
-                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_options(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_options(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->options(pattern, nullptr);
@@ -129,18 +150,7 @@ extern "C"
       }
       uwsApp->options(pattern, [handler, user_data](auto *res, auto *req)
                       { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->options(pattern, nullptr);
-        return;
-      }
-      uwsApp->options(pattern, [handler, user_data](auto *res, auto *req)
-                      { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
   extern "C" void uws_res_clear_corked_socket(us_loop_t *loop) {
@@ -158,12 +168,10 @@ extern "C"
     }
 }
 
-  void uws_app_delete(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_delete(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->del(pattern, nullptr);
@@ -171,26 +179,13 @@ extern "C"
       }
       uwsApp->del(pattern, [handler, user_data](auto *res, auto *req)
                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->del(pattern, nullptr);
-        return;
-      }
-      uwsApp->del(pattern, [handler, user_data](auto *res, auto *req)
-                  { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_patch(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_patch(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->patch(pattern, nullptr);
@@ -198,26 +193,13 @@ extern "C"
       }
       uwsApp->patch(pattern, [handler, user_data](auto *res, auto *req)
                     { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->patch(pattern, nullptr);
-        return;
-      }
-      uwsApp->patch(pattern, [handler, user_data](auto *res, auto *req)
-                    { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_put(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_put(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->put(pattern, nullptr);
@@ -225,26 +207,13 @@ extern "C"
       }
       uwsApp->put(pattern, [handler, user_data](auto *res, auto *req)
                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->put(pattern, nullptr);
-        return;
-      }
-      uwsApp->put(pattern, [handler, user_data](auto *res, auto *req)
-                  { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_head(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_head(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->head(pattern, nullptr);
@@ -252,25 +221,12 @@ extern "C"
       }
       uwsApp->head(pattern, [handler, user_data](auto *res, auto *req)
                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->head(pattern, nullptr);
-        return;
-      }
-      uwsApp->head(pattern, [handler, user_data](auto *res, auto *req)
-                  { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
-  void uws_app_connect(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_connect(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->connect(pattern, nullptr);
@@ -278,26 +234,13 @@ extern "C"
       }
       uwsApp->connect(pattern, [handler, user_data](auto *res, auto *req)
                       { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->connect(pattern, nullptr);
-        return;
-      }
-      uwsApp->connect(pattern, [handler, user_data](auto *res, auto *req)
-                      { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_trace(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_trace(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->trace(pattern, nullptr);
@@ -305,39 +248,22 @@ extern "C"
       }
       uwsApp->trace(pattern, [handler, user_data](auto *res, auto *req)
                     { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->trace(pattern, nullptr);
-        return;
-      }
-      uwsApp->trace(pattern, [handler, user_data](auto *res, auto *req)
-                    { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  size_t uws_res_get_buffered_amount(int ssl, uws_res_t *res) nonnull_fn_decl;
+  size_t uws_res_get_buffered_amount(int ssl, int node_http, uws_res_t *res) nonnull_fn_decl;
 
-  size_t uws_res_get_buffered_amount(int ssl, uws_res_t *res)
+  size_t uws_res_get_buffered_amount(int ssl, int node_http, uws_res_t *res)
   {
-      if (ssl) {
-        uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> size_t {
         return uwsRes->getBufferedAmount();
-      } else {
-        uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-        return uwsRes->getBufferedAmount();
-      }
+      });
   }
 
-  void uws_app_any(int ssl, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
+  void uws_app_any(int ssl, int node_http, uws_app_t *app, const char *pattern_ptr, size_t pattern_len, uws_method_handler handler, void *user_data)
   {
     std::string_view pattern = std::string_view(pattern_ptr, pattern_len);
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       if (handler == nullptr)
       {
         uwsApp->any(pattern, nullptr);
@@ -345,67 +271,28 @@ extern "C"
       }
       uwsApp->any(pattern, [handler, user_data](auto *res, auto *req)
                   { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr)
-      {
-        uwsApp->any(pattern, nullptr);
-        return;
-      }
-      uwsApp->any(pattern, [handler, user_data](auto *res, auto *req)
-                  { handler((uws_res_t *)res, (uws_req_t *)req, user_data); });
-    }
+    });
   }
 
-  void uws_app_run(int ssl, uws_app_t *app)
+  void uws_app_run(int ssl, int node_http, uws_app_t *app)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->run();
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->run();
-    }
+    uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) { uwsApp->run(); });
   }
 
-  void uws_app_close(int ssl, uws_app_t *app)
+  void uws_app_close(int ssl, int node_http, uws_app_t *app)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->close();
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->close();
-    }
+    uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) { uwsApp->close(); });
   }
 
-  void uws_app_close_idle(int ssl, uws_app_t *app)
+  void uws_app_close_idle(int ssl, int node_http, uws_app_t *app)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->closeIdle();
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->closeIdle();
-    }
+    uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) { uwsApp->closeIdle(); });
   }
 
+  // node:http-only: onClientError is compiled out of HttpContextData<SSL, false>.
   void uws_app_set_on_clienterror(int ssl, uws_app_t *app, void (*handler)(void *user_data, int is_ssl, struct us_socket_t *rawSocket, uint8_t errorCode, char *rawPacket, int rawPacketLength), void *user_data)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch_node(ssl, app, [&](auto* uwsApp) {
       if (handler == nullptr) {
         uwsApp->setOnClientError(nullptr);
         return;
@@ -413,21 +300,10 @@ extern "C"
       uwsApp->setOnClientError([handler, user_data](int is_ssl, struct us_socket_t *rawSocket, uint8_t errorCode, char *rawPacket, int rawPacketLength) {
         handler(user_data, is_ssl, rawSocket, errorCode, rawPacket, rawPacketLength);
       });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      if (handler == nullptr) {
-        uwsApp->setOnClientError(nullptr);
-        return;
-      }
-      uwsApp->setOnClientError([handler, user_data](int is_ssl, struct us_socket_t *rawSocket, uint8_t errorCode, char *rawPacket, int rawPacketLength) {
-        handler(user_data, is_ssl, rawSocket, errorCode, rawPacket, rawPacketLength);
-      });
-    }
+    });
   }
 
-  void uws_app_listen(int ssl, uws_app_t *app, int port,
+  void uws_app_listen(int ssl, int node_http, uws_app_t *app, int port,
                       uws_listen_handler handler, void *user_data)
   {
     uws_app_listen_config_t config;
@@ -435,120 +311,60 @@ extern "C"
     config.host = nullptr;
     config.options = 0;
 
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->listen(port, [handler,
                             user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-
-      uwsApp->listen(port, [handler,
-                            user_data](struct us_listen_socket_t *listen_socket)
-                     { handler((struct us_listen_socket_t *)listen_socket, user_data); });
-    }
+    });
   }
 
-  void uws_app_listen_with_config(int ssl, uws_app_t *app, const char *host,
+  void uws_app_listen_with_config(int ssl, int node_http, uws_app_t *app, const char *host,
                                   uint16_t port, int32_t options,
                                   uws_listen_handler handler, void *user_data)
   {
     std::string hostname = host && host[0] ? std::string(host, strlen(host)) : "";
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->listen(
           hostname, port, options,
           [handler, user_data](struct us_listen_socket_t *listen_socket)
           {
             handler((struct us_listen_socket_t *)listen_socket, user_data);
           });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->listen(
-          hostname, port, options,
-          [handler, user_data](struct us_listen_socket_t *listen_socket)
-          {
-            handler((struct us_listen_socket_t *)listen_socket, user_data);
-          });
-    }
+    });
   }
 
   /* callback, path to unix domain socket */
-  void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, size_t pathlen, uws_listen_domain_handler handler, void *user_data)
+  void uws_app_listen_domain(int ssl, int node_http, uws_app_t *app, const char *domain, size_t pathlen, uws_listen_domain_handler handler, void *user_data)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->listen(0,[handler, domain, user_data](struct us_listen_socket_t *listen_socket)
                      { handler((struct us_listen_socket_t *)listen_socket, domain, 0, user_data); },
                      {domain, pathlen});
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->listen(0, [handler, domain, user_data](struct us_listen_socket_t *listen_socket)
-                     { handler((struct us_listen_socket_t *)listen_socket, domain, 0, user_data); },
-                     {domain, pathlen});
-    }
+    });
   }
 
   /* callback, path to unix domain socket */
-  void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain, size_t pathlen, int options, uws_listen_domain_handler handler, void *user_data)
+  void uws_app_listen_domain_with_options(int ssl, int node_http, uws_app_t *app, const char *domain, size_t pathlen, int options, uws_listen_domain_handler handler, void *user_data)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->listen(
           options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
           { handler((struct us_listen_socket_t *)listen_socket, domain, options, user_data); },
           {domain, pathlen});
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->listen(
-          options, [handler, domain, options, user_data](struct us_listen_socket_t *listen_socket)
-          { handler((struct us_listen_socket_t *)listen_socket, domain, options, user_data); },
-          {domain, pathlen});
-    }
+    });
   }
 
-  void uws_app_domain(int ssl, uws_app_t *app, const char *server_name)
+  void uws_app_domain(int ssl, int node_http, uws_app_t *app, const char *server_name)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->domain(server_name);
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->domain(server_name);
-    }
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) { uwsApp->domain(server_name); });
   }
-  void uws_app_set_max_http_header_size(int ssl, uws_app_t *app, uint64_t max_header_size) {
-    if (ssl) {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->setMaxHTTPHeaderSize(max_header_size);
-    } else {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->setMaxHTTPHeaderSize(max_header_size);
-    }
+  void uws_app_set_max_http_header_size(int ssl, int node_http, uws_app_t *app, uint64_t max_header_size) {
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) { uwsApp->setMaxHTTPHeaderSize(max_header_size); });
   }
-  void uws_app_set_flags(int ssl, uws_app_t *app, bool require_host_header, bool use_strict_method_validation, bool use_insecure_http_parser, bool http_allow_half_open) {
-    if (ssl) {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+  void uws_app_set_flags(int ssl, int node_http, uws_app_t *app, bool require_host_header, bool use_strict_method_validation, bool use_insecure_http_parser, bool http_allow_half_open) {
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->setFlags(require_host_header, use_strict_method_validation, use_insecure_http_parser, http_allow_half_open);
-    } else {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->setFlags(require_host_header, use_strict_method_validation, use_insecure_http_parser, http_allow_half_open);
-    }
+    });
   }
 
   void uws_app_destroy(int ssl, uws_app_t *app)
@@ -566,152 +382,99 @@ extern "C"
     }
   }
 
-  bool uws_constructor_failed(int ssl, uws_app_t *app)
+  void uws_app_destroy_node_http(int ssl, uws_app_t *app)
   {
     if (ssl)
     {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      delete (uWS::NodeHttpSSLApp *)app;
+    }
+    else
+    {
+      delete (uWS::NodeHttpApp *)app;
+    }
+  }
+
+  bool uws_constructor_failed(int ssl, int node_http, uws_app_t *app)
+  {
+    return uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) -> bool {
       if (!uwsApp)
         return true;
       return uwsApp->constructorFailed();
-    }
-    uWS::App *uwsApp = (uWS::App *)app;
-    if (!uwsApp)
-      return true;
-    return uwsApp->constructorFailed();
+    });
   }
 
-  unsigned int uws_num_subscribers(int ssl, uws_app_t *app, const char *topic, size_t topic_length)
+  unsigned int uws_num_subscribers(int ssl, int node_http, uws_app_t *app, const char *topic, size_t topic_length)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    return uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) -> unsigned int {
       return uwsApp->numSubscribers(stringViewFromC(topic, topic_length));
-    }
-    uWS::App *uwsApp = (uWS::App *)app;
-    return uwsApp->numSubscribers(stringViewFromC(topic, topic_length));
+    });
   }
-  uws_sendstatus_t uws_publish(int ssl, uws_app_t *app, const char *topic,
+  uws_sendstatus_t uws_publish(int ssl, int node_http, uws_app_t *app, const char *topic,
                                size_t topic_length, const char *message,
                                size_t message_length, uws_opcode_t opcode, bool compress)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    return uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) -> uws_sendstatus_t {
       return (uws_sendstatus_t)uwsApp->publish(stringViewFromC(topic, topic_length),
                                                stringViewFromC(message, message_length),
                                                (uWS::OpCode)(unsigned char)opcode, compress);
-    }
-    uWS::App *uwsApp = (uWS::App *)app;
-    return (uws_sendstatus_t)uwsApp->publish(stringViewFromC(topic, topic_length),
-                                             stringViewFromC(message, message_length),
-                                             (uWS::OpCode)(unsigned char)opcode, compress);
+    });
   }
-  void *uws_get_native_handle(int ssl, uws_app_t *app)
+  void *uws_get_native_handle(int ssl, int node_http, uws_app_t *app)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      return uwsApp->getNativeHandle();
-    }
-    uWS::App *uwsApp = (uWS::App *)app;
-    return uwsApp->getNativeHandle();
+    return uws_app_dispatch(ssl, node_http, app, [](auto* uwsApp) -> void* { return uwsApp->getNativeHandle(); });
   }
-  void uws_remove_server_name(int ssl, uws_app_t *app,
+  void uws_remove_server_name(int ssl, int node_http, uws_app_t *app,
                               const char *hostname_pattern)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->removeServerName(hostname_pattern);
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->removeServerName(hostname_pattern);
-    }
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) { uwsApp->removeServerName(hostname_pattern); });
   }
-  void uws_add_server_name(int ssl, uws_app_t *app,
+  void uws_add_server_name(int ssl, int node_http, uws_app_t *app,
                            const char *hostname_pattern)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->addServerName(hostname_pattern);
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->addServerName(hostname_pattern);
-    }
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) { uwsApp->addServerName(hostname_pattern); });
   }
   int uws_add_server_name_with_options(
-      int ssl, uws_app_t *app, const char *hostname_pattern,
+      int ssl, int node_http, uws_app_t *app, const char *hostname_pattern,
       struct us_bun_socket_context_options_t options)
   {
     uWS::SocketContextOptions sco;
     memcpy(&sco, &options, sizeof(uWS::SocketContextOptions));
     bool success = false;
 
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->addServerName(hostname_pattern, sco, &success);
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->addServerName(hostname_pattern, sco, &success);
-    }
+    });
     return !success;
   }
 
-  void uws_missing_server_name(int ssl, uws_app_t *app,
+  void uws_missing_server_name(int ssl, int node_http, uws_app_t *app,
                                uws_missing_server_handler handler,
                                void *user_data)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->missingServerName(
           [handler, user_data](auto hostname)
           { handler(hostname, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->missingServerName(
-          [handler, user_data](auto hostname)
-          { handler(hostname, user_data); });
-    }
+    });
   }
-  void uws_filter(int ssl, uws_app_t *app, uws_filter_handler handler,
+  void uws_filter(int ssl, int node_http, uws_app_t *app, uws_filter_handler handler,
                   void *user_data)
   {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
       uwsApp->filter([handler, user_data](auto res, auto i)
                      { handler((uws_res_t *)res, i, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-
-      uwsApp->filter([handler, user_data](auto res, auto i)
-                     { handler((uws_res_t *)res, i, user_data); });
-    }
+    });
   }
 
-  void uws_ws(int ssl, uws_app_t *app, void *upgradeContext, const char *pattern,
+  void uws_ws(int ssl, int node_http, uws_app_t *app, void *upgradeContext, const char *pattern,
               size_t pattern_length, size_t id,
               const uws_socket_behavior_t *behavior_)
   {
     uws_socket_behavior_t behavior = *behavior_;
 
-    if (ssl)
-    {
-      auto generic_handler = uWS::SSLApp::WebSocketBehavior<void *>{
+    uws_app_dispatch(ssl, node_http, app, [&](auto* uwsApp) {
+      using AppT = std::remove_pointer_t<decltype(uwsApp)>;
+      auto generic_handler = typename AppT::template WebSocketBehavior<void *>{
           .compression = (uWS::CompressOptions)(uint64_t)behavior.compression,
           .maxPayloadLength = behavior.maxPayloadLength,
           .idleTimeout = behavior.idleTimeout,
@@ -762,68 +525,10 @@ extern "C"
           behavior.close((uws_websocket_t *)ws, code, message.data(),
                          message.length());
         };
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
 
-      uwsApp->ws<void *>(std::string(pattern, pattern_length),
+      uwsApp->template ws<void *>(std::string(pattern, pattern_length),
                          std::move(generic_handler));
-    }
-    else
-    {
-      auto generic_handler = uWS::App::WebSocketBehavior<void *>{
-          .compression = (uWS::CompressOptions)(uint64_t)behavior.compression,
-          .maxPayloadLength = behavior.maxPayloadLength,
-          .idleTimeout = behavior.idleTimeout,
-          .maxBackpressure = behavior.maxBackpressure,
-          .closeOnBackpressureLimit = behavior.closeOnBackpressureLimit,
-          .resetIdleTimeoutOnSend = behavior.resetIdleTimeoutOnSend,
-          .sendPingsAutomatically = behavior.sendPingsAutomatically,
-          .maxLifetime = behavior.maxLifetime,
-      };
-
-      if (behavior.upgrade)
-        generic_handler.upgrade = [behavior, upgradeContext,
-                                   id](auto *res, auto *req, auto *context)
-        {
-          behavior.upgrade(upgradeContext, (uws_res_t *)res, (uws_req_t *)req,
-                           (uws_socket_context_t *)context, id);
-        };
-      if (behavior.open)
-        generic_handler.open = [behavior](auto *ws)
-        {
-          behavior.open((uws_websocket_t *)ws);
-        };
-      if (behavior.message)
-        generic_handler.message = [behavior](auto *ws, auto message,
-                                             auto opcode)
-        {
-          behavior.message((uws_websocket_t *)ws, message.data(),
-                           message.length(), (uws_opcode_t)opcode);
-        };
-      if (behavior.drain)
-        generic_handler.drain = [behavior](auto *ws)
-        {
-          behavior.drain((uws_websocket_t *)ws);
-        };
-      if (behavior.ping)
-        generic_handler.ping = [behavior](auto *ws, auto message)
-        {
-          behavior.ping((uws_websocket_t *)ws, message.data(), message.length());
-        };
-      if (behavior.pong)
-        generic_handler.pong = [behavior](auto *ws, auto message)
-        {
-          behavior.pong((uws_websocket_t *)ws, message.data(), message.length());
-        };
-      if (behavior.close)
-        generic_handler.close = [behavior](auto *ws, int code, auto message)
-        {
-          behavior.close((uws_websocket_t *)ws, code, message.data(),
-                         message.length());
-        };
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->ws<void *>(std::string(pattern, pattern_length),
-                         std::move(generic_handler));
-    }
+    });
   }
 
   void *uws_ws_get_user_data(int ssl, uws_websocket_t *ws)
@@ -1150,332 +855,180 @@ extern "C"
     return value.length();
   }
 
-  void uws_res_end(int ssl, uws_res_r res, const char *data, size_t length,
+  void uws_res_end(int ssl, int node_http, uws_res_r res, const char *data, size_t length,
                    bool close_connection)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->clearOnWritableAndAborted();
       uwsRes->end(stringViewFromC(data, length), close_connection);
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->clearOnWritableAndAborted();
-      uwsRes->end(stringViewFromC(data, length), close_connection);
-    }
+    });
   }
 
-  void uws_res_end_stream(int ssl, uws_res_r res, bool close_connection)
+  void uws_res_end_stream(int ssl, int node_http, uws_res_r res, bool close_connection)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->clearOnWritableAndAborted();
       uwsRes->sendTerminatingChunk(close_connection);
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->clearOnWritableAndAborted();
-      uwsRes->sendTerminatingChunk(close_connection);
-    }
+    });
   }
 
-  void uws_res_pause(int ssl, uws_res_r res)
+  void uws_res_pause(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->pause();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->pause();
-    }
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->pause(); });
   }
 
-  void uws_res_resume(int ssl, uws_res_r res)
+  void uws_res_resume(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->resume();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->resume();
-    }
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->resume(); });
   }
 
-  void uws_res_write_continue(int ssl, uws_res_r res)
+  void uws_res_write_continue(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->writeContinue();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeContinue();
-    }
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->writeContinue(); });
   }
 
+  // node:http-only: writeRawInformational() is `if constexpr (NODE_HTTP)`.
   void uws_res_write_informational(int ssl, uws_res_r res, const char *data,
                                    size_t length)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch_node(ssl, res, [&](auto* uwsRes) {
       uwsRes->writeRawInformational(stringViewFromC(data, length));
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeRawInformational(stringViewFromC(data, length));
-    }
+    });
   }
 
-  void uws_res_write_status(int ssl, uws_res_r res, const char *status,
+  void uws_res_write_status(int ssl, int node_http, uws_res_r res, const char *status,
                             size_t length)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->writeStatus(stringViewFromC(status, length));
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeStatus(stringViewFromC(status, length));
-    }
+    });
   }
 
-  void uws_res_mark_wrote_content_length_header(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<true>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<false>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
-    }
+  void uws_res_mark_wrote_content_length_header(int ssl, int node_http, uws_res_r res) {
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) {
+      using DataT = std::remove_pointer_t<decltype(uwsRes->getHttpResponseData())>;
+      uwsRes->getHttpResponseData()->state |= DataT::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+    });
   }
 
-  void uws_res_write_mark(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->writeMark();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeMark();
-    }
+  void uws_res_write_mark(int ssl, int node_http, uws_res_r res) {
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->writeMark(); });
   }
 
-  void uws_res_write_header(int ssl, uws_res_r res, const char *key,
+  void uws_res_write_header(int ssl, int node_http, uws_res_r res, const char *key,
                             size_t key_length, const char *value,
                             size_t value_length)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->writeHeader(stringViewFromC(key, key_length),
                           stringViewFromC(value, value_length));
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeHeader(stringViewFromC(key, key_length),
-                          stringViewFromC(value, value_length));
-    }
+    });
   }
-  void uws_res_write_header_int(int ssl, uws_res_r res, const char *key,
+  void uws_res_write_header_int(int ssl, int node_http, uws_res_r res, const char *key,
                                 size_t key_length, uint64_t value)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->writeHeader(stringViewFromC(key, key_length), value);
-    }
-    else
-    {
-
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeHeader(stringViewFromC(key, key_length), value);
-    }
+    });
   }
-  void uws_res_end_sendfile(int ssl, uws_res_r res, uint64_t offset, bool close_connection)
+  void uws_res_end_sendfile(int ssl, int node_http, uws_res_r res, uint64_t offset, bool close_connection)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using DataT = std::remove_pointer_t<decltype(uwsRes->getHttpResponseData())>;
       auto *data = uwsRes->getHttpResponseData();
       data->offset = offset;
-      data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
+      data->state |= DataT::HTTP_END_CALLED;
       data->markDone(uwsRes);
       uwsRes->resetTimeout();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto *data = uwsRes->getHttpResponseData();
-      data->offset = offset;
-      data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
-      uwsRes->resetTimeout();
-    }
+    });
   }
-  void uws_res_reset_timeout(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->resetTimeout();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->resetTimeout();
-    }
+  void uws_res_reset_timeout(int ssl, int node_http, uws_res_r res) {
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->resetTimeout(); });
   }
-  void uws_res_timeout(int ssl, uws_res_r res, uint8_t seconds) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->setTimeout(seconds);
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->setTimeout(seconds);
-    }
+  void uws_res_timeout(int ssl, int node_http, uws_res_r res, uint8_t seconds) {
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) { uwsRes->setTimeout(seconds); });
   }
 
-  void uws_res_end_without_body(int ssl, uws_res_r res, bool close_connection)
+  void uws_res_end_without_body(int ssl, int node_http, uws_res_r res, bool close_connection)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      using DataT = std::remove_pointer_t<decltype(uwsRes->getHttpResponseData())>;
       auto *data = uwsRes->getHttpResponseData();
       if (close_connection)
       {
-        if (!(data->state & uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE))
+        if (!(data->state & DataT::HTTP_CONNECTION_CLOSE))
         {
           uwsRes->writeHeader("Connection", "close");
         }
-        data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
+        data->state |= DataT::HTTP_CONNECTION_CLOSE;
       }
-      if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
-      {
-        uwsRes->AsyncSocket<true>::write("\r\n", 2);
-      }
-      data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
-      uwsRes->resetTimeout();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto *data = uwsRes->getHttpResponseData();
-      if (close_connection)
-      {
-        if (!(data->state & uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE))
-        {
-          uwsRes->writeHeader("Connection", "close");
-        }
-        data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
-      }
-      if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))
+      if (!(data->state & DataT::HTTP_END_CALLED))
       {
         // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
         // If not, they may throw a ConnectionError.
-        uwsRes->AsyncSocket<false>::write("\r\n", 2);
+        static_cast<typename ResT::Super*>(uwsRes)->write("\r\n", 2);
       }
-      data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
+      data->state |= DataT::HTTP_END_CALLED;
       data->markDone(uwsRes);
       uwsRes->resetTimeout();
-    }
+    });
   }
 
-  bool uws_res_write(int ssl, uws_res_r res, const char *data, size_t *length) nonnull_fn_decl;
+  bool uws_res_write(int ssl, int node_http, uws_res_r res, const char *data, size_t *length) nonnull_fn_decl;
 
-  bool uws_res_write(int ssl, uws_res_r res, const char *data, size_t *length)
+  bool uws_res_write(int ssl, int node_http, uws_res_r res, const char *data, size_t *length)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) -> bool {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      auto* asyncSocket = static_cast<typename ResT::Super*>(uwsRes);
       if (*length < 16 * 1024 && *length > 0) {
-        if (!uwsRes->uWS::AsyncSocket<true>::isCorked()) {
-          uwsRes->uWS::AsyncSocket<true>::cork();
+        if (!asyncSocket->isCorked()) {
+          asyncSocket->cork();
         }
       }
       return uwsRes->write(stringViewFromC(data, *length), length);
-    }
-    uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-    if (*length < 16 * 1024 && *length > 0) {
-        if (!uwsRes->uWS::AsyncSocket<false>::isCorked()) {
-          uwsRes->uWS::AsyncSocket<false>::cork();
-        }
-      }
-    return uwsRes->write(stringViewFromC(data, *length), length);
+    });
   }
-  uint64_t uws_res_get_write_offset(int ssl, uws_res_r res) nonnull_fn_decl;
-  uint64_t uws_res_get_write_offset(int ssl, uws_res_r res)
+  uint64_t uws_res_get_write_offset(int ssl, int node_http, uws_res_r res) nonnull_fn_decl;
+  uint64_t uws_res_get_write_offset(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> uint64_t {
       return uwsRes->getWriteOffset();
-    }
-    uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-    return uwsRes->getWriteOffset();
+    });
   }
 
-  bool uws_res_has_responded(int ssl, uws_res_r res) nonnull_fn_decl;
-  bool uws_res_has_responded(int ssl, uws_res_r res)
+  bool uws_res_has_responded(int ssl, int node_http, uws_res_r res) nonnull_fn_decl;
+  bool uws_res_has_responded(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> bool {
       return uwsRes->hasResponded();
-    }
-    uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-    return uwsRes->hasResponded();
+    });
   }
 
-  void uws_res_on_writable(int ssl, uws_res_r res,
+  void uws_res_on_writable(int ssl, int node_http, uws_res_r res,
                            bool (*handler)(uws_res_r res, uint64_t,
                                            void *optional_data),
                            void *optional_data)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      auto onWritable = reinterpret_cast<bool (*)(uWS::HttpResponse<true>*, uint64_t, void*)>(handler);
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      auto onWritable = reinterpret_cast<bool (*)(ResT*, uint64_t, void*)>(handler);
       uwsRes->onWritable(optional_data, onWritable);
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto onWritable = reinterpret_cast<bool (*)(uWS::HttpResponse<false>*, uint64_t, void*)>(handler);
-      uwsRes->onWritable(optional_data, onWritable);
-    }
+    });
   }
 
-  void uws_res_clear_on_writable(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->clearOnWritable();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->clearOnWritable();
-    }
+  void uws_res_clear_on_writable(int ssl, int node_http, uws_res_r res) {
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->clearOnWritable(); });
   }
 
-  void uws_res_on_aborted(int ssl, uws_res_r res,
+  void uws_res_on_aborted(int ssl, int node_http, uws_res_r res,
                           void (*handler)(uws_res_r res, void *optional_data),
                           void *optional_data)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      auto* onAborted = reinterpret_cast<void (*)(uWS::HttpResponse<true>*, void*)>(handler);
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      auto* onAborted = reinterpret_cast<void (*)(ResT*, void*)>(handler);
       if (handler)
       {
         uwsRes->onAborted(optional_data, onAborted);
@@ -1484,30 +1037,16 @@ extern "C"
       {
         uwsRes->clearOnAborted();
       }
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto* onAborted = reinterpret_cast<void (*)(uWS::HttpResponse<false>*, void*)>(handler);
-      if (handler)
-      {
-        uwsRes->onAborted(optional_data, onAborted);
-      }
-      else
-      {
-        uwsRes->clearOnAborted();
-      }
-    }
+    });
   }
 
-  void uws_res_on_timeout(int ssl, uws_res_r res,
+  void uws_res_on_timeout(int ssl, int node_http, uws_res_r res,
                           void (*handler)(uws_res_r res, void *optional_data),
                           void *optional_data)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      auto* onTimeout = reinterpret_cast<void (*)(uWS::HttpResponse<true>*, void*)>(handler);
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      auto* onTimeout = reinterpret_cast<void (*)(ResT*, void*)>(handler);
       if (handler)
       {
         uwsRes->onTimeout(optional_data, onTimeout);
@@ -1516,48 +1055,24 @@ extern "C"
       {
         uwsRes->clearOnTimeout();
       }
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto* onTimeout = reinterpret_cast<void (*)(uWS::HttpResponse<false>*, void*)>(handler);
-      if (handler)
-      {
-        uwsRes->onTimeout(optional_data, onTimeout);
-      }
-      else
-      {
-        uwsRes->clearOnTimeout();
-      }
-    }
+    });
   }
 
-  void uws_res_on_data(int ssl, uws_res_r res,
+  void uws_res_on_data(int ssl, int node_http, uws_res_r res,
                        void (*handler)(uws_res_r res, const char *chunk,
                                        size_t chunk_length, bool is_end,
                                        void *optional_data),
                        void *optional_data)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      auto onData = reinterpret_cast<void (*)(uWS::HttpResponse<true>* response, const char* chunk, size_t chunk_length, bool, void*)>(handler);
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
+      using ResT = std::remove_pointer_t<decltype(uwsRes)>;
+      auto onData = reinterpret_cast<void (*)(ResT* response, const char* chunk, size_t chunk_length, bool, void*)>(handler);
       if (handler) {
         uwsRes->onData(optional_data, onData);
       } else {
         uwsRes->onData(optional_data, nullptr);
       }
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto onData = reinterpret_cast<void (*)(uWS::HttpResponse<false>* response, const char* chunk, size_t chunk_length, bool, void*)>(handler);
-      if (handler) {
-        uwsRes->onData(optional_data, onData);
-      } else {
-        uwsRes->onData(optional_data, nullptr);
-      }
-    }
+    });
   }
 
   bool uws_req_is_ancient(uws_req_t *res)
@@ -1636,7 +1151,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return value.length();
   }
 
-  us_socket_t *uws_res_upgrade(int ssl, uws_res_r res, void *data,
+  us_socket_t *uws_res_upgrade(int ssl, int node_http, uws_res_r res, void *data,
                              const char *sec_web_socket_key,
                              size_t sec_web_socket_key_length,
                              const char *sec_web_socket_protocol,
@@ -1646,25 +1161,29 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
                              uws_socket_context_t *ws)
   {
     if (ssl) {
-    uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-
-    return uwsRes->template upgrade<void *>(
-        data ? std::move(data) : nullptr,
-        stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
-        stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
-        stringViewFromC(sec_web_socket_extensions,
-                         sec_web_socket_extensions_length),
-        (uWS::WebSocketContext<true, true, void *> *)ws);
+        auto up = [&](auto* uwsRes) -> us_socket_t* {
+            return uwsRes->template upgrade<void *>(
+                data ? std::move(data) : nullptr,
+                stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
+                stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
+                stringViewFromC(sec_web_socket_extensions,
+                                 sec_web_socket_extensions_length),
+                (uWS::WebSocketContext<true, true, void *> *)ws);
+        };
+        if (node_http) return up((uWS::HttpResponse<true, true>*)res);
+        return up((uWS::HttpResponse<true, false>*)res);
     } else {
-    uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-
-    return uwsRes->template upgrade<void *>(
-        data ? std::move(data) : nullptr,
-        stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
-        stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
-        stringViewFromC(sec_web_socket_extensions,
-                         sec_web_socket_extensions_length),
-        (uWS::WebSocketContext<false, true, void *> *)ws);
+        auto up = [&](auto* uwsRes) -> us_socket_t* {
+            return uwsRes->template upgrade<void *>(
+                data ? std::move(data) : nullptr,
+                stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
+                stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
+                stringViewFromC(sec_web_socket_extensions,
+                                 sec_web_socket_extensions_length),
+                (uWS::WebSocketContext<false, true, void *> *)ws);
+        };
+        if (node_http) return up((uWS::HttpResponse<false, true>*)res);
+        return up((uWS::HttpResponse<false, false>*)res);
     }
   }
 
@@ -1708,18 +1227,9 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
                    { cb(ctx); });
   }
 
-  void uws_res_uncork(int ssl, uws_res_r res)
+  void uws_res_uncork(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->uncork();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->uncork();
-    }
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) { uwsRes->uncork(); });
   }
 
   void us_socket_mark_needs_more_not_ssl(uws_res_r res)
@@ -1731,154 +1241,89 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
                    LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
   }
 
-  void uws_res_override_write_offset(int ssl, uws_res_r res, uint64_t offset)
+  void uws_res_override_write_offset(int ssl, int node_http, uws_res_r res, uint64_t offset)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->setWriteOffset(offset); //TODO: when updated to master this will bechanged to overrideWriteOffset
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->setWriteOffset(offset); //TODO: when updated to master this will bechanged to overrideWriteOffset
-    }
+    });
   }
 
 __attribute__((callback (corker, ctx)))
-  void uws_res_cork(int ssl, uws_res_r res, void *ctx,
+  void uws_res_cork(int ssl, int node_http, uws_res_r res, void *ctx,
                     void (*corker)(void *ctx)) nonnull_fn_decl;
 
-  void uws_res_cork(int ssl, uws_res_r res, void *ctx,
+  void uws_res_cork(int ssl, int node_http, uws_res_r res, void *ctx,
                     void (*corker)(void *ctx))
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->cork([ctx, corker]()
                    { corker(ctx); });
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->cork([ctx, corker]()
-                   { corker(ctx); });
-    }
+    });
   }
 
-  void uws_res_prepare_for_sendfile(int ssl, uws_res_r res)
+  void uws_res_prepare_for_sendfile(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) {
       uwsRes->writeMark();
       auto pair = uwsRes->getSendBuffer(2);
       char *ptr = pair.first;
       ptr[0] = '\r';
       ptr[1] = '\n';
       uwsRes->uncork();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeMark();
-      auto pair = uwsRes->getSendBuffer(2);
-      char *ptr = pair.first;
-      ptr[0] = '\r';
-      ptr[1] = '\n';
-      uwsRes->uncork();
-    }
+    });
   }
 
-  bool uws_res_try_end(int ssl, uws_res_r res, const char *bytes, size_t len,
+  bool uws_res_try_end(int ssl, int node_http, uws_res_r res, const char *bytes, size_t len,
                        size_t total_len, bool close)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) -> bool {
       auto pair = uwsRes->tryEnd(stringViewFromC(bytes, len), total_len, close);
       if (pair.first) {
         uwsRes->clearOnWritableAndAborted();
       }
 
       return pair.first;
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto pair = uwsRes->tryEnd(stringViewFromC(bytes, len), total_len, close);
-      if (pair.first) {
-          uwsRes->clearOnWritableAndAborted();
-      }
-
-      return pair.first;
-    }
+    });
   }
 
-  int uws_res_state(int ssl, uws_res_r res)
+  int uws_res_state(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> int {
       return uwsRes->getHttpResponseData()->state;
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      return uwsRes->getHttpResponseData()->state;
-    }
+    });
   }
 
-  void uws_res_flush_headers(int ssl, uws_res_r res, bool flushImmediately) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+  void uws_res_flush_headers(int ssl, int node_http, uws_res_r res, bool flushImmediately) {
+    uws_res_dispatch(ssl, node_http, res, [&](auto* uwsRes) {
       uwsRes->flushHeaders(flushImmediately);
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->flushHeaders(flushImmediately);
-    }
+    });
   }
 
-  bool uws_res_is_corked(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+  bool uws_res_is_corked(int ssl, int node_http, uws_res_r res) {
+    return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> bool {
       return uwsRes->isCorked();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      return uwsRes->isCorked();
-    }
+    });
   }
 
+  // node:http-only: socketData lives in nodeCompat.
   void *uws_res_get_socket_data(int ssl, uws_res_r res) {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch_node(ssl, res, [](auto* uwsRes) -> void* {
       return uwsRes->getSocketData();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      return uwsRes->getSocketData();
-    }
+    });
   }
 
+  // node:http-only: isConnectRequest lives in nodeCompat.
   bool uws_res_is_connect_request(int ssl, uws_res_r res)
   {
-    if (ssl) {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch_node(ssl, res, [](auto* uwsRes) -> bool {
       return uwsRes->isConnectRequest();
-    } else {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      return uwsRes->isConnectRequest();
-    }
+    });
   }
-  void *uws_res_get_native_handle(int ssl, uws_res_r res)
+  void *uws_res_get_native_handle(int ssl, int node_http, uws_res_r res)
   {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+    return uws_res_dispatch(ssl, node_http, res, [](auto* uwsRes) -> void* {
       return uwsRes->getNativeHandle();
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      return uwsRes->getNativeHandle();
-    }
+    });
   }
 
   size_t uws_ws_memory_cost(int ssl, uws_websocket_t *ws) {
@@ -1950,4 +1395,4 @@ __attribute__((callback (corker, ctx)))
   }
 
 #pragma clang attribute pop
-}
+} // extern "C"


### PR DESCRIPTION
Recovers the Bun.serve regression on #32488 by making the node:http compat state a compile-time template parameter instead of runtime state on every socket.

## What

`template<bool SSL, bool NODE_HTTP>` on `HttpResponseData`, `HttpResponse`, `HttpContext`, `HttpContextData`, `HttpParser`, `TemplatedApp`. All nodeHttp* fields move into `[[no_unique_address]] std::conditional_t<NODE_HTTP, NodeHttpResponseFields, EmptyNodeHttp> nodeCompat` (bitfielded bools). Every access is `if constexpr (NODE_HTTP)`. `usingNodeHttpCompat` runtime flag deleted.

C wrapper: 4-way `(ssl, node_http)` dispatch. Rust: `AnyResponse{is_node_http}` + `App::create(opts, node_http)` picks the instantiation from `config.is_node_http`.

## Result

- `sizeof(HttpResponseData<SSL, false>)` = **152B** (was 232B on #32488, ~160B on main) — Bun.serve socket 80B smaller than #32488 head, at/below main
- `sizeof(HttpParser<false>)` = 40B (was 72B)
- `shouldCloseConnection()` for Bun.serve is back to `state & HTTP_CONNECTION_CLOSE` — no cold-field reads
- 672 tests pass / 0 fail (serve.test.ts + node-http.test.ts + node-http2.test.js)
- `static_assert(sizeof(HttpResponseData<false,false>) <= 160)` guards it

LTO throughput bench pending (laptop non-LTO noise σ~20% swamps the 3.8% signal).