### PR TITLE
Bun.plugin: let runtime onLoad return undefined to fall through

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -384,18 +384,6 @@ void BunPlugin::Base::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* fu
     }
 }
 
-JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String& path)
-{
-    size_t count = filters.size();
-    for (size_t i = 0; i < count; i++) {
-        if (filters[i].get()->match(globalObject, path, 0)) {
-            return callbacks[i].get();
-        }
-    }
-
-    return nullptr;
-}
-
 void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -735,48 +735,84 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
         return JSValue::encode(jsUndefined());
     }
     Group& group = *groupPtr;
+    auto& filters = group.filters;
 
-    auto pathString = path->toWTFString(BunString::ZeroCopy);
-
-    auto* function = group.find(globalObject, pathString);
-    if (!function) {
-        return JSValue::encode(JSC::jsUndefined());
+    if (filters.size() == 0) {
+        return JSValue::encode(jsUndefined());
     }
 
-    JSC::MarkedArgumentBuffer arguments;
+    auto& callbacks = group.callbacks;
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     scope.assertNoExceptionExceptTermination();
+    auto pathString = path->toWTFString(BunString::ZeroCopy);
 
-    JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
-    const auto& builtinNames = WebCore::builtinNames(vm);
-    paramsObject->putDirect(
-        vm, builtinNames.pathPublicName(),
-        jsString(vm, pathString));
-    arguments.append(paramsObject);
-
-    auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    if (auto* promise = dynamicDowncast<JSPromise>(result)) {
-        switch (promise->status()) {
-        case JSPromise::Status::Rejected:
-        case JSPromise::Status::Pending: {
-            return JSValue::encode(promise);
-        }
-        case JSPromise::Status::Fulfilled: {
-            result = promise->result();
-            break;
-        }
-        }
+    JSC::MarkedArgumentBuffer matchedCallbacks;
+    matchedCallbacks.ensureCapacity(filters.size());
+    if (matchedCallbacks.hasOverflowed()) [[unlikely]] {
+        JSC::throwOutOfMemoryError(globalObject, scope);
+        return {};
     }
-
-    if (!result.isObject()) {
-        JSC::throwTypeError(globalObject, scope, "onLoad() expects an object returned"_s);
+    for (size_t i = 0; i < filters.size(); i++) {
+        if (!filters[i].get()->match(globalObject, pathString, 0)) {
+            continue;
+        }
+        auto* function = callbacks[i].get();
+        if (!function) [[unlikely]] {
+            continue;
+        }
+        matchedCallbacks.append(function);
+    }
+    if (matchedCallbacks.hasOverflowed()) [[unlikely]] {
+        JSC::throwOutOfMemoryError(globalObject, scope);
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(result));
+    const auto& builtinNames = WebCore::builtinNames(vm);
+
+    for (size_t i = 0; i < matchedCallbacks.size(); i++) {
+        auto* function = matchedCallbacks.at(i).getObject();
+
+        JSC::MarkedArgumentBuffer arguments;
+        JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
+        paramsObject->putDirect(
+            vm, builtinNames.pathPublicName(),
+            jsString(vm, pathString));
+        arguments.append(paramsObject);
+
+        auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        if (result.isUndefinedOrNull()) {
+            continue;
+        }
+
+        if (auto* promise = dynamicDowncast<JSPromise>(result)) {
+            switch (promise->status()) {
+            case JSPromise::Status::Rejected:
+            case JSPromise::Status::Pending: {
+                return JSValue::encode(promise);
+            }
+            case JSPromise::Status::Fulfilled: {
+                result = promise->result();
+                break;
+            }
+            }
+        }
+
+        if (result.isUndefinedOrNull()) {
+            continue;
+        }
+
+        if (!result.isObject()) {
+            JSC::throwTypeError(globalObject, scope, "onLoad() expects an object returned"_s);
+            return {};
+        }
+
+        RELEASE_AND_RETURN(scope, JSValue::encode(result));
+    }
+
+    return JSValue::encode(JSC::jsUndefined());
 }
 
 std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path, const String& from)

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -29,7 +29,6 @@ public:
         BunPluginTarget target { BunPluginTargetBun };
 
         void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func);
