### PR TITLE
node:module: give require.cache entries Node's own enumerable properties and Module prototype

### DIFF
--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -141,7 +141,7 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
     RETURN_IF_EXCEPTION(scope, );
 
     requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
-    moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, 0);
+    moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     globalObject->putDirect(vm, WebCore::builtinNames(vm).requirePublicName(), requireFunction, 0);
     globalObject->putDirect(vm, Identifier::fromString(vm, "module"_s), moduleObject, 0);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -67,6 +67,7 @@
 
 #include <JavaScriptCore/JSMapInlines.h>
 #include <JavaScriptCore/GetterSetter.h>
+#include <JavaScriptCore/CustomGetterSetter.h>
 #include "ZigSourceProvider.h"
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSCommonJSModule.h"
@@ -142,7 +143,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         RETURN_IF_EXCEPTION(scope, );
         requireFunction->putDirect(vm, vm.propertyNames->resolve, resolveFunction, 0);
         RETURN_IF_EXCEPTION(scope, );
-        moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, 0);
+        moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), requireFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
         RETURN_IF_EXCEPTION(scope, );
         moduleObject->hasEvaluated = true;
     };
@@ -768,15 +769,12 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     return JSValue::encode(jsUndefined());
 }
 
+// id/path/filename/loaded/children/paths live as own CustomValue properties on
+// each instance (see JSCommonJSModule::finishCreation) so that
+// Object.keys/{...spread}/for...in see them, matching Node.js.
 static const struct HashTableValue JSCommonJSModulePrototypeTableValues[] = {
     { "_compile"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterUnderscoreCompile, setterUnderscoreCompile } },
-    { "children"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterChildren, setterChildren } },
-    { "filename"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterFilename, setterFilename } },
-    { "id"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterId, setterId } },
-    { "loaded"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterLoaded, setterLoaded } },
     { "parent"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterParent, setterParent } },
