### PR TITLE
Bun.serve: handle the internal cancel() promise when the peer aborts a streaming Response

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1403,8 +1403,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onBufferedFastPathRejected, (JSGlob
     auto* stream = uncheckedDowncast<JSReadableStream>(callFrame->uncheckedArgument(1));
     JSValue error = callFrame->argument(0);
     stream->m_lockedWithoutReader = false;
-    Bun::WebStreams::readableStreamCancel(globalObject, stream, error);
+    auto* cancelPromise = Bun::WebStreams::readableStreamCancel(globalObject, stream, error);
     RETURN_IF_EXCEPTION(scope, {});
+    if (cancelPromise)
+        Bun::WebStreams::markPromiseAsHandled(vm, cancelPromise);
     Bun::WebStreams::readableStreamCloseIfPossible(globalObject, stream);
     RETURN_IF_EXCEPTION(scope, {});
     throwException(globalObject, scope, error);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1261,11 +1261,15 @@ static void readStreamIntoSinkOnCloseImpl(JSC::VM& vm, JSGlobalObject* globalObj
     if (!op->m_didThrow && !op->m_didClose) {
         auto* stream = dynamicDowncast<JSReadableStream>(streamValue);
         if (stream && stream->m_state != ReadableStreamState::Closed) {
-            readableStreamCancel(globalObject, stream, reason);
+            auto* cancelPromise = readableStreamCancel(globalObject, stream, reason);
             if (scope.exception()) [[unlikely]] {
                 op->m_didClose = true;
                 return;
             }
+            // The sink initiated this cancel (peer abort / sink close); the source's
+            // cancel() rejection has no consumer, so keep it out of unhandledRejection.
+            if (cancelPromise)
+                markPromiseAsHandled(vm, cancelPromise);
         }
     }
     op->m_didClose = true;
@@ -1431,8 +1435,10 @@ static void resumableCancelImpl(JSC::VM& vm, JSGlobalObject* globalObject, JSRes
     JSValue error = op->m_error.get();
     bool hasTruthyError = !error.isEmpty() && error.toBoolean(globalObject);
     if (stream && !hasTruthyError && stream->m_state != ReadableStreamState::Closed) {
-        readableStreamCancel(globalObject, stream, reason);
+        auto* cancelPromise = readableStreamCancel(globalObject, stream, reason);
         RETURN_IF_EXCEPTION(scope, );
+        if (cancelPromise)
+            markPromiseAsHandled(vm, cancelPromise);
     }
     RELEASE_AND_RETURN(scope, resumableReleaseReader(vm, globalObject, op));
 }

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -17,6 +17,10 @@ const development = process.argv[3] === "development";
 // wire. Called from the raw request's data handler below.
 let midStreamResolve: (() => void) | undefined;
 
+// Set by the cancel variants: resolved once the source's cancel() has run, so
+// the test observes any resulting rejection before declaring success.
+const cancelRan = Promise.withResolvers<void>();
+
 const sources: Record<string, () => ReadableStream> = {
   // Already errored by the time Bun.serve starts rendering the body.
   "pull-throw": () =>
@@ -69,6 +73,43 @@ const sources: Record<string, () => ReadableStream> = {
         throw new Error("boom");
       },
     }),
+  // The client aborts the download mid-stream, which makes Bun cancel the body
+  // stream; the source's cancel() then throws. That rejection belongs to a
+  // promise Bun created internally and must not surface as unhandledRejection.
+  "cancel-throw": () =>
+    new ReadableStream({
+      async pull(c) {
+        c.enqueue("chunk-a");
+        await Bun.sleep(4);
+      },
+      cancel() {
+        queueMicrotask(cancelRan.resolve);
+        throw new Error("boom");
+      },
+    }),
+  "cancel-async-reject": () =>
+    new ReadableStream({
+      async pull(c) {
+        c.enqueue("chunk-a");
+        await Bun.sleep(4);
+      },
+      async cancel() {
+        queueMicrotask(cancelRan.resolve);
+        throw new Error("boom");
+      },
+    }),
+  "cancel-byte-throw": () =>
+    new ReadableStream({
+      type: "bytes",
+      async pull(c) {
+        c.enqueue(new TextEncoder().encode("chunk-a"));
+        await Bun.sleep(4);
+      },
+      cancel() {
+        queueMicrotask(cancelRan.resolve);
+        throw new Error("boom");
+      },
+    }),
 };
 
 const source = sources[variant];
@@ -76,6 +117,7 @@ if (!source) {
   console.error(`unknown variant: ${variant}`);
   process.exit(3);
 }
+const clientAborts = variant.startsWith("cancel-");
 
 // Counting instead of relying on the default exit-on-unhandledRejection
 // policy gives the test an exact number and keeps the process alive long
