### PR TITLE
Bun.plugin: error when an onResolve'd namespace has no matching onLoad

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -77,8 +77,7 @@ impl PluginRunner {
             && colon == 1
             && specifier.len() > 3
             && bun_paths::resolve_path::is_sep_any(specifier[2])
-            && ((specifier[0] > b'a' && specifier[0] < b'z')
-                || (specifier[0] > b'A' && specifier[0] < b'Z'))
+            && specifier[0].is_ascii_alphabetic()
         {
             return b"";
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4105,7 +4105,10 @@ unsafe fn transpile_file(
     // it; never fall through to extension-based loading on the "ns:path"
     // string. Mirrors `bundle_v2::LoadValue::NoMatch` for non-file namespaces.
     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-    if lr.virtual_source.is_none() && unsafe { &*jsc_vm }.plugin_runner.is_some() {
+    if lr.virtual_source.is_none()
+        && !bun_paths::is_absolute(lr.path.text)
+        && unsafe { &*jsc_vm }.plugin_runner.is_some()
+    {
         let ns = bun_bundler::transpiler::PluginRunner::extract_namespace(lr.path.text);
         let is_builtin_scheme = matches!(ns, b"" | b"file" | b"bun" | b"node" | b"data" | b"macro");
         if !is_builtin_scheme {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4109,7 +4109,10 @@ unsafe fn transpile_file(
     if has_plugin_runner && lr.virtual_source.is_none() && !bun_paths::is_absolute(lr.path.text) {
         let ns = bun_bundler::transpiler::PluginRunner::extract_namespace(lr.path.text);
         let is_builtin_scheme = matches!(ns, b"" | b"file" | b"bun" | b"node" | b"data" | b"macro");
-        if !is_builtin_scheme {
+        // `isValidNamespaceString` rejects '.' and '\\', so a prefix containing
+        // either is a path fragment (./x, ..\x), never a registered namespace.
+        let is_path_fragment = ns.iter().any(|&b| b == b'.' || b == b'\\');
+        if !is_builtin_scheme && !is_path_fragment {
             let after_ns = &lr.path.text[(ns.len() + 1).min(lr.path.text.len())..];
             let js = global_ref
                 .err(

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4105,10 +4105,8 @@ unsafe fn transpile_file(
     // it; never fall through to extension-based loading on the "ns:path"
     // string. Mirrors `bundle_v2::LoadValue::NoMatch` for non-file namespaces.
     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-    if lr.virtual_source.is_none()
-        && !bun_paths::is_absolute(lr.path.text)
-        && unsafe { &*jsc_vm }.plugin_runner.is_some()
-    {
+    let has_plugin_runner = unsafe { &*jsc_vm }.plugin_runner.is_some();
+    if has_plugin_runner && lr.virtual_source.is_none() && !bun_paths::is_absolute(lr.path.text) {
         let ns = bun_bundler::transpiler::PluginRunner::extract_namespace(lr.path.text);
         let is_builtin_scheme = matches!(ns, b"" | b"file" | b"bun" | b"node" | b"data" | b"macro");
         if !is_builtin_scheme {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4101,6 +4101,33 @@ unsafe fn transpile_file(
         }
     });
 
+    // A plugin namespace still on the specifier here means no onLoad claimed
+    // it; never fall through to extension-based loading on the "ns:path"
+    // string. Mirrors `bundle_v2::LoadValue::NoMatch` for non-file namespaces.
+    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+    if lr.virtual_source.is_none() && unsafe { &*jsc_vm }.plugin_runner.is_some() {
+        let ns = bun_bundler::transpiler::PluginRunner::extract_namespace(lr.path.text);
+        let is_builtin_scheme = matches!(ns, b"" | b"file" | b"bun" | b"node" | b"data" | b"macro");
+        if !is_builtin_scheme {
+            let after_ns = &lr.path.text[(ns.len() + 1).min(lr.path.text.len())..];
+            let js = global_ref
+                .err(
+                    bun_jsc::ErrCode::ERR_MODULE_NOT_FOUND,
+                    format_args!(
+                        "No plugin onLoad handler matched {} in namespace {}",
+                        bun_core::fmt::quote(after_ns),
+                        bun_core::fmt::quote(ns),
+                    ),
+                )
+                .to_js();
+            // SAFETY: per fn contract — `ret` is a valid out-param.
+            unsafe {
+                *ret = ErrorableResolvedSource::err(bun_core::err!("JSErrorObject"), js);
+            }
+            return ptr::null_mut();
+        }
+    }
+
     // ── force_loader / require.extensions override ──────────────────────────
     if let Some(loader_type) = force_loader_type {
         // Note: `@branchHint(.unlikely)` dropped (no stable Rust equiv).

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -816,11 +816,13 @@ it.concurrent("onResolve into a custom namespace with no matching onLoad is a ha
 });
 
 // ':' is a legal POSIX filename character; Windows cannot create it on disk.
-it.skipIf(isWindows).concurrent("the unmatched-onLoad guard does not trip on absolute paths containing ':'", async () => {
-  using dir = tempDir("plugin-colon-in-path", {
-    "sub:dir/mod.js": `export default "from-colon-dir";`,
-    "sub:dir/asset.xyz": `ignored`,
-    "entry.js": `
+it.skipIf(isWindows).concurrent(
+  "the unmatched-onLoad guard does not trip on absolute paths containing ':'",
+  async () => {
+    using dir = tempDir("plugin-colon-in-path", {
+      "sub:dir/mod.js": `export default "from-colon-dir";`,
+      "sub:dir/asset.xyz": `ignored`,
+      "entry.js": `
       Bun.plugin({
         name: "dummy",
         setup(b) {
@@ -831,19 +833,20 @@ it.skipIf(isWindows).concurrent("the unmatched-onLoad guard does not trip on abs
       const asset = await import("./sub:dir/asset.xyz");
       console.log(JSON.stringify({ js: js.default, asset: typeof asset.default }));
     `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
-    js: "from-colon-dir",
-    asset: "string",
-  });
-  expect(exitCode).toBe(0);
-});
+    expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+      js: "from-colon-dir",
+      asset: "string",
+    });
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,95 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+it.concurrent("onResolve into a custom namespace with no matching onLoad is a hard error", async () => {
+  const fixture = `
+    Bun.plugin({
+      name: "p",
+      setup(b) {
+        b.onResolve({ filter: /.*/, namespace: "virt" }, a => ({ path: a.path, namespace: "virtl" }));
+        // Only this exact path is loadable in namespace "virtl".
+        b.onLoad({ filter: /^handled$/, namespace: "virtl" }, () => ({ contents: "export default 'H'", loader: "js" }));
+      },
+    });
+    async function attempt(label, fn) {
+      try {
+        const m = await fn();
+        return { label, ok: true, value: m.default };
+      } catch (e) {
+        return { label, ok: false, code: e.code, message: String(e.message).split("\\n")[0] };
+      }
+    }
+    const results = [
+      await attempt("esm:handled", () => import("virt:handled")),
+      await attempt("esm:img.png", () => import("virt:img.png")),
+      await attempt("esm:style.q", () => import("virt:style.q")),
+      await attempt("esm:note.svg", () => import("virt:note.svg")),
+      await attempt("esm:mod.js", () => import("virt:mod.js")),
+      await attempt("esm:noext", () => import("virt:noext")),
+      await attempt("esm:data.json", () => import("virt:data.json")),
+      await attempt("cjs:other.png", () => Promise.resolve(require("virt:other.png"))),
+      // Built-in schemes must keep working while a plugin runner is active.
+      await attempt("data:", () => import("data:text/javascript,export default 42")),
+      await attempt("node:path", () => import("node:path").then(m => ({ default: typeof m.basename }))),
+    ];
+    console.log(JSON.stringify(results));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = stdout.trim() ? JSON.parse(stdout) : { crashed: stderr };
+  expect(results).toEqual([
+    { label: "esm:handled", ok: true, value: "H" },
+    {
+      label: "esm:img.png",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "img.png" in namespace "virtl"',
+    },
+    {
+      label: "esm:style.q",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "style.q" in namespace "virtl"',
+    },
+    {
+      label: "esm:note.svg",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "note.svg" in namespace "virtl"',
+    },
+    {
+      label: "esm:mod.js",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "mod.js" in namespace "virtl"',
+    },
+    {
+      label: "esm:noext",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "noext" in namespace "virtl"',
+    },
+    {
+      label: "esm:data.json",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "data.json" in namespace "virtl"',
+    },
+    {
+      label: "cjs:other.png",
+      ok: false,
+      code: "ERR_MODULE_NOT_FOUND",
+      message: 'No plugin onLoad handler matched "other.png" in namespace "virtl"',
+    },
+    { label: "data:", ok: true, value: 42 },
+    { label: "node:path", ok: true, value: "function" },
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,7 +197,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";
@@ -815,12 +815,8 @@ it.concurrent("onResolve into a custom namespace with no matching onLoad is a ha
   expect(exitCode).toBe(0);
 });
 
-it.concurrent("the unmatched-onLoad guard does not trip on absolute paths containing ':'", async () => {
-  // ':' is a legal POSIX filename character. On Windows the absolute-path
-  // check in bun_paths::is_absolute covers "X:\...", so a real file's path
-  // cannot be mistaken for a plugin namespace there either.
-  if (process.platform === "win32") return;
-
+// ':' is a legal POSIX filename character; Windows cannot create it on disk.
+it.skipIf(isWindows).concurrent("the unmatched-onLoad guard does not trip on absolute paths containing ':'", async () => {
   using dir = tempDir("plugin-colon-in-path", {
     "sub:dir/mod.js": `export default "from-colon-dir";`,
     "sub:dir/asset.xyz": `ignored`,

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -814,3 +814,40 @@ it.concurrent("onResolve into a custom namespace with no matching onLoad is a ha
   ]);
   expect(exitCode).toBe(0);
 });
+
+it.concurrent("the unmatched-onLoad guard does not trip on absolute paths containing ':'", async () => {
+  // ':' is a legal POSIX filename character. On Windows the absolute-path
+  // check in bun_paths::is_absolute covers "X:\...", so a real file's path
+  // cannot be mistaken for a plugin namespace there either.
+  if (process.platform === "win32") return;
+
+  using dir = tempDir("plugin-colon-in-path", {
+    "sub:dir/mod.js": `export default "from-colon-dir";`,
+    "sub:dir/asset.xyz": `ignored`,
+    "entry.js": `
+      Bun.plugin({
+        name: "dummy",
+        setup(b) {
+          b.onLoad({ filter: /^never$/, namespace: "dummy" }, () => ({ contents: "", loader: "js" }));
+        },
+      });
+      const js = await import("./sub:dir/mod.js");
+      const asset = await import("./sub:dir/asset.xyz");
+      console.log(JSON.stringify({ js: js.default, asset: typeof asset.default }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    js: "from-colon-dir",
+    asset: "string",
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem

When a runtime `Bun.plugin` `onResolve` handler assigns a specifier a custom (non-`file`) namespace but no registered `onLoad` filter matches that path in that namespace, the module loader silently falls through to the built-in file-extension loader table applied to the literal `"ns:path"` string. Which of two bad outcomes you get depends only on the extension of the virtual path:

```js
Bun.plugin({
  name: "p",
  setup(b) {
    b.onResolve({ filter: /.*/, namespace: "virt" }, a => ({ path: a.path, namespace: "virtl" }));
    // the only onLoad for "virtl": anything else is unhandled
    b.onLoad({ filter: /^only-this-exact-path$/, namespace: "virtl" },
      () => ({ contents: "export default 'HANDLED'", loader: "js" }));
  },
});
await import("virt:img.png");  // resolves, default === "virtl:img.png"   (file loader on the specifier)
await import("virt:note.svg"); // resolves, default === "virtl:note.svg"
await import("virt:mod.js");   // BuildMessage: ENOENT reading "virtl:mod.js"
await import("virt:noext");    // BuildMessage: ENOENT reading "virtl:noext"
```

A typo'd `onLoad` filter or namespace is the most common plugin-writing mistake, and here it produces no signal at all for asset/unknown extensions: the import succeeds, exporting the raw namespace-qualified specifier as a string that then gets embedded into HTML/CSS as a URL. Both esbuild and `Bun.build` already error in this case.

### Cause

`Bun::runVirtualModule` dispatches all registered `onLoad` handlers for the namespace and returns a falsy value when none match. `fetchESMSourceCode` / `fetchCommonJSModule` then fall through to `Bun__transpileFile` with the `"ns:path"` string as the specifier, which `get_loader_and_virtual_source` feeds into `loader_for_path` purely by extension.

### Fix

`transpile_file` (in `src/runtime/jsc_hooks.rs`) now rejects a specifier that still carries a plugin namespace after the onLoad dispatch has missed, before any extension-based loader selection runs:

```
error: No plugin onLoad handler matched "img.png" in namespace "virtl"
code: ERR_MODULE_NOT_FOUND
```

This mirrors what `Bun.build` already does for the same case (`bundle_v2` `LoadValue::NoMatch` on a non-file namespace). The guard is scoped so it never fires on real filesystem paths that happen to contain a `:`:

- the plugin runner must be active (otherwise no onResolve could have produced the namespace)
- the specifier must not be an absolute path (covers POSIX paths with `:` in a directory/file name and every Windows drive)
- the extracted prefix must not contain `.` or `\` (neither is accepted by `isValidNamespaceString`, so such a prefix is a relative-path fragment, not a registered namespace)
- the built-in schemes this layer handles (`file`, `data`, `bun`, `node`, `macro`) are allowlisted

Also fixes the pre-existing strict-inequality off-by-one in `PluginRunner::extract_namespace`'s Windows drive-letter check (`> 'a'`/`< 'z'` instead of `>=`/`<=`), which treated `A:` / `Z:` / `a:` / `z:` drive prefixes as plugin namespaces. That bug was latent (the only existing caller fell through harmlessly on a miss) but this PR adds a caller that would turn it into a hard error.

### Verification

New spawned-subprocess test in `test/js/bun/plugin/plugins.test.ts` covers the matrix: the one path the `onLoad` filter accepts still loads; asset extensions (`.png`, `.svg`, `.q`), JS-ish (`.js`, `.json`) and extensionless paths now all reject with `ERR_MODULE_NOT_FOUND` and the new message for both `import()` and `require()`; and `data:` / `node:` imports still work while plugins are registered. A second POSIX-only test imports from a `sub:dir/` directory with a plugin runner active to guard the absolute-path exclusion. Fails on current main (asset extensions "resolve" with the raw specifier as default, others ENOENT on the virtual path), passes with the fix. The rest of `test/js/bun/plugin/` is unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/plugin/plugins.test.ts

<!-- robobun:evidence:end -->