-        JSObject* find(JSC::JSGlobalObject* globalObj, String& path);
         void clear()
         {
             filters.clear();

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,103 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+describe("runtime onLoad returning undefined falls through", () => {
+  // The published OnLoadResult type allows `undefined | void` meaning "not interested, defer".
+  // This mirrors Bun.build's onLoad and runtime onResolve, which already fall through.
+
+  it("sync undefined defers to the next matching onLoad", async () => {
+    const calls: string[] = [];
+    Bun.plugin({
+      name: "onload-fallthrough-sync",
+      setup(b) {
+        b.onResolve({ filter: /.*/, namespace: "ftsync" }, a => ({ path: a.path, namespace: "ftsync-load" }));
+        b.onLoad({ filter: /.*/, namespace: "ftsync-load" }, () => {
+          calls.push("first");
+          return undefined;
+        });
+        b.onLoad({ filter: /.*/, namespace: "ftsync-load" }, () => {
+          calls.push("second");
+          return { contents: "export default 'SECOND'", loader: "js" };
+        });
+      },
+    });
+
+    const mod = await import("ftsync:x");
+    expect({ default: mod.default, calls }).toEqual({ default: "SECOND", calls: ["first", "second"] });
+  });
+
+  it("Promise.resolve(undefined) defers to the next matching onLoad", async () => {
+    const calls: string[] = [];
+    Bun.plugin({
+      name: "onload-fallthrough-promise",
+      setup(b) {
+        b.onResolve({ filter: /.*/, namespace: "ftprom" }, a => ({ path: a.path, namespace: "ftprom-load" }));
+        b.onLoad({ filter: /.*/, namespace: "ftprom-load" }, () => {
+          calls.push("first");
+          return Promise.resolve(undefined);
+        });
+        b.onLoad({ filter: /.*/, namespace: "ftprom-load" }, () => {
+          calls.push("second");
+          return { contents: "export default 'PROMISE-SECOND'", loader: "js" };
+        });
+      },
+    });
+
+    const mod = await import("ftprom:x");
+    expect({ default: mod.default, calls }).toEqual({ default: "PROMISE-SECOND", calls: ["first", "second"] });
+  });
+
+  it("null defers to the next matching onLoad", async () => {
+    Bun.plugin({
+      name: "onload-fallthrough-null",
+      setup(b) {
+        b.onResolve({ filter: /.*/, namespace: "ftnull" }, a => ({ path: a.path, namespace: "ftnull-load" }));
+        b.onLoad({ filter: /.*/, namespace: "ftnull-load" }, () => null as any);
+        b.onLoad({ filter: /.*/, namespace: "ftnull-load" }, () => ({
+          contents: "export default 'NULL-SECOND'",
+          loader: "js",
+        }));
+      },
+    });
+
+    expect((await import("ftnull:x")).default).toBe("NULL-SECOND");
+  });
+
+  it("a non-undefined non-object return still throws TypeError", async () => {
+    Bun.plugin({
+      name: "onload-bad-return",
+      setup(b) {
+        b.onResolve({ filter: /.*/, namespace: "ftbad" }, a => ({ path: a.path, namespace: "ftbad-load" }));
+        b.onLoad({ filter: /.*/, namespace: "ftbad-load" }, () => 42 as any);
+      },
+    });
+
+    await expect(import("ftbad:x")).rejects.toThrow(TypeError);
+  });
+
+  it.concurrent("defers to the default loader in the file namespace", async () => {
+    using dir = tempDir("plugin-onload-fallthrough-file", {
+      "preload.js": `
+        Bun.plugin({
+          name: "noop-onload",
+          setup(b) {
+            b.onLoad({ filter: /\\.js$/ }, () => undefined);
+          },
+        });
+      `,
+      "entry.js": `console.log("default-loader-ran");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim() || stderr).toBe("default-loader-ran");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

The published `OnLoadResult` type explicitly allows `undefined | void`:

```ts
type OnLoadResult = OnLoadResultSourceCode | OnLoadResultObject | undefined | void;
```

Returning `undefined` from an `onLoad` callback is the standard esbuild idiom for "not interested, let the next plugin or the default loader handle it". `Bun.build`'s `onLoad` and the runtime `onResolve` both honor this. Only the runtime `onLoad` path throws:

```
TypeError: onLoad() expects an object returned
```

## Repro

```ts
Bun.plugin({
  name: "ft",
  setup(b) {
    b.onResolve({ filter: /.*/, namespace: "ft" }, a => ({ path: a.path, namespace: "ftl" }));
    b.onLoad({ filter: /.*/, namespace: "ftl" }, () => undefined);             // should defer
    b.onLoad({ filter: /.*/, namespace: "ftl" }, () => ({ contents: "export default 'SECOND'", loader: "js" }));
  },
});
await import("ft:x");   // TypeError: onLoad() expects an object returned
```

## Cause

`BunPlugin::OnLoad::run` used `group.find()` to pick only the first matching callback, then unconditionally threw when that callback's result was not an object. `BunPlugin::OnResolve::run` in the same file already loops every matching callback and `continue`s on `undefined`/`null`.

## Fix

Rewrite `OnLoad::run` to mirror `OnResolve::run`: collect every matching callback up front, invoke them in order, and treat an `undefined`/`null` return (or an already-fulfilled promise resolving to `undefined`/`null`) as "continue to the next callback". When every callback declines, return `jsUndefined()` so the caller falls through to the default loader. A non-null non-object return still throws `TypeError`.

Note: a callback that returns a still-pending promise (e.g. `async () => { await fetch(...); return undefined; }`) is handed off to the existing async resolution path unchanged; fall-through across that boundary would need state threaded through `PendingVirtualModuleResult` and is out of scope here.

## Verification

New tests in `test/js/bun/plugin/plugins.test.ts` cover sync `undefined`, `Promise.resolve(undefined)`, `null`, the preserved TypeError for other non-objects, and fall-through to the default file loader. Before the fix 4 of the 5 fail with `TypeError: onLoad() expects an object returned`; all pass after.

Fixes #19957
Fixes #5303

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (37baccaef)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1111.64ms]
(pass) require > beep:boop returns 42 [9.07ms]
(pass) require > object module works [8.28ms]
(pass) module > throws with require() [12.71ms]
(pass) module > async module works with async import [24.94ms]
(pass) module > sync module module works with require() [4.56ms]
(pass) module > sync module module works with require.resolve() [3.11ms]
(pass) module > sync modul
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (37baccaef)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [32.42ms]
(pass) require > beep:boop returns 42 [0.18ms]
(pass) require > object module works [0.11ms]
(pass) module > throws with require() [0.16ms]
(pass) module > async module works with async import [2.64ms]
(pass) module > sync module module works with require() [0.08ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.08ms]
(pass) module > modules are overridable [0.21ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.12ms]
(pass) dynamic import > beep:boop returns 42 [0.06ms]
(pass) dynamic import > async:onLoad returns 42 [1.39ms]
(pass) dynamic import > async object loader returns 42 [1.25ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [1.85ms]
(todo) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (37baccaef)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1083.15ms]
(pass) require > beep:boop returns 42 [8.56ms]
(pass) require > object module works [7.79ms]
(pass) module > throws with require() [12.59ms]
(pass) module > async module works with async import [24.16ms]
(pass) module > sync module module works with require() [4.16ms]
(pass) module > sync module module works with require.resolve() [2.94ms]
(pass) module > sync modul
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/118] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[2/118] gen cpp.rs (cppbind)
[2/118] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp     | 100 +++++++++++++++++++++++--------------
 src/jsc/bindings/BunPlugin.h       |   1 -
 test/js/bun/plugin/plugins.test.ts | 100 +++++++++++++++++++++++++++++++++++++
 3 files changed, 162 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/BunPlugin.cpp          4      3      0
src/jsc/bindings/BunPlugin.h            1      1      0
test/js/bun/plugin/plugins.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->