### PR TITLE
node: fix main-module identity for -e/-r/stdin entries

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -1,10 +1,5 @@
 // This file contains functions used for the CommonJS module loader
 
-$getter;
-export function main() {
-  return $requireMap.$get(Bun.main);
-}
-
 // This function is bound when constructing instances of CommonJSModule
 $visibility = "Private";
 export function require(this: JSCommonJSModule, _: string) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3987,30 +3987,22 @@ extern "C" void Bun__Process__queueNextTick2(GlobalObject* globalObject, Encoded
     process->queueNextTick<2>(globalObject, function, { JSValue::decode(arg1), JSValue::decode(arg2) });
 }
 
-// This does the equivalent of
-// return require.cache.get(Bun.main)
-static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
+// process.mainModule must be a live view, not a first-read memoization: a -r
+// preload that reads it (legitimately undefined at that instant) would otherwise
+// cache undefined for the life of the process.
+JSC_DEFINE_CUSTOM_GETTER(processMainModule, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    auto* globalObject = defaultGlobalObject(processObject->globalObject());
-    auto* bun = globalObject->bunObject();
-    auto& builtinNames = Bun::builtinNames(vm);
-    JSValue mainValue = bun->get(globalObject, builtinNames.mainPublicName());
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        return JSC::jsUndefined();
-    }
-    auto* requireMap = globalObject->requireMap();
-    JSValue mainModule = requireMap->get(globalObject, mainValue);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        return JSC::jsUndefined();
-    }
-    return mainModule;
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    return JSValue::encode(Bun::resolveMainCommonJSModule(globalObject));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setProcessMainModule, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
+{
+    auto* thisObject = dynamicDowncast<Process>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]]
+        return false;
+    thisObject->putDirect(JSC::getVM(globalObject), propertyName, JSValue::decode(encodedValue), 0);
+    return true;
 }
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
@@ -4449,7 +4441,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   hrtime                           constructProcessHrtimeObject                        PropertyCallback
   isBun                            constructIsBun                                      PropertyCallback
   kill                             Process_functionKill                                Function 2
-  mainModule                       constructMainModuleProperty                         PropertyCallback
+  mainModule                       processMainModule                                   CustomAccessor
   memoryUsage                      constructMemoryUsage                                PropertyCallback
   moduleLoadList                   Process_stubEmptyArray                              PropertyCallback
   nextTick                         constructProcessNextTickFn                          PropertyCallback

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1486,21 +1486,30 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
 static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sourceOrigin, const WTF::String& sourceURL);
 
 // module.id for a new CJS module object. id="." marks the Node main module, so
-// compare against vm.main instead of "first module seen" so -r preloads (which
-// run first) do not steal the main identity. For -e/-p/stdin entries Node uses
-// "[eval]"/"[stdin]" (the basename of the synthetic absolute filename).
+// compare against the entry path instead of "first module seen" so -r preloads
+// (which run first) do not steal the main identity. For -e/-p/stdin entries
+// Node uses "[eval]"/"[stdin]" (the basename of the synthetic absolute filename).
 static JSString* moduleIdForNewCommonJSModule(Zig::GlobalObject* globalObject, JSString* filename, const WTF::String& sourceURL, size_t sepIndex)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
         if (sepIndex != WTF::notFound) {
-            return JSC::jsSubstring(globalObject, filename, sepIndex + 1, sourceURL.length() - sepIndex - 1);
+            RELEASE_AND_RETURN(scope, JSC::jsSubstring(globalObject, filename, sepIndex + 1, sourceURL.length() - sepIndex - 1));
         }
         return filename;
     }
-    BunString sourceURLBunStr = Bun::toString(sourceURL);
-    if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
-        return JSC::jsString(vm, WTF::String("."_s));
+    // Compare against Bun.main (the realpath of the entry) rather than raw
+    // vm.main(): under e.g. the node-argv0 shim the entry may be requested via
+    // a symlink while this module is keyed by its realpath.
+    JSValue mainValue = globalObject->bunObject()->get(globalObject, Bun::builtinNames(vm).mainPublicName());
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (mainValue.isString()) {
+        auto mainStr = asString(mainValue)->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (mainStr == sourceURL) {
+            return JSC::jsString(vm, WTF::String("."_s));
+        }
     }
     return filename;
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1485,6 +1485,26 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
 
 static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sourceOrigin, const WTF::String& sourceURL);
 
