### PR TITLE
node:http2: validate ping() arguments synchronously and accept DataView payloads

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3943,8 +3943,10 @@ class ServerHttp2Session extends Http2Session {
       payload.writeBigUInt64LE(process.hrtime.bigint());
     }
     const parser = this.#parser;
-    if (!parser) return false;
-    if (!this[bunHTTP2Socket]) return false;
+    if (!parser || !this[bunHTTP2Socket]) {
+      process.nextTick(callback, $ERR_HTTP2_PING_CANCEL());
+      return false;
+    }
 
     if (this.#pingCallbacks) {
       this.#pingCallbacks.push([callback, Date.now()]);
@@ -4622,8 +4624,10 @@ class ClientHttp2Session extends Http2Session {
       payload.writeBigUInt64LE(process.hrtime.bigint());
     }
     const parser = this.#parser;
-    if (!parser) return false;
-    if (!this[bunHTTP2Socket]) return false;
+    if (!parser || !this[bunHTTP2Socket]) {
+      process.nextTick(callback, $ERR_HTTP2_PING_CANCEL());
+      return false;
+    }
 
     if (this.#pingCallbacks) {
       this.#pingCallbacks.push([callback, Date.now()]);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3952,7 +3952,13 @@ class ServerHttp2Session extends Http2Session {
       this.#pingCallbacks = [[callback, Date.now()]];
     }
 
-    parser.ping(payload);
+    try {
+      parser.ping(payload);
+    } catch {
+      this.#pingCallbacks.pop();
+      process.nextTick(callback, $ERR_HTTP2_PING_CANCEL());
+      return false;
+    }
     return true;
   }
   goaway(code = NGHTTP2_NO_ERROR, lastStreamID = 0, opaqueData) {
@@ -4625,7 +4631,13 @@ class ClientHttp2Session extends Http2Session {
       this.#pingCallbacks = [[callback, Date.now()]];
     }
 
-    parser.ping(payload);
+    try {
+      parser.ping(payload);
+    } catch {
+      this.#pingCallbacks.pop();
+      process.nextTick(callback, $ERR_HTTP2_PING_CANCEL());
+      return false;
+    }
     return true;
   }
   goaway(errorCode = constants.NGHTTP2_NO_ERROR, lastStreamId = 0, opaqueData) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3929,30 +3929,27 @@ class ServerHttp2Session extends Http2Session {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();
     if (typeof payload === "function") {
       callback = payload;
-      payload = Buffer.alloc(8);
-    } else {
-      payload = payload || Buffer.alloc(8);
+      payload = undefined;
     }
-    if (!(payload instanceof Buffer) && !isTypedArray(payload)) {
-      throw $ERR_INVALID_ARG_TYPE("payload", ["Buffer", "TypedArray"], payload);
+    if (payload != null) {
+      validateBuffer(payload, "payload");
+      if (payload.byteLength !== 8) {
+        throw $ERR_HTTP2_PING_LENGTH();
+      }
+    }
+    validateFunction(callback, "callback");
+    if (payload == null) {
+      payload = Buffer.allocUnsafe(8);
+      payload.writeBigUInt64LE(process.hrtime.bigint());
     }
     const parser = this.#parser;
     if (!parser) return false;
     if (!this[bunHTTP2Socket]) return false;
 
-    if (typeof callback === "function") {
-      if (payload.byteLength !== 8) {
-        const error = $ERR_HTTP2_PING_LENGTH();
-        callback(error, 0, payload);
-        return;
-      }
-      if (this.#pingCallbacks) {
-        this.#pingCallbacks.push([callback, Date.now()]);
-      } else {
-        this.#pingCallbacks = [[callback, Date.now()]];
-      }
-    } else if (payload.byteLength !== 8) {
-      throw $ERR_HTTP2_PING_LENGTH();
+    if (this.#pingCallbacks) {
+      this.#pingCallbacks.push([callback, Date.now()]);
+    } else {
+      this.#pingCallbacks = [[callback, Date.now()]];
     }
 
     parser.ping(payload);
@@ -4605,30 +4602,27 @@ class ClientHttp2Session extends Http2Session {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();
     if (typeof payload === "function") {
       callback = payload;
-      payload = Buffer.alloc(8);
-    } else {
-      payload = payload || Buffer.alloc(8);
+      payload = undefined;
     }
-    if (!(payload instanceof Buffer) && !isTypedArray(payload)) {
-      throw $ERR_INVALID_ARG_TYPE("payload", ["Buffer", "TypedArray"], payload);
+    if (payload != null) {
+      validateBuffer(payload, "payload");
+      if (payload.byteLength !== 8) {
+        throw $ERR_HTTP2_PING_LENGTH();
+      }
+    }
+    validateFunction(callback, "callback");
+    if (payload == null) {
+      payload = Buffer.allocUnsafe(8);
+      payload.writeBigUInt64LE(process.hrtime.bigint());
     }
     const parser = this.#parser;
     if (!parser) return false;
     if (!this[bunHTTP2Socket]) return false;
 
-    if (typeof callback === "function") {
-      if (payload.byteLength !== 8) {
-        const error = $ERR_HTTP2_PING_LENGTH();
-        callback(error, 0, payload);
-        return;
-      }
-      if (this.#pingCallbacks) {
-        this.#pingCallbacks.push([callback, Date.now()]);
-      } else {
-        this.#pingCallbacks = [[callback, Date.now()]];
-      }
-    } else if (payload.byteLength !== 8) {
-      throw $ERR_HTTP2_PING_LENGTH();
+    if (this.#pingCallbacks) {
+      this.#pingCallbacks.push([callback, Date.now()]);
+    } else {
+      this.#pingCallbacks = [[callback, Date.now()]];
     }
 
     parser.ping(payload);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1027,6 +1027,39 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             client.close();
           }
         });
+        it("ping returns false and cancels via callback once maxOutstandingPings is reached", async () => {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          const client = http2.connect(HTTPS_SERVER, { ...TLS_OPTIONS, maxOutstandingPings: 2 });
+          client.on("error", reject);
+          client.on("connect", () => resolve());
+          await promise;
+          try {
+            const pA = Buffer.from("AAAAAAAA");
+            const pB = Buffer.from("BBBBBBBB");
+            const acks = [];
+            const ackPromise = new Promise((res, rej) => {
+              const record = name => (err, d, ret) => {
+                if (err) return rej(err);
+                acks.push([name, Buffer.from(ret)]);
+                if (acks.length === 2) res();
+              };
+              expect(client.ping(pA, record("A"))).toBe(true);
+              expect(client.ping(pB, record("B"))).toBe(true);
+            });
+            const cancelled = await new Promise((res, rej) => {
+              const ok = client.ping(Buffer.from("CCCCCCCC"), err => (err ? res(err) : rej("expected cancel")));
+              expect(ok).toBe(false);
+            });
+            expect(cancelled).toMatchObject({ code: "ERR_HTTP2_PING_CANCEL", name: "Error" });
+            await ackPromise;
+            expect(acks).toEqual([
+              ["A", pA],
+              ["B", pB],
+            ]);
+          } finally {
+            client.close();
+          }
+        });
         it("ping without payload echoes a non-zero timestamp", async () => {
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -981,7 +981,13 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           client.on("connect", () => resolve());
           await promise;
           try {
-            for (const args of [[], [Buffer.alloc(8)], [Buffer.alloc(8), 5], [Buffer.alloc(8), null], [Buffer.alloc(8), {}]]) {
+            for (const args of [
+              [],
+              [Buffer.alloc(8)],
+              [Buffer.alloc(8), 5],
+              [Buffer.alloc(8), null],
+              [Buffer.alloc(8), {}],
+            ]) {
               expect(() => client.ping(...args)).toThrow(
                 expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
               );

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -952,23 +952,90 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           // See above: no 'ping' event for ACKs of our own pings (node parity).
           expect(received_ping).toBeUndefined();
         });
-        it("ping with wrong payload length events should error", async () => {
+        it("ping with wrong payload length should throw synchronously", async () => {
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
-          client.on("connect", () => {
-            client.ping(Buffer.from("oops"), (err, duration, payload) => {
-              if (err) {
-                resolve(err);
-              } else {
-                reject("unreachable");
-              }
-              client.close();
+          client.on("connect", () => resolve());
+          await promise;
+          try {
+            for (const bad of [
+              Buffer.from("oops"),
+              Buffer.from("abcdefg"),
+              Buffer.from("abcdefghi"),
+              new Uint32Array(8),
+              new DataView(new ArrayBuffer(7)),
+            ]) {
+              expect(() => client.ping(bad, () => reject("callback must not run"))).toThrow(
+                expect.objectContaining({ code: "ERR_HTTP2_PING_LENGTH", name: "RangeError" }),
+              );
+            }
+          } finally {
+            client.close();
+          }
+        });
+        it("ping requires a function callback", async () => {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
+          client.on("error", reject);
+          client.on("connect", () => resolve());
+          await promise;
+          try {
+            for (const args of [[], [Buffer.alloc(8)], [Buffer.alloc(8), 5], [Buffer.alloc(8), null], [Buffer.alloc(8), {}]]) {
+              expect(() => client.ping(...args)).toThrow(
+                expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
+              );
+            }
+          } finally {
+            client.close();
+          }
+        });
+        it("ping accepts any 8-byte ArrayBufferView as payload", async () => {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
+          client.on("error", reject);
+          client.on("connect", () => resolve());
+          await promise;
+          try {
+            const sent = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+            const cases = [
+              new DataView(sent.buffer.slice(0)),
+              new Uint16Array(sent.buffer.slice(0)),
+              new Uint32Array(sent.buffer.slice(0)),
+              Buffer.from(sent.buffer.slice(0)),
+            ];
+            const results = await Promise.all(
+              cases.map(
+                p =>
+                  new Promise((res, rej) => {
+                    const ok = client.ping(p, (err, duration, ret) => (err ? rej(err) : res({ duration, ret })));
+                    if (ok !== true) rej(new Error("ping() returned " + ok));
+                  }),
+              ),
+            );
+            for (const { duration, ret } of results) {
+              expect(typeof duration).toBe("number");
+              expect(Buffer.from(ret)).toEqual(Buffer.from(sent));
+            }
+          } finally {
+            client.close();
+          }
+        });
+        it("ping without payload echoes a non-zero timestamp", async () => {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
+          client.on("error", reject);
+          client.on("connect", () => resolve());
+          await promise;
+          try {
+            const echoed = await new Promise((res, rej) => {
+              client.ping((err, duration, ret) => (err ? rej(err) : res(ret)));
             });
-          });
-          const result = await promise;
-          expect(result).toBeDefined();
-          expect(result.code).toBe("ERR_HTTP2_PING_LENGTH");
+            expect(echoed.byteLength).toBe(8);
+            expect(Buffer.from(echoed).every(b => b === 0)).toBe(false);
+          } finally {
+            client.close();
+          }
         });
         it("ping with wrong payload type events should throw", async () => {
           const { promise, resolve, reject } = Promise.withResolvers();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2003,7 +2003,7 @@ it(
       });
     });
   },
-  15_000 * ASAN_MULTIPLIER,
+  20_000 * ASAN_MULTIPLIER,
 );
 
 it("http2.createServer validates input options", () => {


### PR DESCRIPTION
`Http2Session.prototype.ping` diverged from Node on the whole argument-validation / callback contract.

## Reproduction

```js
import http2 from "node:http2";
const srv = http2.createServer();
srv.listen(0, "127.0.0.1", () => {
  const ses = http2.connect(`http://127.0.0.1:${srv.address().port}`);
  ses.on("connect", () => {
    const t = (n, f) => { try { console.log(n, "-> returned", f()); } catch (e) { console.log(n, "-> THREW", e.code); } };
    t("ping(7B, cb)     ", () => ses.ping(Buffer.from("abcdefg"), e => console.log("   async cb err =", e?.code)));
    t("ping()           ", () => ses.ping());
    t("ping(8B)         ", () => ses.ping(Buffer.alloc(8)));
    t("ping(8B, 5)      ", () => ses.ping(Buffer.alloc(8), 5));
    t("ping(DataView(8))", () => ses.ping(new DataView(new ArrayBuffer(8)), () => {}));
    ses.ping((e, d, p) => { console.log("ping(cb) payload all-zero:", Buffer.from(p).every(b => b === 0)); process.exit(0); });
  });
});
```

Before (Bun 1.4.0):

```
   async cb err = ERR_HTTP2_PING_LENGTH
ping(7B, cb)      -> returned undefined
ping()            -> returned true
ping(8B)          -> returned true
ping(8B, 5)       -> returned true
ping(DataView(8)) -> THREW ERR_INVALID_ARG_TYPE
ping(cb) payload all-zero: true
```

After / Node v26.3.0:

```
ping(7B, cb)      -> THREW ERR_HTTP2_PING_LENGTH
ping()            -> THREW ERR_INVALID_ARG_TYPE
ping(8B)          -> THREW ERR_INVALID_ARG_TYPE
ping(8B, 5)       -> THREW ERR_INVALID_ARG_TYPE
ping(DataView(8)) -> returned true
ping(cb) payload all-zero: false
```

## Cause

`ping()` in `src/js/node/http2.ts` only checked `Buffer`/`isTypedArray` (rejecting `DataView`), reported a bad length through the callback instead of throwing, never required the callback at all, and defaulted an omitted payload to `Buffer.alloc(8)` (eight zero bytes) rather than the documented timestamp. The silently-accepted callback-less pings also desynced the callback FIFO, so a later `ping(payload, cb)` could receive the ACK for an earlier zero-payload ping.

## Fix

Both session classes now validate up front before touching the native parser: `validateBuffer(payload, "payload")` (any `ArrayBufferView`), a synchronous `ERR_HTTP2_PING_LENGTH` when `byteLength !== 8`, and `validateFunction(callback, "callback")` unconditionally. When no payload is supplied, the default is `process.hrtime.bigint()` written little-endian, matching Node's documented behaviour.

## Verification

New assertions in `test/js/node/http2/node-http2.test.js` cover each face of the contract (wrong-length throws, callback required, `DataView`/`Uint16Array`/`Uint32Array` accepted and echoed byte-for-byte, default payload is non-zero). The pre-existing "ping with wrong payload length" case was updated to expect a synchronous throw.

```
bun bd test test/js/node/http2/node-http2.test.js -t ping
# 42 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 30 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0024f4f1e)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [729.85ms]
(pass) node none > Client Basics > should be able to send a POST request [490.27ms]
(pass) node none > Client Basics > constants [18.91ms]
(pass) node none > Client Basics > getDefaultSettings [7.39ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.48ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.25ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.64ms
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (0024f4f1e)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.76ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.10ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [1.83ms]
(pass) node none > Client Basics > is possible to abort request [0.97ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.73ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.60ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.93ms]
(pass) node none > Client Basics > close callback [13.81ms]
(pass) node none > Client Basics > should fail to co
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0024f4f1e)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1097.85ms]
(pass) node none > Client Basics > should be able to send a POST request [707.95ms]
(pass) node none > Client Basics > constants [32.99ms]
(pass) node none > Client Basics > getDefaultSettings [11.79ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [39.38ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [7.99ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [5.62ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [9.37
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (8992ms)
Bundle modules (42ms)
Postprocesss modules (25ms)
Bundle Functions (685ms)
Generate Code (85ms)

[9.84s] Bundled "src/js" for production
  1888 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (0024f4f1e)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.78ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  |  94 +++++++++++++-----------
 test/js/node/http2/node-http2.test.js | 134 ++++++++++++++++++++++++++++++----
 2 files changed, 172 insertions(+), 56 deletions(-)
```

</details>

**gate history** · 1 passed · 3 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       5      6      0
test/js/node/http2/node-http2.test.js      5      3      0
```

</details>

<!-- robobun:evidence:end -->