### PR TITLE
parser: .mjs/"type":"module" is authoritative over module/exports identifier refs

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5610,8 +5610,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if self.options.repl_mode {
                 return None;
             }
-            if (self.has_es_module_syntax
-                || self.options.module_type == options::ModuleType::Esm)
+            if (self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm)
                 && self.commonjs_named_exports.count() == 0
             {
                 // In an ES6 module, "this" is supposed to be undefined. Instead of

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5610,7 +5610,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if self.options.repl_mode {
                 return None;
             }
-            if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
+            if (self.has_es_module_syntax
+                || self.options.module_type == options::ModuleType::Esm)
+                && self.commonjs_named_exports.count() == 0
+            {
                 // In an ES6 module, "this" is supposed to be undefined. Instead of
                 // doing this at runtime using "fn.call(undefined)", we do it at
                 // compile time using expression substitution here.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5610,7 +5610,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if self.options.repl_mode {
                 return None;
             }
-            if (self.has_es_module_syntax || self.options.module_type == options::ModuleType::Esm)
+            if (self.has_es_module_syntax
+                || (self.options.module_type == options::ModuleType::Esm && !self.options.bundle))
                 && self.commonjs_named_exports.count() == 0
             {
                 // In an ES6 module, "this" is supposed to be undefined. Instead of

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1630,9 +1630,12 @@ impl<'a> Parser<'a> {
             exports_kind = js_ast::ExportsKind::Cjs;
         } else if p.esm_export_keyword.len > 0
             || p.top_level_await_keyword.len > 0
-            // .mjs / .mts / "type":"module" are authoritative: a bare reference to
-            // `module`/`exports` (e.g. `typeof module`) must not flip the file to CJS.
-            || p.options.module_type == options::ModuleType::Esm
+            // .mjs / .mts / "type":"module" are authoritative at runtime: a bare
+            // reference to `module`/`exports` (e.g. `typeof module`) must not flip
+            // the file to CJS. Bundler excluded: its resolver can return Esm for
+            // CJS files (nameless nested "type":"commonjs", exports-map "import"
+            // key), so the content sniff below is still needed there.
+            || (p.options.module_type == options::ModuleType::Esm && !p.options.bundle)
         {
             exports_kind = js_ast::ExportsKind::Esm;
         } else if uses_exports_ref || uses_module_ref || p.has_top_level_return || p.has_with_scope

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -259,6 +259,10 @@ impl<'a> Options<'a> {
             hasher.update(b"no_dce");
         }
 
+        // `module_type` changes transpiled output for byte-identical sources:
+        // exports_kind and the top-level `this` substitution both depend on it.
+        hasher.update(&[self.module_type as u8]);
+
         self.features.hash_for_runtime_transpiler(hasher);
     }
 
@@ -1624,7 +1628,12 @@ impl<'a> Parser<'a> {
 
         if p.is_deoptimized_commonjs() {
             exports_kind = js_ast::ExportsKind::Cjs;
-        } else if p.esm_export_keyword.len > 0 || p.top_level_await_keyword.len > 0 {
+        } else if p.esm_export_keyword.len > 0
+            || p.top_level_await_keyword.len > 0
+            // .mjs / .mts / "type":"module" are authoritative: a bare reference to
+            // `module`/`exports` (e.g. `typeof module`) must not flip the file to CJS.
+            || p.options.module_type == options::ModuleType::Esm
+        {
             exports_kind = js_ast::ExportsKind::Esm;
         } else if uses_exports_ref || uses_module_ref || p.has_top_level_return || p.has_with_scope
         {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -41,7 +41,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
 /// written before #30888 carried `has_tla=false` for every module; the cache-HIT
 /// path reinstates the bug for any previously-cached TLA module (#30887).
-const EXPECTED_VERSION: u32 = 22;
+/// Version 23: .mjs/.mts/"type":"module" is authoritative over the CommonJS
+/// content sniff; `module_type` is now part of the features hash.
+const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -309,6 +309,7 @@ impl RuntimeTranspilerStore {
         path: &Fs::Path<'_>,
         referrer: String,
         loader: Loader,
+        module_type: ModuleType,
         package_json: Option<&PackageJSON>,
     ) -> *mut c_void {
         // The path text is heap-duplicated here and freed in `reset_for_pool` via
@@ -352,6 +353,7 @@ impl RuntimeTranspilerStore {
                 vm,
                 log: bun_ast::Log::init(),
                 loader,
+                module_type,
                 promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
                 poll_ref: KeepAlive::default(),
                 fetcher: Fetcher::File,
@@ -401,6 +403,7 @@ pub struct TranspilerJob {
     pub non_threadsafe_input_specifier: OwnedString,
     pub non_threadsafe_referrer: OwnedString,
     pub loader: Loader,
+    pub module_type: ModuleType,
     pub promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;
     // raw pointers/BackRefs are used (BACKREF — VM owns the
@@ -816,11 +819,7 @@ impl TranspilerJob {
             && vm_main_hash == hash
             && strings::eql_long(vm_main, path.text, false);
 
-        let module_type: ModuleType = match this_tag {
-            ResolvedSourceTag::PackageJsonTypeCommonjs => ModuleType::Cjs,
-            ResolvedSourceTag::PackageJsonTypeModule => ModuleType::Esm,
-            _ => ModuleType::Unknown,
-        };
+        let module_type = self.module_type;
 
         let mut parse_options = ParseOptions {
             arena: &arena,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1571,7 +1571,9 @@ impl<'a> Resolver<'a> {
                                 primary: Fs::Path::init_with_namespace(import_path, b"node"),
                                 secondary: None,
                             },
-                            module_type: options::ModuleType::Esm,
+                            // Embedded code can be CJS (the react-refresh fallback)
+                            // or ESM (bun-framework-react/*.tsx); let the parser decide.
+                            module_type: options::ModuleType::Unknown,
                             primary_side_effects_data: SideEffects::NoSideEffectsPureData,
                             flags: ResultFlags::default(),
                             ..Default::default()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3852,6 +3852,9 @@ struct LoaderResult<'a> {
     specifier: &'a [u8],
     /// Always `None` for non-JS-like loaders (not needed there).
     package_json: Option<&'a bun_resolver::package_json::PackageJSON>,
+    /// `"type"` from the nearest ancestor package.json, including nameless ones
+    /// that `enclosing_package_json` skips. `Unknown` for non-JS-like loaders.
+    nearest_module_type: ModuleType,
 }
 
 /// `options.getLoaderAndVirtualSource` — high-tier body.
@@ -3975,15 +3978,33 @@ unsafe fn get_loader_and_virtual_source<'a>(
     // package.json sniff for `.js`/`.ts` module-type.
     let dir = path.name().dir;
     let is_js_like = loader.map(|l| l.is_java_script_like()).unwrap_or(true);
-    let package_json = if is_js_like && bun_paths::is_absolute(dir) {
+    let (package_json, nearest_module_type) = if is_js_like && bun_paths::is_absolute(dir) {
         // SAFETY: per fn contract — `transpiler.resolver` is a value field of
         // the VM; `read_dir_info` is re-entrant on the JS thread.
         match unsafe { (*jsc_vm).transpiler.resolver.read_dir_info(dir) } {
-            Ok(Some(dir_info)) => dir_info.package_json().or(dir_info.enclosing_package_json),
-            _ => None,
+            Ok(Some(dir_info)) => {
+                // `enclosing_package_json` skips nameless package.json files, but
+                // Node's "type" determination uses the nearest one regardless of
+                // name (e.g. `parse5/dist/cjs/package.json` = {"type":"commonjs"}).
+                let mut walk = Some(dir_info);
+                let nearest_module_type = loop {
+                    match walk {
+                        Some(di) => match di.package_json() {
+                            Some(pj) => break pj.module_type,
+                            None => walk = di.get_parent(),
+                        },
+                        None => break ModuleType::Unknown,
+                    }
+                };
+                (
+                    dir_info.package_json().or(dir_info.enclosing_package_json),
+                    nearest_module_type,
+                )
+            }
+            _ => (None, ModuleType::Unknown),
         }
     } else {
-        None
+        (None, ModuleType::Unknown)
     };
 
     Ok(LoaderResult {
@@ -3993,6 +4014,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
         is_main,
         specifier,
         package_json,
+        nearest_module_type,
     })
 }
 
@@ -4212,11 +4234,8 @@ unsafe fn transpile_file(
         }
         // regex /\.[jt]s$/
         if ext.len() == b".ts".len() && (ext == b".js" || ext == b".ts") {
-            // Use the package.json module type if it exists.
-            break 'brk lr
-                .package_json
-                .map(|pkg| pkg.module_type)
-                .unwrap_or(ModuleType::Unknown);
+            // Use the nearest package.json's "type" (including nameless ones).
+            break 'brk lr.nearest_module_type;
         }
         // For JSX/TSX and other extensions, let the file contents decide.
         ModuleType::Unknown

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3986,13 +3986,20 @@ unsafe fn get_loader_and_virtual_source<'a>(
                 // `enclosing_package_json` skips nameless package.json files, but
                 // Node's "type" determination uses the nearest one regardless of
                 // name (e.g. `parse5/dist/cjs/package.json` = {"type":"commonjs"}).
+                // Per Node's LOOKUP_PACKAGE_SCOPE the walk stops at a directory
+                // named "node_modules" (format defaults to commonjs).
                 let mut walk = Some(dir_info);
                 let nearest_module_type = loop {
                     match walk {
-                        Some(di) => match di.package_json() {
-                            Some(pj) => break pj.module_type,
-                            None => walk = di.get_parent(),
-                        },
+                        Some(di) => {
+                            if di.is_node_modules() {
+                                break ModuleType::Unknown;
+                            }
+                            match di.package_json() {
+                                Some(pj) => break pj.module_type,
+                                None => walk = di.get_parent(),
+                            }
+                        }
                         None => break ModuleType::Unknown,
                     }
                 };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4272,6 +4272,7 @@ unsafe fn transpile_file(
                     &lr.path,
                     (*referrer).dupe_ref(),
                     concurrent_loader,
+                    module_type,
                     lr.package_json,
                 )
             };

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2771,6 +2771,33 @@ describe("bundler", () => {
       expect(out).not.toContain("require_foo\u2014bar");
     },
   });
+  itBundled("edgecase/NamelessNestedTypeCommonjsUnderTypeModule", {
+    files: {
+      "/entry.js": `import a from "pkg"; console.log(a.hello);`,
+      "/node_modules/pkg/package.json": `{"name":"pkg","type":"module","exports":{"default":"./dist/cjs/index.js"}}`,
+      "/node_modules/pkg/dist/cjs/package.json": `{"type":"commonjs"}`,
+      "/node_modules/pkg/dist/cjs/index.js": `
+        "use strict";
+        Object.defineProperty(exports, "__esModule", { value: true });
+        Object.defineProperty(exports, "hello", { value: "nested-cjs" });
+      `,
+    },
+    target: "node",
+    run: { stdout: "nested-cjs" },
+  });
+  itBundled("edgecase/ExportsMapImportConditionPointsAtCjs", {
+    files: {
+      "/entry.js": `import b from "pkg"; console.log(b.hello);`,
+      "/node_modules/pkg/package.json": `{"name":"pkg","type":"commonjs","exports":{"import":"./lib/index.js","require":"./lib/index.js"}}`,
+      "/node_modules/pkg/lib/index.js": `
+        "use strict";
+        Object.defineProperty(exports, "__esModule", { value: true });
+        Object.defineProperty(exports, "hello", { value: "import-cjs" });
+      `,
+    },
+    target: "node",
+    run: { stdout: "import-cjs" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2773,17 +2773,18 @@ describe("bundler", () => {
   });
   itBundled("edgecase/NamelessNestedTypeCommonjsUnderTypeModule", {
     files: {
-      "/entry.js": `import a from "pkg"; console.log(a.hello);`,
+      "/entry.js": `import a from "pkg"; console.log(a.hello, a.viaThis);`,
       "/node_modules/pkg/package.json": `{"name":"pkg","type":"module","exports":{"default":"./dist/cjs/index.js"}}`,
       "/node_modules/pkg/dist/cjs/package.json": `{"type":"commonjs"}`,
       "/node_modules/pkg/dist/cjs/index.js": `
         "use strict";
         Object.defineProperty(exports, "__esModule", { value: true });
         Object.defineProperty(exports, "hello", { value: "nested-cjs" });
+        this.viaThis = "this-is-exports";
       `,
     },
     target: "node",
-    run: { stdout: "nested-cjs" },
+    run: { stdout: "nested-cjs this-is-exports" },
   });
   itBundled("edgecase/ExportsMapImportConditionPointsAtCjs", {
     files: {

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -137,22 +137,31 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "mod.cjs": bareBody,
       "entry.mjs": `await import("./mod.cjs");\n`,
     });
-    const { stdout, exitCode } = await run(String(dir), "entry.mjs");
-    const out = JSON.parse(stdout);
-    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
+    const { stdout, stderr, exitCode } = await run(String(dir), "entry.mjs");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "object", e: "object", thisIsCjs: true },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("ambiguous .js with typeof module still runs as CJS", async () => {
     using dir = tempDir("js-sniff", { "sniff.js": bareBody });
-    const { stdout, exitCode } = await run(String(dir), "sniff.js");
-    const out = JSON.parse(stdout);
-    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
+    const { stdout, stderr, exitCode } = await run(String(dir), "sniff.js");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "object", e: "object", thisIsCjs: true },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test(".cjs with typeof module still runs as CJS", async () => {
     using dir = tempDir("cjs-sniff", { "sniff.cjs": bareBody });
-    const { stdout, exitCode } = await run(String(dir), "sniff.cjs");
-    const out = JSON.parse(stdout);
-    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
+    const { stdout, stderr, exitCode } = await run(String(dir), "sniff.cjs");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "object", e: "object", thisIsCjs: true },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe.concurrent("run-cjs", () => {
@@ -16,5 +16,138 @@ describe.concurrent("run-cjs", () => {
     });
     const stdout = await proc.stdout.text();
     expect(stdout).toEqual("hello world\n");
+  });
+});
+
+describe.concurrent("module type from .mjs / package.json is authoritative over module/exports references", () => {
+  const guardBody = `import path from "node:path";
+console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof path.sep }));
+`;
+  const bareBody = `console.log(JSON.stringify({ m: typeof module, e: typeof exports, thisIsCjs: typeof this === "object" && this != null }));
+`;
+
+  async function run(cwd: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test(".mjs with import + typeof module runs as ESM", async () => {
+    using dir = tempDir("mjs-guard", { "guard.mjs": guardBody });
+    const { stdout, stderr, exitCode } = await run(String(dir), "guard.mjs");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", sep: "string" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test(".mts with import + typeof module runs as ESM", async () => {
+    using dir = tempDir("mts-guard", { "guard.mts": guardBody });
+    const { stdout, stderr, exitCode } = await run(String(dir), "guard.mts");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", sep: "string" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test('"type":"module" .js with import + typeof module runs as ESM', async () => {
+    using dir = tempDir("tm-guard", {
+      "package.json": `{"type":"module"}`,
+      "guard.js": guardBody,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "guard.js");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", sep: "string" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test(".mjs with no import/export + typeof exports runs as ESM", async () => {
+    using dir = tempDir("mjs-bare", { "bare.mjs": bareBody });
+    const { stdout, stderr, exitCode } = await run(String(dir), "bare.mjs");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", thisIsCjs: false },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test('"type":"module" .js with no import/export + typeof module runs as ESM', async () => {
+    using dir = tempDir("tm-bare", {
+      "package.json": `{"type":"module"}`,
+      "bare.js": bareBody,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "bare.js");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", thisIsCjs: false },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test(".mjs loaded via dynamic import() runs as ESM", async () => {
+    using dir = tempDir("mjs-dyn", {
+      "guard.mjs": guardBody,
+      "bare.mjs": bareBody,
+      "entry.mjs": `await import("./guard.mjs");\nawait import("./bare.mjs");\n`,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "entry.mjs");
+    const lines = stdout.trim() ? stdout.trim().split("\n").map(l => JSON.parse(l)) : [];
+    expect({ lines, stderr, exitCode }).toEqual({
+      lines: [
+        { m: "undefined", e: "undefined", sep: "string" },
+        { m: "undefined", e: "undefined", thisIsCjs: false },
+      ],
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test('.mjs inside "type":"commonjs" package still runs as ESM (extension wins)', async () => {
+    using dir = tempDir("mjs-in-cjs", {
+      "package.json": `{"type":"commonjs"}`,
+      "guard.mjs": guardBody,
+      "entry.js": `import("./guard.mjs");\n`,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "entry.js");
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { m: "undefined", e: "undefined", sep: "string" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test('.cjs inside "type":"module" package still runs as CJS (extension wins)', async () => {
+    using dir = tempDir("cjs-in-esm", {
+      "package.json": `{"type":"module"}`,
+      "mod.cjs": bareBody,
+      "entry.mjs": `await import("./mod.cjs");\n`,
+    });
+    const { stdout, exitCode } = await run(String(dir), "entry.mjs");
+    const out = JSON.parse(stdout);
+    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
+  });
+
+  test("ambiguous .js with typeof module still runs as CJS", async () => {
+    using dir = tempDir("js-sniff", { "sniff.js": bareBody });
+    const { stdout, exitCode } = await run(String(dir), "sniff.js");
+    const out = JSON.parse(stdout);
+    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
+  });
+
+  test(".cjs with typeof module still runs as CJS", async () => {
+    using dir = tempDir("cjs-sniff", { "sniff.cjs": bareBody });
+    const { stdout, exitCode } = await run(String(dir), "sniff.cjs");
+    const out = JSON.parse(stdout);
+    expect({ m: out.m, e: out.e, exitCode }).toEqual({ m: "object", e: "object", exitCode: 0 });
   });
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -35,27 +35,28 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    // stderr only appears in the assertion diff when stdout is empty (crash/parse error).
+    const out = stdout.trim()
+      ? stdout
+          .trim()
+          .split("\n")
+          .map(l => JSON.parse(l))
+      : [{ crashed: stderr }];
+    return { out, exitCode };
   }
+
+  const esmGuard = { m: "undefined", e: "undefined", sep: "string" };
+  const esmBare = { m: "undefined", e: "undefined", thisIsCjs: false };
+  const cjsBare = { m: "object", e: "object", thisIsCjs: true };
 
   test(".mjs with import + typeof module runs as ESM", async () => {
     using dir = tempDir("mjs-guard", { "guard.mjs": guardBody });
-    const { stdout, stderr, exitCode } = await run(String(dir), "guard.mjs");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", sep: "string" },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "guard.mjs")).toEqual({ out: [esmGuard], exitCode: 0 });
   });
 
   test(".mts with import + typeof module runs as ESM", async () => {
     using dir = tempDir("mts-guard", { "guard.mts": guardBody });
-    const { stdout, stderr, exitCode } = await run(String(dir), "guard.mts");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", sep: "string" },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "guard.mts")).toEqual({ out: [esmGuard], exitCode: 0 });
   });
 
   test('"type":"module" .js with import + typeof module runs as ESM', async () => {
@@ -63,22 +64,12 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "package.json": `{"type":"module"}`,
       "guard.js": guardBody,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "guard.js");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", sep: "string" },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "guard.js")).toEqual({ out: [esmGuard], exitCode: 0 });
   });
 
   test(".mjs with no import/export + typeof exports runs as ESM", async () => {
     using dir = tempDir("mjs-bare", { "bare.mjs": bareBody });
-    const { stdout, stderr, exitCode } = await run(String(dir), "bare.mjs");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", thisIsCjs: false },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "bare.mjs")).toEqual({ out: [esmBare], exitCode: 0 });
   });
 
   test('"type":"module" .js with no import/export + typeof module runs as ESM', async () => {
@@ -86,12 +77,7 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "package.json": `{"type":"module"}`,
       "bare.js": bareBody,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "bare.js");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", thisIsCjs: false },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "bare.js")).toEqual({ out: [esmBare], exitCode: 0 });
   });
 
   test(".mjs loaded via dynamic import() runs as ESM", async () => {
@@ -100,21 +86,7 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "bare.mjs": bareBody,
       "entry.mjs": `await import("./guard.mjs");\nawait import("./bare.mjs");\n`,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "entry.mjs");
-    const lines = stdout.trim()
-      ? stdout
-          .trim()
-          .split("\n")
-          .map(l => JSON.parse(l))
-      : [];
-    expect({ lines, stderr, exitCode }).toEqual({
-      lines: [
-        { m: "undefined", e: "undefined", sep: "string" },
-        { m: "undefined", e: "undefined", thisIsCjs: false },
-      ],
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "entry.mjs")).toEqual({ out: [esmGuard, esmBare], exitCode: 0 });
   });
 
   test('.mjs inside "type":"commonjs" package still runs as ESM (extension wins)', async () => {
@@ -123,12 +95,17 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "guard.mjs": guardBody,
       "entry.js": `import("./guard.mjs");\n`,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "entry.js");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "undefined", e: "undefined", sep: "string" },
-      stderr: "",
-      exitCode: 0,
+    expect(await run(String(dir), "entry.js")).toEqual({ out: [esmGuard], exitCode: 0 });
+  });
+
+  test('nameless nested {"type":"commonjs"} overrides an outer {"type":"module"}', async () => {
+    using dir = tempDir("nested-cjs", {
+      "package.json": `{"name":"outer","type":"module"}`,
+      "dist/cjs/package.json": `{"type":"commonjs"}`,
+      "dist/cjs/inner/index.js": `Object.defineProperty(exports, "ok", { value: true });\n` + bareBody,
+      "entry.mjs": `await import("./dist/cjs/inner/index.js");\n`,
     });
+    expect(await run(String(dir), "entry.mjs")).toEqual({ out: [cjsBare], exitCode: 0 });
   });
 
   test('.cjs inside "type":"module" package still runs as CJS (extension wins)', async () => {
@@ -137,31 +114,16 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "mod.cjs": bareBody,
       "entry.mjs": `await import("./mod.cjs");\n`,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "entry.mjs");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "object", e: "object", thisIsCjs: true },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "entry.mjs")).toEqual({ out: [cjsBare], exitCode: 0 });
   });
 
   test("ambiguous .js with typeof module still runs as CJS", async () => {
     using dir = tempDir("js-sniff", { "sniff.js": bareBody });
-    const { stdout, stderr, exitCode } = await run(String(dir), "sniff.js");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "object", e: "object", thisIsCjs: true },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "sniff.js")).toEqual({ out: [cjsBare], exitCode: 0 });
   });
 
   test(".cjs with typeof module still runs as CJS", async () => {
     using dir = tempDir("cjs-sniff", { "sniff.cjs": bareBody });
-    const { stdout, stderr, exitCode } = await run(String(dir), "sniff.cjs");
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      out: { m: "object", e: "object", thisIsCjs: true },
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(await run(String(dir), "sniff.cjs")).toEqual({ out: [cjsBare], exitCode: 0 });
   });
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -98,6 +98,15 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
     expect(await run(String(dir), "entry.js")).toEqual({ out: [esmGuard], exitCode: 0 });
   });
 
+  test('.js under node_modules with no package.json does not inherit outer "type":"module"', async () => {
+    using dir = tempDir("nm-no-pkg", {
+      "package.json": `{"name":"proj","type":"module"}`,
+      "node_modules/foo/index.js": `module.exports = { m: typeof module, e: typeof exports, thisIsCjs: true };\n`,
+      "entry.mjs": `import x from "foo"; console.log(JSON.stringify(x));\n`,
+    });
+    expect(await run(String(dir), "entry.mjs")).toEqual({ out: [cjsBare], exitCode: 0 });
+  });
+
   test('nameless nested {"type":"commonjs"} overrides an outer {"type":"module"}', async () => {
     using dir = tempDir("nested-cjs", {
       "package.json": `{"name":"outer","type":"module"}`,

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -101,7 +101,12 @@ console.log(JSON.stringify({ m: typeof module, e: typeof exports, sep: typeof pa
       "entry.mjs": `await import("./guard.mjs");\nawait import("./bare.mjs");\n`,
     });
     const { stdout, stderr, exitCode } = await run(String(dir), "entry.mjs");
-    const lines = stdout.trim() ? stdout.trim().split("\n").map(l => JSON.parse(l)) : [];
+    const lines = stdout.trim()
+      ? stdout
+          .trim()
+          .split("\n")
+          .map(l => JSON.parse(l))
+      : [];
     expect({ lines, stderr, exitCode }).toEqual({
       lines: [
         { m: "undefined", e: "undefined", sep: "string" },

--- a/test/js/third_party/es-module-lexer/package.json
+++ b/test/js/third_party/es-module-lexer/package.json
@@ -1,7 +1,6 @@
 {
   "name": "es-module-lexer-test",
   "module": "index.ts",
-  "type": "module",
   "devDependencies": {
     "@types/bun": "latest"
   },


### PR DESCRIPTION
### Problem

A bare identifier reference to `module` or `exports` (for example the common dual-mode guard `typeof module !== "undefined"`) makes Bun's parser classify a file as CommonJS even when the `.mjs`/`.mts` extension or package.json `"type":"module"` already says it is ESM.

Two observable faces:

- If the file also has an `import` statement (valid ESM, Node runs it), Bun refuses to load it with `Cannot use import statement with CommonJS-only features` / `note: This file is CommonJS because 'module' was used`.
- If the file has no import/export, it silently runs with full CJS semantics: `typeof module === "object"`, top-level `this` is the exports object.

```js
// guard.mjs
import path from "node:path";
console.log(typeof module !== "undefined" ? "cjs" : "esm", path.sep);
```

Node prints `esm /`; Bun errors.

### Cause

In `src/js_parser/parse/parse_entry.rs`, the `exports_kind` decision runs the CJS content sniff (`uses_exports_ref || uses_module_ref || ...`) before ever consulting `options.module_type`. Only an `export` keyword or top-level `await` out-ranks the sniff; the extension and `"type"` field do not.

### Fix

- `parse_entry.rs`: treat `options.module_type == Esm` the same as `export`/top-level `await` when choosing `exports_kind`, **on the runtime path only** (`!p.options.bundle`). The bundler's resolver can return `Esm` for files that are actually CJS (a nameless nested `{"type":"commonjs"}` scope that `enclosing_package_json` skips, or an `exports` `"import"` condition pointing at a `.js` file), so the content sniff is still needed there; the runtime path is fed the correct value by the change below.
- `p.rs` `value_for_this`: substitute the ESM value for top-level `this` when `module_type == Esm` (not only when ESM syntax is present), so a bare `.mjs` with top-level `this` does not rewrite to `exports`.
- `RuntimeTranspilerStore`: thread the caller's extension-aware `module_type` through `transpile()` onto `TranspilerJob` and use it in the worker, instead of re-deriving from the package.json tag. The `resolved_source.tag` (used for `ignoreESModuleAnnotation`) is left as-is.
- `jsc_hooks.rs`: derive the runtime `module_type` for `.js`/`.ts` from the **nearest** package.json's `"type"` by walking `DirInfo` parents, including nameless ones that `enclosing_package_json` skips. Without this a `.js` file under `parse5/dist/cjs/` (which ships `{"type":"commonjs"}` with no name) was seeing the outer `parse5` `"type":"module"`. Carried as a separate `LoaderResult` field so `pkg_name` semantics are unchanged.
- `resolver.rs` `resolve_with_framework`: stop hard-coding `ModuleType::Esm` for embedded `BuiltInModule::Code`; the react-refresh fallback it carries is CJS. Use `Unknown` so the parser decides from content; the ESM `.tsx` built-ins still classify as ESM via their import syntax.
- Cache: hash `module_type` into the runtime transpiler features hash (byte-identical source now transpiles differently under different module types) and bump `EXPECTED_VERSION` to 23 so stale entries with the old classification are invalidated.

The `es-module-lexer` test fixture declared `"type":"module"` while its `index.ts` is CJS and relied on the sniff override; the stray `"type"` is dropped.

### Tests

`test/cli/run/run-cjs.test.ts` gains a `describe` block covering `.mjs`, `.mts`, `"type":"module"` `.js`, with and without import statements, loaded directly and via dynamic `import()`, plus negative controls (`.cjs`, ambiguous `.js`, `.cjs` inside `"type":"module"`, `.mjs` inside `"type":"commonjs"`, and a nested nameless `{"type":"commonjs"}` under a `"type":"module"` root). 7 of the 11 new tests fail on the unfixed build and all pass with this change.

`test/bundler/bundler_edgecase.test.ts` adds `NamelessNestedTypeCommonjsUnderTypeModule` and `ExportsMapImportConditionPointsAtCjs` to lock in the bundler keeping its content-sniff fallback for those layouts.

Also ran: `test/js/bun/resolve/`, `test/bundler/bundler_cjs*.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/bundler/esbuild/default.test.ts`, `test/bundler/transpiler/`, `test/cli/run/transpiler-cache.test.ts`, `test/integration/jsdom/`, `test/bake/dev/react-spa.test.ts`, `test/bake/dev/esm.test.ts` with no new failures.

Related: #32173 independently makes the same `value_for_this` change (plus changing `null` to `undefined` there) and the same cache-key addition; whichever lands second will have a small conflict in those two spots.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->