### PR TITLE
Bun.plugin: populate namespace/loader/defer/kind/resolveDir in runtime callback args

### DIFF
--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -532,6 +532,7 @@ impl Linker {
                                 } else {
                                     BunPluginTarget::Node
                                 },
+                                import_record.kind,
                             )? {
                                 import_record.path = self.generate_import_path(
                                     source_dir,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -56,6 +56,7 @@ pub trait PluginResolver {
         log: &mut bun_ast::Log,
         loc: bun_ast::Loc,
         target: BunPluginTarget,
+        kind: bun_ast::ImportKind,
     ) -> crate::Result<Option<bun_paths::fs::Path<'static>>>;
 }
 

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -645,11 +645,12 @@ impl JSGlobalObject {
         path: BunString,
         source: BunString,
         target: BunPluginTarget,
+        kind: bun_ast::ImportKind,
     ) -> JsResult<Option<JSValue>> {
         crate::mark_binding();
         let ns = (namespace_.length() > 0).then_some(&namespace_);
         let result = crate::from_js_host_call(self, || {
-            Bun__runOnResolvePlugins(self, ns, &path, &source, target)
+            Bun__runOnResolvePlugins(self, ns, &path, &source, target, kind as u8)
         })?;
         if result.is_undefined_or_null() {
             return Ok(None);
@@ -1645,6 +1646,7 @@ unsafe extern "C" {
         path: &BunString,
         source: &BunString,
         target: BunPluginTarget,
+        kind: u8,
     ) -> JSValue;
 
     // safe: `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle (`&` is

--- a/src/jsc/PluginRunner.rs
+++ b/src/jsc/PluginRunner.rs
@@ -51,6 +51,7 @@ impl PluginResolver for PluginRunner {
         log: &mut bun_ast::Log,
         loc: bun_ast::Loc,
         target: BunPluginTarget,
+        kind: bun_ast::ImportKind,
     ) -> bun_bundler::Result<Option<FsPath<'static>>> {
         let global = self.global();
         let js_err = |e: crate::JsError| {
@@ -77,6 +78,7 @@ impl PluginResolver for PluginRunner {
                 }),
                 BunString::init(importer),
                 target,
+                kind,
             )
             .map_err(js_err)?
         else {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4305,6 +4305,13 @@ impl VirtualMachine {
                     bun_core::String::borrow_utf8(after_namespace),
                     source,
                     crate::BunPluginTarget::Bun,
+                    if is_esm {
+                        bun_ast::ImportKind::Stmt
+                    } else if is_user_require_resolve {
+                        bun_ast::ImportKind::RequireResolve
+                    } else {
+                        bun_ast::ImportKind::Require
+                    },
                 )? {
                     *res = resolved_path;
                     return Ok(());
@@ -6632,6 +6639,7 @@ pub fn plugin_runner_on_resolve_jsc(
     specifier: bun_core::String,
     importer: bun_core::String,
     target: crate::BunPluginTarget,
+    kind: bun_ast::ImportKind,
 ) -> JsResult<Option<ErrorableString>> {
     use crate::StringJsc as _;
     let Some(on_resolve_plugin) = global.run_on_resolve_plugins(
@@ -6643,6 +6651,7 @@ pub fn plugin_runner_on_resolve_jsc(
         specifier,
         importer,
         target,
+        kind,
     )?
     else {
         return Ok(None);

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -34,7 +34,7 @@
 #include "isBuiltinModule.h"
 #include "AsyncContextFrame.h"
 #include "ImportMetaObject.h"
-#include "PathInlines.h"
+#include "headers.h"
 
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
 
@@ -774,6 +774,10 @@ static WTF::ASCIILiteral loaderLabel(BunLoaderType loader)
         return "html"_s;
     case 19:
         return "yaml"_s;
+    case 20:
+        return "json5"_s;
+    case 21:
+        return "md"_s;
     default:
         return "js"_s;
     }
@@ -950,9 +954,10 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
             vm, builtinNames.pathPublicName(),
             pathJS);
         WTF::String importerString = importer->toWTFString(BunString::ZeroCopy);
+        JSC::JSValue importerJS = jsString(vm, importerString);
         paramsObject->putDirect(
             vm, builtinNames.importerPublicName(),
-            jsString(vm, importerString));
+            importerJS);
         bool isFileNamespace = namespaceWTFString.isEmpty() || namespaceWTFString == "file"_s;
         paramsObject->putDirect(
             vm, Identifier::fromString(vm, "namespace"_s),
@@ -962,14 +967,13 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
             jsNontrivialString(vm, importKindLabel(kind)));
         JSC::JSValue resolveDirValue = JSC::jsUndefined();
         if (isFileNamespace && !importerString.isEmpty()) {
-            size_t lastSep = importerString.reverseFind(PLATFORM_SEP);
+            EncodedJSValue encodedImporter = JSValue::encode(importerJS);
 #if OS(WINDOWS)
-            size_t lastSepFwd = importerString.reverseFind('/');
-            if (lastSepFwd != WTF::notFound && (lastSep == WTF::notFound || lastSepFwd > lastSep))
-                lastSep = lastSepFwd;
+            resolveDirValue = JSValue::decode(Bun__Path__dirname(globalObject, true, &encodedImporter, 1));
+#else
+            resolveDirValue = JSValue::decode(Bun__Path__dirname(globalObject, false, &encodedImporter, 1));
 #endif
-            if (lastSep != WTF::notFound && lastSep > 0)
-                resolveDirValue = jsString(vm, importerString.substring(0, lastSep));
+            RETURN_IF_EXCEPTION(scope, {});
         }
         paramsObject->putDirect(
             vm, Identifier::fromString(vm, "resolveDir"_s),

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -34,6 +34,9 @@
 #include "isBuiltinModule.h"
 #include "AsyncContextFrame.h"
 #include "ImportMetaObject.h"
+#include "PathInlines.h"
+
+extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
 
 namespace Zig {
 
@@ -728,9 +731,96 @@ void JSModuleMock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSModuleMock);
 
+// Must be kept in sync with api::Loader in src/options_types/schema.rs (same
+// numbering as $LoaderIdToLabel in the bundler plugin builtins).
+static WTF::ASCIILiteral loaderLabel(BunLoaderType loader)
+{
+    switch (loader) {
+    case 1:
+        return "jsx"_s;
+    case 2:
+        return "js"_s;
+    case 3:
+        return "ts"_s;
+    case 4:
+        return "tsx"_s;
+    case 5:
+        return "css"_s;
+    case 6:
+        return "file"_s;
+    case 7:
+        return "json"_s;
+    case 8:
+        return "jsonc"_s;
+    case 9:
+        return "toml"_s;
+    case 10:
+        return "wasm"_s;
+    case 11:
+        return "napi"_s;
+    case 12:
+        return "base64"_s;
+    case 13:
+        return "dataurl"_s;
+    case 14:
+        return "text"_s;
+    case 15:
+        return "bunsh"_s;
+    case 16:
+        return "sqlite"_s;
+    case 17:
+        return "sqlite_embedded"_s;
+    case 18:
+        return "html"_s;
+    case 19:
+        return "yaml"_s;
+    default:
+        return "js"_s;
+    }
+}
+
+// Must be kept in sync with ImportKind::label() in src/ast/lib.rs (same
+// strings as $ImportKindIdToLabel in the bundler plugin builtins).
+static WTF::ASCIILiteral importKindLabel(uint8_t kind)
+{
+    switch (kind) {
+    case 0:
+        return "entry-point-run"_s;
+    case 1:
+        return "entry-point-build"_s;
+    case 2:
+        return "import-statement"_s;
+    case 3:
+        return "require-call"_s;
+    case 4:
+        return "dynamic-import"_s;
+    case 5:
+        return "require-resolve"_s;
+    case 6:
+        return "import-rule"_s;
+    case 8:
+        return "url-token"_s;
+    case 9:
+        return "composes"_s;
+    case 11:
+        return "internal"_s;
+    default:
+        return "import-statement"_s;
+    }
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionOnLoadDefer, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
+{
+    // Runtime plugins load one module at a time, so there is never anything to
+    // defer for. Return a resolved promise so plugins written against the
+    // bundler API can call defer() unconditionally.
+    return JSValue::encode(JSC::JSPromise::resolvedPromise(globalObject, JSC::jsUndefined()));
+}
+
 EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path)
 {
-    Group* groupPtr = this->group(namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String());
+    WTF::String namespaceWTFString = namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String();
+    Group* groupPtr = this->group(namespaceWTFString);
     if (groupPtr == nullptr) {
         return JSValue::encode(jsUndefined());
     }
@@ -748,11 +838,20 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
     auto scope = DECLARE_THROW_SCOPE(vm);
     scope.assertNoExceptionExceptTermination();
 
-    JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
+    JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
     const auto& builtinNames = WebCore::builtinNames(vm);
     paramsObject->putDirect(
         vm, builtinNames.pathPublicName(),
         jsString(vm, pathString));
+    paramsObject->putDirect(
+        vm, Identifier::fromString(vm, "namespace"_s),
+        namespaceWTFString.isEmpty() ? jsNontrivialString(vm, "file"_s) : jsString(vm, namespaceWTFString));
+    paramsObject->putDirect(
+        vm, Identifier::fromString(vm, "loader"_s),
+        jsNontrivialString(vm, loaderLabel(Bun__getDefaultLoader(globalObject, path))));
+    paramsObject->putDirect(
+        vm, Identifier::fromString(vm, "defer"_s),
+        JSC::JSFunction::create(vm, globalObject, 0, "defer"_s, jsFunctionOnLoadDefer, JSC::ImplementationVisibility::Public));
     arguments.append(paramsObject);
 
     auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
@@ -798,9 +897,10 @@ std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path
     return virtualModules->contains(path) ? std::optional<String> { path } : std::nullopt;
 }
 
-EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* importer)
+EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* importer, uint8_t kind)
 {
-    Group* groupPtr = this->group(namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String());
+    WTF::String namespaceWTFString = namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : String();
+    Group* groupPtr = this->group(namespaceWTFString);
     if (groupPtr == nullptr) {
         return JSValue::encode(jsUndefined());
     }
@@ -842,18 +942,38 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
 
         JSC::MarkedArgumentBuffer arguments;
 
-        JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
+        JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 5);
         const auto& builtinNames = WebCore::builtinNames(vm);
         auto* pathJS = Bun::toJS(globalObject, *path);
         RETURN_IF_EXCEPTION(scope, {});
         paramsObject->putDirect(
             vm, builtinNames.pathPublicName(),
             pathJS);
-        auto* importerJS = Bun::toJS(globalObject, *importer);
-        RETURN_IF_EXCEPTION(scope, {});
+        WTF::String importerString = importer->toWTFString(BunString::ZeroCopy);
         paramsObject->putDirect(
             vm, builtinNames.importerPublicName(),
-            importerJS);
+            jsString(vm, importerString));
+        bool isFileNamespace = namespaceWTFString.isEmpty() || namespaceWTFString == "file"_s;
+        paramsObject->putDirect(
+            vm, Identifier::fromString(vm, "namespace"_s),
+            isFileNamespace ? jsNontrivialString(vm, "file"_s) : jsString(vm, namespaceWTFString));
+        paramsObject->putDirect(
+            vm, Identifier::fromString(vm, "kind"_s),
+            jsNontrivialString(vm, importKindLabel(kind)));
+        JSC::JSValue resolveDirValue = JSC::jsUndefined();
+        if (isFileNamespace && !importerString.isEmpty()) {
+            size_t lastSep = importerString.reverseFind(PLATFORM_SEP);
+#if OS(WINDOWS)
+            size_t lastSepFwd = importerString.reverseFind('/');
+            if (lastSepFwd != WTF::notFound && (lastSep == WTF::notFound || lastSepFwd > lastSep))
+                lastSep = lastSepFwd;
+#endif
+            if (lastSep != WTF::notFound && lastSep > 0)
+                resolveDirValue = jsString(vm, importerString.substring(0, lastSep));
+        }
+        paramsObject->putDirect(
+            vm, Identifier::fromString(vm, "resolveDir"_s),
+            resolveDirValue);
         arguments.append(paramsObject);
 
         auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
@@ -899,9 +1019,9 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
 
 } // namespace Zig
 
-extern "C" JSC::EncodedJSValue Bun__runOnResolvePlugins(Zig::GlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* from, BunPluginTarget target)
+extern "C" JSC::EncodedJSValue Bun__runOnResolvePlugins(Zig::GlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* from, BunPluginTarget target, uint8_t kind)
 {
-    return globalObject->onResolvePlugins.run(globalObject, namespaceString, path, from);
+    return globalObject->onResolvePlugins.run(globalObject, namespaceString, path, from, kind);
 }
 
 extern "C" JSC::EncodedJSValue Bun__runOnLoadPlugins(Zig::GlobalObject* globalObject, BunString* namespaceString, BunString* path, BunPluginTarget target)

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -783,8 +783,8 @@ static WTF::ASCIILiteral loaderLabel(BunLoaderType loader)
     }
 }
 
