### PR TITLE
run: translate npm workspace flags when rewriting npm run scripts

### DIFF
--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -270,8 +270,10 @@ pub fn replace_package_manager_run(
 /// placed before the script name and return the number of input bytes consumed.
 /// Returns 0 (caller falls back to the plain `npm run` -> `bun run` prefix swap,
 /// keeping byte-for-byte output) when no workspace flag is present, when the
-/// match is inside a quoted string, or when the segment's quotes are unbalanced:
-/// reordering tokens is only safe at shell top level with balanced quoting.
+/// match is inside a quoted string, when the segment's quotes are unbalanced, or
+/// when it contains shell grouping/escaping the tokenizer does not model (`(`,
+/// `)`, `$`, `` ` ``, `\`): reordering tokens is only safe at shell top level
+/// with balanced quoting and no such constructs.
 fn rewrite_npm_run_workspaces(
     out: &mut Vec<u8>,
     cmd: &[u8],
@@ -289,6 +291,9 @@ fn rewrite_npm_run_workspaces(
     // End of this simple command: first top-level (unquoted) shell separator.
     let mut seg_end = args.len();
     let (mut in_single, mut in_double) = (false, false);
+    // Shell grouping/escaping the tokenizer below does not model. Reordering
+    // tokens across these would scramble the command, so bail when present.
+    let mut has_unsupported = false;
     {
         let mut i = 0;
         while i < args.len() {
@@ -305,14 +310,15 @@ fn rewrite_npm_run_workspaces(
                         seg_end = i;
                         break;
                     }
+                    b'(' | b')' | b'$' | b'`' | b'\\' => has_unsupported = true,
                     _ => {}
                 }
             }
             i += 1;
         }
     }
-    // Unbalanced quotes mean we cannot safely tokenize/reorder this segment.
-    if in_single || in_double {
+    // Unbalanced quotes or unmodeled shell constructs: not safe to reorder.
+    if in_single || in_double || has_unsupported {
         return 0;
     }
     let segment = &args[..seg_end];

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -272,7 +272,12 @@ pub fn replace_package_manager_run(
 /// keeping byte-for-byte output) when no workspace flag is present, when the
 /// match is inside a quoted string, or when the segment's quotes are unbalanced:
 /// reordering tokens is only safe at shell top level with balanced quoting.
-fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize, delimiter: u8) -> usize {
+fn rewrite_npm_run_workspaces(
+    out: &mut Vec<u8>,
+    cmd: &[u8],
+    prefix_len: usize,
+    delimiter: u8,
+) -> usize {
     // Reordering tokens inside a quoted string would move the closing quote;
     // leave those to the plain prefix swap.
     if delimiter != b' ' {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -203,7 +203,6 @@ pub fn replace_package_manager_run(
                             copy_script,
                             &script[start..],
                             b"npm run ".len(),
-                            delimiter,
                         );
                         if consumed > 0 {
                             entry_i += consumed;
@@ -261,94 +260,63 @@ pub fn replace_package_manager_run(
 }
 
 /// Translate npm's workspace-selection flags into Bun's when rewriting an
-/// `npm run ...` invocation. `cmd` starts at `npm run `, `prefix_len` is its
-/// length, and `delimiter` is the outer scanner's state at the match (a quote
-/// byte means `npm run` sits inside a quoted string). When the remainder of this
-/// simple command (up to the next top-level shell separator) carries
-/// `-w`/`--workspace[=<pkg>]`, `--workspaces`/`--ws`, or `--if-present`, emit a
-/// `bun run` with the equivalent `--filter=<pkg>`/`--workspaces`/`--if-present`
-/// placed before the script name and return the number of input bytes consumed.
-/// Returns 0 (caller falls back to the plain `npm run` -> `bun run` prefix swap,
-/// keeping byte-for-byte output) when no workspace flag is present, when the
-/// match is inside a quoted string, when the segment's quotes are unbalanced, or
-/// when it contains shell grouping/escaping/comments the tokenizer does not
-/// model (`(`, `)`, `$`, `` ` ``, `\`, `#`): reordering tokens is only safe at
-/// shell top level with balanced quoting and no such constructs.
-fn rewrite_npm_run_workspaces(
-    out: &mut Vec<u8>,
-    cmd: &[u8],
-    prefix_len: usize,
-    delimiter: u8,
-) -> usize {
-    // Reordering tokens inside a quoted string would move the closing quote;
-    // leave those to the plain prefix swap.
-    if delimiter != b' ' {
-        return 0;
-    }
-
+/// `npm run ...` invocation. `cmd` starts at `npm run ` and `prefix_len` is its
+/// length. When the remainder of this simple command (up to the next top-level
+/// shell separator) carries `-w`/`--workspace[=<pkg>]`, `--workspaces`/`--ws`, or
+/// `--if-present`, emit a `bun run` with the equivalent
+/// `--filter=<pkg>`/`--workspaces`/`--if-present` placed before the script name
+/// and return the number of input bytes consumed. Returns 0 (caller falls back
+/// to the plain `npm run` -> `bun run` prefix swap, keeping byte-for-byte output)
+/// when no workspace flag is present, or when the segment contains a quote or
+/// shell grouping/escaping/comment the whitespace tokenizer does not model (`'`,
+/// `"`, `(`, `)`, `$`, `` ` ``, `\`, `#`): reordering tokens is only safe for a
+/// quote-free, construct-free simple command.
+fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) -> usize {
     let args = &cmd[prefix_len..];
 
-    // End of this simple command: first top-level (unquoted) shell separator.
+    // Scan to the end of this simple command (first top-level shell separator).
+    // Bail (return 0, leaving the plain `npm run` -> `bun run` prefix swap) on
+    // any quote or shell construct the whitespace tokenizer below cannot model:
+    // reordering tokens across them would scramble the command, and the outer
+    // scanner's one-byte lookback cannot tell us whether we are inside a quote.
+    // Quoted workspace names do not occur in practice, so bailing on quotes is
+    // safe.
     let mut seg_end = args.len();
-    let (mut in_single, mut in_double) = (false, false);
-    // Shell grouping/escaping the tokenizer below does not model. Reordering
-    // tokens across these would scramble the command, so bail when present.
     let mut has_unsupported = false;
     {
         let mut i = 0;
         while i < args.len() {
-            let c = args[i];
-            if in_single {
-                in_single = c != b'\'';
-            } else if in_double {
-                in_double = c != b'"';
-            } else {
-                match c {
-                    b'\'' => in_single = true,
-                    b'"' => in_double = true,
-                    b';' | b'&' | b'|' | b'\n' | b'\r' => {
-                        seg_end = i;
-                        break;
-                    }
-                    b'(' | b')' | b'$' | b'`' | b'\\' | b'#' => has_unsupported = true,
-                    _ => {}
+            match args[i] {
+                b';' | b'&' | b'|' | b'\n' | b'\r' => {
+                    seg_end = i;
+                    break;
                 }
+                b'\'' | b'"' | b'(' | b')' | b'$' | b'`' | b'\\' | b'#' => {
+                    has_unsupported = true;
+                }
+                _ => {}
             }
             i += 1;
         }
     }
-    // Unbalanced quotes or unmodeled shell constructs: not safe to reorder.
-    if in_single || in_double || has_unsupported {
+    if has_unsupported {
         return 0;
     }
     let segment = &args[..seg_end];
 
-    // Split into tokens on top-level whitespace, preserving any quote bytes.
+    // Split into tokens on whitespace (no quotes remain after the bail above).
     let mut tokens: Vec<&[u8]> = Vec::new();
     {
-        let (mut in_single, mut in_double) = (false, false);
         let mut tok_start: Option<usize> = None;
         let mut j = 0;
         while j < segment.len() {
             let c = segment[j];
-            let is_sep = !in_single && !in_double && (c == b' ' || c == b'\t');
-            if is_sep {
+            if c == b' ' || c == b'\t' {
                 if let Some(s) = tok_start.take() {
                     tokens.push(&segment[s..j]);
                 }
-            } else {
-                if tok_start.is_none() {
-                    tok_start = Some(j);
-                }
-                if in_single {
-                    in_single = c != b'\'';
-                } else if in_double {
-                    in_double = c != b'"';
-                } else if c == b'\'' {
-                    in_single = true;
-                } else if c == b'"' {
-                    in_double = true;
-                }
+            } else if tok_start.is_none() {
+                tok_start = Some(j);
             }
             j += 1;
         }

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -339,9 +339,14 @@ fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) 
         } else if t == b"--workspaces" || t == b"--ws" {
             all_workspaces = true;
         } else if t == b"-w" || t == b"--workspace" {
-            if k + 1 < tokens.len() {
+            // The value must be the next token and must not itself be a flag;
+            // otherwise we would swallow a real flag (e.g. `--if-present`) as a
+            // bogus workspace name. Bail to the plain prefix swap instead.
+            if k + 1 < tokens.len() && !tokens[k + 1].starts_with(b"-") {
                 filters.push(tokens[k + 1]);
                 k += 1;
+            } else {
+                return 0;
             }
         } else if let Some(v) = t.strip_prefix(b"--workspace=") {
             filters.push(v);

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -122,122 +122,6 @@ impl YarnCommands {
 /// `.text.unlikely.*` keeps the byte-scanning loop out of the hot
 /// fault-around windows the startup/dot benches page in (belt-and-suspenders
 /// alongside `startup.order` regen — survives mangling-hash drift).
-/// Translate npm's workspace-selection flags into Bun's when rewriting an
-/// `npm run ...` invocation. `cmd` starts at `npm run ` and `prefix_len` is its
-/// length. When the remainder of this simple command (up to the next top-level
-/// shell separator) carries `-w`/`--workspace[=<pkg>]` or `--workspaces`, emit a
-/// `bun run` with the equivalent `--filter=<pkg>`/`--workspaces` placed before
-/// the script name and return the number of input bytes consumed. Returns 0 when
-/// no workspace flag is present so the caller falls back to the plain
-/// `npm run` -> `bun run` rewrite, keeping byte-for-byte output for that case.
-fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) -> usize {
-    let args = &cmd[prefix_len..];
-
-    // End of this simple command: first top-level (unquoted) shell separator.
-    let mut seg_end = args.len();
-    {
-        let (mut in_single, mut in_double) = (false, false);
-        let mut i = 0;
-        while i < args.len() {
-            let c = args[i];
-            if in_single {
-                in_single = c != b'\'';
-            } else if in_double {
-                in_double = c != b'"';
-            } else {
-                match c {
-                    b'\'' => in_single = true,
-                    b'"' => in_double = true,
-                    b';' | b'&' | b'|' | b'\n' | b'\r' => {
-                        seg_end = i;
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-            i += 1;
-        }
-    }
-    let segment = &args[..seg_end];
-
-    // Split into tokens on top-level whitespace, preserving any quote bytes.
-    let mut tokens: Vec<&[u8]> = Vec::new();
-    {
-        let (mut in_single, mut in_double) = (false, false);
-        let mut tok_start: Option<usize> = None;
-        let mut j = 0;
-        while j < segment.len() {
-            let c = segment[j];
-            let is_sep = !in_single && !in_double && (c == b' ' || c == b'\t');
-            if is_sep {
-                if let Some(s) = tok_start.take() {
-                    tokens.push(&segment[s..j]);
-                }
-            } else {
-                if tok_start.is_none() {
-                    tok_start = Some(j);
-                }
-                if in_single {
-                    in_single = c != b'\'';
-                } else if in_double {
-                    in_double = c != b'"';
-                } else if c == b'\'' {
-                    in_single = true;
-                } else if c == b'"' {
-                    in_double = true;
-                }
-            }
-            j += 1;
-        }
-        if let Some(s) = tok_start {
-            tokens.push(&segment[s..]);
-        }
-    }
-
-    let mut filters: Vec<&[u8]> = Vec::new();
-    let mut all_workspaces = false;
-    let mut rest: Vec<&[u8]> = Vec::new();
-    let mut k = 0;
-    while k < tokens.len() {
-        let t = tokens[k];
-        if t == b"--workspaces" {
-            all_workspaces = true;
-        } else if t == b"-w" || t == b"--workspace" {
-            if k + 1 < tokens.len() {
-                filters.push(tokens[k + 1]);
-                k += 1;
-            }
-        } else if let Some(v) = t.strip_prefix(b"--workspace=") {
-            filters.push(v);
-        } else if let Some(v) = t.strip_prefix(b"-w=") {
-            filters.push(v);
-        } else {
-            rest.push(t);
-        }
-        k += 1;
-    }
-
-    if filters.is_empty() && !all_workspaces {
-        return 0;
-    }
-
-    out.extend_from_slice(BUN_BIN_NAME);
-    out.extend_from_slice(b" run");
-    if all_workspaces {
-        out.extend_from_slice(b" --workspaces");
-    }
-    for f in &filters {
-        out.extend_from_slice(b" --filter=");
-        out.extend_from_slice(f);
-    }
-    for t in &rest {
-        out.push(b' ');
-        out.extend_from_slice(t);
-    }
-
-    prefix_len + seg_end
-}
-
 #[cold]
 pub fn replace_package_manager_run(
     copy_script: &mut Vec<u8>,
@@ -319,6 +203,7 @@ pub fn replace_package_manager_run(
                             copy_script,
                             &script[start..],
                             b"npm run ".len(),
+                            delimiter,
                         );
                         if consumed > 0 {
                             entry_i += consumed;
@@ -373,6 +258,146 @@ pub fn replace_package_manager_run(
     }
 
     Ok(())
+}
+
+/// Translate npm's workspace-selection flags into Bun's when rewriting an
+/// `npm run ...` invocation. `cmd` starts at `npm run `, `prefix_len` is its
+/// length, and `delimiter` is the outer scanner's state at the match (a quote
+/// byte means `npm run` sits inside a quoted string). When the remainder of this
+/// simple command (up to the next top-level shell separator) carries
+/// `-w`/`--workspace[=<pkg>]`, `--workspaces`/`--ws`, or `--if-present`, emit a
+/// `bun run` with the equivalent `--filter=<pkg>`/`--workspaces`/`--if-present`
+/// placed before the script name and return the number of input bytes consumed.
+/// Returns 0 (caller falls back to the plain `npm run` -> `bun run` prefix swap,
+/// keeping byte-for-byte output) when no workspace flag is present, when the
+/// match is inside a quoted string, or when the segment's quotes are unbalanced:
+/// reordering tokens is only safe at shell top level with balanced quoting.
+fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize, delimiter: u8) -> usize {
+    // Reordering tokens inside a quoted string would move the closing quote;
+    // leave those to the plain prefix swap.
+    if delimiter != b' ' {
+        return 0;
+    }
+
+    let args = &cmd[prefix_len..];
+
+    // End of this simple command: first top-level (unquoted) shell separator.
+    let mut seg_end = args.len();
+    let (mut in_single, mut in_double) = (false, false);
+    {
+        let mut i = 0;
+        while i < args.len() {
+            let c = args[i];
+            if in_single {
+                in_single = c != b'\'';
+            } else if in_double {
+                in_double = c != b'"';
+            } else {
+                match c {
+                    b'\'' => in_single = true,
+                    b'"' => in_double = true,
+                    b';' | b'&' | b'|' | b'\n' | b'\r' => {
+                        seg_end = i;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+    }
+    // Unbalanced quotes mean we cannot safely tokenize/reorder this segment.
+    if in_single || in_double {
+        return 0;
+    }
+    let segment = &args[..seg_end];
+
+    // Split into tokens on top-level whitespace, preserving any quote bytes.
+    let mut tokens: Vec<&[u8]> = Vec::new();
+    {
+        let (mut in_single, mut in_double) = (false, false);
+        let mut tok_start: Option<usize> = None;
+        let mut j = 0;
+        while j < segment.len() {
+            let c = segment[j];
+            let is_sep = !in_single && !in_double && (c == b' ' || c == b'\t');
+            if is_sep {
+                if let Some(s) = tok_start.take() {
+                    tokens.push(&segment[s..j]);
+                }
+            } else {
+                if tok_start.is_none() {
+                    tok_start = Some(j);
+                }
+                if in_single {
+                    in_single = c != b'\'';
+                } else if in_double {
+                    in_double = c != b'"';
+                } else if c == b'\'' {
+                    in_single = true;
+                } else if c == b'"' {
+                    in_double = true;
+                }
+            }
+            j += 1;
+        }
+        if let Some(s) = tok_start {
+            tokens.push(&segment[s..]);
+        }
+    }
+
+    let mut filters: Vec<&[u8]> = Vec::new();
+    let mut all_workspaces = false;
+    let mut if_present = false;
+    let mut rest: Vec<&[u8]> = Vec::new();
+    let mut k = 0;
+    while k < tokens.len() {
+        let t = tokens[k];
+        // `--` ends option parsing: everything after it is passthrough.
+        if t == b"--" {
+            rest.extend_from_slice(&tokens[k..]);
+            break;
+        } else if t == b"--workspaces" || t == b"--ws" {
+            all_workspaces = true;
+        } else if t == b"-w" || t == b"--workspace" {
+            if k + 1 < tokens.len() {
+                filters.push(tokens[k + 1]);
+                k += 1;
+            }
+        } else if let Some(v) = t.strip_prefix(b"--workspace=") {
+            filters.push(v);
+        } else if let Some(v) = t.strip_prefix(b"-w=") {
+            filters.push(v);
+        } else if t == b"--if-present" {
+            if_present = true;
+        } else {
+            rest.push(t);
+        }
+        k += 1;
+    }
+
+    if filters.is_empty() && !all_workspaces {
+        return 0;
+    }
+
+    out.extend_from_slice(BUN_BIN_NAME);
+    out.extend_from_slice(b" run");
+    if all_workspaces {
+        out.extend_from_slice(b" --workspaces");
+    }
+    if if_present {
+        out.extend_from_slice(b" --if-present");
+    }
+    for f in &filters {
+        out.extend_from_slice(b" --filter=");
+        out.extend_from_slice(f);
+    }
+    for t in &rest {
+        out.push(b' ');
+        out.extend_from_slice(t);
+    }
+
+    prefix_len + seg_end
 }
 
 pub struct LifecycleScriptSubprocess<'a> {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -325,6 +325,14 @@ fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) 
         }
     }
 
+    // A usable workspace value is not itself a flag and carries no redirect
+    // byte: `>`/`<` never appear in workspace names, but a glued compound
+    // redirect (`-w app>&2`) would otherwise be hoisted into the filter.
+    #[inline]
+    fn is_workspace_value(t: &[u8]) -> bool {
+        !t.is_empty() && !t.starts_with(b"-") && !t.iter().any(|&c| c == b'<' || c == b'>')
+    }
+
     let mut filters: Vec<&[u8]> = Vec::new();
     let mut all_workspaces = false;
     let mut if_present = false;
@@ -339,18 +347,23 @@ fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) 
         } else if t == b"--workspaces" || t == b"--ws" {
             all_workspaces = true;
         } else if t == b"-w" || t == b"--workspace" {
-            // The value must be the next token and must not itself be a flag;
-            // otherwise we would swallow a real flag (e.g. `--if-present`) as a
-            // bogus workspace name. Bail to the plain prefix swap instead.
-            if k + 1 < tokens.len() && !tokens[k + 1].starts_with(b"-") {
+            // The value must be the next token; bail to the plain prefix swap
+            // rather than swallow a flag (e.g. `--if-present`) or a redirect.
+            if k + 1 < tokens.len() && is_workspace_value(tokens[k + 1]) {
                 filters.push(tokens[k + 1]);
                 k += 1;
             } else {
                 return 0;
             }
         } else if let Some(v) = t.strip_prefix(b"--workspace=") {
+            if !is_workspace_value(v) {
+                return 0;
+            }
             filters.push(v);
         } else if let Some(v) = t.strip_prefix(b"-w=") {
+            if !is_workspace_value(v) {
+                return 0;
+            }
             filters.push(v);
         } else if t == b"--if-present" {
             if_present = true;

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -122,6 +122,122 @@ impl YarnCommands {
 /// `.text.unlikely.*` keeps the byte-scanning loop out of the hot
 /// fault-around windows the startup/dot benches page in (belt-and-suspenders
 /// alongside `startup.order` regen — survives mangling-hash drift).
+/// Translate npm's workspace-selection flags into Bun's when rewriting an
+/// `npm run ...` invocation. `cmd` starts at `npm run ` and `prefix_len` is its
+/// length. When the remainder of this simple command (up to the next top-level
+/// shell separator) carries `-w`/`--workspace[=<pkg>]` or `--workspaces`, emit a
+/// `bun run` with the equivalent `--filter=<pkg>`/`--workspaces` placed before
+/// the script name and return the number of input bytes consumed. Returns 0 when
+/// no workspace flag is present so the caller falls back to the plain
+/// `npm run` -> `bun run` rewrite, keeping byte-for-byte output for that case.
+fn rewrite_npm_run_workspaces(out: &mut Vec<u8>, cmd: &[u8], prefix_len: usize) -> usize {
+    let args = &cmd[prefix_len..];
+
+    // End of this simple command: first top-level (unquoted) shell separator.
+    let mut seg_end = args.len();
+    {
+        let (mut in_single, mut in_double) = (false, false);
+        let mut i = 0;
+        while i < args.len() {
+            let c = args[i];
+            if in_single {
+                in_single = c != b'\'';
+            } else if in_double {
+                in_double = c != b'"';
+            } else {
+                match c {
+                    b'\'' => in_single = true,
+                    b'"' => in_double = true,
+                    b';' | b'&' | b'|' | b'\n' | b'\r' => {
+                        seg_end = i;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+    }
+    let segment = &args[..seg_end];
+
+    // Split into tokens on top-level whitespace, preserving any quote bytes.
+    let mut tokens: Vec<&[u8]> = Vec::new();
+    {
+        let (mut in_single, mut in_double) = (false, false);
+        let mut tok_start: Option<usize> = None;
+        let mut j = 0;
+        while j < segment.len() {
+            let c = segment[j];
+            let is_sep = !in_single && !in_double && (c == b' ' || c == b'\t');
+            if is_sep {
+                if let Some(s) = tok_start.take() {
+                    tokens.push(&segment[s..j]);
+                }
+            } else {
+                if tok_start.is_none() {
+                    tok_start = Some(j);
+                }
+                if in_single {
+                    in_single = c != b'\'';
+                } else if in_double {
+                    in_double = c != b'"';
+                } else if c == b'\'' {
+                    in_single = true;
+                } else if c == b'"' {
+                    in_double = true;
+                }
+            }
+            j += 1;
+        }
+        if let Some(s) = tok_start {
+            tokens.push(&segment[s..]);
+        }
+    }
+
+    let mut filters: Vec<&[u8]> = Vec::new();
+    let mut all_workspaces = false;
+    let mut rest: Vec<&[u8]> = Vec::new();
+    let mut k = 0;
+    while k < tokens.len() {
+        let t = tokens[k];
+        if t == b"--workspaces" {
+            all_workspaces = true;
+        } else if t == b"-w" || t == b"--workspace" {
+            if k + 1 < tokens.len() {
+                filters.push(tokens[k + 1]);
+                k += 1;
+            }
+        } else if let Some(v) = t.strip_prefix(b"--workspace=") {
+            filters.push(v);
+        } else if let Some(v) = t.strip_prefix(b"-w=") {
+            filters.push(v);
+        } else {
+            rest.push(t);
+        }
+        k += 1;
+    }
+
+    if filters.is_empty() && !all_workspaces {
+        return 0;
+    }
+
+    out.extend_from_slice(BUN_BIN_NAME);
+    out.extend_from_slice(b" run");
+    if all_workspaces {
+        out.extend_from_slice(b" --workspaces");
+    }
+    for f in &filters {
+        out.extend_from_slice(b" --filter=");
+        out.extend_from_slice(f);
+    }
+    for t in &rest {
+        out.push(b' ');
+        out.extend_from_slice(t);
+    }
+
+    prefix_len + seg_end
+}
+
 #[cold]
 pub fn replace_package_manager_run(
     copy_script: &mut Vec<u8>,
@@ -199,6 +315,16 @@ pub fn replace_package_manager_run(
             b'n' => {
                 if delimiter > 0 {
                     if strings::has_prefix_comptime(&script[start..], b"npm run ") {
+                        let consumed = rewrite_npm_run_workspaces(
+                            copy_script,
+                            &script[start..],
+                            b"npm run ".len(),
+                        );
+                        if consumed > 0 {
+                            entry_i += consumed;
+                            delimiter = 0;
+                            continue;
+                        }
                         append_bun_run(copy_script);
                         copy_script.push(b' ');
                         entry_i += b"npm run ".len();

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -271,9 +271,9 @@ pub fn replace_package_manager_run(
 /// Returns 0 (caller falls back to the plain `npm run` -> `bun run` prefix swap,
 /// keeping byte-for-byte output) when no workspace flag is present, when the
 /// match is inside a quoted string, when the segment's quotes are unbalanced, or
-/// when it contains shell grouping/escaping the tokenizer does not model (`(`,
-/// `)`, `$`, `` ` ``, `\`): reordering tokens is only safe at shell top level
-/// with balanced quoting and no such constructs.
+/// when it contains shell grouping/escaping/comments the tokenizer does not
+/// model (`(`, `)`, `$`, `` ` ``, `\`, `#`): reordering tokens is only safe at
+/// shell top level with balanced quoting and no such constructs.
 fn rewrite_npm_run_workspaces(
     out: &mut Vec<u8>,
     cmd: &[u8],
@@ -310,7 +310,7 @@ fn rewrite_npm_run_workspaces(
                         seg_end = i;
                         break;
                     }
-                    b'(' | b')' | b'$' | b'`' | b'\\' => has_unsupported = true,
+                    b'(' | b')' | b'$' | b'`' | b'\\' | b'#' => has_unsupported = true,
                     _ => {}
                 }
             }

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -730,6 +730,26 @@ describe.concurrent("bun run", () => {
       expect(exitCode).toBe(0);
     });
 
+    it("does not hoist a redirect glued to the -w value", async () => {
+      using dir = tempDir("npm-ws-redirect", rootScriptRepo("npm run greet -w app>&2"));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // Falls back to the plain prefix swap: the greet script runs with `-w app`
+      // passed through and its output redirected to stderr.
+      expect(stderr).toContain("greet-done");
+      expect(stderr).not.toContain("--filter");
+      expect(exitCode).toBe(0);
+    });
+
     it.skipIf(isWindows)("does not mangle quoting for npm run -w inside a quoted string", async () => {
       using dir = tempDir("npm-ws-quoted", rootScriptRepo("sh -c 'npm run greet -w app'"));
       await using proc = Bun.spawn({

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -633,6 +633,101 @@ describe.concurrent("bun run", () => {
       expect(stderr).not.toContain("Script not found");
       expect(exitCode).toBe(0);
     });
+
+    // https://github.com/oven-sh/bun/issues/22719
+    const allWorkspacesRepo = (rootScript: string) => ({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["apps/*"],
+        scripts: { start: rootScript },
+      }),
+      "apps": {
+        "app": {
+          "package.json": JSON.stringify({
+            name: "app",
+            private: true,
+            scripts: { hello: "echo workspace-ok" },
+          }),
+        },
+        // No "hello" script: --if-present must skip it rather than error.
+        "lib": {
+          "package.json": JSON.stringify({ name: "lib", private: true, scripts: {} }),
+        },
+      },
+    });
+
+    it.each([
+      ["npm run hello --ws --if-present", "--ws"],
+      ["npm run hello --workspaces --if-present", "--workspaces"],
+      ["echo chained && npm run hello --ws --if-present", "chained with &&"],
+    ])("%s runs workspace scripts without recursing (%s)", async rootScript => {
+      using dir = tempDir("npm-workspaces-flag", allWorkspacesRepo(rootScript));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("workspace-ok");
+      expect(stderr).not.toContain("Script not found");
+      expect(stderr).not.toContain("Missing");
+      expect(exitCode).toBe(0);
+    });
+
+    // A root script is present so the plain rewrite keeps working; `-w app` must
+    // NOT be hoisted into a filter in these cases.
+    const rootScriptRepo = (rootScript: string) => ({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["apps/*"],
+        scripts: { start: rootScript, greet: "echo greet-done" },
+      }),
+      "apps": {
+        "app": {
+          "package.json": JSON.stringify({ name: "app", private: true, scripts: {} }),
+        },
+      },
+    });
+
+    it("does not treat -w after -- as a workspace filter", async () => {
+      using dir = tempDir("npm-ws-ddash", rootScriptRepo("npm run greet -- -w app"));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("greet-done");
+      expect(stderr).not.toContain("Missing");
+      expect(exitCode).toBe(0);
+    });
+
+    it.skipIf(isWindows)("does not mangle quoting for npm run -w inside a quoted string", async () => {
+      using dir = tempDir("npm-ws-quoted", rootScriptRepo("sh -c 'npm run greet -w app'"));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("greet-done");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("'bun run' priority", async () => {

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -712,6 +712,24 @@ describe.concurrent("bun run", () => {
       expect(exitCode).toBe(0);
     });
 
+    it("does not consume a following flag as the -w value", async () => {
+      using dir = tempDir("npm-ws-flagvalue", rootScriptRepo("npm run greet -w --if-present"));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("greet-done");
+      expect(stderr).not.toContain("filter");
+      expect(exitCode).toBe(0);
+    });
+
     it.skipIf(isWindows)("does not mangle quoting for npm run -w inside a quoted string", async () => {
       using dir = tempDir("npm-ws-quoted", rootScriptRepo("sh -c 'npm run greet -w app'"));
       await using proc = Bun.spawn({

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -751,6 +751,31 @@ describe.concurrent("bun run", () => {
       expect(stdout).toContain("greet-done");
       expect(exitCode).toBe(0);
     });
+
+    // A later quoted string with a separator can defeat a naive quote tracker;
+    // the rewrite must leave a quoted npm run (with text before it) untouched.
+    it.skipIf(isWindows)("does not hoist -w out of an earlier quoted string", async () => {
+      using dir = tempDir(
+        "npm-ws-quote-align",
+        rootScriptRepo("echo 'step: npm run build -w app' && echo 'ok; done'"),
+      );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The `-w app` lives inside a string being echoed; it must stay there and
+      // never be turned into a live `--filter`.
+      expect(stdout).toContain("-w app");
+      expect(stdout).not.toContain("--filter");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("'bun run' priority", async () => {

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -755,10 +755,7 @@ describe.concurrent("bun run", () => {
     // A later quoted string with a separator can defeat a naive quote tracker;
     // the rewrite must leave a quoted npm run (with text before it) untouched.
     it.skipIf(isWindows)("does not hoist -w out of an earlier quoted string", async () => {
-      using dir = tempDir(
-        "npm-ws-quote-align",
-        rootScriptRepo("echo 'step: npm run build -w app' && echo 'ok; done'"),
-      );
+      using dir = tempDir("npm-ws-quote-align", rootScriptRepo("echo 'step: npm run build -w app' && echo 'ok; done'"));
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "start"],
         cwd: String(dir),

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -734,6 +734,7 @@ describe.concurrent("bun run", () => {
     it.each([
       ["(true && npm run greet -w app)", "subshell"],
       ["npm run greet -w $(echo app)", "command substitution"],
+      ["npm run greet # switch to -w app", "trailing comment"],
     ])("%s is not mangled by workspace-flag reordering (%s)", async rootScript => {
       using dir = tempDir("npm-ws-shell", rootScriptRepo(rootScript));
       await using proc = Bun.spawn({

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -731,7 +731,7 @@ describe.concurrent("bun run", () => {
     });
 
     it("does not hoist a redirect glued to the -w value", async () => {
-      using dir = tempDir("npm-ws-redirect", rootScriptRepo("npm run greet -w app>&2"));
+      using dir = tempDir("npm-ws-redirect", rootScriptRepo("npm run greet -w app>out.txt"));
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "start"],
         cwd: String(dir),
@@ -744,9 +744,9 @@ describe.concurrent("bun run", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       // Falls back to the plain prefix swap: the greet script runs with `-w app`
-      // passed through and its output redirected to stderr.
-      expect(stderr).toContain("greet-done");
+      // passed through and its output redirected into out.txt.
       expect(stderr).not.toContain("--filter");
+      expect(await Bun.file(join(String(dir), "out.txt")).text()).toContain("greet-done");
       expect(exitCode).toBe(0);
     });
 

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -591,6 +591,50 @@ describe.concurrent("bun run", () => {
     }
   });
 
+  // https://github.com/oven-sh/bun/issues/33796
+  describe("npm workspace flags in scripts", () => {
+    const workspaceRepo = (rootScript: string) => ({
+      "package.json": JSON.stringify({
+        private: true,
+        workspaces: ["apps/*"],
+        scripts: { start: rootScript },
+      }),
+      "apps": {
+        "app": {
+          "package.json": JSON.stringify({
+            name: "app",
+            private: true,
+            scripts: { hello: "echo workspace-ok" },
+          }),
+        },
+      },
+    });
+
+    it.each([
+      ["npm run hello -w app", "-w after script"],
+      ["npm run -w app hello", "-w before script"],
+      ["npm run hello --workspace app", "--workspace after script"],
+      ["npm run hello --workspace=app", "--workspace=pkg"],
+      ["npm run hello -w=app", "-w=pkg"],
+    ])("%s runs the workspace script instead of re-entering the root (%s)", async rootScript => {
+      using dir = tempDir("npm-workspace-flag", workspaceRepo(rootScript));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("workspace-ok");
+      expect(stderr).not.toContain("Script not found");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("'bun run' priority", async () => {
     // priority:
     // - 1: run script with matching name

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -728,6 +728,28 @@ describe.concurrent("bun run", () => {
       expect(stdout).toContain("greet-done");
       expect(exitCode).toBe(0);
     });
+
+    // Shell grouping/substitution the rewrite does not model: it must fall back
+    // to the plain prefix swap rather than reorder tokens across them.
+    it.each([
+      ["(true && npm run greet -w app)", "subshell"],
+      ["npm run greet -w $(echo app)", "command substitution"],
+    ])("%s is not mangled by workspace-flag reordering (%s)", async rootScript => {
+      using dir = tempDir("npm-ws-shell", rootScriptRepo(rootScript));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "start"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 15_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("greet-done");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("'bun run' priority", async () => {


### PR DESCRIPTION
Fixes #33796
Fixes #22719
Fixes #24838
Fixes #41543

## Repro

```sh
mkdir -p apps/app
cat > package.json <<'JSON'
{ "private": true, "workspaces": ["apps/*"], "scripts": { "dev": "npm run dev -w app" } }
JSON
cat > apps/app/package.json <<'JSON'
{ "name": "app", "private": true, "scripts": { "dev": "echo workspace-ok" } }
JSON

bun run dev
```

Before this change `bun run dev` recurses forever, appending another `-w app` each pass:

```text
$ bun run dev -w app
$ bun run dev -w app -w app
$ bun run dev -w app -w app -w app
...
```

## Cause

When executing a package.json script, Bun rewrites `npm run <x>` / `pnpm run <x>` / `yarn run <x>` into `bun run <x>` so scripts re-enter Bun instead of spawning another package manager (`replace_package_manager_run` in `src/install/lifecycle_script_runner.rs`).

The root `dev` body `npm run dev -w app` was rewritten to `bun run dev -w app`. Bun does not recognize npm's `-w`/`--workspace` flag, and because it comes after the script name it is treated as passthrough arguments for the `dev` script. That re-invokes the same root `dev`, which rewrites again and appends another `-w app`, so it re-enters itself without end. The same shape with `--ws`/`--if-present` (#22719) and `-w <pkg>` in lifecycle scripts (#24838) hit the same bug.

## Fix

When rewriting an `npm run ...` invocation, translate npm's workspace-selection flags to Bun's equivalents and place them before the script name:

- `-w <pkg>` / `-w=<pkg>` / `--workspace <pkg>` / `--workspace=<pkg>` -> `--filter=<pkg>`
- `--workspaces` / `--ws` -> `--workspaces`
- `--if-present` -> `--if-present` (hoisted before the script name so it is recognized)

So `npm run dev -w app` becomes `bun run --filter=app dev`, which runs the `dev` script in the `app` workspace instead of re-entering the root script.

Guards so the rewrite only reorders when it is safe:

- Flags are matched only within the current simple command (up to the next top-level shell separator); quotes are respected.
- If the `npm run` match sits inside a quoted string (e.g. `sh -c 'npm run build -w app'`) or the segment's quotes are unbalanced, fall back to the plain prefix swap, keeping byte-for-byte output, since reordering would move the closing quote.
- A bare `--` ends flag parsing: `npm run build -- -w src` keeps `-w src` as a passthrough script arg.
- When no workspace flag is present the output is byte-for-byte identical to before.

Only `npm run` is translated: `pnpm`'s `-w` means `--workspace-root` and yarn uses a different syntax, so those are left unchanged.

## Verification

```
bun bd test test/cli/install/bun-run.test.ts -t "npm workspace flags"
```

New tests cover `-w` before/after the script name, `--workspace`, `--workspace=pkg`, `-w=pkg`, `--ws`/`--workspaces` with `--if-present`, `&&`-chained commands, the `--` passthrough boundary, and quoting inside `sh -c '...'`. Each fails on the released binary and passes with this change. The existing `npm run` / `pnpm run` / `yarn run` rewrite tests are unchanged and still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run.test.ts

<!-- robobun:evidence:end -->
