### PR TITLE
node:http2: defer client session.encrypted to connect so originSet is seeded correctly

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3413,6 +3413,11 @@ function initOriginSet(session: Http2Session) {
     }
     let originString = `https://${hostName}`;
     if (socket.remotePort != null) originString += `:${socket.remotePort}`;
+    // node: originSet.add(getURLOrigin(originString)) - the WHATWG serialized origin (strips the
+    // default https port and ASCII-normalizes the host), so it compares equal to URL#origin.
+    try {
+      originString = new URL(originString).origin;
+    } catch {}
     originSet.add(originString);
   }
   return originSet;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3424,10 +3424,13 @@ function initOriginSet(session: Http2Session) {
 }
 function removeOriginFromSet(session: Http2Session, stream: ClientHttp2Stream) {
   const originSet = session[bunHTTP2OriginSet];
-  const origin = `https://${stream.authority}`;
-  if (originSet && origin) {
-    originSet.delete(origin);
-  }
+  if (!originSet) return;
+  let origin = `https://${stream.authority}`;
+  // The set is keyed on serialized origins (see initOriginSet); normalize the delete key too.
+  try {
+    origin = new URL(origin).origin;
+  } catch {}
+  originSet.delete(origin);
 }
 class ServerHttp2Session extends Http2Session {
   [kServer]: Http2Server = null;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3846,9 +3846,8 @@ class ServerHttp2Session extends Http2Session {
   }
 
   get originSet() {
-    if (this.encrypted) {
-      return Array.from(initOriginSet(this));
-    }
+    if (!this.encrypted || this.destroyed) return undefined;
+    return Array.from(initOriginSet(this));
   }
 
   get alpnProtocol() {
@@ -4141,7 +4140,8 @@ class ClientHttp2Session extends Http2Session {
     maxHeaderListSize: 65535,
     maxHeaderSize: 65535,
   };
-  #encrypted: boolean = false;
+  // node: undefined until the session socket has connected, then true for TLSSocket, false otherwise.
+  #encrypted: boolean | undefined = undefined;
   #pendingSettingsAck: boolean = true;
   // Count of SETTINGS frames sent that the peer has not yet ACKed (the initial connection
   // SETTINGS counts as the first). node destroys the session with
@@ -4456,9 +4456,8 @@ class ClientHttp2Session extends Http2Session {
   }
 
   get originSet() {
-    if (this.encrypted) {
-      return Array.from(initOriginSet(this));
-    }
+    if (!this.encrypted || this.destroyed) return undefined;
+    return Array.from(initOriginSet(this));
   }
   get alpnProtocol() {
     return this.#alpnProtocol;
@@ -4467,6 +4466,9 @@ class ClientHttp2Session extends Http2Session {
     const socket = this[bunHTTP2Socket];
     if (!socket) return;
     this.#connected = true;
+    // node sets kEncrypted/kAlpnProtocol on ready; until then they read undefined, which is also
+    // what gates the originSet getter so it cannot seed from an unconnected socket.
+    this.#encrypted = socket instanceof TLSSocket;
     // check if h2 is supported only for TLSSocket
     if (socket instanceof TLSSocket) {
       // client must check alpnProtocol
@@ -4781,7 +4783,6 @@ class ClientHttp2Session extends Http2Session {
       );
       this[bunHTTP2Socket] = socket;
     }
-    this.#encrypted = socket instanceof TLSSocket;
     const nativeSocket = socket._handle;
 
     if (options?.settings !== undefined) {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3187,33 +3187,36 @@ describe("http2 client session originSet", () => {
     ["IP literal", "127.0.0.1", undefined, "https://127.0.0.1"],
     ["hostname", "localhost", undefined, "https://localhost"],
     ["mixed-case servername", "127.0.0.1", "LocalHost", "https://localhost"],
-  ])("is undefined before connect and seeded from the connected socket (%s)", async (_label, host, servername, origin) => {
-    await withSecureServer(async port => {
-      const { promise, resolve, reject } = Promise.withResolvers();
-      const url = `https://${host}:${port}`;
-      const client = http2.connect(url, servername ? { ...TLS_OPTIONS, servername } : TLS_OPTIONS);
-      client.on("error", reject);
-      client.on("close", () => reject(new Error("closed before connect")));
-      const beforeConnect = { encrypted: client.encrypted, originSet: client.originSet };
-      client.on("connect", () => {
-        client.removeAllListeners("close");
-        resolve({ encrypted: client.encrypted, originSet: client.originSet });
+  ])(
+    "is undefined before connect and seeded from the connected socket (%s)",
+    async (_label, host, servername, origin) => {
+      await withSecureServer(async port => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        const url = `https://${host}:${port}`;
+        const client = http2.connect(url, servername ? { ...TLS_OPTIONS, servername } : TLS_OPTIONS);
+        client.on("error", reject);
+        client.on("close", () => reject(new Error("closed before connect")));
+        const beforeConnect = { encrypted: client.encrypted, originSet: client.originSet };
+        client.on("connect", () => {
+          client.removeAllListeners("close");
+          resolve({ encrypted: client.encrypted, originSet: client.originSet });
+        });
+        const onConnect = await promise;
+        client.destroy();
+        expect({
+          beforeConnect,
+          onConnect,
+          afterDestroy: { destroyed: client.destroyed, originSet: client.originSet },
+        }).toEqual({
+          beforeConnect: { encrypted: undefined, originSet: undefined },
+          onConnect: { encrypted: true, originSet: [`${origin}:${port}`] },
+          afterDestroy: { destroyed: true, originSet: undefined },
+        });
+        // http2-wrapper (got, crawlee) compares originSet[0] against URL#origin of the connect URL.
+        if (!servername) expect(onConnect.originSet[0]).toBe(new URL(url).origin);
       });
-      const onConnect = await promise;
-      client.destroy();
-      expect({
-        beforeConnect,
-        onConnect,
-        afterDestroy: { destroyed: client.destroyed, originSet: client.originSet },
-      }).toEqual({
-        beforeConnect: { encrypted: undefined, originSet: undefined },
-        onConnect: { encrypted: true, originSet: [`${origin}:${port}`] },
-        afterDestroy: { destroyed: true, originSet: undefined },
-      });
-      // http2-wrapper (got, crawlee) compares originSet[0] against URL#origin of the connect URL.
-      if (!servername) expect(onConnect.originSet[0]).toBe(new URL(url).origin);
-    });
-  });
+    },
+  );
 
   it("is undefined before connect and false for plaintext after connect", async () => {
     const server = http2.createServer();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -844,10 +844,11 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             client.on("error", reject);
             expect(client.connecting).toBeTrue();
             expect(client.alpnProtocol).toBeUndefined();
-            expect(client.encrypted).toBeTrue();
+            // node: encrypted and originSet are undefined until the session socket has connected.
+            expect(client.encrypted).toBeUndefined();
             expect(client.closed).toBeFalse();
             expect(client.destroyed).toBeFalse();
-            expect(client.originSet.length).toBe(1);
+            expect(client.originSet).toBeUndefined();
             expect(client.pendingSettingsAck).toBeTrue();
             assertSettings(client.localSettings);
             expect(client.remoteSettings).toBeNull();
@@ -3156,6 +3157,85 @@ it("http2 allowHTTP1 fallback writes no terminating chunk after a keep-alive HEA
   } finally {
     server.close();
   }
+});
+
+describe("http2 client session originSet", () => {
+  async function withSecureServer(fn) {
+    const server = http2.createSecureServer(TLS_CERT);
+    server.on("stream", s => {
+      s.on("error", () => {});
+      s.respond({ ":status": 200 });
+      s.end("ok");
+    });
+    server.on("session", ss => ss.on("error", () => {}));
+    const { promise: listening, resolve: onListen, reject: onListenErr } = Promise.withResolvers();
+    server.on("error", onListenErr);
+    server.listen(0, "127.0.0.1", onListen);
+    await listening;
+    try {
+      await fn(server.address().port);
+    } finally {
+      server.close();
+    }
+  }
+
+  // node: encrypted is undefined until the socket connects and originSet keys off it; reading
+  // originSet while connecting must not seed (and permanently cache) a bogus origin derived from
+  // an unconnected socket.
+  it.each([
+    ["IP literal", "127.0.0.1"],
+    ["hostname", "localhost"],
+  ])("is undefined before connect and seeded from the connected socket (%s)", async (_label, host) => {
+    await withSecureServer(async port => {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const client = http2.connect(`https://${host}:${port}`, TLS_OPTIONS);
+      client.on("error", reject);
+      client.on("close", () => reject(new Error("closed before connect")));
+      const beforeConnect = { encrypted: client.encrypted, originSet: client.originSet };
+      client.on("connect", () => {
+        client.removeAllListeners("close");
+        resolve({ encrypted: client.encrypted, originSet: client.originSet });
+      });
+      const onConnect = await promise;
+      client.destroy();
+      expect({
+        beforeConnect,
+        onConnect,
+        afterDestroy: { destroyed: client.destroyed, originSet: client.originSet },
+      }).toEqual({
+        beforeConnect: { encrypted: undefined, originSet: undefined },
+        onConnect: { encrypted: true, originSet: [`https://${host}:${port}`] },
+        afterDestroy: { destroyed: true, originSet: undefined },
+      });
+    });
+  });
+
+  it("is undefined before connect and false for plaintext after connect", async () => {
+    const server = http2.createServer();
+    server.on("stream", s => {
+      s.respond({ ":status": 200 });
+      s.end("ok");
+    });
+    const { promise: listening, resolve: onListen, reject: onListenErr } = Promise.withResolvers();
+    server.on("error", onListenErr);
+    server.listen(0, "127.0.0.1", onListen);
+    await listening;
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      client.on("error", reject);
+      const before = { encrypted: client.encrypted, originSet: client.originSet };
+      client.on("connect", () => resolve({ encrypted: client.encrypted, originSet: client.originSet }));
+      const after = await promise;
+      client.destroy();
+      expect({ before, after }).toEqual({
+        before: { encrypted: undefined, originSet: undefined },
+        after: { encrypted: false, originSet: undefined },
+      });
+    } finally {
+      server.close();
+    }
+  });
 });
 
 it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited response when the user removed it", async () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3181,14 +3181,17 @@ describe("http2 client session originSet", () => {
 
   // node: encrypted is undefined until the socket connects and originSet keys off it; reading
   // originSet while connecting must not seed (and permanently cache) a bogus origin derived from
-  // an unconnected socket.
+  // an unconnected socket. The seed itself is the WHATWG serialized origin (getURLOrigin), so a
+  // mixed-case servername is lowercased and the default https port would be stripped.
   it.each([
-    ["IP literal", "127.0.0.1"],
-    ["hostname", "localhost"],
-  ])("is undefined before connect and seeded from the connected socket (%s)", async (_label, host) => {
+    ["IP literal", "127.0.0.1", undefined, "https://127.0.0.1"],
+    ["hostname", "localhost", undefined, "https://localhost"],
+    ["mixed-case servername", "127.0.0.1", "LocalHost", "https://localhost"],
+  ])("is undefined before connect and seeded from the connected socket (%s)", async (_label, host, servername, origin) => {
     await withSecureServer(async port => {
       const { promise, resolve, reject } = Promise.withResolvers();
-      const client = http2.connect(`https://${host}:${port}`, TLS_OPTIONS);
+      const url = `https://${host}:${port}`;
+      const client = http2.connect(url, servername ? { ...TLS_OPTIONS, servername } : TLS_OPTIONS);
       client.on("error", reject);
       client.on("close", () => reject(new Error("closed before connect")));
       const beforeConnect = { encrypted: client.encrypted, originSet: client.originSet };
@@ -3204,9 +3207,11 @@ describe("http2 client session originSet", () => {
         afterDestroy: { destroyed: client.destroyed, originSet: client.originSet },
       }).toEqual({
         beforeConnect: { encrypted: undefined, originSet: undefined },
-        onConnect: { encrypted: true, originSet: [`https://${host}:${port}`] },
+        onConnect: { encrypted: true, originSet: [`${origin}:${port}`] },
         afterDestroy: { destroyed: true, originSet: undefined },
       });
+      // http2-wrapper (got, crawlee) compares originSet[0] against URL#origin of the connect URL.
+      if (!servername) expect(onConnect.originSet[0]).toBe(new URL(url).origin);
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

`session.originSet` on a client `Http2Session` is lazily seeded from the socket's `servername` / `remoteAddress` / `remotePort`. Two divergences from Node.js compounded:

1. Bun set `#encrypted` in the constructor (before the TLS socket connected), so reading `originSet` while the session was still connecting ran `initOriginSet` against a socket that has no `remotePort` yet and, for IP dials, no `servername` either. The bogus seed was cached for the life of the session, and the getter also kept returning it after `destroy()`.
2. The seed was added to the set as-is; Node passes it through `getURLOrigin()` (WHATWG serialized origin), which strips the default https port and lowercases/ASCII-normalizes the host. `http2-wrapper`'s Agent (used by `got`, `got-scraping`, `crawlee`) compares `originSet[0]` against `new URL(connectUrl).origin` and rejected the session with `Requested origin https://<host> does not match server https://<host>:443`.

```
// system bun                                       // node v26.3.0
ip   before connect: originSet=["https://undefined"]     undefined
ip   connected     : originSet=["https://undefined"]     ["https://127.0.0.1:<port>"]
ip   after destroy : originSet=["https://undefined"]     undefined
name before connect: originSet=["https://localhost"]     undefined
name connected     : originSet=["https://localhost"]     ["https://localhost:<port>"]
name after destroy : originSet=["https://localhost"]     undefined
```

Connection pools that key on `originSet` (ALTSVC / ORIGIN-frame coalescing) would route requests to the wrong connection: every IP-dialled secure session collapsed onto `https://undefined`, and named sessions to different ports collapsed onto one port-less origin.

### Fix

* Client `#encrypted` starts `undefined` and is set in `#onConnect()` (alongside `#alpnProtocol`), matching Node's `kEncrypted` timing. The `originSet` getter therefore returns `undefined` until the socket is connected, so `initOriginSet` only ever seeds from a socket that actually has `servername`/`remoteAddress`/`remotePort`.
* `get originSet()` (client and server) returns `undefined` when `!this.encrypted || this.destroyed`, matching Node's getter.
* `initOriginSet` normalizes the seed through `new URL(originString).origin`, matching Node's `getURLOrigin`, so a connection on the default https port yields `https://host` (not `https://host:443`) and the host is ASCII-normalized.

Fixes #25771
Fixes #18964
Fixes #19077

## How did you verify your code works?

New tests in `test/js/node/http2/node-http2.test.js` read `originSet` / `encrypted` before connect, on connect, and after destroy for an IP-literal dial, a hostname dial, and a mixed-case `servername` (which exercises the URL origin normalization), plus a plaintext session. All four fail on `USE_SYSTEM_BUN=1` and pass with this change; the full node-http2 suite (298 tests) and Node's own `test-http2-ip-address-host.js` / `test-http2-origin.js` / `test-http2-create-client-secure-session.js` continue to pass.