-// Must be kept in sync with ImportKind::label() in src/ast/lib.rs (same
-// strings as $ImportKindIdToLabel in the bundler plugin builtins).
+// Must be kept in sync with ImportKind::label() in src/ast/lib.rs.
+// AtConditional (7) has an empty label in Rust and is never dispatched here.
 static WTF::ASCIILiteral importKindLabel(uint8_t kind)
 {
     switch (kind) {
@@ -806,6 +806,8 @@ static WTF::ASCIILiteral importKindLabel(uint8_t kind)
         return "url-token"_s;
     case 9:
         return "composes"_s;
+    case 10:
+        return "html_manifest"_s;
     case 11:
         return "internal"_s;
     default:

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -95,7 +95,7 @@ public:
         {
         }
 
-        JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* importer);
+        JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* importer, uint8_t kind);
     };
 };
 

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -266,10 +266,16 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
                     loader = BunLoaderTypeTSX;
                 } else if (loaderString == "json"_s) {
                     loader = BunLoaderTypeJSON;
+                } else if (loaderString == "jsonc"_s) {
+                    loader = BunLoaderTypeJSONC;
+                } else if (loaderString == "json5"_s) {
+                    loader = BunLoaderTypeJSON5;
                 } else if (loaderString == "toml"_s) {
                     loader = BunLoaderTypeTOML;
                 } else if (loaderString == "yaml"_s) {
                     loader = BunLoaderTypeYAML;
+                } else if (loaderString == "text"_s) {
+                    loader = BunLoaderTypeTEXT;
                 } else if (loaderString == "md"_s) {
                     loader = BunLoaderTypeMD;
                 }
