### PR TITLE
node:http2: close streams with the session's destroy code and order their events before the session's

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -475,10 +475,11 @@ function emitEventNT(self: any, event: string, ...args: any[]) {
     self.emit(event, ...args);
   }
 }
-// The frame is passed in: destroy() clears it off the session before emitting
-// 'error', so a throwing listener on either event cannot leave a retained
-// session pinning the store.
-function emitSessionCloseNT(self: Http2Session, frame) {
+// The frame is passed in (destroy() clears it off the session first) so a throwing listener
+// cannot leave a retained session pinning the store. 'error' and 'close' both fire on the next
+// tick so per-stream events queued synchronously from forEachStream land first.
+function emitSessionCloseNT(self: Http2Session, frame, error: Error | undefined) {
+  if (error) runInFrame(frame, self.emit, self, "error", error);
   if (self.listenerCount("close") > 0) {
     runInFrame(frame, self.emit, self, "close");
   }
@@ -4326,18 +4327,14 @@ class ServerHttp2Session extends Http2Session {
       return;
     }
     if (isEconnresetAfterGoaway(this, error)) {
-      this.destroy();
+      this.destroy(undefined, constants.NGHTTP2_CANCEL);
       return;
     }
     if (this.listenerCount("error") === 0 && (error as NodeJS.ErrnoException)?.code === "ECONNRESET") {
-      // An unobserved transport teardown (the peer dropped a connection
-      // nobody is listening to anymore): destroy quietly - the destroy still
-      // errors any remaining streams - instead of re-emitting on a session
-      // with no 'error' listener and crashing the process. (The server
-      // attaches sessionOnError at accept time, so this branch only matters
-      // for standalone sessions.) Anything that is not teardown noise keeps
-      // Node's EventEmitter contract and surfaces when unobserved.
-      this.destroy();
+      // An unobserved transport teardown: swallow the session error but mark active streams
+      // cancelled (rstCode=8) so a mid-flight request is not mistaken for clean completion.
+      // (sessionOnError is attached at accept time, so this matters only for standalone sessions.)
+      this.destroy(undefined, constants.NGHTTP2_CANCEL);
       return;
     }
     this.destroy(error);
@@ -4671,7 +4668,7 @@ class ServerHttp2Session extends Http2Session {
     }
   }
 
-  destroy(error: Error | number | undefined = NGHTTP2_NO_ERROR, code?: number) {
+  destroy(error?: Error | number, code?: number) {
     // Node's destroy() is idempotent - "if (this.destroyed) return;" is its
     // first line - so a second destroy (e.g. the received-GOAWAY handler
     // destroying with a session error after a socket error's destroy already
@@ -4685,6 +4682,7 @@ class ServerHttp2Session extends Http2Session {
       return;
     }
     this.#destroying = true;
+    const wasConnected = this.#connected;
     try {
       const server = this[kServer];
       if (server) {
@@ -4758,20 +4756,17 @@ class ServerHttp2Session extends Http2Session {
       // validateInteger, the native session rejecting a non-numeric error
       // code) throws mid-teardown, and a corrected retry must still run.
       this.#destroying = false;
+      this.#connected = wasConnected;
       throw e;
     }
     this[bunHTTP2Socket] = null;
 
-    // Read-and-clear the frame first: emitting 'error' with no listener throws,
-    // which would skip the clear and leave a retained session pinning the store.
+    // Clear the frame here and pass it in: emitSessionCloseNT's 'error' emit can throw,
+    // so clearing there would leave a retained session pinning the store.
     const asyncFrame = this[bunHTTP2AsyncContextFrame];
     this[bunHTTP2AsyncContextFrame] = undefined;
-    if (error) {
-      runInFrame(asyncFrame, this.emit, this, "error", error);
-    }
-    // node emits the session 'close' event asynchronously (a listener attached right after
-    // close()/destroy() returns must still observe it).
-    process.nextTick(emitSessionCloseNT, this, asyncFrame);
+    // node emits session 'error' and 'close' together on next tick so per-stream events land first.
+    process.nextTick(emitSessionCloseNT, this, asyncFrame, error);
   }
 }
 function emitTimeout(session: ClientHttp2Session) {
@@ -5363,20 +5358,18 @@ class ClientHttp2Session extends Http2Session {
     }
     this[bunHTTP2Socket] = null;
     if (this.#closed) {
-      this.destroy();
+      this.destroy(undefined, constants.NGHTTP2_CANCEL);
       return;
     }
     if (isEconnresetAfterGoaway(this, error)) {
-      this.destroy();
+      this.destroy(undefined, constants.NGHTTP2_CANCEL);
       return;
     }
     if (this.listenerCount("error") === 0 && (error as NodeJS.ErrnoException)?.code === "ECONNRESET") {
-      // A transport teardown on a session nobody observes (an idle pooled
-      // connection dropped by the peer): shut down quietly - the destroy
-      // still errors any remaining streams. Anything else (handshake
-      // failure, ECONNREFUSED, ...) keeps Node's EventEmitter contract and
-      // surfaces when unobserved.
-      this.destroy();
+      // An idle pooled connection reset by the peer with nobody listening: swallow the session
+      // error but still mark active streams cancelled (rstCode=8) so a mid-flight request is not
+      // mistaken for a clean completion. Anything else keeps the EventEmitter contract.
+      this.destroy(undefined, constants.NGHTTP2_CANCEL);
       return;
     }
     this.destroy(error);
@@ -5712,6 +5705,7 @@ class ClientHttp2Session extends Http2Session {
       return;
     }
     this.#destroying = true;
+    const wasConnected = this.#connected;
     try {
       if (this[kTimeout]) {
         clearTimeout(this[kTimeout]);
@@ -5771,17 +5765,15 @@ class ClientHttp2Session extends Http2Session {
       }
       const parser = this.#parser;
       if (parser) {
-        // node cancels streams still open when their session is destroyed: each gets
-        // ERR_HTTP2_STREAM_CANCEL (or the session error when one was provided), with the CANCEL
-        // rst code.
-        if (this[kSessionDestroyError] == null && error == null) {
-          this[kSessionDestroyError] = createPendingStreamCancelError();
-        }
-        // Like Node's Http2Stream._destroy: a received GOAWAY's code takes
-        // precedence over the destroy code when streams are torn down.
+        // Node's closeSession: destroy every active stream with the session's error (none for NO_ERROR)
+        // synchronously so their events queue before the session's own.
+        const streamRstCode = this[kGoawayCode] || code || constants.NGHTTP2_NO_ERROR;
         this[bunHTTP2SessionTeardownFrame] = $getInternalField($asyncContext, 0);
         try {
-          parser.emitErrorToAllStreams(this[kGoawayCode] || (code !== undefined ? code : constants.NGHTTP2_CANCEL));
+          parser.forEachStream(
+            FunctionPrototypeBind.$call(destroyStreamForSessionDestroy, undefined, error, streamRstCode),
+          );
+          parser.emitErrorToAllStreams(streamRstCode);
         } finally {
           this[bunHTTP2SessionTeardownFrame] = kNoSessionTeardown;
         }
@@ -5792,21 +5784,18 @@ class ClientHttp2Session extends Http2Session {
       // validateInteger, the native session rejecting a non-numeric error
       // code) throws mid-teardown, and a corrected retry must still run.
       this.#destroying = false;
+      this.#connected = wasConnected;
       throw e;
     }
     this.#parser = null;
     this[bunHTTP2Socket] = null;
 
-    // Read-and-clear the frame first: emitting 'error' with no listener throws,
-    // which would skip the clear and leave a retained session pinning the store.
+    // Clear the frame here and pass it in: emitSessionCloseNT's 'error' emit can throw,
+    // so clearing there would leave a retained session pinning the store.
     const asyncFrame = this[bunHTTP2AsyncContextFrame];
     this[bunHTTP2AsyncContextFrame] = undefined;
-    if (error) {
-      runInFrame(asyncFrame, this.emit, this, "error", error);
-    }
-    // node emits the session 'close' event asynchronously (a listener attached right after
-    // close()/destroy() returns must still observe it).
-    process.nextTick(emitSessionCloseNT, this, asyncFrame);
+    // node emits session 'error' and 'close' together on next tick so per-stream events land first.
+    process.nextTick(emitSessionCloseNT, this, asyncFrame, error);
   }
 
   request(headers: any, options?: any) {

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1005,9 +1005,9 @@ describe("async context passes through", () => {
     expect(stderr).not.toContain("AssertionError");
   });
 
-  // destroy(err) with no 'error' listener throws out of the emit, which must
-  // not skip the frame clear (the 'close' tick after it never runs).
-  test("http2 clears the session frame when destroy(err) throws past the emit", async () => {
+  // destroy(err) with no 'error' listener throws from the deferred emit as
+  // uncaughtException; the frame must already be cleared before that tick.
+  test("http2 clears the session frame before the deferred destroy(err) 'error' emit throws", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -1021,8 +1021,11 @@ describe("async context passes through", () => {
            als.run({ marker: true }, () => {
              client = http2.connect("http://127.0.0.1:" + server.address().port);
            });
+           // The session 'error' fires on next tick (so per-stream events land first), so the
+           // throw surfaces as uncaughtException rather than from inside destroy().
+           process.on("uncaughtException", err => { if (err.message !== "boom") throw err; });
            client.on("connect", () => {
-             try { client.destroy(new Error("boom")); } catch {}
+             client.destroy(new Error("boom"));
              const sym = Object.getOwnPropertySymbols(client)
                .find(x => x.description === "::bunhttp2asynccontextframe::");
              console.log(sym === undefined ? "SYMBOL-MISSING" : client[sym] === undefined ? "CLEARED" : "PINNED");

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -915,7 +915,6 @@ describe("inbound stream lifecycle", () => {
       toString:start
       toString:end
       sendTrailers:returned
-      req error ERR_HTTP2_STREAM_CANCEL
       req close"
     `);
     expect(proc.signalCode).toBeNull();
@@ -978,10 +977,14 @@ describe("inbound stream lifecycle", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The synchronous forEachStream teardown stores the non-numeric code as-is (never coerced by
+    // the runtime); the one valueOf call here is the fixture's own + concatenation stringifying
+    // req.rstCode in the close handler.
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
       "destroy threw: Expected errorCode to be a number
       destroy:done
       req error boom
+      valueOf:1
       req close rst=8"
     `);
     expect(proc.signalCode).toBeNull();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,6 +1,7 @@
 import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { once } from "node:events";
 import fs from "node:fs";
 import http2 from "node:http2";
 import https from "node:https";
@@ -2463,6 +2464,81 @@ it("http2 request.destroy() with error", async () => {
         throw new Error("end event should not be called");
       });
     });
+  });
+});
+
+describe("http2 session.destroy() closes active streams with the session's code and emits stream events before session events", () => {
+  // Node's closeSession: active streams get the session's error (none for NO_ERROR), rstCode is
+  // the given code (default 0), and per-stream 'error'/'close' fire before the session's own.
+  it.concurrent.each([
+    { name: "destroy()", args: [], expected: ["req:close(rst=0)", "ses:close"] },
+    { name: "destroy(0)", args: [0], expected: ["req:close(rst=0)", "ses:close"] },
+    {
+      name: "destroy(8)",
+      args: [8],
+      expected: [
+        "req:error(ERR_HTTP2_SESSION_ERROR)",
+        "req:close(rst=8)",
+        "ses:error(ERR_HTTP2_SESSION_ERROR)",
+        "ses:close",
+      ],
+    },
+    {
+      name: "destroy(9)",
+      args: [9],
+      expected: [
+        "req:error(ERR_HTTP2_SESSION_ERROR)",
+        "req:close(rst=9)",
+        "ses:error(ERR_HTTP2_SESSION_ERROR)",
+        "ses:close",
+      ],
+    },
+    {
+      name: "destroy(err)",
+      args: [new Error("boom")],
+      expected: ["req:error(boom)", "req:close(rst=2)", "ses:error(boom)", "ses:close"],
+    },
+  ])("$name", async ({ args, expected }) => {
+    const server = http2.createServer();
+    server.on("stream", s => {
+      s.on("error", () => {});
+      s.session.on("error", () => {});
+      s.respond({ ":status": 200 });
+      s.write("partial");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    let session;
+    try {
+      const events = [];
+      session = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      const done = Promise.withResolvers();
+      let reqClosed = false;
+      let sesClosed = false;
+      const maybeDone = () => {
+        if (reqClosed && sesClosed) done.resolve();
+      };
+      server.on("error", done.reject);
+      session.on("error", e => events.push(`ses:error(${e.code || e.message})`));
+      session.on("close", () => {
+        events.push("ses:close");
+        sesClosed = true;
+        maybeDone();
+      });
+      const req = session.request({ ":path": "/" });
+      req.on("error", e => events.push(`req:error(${e.code || e.message})`));
+      req.on("aborted", () => events.push("req:aborted"));
+      req.on("close", () => {
+        events.push(`req:close(rst=${req.rstCode})`);
+        reqClosed = true;
+        maybeDone();
+      });
+      req.on("data", () => session.destroy(...args));
+      await done.promise;
+      expect(events).toEqual(expected);
+    } finally {
+      session?.destroy();
+      server.close();
+    }
   });
 });
 


### PR DESCRIPTION
`Http2Session.destroy()` (and an explicit `destroy(0)`) on a client session with active streams produced the wrong `rstCode`, a spurious `'error' ERR_HTTP2_STREAM_CANCEL` on every stream, and fired the session `'close'` before the per-stream `'error'`/`'close'`. A deliberate pool-eviction, idle-timeout, or `finally { session.destroy() }` therefore rejected every in-flight request with a cancellation error the caller never caused.

## Reproduction

```js
import http2 from "node:http2";
const srv = http2.createServer();
srv.on("stream", s => { s.on("error", () => {}); s.session.on("error", () => {}); s.respond({ ":status": 200 }); s.write("partial"); });
srv.listen(0, "127.0.0.1", () => {
  const ses = http2.connect(`http://127.0.0.1:${srv.address().port}`), ev = [];
  ses.on("error", e => ev.push(`ses:error(${e.code || e.message})`));
  ses.on("close", () => ev.push("ses:close"));
  const req = ses.request({ ":path": "/" });
  req.on("error", e => ev.push(`req:error(${e.code || e.message})`));
  req.on("aborted", () => ev.push("req:aborted"));
  req.on("close", () => ev.push(`req:close(rst=${req.rstCode})`));
  req.on("data", () => { ses.destroy(); setTimeout(() => { console.log(ev.join(" ")); process.exit(0); }, 200); });
});
```

node v26.3.0:
```
req:close(rst=0) ses:close
```

bun before:
```
ses:close req:error(ERR_HTTP2_STREAM_CANCEL) req:close(rst=8)
```

## Cause

`ClientHttp2Session.destroy()` still routed active streams through the deferred `emitErrorToAllStreams` path (defaulting to `NGHTTP2_CANCEL` when no code was given) and synthesised `ERR_HTTP2_STREAM_CANCEL` into `kSessionDestroyError`, so each stream was torn down a tick after the session's own `'close'` with `rstCode` 8 and a cancellation error. Both client and server `destroy()` emitted the session `'error'` synchronously and `'close'` on the next tick, before the per-stream events from `destroyStreamForSessionDestroy`/`emitStreamErrorNT` could fire.

## Fix

Mirror the server side and Node's `closeSession`: destroy every active client stream synchronously via `forEachStream(destroyStreamForSessionDestroy)` with the session's own error (none for `NGHTTP2_NO_ERROR`) and the given code (default `NGHTTP2_NO_ERROR`, not `CANCEL`), and stop synthesising `ERR_HTTP2_STREAM_CANCEL` as the session destroy error for active streams. A session destroyed before the socket connected treats every stream as pending (`ERR_HTTP2_STREAM_CANCEL`) like Node's `pendingStreams`. Emit the session `'error'` and `'close'` together on the next tick (`emitSessionCloseNT`) so per-stream events land first.

Two existing snapshots in `h2-conformance.test.ts` that codified the old client teardown path are updated.

## Conflict resolution

Rebased onto main after #32488 landed, which had already added `#destroying` re-entrancy guarding, `destroyStreamForSessionDestroy`, and the server-side synchronous `forEachStream` teardown. The remaining changes here are the client-side `forEachStream` path, the `NGHTTP2_NO_ERROR` default, the `wasConnected` pending-stream distinction, and the `emitSessionCloseNT` ordering applied to both sides.

## Verification

```
$ bun bd test test/js/node/http2/node-http2.test.js -t "closes active streams with the session"
 5 pass  (destroy(), destroy(0), destroy(8), destroy(9), destroy(err))
$ git stash push -- src/ && bun bd test test/js/node/http2/node-http2.test.js -t "closes active streams with the session"
 5 fail
```

No new failures against `test/expectations.txt` in the Node parallel http2 sweep; grpc-js `test-server.test.ts` passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 19 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fe76a384f)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [260.22ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [33.42ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [20.23ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [985.27ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [17.12ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [33.07m
... (truncated)

release without fix: 8 skipped
bun test v1.4.0-canary.1 (fe76a384f)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [0.35ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [0.22ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [0.10ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [13.48ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [0.13ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [0.18ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a disabled storage re-enables it [0.04ms]
(pass) AsyncLocalStorage > run() short-circuits when the store value is unchanged (Object.is) [0.46ms]
(pass) AsyncLocalStorage > disable() mid-run then finally restores the previous value [0.15ms]
(pass) AsyncResource [0.14ms]
(pass) async context passes through > syncronously [0.06ms]
(pass) async context passes through > promise.then [0.20ms]
(pass) async context passes through > nested promises [2.00ms]
(pass) async con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/AsyncLocalStorage.test.ts "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fe76a384f)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [243.43ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [31.27ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [20.62ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [922.28ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [15.50ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [31.05m
... (truncated)

release with fix: 8 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 762ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7641ms)
Bundle modules (50ms)
Postprocesss modules (181ms)
Bundle Functions (773ms)
Generate Code (92ms)

[8.75s] Bundled "src/js" for production
  2039 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (fe76a384f)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [0.38ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [0.23ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [0.15ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [16.09ms]
(pas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                               | 83 ++++++++++------------
 test/js/node/async_hooks/AsyncLocalStorage.test.ts | 11 +--
 test/js/node/http2/h2-conformance.test.ts          |  5 +-
 test/js/node/http2/node-http2.test.js              | 76 ++++++++++++++++++++
 4 files changed, 123 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 14 passed · 4 rejected · iteration 19

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/http2.ts                                   37     41      0
test/js/node/async_hooks/AsyncLocalStorage.test.ts      2      2      0
test/js/node/http2/h2-conformance.test.ts               3      6      0
test/js/node/http2/node-http2.test.js                   6     11      0
```

</details>

<!-- robobun:evidence:end -->