### PR TITLE
perf_hooks: alias globalThis.PerformanceObserver to the node:perf_hooks class

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -12,9 +12,12 @@ var {
   PerformanceEntry,
   PerformanceMark,
   PerformanceMeasure,
-  PerformanceObserver: NodePerformanceObserver,
   PerformanceObserverEntryList,
 } = globalThis;
+
+// globalThis.PerformanceObserver now resolves to this module's subclass, so the
+// native class is fetched directly to avoid re-entering this module on load.
+var NodePerformanceObserver = $cpp("JSPerformanceObserver.cpp", "getPerformanceObserverConstructor");
 
 var constants = {
   NODE_PERFORMANCE_ENTRY_TYPE_DNS: 4,

--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -117,8 +117,8 @@ const kObserverCallback = Symbol("kObserverCallback");
  * The native (WebCore) observer only understands mark/measure/resource.
  * Node-only entry types ('net', 'dns', ...) are routed to the JS-side
  * registry in internal/shared; everything else is delegated to the native
- * observer unchanged. (`NodePerformanceObserver` is the existing alias for
- * the native class destructured from globalThis above.)
+ * observer unchanged. `NodePerformanceObserver` is the native class, fetched
+ * via `getPerformanceObserverConstructor` above.
  */
 class PerformanceObserverForNodeTypes extends NodePerformanceObserver {
   constructor(callback) {

--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -7,13 +7,7 @@ const cppCreateHistogram = $newCppFunction("JSNodePerformanceHooksHistogram.cpp"
   figures: number,
 ) => import("node:perf_hooks").RecordableHistogram;
 
-var {
-  Performance,
-  PerformanceEntry,
-  PerformanceMark,
-  PerformanceMeasure,
-  PerformanceObserverEntryList,
-} = globalThis;
+var { Performance, PerformanceEntry, PerformanceMark, PerformanceMeasure, PerformanceObserverEntryList } = globalThis;
 
 // globalThis.PerformanceObserver now resolves to this module's subclass, so the
 // native class is fetched directly to avoid re-entering this module on load.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1200,6 +1200,7 @@ JSC_DEFINE_CUSTOM_GETTER(getPerformanceObserverGlobal, (JSGlobalObject * lexical
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     JSValue perfHooks = globalObject->internalModuleRegistry()->requireId(globalObject, vm, Bun::InternalModuleRegistry::Field::NodePerfHooks);
     RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_ASSERT(perfHooks.isObject());
     JSValue result = perfHooks.getObject()->get(globalObject, Identifier::fromString(vm, "PerformanceObserver"_s));
     RETURN_IF_EXCEPTION(scope, {});
     if (auto* thisObject = JSValue::decode(thisValue).getObject())

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1190,7 +1190,22 @@ WEBCORE_GENERATED_CONSTRUCTOR_GETTER(Performance);
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceEntry);
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceMark);
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceMeasure);
-WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceObserver);
+// globalThis.PerformanceObserver === require("node:perf_hooks").PerformanceObserver.
+// Not a static-table PropertyCallback: abstractResolve() reifies those under a
+// VMInquiry slot that forbids VM re-entry, and loading perf_hooks runs JS.
+JSC_DEFINE_CUSTOM_GETTER(getPerformanceObserverGlobal, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName property))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSValue perfHooks = globalObject->internalModuleRegistry()->requireId(globalObject, vm, Bun::InternalModuleRegistry::Field::NodePerfHooks);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue result = perfHooks.getObject()->get(globalObject, Identifier::fromString(vm, "PerformanceObserver"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* thisObject = JSValue::decode(thisValue).getObject())
+        thisObject->putDirect(vm, property, result, 0);
+    return JSValue::encode(result);
+}
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceObserverEntryList)
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceResourceTiming)
 WEBCORE_GENERATED_CONSTRUCTOR_GETTER(PerformanceServerTiming)
