### PR TITLE
node:http2: return undefined from session.socket after destroy()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3891,9 +3891,11 @@ class ServerHttp2Session extends Http2Session {
   }
 
   get socket() {
+    // Once the underlying socket is detached (destroy/close), Node returns
+    // undefined instead of the cached proxy so `instanceof` and truthiness
+    // guards in cleanup handlers stay inert.
+    if (!this[bunHTTP2Socket]) return undefined;
     if (this.#socket_proxy) return this.#socket_proxy;
-    const socket = this[bunHTTP2Socket];
-    if (!socket) return null;
     this.#socket_proxy = new Proxy(this, proxySocketHandler);
     return this.#socket_proxy;
   }
@@ -4646,9 +4648,11 @@ class ClientHttp2Session extends Http2Session {
     return this.#parser?.setLocalWindowSize?.(windowSize);
   }
   get socket() {
+    // Once the underlying socket is detached (destroy/close), Node returns
+    // undefined instead of the cached proxy so `instanceof` and truthiness
+    // guards in cleanup handlers stay inert.
+    if (!this[bunHTTP2Socket]) return undefined;
     if (this.#socket_proxy) return this.#socket_proxy;
-    const socket = this[bunHTTP2Socket];
-    if (!socket) return null;
     this.#socket_proxy = new Proxy(this, proxySocketHandler);
     return this.#socket_proxy;
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1617,6 +1617,47 @@ it("sensitive headers should work", async () => {
   }
 });
 
+it("session.socket is undefined after the session is destroyed", async () => {
+  const server = http2.createServer();
+  try {
+    server.on("session", ss => ss.on("error", () => {}));
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    const listening = Promise.withResolvers();
+    server.on("error", listening.reject);
+    server.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    const connected = Promise.withResolvers();
+    client.on("error", connected.reject);
+    client.on("connect", connected.resolve);
+    await connected.promise;
+
+    // Cache the proxy before destroy so we exercise the stale-proxy path;
+    // operations on the captured reference must still throw SOCKET_UNBOUND.
+    const socketBefore = client.socket;
+    expect(socketBefore).toBeDefined();
+
+    const closed = Promise.withResolvers();
+    client.on("close", closed.resolve);
+    client.destroy();
+    await closed.promise;
+
+    expect(client.socket).toBeUndefined();
+    expect(() => client.socket instanceof net.Socket).not.toThrow();
+    expect(client.socket instanceof net.Socket).toBe(false);
+    expect(() => socketBefore instanceof net.Socket).toThrow(
+      expect.objectContaining({ code: "ERR_HTTP2_SOCKET_UNBOUND" }),
+    );
+  } finally {
+    server.close();
+  }
+});
+
 it("http2 session.goaway() validates input types", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer((req, res) => {


### PR DESCRIPTION
## Repro

```js
import http2 from "node:http2";
import net from "node:net";
const srv = http2.createServer();
srv.on("stream", s => { s.respond({ ":status": 200 }); s.end("ok"); });
srv.listen(0, "127.0.0.1", () => {
  const ses = http2.connect(`http://127.0.0.1:${srv.address().port}`);
  ses.on("connect", () => {
    void ses.socket;   // cache the proxy
    ses.destroy();
    setTimeout(() => {
      console.log(typeof ses.socket);                 // node: undefined   bun: object
      console.log(ses.socket instanceof net.Socket);  // node: false       bun: throws ERR_HTTP2_SOCKET_UNBOUND
      process.exit(0);
    }, 100);
  });
});
```

Node [documents](https://nodejs.org/api/http2.html#http2sessionsocket) that `session.socket` is `undefined` once the session is destroyed. Bun kept returning the cached Proxy wrapper, whose traps (including `getPrototypeOf`, which `instanceof` calls) throw `ERR_HTTP2_SOCKET_UNBOUND` once the underlying socket is detached. The standard post-teardown guard `if (session.socket && !session.socket.destroyed)` therefore either saw a live-looking object or threw from inside cleanup code.

## Cause

Both `ServerHttp2Session` and `ClientHttp2Session` implement the getter as:

```js
get socket() {
  if (this.#socket_proxy) return this.#socket_proxy;
  const socket = this[bunHTTP2Socket];
  if (!socket) return null;
  ...
}
```

`destroy()` nulls `bunHTTP2Socket` but never touches `#socket_proxy`, so once the proxy was cached the first branch won forever. (And the uncached path returned `null`, not `undefined`.)

## Fix

Check `bunHTTP2Socket` first and return `undefined` when it is gone, in both session classes. A proxy reference captured *before* destroy still throws `ERR_HTTP2_SOCKET_UNBOUND` on access, matching Node (`test/js/node/test/parallel/test-http2-unbound-socket-proxy.js`, which still passes).

## Verification

New test in `test/js/node/http2/node-http2.test.js`:

```
USE_SYSTEM_BUN=1 bun test node-http2.test.js -t "session.socket is undefined"
  → fail (Received: <Proxy>)
bun bd test node-http2.test.js -t "session.socket is undefined"
  → pass
```

Full `node-http2.test.js`: 294 pass, 6 skip, 1 pre-existing timeout (`maxSessionMemory` 10k-request stress test under debug+ASAN, same on main).