@@ -102,7 +144,7 @@ await using server = Bun.serve({
 // the server closed the connection, so the test can assert on the HTTP
 // framing. A forced close (ECONNRESET) is an expected, asserted-on outcome
 // for the mid-stream variant, so socket errors are not fatal.
-function rawRequest(): Promise<string> {
+function rawRequest(abort: boolean): Promise<string> {
   const chunks: Buffer[] = [];
   return new Promise(resolve => {
     const sock = net.connect(server.port, "127.0.0.1", () => {
@@ -110,16 +152,25 @@ function rawRequest(): Promise<string> {
     });
     sock.on("data", d => {
       chunks.push(d);
-      if (Buffer.concat(chunks).includes("chunk-a")) midStreamResolve?.();
+      if (Buffer.concat(chunks).includes("chunk-a")) {
+        midStreamResolve?.();
+        // The cancel variants tear down the socket once a body chunk has
+        // provably reached the client, so the server's onAborted path fires
+        // and cancels the source while pull() is still pending.
+        if (abort) sock.resetAndDestroy();
+      }
     });
     sock.on("error", () => {});
     sock.on("close", () => resolve(Buffer.concat(chunks).toString("latin1")));
   });
 }
 
-const wire = await rawRequest();
-// A second request proves the server is still accepting and answering.
-const secondWire = await rawRequest();
+const wire = await rawRequest(clientAborts);
+if (clientAborts) await cancelRan.promise;
+// A second request proves the server is still accepting and answering. For the
+// cancel variants the body stream never self-terminates, so abort that one too;
+// only the status line is asserted.
+const secondWire = await rawRequest(clientAborts);
 
 // Cycle the event loop so any stray rejected promise reaches the
 // unhandledRejection reporter before we declare success.

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -118,6 +118,95 @@ test.concurrent("mid-stream error in development mode: reported and not terminat
   expect(stderr).toContain("boom");
 });
 
+// The client aborts the download mid-stream, which makes Bun cancel the body
+// ReadableStream. The source's cancel() throws, but the rejected promise is
+// one Bun created internally: it must be marked handled rather than surfacing
+// as an unhandledRejection (which, under Bun's default policy, would exit the
+// whole server process because a remote peer hung up).
+test.concurrent.each(["cancel-throw", "cancel-async-reject", "cancel-byte-throw"])(
+  "%s: a throwing cancel() on client abort is not an unhandledRejection",
+  async variant => {
+    const { stdout, stderr, exitCode } = await runFixture(variant);
+    const result = JSON.parse(stdout);
+    expect({
+      result: {
+        statusLine: result.statusLine,
+        errorCb: result.errorCb,
+        unhandled: result.unhandled,
+        secondStatusLine: result.secondStatusLine,
+      },
+      stderr,
+      exitCode,
+    }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
+
+// Same under `development: true` (the DEBUG RequestContext monomorphization).
+test.concurrent("cancel-throw in development mode: not an unhandledRejection", async () => {
+  const { stdout, stderr, exitCode } = await runFixture("cancel-throw", "development");
+  const result = JSON.parse(stdout);
+  expect({ unhandled: result.unhandled, errorCb: result.errorCb, stderr, exitCode }).toEqual({
+    unhandled: 0,
+    errorCb: 0,
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// With Bun's default unhandledRejection policy (no handler installed), a
+// throwing cancel() triggered by a remote peer disconnecting mid-download
+// must not exit the server process.
+test.concurrent("a throwing cancel() on client abort does not kill the server process", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import net from "node:net";
+      const cancelRan = Promise.withResolvers();
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        fetch() {
+          return new Response(new ReadableStream({
+            async pull(c) { c.enqueue("chunk-a"); await Bun.sleep(4); },
+            cancel() { queueMicrotask(cancelRan.resolve); throw new Error("boom"); },
+          }));
+        },
+      });
+      await new Promise(resolve => {
+        const sock = net.connect(server.port, "127.0.0.1", () => {
+          sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+        });
+        let buf = "";
+        sock.on("data", d => { buf += d; if (buf.includes("chunk-a")) sock.resetAndDestroy(); });
+        sock.on("error", () => {});
+        sock.on("close", resolve);
+      });
+      await cancelRan.promise;
+      // Tick the event loop past the unhandledRejection checkpoint that used
+      // to exit the process before this line was reached.
+      for (let i = 0; i < 10; i++) await Bun.sleep(0);
+      const res = await fetch(new URL("/ok", server.url));
+      console.log("alive", res.status);
+      server.stop(true);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "alive 200\n", stderr: "", exitCode: 0 });
+});
+
 // The whole point: with Bun's default unhandledRejection policy (no handler
 // installed), a single request whose Response body errors must not exit the
 // server process.


### PR DESCRIPTION
## Repro

```js
Bun.serve({
  port: 3000, development: false,
  fetch() {
    return new Response(new ReadableStream({
      async pull(c) { c.enqueue("P".repeat(8)); await Bun.sleep(4); },
      cancel() { throw new Error("CX:cancel"); }, // runs when the PEER hangs up
    }));
  },
  error(e) { return new Response("E", { status: 597 }); },
});
```

Hit it with any client that aborts mid-download (a browser navigating away, `curl` ^C, a `net.Socket` that `resetAndDestroy()`s after a few chunks):

```
error: CX:cancel
Bun v1.4.0 (Linux x64)
$ echo $?
1
```

The whole server process exits. With `process.on("unhandledRejection", ...)` installed it survives but receives `unhandledRejection: CX:cancel`; `error()` and `uncaughtException` are never reached.

## Cause

When the peer aborts mid-stream, `RequestContext::on_abort` fires the response sink's `onClose`, which lands in `readStreamIntoSinkOnCloseImpl` (`BunStreamSource.cpp`). That calls `readableStreamCancel()` and discards the returned promise. The underlying source's `cancel()` throw becomes the rejection of that promise (per the Streams spec's `[[CancelSteps]]`), and since Bun created it internally and dropped it without a handler, it falls through to the global `unhandledRejection` funnel, whose default policy in Bun is process exit.

The `ReadableStream__cancel` / `ReadableStream__cancelWithReason` FFI entry points already `markPromiseAsHandled()` the result, as does `publicStreamCancelIgnoringResult`; the sink-pump `onClose` path did not.

## Fix

Mark the `readableStreamCancel()` result as handled at the three internal call sites that were discarding it:

- `readStreamIntoSinkOnCloseImpl` (Bun.serve response-body pump, the repro path)
- `resumableCancelImpl` (the ResumableSink pump)
- `jsWebStreamsHandler_onBufferedFastPathRejected` (the buffered fast-path consumer)

This brings `cancel()` in line with `start()`/`pull()` failures on the same stream, which already do not surface as `unhandledRejection`.

## Verification

`test/js/bun/http/serve-stream-body-error.test.ts` gains variants where the client aborts mid-download and the source's `cancel()` throws (sync), rejects (async), and throws on a `type: "bytes"` stream, plus `development: true`, plus a no-handler process-survival check. All fail on the unfixed build (`unhandled: 2` / process exit 1), all pass with this change; the existing 9 tests in the file are unaffected.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-stream-body-error.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d100179e)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [1580.64ms]
(pass) start-async-reject: the rejection is handled and the error is still reported [1604.05ms]
(pass) controller-error: the rejection is handled and the error is still reported [1690.11ms]
(pass) pull-throw: the rejection is handled and the error is still reported [2016.33ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [2026.00ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [1477.97ms]
(pass) mid-stream error: the chunked body is not terminated as complete [1644.24ms]
(pass) pull-th
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (7710ebf28)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) start-async-reject: the rejection is handled and the error is still reported [29.45ms]
(pass) pull-throw in development mode: the rejection is handled [29.38ms]
(pass) mid-stream error: the chunked body is not terminated as complete [29.27ms]
(pass) pull-throw: the rejection is handled and the error is still reported [34.94ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [34.09ms]
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [33.69ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [34.41ms]
(pass) cancel-throw: a throwing cancel() on client abort is not an unhandledRejection [38.02ms]
(pass) controller-error: the rejection is handled and the error is still reported [47.25ms]
(pass) cancel-async-reject: a throwing cancel() on client abort is not an unhandledRejection [57.72ms]
(pass) cancel-byte-throw: a throwing cancel() on client abort is not an unhandledRejection [57.69ms]
(pass) a stream body error does not kill the server process [53.82ms]
(pass) a throwi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-stream-body-error.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d100179e)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) controller-error: the rejection is handled and the error is still reported [1491.08ms]
(pass) start-async-reject: the rejection is handled and the error is still reported [1525.45ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [1559.68ms]
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [1562.56ms]
(pass) pull-throw: the rejection is handled and the error is still reported [1676.72ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [1479.94ms]
(pass) mid-stream error: the chunked body is not terminated as complete [1511.95ms]
(pass) pull-th
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 861ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[2/7] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimize
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         |  4 +-
 .../bindings/webcore/streams/BunStreamSource.cpp   | 10 ++-
 .../js/bun/http/serve-stream-body-error-fixture.ts | 61 +++++++++++++--
 test/js/bun/http/serve-stream-body-error.test.ts   | 89 ++++++++++++++++++++++
 4 files changed, 156 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp      1      1      0
src/jsc/bindings/webcore/streams/BunStreamSource.cpp         7      2      0
test/js/bun/http/serve-stream-body-error-fixture.ts          1      5      0
test/js/bun/http/serve-stream-body-error.test.ts             2      1      0
```

</details>

<!-- robobun:evidence:end -->