@@ -2985,6 +3000,8 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
             JSFunction::create(vm, this, 0, "get"_s, functionGetSelf, ImplementationVisibility::Public),
             JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
         PropertyAttribute::Accessor | 0);
+
+    putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "PerformanceObserver"_s), JSC::CustomGetterSetter::create(vm, getPerformanceObserverGlobal, nullptr), PropertyAttribute::CustomValue | 0);
 
     // TODO: this should be usable on the lookup table. it crashed las time i tried it
     putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -66,7 +66,6 @@
   PerformanceEntry                PerformanceEntryConstructorCallback                  PropertyCallback
   PerformanceMark                 PerformanceMarkConstructorCallback                   PropertyCallback
   PerformanceMeasure              PerformanceMeasureConstructorCallback                PropertyCallback
-  PerformanceObserver             PerformanceObserverConstructorCallback               PropertyCallback
   PerformanceObserverEntryList    PerformanceObserverEntryListConstructorCallback      PropertyCallback
   PerformanceResourceTiming       PerformanceResourceTimingConstructorCallback         PropertyCallback
   PerformanceServerTiming         PerformanceServerTimingConstructorCallback           PropertyCallback

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
@@ -423,4 +423,9 @@ PerformanceObserver* JSPerformanceObserver::toWrapped(JSC::VM&, JSC::JSValue val
     return nullptr;
 }
 
+JSC::JSValue getPerformanceObserverConstructor(Zig::GlobalObject* globalObject)
+{
+    return WebCore::JSPerformanceObserver::getConstructor(globalObject->vm(), globalObject);
+}
+
 }

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.h
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.h
@@ -97,4 +97,6 @@ template<> struct JSDOMWrapperConverterTraits<PerformanceObserver> {
 };
 template<> PerformanceObserver::Init convertDictionary<PerformanceObserver::Init>(JSC::JSGlobalObject&, JSC::JSValue);
 
