### PR TITLE
Bun.serve: mark request pending when error() returns a streaming body

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3210,6 +3210,10 @@ where
                                 return;
                             }
                             this.ref_();
+                            // Same as do_render_stream's Pending branch: the
+                            // body is in flight, so `handle_reject` must not
+                            // fall through to render_missing() and end it.
+                            this.flags.set_has_marked_pending(true);
                             byte_stream.pipe.set(WebCore::Wrap::<Self>::init(this));
                             // Deinit the old Strong reference before creating a new one
                             // to avoid leaking the Strong.Impl memory

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2136,6 +2136,11 @@ where
                 match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
                     jsc::PromiseResult::Pending => {
                         stream_log!("promise still Pending");
+                        // The sink now owns a raw `resp` pointer and the pump
+                        // promise holds a ref on this context. Marking pending
+                        // keeps `handle_reject` from ending the response out
+                        // from under the sink while the stream is in flight.
+                        this.flags.set_has_marked_pending(true);
                         if !this.flags.has_written_status() {
                             response_stream.sink.on_first_write = None;
                             response_stream.sink.ctx = None;

--- a/test/js/bun/http/serve-async-stream-client-abort.test.ts
+++ b/test/js/bun/http/serve-async-stream-client-abort.test.ts
@@ -2,6 +2,29 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
+// An async-rejecting fetch() whose error() handler returns a streaming
+// Response must not have that stream ended underneath it by handle_reject's
+// render_missing() fallback: that truncated the body on the happy path and,
+// after a client abort, left the sink pointing at a freed uWS response
+// (ASAN: heap-use-after-free in uws_res_has_responded via end_from_js).
+test("streaming error() response from an async-rejecting fetch is not ended by render_missing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-error-stream-client-abort-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stderr: "",
+    stdout: expect.stringContaining('"ok":true'),
+    exitCode: 0,
+    signalCode: null,
+  });
+}, 60_000);
+
 // https://github.com/oven-sh/bun/issues/32111
 test("client aborting an async-pull ReadableStream response does not crash the server", async () => {
   await using proc = Bun.spawn({

--- a/test/js/bun/http/serve-error-handler-stream-fixture.ts
+++ b/test/js/bun/http/serve-error-handler-stream-fixture.ts
@@ -1,0 +1,105 @@
+// Fixture for serve-error-handler-stream.test.ts.
+// Runs a server whose error() returns a streaming Response, issues one request
+// to the given path, and prints {status, len, pulls} to stdout. The test
+// asserts the full body was received. Runs in a subprocess so an ASAN crash
+// (the pre-fix UAF in uws_res_has_responded) is observed as a test failure
+// instead of killing the parent test runner before junit is written.
+
+const [path, closeHeader] = process.argv.slice(2);
+
+const CHUNK = Buffer.alloc(64, "P").toString();
+const CHUNKS = 12;
+let pulls = 0;
+
+function chunkedBody() {
+  let i = 0;
+  return new ReadableStream({
+    async pull(c) {
+      pulls++;
+      if (i++ < CHUNKS) {
+        c.enqueue(CHUNK);
+        await Bun.sleep(4);
+      } else {
+        c.close();
+      }
+    },
+  });
+}
+
+function lazyBody() {
+  return new ReadableStream({
+    async pull(c) {
+      pulls++;
+      await Bun.sleep(10);
+      c.enqueue(CHUNK);
+      c.close();
+    },
+  });
+}
+
+function directBody() {
+  return new ReadableStream({
+    type: "direct",
+    async pull(c: any) {
+      for (let i = 0; i < CHUNKS; i++) {
+        pulls++;
+        c.write(CHUNK);
+        await c.flush();
+        await Bun.sleep(4);
+      }
+      await c.end();
+    },
+  } as any);
+}
+
+async function* iteratorBody() {
+  for (let i = 0; i < CHUNKS; i++) {
+    pulls++;
+    yield CHUNK;
+    await Bun.sleep(4);
+  }
+}
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  fetch(req) {
+    const p = new URL(req.url).pathname;
+    if (p === "/sync") throw new Error("boom");
+    if (p === "/async")
+      return (async () => {
+        throw new Error("boom");
+      })();
+    if (p === "/reject") return Promise.reject(new Error("boom"));
+    if (p === "/lazy")
+      return (async () => {
+        throw new Error("lazy");
+      })();
+    if (p === "/direct")
+      return (async () => {
+        throw new Error("direct");
+      })();
+    if (p === "/iter")
+      return (async () => {
+        throw new Error("iter");
+      })();
+    return new Response(chunkedBody(), { status: 200 });
+  },
+  error(e) {
+    const msg = String((e as Error).message);
+    if (msg === "lazy") return new Response(lazyBody(), { status: 597 });
+    if (msg === "direct") return new Response(directBody(), { status: 597 });
+    if (msg === "iter") return new Response(iteratorBody() as any, { status: 597 });
+    return new Response(chunkedBody(), { status: 597 });
+  },
+});
+
+const headers: Record<string, string> = {};
+if (closeHeader === "close") headers.Connection = "close";
+
+const res = await fetch(`http://127.0.0.1:${server.port}${path}`, { headers });
+const body = await res.text();
+// Let any orphaned producer (pre-fix) write to the freed socket.
+await Bun.sleep(100);
+process.stdout.write(JSON.stringify({ status: res.status, len: body.length, pulls }));
+server.stop(true);

--- a/test/js/bun/http/serve-error-handler-stream.test.ts
+++ b/test/js/bun/http/serve-error-handler-stream.test.ts
@@ -9,7 +9,7 @@
 // Each case runs in a subprocess so a pre-fix ASAN crash is observed as a
 // test failure rather than killing the parent runner before junit is written.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "serve-error-handler-stream-fixture.ts");
@@ -19,7 +19,11 @@ const CHUNK_LEN = 64;
 async function runFixture(path: string, close = false) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), fixture, path, ...(close ? ["close"] : [])],
