### PR TITLE
node:http2: stop session.ref()/unref() from returning the raw net.Socket

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3907,12 +3907,14 @@ class ServerHttp2Session extends Http2Session {
 
   unref() {
     // Generic-stream sockets (e.g. duplexPair) have no unref; node treats it as a no-op.
+    // Do not return the socket's return value: net.Socket#unref returns `this`, which would
+    // leak the un-proxied socket past the ERR_HTTP2_NO_SOCKET_MANIPULATION guard.
     const socket = this[bunHTTP2Socket];
-    if (typeof socket?.unref === "function") return socket.unref();
+    if (typeof socket?.unref === "function") socket.unref();
   }
   ref() {
     const socket = this[bunHTTP2Socket];
-    if (typeof socket?.ref === "function") return socket.ref();
+    if (typeof socket?.ref === "function") socket.ref();
   }
   setTimeout(msecs, callback) {
     // node registers the callback as a one-shot 'timeout' listener on the session itself; the
@@ -4577,12 +4579,14 @@ class ClientHttp2Session extends Http2Session {
   }
   unref() {
     // Generic-stream sockets (e.g. duplexPair) have no unref; node treats it as a no-op.
+    // Do not return the socket's return value: net.Socket#unref returns `this`, which would
+    // leak the un-proxied socket past the ERR_HTTP2_NO_SOCKET_MANIPULATION guard.
     const socket = this[bunHTTP2Socket];
-    if (typeof socket?.unref === "function") return socket.unref();
+    if (typeof socket?.unref === "function") socket.unref();
   }
   ref() {
     const socket = this[bunHTTP2Socket];
-    if (typeof socket?.ref === "function") return socket.ref();
+    if (typeof socket?.ref === "function") socket.ref();
   }
   setNextStreamID(id) {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3186,3 +3186,56 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
     server.close();
   }
 });
+
+it("session.ref()/unref() and session.socket.ref()/unref() return undefined and do not expose the raw socket", async () => {
+  const serverSide = Promise.withResolvers();
+  const server = http2.createServer();
+  server.on("session", session => {
+    session.on("error", () => {});
+    try {
+      serverSide.resolve({
+        sessionRef: session.ref(),
+        sessionUnref: session.unref(),
+        socketRef: session.socket.ref(),
+        socketUnref: session.socket.unref(),
+      });
+      session.ref();
+    } catch (e) {
+      serverSide.reject(e);
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const connected = Promise.withResolvers();
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", connected.reject);
+    client.on("connect", () => connected.resolve());
+    await connected.promise;
+    try {
+      // These methods route to the session (not blocked by ERR_HTTP2_NO_SOCKET_MANIPULATION) but
+      // must not hand back net.Socket#ref/#unref's `this`, or the proxy guard is bypassed.
+      expect({
+        sessionRef: client.ref(),
+        sessionUnref: client.unref(),
+        socketRef: client.socket.ref(),
+        socketUnref: client.socket.unref(),
+      }).toEqual({
+        sessionRef: undefined,
+        sessionUnref: undefined,
+        socketRef: undefined,
+        socketUnref: undefined,
+      });
+      expect(client.ref()).not.toBeInstanceOf(net.Socket);
+      expect(await serverSide.promise).toEqual({
+        sessionRef: undefined,
+        sessionUnref: undefined,
+        socketRef: undefined,
+        socketUnref: undefined,
+      });
+    } finally {
+      client.close();
+    }
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Repro

```js
import http2 from "node:http2";
import net from "node:net";
const srv = http2.createServer();
srv.listen(0, "127.0.0.1", () => {
  const ses = http2.connect(`http://127.0.0.1:${srv.address().port}`);
  ses.on("connect", () => {
    const r = [ses.socket.ref(), ses.socket.unref(), ses.ref(), ses.unref()];
    console.log(r.map(v => v === undefined ? "undefined" : v instanceof net.Socket ? "RAW net.Socket" : v).join(" | "));
    // node: undefined | undefined | undefined | undefined
    // bun : RAW net.Socket | RAW net.Socket | RAW net.Socket | RAW net.Socket
    if (r[0] instanceof net.Socket) r[0].destroy();   // guard bypassed
    process.exit(0);
  });
});
```

`session.socket` is a Proxy whose sole purpose is to make it impossible for user code to mutate the TCP/TLS socket behind the frame parser's back. `destroy`/`end`/`write`/`pause`/`resume`/`emit`/`setEncoding`/`setKeepAlive`/`setNoDelay` all throw `ERR_HTTP2_NO_SOCKET_MANIPULATION`. `ref`/`unref`/`setTimeout` are instead routed to the session, which is correct, but `Http2Session.prototype.ref()`/`unref()` did `return socket.ref()`. Since `net.Socket#ref`/`#unref` return `this`, the un-proxied socket was handed straight back. `session.ref()`/`session.unref()` (the documented API that agent pools call on every checkout/checkin) leaked the same handle directly.

## Fix

Drop the `return` from `ref()`/`unref()` on both `ClientHttp2Session` and `ServerHttp2Session`. Node's `Http2Session#ref/#unref` resolve to `undefined`.

## Verification

New test in `test/js/node/http2/node-http2.test.js` asserts all four entry points (`session.ref()`, `session.unref()`, `session.socket.ref()`, `session.socket.unref()`) on both the client and server session return `undefined` and are not `net.Socket` instances.

```
USE_SYSTEM_BUN=1 bun test node-http2.test.js -t "return undefined and do not expose the raw socket"
  → fail (Received: <Socket ...>)
bun bd test node-http2.test.js -t "return undefined and do not expose the raw socket"
  → pass
```

Full `node-http2.test.js`: 294 pass, 6 skip, 1 pre-existing timeout (`maxSessionMemory` 10k-request stress test under debug+ASAN, same on main). `test-http2-session-unref.js`, `test-http2-socket-close.js`, `test-http2-socket-proxy-handler-for-has.js` from the Node parallel suite all still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9cb040762)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [762.31ms]
(pass) node none > Client Basics > should be able to send a POST request [529.08ms]
(pass) node none > Client Basics > constants [18.89ms]
(pass) node none > Client Basics > getDefaultSettings [7.59ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.42ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.86ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.62ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.86ms
... (truncated)

release without fix: 7 failed, 6 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.82ms]
(pass) node none > Client Basics > getDefaultSettings [0.20ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.46ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.09ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.11ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [1.82ms]
(pass) node none > Client Basics > is possible to abort request [1.01ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.76ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.62ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.98ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [16.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9cb040762)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [799.76ms]
(pass) node none > Client Basics > should be able to send a POST request [549.49ms]
(pass) node none > Client Basics > constants [19.20ms]
(pass) node none > Client Basics > getDefaultSettings [7.98ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [25.91ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.57ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [4.01ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [6.38ms
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 771ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/121] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[2/121] gen cpp.rs (cppbind)
[3/121] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - Fi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 12 +++++---
 test/js/node/http2/node-http2.test.js | 53 +++++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       1      2      0
test/js/node/http2/node-http2.test.js      3      1      0
```

</details>

<!-- robobun:evidence:end -->