### PR TITLE
Add regression test for AsyncLocalStorage context loss in .then() continuations after DFG tier-up

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,9 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "c9ad5813fd23bd8b98b0738abc3d037ec716aa92";
+// Preview build of oven-sh/WebKit#278 (c9ad5813fd + the async-context promise
+// fast path fix); move to the merge commit's autobuild when that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-278-45bbb77c";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/regression/issue/33806.test.ts
+++ b/test/regression/issue/33806.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/33806
+// AsyncLocalStorage.getStore() returned undefined inside promise .then()
+// continuations once the calling function tiered up to the DFG JIT: the
+// PerformPromiseThenOneHandler fast path stored the reaction inline without
+// capturing the async context. Settled promises take the slow path, so each
+// handler must attach while the promise is still pending to hit the bug.
+test("AsyncLocalStorage store survives .then() continuations after JIT tier-up", async () => {
+  const script = `
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    const als = new AsyncLocalStorage();
+
+    function thenChain() {
+      let p = Promise.resolve();
+      for (let i = 0; i < 3; i++) p = p.then(() => {});
+      return p.then(() => als.getStore());
+    }
+
+    function catchChain() {
+      const { promise, reject } = Promise.withResolvers();
+      const out = promise.catch(() => als.getStore());
+      reject(new Error("boom"));
+      return out;
+    }
+
+    async function main() {
+      let badThen = 0;
+      let badCatch = 0;
+      for (let i = 0; i < 400; i++) {
+        const store = { v: i };
+        if ((await als.run(store, thenChain)) !== store) badThen++;
+        if ((await als.run(store, catchChain)) !== store) badCatch++;
+      }
+      console.log(JSON.stringify({ badThen, badCatch }));
+    }
+    main();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    // Lowered DFG threshold keeps the loop count (and test runtime) small.
+    env: { ...bunEnv, BUN_JSC_thresholdForOptimizeAfterWarmUp: "100" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({
+    stdout: JSON.stringify({ badThen: 0, badCatch: 0 }),
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/33806.test.ts
+++ b/test/regression/issue/33806.test.ts
@@ -45,8 +45,11 @@ test("AsyncLocalStorage store survives .then() continuations after JIT tier-up",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode }).toEqual({
+  // Surface stderr in the failure diff if the child crashed, without requiring
+  // it to be empty on success (debug/ASAN builds may emit benign warnings).
+  expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
     stdout: JSON.stringify({ badThen: 0, badCatch: 0 }),
+    stderr: "",
     exitCode: 0,
   });
 });


### PR DESCRIPTION
Fixes #33806. Depends on oven-sh/WebKit#278: the fix is a JavaScriptCore change and lands via a `WEBKIT_VERSION` bump once that PR is released. This PR adds the regression test.

## Repro

```js
import { AsyncLocalStorage } from 'node:async_hooks';
const als = new AsyncLocalStorage();

function chain() {
  let p = Promise.resolve();
  for (let i = 0; i < 3; i++) p = p.then(() => {});
  return p.then(() => als.getStore());
}

let bad = 0, firstBad = -1;
for (let i = 0; i < 8000; i++) {
  const r = await als.run({ v: i }, chain);
  if (!r || r.v !== i) { bad++; if (firstBad < 0) firstBad = i; }
}
console.log(bad ? `FAIL ${bad}/8000, first bad iteration ${firstBad}` : 'PASS');
```

Bun 1.4.0 prints `FAIL 7538/8000, first bad iteration 462`; Bun 1.3.14 prints `PASS`. The issue's concurrent scoped/un-scoped framing is a red herring: a fully serial loop reproduces it, and the trigger is the caller tiering up to the DFG JIT (`BUN_JSC_useDFGJIT=0` passes, `BUN_JSC_useFTLJIT=0` still fails).

## Cause

`Promise.prototype.then` with one callable handler folds to a `PerformPromiseThenOneHandler` DFG node whose DFG/FTL fast path stores the handler on the promise as an inline reaction. Inline reactions cannot carry the async context: the C++ `performPromiseThen` deliberately skips the inline-reaction path when `globalObject->m_asyncContextData` holds an active context (JSPromise.cpp), but the JIT fast path had no such check, so the reaction was enqueued without the context and the continuation ran with `getStore() === undefined`. `.catch` folds through the same node and was equally affected (only for handlers attached while the promise is still pending; settled promises already take the slow path).

oven-sh/WebKit#278 mirrors the C++ check in both JIT tiers: when the current async context is not undefined, take the existing slow path, which captures the context into a full reaction.

## Test

`test/regression/issue/33806.test.ts` spawns a child that runs 400 `als.run()` iterations of a `.then()` chain and a pending-promise `.catch()`, with a lowered DFG threshold so tier-up happens early. On current main (prebuilt WebKit) it fails with 357/400 and 348/400 lost contexts; with a `bun run build:local` build including oven-sh/WebKit#278 it passes, as do the original issue repro (`PASS: all 3200 scoped renders kept their context`), `test/js/node/async_hooks/` (111 tests), and `test/js/node/promise/`.

## Gate

The fix lives in `vendor/WebKit/` (outside `src/`), so the stash-based fail-before/pass-after proof cannot observe it; with the prebuilt WebKit both runs fail the same way. Fail-before evidence is the `USE_SYSTEM_BUN=1` / current-main run above; pass-after is the local-WebKit build. This PR should land together with the `WEBKIT_VERSION` bump that picks up oven-sh/WebKit#278.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 4 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/33806.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/33806.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (71385e468)

test/regression/issue/33806.test.ts:
(pass) AsyncLocalStorage store survives .then() continuations after JIT tier-up [2978.02ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [5.02s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts        |  4 ++-
 test/regression/issue/33806.test.ts | 55 +++++++++++++++++++++++++++++++++++++
 2 files changed, 58 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
scripts/build/deps/webkit.ts             1      1      0
test/regression/issue/33806.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->