-    env: { ...bunEnv, Malloc: "1" },
+    // Malloc=1 forces system malloc so bmalloc/libpas pools don't mask the
+    // UAF from ASAN. bmalloc's SystemHeap is unimplemented on Windows and
+    // would RELEASE_BASSERT, so leave bmalloc in place there (no ASAN lane
+    // on Windows anyway).
+    env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/bun/http/serve-error-handler-stream.test.ts
+++ b/test/js/bun/http/serve-error-handler-stream.test.ts
@@ -1,0 +1,93 @@
+// When an async fetch handler rejects and error() returns a Response whose
+// body is a ReadableStream, the stream must be allowed to finish.
+// Previously handle_reject() fell through to render_missing() while the sink
+// was still pumping, which force-ended the exchange after the first
+// synchronous chunk (or with an empty Content-Length: 0 body if the stream's
+// first pull awaited before enqueuing). With Connection: close the freed
+// socket is then written by the orphaned sink: heap-use-after-free under ASAN.
+//
+// Each case runs in a subprocess so a pre-fix ASAN crash is observed as a
+// test failure rather than killing the parent runner before junit is written.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+const fixture = join(import.meta.dir, "serve-error-handler-stream-fixture.ts");
+const CHUNKS = 12;
+const CHUNK_LEN = 64;
+
+async function runFixture(path: string, close = false) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, path, ...(close ? ["close"] : [])],
+    env: { ...bunEnv, Malloc: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("Bun.serve error() returning a streaming Response", () => {
+  // Controls: neither path hits handle_reject()'s fallthrough.
+  test.concurrent("control: plain streaming response completes", async () => {
+    const { stdout, stderr, exitCode } = await runFixture("/plain");
+    expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+      result: { status: 200, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS + 1 },
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("control: sync throw -> error() stream completes", async () => {
+    const { stdout, stderr, exitCode } = await runFixture("/sync");
+    expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+      result: { status: 597, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS + 1 },
+      exitCode: 0,
+    });
+  });
+
+  // The bug: async handler rejects, error() body is truncated to its
+  // synchronous prefix.
+  for (const close of [false, true]) {
+    const tag = close ? " (Connection: close)" : "";
+
+    test.concurrent(`async reject -> error() pull-stream completes${tag}`, async () => {
+      const { stdout, stderr, exitCode } = await runFixture("/async", close);
+      expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+        result: { status: 597, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS + 1 },
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`Promise.reject -> error() stream completes${tag}`, async () => {
+      const { stdout, stderr, exitCode } = await runFixture("/reject", close);
+      expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+        result: { status: 597, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS + 1 },
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`async reject -> error() stream whose first pull awaits is not emptied${tag}`, async () => {
+      const { stdout, stderr, exitCode } = await runFixture("/lazy", close);
+      expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+        result: { status: 597, len: CHUNK_LEN, pulls: 1 },
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`async reject -> error() direct stream completes${tag}`, async () => {
+      const { stdout, stderr, exitCode } = await runFixture("/direct", close);
+      expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+        result: { status: 597, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS },
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`async reject -> error() async-iterator body completes${tag}`, async () => {
+      const { stdout, stderr, exitCode } = await runFixture("/iter", close);
+      expect({ result: stdout === "" ? stderr : JSON.parse(stdout), exitCode }).toEqual({
+        result: { status: 597, len: CHUNK_LEN * CHUNKS, pulls: CHUNKS },
+        exitCode: 0,
+      });
+    });
+  }
+});

--- a/test/js/bun/http/serve-error-stream-client-abort-fixture.ts
+++ b/test/js/bun/http/serve-error-stream-client-abort-fixture.ts
@@ -1,0 +1,94 @@
+// An async-rejecting fetch() routes through handle_reject -> run_error_handler.
+// When error() returns a streaming Response whose producer is still pending,
+// handle_reject would fall through to render_missing() and end() the uWS
+// response underneath the live sink. A client abort then frees the socket and
+// a later controller.close()/enqueue() reads the freed HttpResponseData
+// (ASAN: heap-use-after-free in uws_res_has_responded).
+
+import net from "node:net";
+
+let resolveStarted!: () => void;
+let resumeProducer!: Promise<void>;
+let resolveOutcome!: (late: string) => void;
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  fetch: async () => {
+    throw new Error("boom");
+  },
+  error() {
+    return new Response(
+      new ReadableStream({
+        async pull(c) {
+          c.enqueue("EB");
+          resolveStarted();
+          // Park until the driver releases us (after the client has RST'd on
+          // the abort path), then yield once more so uSockets' post-tick
+          // closed-socket sweep has run before the late controller touch.
+          await resumeProducer;
+          await Bun.sleep(1);
+          try {
+            c.enqueue("MORE");
+            c.close();
+            resolveOutcome("ok");
+          } catch (e) {
+            resolveOutcome(String((e as Error)?.message ?? e));
+          }
+        },
+      }),
+      { status: 597 },
+    );
+  },
+});
+
+function armRequest() {
+  const started = new Promise<void>(r => (resolveStarted = r));
+  let releaseProducer!: () => void;
+  resumeProducer = new Promise(r => (releaseProducer = r));
+  const outcome = new Promise<string>(r => (resolveOutcome = r));
+  return { started, releaseProducer, outcome };
+}
+
+// Happy path: no abort, the stream must deliver both chunks.
+{
+  const { started, releaseProducer, outcome } = armRequest();
+  const bodyP = fetch(server.url).then(r => r.text());
+  await started;
+  releaseProducer();
+  const [body, late] = await Promise.all([bodyP, outcome]);
+  if (body !== "EBMORE" || late !== "ok") {
+    console.error(`happy-path body truncated: body=${JSON.stringify(body)} late=${late}`);
+    process.exit(1);
+  }
+}
+
+// Abort path: read the first bytes so the server has flushed the first chunk,
+// then RST the socket. The server must survive and the late close must observe
+// a detached controller.
+const closedMsg = "Controller is already closed";
+const lateCloseResults: string[] = [];
+for (let i = 0; i < 3; i++) {
+  const { started, releaseProducer, outcome } = armRequest();
+  await new Promise<void>((resolve, reject) => {
+    const s = net.connect(server.port, "127.0.0.1", () => {
+      s.write("GET /x HTTP/1.1\r\nHost: x\r\n\r\n");
+    });
+    s.once("data", () => {
+      s.resetAndDestroy();
+      resolve();
+    });
+    s.once("error", reject);
+  });
+  await started;
+  releaseProducer();
+  lateCloseResults.push(await outcome);
+}
+
+server.stop(true);
+
+if (lateCloseResults.length !== 3 || !lateCloseResults.every(r => r.includes(closedMsg))) {
+  console.error(`expected 3x "${closedMsg}", got: ${JSON.stringify(lateCloseResults)}`);
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, lateCloseResults }));

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -9,7 +9,7 @@
 //      with a clean `0\r\n\r\n`, so the client could not tell the truncated
 //      body apart from a complete one.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "serve-stream-body-error-fixture.ts");
@@ -150,3 +150,87 @@ test.concurrent("a stream body error does not kill the server process", async ()
   // The error must still be surfaced to the operator.
   expect(stderr).toContain("boom");
 });