+JSC::JSValue getPerformanceObserverConstructor(Zig::GlobalObject* globalObject);
+
 } // namespace WebCore

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -90,12 +90,17 @@ test("globalThis.PerformanceObserver delivers node-only entry types", async () =
     stdio: ["ignore", "pipe", "pipe"],
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const result = JSON.parse(stdout);
-  expect(result).toEqual({
+  let result;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    result = { parseFailed: true, stdout };
+  }
+  expect({ ...result, stderr, exitCode }).toEqual({
     sameClass: true,
     viaGlobal: ["http:HttpClient", "http:HttpRequest", "net:connect"],
     viaModule: ["http:HttpClient", "http:HttpRequest", "net:connect"],
+    stderr: "",
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import perf from "perf_hooks";
 
 test("stubs", () => {
@@ -20,4 +21,81 @@ test("doesn't throw", () => {
   expect(() => performance.now()).not.toThrow();
   expect(() => performance.timeOrigin).not.toThrow();
   expect(() => performance.markResourceTiming()).not.toThrow();
+});
+
+test("globalThis.PerformanceObserver is the node:perf_hooks PerformanceObserver", () => {
+  expect(globalThis.PerformanceObserver).toBe(perf.PerformanceObserver);
+  const types = globalThis.PerformanceObserver.supportedEntryTypes;
+  for (const nodeType of ["http", "net", "dns"]) {
+    expect(types).toContain(nodeType);
+  }
+});
+
+// Instrumentation written against globalThis.PerformanceObserver must receive the
+// same node-only entries (http/net/dns) that the node:perf_hooks observer gets.
+test("globalThis.PerformanceObserver delivers node-only entry types", async () => {
+  // The global is resolved as a bare identifier (not via globalThis.) so that
+  // scope resolution exercises the lazy custom accessor. node:perf_hooks is not
+  // loaded until after the observer is constructed.
+  const src = `
+    const http = require("node:http");
+
+    const srv = http.createServer((q, r) => r.end("hello"));
+    srv.listen(0, "127.0.0.1", () => {
+      const viaGlobal = [];
+      const viaModule = [];
+      const og = new PerformanceObserver(list => {
+        for (const e of list.getEntries()) viaGlobal.push(e.entryType + ":" + e.name);
+      });
+      og.observe({ entryTypes: ["http", "net"] });
+      const ModulePO = require("node:perf_hooks").PerformanceObserver;
+      const om = new ModulePO(list => {
+        for (const e of list.getEntries()) viaModule.push(e.entryType + ":" + e.name);
+      });
+      om.observe({ entryTypes: ["http", "net"] });
+
+      const req = http.request(
+        { host: "127.0.0.1", port: srv.address().port, path: "/x", agent: false },
+        res => {
+          res.resume();
+          res.on("end", () => {
+            // Observers dispatch on a fresh tick; let the buffered entries flush.
+            setImmediate(() => {
+              setImmediate(() => {
+                og.disconnect();
+                om.disconnect();
+                srv.close();
+                process.stdout.write(
+                  JSON.stringify({
+                    sameClass: PerformanceObserver === ModulePO,
+                    viaGlobal: viaGlobal.sort(),
+                    viaModule: viaModule.sort(),
+                  }),
+                );
+              });
+            });
+          });
+        },
+      );
+      req.on("error", err => {
+        process.stderr.write(String(err));
+        process.exit(1);
+      });
+      req.end();
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout);
+  expect(result).toEqual({
+    sameClass: true,
+    viaGlobal: ["http:HttpClient", "http:HttpRequest", "net:connect"],
+    viaModule: ["http:HttpClient", "http:HttpRequest", "net:connect"],
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What

`globalThis.PerformanceObserver` was the raw WebCore class, while `require('node:perf_hooks').PerformanceObserver` is a subclass that routes node-only entry types (`http`/`net`/`dns`) through a JS-side registry. Instrumentation written against the global accepted `observe({entryTypes:['http','net']})` without error but never delivered any entries; only the perf_hooks export did. Node documents the two as the same object.

```js
import { PerformanceObserver as ModulePO } from 'node:perf_hooks';
import http from 'node:http';

console.log(globalThis.PerformanceObserver === ModulePO);       // node: true,  bun: false
console.log(globalThis.PerformanceObserver.supportedEntryTypes);
// node: ['dns','function','gc','http','http2','mark','measure','net','quic','resource']
// bun:  ['mark','measure','resource']

const got = [];
new globalThis.PerformanceObserver(l => got.push(...l.getEntries().map(e => e.entryType)))
  .observe({ entryTypes: ['http', 'net'] });   // accepted silently
// ... make an http.request ...
// node: got = ['net','http','http']   bun: got = []
```

Companion to #33475 (`perf_hooks.performance !== globalThis.performance`); that was the `performance` object split, this is the observer class/registry split.

### Fix

`globalThis.PerformanceObserver` is now a lazy custom accessor that resolves to the `node:perf_hooks` subclass, so the two are the same object with one `supportedEntryTypes` list that includes the node types.

Two mechanical pieces:

- `perf_hooks.ts` previously read the native base class off `globalThis`; that would now re-enter the module load, so it fetches the native constructor directly via `getPerformanceObserverConstructor` in `JSPerformanceObserver.cpp` (same shape as `getWebSocketConstructor`).
- The global cannot stay in the static lut as a `PropertyCallback`: `JSScope::abstractResolve()` reifies those under a `VMInquiry` `PropertySlot` that forbids VM re-entry, and loading `perf_hooks` runs JS (crashes with a `checkVMEntryPermission` abort on the first bare-identifier reference). It is installed via `putDirectCustomAccessor` instead, which only records the getter in the slot; the value is materialized on first runtime read and then cached with `putDirect`.

### Verification

New tests in `test/js/node/perf_hooks/perf_hooks.test.ts`, both failing on main:

- identity: `globalThis.PerformanceObserver === perf.PerformanceObserver` and `supportedEntryTypes` includes `http`/`net`/`dns`.
- a spawned subprocess that resolves the global as a bare identifier without importing `node:perf_hooks`, observes `['http','net']`, makes an `http.request`, and asserts the global observer receives the same `http:HttpClient`/`http:HttpRequest`/`net:connect` entries the perf_hooks observer does.

Also pass: `performance-observer-leak.test.ts` (Worker with an undisconnected observer, exercises the lazy accessor inside a worker VM), `test/js/deno/performance/performance.test.ts`, the vendored `test-net-perf_hooks.js`, `test-http-perf_hooks.js`, `test-performance-measure.js`, and `web-globals.test.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ad5d5ad5e)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [5.00ms]
(pass) doesn't throw [15.17ms]
22 |   expect(() => performance.timeOrigin).not.toThrow();
23 |   expect(() => performance.markResourceTiming()).not.toThrow();
24 | });
25 | 
26 | test("globalThis.PerformanceObserver is the node:perf_hooks PerformanceObserver", () => {
27 |   expect(globalThis.PerformanceObserver).toBe(perf.PerformanceObserver);
                                              ^
error: expect(received).toBe(expected)

Expected: [class PerformanceObserverForNodeTypes extends PerformanceObserver]
Received: [class PerformanceObserver]

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:27:42)
(fail) globalThi
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.07ms]
(pass) doesn't throw [0.14ms]
22 |   expect(() => performance.timeOrigin).not.toThrow();
23 |   expect(() => performance.markResourceTiming()).not.toThrow();
24 | });
25 | 
26 | test("globalThis.PerformanceObserver is the node:perf_hooks PerformanceObserver", () => {
27 |   expect(globalThis.PerformanceObserver).toBe(perf.PerformanceObserver);
                                              ^
error: expect(received).toBe(expected)

Expected: [class PerformanceObserverForNodeTypes extends PerformanceObserver]
Received: [class PerformanceObserver]

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:27:42)
(fail) globalThis.PerformanceObserver is the node:perf_hooks PerformanceObserver [0.19ms]
94 |   try {
95 |     result = JSON.parse(stdout);
96 |   } catch {
97 |     result = { parseFailed: true, stdout };
98 |   }
99 |   expect({ ...result, stderr, exitCode }).toEqual({
                                               ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
-   "sameClass": true,
+   "sameClass": false,
    "st
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ad5d5ad5e)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [4.58ms]
(pass) doesn't throw [15.13ms]
(pass) globalThis.PerformanceObserver is the node:perf_hooks PerformanceObserver [12.07ms]
(pass) globalThis.PerformanceObserver delivers node-only entry types [3357.55ms]

 4 pass
 0 fail
 19 expect() calls
Ran 4 tests across 1 file. [6.43s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ad5d5ad5ef
  features     (none)

22 deps, 105 codegen, 1167 objects in 1271ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] gen ErrorCode+*.h
[2/1230] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [13.00ms]
[3/1230] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1230] gen .bind.ts → GeneratedBindings.cpp
[5/1230] fetch picohttpparser
[picohttpparser] up to date
[6/1230] gen bindgenv2
[7/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[8/1230
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/perf_hooks.ts                          | 17 ++---
 src/jsc/bindings/ZigGlobalObject.cpp               | 20 +++++-
 src/jsc/bindings/ZigGlobalObject.lut.txt           |  1 -
 src/jsc/bindings/webcore/JSPerformanceObserver.cpp |  5 ++
 src/jsc/bindings/webcore/JSPerformanceObserver.h   |  2 +
 test/js/node/perf_hooks/perf_hooks.test.ts         | 83 ++++++++++++++++++++++
 6 files changed, 116 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/perf_hooks.ts                               3      2      0
src/jsc/bindings/ZigGlobalObject.cpp                    4      7      0
src/jsc/bindings/ZigGlobalObject.lut.txt                1      1      0
src/jsc/bindings/webcore/JSPerformanceObserver.cpp      1      1      0
src/jsc/bindings/webcore/JSPerformanceObserver.h        1      1      0
test/js/node/perf_hooks/perf_hooks.test.ts              4      5      0
```

</details>

<!-- robobun:evidence:end -->