### PR TITLE
usockets: treat ENOBUFS/ENOMEM from send() as would-block, not fatal

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1010,6 +1010,18 @@ int bsd_would_block() {
 #endif
 }
 
+/* Transient kernel resource exhaustion from send(): the connection is still
+ * healthy and a later retry can succeed. Kept distinct from bsd_would_block()
+ * so recv() callers that use that to mean EOF-vs-error do not start spinning
+ * on ENOBUFS. */
+int bsd_send_is_transient_error() {
+#ifdef _WIN32
+    return WSAGetLastError() == WSAENOBUFS;
+#else
+    return errno == ENOBUFS || errno == ENOMEM;
+#endif
+}
+
 static int us_internal_bind_and_listen(LIBUS_SOCKET_DESCRIPTOR listenFd, struct sockaddr *listenAddr, socklen_t listenAddrLength, int backlog, int* error) {
     int result;
     do

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -224,6 +224,7 @@ struct us_iovec_t;
 ssize_t bsd_writev(LIBUS_SOCKET_DESCRIPTOR fd, const struct us_iovec_t *iov, int count);
 ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length);
 int bsd_would_block();
+int bsd_send_is_transient_error();
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -494,8 +494,11 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
     int written = bsd_send(us_poll_fd(&s->p), data, length);
     if (written < 0) {
         /* bsd_send already retries EINTR; bsd_would_block() reads errno on
-         * POSIX and WSAGetLastError() on Windows. */
-        if (bsd_would_block()) {
+         * POSIX and WSAGetLastError() on Windows. ENOBUFS/ENOMEM are
+         * transient kernel resource exhaustion on a healthy connection -
+         * classifying them as fatal made the node:net drain path drop the
+         * buffered bytes on a socket that kept flowing. */
+        if (bsd_would_block() || bsd_send_is_transient_error()) {
             s->flags.last_write_failed = 1;
             us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
             return 0;

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -116,48 +116,54 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
   // fails with a transient errno (ENOBUFS/ENOMEM on a healthy connection) the
   // bytes must stay buffered and be retried, not dropped. Dropping them fired
   // 'drain' on a socket that had silently lost a span of the application's
-  // byte stream.
-  test.each(["ENOBUFS", "ENOMEM"] as const)(
-    "send → %s on the drain-path flush of buffered data does not drop bytes",
-    async errno => {
-      let received = Buffer.alloc(0);
-      using p = await connectedPair(s => {
-        s.on("data", c => (received = Buffer.concat([received, c])));
-      });
-      const clientFd = (p.client as any)._handle.fd as number;
-      expect(clientFd).toBeGreaterThanOrEqual(0);
+  // byte stream. SocketBody is shared by connecting and accepted sockets, so
+  // both the client writer and the net.createServer response writer are
+  // exercised.
+  for (const side of ["client", "server"] as const) {
+    test.each(["ENOBUFS", "ENOMEM"] as const)(
+      `send → %s on the drain-path flush of buffered data does not drop bytes (${side} writer)`,
+      async errno => {
+        using p = await connectedPair();
+        const writer = side === "client" ? p.client : p.serverSock;
+        const reader = side === "client" ? p.serverSock : p.client;
+        let received = Buffer.alloc(0);
+        reader.on("data", c => (received = Buffer.concat([received, c])));
 
-      const head = Buffer.from(Array.from({ length: 200 }, (_, i) => i & 0xff));
-      const body = Buffer.alloc(4096, 0xee);
+        const writerFd = (writer as any)._handle.fd as number;
+        expect(writerFd).toBeGreaterThanOrEqual(0);
 
-      // send #0: clamp to 1 byte so the other 199 bytes of `head` land in
-      // buffered_data_for_node_net and the writable poll is armed.
-      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: 1, fd: clientFd });
-      const headWritten = new Promise<void>((resolve, reject) =>
-        p.client.write(head, err => (err ? reject(err) : resolve())),
-      );
+        const head = Buffer.from(Array.from({ length: 200 }, (_, i) => i & 0xff));
+        const body = Buffer.alloc(4096, 0xee);
 
-      // send #1: the drain-path flush of the buffered remainder. Inject a
-      // one-shot transient errno; once it fires the rule self-disarms and the
-      // next retry must deliver the bytes.
-      fault.set({ syscall: "send", action: "errno", errno, repeat: 1, fd: clientFd });
+        // send #0: clamp to 1 byte so the other 199 bytes of `head` land in
+        // buffered_data_for_node_net and the writable poll is armed.
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: 1, fd: writerFd });
+        const headWritten = new Promise<void>((resolve, reject) =>
+          writer.write(head, err => (err ? reject(err) : resolve())),
+        );
 
-      // A follow-up write on the same connection after the first write's
-      // callback fires lets the peer observe a mid-stream gap (head[0]
-      // followed by body) if the buffered remainder was dropped.
-      await headWritten;
-      p.client.write(body);
-      p.client.end();
-      await once(p.serverSock, "end");
-      fault.clear();
+        // send #1: the drain-path flush of the buffered remainder. Inject a
+        // one-shot transient errno; once it fires the rule self-disarms and the
+        // next retry must deliver the bytes.
+        fault.set({ syscall: "send", action: "errno", errno, repeat: 1, fd: writerFd });
 
-      const expected = Buffer.concat([head, body]);
-      expect({ length: received.length, intact: received.equals(expected) }).toEqual({
-        length: expected.length,
-        intact: true,
-      });
-    },
-  );
+        // A follow-up write on the same connection after the first write's
+        // callback fires lets the peer observe a mid-stream gap (head[0]
+        // followed by body) if the buffered remainder was dropped.
+        await headWritten;
+        writer.write(body);
+        writer.end();
+        await once(reader, "end");
+        fault.clear();
+
+        const expected = Buffer.concat([head, body]);
+        expect({ length: received.length, intact: received.equals(expected) }).toEqual({
+          length: expected.length,
+          intact: true,
+        });
+      },
+    );
+  }
 
   test("connect → ECONNREFUSED is reported on connecting socket", async () => {
     const server = net.createServer();

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -111,6 +111,54 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     expect(received.equals(payload)).toBe(true);
   });
 