+
+// An already-rejected async fetch handler reaches handle_reject synchronously
+// inside the uWS request callback. If error() then returns a Response whose
+// body is a ReadableStream that goes pending, do_render_stream attaches a
+// sink holding a raw uWS response pointer and returns. handle_reject's
+// "did the error handler respond?" check used to miss the pending stream and
+// call render_missing(), which ended the uWS response while the sink still
+// held the pointer. The socket was then freed in us_internal_free_closed_sockets,
+// and the stream's later rejection drove controller.close() -> sink.end()
+// -> uws_res_has_responded on the freed socket:
+//   AddressSanitizer: heap-use-after-free (READ of size 1)
+//     uws_res_has_responded <- HTTPServerWritable::end <- JSSink::js_close
+//     <- rsisSinkClose <- rsisAbrupt
+test.skipIf(!isASAN)(
+  "error() returning a pending stream after an already-rejected handler does not use-after-free the socket",
+  async () => {
+    const fixture = `
+      const net = require("node:net");
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: false,
+        // async + throw-before-await: an already-rejected promise, unwrapped
+        // synchronously in on_response -> handle_reject.
+        fetch: async () => { throw new Error("boom"); },
+        error() {
+          let i = 0;
+          return new Response(
+            new ReadableStream({
+              async pull(c) {
+                if (i++ === 0) { c.enqueue("EB"); await Bun.sleep(1); }
+                else throw new Error("nested");
+              },
+            }),
+            { status: 597 },
+          );
+        },
+      });
+
+      function rawRequest() {
+        return new Promise(resolve => {
+          const chunks = [];
+          const sock = net.connect(server.port, "127.0.0.1", () => {
+            sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+          });
+          sock.on("data", d => chunks.push(d));
+          sock.on("error", () => {});
+          sock.on("close", () => resolve(Buffer.concat(chunks).toString("latin1")));
+        });
+      }
+
+      const results = [];
+      for (let i = 0; i < 6; i++) {
+        const wire = await rawRequest();
+        results.push({
+          status: wire.split("\\r\\n")[0],
+          terminated: wire.endsWith("0\\r\\n\\r\\n"),
+        });
+        // Let the stream's rejection microtask and the socket-free loop post run.
+        for (let j = 0; j < 4; j++) await Bun.sleep(0);
+      }
+      console.log(JSON.stringify(results));
+      server.stop(true);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The stream errors after "EB" is on the wire, so the body is force-closed
+    // without the terminating 0\r\n\r\n chunk (RFC 9112 section 7).
+    const expected = Array(6).fill({ status: "HTTP/1.1 597 HM", terminated: false });
+    expect({ stderr, results: stdout.trim() ? JSON.parse(stdout) : stdout, exitCode }).toEqual({
+      stderr: "",
+      results: expected,
+      exitCode: 0,
+    });
+  },
+  30_000,
+);


### PR DESCRIPTION
## Reproduction

```js
Bun.serve({
  port: 0, development: false,
  // async + throw-before-await: an already-rejected promise
  fetch: async () => { throw new Error("boom"); },
  error() {
    let i = 0;
    return new Response(new ReadableStream({
      async pull(c) {
        if (i++ === 0) { c.enqueue("EB"); await Bun.sleep(1); }
        else throw new Error("nested");
      },
    }), { status: 597 });
  },
});
```

Two plain `GET / HTTP/1.1` requests with `Connection: close` crash an ASan build on the second request:

```
AddressSanitizer: heap-use-after-free (READ of size 1)
  uws_res_has_responded                  packages/bun-uws/src/HttpResponse.h:710
  HTTPServerWritable::end                src/runtime/webcore/streams.rs:1796
  JSSink::js_close                       src/runtime/webcore/Sink.rs:1077
  JSReadableHTTPResponseSinkController__close
  rsisSinkClose / rsisAbrupt             BunStreamSource.cpp
freed by: us_internal_free_closed_sockets  packages/bun-usockets/src/loop.c:305
```

Release builds read through the freed byte silently.

## Cause

`on_response` unwraps the already-rejected promise synchronously and calls `handle_reject`, which invokes the server's `error()` callback via `run_error_handler`. `error()` returns a Response whose body is a ReadableStream; `do_render_stream` attaches an `HTTPResponseSink` that stores the raw uWS response pointer, takes a ref on the context, registers the stream-resolution reactions, and returns with the pump promise still pending.

`handle_reject`'s post-`run_error_handler` guard decides whether the error handler produced a response:

```rust
if !resp.has_responded()
    && !ctx.flags.has_marked_pending()
    && !ctx.flags.is_error_promise_pending()
{
    ctx.render_missing();
}
```

A pending ReadableStream body sets none of these (`has_marked_pending` is set by the sendfile and write-backpressure paths, `is_error_promise_pending` only when `error()` itself returns a Promise), so `render_missing()` ran. That called `resp.end(b"")`, which in uWS `markDone()` drops `onAborted`, and `detach_response()` nulled `ctx.resp` while the sink still held the raw pointer. `to_async()`'s `set_abort_handler()` then saw `ctx.resp == None` and installed nothing.

With the client's `Connection: close`, uSockets frees the socket in `us_internal_free_closed_sockets` at loop post. The stream's second `pull()` later rejects; the read-stream-into-sink abort path calls `controller.close()`, and `HTTPServerWritable::end()` evaluates `self.any_res().unwrap().has_responded()` on the freed socket.

## Fix

`do_render_stream`'s `Pending` branch now sets `has_marked_pending`, matching what the sendfile and backpressure paths already do for an in-flight response. `handle_reject` then leaves the response alone; `to_async()` arms `onAborted`; and when the stream later rejects, `handle_reject_stream` tears the sink down and force-closes the body without the terminating chunk so the client observes an incomplete message.

## Verification

Added an ASan-gated subprocess test in `serve-stream-body-error.test.ts` that sends six requests to this server and asserts exit 0 with no sanitizer report. Without the fix the subprocess aborts with the heap-use-after-free above on the second request.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-error-handler-stream.test.ts

<!-- robobun:evidence:end -->