+// module.id for a new CJS module object. id="." marks the Node main module, so
+// compare against vm.main instead of "first module seen" so -r preloads (which
+// run first) do not steal the main identity. For -e/-p/stdin entries Node uses
+// "[eval]"/"[stdin]" (the basename of the synthetic absolute filename).
+static JSString* moduleIdForNewCommonJSModule(Zig::GlobalObject* globalObject, JSString* filename, const WTF::String& sourceURL, size_t sepIndex)
+{
+    auto& vm = JSC::getVM(globalObject);
+    if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
+        if (sepIndex != WTF::notFound) {
+            return JSC::jsSubstring(globalObject, filename, sepIndex + 1, sourceURL.length() - sepIndex - 1);
+        }
+        return filename;
+    }
+    BunString sourceURLBunStr = Bun::toString(sourceURL);
+    if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
+        return JSC::jsString(vm, WTF::String("."_s));
+    }
+    return filename;
+}
+
 std::optional<JSC::SourceCode> createCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSString* requireMapKey,
@@ -1516,20 +1536,8 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             dirname = jsEmptyString(vm);
         }
         auto requireMap = globalObject->requireMap();
-        if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
-            // Node: module.id is "[eval]"/"[stdin]"; module.filename stays absolute.
-            if (index != WTF::notFound) {
-                requireMapKey = JSC::jsSubstring(globalObject, filename, index + 1, sourceURL.length() - index - 1);
-                RETURN_IF_EXCEPTION(scope, {});
-            }
-        } else {
-            // id="." marks the Node main module. Compare against vm.main so -r
-            // preloads (which run first) do not steal the main identity.
-            BunString sourceURLBunStr = Bun::toString(sourceURL);
-            if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
-                requireMapKey = JSC::jsString(vm, WTF::String("."_s));
-            }
-        }
+        requireMapKey = moduleIdForNewCommonJSModule(globalObject, filename, sourceURL, index);
+        RETURN_IF_EXCEPTION(scope, {});
 
         if (globalObject->hasOverriddenModuleWrapper) [[unlikely]] {
             auto concat = makeString(
@@ -1644,17 +1652,8 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             dirname = jsEmptyString(vm);
         }
         auto requireMap = globalObject->requireMap();
-        if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
-            if (index != WTF::notFound) {
-                requireMapKey = JSC::jsSubstring(globalObject, filename, index + 1, sourceURL.length() - index - 1);
-                RETURN_IF_EXCEPTION(scope, {});
-            }
-        } else {
-            BunString sourceURLBunStr = Bun::toString(sourceURL);
-            if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
-                requireMapKey = JSC::jsString(vm, WTF::String("."_s));
-            }
-        }
+        requireMapKey = moduleIdForNewCommonJSModule(globalObject, filename, sourceURL, index);
+        RETURN_IF_EXCEPTION(scope, {});
 
         moduleObject = JSCommonJSModule::create(
             vm,

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -109,6 +109,7 @@ static bool canPerformFastEnumeration(Structure* s)
 }
 
 extern "C" bool Bun__VM__specifierIsEvalEntryPoint(void*, EncodedJSValue);
+extern "C" bool Bun__VM__hasEvalEntryPoint(void*);
 extern "C" void Bun__VM__setEntryPointEvalResultCJS(void*, EncodedJSValue);
 
 static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObject, JSCommonJSModule* moduleObject, JSString* dirname, JSValue filename)
@@ -158,8 +159,9 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         globalObject->putDirect(vm, builtinNames(vm).exportsPublicName(), exports, 0);
         globalObject->putDirect(vm, builtinNames(vm).requirePublicName(), requireFunction, 0);
         globalObject->putDirect(vm, Identifier::fromString(vm, "module"_s), moduleObject, 0);