+  // A short send leaves the remainder in the native buffered_data_for_node_net;
+  // the next writable event drives internal_flush(), and if that retry's send()
+  // fails with a transient errno (ENOBUFS/ENOMEM on a healthy connection) the
+  // bytes must stay buffered and be retried, not dropped. Dropping them fired
+  // 'drain' on a socket that had silently lost a span of the application's
+  // byte stream.
+  test.each(["ENOBUFS", "ENOMEM"] as const)(
+    "send → %s on the drain-path flush of buffered data does not drop bytes",
+    async errno => {
+      let received = Buffer.alloc(0);
+      using p = await connectedPair(s => {
+        s.on("data", c => (received = Buffer.concat([received, c])));
+      });
+      const clientFd = (p.client as any)._handle.fd as number;
+      expect(clientFd).toBeGreaterThanOrEqual(0);
+
+      const head = Buffer.from(Array.from({ length: 200 }, (_, i) => i & 0xff));
+      const body = Buffer.alloc(4096, 0xee);
+
+      // send #0: clamp to 1 byte so the other 199 bytes of `head` land in
+      // buffered_data_for_node_net and the writable poll is armed.
+      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: 1, fd: clientFd });
+      const headWritten = new Promise<void>((resolve, reject) =>
+        p.client.write(head, err => (err ? reject(err) : resolve())),
+      );
+
+      // send #1: the drain-path flush of the buffered remainder. Inject a
+      // one-shot transient errno; once it fires the rule self-disarms and the
+      // next retry must deliver the bytes.
+      fault.set({ syscall: "send", action: "errno", errno, repeat: 1, fd: clientFd });
+
+      // A follow-up write on the same connection after the first write's
+      // callback fires lets the peer observe a mid-stream gap (head[0]
+      // followed by body) if the buffered remainder was dropped.
+      await headWritten;
+      p.client.write(body);
+      p.client.end();
+      await once(p.serverSock, "end");
+      fault.clear();
+
+      const expected = Buffer.concat([head, body]);
+      expect({ length: received.length, intact: received.equals(expected) }).toEqual({
+        length: expected.length,
+        intact: true,
+      });
+    },
+  );
+
   test("connect → ECONNREFUSED is reported on connecting socket", async () => {
     const server = net.createServer();
     server.listen(0, "127.0.0.1");


### PR DESCRIPTION
`us_socket_write_check_error` classified every non-`EWOULDBLOCK` `send()` errno as a fatal write error. For transient kernel resource exhaustion (`ENOBUFS`/`ENOMEM` on POSIX, `WSAENOBUFS` on Windows) the connection is still healthy and a later retry can succeed, so the `node:net` drain path must keep the buffered bytes and re-arm the writable poll instead of dropping them.

## Repro

Deterministic via the in-tree usockets fault injection (debug/ASan builds):

```js
// net.Socket client: a short write leaves bytes in buffered_data_for_node_net,
// the drain-path flush (internal_flush) then hits ENOBUFS.
fault.set({ syscall: "send", action: "short", bytes: 1, repeat: 1, fd: clientFd });
client.write(head);  // send #0: 1 byte accepted, 199 buffered
fault.set({ syscall: "send", action: "errno", errno: "ENOBUFS", repeat: 1, fd: clientFd });
// on_writable -> internal_flush -> send() -> ENOBUFS
```

Without the fix the peer receives `head[0]` followed by whatever is written next; the 199 buffered bytes are gone, no `'error'` event, no failed write callback, no close. The short send that leaves data buffered is ordinary kernel backpressure on any real-network upload; a one-off `ENOBUFS`/`ENOMEM` from `send(2)` under memory pressure is ordinary kernel behaviour.

## Cause

`packages/bun-usockets/src/socket.c` `us_socket_write_check_error()`:

```c
if (bsd_would_block()) { ...retry... }   /* errno == EWOULDBLOCK only */
if (fatal_write_error) *fatal_write_error = 1;   /* ENOBUFS/ENOMEM land here */
```

`src/runtime/socket/socket_body.rs` `internal_flush()` then clears `buffered_data_for_node_net` on `fatal`, and `on_writable` dispatches `'drain'` regardless, so JS keeps writing on a connection that has silently lost a span of its byte stream.

## Fix

Add `bsd_send_is_transient_error()` (ENOBUFS/ENOMEM on POSIX, WSAENOBUFS on Windows) and treat it the same as would-block in `us_socket_write_check_error`: set `last_write_failed`, re-arm the writable poll, return 0, do not set `fatal_write_error`. This matches libuv's `uv__write`, which retries on `EAGAIN || EWOULDBLOCK || ENOBUFS`.

`EPIPE`/`ECONNRESET` still reach the fatal branch; those are connection-fatal and surfaced on the read side. Making the write side itself fail those pending writes is the complementary fix in #33506.

## Verification

New `test.each(["ENOBUFS", "ENOMEM"])` case in `test/js/node/net/net-syscall-fault.test.ts`.

Without the fix (`git stash -- packages/ && bun bd test ...`):
```
{ intact: false, length: 4097 }   // 1 head byte + 4096 body; 199 bytes dropped
```

With the fix:
```
{ intact: true, length: 4296 }    // 200 head + 4096 body, byte-exact
```

The rest of `net-syscall-fault.test.ts`, `tls-syscall-fault.test.ts`, and `socket-syscall-fault.test.ts` pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/net-syscall-fault.test.ts

<!-- robobun:evidence:end -->