### PR TITLE
node:dns: drive c-ares retransmits from ares_timeout() instead of a fixed 1s timer

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -969,6 +969,24 @@ impl Channel {
             if writable { fd } else { ARES_SOCKET_BAD },
         );
     }
+
+    /// Milliseconds until the channel's next retransmission / timeout deadline,
+    /// capped at `max_ms`. Returns `max_ms` when no query is pending. See
+    /// ares_timeout(3).
+    pub fn timeout_ms(&mut self, max_ms: i64) -> i64 {
+        let mut max = struct_timeval {
+            tv_sec: (max_ms / 1000) as _,
+            tv_usec: ((max_ms % 1000) * 1000) as _,
+        };
+        let mut tv = struct_timeval { tv_sec: 0, tv_usec: 0 };
+        // SAFETY: c-ares FFI; both pointers are live stack locals. The return
+        // aliases one of them (or is null only when `channel`/`tv` are null,
+        // which they are not here).
+        let ret = unsafe { ares_timeout(self, &raw mut max, &raw mut tv) };
+        // SAFETY: `ret` is either `&max` or `&tv`, both live above.
+        let out = unsafe { &*ret };
+        (out.tv_sec as i64) * 1000 + (out.tv_usec as i64 + 999) / 1000
+    }
 }
 
 fn library_init() {

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -978,7 +978,10 @@ impl Channel {
             tv_sec: (max_ms / 1000) as _,
             tv_usec: ((max_ms % 1000) * 1000) as _,
         };
-        let mut tv = struct_timeval { tv_sec: 0, tv_usec: 0 };
+        let mut tv = struct_timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        };
         // SAFETY: c-ares FFI; both pointers are live stack locals. The return
         // aliases one of them (or is null only when `channel`/`tv` are null,
         // which they are not here).

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4161,7 +4161,15 @@ impl Resolver {
         let now_ts = now
             .copied()
             .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::AllowMockedTime));