-        globalObject->putDirect(vm, Identifier::fromString(vm, "__filename"_s), filename, 0);
-        globalObject->putDirect(vm, Identifier::fromString(vm, "__dirname"_s), dirname, 0);
+        // Node: __filename is "[eval]"/"[stdin]" (the module id), __dirname is ".".
+        globalObject->putDirect(vm, Identifier::fromString(vm, "__filename"_s), moduleObject->m_id.get(), 0);
+        globalObject->putDirect(vm, Identifier::fromString(vm, "__dirname"_s), JSC::jsString(vm, WTF::String("."_s)), 0);
 
         // The 3-arg JSC::evaluate overload catches the exception into a
         // discarded NakedPtr (Completion.h), so a require() failure or any
@@ -372,6 +374,29 @@ JSC_DEFINE_CUSTOM_SETTER(jsRequireExtensionsSetter,
     return true;
 }
 
+// Shared by require.main and process.mainModule: the CJS main-module object,
+// or undefined for -e/-p/stdin entries (which have no main module in Node).
+JSValue resolveMainCommonJSModule(Zig::GlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (Bun__VM__hasEvalEntryPoint(globalObject->bunVM())) {
+        return jsUndefined();
+    }
+    auto& builtinNames = Bun::builtinNames(vm);
+    JSValue mainValue = globalObject->bunObject()->get(globalObject, builtinNames.mainPublicName());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue mainModule = globalObject->requireMap()->get(globalObject, mainValue);
+    RETURN_IF_EXCEPTION(scope, {});
+    return mainModule;
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsRequireMainGetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame*))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    return JSValue::encode(resolveMainCommonJSModule(globalObject));
+}
+
 static const HashTableValue RequireResolveFunctionPrototypeValues[] = {
     { "paths"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, requireResolvePathsFunction, 1 } },
 };
@@ -431,10 +456,7 @@ void RequireFunctionPrototype::finishCreation(JSC::VM& vm)
 
     reifyStaticProperties(vm, info(), RequireFunctionPrototypeValues, *this);
     JSC::JSFunction* requireDotMainFunction = JSFunction::create(
-        vm,
-        globalObject,
-        commonJSMainCodeGenerator(vm),
-        globalObject->globalScope());
+        vm, globalObject, 0, "main"_s, jsRequireMainGetter, ImplementationVisibility::Public);
 
     this->putDirectAccessor(
         globalObject,
@@ -1494,8 +1516,19 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             dirname = jsEmptyString(vm);
         }
         auto requireMap = globalObject->requireMap();
-        if (requireMap->size() == 0) {
-            requireMapKey = JSC::jsString(vm, WTF::String("."_s));
+        if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
+            // Node: module.id is "[eval]"/"[stdin]"; module.filename stays absolute.
+            if (index != WTF::notFound) {
+                requireMapKey = JSC::jsSubstring(globalObject, filename, index + 1, sourceURL.length() - index - 1);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        } else {
+            // id="." marks the Node main module. Compare against vm.main so -r
+            // preloads (which run first) do not steal the main identity.
+            BunString sourceURLBunStr = Bun::toString(sourceURL);
+            if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
+                requireMapKey = JSC::jsString(vm, WTF::String("."_s));
+            }
         }
 
         if (globalObject->hasOverriddenModuleWrapper) [[unlikely]] {
@@ -1611,8 +1644,16 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             dirname = jsEmptyString(vm);
         }
         auto requireMap = globalObject->requireMap();