@@ -278,7 +284,7 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
     }
 
     if (loader == BunLoaderTypeNone) [[unlikely]] {
-        throwException(globalObject, scope, createError(globalObject, "Expected loader to be one of \"js\", \"jsx\", \"object\", \"ts\", \"tsx\", \"toml\", \"yaml\", \"json\", or \"md\""_s));
+        throwException(globalObject, scope, createError(globalObject, "Expected loader to be one of \"js\", \"jsx\", \"object\", \"ts\", \"tsx\", \"toml\", \"yaml\", \"json\", \"jsonc\", \"json5\", \"text\", or \"md\""_s));
         result.value.error = scope.exception();
         (void)scope.tryClearException();
         return result;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -266,8 +266,10 @@ inline constexpr BunLoaderType BunLoaderTypeJSONC = 8;
 inline constexpr BunLoaderType BunLoaderTypeTOML = 9;
 inline constexpr BunLoaderType BunLoaderTypeWASM = 10;
 inline constexpr BunLoaderType BunLoaderTypeNAPI = 11;
+inline constexpr BunLoaderType BunLoaderTypeTEXT = 14;
 inline constexpr BunLoaderType BunLoaderTypeYAML = 19;
-inline constexpr BunLoaderType BunLoaderTypeMD = 20;
+inline constexpr BunLoaderType BunLoaderTypeJSON5 = 20;
+inline constexpr BunLoaderType BunLoaderTypeMD = 21;
 
 #pragma mark - Stream
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5086,6 +5086,13 @@ unsafe fn resolve_hook(
                 bun_core::String::borrow_utf8(after_namespace),
                 source,
                 bun_jsc::BunPluginTarget::Bun,
+                if is_esm {
+                    ImportKind::Stmt
+                } else if is_user_require_resolve {
+                    ImportKind::RequireResolve
+                } else {
+                    ImportKind::Require
+                },
             ) {
                 Ok(Some(resolved_path)) => {
                     // SAFETY: per fn contract.

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -693,6 +693,96 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("runtime onLoad/onResolve receive the documented OnLoadArgs/OnResolveArgs fields", async () => {
+  using dir = tempDir("plugin-arg-shape", {
+    "preload.js": `
+      Bun.plugin({
+        name: "argprobe",
+        setup(build) {
+          const path = require("node:path");
+          build.onResolve({ filter: /probe-arg-entry/ }, a => {
+            globalThis.__resolveArgs ??= {
+              keys: Object.keys(a).sort(),
+              importer: a.importer,
+              namespace: a.namespace,
+              kind: a.kind,
+              resolveDirOK: a.resolveDir === path.dirname(a.importer),
+            };
+            return undefined;
+          });
+          build.onResolve({ filter: /.*/, namespace: "probe" }, a => {
+            globalThis.__resolveNsArgs ??= { namespace: a.namespace, kind: a.kind };
+            return { path: a.path, namespace: "probe" };
+          });
+          build.onLoad({ filter: /probe-arg-entry\\.ts$/ }, async a => {
+            let deferred;
+            let deferError = null;
+            try { deferred = a.defer(); } catch (e) { deferError = String(e); }
+            let deferResolved = deferred instanceof Promise;
+            if (deferResolved) await deferred;
+            globalThis.__loadArgs = {
+              keys: Object.keys(a).sort(),
+              namespace: a.namespace,
+              loader: a.loader,
+              deferType: typeof a.defer,
+              deferError,
+              deferResolved,
+            };
+            return { contents: "export default 1", loader: a.loader };
+          });
+          build.onLoad({ filter: /.*/, namespace: "probe" }, a => {
+            globalThis.__loadNsArgs = { namespace: a.namespace, loader: a.loader };
+            return { contents: "export default 2", loader: "js" };
+          });
+        },
+      });
+    `,
+    "sub/probe-arg-entry.ts": `export default 0;`,
+    "entry.js": `
+      const { createRequire } = require("node:module");
+      const req = createRequire(import.meta.url);
+      await import("./sub/probe-arg-entry.ts");
+      req("probe:whatever.json");
+      console.log(JSON.stringify({
+        load: globalThis.__loadArgs,
+        loadNs: globalThis.__loadNsArgs,
+        resolve: globalThis.__resolveArgs,
+        resolveNs: globalThis.__resolveNsArgs,
+      }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const out = stdout.trim() ? JSON.parse(stdout) : { crashed: stderr };
+  expect(out).toEqual({
+    load: {
+      keys: ["defer", "loader", "namespace", "path"],
+      namespace: "file",
+      loader: "ts",
+      deferType: "function",
+      deferError: null,
+      deferResolved: true,
+    },
+    loadNs: { namespace: "probe", loader: "json" },
+    resolve: {
+      keys: ["importer", "kind", "namespace", "path", "resolveDir"],
+      importer: resolve(String(dir), "entry.js"),
+      namespace: "file",
+      kind: "import-statement",
+      resolveDirOK: true,
+    },
+    resolveNs: { namespace: "probe", kind: "require-call" },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("a no-op onResolve that returns args.path unchanged is transparent", async () => {
   using dir = tempDir("plugin-onresolve-no-op", {
     "preload.js": `


### PR DESCRIPTION
## Problem

Bun documents one "universal plugin API that extends both the runtime and the bundler", and `OnLoadArgs`/`OnResolveArgs` declare every field non-optional. But the runtime module loader's plugin dispatch only marshals `path` (and `importer` for onResolve) into the callback argument, while the identical plugin under `Bun.build` gets the full shape:

```js
Bun.plugin({
  name: "argprobe",
  setup(b) {
    b.onResolve({ filter: /probe/ }, a => { console.log("resolve", Object.keys(a).sort()); return undefined; });
    b.onLoad({ filter: /probe\.ts$/ }, a => {
      console.log("load", Object.keys(a).sort());
      a.defer();  // TypeError: a.defer is not a function
      return { contents: "export default 1", loader: a.loader };  // loader is undefined
    });
  },
});
await import("/tmp/probe.ts");
// load ["path"]
// resolve ["importer","path"]
```

Any plugin that branches on `args.namespace`, passes through `loader: args.loader`, reads `args.resolveDir`/`args.kind`, or awaits `args.defer()` (the standard esbuild patterns) works under `Bun.build` and then breaks, silently or with a `TypeError`, the moment it is loaded at runtime via `Bun.plugin` or bunfig `preload`.

## Cause

`BunPlugin::OnLoad::run` and `BunPlugin::OnResolve::run` in `src/jsc/bindings/BunPlugin.cpp` construct the params object with only `path` (and `importer`). Both functions already receive `namespaceString` but never put it on the object. The bundler side (`src/js/builtins/BundlerPlugin.ts`) builds the full object.

## Fix

`onLoad` now also receives:
- `namespace`: the matched namespace (`"file"` for the default)
- `loader`: the default loader for the path's extension, via the existing `Bun__getDefaultLoader`
- `defer`: a function returning a resolved promise. Runtime imports load one module at a time, so there is nothing to defer for; this lets plugins written against the bundler API call `await args.defer()` unconditionally.

`onResolve` now also receives:
- `namespace`: the matched namespace (`"file"` for the default)
- `kind`: the import kind label (`"import-statement"`, `"require-call"`, `"require-resolve"`), threaded through `Bun__runOnResolvePlugins` from the resolve hooks, which already computed it from `is_esm`/`is_user_require_resolve` for error messages. The linker path passes `import_record.kind`.
- `resolveDir`: `dirname(importer)` when in the file namespace, matching `BundlerPlugin.ts`

## Verification

```
runtime onLoad args   : ["defer","loader","namespace","path"]
runtime onResolve args: ["importer","kind","namespace","path","resolveDir"]
build   onLoad args   : ["defer","loader","namespace","path","side"]
build   onResolve args: ["importer","kind","namespace","path","resolveDir"]
```

New test in `test/js/bun/plugin/plugins.test.ts` covers the field set and values for both the default file namespace and a custom namespace, for both `import()` (`kind: "import-statement"`) and `require()` (`kind: "require-call"`), and exercises `await args.defer()`. Fails on `main`, passes with the fix.

Existing `plugins.test.ts`, `bundler_plugin.test.ts`, `22199.test.ts`, `12548.test.ts`, and `plugin-namespace-drive-letter.test.ts` all pass.

Fixes #3894

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (af60e9fec)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1078.95ms]
(pass) require > beep:boop returns 42 [8.45ms]
(pass) require > object module works [7.98ms]
(pass) module > throws with require() [12.30ms]
(pass) module > async module works with async import [24.31ms]
(pass) module > sync module module works with require() [3.90ms]
(pass) module > sync module module works with require.resolve() [4.11ms]
(pass) module > sync modul
... (truncated)

release without fix: 4 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [32.80ms]
(pass) require > beep:boop returns 42 [0.18ms]
(pass) require > object module works [0.11ms]
(pass) module > throws with require() [0.24ms]
(pass) module > async module works with async import [2.56ms]
(pass) module > sync module module works with require() [0.07ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.10ms]
(pass) module > modules are overridable [0.22ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.12ms]
(pass) dynamic import > beep:boop returns 42 [0.06ms]
(pass) dynamic import > async:onLoad returns 42 [1.37ms]
(pass) dynamic import > async object loader returns 42 [1.28ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [1.73ms]
(todo) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (af60e9fec)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1080.25ms]
(pass) require > beep:boop returns 42 [8.48ms]
(pass) require > object module works [7.77ms]
(pass) module > throws with require() [12.12ms]
(pass) module > async module works with async import [22.98ms]
(pass) module > sync module module works with require() [3.84ms]
(pass) module > sync module module works with require.resolve() [3.19ms]
(pass) module > sync modul
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     af60e9fec8
  features     (none)

22 deps, 106 codegen, 1168 objects in 770ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [20.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1231] gen ErrorCode+*.h
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch picohttpparser
[picohttpparser] up to date
[8/1230] gen Pr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/linker.rs                  |   1 +
 src/bundler/transpiler.rs              |   1 +
 src/jsc/JSGlobalObject.rs              |   4 +-
 src/jsc/PluginRunner.rs                |   2 +
 src/jsc/VirtualMachine.rs              |   9 +++
 src/jsc/bindings/BunPlugin.cpp         | 144 ++++++++++++++++++++++++++++++---
 src/jsc/bindings/BunPlugin.h           |   2 +-
 src/jsc/bindings/ModuleLoader.cpp      |   8 +-
 src/jsc/bindings/headers-handwritten.h |   4 +-
 src/runtime/jsc_hooks.rs               |   7 ++
 test/js/bun/plugin/plugins.test.ts     |  90 +++++++++++++++++++++
 11 files changed, 259 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 2 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/bundler/linker.rs                       2      1      0
src/bundler/transpiler.rs                   3      2      0
src/jsc/JSGlobalObject.rs                   2      2      0
src/jsc/PluginRunner.rs                     2      3      0
src/jsc/VirtualMachine.rs                   3      2      0
src/jsc/bindings/BunPlugin.cpp              7     11      0
src/jsc/bindings/BunPlugin.h                1      1      0
src/jsc/bindings/ModuleLoader.cpp           2      1      0
src/jsc/bindings/headers-handwritten.h      3      3      0
src/runtime/jsc_hooks.rs                    5      1      0
test/js/bun/plugin/plugins.test.ts          2      2      0
```

</details>

<!-- robobun:evidence:end -->