### PR TITLE
Bun.serve: do not re-render error() after the status line is committed

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -954,6 +954,32 @@ where
         let resp = ctx.resp.expect("infallible: resp bound");
         // SAFETY: FFI handle, just checked Some
         let has_responded = resp.has_responded();
+
+        // The status line is already committed (a direct ReadableStream's
+        // pull() threw synchronously after do_render_stream wrote headers).
+        // error() cannot replace a response whose status is on the wire;
+        // report the failure and terminate the body so the client observes an
+        // incomplete message instead of a second header block spliced into
+        // the chunked body.
+        if !has_responded && ctx.flags.has_written_status() {
+            if !value.is_empty_or_undefined_or_null()
+                && let Some(server) = ctx.server
+            {
+                // SAFETY: BACKREF; see drain_microtasks() re: the const→mut cast.
+                unsafe {
+                    (*std::ptr::from_ref::<VirtualMachine>((*server).vm()).cast_mut())
+                        .run_error_handler(value, None);
+                }
+            }
+            let state = resp.state();
+            if state.is_http_write_called() && state.is_response_pending() {
+                ctx.force_close();
+            } else {
+                ctx.end_stream(ctx.should_close_connection());
+            }
+            return;
+        }
+
         if !has_responded {
             let original_state = ctx.defer_deinit_until_callback_completes;
             let should_deinit_context = core::cell::Cell::new(match original_state {

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -367,6 +367,87 @@ test.skipIf(!isASAN)(
   60_000,
 );
 
+// A direct stream's pull() that throws synchronously reaches handle_reject
+// AFTER do_render_stream already wrote the 200 status+headers. handle_reject
+// gated only on has_responded() (response ended), not has_written_status(),
+// so the server's error() handler was asked to produce a second Response and
+// render_metadata wrote its status/headers into the in-flight body. Debug
+// builds hit the !has_written_status assert in do_write_status and aborted;
+// release builds spliced the error() header block into the chunked body.
+describe("sync pull() throw after status is written does not re-render error()", () => {
+  function fixture(pullBody: string) {
+    return `
+      const net = require("node:net");
+      let errorHandlerCalls = 0;
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        error() {
+          errorHandlerCalls++;
+          return new Response("FROM-ERROR-HANDLER", { status: 500, headers: { "x-err": "1" } });
+        },
+        fetch() {
+          return new Response(new ReadableStream({
+            type: "direct",
+            pull(c) { ${pullBody} },
+          }));
+        },
+      });
+      const wire = await new Promise(resolve => {
+        let buf = "";
+        const s = net.connect(server.port, "127.0.0.1", () => {
+          s.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+        });
+        s.on("data", d => (buf += d.toString("latin1")));
+        s.on("close", () => resolve(buf));
+        s.on("error", () => resolve(buf));
+      });
+      server.stop(true);
+      console.log(JSON.stringify({ wire, errorHandlerCalls }));
+    `;
+  }
+
+  test("body bytes already flushed: connection is force-closed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`c.write("PARTIAL-BYTES"); c.flush(); throw new Error("boom");`)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error: boom");
+    const { wire, errorHandlerCalls } = JSON.parse(stdout);
+    // error() cannot replace a response whose status is committed; the
+    // connection is force-closed so the client observes failure instead of
+    // the error() header block spliced where a chunk-size line belongs.
+    expect(wire).not.toContain("x-err");
+    expect(wire).not.toContain("FROM-ERROR-HANDLER");
+    expect(wire).not.toContain("Something went wrong");
+    expect(errorHandlerCalls).toBe(0);
+    expect(exitCode).toBe(0);
+  });
+
+  test("no body bytes flushed: stream is ended without splicing error() headers", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`throw new Error("boom");`)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error: boom");
+    const { wire, errorHandlerCalls } = JSON.parse(stdout);
+    // Status 200 was already written; the stream is ended empty. The error()
+    // response's status (500), headers, and body must not appear on the wire.
+    expect(wire).not.toContain("x-err");
+    expect(wire).not.toContain("FROM-ERROR-HANDLER");
+    expect(wire.startsWith("HTTP/1.1 200 OK\r\n")).toBe(true);
+    expect(errorHandlerCalls).toBe(0);
+    expect(exitCode).toBe(0);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/32137
 // react-dom/server.bun's renderToReadableStream returns a direct ReadableStream
 // whose pull() writes the shell, captures the controller, and returns


### PR DESCRIPTION
## Reproduction

```js
const srv = Bun.serve({
  port: 0, development: false,
  error() { return new Response("FROM-ERROR-HANDLER", { status: 500, headers: { "x-err": "1" } }); },
  fetch() {
    return new Response(new ReadableStream({
      type: "direct",
      pull(c) { c.write("PARTIAL-BYTES"); c.flush(); throw new Error("boom"); },
    }));
  },
});
```

One request to this server on a debug build aborts the process:

```
panic: assertion failed: !self.flags.has_written_status()
  do_render_stream -> handle_reject -> run_error_handler -> render_metadata -> do_write_status
```

On a release build the `error()` Response's header block is written where a chunk-size line belongs, destroying the chunked framing:

```
HTTP/1.1 200 OK\r\n...Transfer-Encoding: chunked\r\n\r\n
d\r\nPARTIAL-BYTES\r\n
x-err: 1\r\ncontent-type: text/plain;charset=utf-8\r\n
12\r\nFROM-ERROR-HANDLER\r\n0\r\n\r\n
```

Without the preceding `write()`/`flush()`, the 500 status is silently dropped and the client receives a clean `200 OK` carrying `x-err: 1` and the `error()` body.

## Cause

`do_render_stream` writes the status+headers (`render_metadata`) before invoking `assign_to_stream`, which runs the direct stream's `pull()`. A synchronous throw from `pull()` is routed to `handle_reject`, which gated the `error()` re-render only on `resp.has_responded()` (response *ended*), never on `has_written_status()`. The server's `error()` handler was therefore asked to produce a second Response for an exchange whose status line was already on the wire, and `render_metadata` wrote a second status/header block into the in-flight body.

The async sibling (`handle_reject_stream`) already handles this state correctly.

## Fix

When `has_written_status()` is set, `handle_reject` now reports the failure via the VM error reporter and terminates the body (`force_close` if body bytes were written, `end_stream` otherwise) instead of re-rendering, matching `handle_reject_stream`.

## Verification

Added two subprocess tests in `test/js/bun/http/serve-direct-readable-stream.test.ts` covering the with-flush and without-flush shapes. Both fail on the unfixed build (debug: `!has_written_status` assert; release: `error()` headers spliced into the wire) and pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ed033fa10)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [60.98ms]
(pass) controller.end() after pull() resolved does not use the sink after free [556.86ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1481.81ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1527.34ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [695.93ms]
killed 1 dangling process
(fail) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-clo
... (truncated)

release without fix: 2 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [13.12ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end() with a parked pull() does not use the socket after free
(skip) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free
(skip) h3: controller.end() from a parked pull() disarms onAborted before the context is released
414 |       env: bunEnv,
415 |       stdout: "pipe",
416 |       stderr: "pipe",
417 |     });
418 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
419 |     expect(stderr).toContain("error: boom");
                         ^
error: expect(received).toContain(expected)

Expected to contain: "error: boom"
Received: ""

      at <anonymous> (/workspace/bun/test/js/bun/http/serve-direct-readable-stream.test.ts:419:20)
(fail) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [35.72ms]
434 |    
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ed033fa10)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [62.97ms]
(pass) controller.end() after pull() resolved does not use the sink after free [545.02ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1447.99ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1465.50ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [673.69ms]
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [1393.06ms]
(pass) syn
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ed033fa106
  features     (none)

22 deps, 105 codegen, 1167 objects in 858ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [4.00ms]
[2/1230] gen ErrorCode+*.h
[3/1230] gen bindgenv2
[4/1230] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/1230] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[6/1230] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs               | 26 +++++++
 .../bun/http/serve-direct-readable-stream.test.ts  | 81 ++++++++++++++++++++++
 2 files changed, 107 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/server/RequestContext.rs                       7      1      0
test/js/bun/http/serve-direct-readable-stream.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->