-        if (requireMap->size() == 0) {
-            requireMapKey = JSC::jsString(vm, WTF::String("."_s));
+        if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
+            if (index != WTF::notFound) {
+                requireMapKey = JSC::jsSubstring(globalObject, filename, index + 1, sourceURL.length() - index - 1);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        } else {
+            BunString sourceURLBunStr = Bun::toString(sourceURL);
+            if (Bun__isBunMain(globalObject, &sourceURLBunStr)) {
+                requireMapKey = JSC::jsString(vm, WTF::String("."_s));
+            }
         }
 
         moduleObject = JSCommonJSModule::create(

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -25,6 +25,8 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(functionJSCommonJSModule_compile);
 
+JSC::JSValue resolveMainCommonJSModule(Zig::GlobalObject* globalObject);
+
 void populateESMExports(
     JSC::JSGlobalObject* globalObject,
     JSC::JSValue result,

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -131,6 +131,14 @@ pub fn set_entry_point_eval_result_cjs(this: &mut VirtualMachine, value: JSValue
     }
 }
 
+/// Exported as `Bun__VM__hasEvalEntryPoint`.
+/// True when the process entry point is `-e`/`-p` eval or piped stdin. Node has
+/// no `require.main`/`process.mainModule` for such entries.
+// HOST_EXPORT(Bun__VM__hasEvalEntryPoint, c)
+pub fn has_eval_entry_point(this: &mut VirtualMachine) -> bool {
+    this.module_loader.eval_source.is_some()
+}
+
 /// Exported as `Bun__VM__specifierIsEvalEntryPoint`.
 // HOST_EXPORT(Bun__VM__specifierIsEvalEntryPoint, c)
 pub fn specifier_is_eval_entry_point(this: &mut VirtualMachine, specifier: JSValue) -> bool {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath, tempDir } from "harness";
+import { symlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -388,6 +389,24 @@ describe.concurrent("main-module identity", () => {
       isMain: true,
       assigned: 42,
     });
+  });
+
+  test.skipIf(isWindows)("symlinked entry under the node-argv0 shim still gets id='.'", async () => {
+    using dir = tempDir("main-module-symlink", {
+      "real/main.cjs": `console.log(JSON.stringify({ id: module.id, reqMainIsModule: require.main === module }));\n`,
+    });
+    const cwd = String(dir);
+    symlinkSync("real", path.join(cwd, "link"), "dir");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join("link", "main.cjs")],
+      argv0: "node",
+      env: bunEnv,
+      cwd,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) expect({ stdout, stderr, exitCode }).toEqual({ stdout, stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout.trim())).toEqual({ id: ".", reqMainIsModule: true });
   });
 
   test("first CJS imported from an ESM entry is not the main module", async () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -299,5 +299,107 @@ describe.concurrent("node-module-module", () => {
    ./j.cjs (seen)
    ./k.cjs (seen)`);
     expect(await proc.exited).toBe(0);
+  });
+});
+
+describe.concurrent("main-module identity", () => {
+  const runJSON = async (cmd, cwd) => {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) expect({ stdout, stderr, exitCode }).toEqual({ stdout, stderr: "", exitCode: 0 });
+    return JSON.parse(stdout.trim());
+  };
+
+  const evalBody = `JSON.stringify({
+    reqMainIsModule: require.main === module,
+    reqMain: require.main,
+    mainModule: process.mainModule,
+    moduleId: module.id,
+    filename: __filename,
+    dirname: __dirname,
+  })`;
+
+  // Node has no main module for -e/-p/stdin entries.
+  test.each([["-e"], ["--print"], ["-p"]])("bun %s has no main module", async flag => {
+    const src = flag === "-e" ? `console.log(${evalBody})` : evalBody;
+    expect(await runJSON([bunExe(), flag, src])).toEqual({
+      reqMainIsModule: false,
+      reqMain: undefined,
+      mainModule: undefined,
+      moduleId: "[eval]",
+      filename: "[eval]",
+      dirname: ".",
+    });
+  });
+
+  test("stdin entry has no main module", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-"],
+      env: bunEnv,
+      stdin: new Blob([`console.log(${evalBody})`]),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) expect({ stdout, stderr, exitCode }).toEqual({ stdout, stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout.trim())).toEqual({
+      reqMainIsModule: false,
+      reqMain: undefined,
+      mainModule: undefined,
+      moduleId: "[stdin]",
+      filename: "[stdin]",
+      dirname: ".",
+    });
+  });
+
+  test("-r preload does not steal the main-module identity", async () => {
+    using dir = tempDir("main-module-preload", {
+      "pre.cjs": `globalThis.__pre = { preId: module.id, preReqMain: require.main, preMainModule: process.mainModule };\n`,
+      "main.cjs": `const p = globalThis.__pre;
+        console.log(JSON.stringify({
+          ...p,
+          mainId: module.id,
+          reqMainId: require.main && require.main.id,
+          reqMainIsModule: require.main === module,
+          mainModuleIsModule: process.mainModule === module,
+        }));\n`,
+    });
+    const cwd = String(dir);
+    expect(await runJSON([bunExe(), "-r", "./pre.cjs", "./main.cjs"], cwd)).toEqual({
+      preId: path.join(cwd, "pre.cjs"),
+      preReqMain: undefined,
+      preMainModule: undefined,
+      mainId: ".",
+      reqMainId: ".",
+      reqMainIsModule: true,
+      mainModuleIsModule: true,
+    });
+  });
+
+  test("reading process.mainModule during preload does not poison it", async () => {
+    using dir = tempDir("main-module-poison", {
+      "pre.cjs": `void String(process.mainModule);\n`,
+      "main.cjs": `const after = process.mainModule && process.mainModule.id;
+        const isMain = process.mainModule === module;
+        process.mainModule = 42;
+        console.log(JSON.stringify({ after, isMain, assigned: process.mainModule }));\n`,
+    });
+    expect(await runJSON([bunExe(), "-r", "./pre.cjs", "./main.cjs"], String(dir))).toEqual({
+      after: ".",
+      isMain: true,
+      assigned: 42,
+    });
+  });
+
+  test("first CJS imported from an ESM entry is not the main module", async () => {
+    using dir = tempDir("main-module-esm-entry", {
+      "main.mjs": `import { id, isReqMain } from "./foo.cjs";
+        console.log(JSON.stringify({ fooId: id, isReqMain }));\n`,
+      "foo.cjs": `module.exports = { id: module.id, isReqMain: require.main === module };\n`,
+    });
+    const cwd = String(dir);
+    expect(await runJSON([bunExe(), "./main.mjs"], cwd)).toEqual({
+      fooId: path.join(cwd, "foo.cjs"),
+      isReqMain: false,
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes three related main-module identity bugs so Bun matches Node:

1. **`bun -e`/`-p`/stdin fabricated a real main module.** `require.main === module` was `true` and `module.id` was `"."`, so every `if (require.main === module)` CLI guard ran under `bun -e 'require("./lib")'`. Node has no main module for eval/stdin entries.
2. **`-r` preloads stole the main identity.** `module.id` was `"."` inside the preload and `require.main.id` in the real entry was its absolute path instead of `"."`. Any `dotenv`/`ts-node/register`/APM preload broke `module.id === "."` checks.
3. **Reading `process.mainModule` during a preload memoized `undefined`** for the life of the process, because it was a lazy `PropertyCallback`.

It also fixes a fourth instance of the same root cause: the first CJS module imported from an ESM entry was getting `id="."` (and matching `require.main`).

### Repro

```js
// node -e: require.main/process.mainModule undefined, module.id "[eval]"
// bun -e (before): require.main===module true, module.id "."
bun -e 'console.log(require.main===module, module.id, __filename)'

// -r: pre.cjs used to see module.id ".", main.cjs saw require.main.id = <abs>
bun -r ./pre.cjs ./main.cjs

// poison: preload reads process.mainModule; main then sees undefined forever
bun -r ./preTouch.cjs ./main.cjs  // preTouch: void process.mainModule
```

### Cause

`createCommonJSModule` assigned `id="."` to whichever CJS module hit an empty `requireMap` first (`requireMap->size() == 0`). Preloads run before the entry, and an ESM entry never populates `requireMap`, so the wrong module was marked main in both cases. The eval entry also went through this path and was then exposed as `require.main`/`process.mainModule` via `requireMap.get(Bun.main)`.

### Fix

- `createCommonJSModule` now assigns `id="."` only when the specifier equals `vm.main()`; eval/stdin get `id="[eval]"`/`"[stdin]"` (basename of the synthetic path).
- The eval entry branch installs `__filename = "[eval]"` (the module id) and `__dirname = "."`.
- A shared `resolveMainCommonJSModule()` returns `undefined` when the entry is eval/stdin; `require.main` uses it via a native getter (replacing the JS builtin) and `process.mainModule` uses it via a `CustomAccessor` with a live lookup and a `putDirect` setter.

### Not addressed

Node parents `-r` preloads under a synthetic `internal/preload` module. After this change a preload's `module.parent` is `undefined` (previously `null`).

## How did you verify your code works?

Added a `main-module identity` describe block in `test/js/node/module/node-module-module.test.js` covering `-e`/`--print`/`-p`, stdin, `-r` preload, the `process.mainModule` poison case, and the ESM-entry-imports-CJS case. All 7 fail under `USE_SYSTEM_BUN=1` and pass with this change. Existing `run-eval.test.ts` and `process.test.js` `mainModule` tests continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->