-        let next = now_ts.add_ms(1000);
+        // Ask c-ares when its next retransmission/timeout is actually due
+        // (capped at 1 s) so sub-second `timeout` options and c-ares's own
+        // adaptive retry schedule are honored instead of quantized to 1 s.
+        let interval_ms = match self.channel.get() {
+            // SAFETY: `channel` is the live c-ares channel owned by `self`.
+            Some(channel) => unsafe { (*channel).timeout_ms(1000) },
+            None => 1000,
+        };
+        let next = now_ts.add_ms(interval_ms);
         // `EventLoopTimer.next` uses the event-loop crate's local
         // `Timespec` (distinct from `bun_core::Timespec`); convert by field.
         self.event_loop_timer.with_mut(|t| {

--- a/test/js/node/dns/dns-resolver-timeout.test.ts
+++ b/test/js/node/dns/dns-resolver-timeout.test.ts
@@ -31,11 +31,7 @@ async function run(opt: { timeout: number; tries: number }) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
   return JSON.parse(stdout.trim()) as {
     err: string;

--- a/test/js/node/dns/dns-resolver-timeout.test.ts
+++ b/test/js/node/dns/dns-resolver-timeout.test.ts
@@ -1,0 +1,70 @@
+// Before the fix, Resolver drove c-ares from a fixed 1-second repeating timer,
+// so every sub-second `timeout` option was quantized up to ~1 s and c-ares's
+// own retransmission schedule was deferred to the next 1 s tick. The fixture
+// runs a UDP "DNS server" that never answers and timestamps every incoming
+// query so the test can observe both total elapsed time and the on-wire
+// retransmit gap.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(opt: { timeout: number; tries: number }) {
+  const src = `
+    import dns from "node:dns";
+    import dgram from "node:dgram";
+    const log = [];
+    const u = dgram.createSocket("udp4");
+    await new Promise(r => u.bind(0, "127.0.0.1", r));
+    u.on("message", () => log.push(Date.now()));
+    const r = new dns.promises.Resolver(${JSON.stringify(opt)});
+    r.setServers(["127.0.0.1:" + u.address().port]);
+    const t0 = Date.now();
+    const err = await r.resolve4("x.test").then(() => "?", e => e.code);
+    const elapsed = Date.now() - t0;
+    await new Promise(r2 => setTimeout(r2, 50));
+    const gaps = log.map((t, i) => (i ? t - log[i - 1] : 0)).slice(1);
+    console.log(JSON.stringify({ err, elapsed, wire_queries: log.length, gaps }));
+    u.close();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
+  return JSON.parse(stdout.trim()) as {
+    err: string;
+    elapsed: number;
+    wire_queries: number;
+    gaps: number[];
+  };
+}
+
+test.concurrent("Resolver honors sub-second timeout (tries=1)", async () => {
+  // c-ares enforces MIN_TIMEOUT_MS=250, so 200 clamps to ~250 ms. Before the
+  // fix this waited ~1000 ms regardless.
+  const { err, elapsed, wire_queries } = await run({ timeout: 200, tries: 1 });
+  expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 1 });
+  expect(elapsed).toBeLessThan(800);
+});
+
+test.concurrent("Resolver retransmits before 1s for sub-second timeout (tries=3)", async () => {
+  // First retransmit is at the base timeout (~250 ms, no jitter on round 0).
+  // Before the fix the first gap was ~1000 ms.
+  const { err, wire_queries, gaps } = await run({ timeout: 200, tries: 3 });
+  expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 3 });
+  expect(gaps.length).toBe(2);
+  expect(gaps[0]).toBeLessThan(800);
+});
+
+test.concurrent("Resolver timeout >= 1s is unaffected", async () => {
+  const { err, elapsed, wire_queries } = await run({ timeout: 2000, tries: 1 });
+  expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 1 });
+  expect(elapsed).toBeGreaterThanOrEqual(1900);
+  expect(elapsed).toBeLessThan(3000);
+});


### PR DESCRIPTION
## Problem

`Resolver.add_timer()` in `src/runtime/dns_jsc/dns.rs` armed the event-loop timer with a hard-coded `now.add_ms(1000)` and `check_timeouts()` pumped `ares_process_fd(ARES_SOCKET_BAD, ARES_SOCKET_BAD)` once a second. Bun never asked c-ares when the next retransmission or timeout was actually due, so every sub-second `Resolver({ timeout })` option, and c-ares 1.34's own adaptive retry schedule, was quantized up to ~1 s ticks.

Wire-level repro against an in-process UDP server that never answers and timestamps every incoming query:

```
timeout=200 tries=1 -> ETIMEOUT elapsed=1001ms  wire_queries=1   (node: 375ms)
timeout=200 tries=3 -> ETIMEOUT elapsed=3002ms  gaps=[1000,1000] (node: [399,601])
```

Retry counts, per-server distribution, failover and error identity were all correct; only the time axis was broken.

## Fix

Add a `Channel::timeout_ms()` wrapper around `ares_timeout(3)` and use it in `add_timer()` to compute the interval (capped at 1 s, so the upper bound on an idle/empty channel is unchanged).

After:

```
timeout=200 tries=1 -> ETIMEOUT elapsed=261ms   wire_queries=1
timeout=200 tries=3 -> ETIMEOUT elapsed=1471ms  gaps=[255,336]
```

c-ares enforces `MIN_TIMEOUT_MS=250` internally, so 200 ms clamps to ~250 ms; subsequent tries apply c-ares's own doubling + jitter. Node polls at a fixed `min(user_timeout, 1000)` interval rather than calling `ares_timeout()`, which is why its first gap for `timeout=200` lands around 400 ms rather than 250 ms; both approaches honor the sub-second option.

## Verification

`test/js/node/dns/dns-resolver-timeout.test.ts` spawns a child per case and asserts on the observed wall-clock / wire timing. Fails on main (`elapsed=1000` / `gaps[0]=1000`) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolver-timeout.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a420b24f5)

test/js/node/dns/dns-resolver-timeout.test.ts:
44 | test.concurrent("Resolver honors sub-second timeout (tries=1)", async () => {
45 |   // c-ares enforces MIN_TIMEOUT_MS=250, so 200 clamps to ~250 ms. Before the
46 |   // fix this waited ~1000 ms regardless.
47 |   const { err, elapsed, wire_queries } = await run({ timeout: 200, tries: 1 });
48 |   expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 1 });
49 |   expect(elapsed).toBeLessThan(800);
                       ^
error: expect(received).toBeLessThan(expected)

Expected: < 800
Received: 1008

      at <anonymous> (/workspace/bun/test/js/node/dns/dns-resolver-timeout.test.ts:49:19)
(fail) Resolver honors sub-second timeout (tries=1) 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/dns/dns-resolver-timeout.test.ts:
44 | test.concurrent("Resolver honors sub-second timeout (tries=1)", async () => {
45 |   // c-ares enforces MIN_TIMEOUT_MS=250, so 200 clamps to ~250 ms. Before the
46 |   // fix this waited ~1000 ms regardless.
47 |   const { err, elapsed, wire_queries } = await run({ timeout: 200, tries: 1 });
48 |   expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 1 });
49 |   expect(elapsed).toBeLessThan(800);
                       ^
error: expect(received).toBeLessThan(expected)

Expected: < 800
Received: 1001

      at <anonymous> (/workspace/bun/test/js/node/dns/dns-resolver-timeout.test.ts:49:19)
(fail) Resolver honors sub-second timeout (tries=1) [2023.13ms]
(pass) Resolver timeout >= 1s is unaffected [3020.93ms]
53 |   // First retransmit is at the base timeout (~250 ms, no jitter on round 0).
54 |   // Before the fix the first gap was ~1000 ms.
55 |   const { err, wire_queries, gaps } = await run({ timeout: 200, tries: 3 });
56 |   expect({ err, wire_queries }).toEqual({ err: "ETIMEOUT", wire_queries: 3 });
57 |   expect(gaps.length).toBe(2);
58 |   expect(gaps[0])
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolver-timeout.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a420b24f5)

test/js/node/dns/dns-resolver-timeout.test.ts:
(pass) Resolver honors sub-second timeout (tries=1) [2137.58ms]
(pass) Resolver retransmits before 1s for sub-second timeout (tries=3) [3082.41ms]
(pass) Resolver timeout >= 1s is unaffected [3916.95ms]

 3 pass
 0 fail
 11 expect() calls
Ran 3 tests across 1 file. [5.92s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a420b24f54
  features     (none)

22 deps, 105 codegen, 1167 objects in 841ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [7.00ms]
[2/1230] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1230] gen ErrorCode+*.h
[4/1230] gen bindgenv2
[5/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[6/1230] gen .bind.ts → GeneratedBindings.cpp
[7/1230] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1230] fet
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/cares_sys/c_ares.rs                       | 21 +++++++++
 src/runtime/dns_jsc/dns.rs                    | 10 +++-
 test/js/node/dns/dns-resolver-timeout.test.ts | 66 +++++++++++++++++++++++++++
 3 files changed, 96 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/cares_sys/c_ares.rs                            5      1      0
src/runtime/dns_jsc/dns.rs                         4      2      0
test/js/node/dns/dns-resolver-timeout.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->