-    { "path"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterPath, setterPath } },
-    { "paths"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, getterPaths, setterPaths } },
 };
 
 class JSCommonJSModulePrototype final : public JSC::JSNonFinalObject {
@@ -846,6 +844,14 @@ void JSCommonJSModule::finishCreation(JSC::VM& vm, const JSC::SourceCode& source
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     this->sourceCode = sourceCode;
+
+    auto& builtinNames = WebCore::builtinNames(vm);
+    putDirectCustomAccessor(vm, vm.propertyNames->id, CustomGetterSetter::create(vm, getterId, setterId), 0);
+    putDirectCustomAccessor(vm, builtinNames.pathPublicName(), CustomGetterSetter::create(vm, getterPath, setterPath), 0);
+    putDirectCustomAccessor(vm, builtinNames.filenamePublicName(), CustomGetterSetter::create(vm, getterFilename, setterFilename), 0);
+    putDirectCustomAccessor(vm, Identifier::fromString(vm, "loaded"_s), CustomGetterSetter::create(vm, getterLoaded, setterLoaded), 0);
+    putDirectCustomAccessor(vm, Identifier::fromString(vm, "children"_s), CustomGetterSetter::create(vm, getterChildren, setterChildren), 0);
+    putDirectCustomAccessor(vm, builtinNames.pathsPublicName(), CustomGetterSetter::create(vm, getterPaths, setterPaths), 0);
 }
 
 JSC::Structure* JSCommonJSModule::createStructure(

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -687,12 +687,10 @@ JSC_DEFINE_CUSTOM_SETTER(setterLoaded,
 JSC_DEFINE_CUSTOM_GETTER(getterUnderscoreCompile, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (!thisObject) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
-    if (thisObject->m_overriddenCompile) {
+    if (thisObject && thisObject->m_overriddenCompile) {
         return JSValue::encode(thisObject->m_overriddenCompile.get());
     }
+    // `Module.prototype._compile` is read with the prototype as receiver; still return the function.
     return JSValue::encode(defaultGlobalObject(globalObject)->modulePrototypeUnderscoreCompileFunction());
 }
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -764,20 +764,12 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
     return true;
 }
 
-static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
+static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleConstructor)
 {
-    auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    auto prototype = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-
-    prototype->putDirectCustomAccessor(
-        vm, WebCore::clientData(vm)->builtinNames().requirePublicName(),
-        JSC::CustomGetterSetter::create(vm, getterRequireFunction,
-            setterRequireFunction),
-        0);
-
-    prototype->putDirect(vm, Identifier::fromString(vm, "_compile"_s), globalObject->modulePrototypeUnderscoreCompileFunction());
-
-    return prototype;
+    auto* globalObject = defaultGlobalObject(moduleConstructor->globalObject());
+    // Return the real JSCommonJSModule prototype so `instanceof Module` works.
+    // `constructor` and `require` are installed in m_nodeModuleConstructor.initLater.
+    return globalObject->CommonJSModuleObjectStructure()->storedPrototypeObject();
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionLoad, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -1054,8 +1046,15 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
 {
     globalObject->m_nodeModuleConstructor.initLater(
         [](const Zig::GlobalObject::Initializer<JSObject>& init) {
-            JSObject* moduleConstructor = JSModuleConstructor::create(
-                init.vm, static_cast<Zig::GlobalObject*>(init.owner));
+            auto* globalObject = static_cast<Zig::GlobalObject*>(init.owner);
+            JSObject* moduleConstructor = JSModuleConstructor::create(init.vm, globalObject);
+            auto* prototype = globalObject->CommonJSModuleObjectStructure()->storedPrototypeObject();
+            prototype->putDirect(init.vm, init.vm.propertyNames->constructor, moduleConstructor,
+                static_cast<unsigned>(PropertyAttribute::DontEnum));
+            prototype->putDirectCustomAccessor(init.vm,
+                WebCore::clientData(init.vm)->builtinNames().requirePublicName(),
+                JSC::CustomGetterSetter::create(init.vm, getterRequireFunction, setterRequireFunction),
+                0);
             init.set(moduleConstructor);
         });
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -214,10 +214,9 @@ describe.concurrent("node-module-module", () => {
       cmd: [bunExe(), "-e", script],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "inherit",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     const result = JSON.parse(stdout);
     const expectedKeys = ["children", "exports", "filename", "id", "loaded", "path", "paths"];
     const expectedDesc = { hasValue: true, enumerable: true, writable: true, configurable: true };

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -175,6 +175,92 @@ describe.concurrent("node-module-module", () => {
     expect(req).toBe(module.require);
     expect(fn).toBe(filename);
     expect(dn).toBe(path.dirname(filename));
+  });
+
+  test("require.cache entries have Node's own enumerable properties and Module prototype", async () => {
+    using dir = tempDir("module-cache-shape", {
+      "a.cjs": "exports.v = 1;\n",
+      "b.cjs": "require('./a.cjs');\n",
+    });
+    const script = `
+      const path = require("node:path");
+      const { Module } = require("node:module");
+      const d = ${JSON.stringify(String(dir))};
+      const bPath = path.join(d, "b.cjs");
+      require(bPath);
+      const en = require.cache[bPath];
+      const forIn = [];
+      for (const k in en) forIn.push(k);
+      const descriptors = {};
+      for (const k of ["id", "path", "filename", "loaded", "children", "paths", "exports"]) {
+        const desc = Object.getOwnPropertyDescriptor(en, k);
+        descriptors[k] = desc ? { hasValue: "value" in desc, enumerable: desc.enumerable, writable: desc.writable, configurable: desc.configurable } : null;
+      }
+      console.log(JSON.stringify({
+        ownKeys: Object.keys(en).sort(),
+        spreadKeys: Object.keys({ ...en }).sort(),
+        forInHasChildren: forIn.includes("children"),
+        forInHasId: forIn.includes("id"),
+        spreadHasRequire: Object.keys({ ...en }).includes("require"),
+        jsonKeys: Object.keys(JSON.parse(JSON.stringify(en))).sort(),
+        instanceofModule: en instanceof Module,
+        ctorIsModule: en.constructor === Module,
+        protoIsModuleProto: Object.getPrototypeOf(en) === Module.prototype,
+        accessStillWorks: { id: en.id === bPath, children: en.children.length, loaded: en.loaded },
+        descriptors,
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    const expectedKeys = ["children", "exports", "filename", "id", "loaded", "path", "paths"];
+    const expectedDesc = { hasValue: true, enumerable: true, writable: true, configurable: true };
+    expect(result).toEqual({
+      ownKeys: expectedKeys,
+      spreadKeys: expectedKeys,
+      forInHasChildren: true,
+      forInHasId: true,
+      spreadHasRequire: false,
+      jsonKeys: expectedKeys,
+      instanceofModule: true,
+      ctorIsModule: true,
+      protoIsModuleProto: true,
+      accessStillWorks: { id: true, children: 1, loaded: true },
+      descriptors: {
+        id: expectedDesc,
+        path: expectedDesc,
+        filename: expectedDesc,
+        loaded: expectedDesc,
+        children: expectedDesc,
+        paths: expectedDesc,
+        exports: expectedDesc,
+      },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("new Module() has Node's own enumerable properties", () => {
+    const m = new Module("xyz");
+    expect(m instanceof Module).toBe(true);
+    expect(m.constructor).toBe(Module);
+    expect(Object.getPrototypeOf(m)).toBe(Module.prototype);
+    const keys = Object.keys(m).sort();
+    for (const k of ["id", "path", "filename", "loaded", "children", "exports"]) {
+      expect(keys).toContain(k);
+      const d = Object.getOwnPropertyDescriptor(m, k);
+      expect({ key: k, hasValue: "value" in d, enumerable: d.enumerable }).toEqual({
+        key: k,
+        hasValue: true,
+        enumerable: true,
+      });
+    }
+    expect({ ...m }.id).toBe("xyz");
   });
 
   test("Module._extensions", () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -263,6 +263,13 @@ describe.concurrent("node-module-module", () => {
     expect({ ...m }.id).toBe("xyz");
   });
 
+  test("Module.prototype._compile is the shared function when read off the prototype", () => {
+    expect(typeof Module.prototype._compile).toBe("function");
+    expect(typeof Module.prototype.require).toBe("function");
+    const m = new Module("x");
+    expect(m._compile).toBe(Module.prototype._compile);
+  });
+
   test("Module._extensions", () => {
     expect(".js" in Module._extensions).toBeTrue();
     expect(".json" in Module._extensions).toBeTrue();


### PR DESCRIPTION
## Repro

```js
const { Module } = require("node:module");
const en = require.cache[require.resolve("./some.cjs")];
console.log({
  own: Object.getOwnPropertyNames(en).sort(),
  spread: Object.keys({ ...en }).sort(),
  instanceofModule: en instanceof Module,
  ctor: en.constructor && en.constructor.name,
});
```

Node v26.3.0:
```
own: ["children","exports","filename","id","loaded","path","paths"]
spread: ["children","exports","filename","id","loaded","path","paths"]
instanceofModule: true, ctor: "Module"
```

Bun before:
```
own: ["exports","require"]
spread: ["exports","require"]
instanceofModule: false, ctor: "Object"
```

Any tool that copies or serializes cache entries (`decache` / `clear-module` / jest-module-registry style, cache-diffing devtools, `for...in` walks) silently loses every field, and `entry instanceof Module` duck-typing is false. Plain property access (`entry.id`, `entry.children`) still works through the prototype, which is why this goes unnoticed until something spreads or stringifies an entry.

## Cause

`JSCommonJSModule` stored `id`/`path`/`filename`/`loaded`/`children`/`paths` as `CustomAccessor` entries on `JSCommonJSModulePrototype`; instances only had `exports` (and a bun-specific `require`) as own properties. Separately, `Module.prototype` from `node:module` was a fresh plain object in `getModulePrototypeObject`, disconnected from the actual module prototype, so `instanceof` and `constructor` never matched.

## Fix

- `JSCommonJSModule::finishCreation` now installs `id`, `path`, `filename`, `loaded`, `children`, `paths` as own, enumerable `CustomValue` properties on each instance. They report as `{value, writable: true, enumerable: true, configurable: true}` while reads/writes continue to route through the existing C++ backing fields (lazy `paths`/`children`, `hasEvaluated`, weak `parent`).
- `JSCommonJSModulePrototype` keeps only `parent` and `_compile` (matching Node, where `parent` is a non-enumerable prototype accessor).
- `getModulePrototypeObject` returns the real `JSCommonJSModule` prototype; `m_nodeModuleConstructor.initLater` wires `constructor` and the `Module.prototype.require` accessor onto it so `instanceof Module` holds, `entry.constructor === Module`, and `Module.prototype.require = ...` overriding (Next.js) keeps working.
- The bun-specific own `require` (the bound function passed to the CJS wrapper) is now `DontEnum`, so it no longer leaks into `{...entry}` / `Object.keys` / `for...in`.

## Verification

New tests in `test/js/node/module/node-module-module.test.js`:

```
bun bd test test/js/node/module/node-module-module.test.js
# 32 pass, 0 fail (includes "Overwriting Module.prototype.require" and both "children" tests)
```

Both new tests fail on `main` (`own: ["exports","require"]`, `instanceofModule: false`) and pass with the fix.

Overlaps with #29256 at `getModulePrototypeObject` (that PR adds `Module.prototype.load`); whichever lands second will need a trivial merge.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b04392296)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [2.10ms]
(pass) node-module-module > isBuiltin() works [5.29ms]
(pass) node-module-module > module.globalPaths exists [2.01ms]
(pass) node-module-module > native module functions are not constructors [14.26ms]
(pass) node-module-module > createRequire trailing slash [5.63ms]
(pass) node-module-module > createRequire trailing slash file url [3.67ms]
(pass) node-module-module > Module exists [1.45ms]
(pass) node-module-module > module.Module works [1.77ms]
(pass) node-module-module > _nodeModulePaths() works [8.90ms]
(pass) node-module-module > Module.wrap [5.28ms]
(pass) node-module-module > Module.prototype._com
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [0.04ms]
(pass) node-module-module > isBuiltin() works [0.06ms]
(pass) node-module-module > module.globalPaths exists [0.03ms]
(pass) node-module-module > native module functions are not constructors [0.17ms]
(pass) node-module-module > createRequire trailing slash [0.11ms]
(pass) node-module-module > createRequire trailing slash file url [0.06ms]
(pass) node-module-module > Module exists [0.01ms]
(pass) node-module-module > module.Module works [0.03ms]
(pass) node-module-module > _nodeModulePaths() works [0.12ms]
(pass) node-module-module > Module.wrap [0.10ms]
(pass) node-module-module > Module.prototype._compile [0.13ms]
(pass) node-module-module > Module.prototype._compile [0.02ms]
(pass) node-module-module > Module.prototype._compile [0.01ms]
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module.prototype._compile
244 |     expect(exitCode).toBe(0);
245 |   });
246 | 
247 |   test("new Module() has Node's own enumerable properties", () => {
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b04392296)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [1.87ms]
(pass) node-module-module > isBuiltin() works [5.17ms]
(pass) node-module-module > module.globalPaths exists [1.97ms]
(pass) node-module-module > native module functions are not constructors [13.83ms]
(pass) node-module-module > createRequire trailing slash [5.15ms]
(pass) node-module-module > createRequire trailing slash file url [3.57ms]
(pass) node-module-module > Module exists [1.54ms]
(pass) node-module-module > module.Module works [1.80ms]
(pass) node-module-module > _nodeModulePaths() works [9.33ms]
(pass) node-module-module > Module.wrap [5.27ms]
(pass) node-module-module > Module.prototype._com
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 672ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/9] gen cpp.rs (cppbind)
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `releas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ExposeNodeModuleGlobals.cpp   |  2 +-
 src/jsc/bindings/JSCommonJSModule.cpp          | 26 ++++---
 src/jsc/modules/NodeModuleModule.cpp           | 29 ++++----
 test/js/node/module/node-module-module.test.js | 94 +++++++++++++++++++++++++-
 4 files changed, 123 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/ExposeNodeModuleGlobals.cpp        1      1      0
src/jsc/bindings/JSCommonJSModule.cpp               4      5      0
src/jsc/modules/NodeModuleModule.cpp                3      5      0
test/js/node/module/node-module-module.test.js      6      4      0
```

</details>

<!-- robobun:evidence:end -->