### PR TITLE
Bun.plugin: propagate getter exceptions from loader: "object" exports

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -661,6 +661,10 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
                             JSC::MarkedArgumentBuffer values;
                             values.ensureCapacity(names.size());
+                            if (values.hasOverflowed()) [[unlikely]] {
+                                JSC::throwOutOfMemoryError(globalObject, scope);
+                                return {};
+                            }
                             for (auto& name : names) {
                                 JSValue value = object->get(globalObject, name);
                                 RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -660,13 +660,8 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             RETURN_IF_EXCEPTION(scope, {});
 
                             for (auto& name : names) {
-                                // consistent with regular esm handling code
-                                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
                                 JSValue value = object->get(globalObject, name);
-                                if (scope.exception()) [[unlikely]] {
-                                    (void)scope.tryClearException();
-                                    value = jsUndefined();
-                                }
+                                RETURN_IF_EXCEPTION(scope, {});
                                 moduleNamespaceObject->overrideExportValue(globalObject, name, value);
                                 RETURN_IF_EXCEPTION(scope, {});
                             }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -659,10 +659,19 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
 
+                            JSC::MarkedArgumentBuffer values;
+                            values.ensureCapacity(names.size());
                             for (auto& name : names) {
                                 JSValue value = object->get(globalObject, name);
                                 RETURN_IF_EXCEPTION(scope, {});
-                                moduleNamespaceObject->overrideExportValue(globalObject, name, value);
+                                values.append(value);
+                            }
+                            if (values.hasOverflowed()) [[unlikely]] {
+                                JSC::throwOutOfMemoryError(globalObject, scope);
+                                return {};
+                            }
+                            for (size_t i = 0; i < names.size(); ++i) {
+                                moduleNamespaceObject->overrideExportValue(globalObject, names[i], values.at(i));
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
 

--- a/src/jsc/modules/ObjectModule.cpp
+++ b/src/jsc/modules/ObjectModule.cpp
@@ -24,12 +24,8 @@ generateObjectModuleSourceCode(JSC::JSGlobalObject* globalObject,
         for (auto& entry : properties.releaseData()->propertyNameVector()) {
             exportNames.append(entry);
 
-            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             JSValue value = object->get(globalObject, entry);
-            if (scope.exception()) [[unlikely]] {
-                (void)scope.tryClearException();
-                value = jsUndefined();
-            }
+            RETURN_IF_EXCEPTION(throwScope, void());
             exportValues.append(value);
         }
     };

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,45 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+it.concurrent("loader: 'object' propagates exceptions from export property getters", async () => {
+  const script = `
+    const sentinel = new Error("GETTER-THROW");
+    const exportsObj = { before: 1 };
+    Object.defineProperty(exportsObj, "boom", { enumerable: true, get() { throw sentinel; } });
+    exportsObj.after = 2;
+
+    Bun.plugin({
+      name: "throwing-getter",
+      setup(build) {
+        build.module("throwing-getter:esm", () => ({ exports: exportsObj, loader: "object" }));
+        build.module("throwing-getter:cjs", () => ({ exports: exportsObj, loader: "object" }));
+      },
+    });
+
+    async function attempt(label, fn) {
+      try {
+        const ns = await fn();
+        return label + " resolved boom=" + ns.boom;
+      } catch (e) {
+        return label + " rejected " + (e === sentinel) + " " + e.message;
+      }
+    }
+
+    console.log(await attempt("import", () => import("throwing-getter:esm")));
+    console.log(await attempt("require", () => require("throwing-getter:cjs")));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim() ? stdout.trim().split("\n") : [stderr];
+  expect({ lines, exitCode }).toEqual({
+    lines: ["import rejected true GETTER-THROW", "require rejected true GETTER-THROW"],
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/test/mock/mock-module-getter-throw-fixture.ts
+++ b/test/js/bun/test/mock/mock-module-getter-throw-fixture.ts
@@ -1,0 +1,1 @@
+export const existing = "original";

--- a/test/js/bun/test/mock/mock-module-getter-throw-fixture.ts
+++ b/test/js/bun/test/mock/mock-module-getter-throw-fixture.ts
@@ -1,1 +1,2 @@
-export const existing = "original";
+export const a = "original-a";
+export const b = "original-b";

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -158,11 +158,11 @@ test("mocking a package", async () => {
 });
 
 test("mock.module propagates a throwing getter on the factory's return value", () => {
-  expect(getterThrowFixture.existing).toBe("original");
+  expect({ a: getterThrowFixture.a, b: getterThrowFixture.b }).toEqual({ a: "original-a", b: "original-b" });
 
   const sentinel = new Error("GETTER-THROW");
-  const mockExports: { existing: string } = {} as any;
-  Object.defineProperty(mockExports, "existing", {
+  const mockExports: { a: string; b: string } = { a: "mock-a" } as any;
+  Object.defineProperty(mockExports, "b", {
     enumerable: true,
     get: () => {
       throw sentinel;
@@ -170,7 +170,8 @@ test("mock.module propagates a throwing getter on the factory's return value", (
   });
 
   expect(() => mock.module("./mock-module-getter-throw-fixture", () => mockExports)).toThrow(sentinel);
-  expect(getterThrowFixture.existing).toBe("original");
+  // All values are read before any override is written, so a throwing getter leaves the namespace untouched.
+  expect({ a: getterThrowFixture.a, b: getterThrowFixture.b }).toEqual({ a: "original-a", b: "original-b" });
 });
 
 test("mocking a builtin", async () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -9,6 +9,7 @@
 
 import { expect, mock, spyOn, test } from "bun:test";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
+import * as getterThrowFixture from "./mock-module-getter-throw-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
 test("mock.module async", async () => {
@@ -154,6 +155,17 @@ test("mocking a package", async () => {
 
   expect(hahaha.wow()).toBe(43);
   expect(require("ha-ha-ha").wow()).toBe(43);
+});
+
+test("mock.module propagates a throwing getter on the factory's return value", () => {
+  expect(getterThrowFixture.existing).toBe("original");
+
+  const sentinel = new Error("GETTER-THROW");
+  const mockExports: { existing: string } = {} as any;
+  Object.defineProperty(mockExports, "existing", { enumerable: true, get: () => { throw sentinel; } });
+
+  expect(() => mock.module("./mock-module-getter-throw-fixture", () => mockExports)).toThrow(sentinel);
+  expect(getterThrowFixture.existing).toBe("original");
 });
 
 test("mocking a builtin", async () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -162,7 +162,12 @@ test("mock.module propagates a throwing getter on the factory's return value", (
 
   const sentinel = new Error("GETTER-THROW");
   const mockExports: { existing: string } = {} as any;
-  Object.defineProperty(mockExports, "existing", { enumerable: true, get: () => { throw sentinel; } });
+  Object.defineProperty(mockExports, "existing", {
+    enumerable: true,
+    get: () => {
+      throw sentinel;
+    },
+  });
 
   expect(() => mock.module("./mock-module-getter-throw-fixture", () => mockExports)).toThrow(sentinel);
   expect(getterThrowFixture.existing).toBe("original");


### PR DESCRIPTION
## Repro

```js
const sentinel = new Error("GETTER-THROW");
const exportsObj = { before: 1 };
Object.defineProperty(exportsObj, "boom", { enumerable: true, get() { throw sentinel; } });
exportsObj.after = 2;

Bun.plugin({ name: "g", setup(b) { b.module("g:m", () => ({ exports: exportsObj, loader: "object" })); } });
const ns = await import("g:m");   // does NOT reject
console.log(Object.keys(ns), ns.boom);
// [ "after", "before", "boom" ] undefined
```

The import resolves, the `boom` export exists, and its value is `undefined`. Nothing is surfaced to the importer or the plugin. The same object handed to a plain JS spread (`{ ...exportsObj }`) throws, and a throwing Proxy `ownKeys` trap on the same object already rejects the import; only the per-property `Get` exception was being dropped.

## Cause

`generateObjectModuleSourceCode` in `src/jsc/modules/ObjectModule.cpp` iterates the exports object's own property names and calls `object->get(globalObject, entry)` for each. If the `Get` threw, it cleared the exception and stored `jsUndefined()`:

```cpp
auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
JSValue value = object->get(globalObject, entry);
if (scope.exception()) [[unlikely]] {
    (void)scope.tryClearException();
    value = jsUndefined();
}
exportValues.append(value);
```

The sibling `generateObjectModuleSourceCodeForJSON` in the same file and `generateInternalModuleSourceCode` in `ModuleLoader.cpp` both use `RETURN_IF_EXCEPTION` after the same `get` call, and this function already uses `RETURN_IF_EXCEPTION` after `getOwnPropertyNames`.

## Fix

Replace the clear-and-default with `RETURN_IF_EXCEPTION(throwScope, void())`, so the getter's exception propagates and the import rejects with it.

The `mock.module()` ESM-override path in `src/jsc/bindings/BunPlugin.cpp` had the same swallow with a comment reading "consistent with regular esm handling code" (i.e. the code above). That copy is updated to propagate as well so the two paths stay consistent.

The analogous swallow in `JSCommonJSModule.cpp` is left untouched: it is documented as matching Node.js behaviour for CJS named-export enumeration and is a different code path.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/plugin/plugins.test.ts -t "propagates exceptions from export property getters"
  -> fail: "import resolved boom=undefined" / "require resolved boom=undefined"

bun bd test test/js/bun/plugin/plugins.test.ts -t "propagates exceptions from export property getters"
  -> pass: "import rejected true GETTER-THROW" / "require rejected true GETTER-THROW"

bun bd test test/js/bun/plugin/plugins.test.ts        # 35 pass, 1 todo
bun bd test test/js/bun/test/mock/mock-module.test.ts #  9 pass, 1 todo
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0152a8640)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1096.54ms]
(pass) require > beep:boop returns 42 [8.83ms]
(pass) require > object module works [7.76ms]
(pass) module > throws with require() [12.81ms]
(pass) module > async module works with async import [26.55ms]
(pass) module > sync module module works with require() [4.45ms]
(pass) module > sync module module works with require.res
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (0152a8640)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [34.19ms]
(pass) require > beep:boop returns 42 [0.19ms]
(pass) require > object module works [0.11ms]
(pass) module > throws with require() [0.18ms]
(pass) module > async module works with async import [2.81ms]
(pass) module > sync module module works with require() [0.08ms]
(pass) module > sync module module works with require.resolve() [0.07ms]
(pass) module > sync module module works with import [0.08ms]
(pass) module > modules are overridable [0.22ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.13ms]
(pass) dynamic import > beep:boop returns 42 [0.07ms]
(pass) dynamic import > async:onLoad returns 42 [1.44ms]
(pass) dynamic import > async object loader returns 42 [1.27ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [2.06ms]
(todo) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0152a8640)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1106.36ms]
(pass) require > beep:boop returns 42 [8.89ms]
(pass) require > object module works [8.17ms]
(pass) module > throws with require() [12.61ms]
(pass) module > async module works with async import [23.57ms]
(pass) module > sync module module works with require() [4.35ms]
(pass) module > sync module module works with require.res
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 710ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[2/9] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[3/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[4/9] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[5/9] gen cpp.rs (cppbind)
[5/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unkno
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp                     | 22 ++++++++----
 src/jsc/modules/ObjectModule.cpp                   |  6 +---
 test/js/bun/plugin/plugins.test.ts                 | 42 ++++++++++++++++++++++
 .../test/mock/mock-module-getter-throw-fixture.ts  |  2 ++
 test/js/bun/test/mock/mock-module.test.ts          | 18 ++++++++++
 5 files changed, 78 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/BunPlugin.cpp                                3      5      0
src/jsc/modules/ObjectModule.cpp                              1      1      0
test/js/bun/plugin/plugins.test.ts                            5      2      0
…st/js/bun/test/mock/mock-module-getter-throw-fixture.ts      0      2      0
test/js/bun/test/mock/mock-module.test.ts                     2      3      0
```

</details>

<!-- robobun:evidence:end -->