### PR TITLE
perf(webstreams): sync-pull fast path, pack flags into bitfields, codegen cleanup

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -350,9 +350,10 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         stringChunks.append({ WTF::String(), 0 });
         if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
             total += view->isDetached() ? 0 : view->byteLength();
-        else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk))
-            total += (jsBuffer->impl() && !jsBuffer->impl()->isDetached()) ? jsBuffer->impl()->byteLength() : 0;
-        else {
+        else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+            auto* impl = jsBuffer->impl();
+            total += (impl && !impl->isDetached()) ? impl->byteLength() : 0;
+        } else {
             throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
             return {};
         }
@@ -627,9 +628,10 @@ static JSValue textAccumulatorWrite(JSC::VM& vm, JSGlobalObject* globalObject, J
     size_t byteLength = 0;
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
         byteLength = view->isDetached() ? 0 : view->byteLength();
-    else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk))
-        byteLength = jsBuffer->impl() ? jsBuffer->impl()->byteLength() : 0;
-    else {
+    else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+        auto* impl = jsBuffer->impl();
+        byteLength = impl ? impl->byteLength() : 0;
+    } else {
         throwTypeError(globalObject, scope, "Expected text, ArrayBuffer or ArrayBufferView"_s);
         return {};
     }
@@ -661,9 +663,11 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         WTF::Locker locker { owner->cellLock() };
         accumulator.reset(locker);
     };
-    if (!accumulator.hasString && !accumulator.hasBuffer)
+    const bool hasString = accumulator.hasString;
+    const bool hasBuffer = accumulator.hasBuffer;
+    if (!hasString && !hasBuffer)
         return WTF::emptyString();
-    if (accumulator.hasString && !accumulator.hasBuffer) {
+    if (hasString && !hasBuffer) {
         if (exceedsStringLimit(accumulator.rope.length())) [[unlikely]] {
             releaseAccumulated();
             throwOutOfMemoryError(globalObject, scope);
@@ -676,8 +680,9 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         return rope;
     }
     WTF::Vector<uint8_t> bytes;
-    if (accumulator.estimatedLength > 0 && accumulator.estimatedLength < static_cast<double>(std::numeric_limits<uint32_t>::max()))
-        bytes.reserveInitialCapacity(static_cast<size_t>(accumulator.estimatedLength));
+    const double estimatedLength = accumulator.estimatedLength;
+    if (estimatedLength > 0 && estimatedLength < static_cast<double>(std::numeric_limits<uint32_t>::max()))
+        bytes.reserveInitialCapacity(static_cast<size_t>(estimatedLength));
     for (auto& piece : accumulator.pieces) {
         JSValue value = piece.get();
         if (!value)
@@ -717,7 +722,7 @@ static JSPromise* readerReadAsPromise(JSC::VM& vm, JSGlobalObject* globalObject,
 
 // The readableStreamIntoArray readMany continuation. Runs synchronously until readMany
 // returns a promise, then chains the next hop onto a fresh derived promise it returns.
-static JSValue intoArrayLoop(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSArray* chunks, JSValue manyResult)
+static JSValue intoArrayLoop(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSArray* __restrict chunks, JSValue manyResult)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* domGlobalObject = defaultGlobalObject(globalObject);
@@ -768,7 +773,8 @@ JSValue readableStreamIntoArray(JSGlobalObject* globalObject, WebCore::JSReadabl
     RETURN_IF_EXCEPTION(scope, {});
     auto* chunks = constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
-    bool isQueueBacked = stream->m_controllerKind == ControllerKind::Default || stream->m_controllerKind == ControllerKind::Byte;
+    const ControllerKind controllerKind = stream->m_controllerKind;
+    bool isQueueBacked = controllerKind == ControllerKind::Default || controllerKind == ControllerKind::Byte;
     if (!isQueueBacked) {
         // Direct (and controller-less) streams keep the generic readMany loop.
         JSValue result;
@@ -885,7 +891,7 @@ static JSValue finishDirectConsumeLoop(JSC::VM& vm, JSGlobalObject* globalObject
         RETURN_IF_EXCEPTION(scope, {});
     }
     if (stream->m_controllerKind == ControllerKind::Direct) {
-        auto* controller = uncheckedDowncast<JSDirectStreamController>(stream->m_controller.get());
+        const auto* controller = uncheckedDowncast<JSDirectStreamController>(stream->m_controller.get());
         if (controller->m_closingPromise)
             return controller->m_closingPromise.get();
     }
@@ -1020,8 +1026,9 @@ JSValue consumeDirectStreamToArrayBuffer(JSGlobalObject* globalObject, WebCore::
     stream->m_disturbed = true;
 
     JSObject* startOptions = constructEmptyObject(globalObject);
-    bool hasNumericHighWaterMark = stream->m_bunHighWaterMarkIsNumber || !std::isnan(stream->m_bunHighWaterMark);
-    startOptions->putDirect(vm, builtinNames(vm).highWaterMarkPublicName(), hasNumericHighWaterMark ? jsNumber(stream->m_bunHighWaterMark) : jsUndefined());
+    const double bunHighWaterMark = stream->m_bunHighWaterMark;
+    bool hasNumericHighWaterMark = stream->m_bunHighWaterMarkIsNumber || !std::isnan(bunHighWaterMark);
+    startOptions->putDirect(vm, builtinNames(vm).highWaterMarkPublicName(), hasNumericHighWaterMark ? jsNumber(bunHighWaterMark) : jsUndefined());
     startOptions->putDirect(vm, builtinNames(vm).asUint8ArrayPublicName(), jsBoolean(asUint8Array));
     MarkedArgumentBuffer startArguments;
     startArguments.append(startOptions);
@@ -1511,7 +1518,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadManyFulfilled, (JSGl
 }
 
 // The persistent-op pump: settle the op's result promise with an error, releasing the reader.
-static void intoArrayFinishWithError(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSPromise* resultPromise, JSValue error)
+static void intoArrayFinishWithError(JSC::VM& vm, JSGlobalObject* globalObject, WebCore::JSReadableStreamDefaultReader* reader, JSPromise* __restrict resultPromise, JSValue error)
 {
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -1601,7 +1608,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onIntoArrayReadRejected, (JSGlobalO
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* op = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(callFrame->uncheckedArgument(1));
+    const auto* op = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(callFrame->uncheckedArgument(1));
     intoArrayFinishWithError(vm, globalObject, op->m_reader.get(), op->m_result.get(), callFrame->argument(0));
     RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
 }
@@ -1651,7 +1658,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onConsumeDirectToArrayBufferPullFul
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
+    const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
     auto* stream = sink->m_stream.get();
     if (stream) {
         stream->m_lockedWithoutReader = false;
@@ -1665,7 +1672,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onConsumeDirectToArrayBufferPullRej
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
+    const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
     JSValue error = callFrame->argument(0);
     auto* stream = sink->m_stream.get();
     if (stream) {
@@ -1690,7 +1697,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectWrite, (JSGlobalO
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
+    const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
     if (sink->m_closed)
         return JSValue::encode(jsUndefined());
     MarkedArgumentBuffer arguments;
@@ -1727,7 +1734,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectClose, (JSGlobalO
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectFlush, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
+    const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
     if (sink->m_closed)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(jsNumber(0));

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -395,9 +395,10 @@ static void scheduleNativeSourceCallClose(JSGlobalObject* globalObject, JSNative
 
 static void nativeAdjustChunkSize(JSNativeStreamSourceAdapter* adapter, size_t resultBytes)
 {
-    if (resultBytes >= adapter->m_chunkSize && !adapter->m_hasResized) {
+    const size_t chunkSize = adapter->m_chunkSize;
+    if (resultBytes >= chunkSize && !adapter->m_hasResized) {
         adapter->m_hasResized = true;
-        adapter->m_chunkSize = std::min<size_t>(adapter->m_chunkSize * 2, nativeSourceMaxChunkSize);
+        adapter->m_chunkSize = std::min<size_t>(chunkSize * 2, nativeSourceMaxChunkSize);
     }
 }
 
@@ -411,12 +412,13 @@ static JSC::JSUint8Array* uint8Subarray(JSGlobalObject* globalObject, JSC::JSUin
 static JSC::JSUint8Array* nativeGetInternalBuffer(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
+    const size_t chunkSize = adapter->m_chunkSize;
     if (JSObject* pending = adapter->m_pendingView.get()) {
         auto* view = uncheckedDowncast<JSC::JSUint8Array>(pending);
-        if (!view->isDetached() && view->possiblySharedBuffer() && view->possiblySharedBuffer()->byteLength() >= adapter->m_chunkSize)
+        if (!view->isDetached() && view->possiblySharedBuffer() && view->possiblySharedBuffer()->byteLength() >= chunkSize)
             return view;
     }
-    auto* fresh = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), adapter->m_chunkSize);
+    auto* fresh = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), chunkSize);
     RETURN_IF_EXCEPTION(scope, nullptr);
     adapter->m_pendingView.set(vm, adapter, fresh);
     return fresh;
@@ -1078,7 +1080,7 @@ static bool rsisWriteChunkArrayFrom(JSC::VM& vm, JSGlobalObject* globalObject, J
 
 static void rsisAfterBatch(JSGlobalObject* globalObject, JSReadStreamIntoSinkOperation* op)
 {
-    auto* stream = op->m_stream.get();
+    const auto* stream = op->m_stream.get();
     if (op->m_didClose || (stream && stream->m_state == ReadableStreamState::Closed)) {
         rsisFinish(globalObject, op);
         return;

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -58,9 +58,9 @@ public:
     // adaptive chunk size (256 KiB default, doubled once up to 2 MiB).
     size_t m_chunkSize { 0 };
     // #hasResized — the one-shot chunk-size adaptation already happened.
-    bool m_hasResized { false };
+    bool m_hasResized : 1 { false };
     // #closed
-    bool m_closed { false };
+    bool m_closed : 1 { false };
 
 private:
     JSNativeStreamSourceAdapter(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
@@ -39,12 +39,12 @@ public:
     JSC::WriteBarrier<JSC::JSObject> m_controller;
     // The single promise returned to every pull() while the iterator runs.
     JSC::WriteBarrier<JSC::JSPromise> m_pullPromise;
-    bool m_cancelled { false };
-    bool m_done { false };
-    bool m_running { false };
+    bool m_cancelled : 1 { false };
+    bool m_done : 1 { false };
+    bool m_running : 1 { false };
     // {done:true, value} still writes the value first; this remembers the done across a
     // backpressure suspension on that final write.
-    bool m_iteratorDone { false };
+    bool m_iteratorDone : 1 { false };
 
 private:
     JSAsyncIteratorSourceOperation(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -167,9 +167,10 @@ static JSValue writeToTextSink(JSGlobalObject* globalObject, JSDirectStreamContr
     size_t byteLength = 0;
     if (auto* view = dynamicDowncast<JSArrayBufferView>(chunk))
         byteLength = view->isDetached() ? 0 : view->byteLength();
-    else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(chunk))
-        byteLength = (!buffer->impl() || buffer->impl()->isDetached()) ? 0 : buffer->impl()->byteLength();
-    else {
+    else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(chunk)) {
+        auto* impl = buffer->impl();
+        byteLength = (!impl || impl->isDetached()) ? 0 : impl->byteLength();
+    } else {
         throwTypeError(globalObject, scope, "Expected text, ArrayBuffer or ArrayBufferView"_s);
         return {};
     }
@@ -226,12 +227,14 @@ static JSValue writeToDirectSink(JSGlobalObject* globalObject, JSDirectStreamCon
 static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
     auto& accumulator = controller->m_textAccumulator;
-    if (!accumulator.hasString && !accumulator.hasBuffer)
+    const bool hasString = accumulator.hasString;
+    const bool hasBuffer = accumulator.hasBuffer;
+    if (!hasString && !hasBuffer)
         return emptyString();
 
     auto scope = DECLARE_THROW_SCOPE(vm);
     // Pure-string rope: the ONLY arm of the direct Text sink that strips a leading BOM.
-    if (accumulator.hasString && !accumulator.hasBuffer) {
+    if (hasString && !hasBuffer) {
         if (Bun::WebStreams::exceedsStringLimit(accumulator.rope.length())) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return String();
@@ -254,8 +257,9 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
             if (!view->isDetached())
                 bytes.append(view->span());
         } else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(value)) {
-            if (buffer->impl() && !buffer->impl()->isDetached())
-                bytes.append(buffer->impl()->span());
+            auto* impl = buffer->impl();
+            if (impl && !impl->isDetached())
+                bytes.append(impl->span());
         }
     }
     if (!accumulator.rope.isEmpty()) {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -63,16 +63,22 @@ public:
     int8_t m_deferClose { 0 };
     // -1 = pull in progress, 0 = idle, 1 = flush deferred
     int8_t m_deferFlush { 0 };
+    // which of the 3 sink flavors this controller runs.
+    DirectSinkKind m_sinkKind { DirectSinkKind::ArrayBuffer };
     // Once closed, the five methods are no-ops (there is NO "swap all 5 methods to a
     // throwing stub" trick).
-    bool m_closed { false };
+    bool m_closed : 1 { false };
     // An async pull()'s returned promise has not yet settled; cleared by its settlement
     // reactions. m_pullAgain is set only when a NEW read arrives while m_pullInFlight
     // (edge-triggered, matching the spec default controller's [[pullAgain]]).
-    bool m_pullInFlight { false };
-    bool m_pullAgain { false };
-    // which of the 3 sink flavors this controller runs.
-    DirectSinkKind m_sinkKind { DirectSinkKind::ArrayBuffer };
+    bool m_pullInFlight : 1 { false };
+    bool m_pullAgain : 1 { false };
+    bool m_calledDone : 1 { false };
+    // End-of-tick auto-flush (the JS-facing analogue of the HTTP sink's AutoFlusher):
+    // armed by write() when data is buffered below the HWM while a consumer waits; the
+    // deferred task runs right after the current microtask drain and delivers it.
+    bool m_endOfTickFlushArmed : 1 { false };
+    bool m_finalChunkArmed : 1 { false };
 
     // ArrayBuffer sink: a real Bun.ArrayBufferSink cell (ArrayBuffer kind only).
     JSC::WriteBarrier<JSC::JSObject> m_arrayBufferSink;
@@ -89,18 +95,12 @@ public:
 
     // Text/Array closing capability.
     JSC::WriteBarrier<JSC::JSPromise> m_closingPromise;
-    bool m_calledDone { false };
 
-    // End-of-tick auto-flush (the JS-facing analogue of the HTTP sink's AutoFlusher):
-    // armed by write() when data is buffered below the HWM while a consumer waits; the
-    // deferred task runs right after the current microtask drain and delivers it.
-    bool m_endOfTickFlushArmed { false };
     void armEndOfTickFlush(JSC::JSGlobalObject*);
 
     // Final-chunk-on-close: the NEXT read() delivers m_finalChunk then closes. onPull checks
     // m_finalChunkArmed FIRST.
     JSC::WriteBarrier<JSC::Unknown> m_finalChunk;
-    bool m_finalChunkArmed { false };
 
     // The state machine. All userJS: YES.
     // the READ pump: the default reader's read()/readMany() on a Direct stream lands here.

--- a/src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h
+++ b/src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h
@@ -57,9 +57,9 @@ public:
     // The underlying source's optional close() method, invoked by end()/close().
     JSC::WriteBarrier<JSC::Unknown> m_closeFunction;
     // Set by end()/close(): later write()/end()/close()/flush() calls are no-ops.
-    bool m_closed { false };
+    bool m_closed : 1 { false };
     // true ⇒ resolve with a Uint8Array (toBytes); false ⇒ an ArrayBuffer (toArrayBuffer).
-    bool m_asUint8Array { false };
+    bool m_asUint8Array : 1 { false };
 
 private:
     JSOneShotDirectSink(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSReadStreamIntoSinkOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSReadStreamIntoSinkOperation.h
@@ -44,9 +44,9 @@ public:
     JSC::WriteBarrier<JSC::JSObject> m_sink;
     // the JSPromise readStreamIntoSink returned (what Rust's Signal protocol awaits).
     JSC::WriteBarrier<JSC::JSPromise> m_result;
-    bool m_didThrow { false };
-    bool m_didClose { false };
-    bool m_started { false };
+    bool m_didThrow : 1 { false };
+    bool m_didClose : 1 { false };
+    bool m_started : 1 { false };
 
 private:
     JSReadStreamIntoSinkOperation(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -512,7 +512,8 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_close, 
         return Bun::ERR::INVALID_THIS(scope, globalObject, "ReadableByteStreamController"_s);
     if (thisObject->m_closeRequested)
         return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream is already closed"_s);
-    if (!thisObject->m_stream || thisObject->m_stream->m_state != ReadableStreamState::Readable)
+    const JSReadableStream* const stream = thisObject->m_stream.get();
+    if (!stream || stream->m_state != ReadableStreamState::Readable)
         return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream is already closed"_s);
     readableByteStreamControllerClose(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -540,7 +541,8 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_enqueue
         return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: chunk ArrayBuffer is zero-length or detached"_s);
     if (thisObject->m_closeRequested)
         return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream is already closed"_s);
-    if (!thisObject->m_stream || thisObject->m_stream->m_state != ReadableStreamState::Readable)
+    const JSReadableStream* const stream = thisObject->m_stream.get();
+    if (!stream || stream->m_state != ReadableStreamState::Readable)
         return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream is already closed"_s);
     readableByteStreamControllerEnqueue(globalObject, thisObject, chunk);
     RETURN_IF_EXCEPTION(scope, {});
@@ -732,7 +734,7 @@ void readableByteStreamControllerEnqueue(JSGlobalObject* globalObject, JSReadabl
             throwOutOfMemoryError(globalObject, scope);
             return;
         }
-        for (size_t i = 0; i < filledPullIntos.size(); ++i) {
+        for (size_t i = 0, count = filledPullIntos.size(); i < count; ++i) {
             readableByteStreamControllerCommitPullIntoDescriptor(globalObject, stream, uncheckedDowncast<JSPullIntoDescriptor>(filledPullIntos.at(i)));
             RETURN_IF_EXCEPTION(scope, void());
         }
@@ -780,8 +782,9 @@ void readableByteStreamControllerEnqueueDetachedPullIntoToQueue(JSGlobalObject* 
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(pullIntoDescriptor->m_readerType == ReaderType::None);
-    if (pullIntoDescriptor->m_bytesFilled > 0) {
-        readableByteStreamControllerEnqueueClonedChunkToQueue(globalObject, controller, *pullIntoDescriptor->m_buffer, pullIntoDescriptor->m_byteOffset, pullIntoDescriptor->m_bytesFilled);
+    const size_t bytesFilled = pullIntoDescriptor->m_bytesFilled;
+    if (bytesFilled > 0) {
+        readableByteStreamControllerEnqueueClonedChunkToQueue(globalObject, controller, *pullIntoDescriptor->m_buffer, pullIntoDescriptor->m_byteOffset, bytesFilled);
         RETURN_IF_EXCEPTION(scope, void());
     }
     readableByteStreamControllerShiftPendingPullInto(controller);
@@ -814,16 +817,17 @@ void readableByteStreamControllerFillHeadPullIntoDescriptor(JSReadableByteStream
 bool readableByteStreamControllerFillPullIntoDescriptorFromQueue(JSReadableByteStreamController* controller, JSPullIntoDescriptor* pullIntoDescriptor)
 {
     size_t elementSize = pullIntoDescriptor->elementSize();
-    size_t maxBytesToCopy = std::min(static_cast<size_t>(controller->m_queue.totalSize()), pullIntoDescriptor->m_byteLength - pullIntoDescriptor->m_bytesFilled);
-    size_t maxBytesFilled = pullIntoDescriptor->m_bytesFilled + maxBytesToCopy;
+    const size_t bytesFilled = pullIntoDescriptor->m_bytesFilled;
+    size_t maxBytesToCopy = std::min(static_cast<size_t>(controller->m_queue.totalSize()), pullIntoDescriptor->m_byteLength - bytesFilled);
+    size_t maxBytesFilled = bytesFilled + maxBytesToCopy;
     size_t totalBytesToCopyRemaining = maxBytesToCopy;
     bool ready = false;
     ASSERT(!pullIntoDescriptor->m_buffer->isDetached());
-    ASSERT(pullIntoDescriptor->m_bytesFilled < pullIntoDescriptor->m_minimumFill);
+    ASSERT(bytesFilled < pullIntoDescriptor->m_minimumFill);
     size_t remainderBytes = maxBytesFilled % elementSize;
     size_t maxAlignedBytes = maxBytesFilled - remainderBytes;
     if (maxAlignedBytes >= pullIntoDescriptor->m_minimumFill) {
-        totalBytesToCopyRemaining = maxAlignedBytes - pullIntoDescriptor->m_bytesFilled;
+        totalBytesToCopyRemaining = maxAlignedBytes - bytesFilled;
         ready = true;
     }
     auto& queue = controller->m_queue;
@@ -885,8 +889,9 @@ JSReadableStreamBYOBRequest* readableByteStreamControllerGetBYOBRequest(JSGlobal
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!controller->m_byobRequest && !controller->m_pendingPullIntos.isEmpty()) {
-        JSPullIntoDescriptor* firstDescriptor = controller->m_pendingPullIntos.first().get();
-        JSArrayBufferView* view = constructViewOfType(globalObject, JSC::TypeUint8, firstDescriptor->m_buffer, firstDescriptor->m_byteOffset + firstDescriptor->m_bytesFilled, firstDescriptor->m_byteLength - firstDescriptor->m_bytesFilled);
+        const JSPullIntoDescriptor* firstDescriptor = controller->m_pendingPullIntos.first().get();
+        const size_t bytesFilled = firstDescriptor->m_bytesFilled;
+        JSArrayBufferView* view = constructViewOfType(globalObject, JSC::TypeUint8, firstDescriptor->m_buffer, firstDescriptor->m_byteOffset + bytesFilled, firstDescriptor->m_byteLength - bytesFilled);
         RETURN_IF_EXCEPTION(scope, nullptr);
         auto* zigGlobalObject = defaultGlobalObject(globalObject);
         JSReadableStreamBYOBRequest* byobRequest = JSReadableStreamBYOBRequest::create(vm, getDOMStructure<JSReadableStreamBYOBRequest>(vm, *zigGlobalObject));
@@ -1083,7 +1088,7 @@ void readableByteStreamControllerRespondInClosedState(JSGlobalObject* globalObje
             throwOutOfMemoryError(globalObject, scope);
             return;
         }
-        for (size_t i = 0; i < filledPullIntos.size(); ++i) {
+        for (size_t i = 0, count = filledPullIntos.size(); i < count; ++i) {
             readableByteStreamControllerCommitPullIntoDescriptor(globalObject, stream, uncheckedDowncast<JSPullIntoDescriptor>(filledPullIntos.at(i)));
             RETURN_IF_EXCEPTION(scope, void());
         }
@@ -1105,18 +1110,19 @@ void readableByteStreamControllerRespondInReadableState(JSGlobalObject* globalOb
             throwOutOfMemoryError(globalObject, scope);
             return;
         }
-        for (size_t i = 0; i < filledPullIntos.size(); ++i) {
+        for (size_t i = 0, count = filledPullIntos.size(); i < count; ++i) {
             readableByteStreamControllerCommitPullIntoDescriptor(globalObject, controller->m_stream.get(), uncheckedDowncast<JSPullIntoDescriptor>(filledPullIntos.at(i)));
             RETURN_IF_EXCEPTION(scope, void());
         }
         return;
     }
-    if (pullIntoDescriptor->m_bytesFilled < pullIntoDescriptor->m_minimumFill)
+    const size_t bytesFilled = pullIntoDescriptor->m_bytesFilled;
+    if (bytesFilled < pullIntoDescriptor->m_minimumFill)
         return;
     readableByteStreamControllerShiftPendingPullInto(controller);
-    size_t remainderSize = pullIntoDescriptor->m_bytesFilled % pullIntoDescriptor->elementSize();
+    size_t remainderSize = bytesFilled % pullIntoDescriptor->elementSize();
     if (remainderSize > 0) {
-        size_t end = pullIntoDescriptor->m_byteOffset + pullIntoDescriptor->m_bytesFilled;
+        size_t end = pullIntoDescriptor->m_byteOffset + bytesFilled;
         readableByteStreamControllerEnqueueClonedChunkToQueue(globalObject, controller, *pullIntoDescriptor->m_buffer, end - remainderSize, remainderSize);
         RETURN_IF_EXCEPTION(scope, void());
     }
@@ -1129,7 +1135,7 @@ void readableByteStreamControllerRespondInReadableState(JSGlobalObject* globalOb
     }
     readableByteStreamControllerCommitPullIntoDescriptor(globalObject, controller->m_stream.get(), pullIntoDescriptor);
     RETURN_IF_EXCEPTION(scope, void());
-    for (size_t i = 0; i < filledPullIntos.size(); ++i) {
+    for (size_t i = 0, count = filledPullIntos.size(); i < count; ++i) {
         readableByteStreamControllerCommitPullIntoDescriptor(globalObject, controller->m_stream.get(), uncheckedDowncast<JSPullIntoDescriptor>(filledPullIntos.at(i)));
         RETURN_IF_EXCEPTION(scope, void());
     }
@@ -1177,7 +1183,8 @@ void readableByteStreamControllerRespondWithNewView(JSGlobalObject* globalObject
             return;
         }
     }
-    if (firstDescriptor->m_byteOffset + firstDescriptor->m_bytesFilled != view->byteOffset()) {
+    const size_t bytesFilled = firstDescriptor->m_bytesFilled;
+    if (firstDescriptor->m_byteOffset + bytesFilled != view->byteOffset()) {
         throwRangeError(globalObject, scope, "The view's byte offset does not match the BYOB request's current write position"_s);
         return;
     }
@@ -1186,7 +1193,7 @@ void readableByteStreamControllerRespondWithNewView(JSGlobalObject* globalObject
         throwRangeError(globalObject, scope, "The view's buffer length does not match the BYOB request's buffer length"_s);
         return;
     }
-    if (firstDescriptor->m_bytesFilled + viewByteLength > firstDescriptor->m_byteLength) {
+    if (bytesFilled + viewByteLength > firstDescriptor->m_byteLength) {
         throwRangeError(globalObject, scope, "The view's byte length exceeds the remaining length of the BYOB request"_s);
         return;
     }

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -597,24 +597,21 @@ void readableByteStreamControllerCallPullIfNeeded(JSGlobalObject* globalObject, 
         controller->m_pullAgain = true;
         return;
     }
-    // See readableStreamDefaultControllerCallPullIfNeeded.
-    while (true) {
-        ASSERT(!controller->m_pullAgain);
-        controller->m_pulling = true;
-        JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (pullPromise) {
-            auto* runtime = JSStreamsRuntime::from(globalObject);
-            pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
-            return;
-        }
-        controller->m_pulling = false;
-        if (!controller->m_pullAgain)
-            return;
-        controller->m_pullAgain = false;
-        if (!readableByteStreamControllerShouldCallPull(controller))
-            return;
+    ASSERT(!controller->m_pullAgain);
+    controller->m_pulling = true;
+    JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
+    RETURN_IF_EXCEPTION(scope, void());
+    auto* runtime = JSStreamsRuntime::from(globalObject);
+    if (pullPromise) {
+        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
+        return;
     }
+    // See readableStreamDefaultControllerCallPullIfNeeded.
+    if (!controller->m_pullAgain) {
+        controller->m_pulling = false;
+        return;
+    }
+    queueStreamsMicrotask(globalObject, runtime->onRSByteControllerPullFulfilled(), jsUndefined(), controller);
 }
 
 bool readableByteStreamControllerShouldCallPull(JSReadableByteStreamController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -602,7 +602,7 @@ void readableByteStreamControllerCallPullIfNeeded(JSGlobalObject* globalObject, 
     JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    if (pullPromise) {
+    if (pullPromise && pullPromise->status() != JSPromise::Status::Fulfilled) {
         pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
         return;
     }

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -144,6 +144,8 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
             return nullptr;
         if (!result.isObject()) [[likely]]
             return nullptr;
+        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->structure() == globalObject->promiseStructure())
+            return resultPromise;
         RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }
     case SourceKind::Nothing:

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -144,7 +144,7 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
             return nullptr;
         if (!result.isObject()) [[likely]]
             return nullptr;
-        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->structure() == globalObject->promiseStructure())
+        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
             return resultPromise;
         RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -111,6 +111,8 @@ static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalOb
 
 // The [[pullAlgorithm]] dispatch. The reachable kind set on a byte controller is exactly
 // {JavaScript, Nothing, ByteTeeBranch}; the switch is total over SourceKind.
+// Returns nullptr with no exception pending when the pull completed synchronously with a
+// non-thenable result: the caller runs the upon-fulfillment steps inline.
 static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSReadableByteStreamController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -118,18 +120,34 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
     case SourceKind::JavaScript: {
         JSC::JSObject* pullMethod = controller->m_algorithms.method1.get();
         if (!pullMethod)
-            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+            return nullptr;
         JSC::MarkedArgumentBuffer args;
         args.append(controller);
         if (args.hasOverflowed()) [[unlikely]] {
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
-        StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, pullMethod, controller->m_algorithms.underlyingObject.get(), args));
+        JSC::JSValue result;
+        JSC::JSValue thrown;
+        {
+            StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
+            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            auto callData = JSC::getCallData(pullMethod);
+            ASSERT(callData.type != JSC::CallData::Type::None);
+            result = JSC::call(globalObject, pullMethod, callData, controller->m_algorithms.underlyingObject.get(), args);
+            if (catchScope.exception()) [[unlikely]]
+                thrown = takeAbruptCompletion(globalObject, catchScope);
+        }
+        if (!thrown.isEmpty()) [[unlikely]]
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+        if (result.isEmpty()) [[unlikely]]
+            return nullptr;
+        if (!result.isObject()) [[likely]]
+            return nullptr;
+        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }
     case SourceKind::Nothing:
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+        return nullptr;
     case SourceKind::ByteTeeBranch:
         RELEASE_AND_RETURN(scope, byteTeePullAlgorithm(globalObject, uncheckedDowncast<JSStreamTeeState>(controller->m_algorithms.algorithmContext.get()), controller->m_algorithms.teeBranchIndex));
     case SourceKind::Transform:
@@ -579,12 +597,24 @@ void readableByteStreamControllerCallPullIfNeeded(JSGlobalObject* globalObject, 
         controller->m_pullAgain = true;
         return;
     }
-    ASSERT(!controller->m_pullAgain);
-    controller->m_pulling = true;
-    JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
-    RETURN_IF_EXCEPTION(scope, void());
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
+    // See readableStreamDefaultControllerCallPullIfNeeded.
+    while (true) {
+        ASSERT(!controller->m_pullAgain);
+        controller->m_pulling = true;
+        JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (pullPromise) {
+            auto* runtime = JSStreamsRuntime::from(globalObject);
+            pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
+            return;
+        }
+        controller->m_pulling = false;
+        if (!controller->m_pullAgain)
+            return;
+        controller->m_pullAgain = false;
+        if (!readableByteStreamControllerShouldCallPull(controller))
+            return;
+    }
 }
 
 bool readableByteStreamControllerShouldCallPull(JSReadableByteStreamController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -112,7 +112,7 @@ static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalOb
 // The [[pullAlgorithm]] dispatch. The reachable kind set on a byte controller is exactly
 // {JavaScript, Nothing, ByteTeeBranch}; the switch is total over SourceKind.
 // Returns nullptr with no exception pending when the pull completed synchronously with a
-// non-thenable result: the caller runs the upon-fulfillment steps inline.
+// non-thenable result: the caller queues the upon-fulfillment handler without a wrapper promise.
 static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSReadableByteStreamController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -127,10 +127,10 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
+        StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
         JSC::JSValue result;
         JSC::JSValue thrown;
         {
-            StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             auto callData = JSC::getCallData(pullMethod);
             ASSERT(callData.type != JSC::CallData::Type::None);
@@ -602,16 +602,10 @@ void readableByteStreamControllerCallPullIfNeeded(JSGlobalObject* globalObject, 
     JSPromise* pullPromise = performByteControllerPullAlgorithm(vm, globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    if (pullPromise && pullPromise->status() != JSPromise::Status::Fulfilled) {
-        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
-        return;
-    }
     // See readableStreamDefaultControllerCallPullIfNeeded.
-    if (!controller->m_pullAgain) {
-        controller->m_pulling = false;
-        return;
-    }
-    queueStreamsMicrotask(globalObject, runtime->onRSByteControllerPullFulfilled(), jsUndefined(), controller);
+    if (!pullPromise || pullPromise->status() == JSPromise::Status::Fulfilled)
+        return queueStreamsMicrotask(globalObject, runtime->onRSByteControllerPullFulfilled(), jsUndefined(), controller);
+    pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSByteControllerPullFulfilled(), runtime->onRSByteControllerPullRejected(), jsUndefined(), controller);
 }
 
 bool readableByteStreamControllerShouldCallPull(JSReadableByteStreamController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.h
@@ -65,13 +65,13 @@ public:
     // [[strategyHWM]]
     double m_strategyHWM { 0 };
     // [[started]]
-    bool m_started { false };
+    bool m_started : 1 { false };
     // [[pulling]]
-    bool m_pulling { false };
+    bool m_pulling : 1 { false };
     // [[pullAgain]]
-    bool m_pullAgain { false };
+    bool m_pullAgain : 1 { false };
     // [[closeRequested]]
-    bool m_closeRequested { false };
+    bool m_closeRequested : 1 { false };
 
     // The algorithm machinery — replaces [[pullAlgorithm]] and [[cancelAlgorithm]]. A byte
     // stream has NO size algorithm (a byte stream given a size strategy is a RangeError at

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -492,10 +492,10 @@ void JSReadableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 void JSReadableStream::materializeIfNeeded(JSGlobalObject* globalObject)
 {
-    if (m_bunMode == BunStreamMode::Default) [[likely]]
+    const auto mode = m_bunMode;
+    if (mode == BunStreamMode::Default) [[likely]]
         return;
     // Clear the mode BEFORE running the thunk so re-entrant consumers see it done.
-    auto mode = m_bunMode;
     m_bunMode = BunStreamMode::Default;
     if (mode == BunStreamMode::DirectPending)
         setUpDirectStreamController(globalObject, this, DirectSinkKind::ArrayBuffer, m_bunHighWaterMark);
@@ -770,7 +770,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsReadableStreamPrototype_nativePtrSetter, (JSGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamPrototype_nativeTypeGetter, (JSGlobalObject*, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* stream = uncheckedDowncast<JSReadableStream>(JSValue::decode(thisValue));
+    const auto* stream = uncheckedDowncast<JSReadableStream>(JSValue::decode(thisValue));
     return JSValue::encode(jsNumber(stream->m_nativeType));
 }
 
@@ -787,7 +787,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsReadableStreamPrototype_nativeTypeSetter, (JSGlobalOb
 
 JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamPrototype_disturbedGetter, (JSGlobalObject*, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* stream = uncheckedDowncast<JSReadableStream>(JSValue::decode(thisValue));
+    const auto* stream = uncheckedDowncast<JSReadableStream>(JSValue::decode(thisValue));
     return JSValue::encode(jsBoolean(stream->m_disturbed));
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -47,23 +47,23 @@ public:
 
     // [[state]]
     ReadableStreamState m_state { ReadableStreamState::Readable };
-    // [[disturbed]]
-    bool m_disturbed { false };
-    // [[Detached]] (transferable streams are not implemented; the slot exists)
-    bool m_detached { false };
-    // Bun: locked by a native/direct consumer WITHOUT a real reader object. Part of every
-    // isReadableStreamLocked() check.
-    bool m_lockedWithoutReader { false };
-    // `$bunNativeType`: write-only today, kept for the FFI ABI.
-    int32_t m_nativeType { 0 };
-    // Set by jsFunctionTransferToNativeReadableStream.
-    bool m_transferred { false };
     // The Bun lazy-start mode; tells materializeIfNeeded() what to do.
     BunStreamMode m_bunMode { BunStreamMode::Default };
     // The tag for the ERASED m_controller below. Every switch over it is TOTAL.
     ControllerKind m_controllerKind { ControllerKind::None };
+    // [[disturbed]]
+    bool m_disturbed : 1 { false };
+    // [[Detached]] (transferable streams are not implemented; the slot exists)
+    bool m_detached : 1 { false };
+    // Bun: locked by a native/direct consumer WITHOUT a real reader object. Part of every
+    // isReadableStreamLocked() check.
+    bool m_lockedWithoutReader : 1 { false };
+    // Set by jsFunctionTransferToNativeReadableStream.
+    bool m_transferred : 1 { false };
     // `typeof rawHighWaterMark === "number"` at construction time.
-    bool m_bunHighWaterMarkIsNumber { false };
+    bool m_bunHighWaterMarkIsNumber : 1 { false };
+    // `$bunNativeType`: write-only today, kept for the FFI ABI.
+    int32_t m_nativeType { 0 };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).
     JSC::WriteBarrier<JSReadableStreamReaderBase> m_reader;

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.h
@@ -45,9 +45,9 @@ public:
     // "ongoing promise" — chains get-the-next-iteration-result / return calls.
     JSC::WriteBarrier<JSC::JSPromise> m_ongoingPromise;
     // "prevent cancel" (values({ preventCancel }))
-    bool m_preventCancel { false };
+    bool m_preventCancel : 1 { false };
     // "is finished"
-    bool m_isFinished { false };
+    bool m_isFinished : 1 { false };
 
 private:
     JSReadableStreamAsyncIterator(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -67,7 +67,7 @@ void readableStreamBYOBReaderErrorReadIntoRequests(JSGlobalObject* globalObject,
     MarkedArgumentBuffer readIntoRequests;
     detachReadIntoRequests(vm, globalObject, reader, readIntoRequests);
     RETURN_IF_EXCEPTION(scope, void());
-    for (size_t i = 0; i < readIntoRequests.size(); ++i) {
+    for (size_t i = 0, count = readIntoRequests.size(); i < count; ++i) {
         uncheckedDowncast<WebCore::JSReadIntoRequest>(readIntoRequests.at(i))->errorSteps(globalObject, error);
         RETURN_IF_EXCEPTION(scope, void());
     }
@@ -370,7 +370,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_constructor, 
 
 JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_closed, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* reader = dynamicDowncast<JSReadableStreamBYOBReader>(JSValue::decode(thisValue));
+    const auto* reader = dynamicDowncast<JSReadableStreamBYOBReader>(JSValue::decode(thisValue));
     if (!reader) [[unlikely]]
         return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamBYOBReader"_s)));
     return JSValue::encode(reader->m_closedPromise.get());

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -52,6 +52,8 @@ static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalOb
 
 // The [[pullAlgorithm]] dispatch. ByteTeeBranch is byte-controller-only and CrossRealm sources
 // are never created (transferable streams are unimplemented); the switch is total over SourceKind.
+// Returns nullptr with no exception pending when the pull completed synchronously with a
+// non-thenable result: the caller runs the upon-fulfillment steps inline.
 static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -59,18 +61,34 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
     case SourceKind::JavaScript: {
         JSC::JSObject* pullMethod = controller->m_algorithms.method1.get();
         if (!pullMethod)
-            RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+            return nullptr;
         JSC::MarkedArgumentBuffer args;
         args.append(controller);
         if (args.hasOverflowed()) [[unlikely]] {
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
-        StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
-        RELEASE_AND_RETURN(scope, invokePromiseReturningMethod(vm, globalObject, pullMethod, controller->m_algorithms.underlyingObject.get(), args));
+        JSC::JSValue result;
+        JSC::JSValue thrown;
+        {
+            StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
+            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            auto callData = JSC::getCallData(pullMethod);
+            ASSERT(callData.type != JSC::CallData::Type::None);
+            result = JSC::call(globalObject, pullMethod, callData, controller->m_algorithms.underlyingObject.get(), args);
+            if (catchScope.exception()) [[unlikely]]
+                thrown = takeAbruptCompletion(globalObject, catchScope);
+        }
+        if (!thrown.isEmpty()) [[unlikely]]
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+        if (result.isEmpty()) [[unlikely]]
+            return nullptr;
+        if (!result.isObject()) [[likely]]
+            return nullptr;
+        RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }
     case SourceKind::Nothing:
-        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+        return nullptr;
     case SourceKind::Transform:
         RELEASE_AND_RETURN(scope, transformStreamDefaultSourcePullAlgorithm(globalObject, uncheckedDowncast<JSTransformStream>(controller->m_algorithms.algorithmContext.get())));
     case SourceKind::TeeBranch:
@@ -475,12 +493,29 @@ void readableStreamDefaultControllerCallPullIfNeeded(JSGlobalObject* globalObjec
         controller->m_pullAgain = true;
         return;
     }
-    ASSERT(!controller->m_pullAgain);
-    controller->m_pulling = true;
-    JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
-    RETURN_IF_EXCEPTION(scope, void());
-    auto* runtime = JSStreamsRuntime::from(globalObject);
-    pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
+    // A pull() that returns a non-thenable (the overwhelmingly common case for a JS source)
+    // completes synchronously: loop the upon-fulfillment steps here instead of allocating a
+    // wrapper promise and a microtask per chunk. Every Bun chunkSteps arm defers its
+    // consumer continuation via a promise or queueReactionJob, so a re-read from inside
+    // enqueue() only sets m_pullAgain (the m_pulling guard holds) and the loop picks it up
+    // after the stack unwinds, keeping stack depth constant.
+    while (true) {
+        ASSERT(!controller->m_pullAgain);
+        controller->m_pulling = true;
+        JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (pullPromise) {
+            auto* runtime = JSStreamsRuntime::from(globalObject);
+            pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
+            return;
+        }
+        controller->m_pulling = false;
+        if (!controller->m_pullAgain)
+            return;
+        controller->m_pullAgain = false;
+        if (!readableStreamDefaultControllerShouldCallPull(controller))
+            return;
+    }
 }
 
 bool readableStreamDefaultControllerShouldCallPull(JSReadableStreamDefaultController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -85,6 +85,11 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
             return nullptr;
         if (!result.isObject()) [[likely]]
             return nullptr;
+        // %Promise.resolve%(x) returns x unchanged when IsPromise(x) and x.constructor is
+        // %Promise%; a vanilla-structure JSPromise satisfies both, so skip the wrapper and the
+        // thenable .then chain. Subclassed/patched promises and other objects fall through.
+        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->structure() == globalObject->promiseStructure())
+            return resultPromise;
         RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }
     case SourceKind::Nothing:

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -498,12 +498,13 @@ void readableStreamDefaultControllerCallPullIfNeeded(JSGlobalObject* globalObjec
     JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    if (pullPromise) {
+    if (pullPromise && pullPromise->status() != JSPromise::Status::Fulfilled) {
         pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
         return;
     }
-    // A pull() that returned a non-thenable completed synchronously: skip the wrapper promise.
-    // When nothing during the pull set m_pullAgain, the upon-fulfillment steps are a no-op and
+    // A non-thenable return, or an already-fulfilled promise from an internal pull arm,
+    // completed synchronously: skip the performPromiseThen reactions. When nothing during
+    // the pull set m_pullAgain, the upon-fulfillment steps are just m_pulling = false and
     // can run inline. When m_pullAgain is set (enqueue()'s trailing callPullIfNeeded), defer
     // the re-pull as its own microtask to preserve spec timing and bound stack depth.
     if (!controller->m_pullAgain) {

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -85,10 +85,10 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
             return nullptr;
         if (!result.isObject()) [[likely]]
             return nullptr;
-        // %Promise.resolve%(x) returns x unchanged when IsPromise(x) and x.constructor is
-        // %Promise%; a vanilla-structure JSPromise satisfies both, so skip the wrapper and the
-        // thenable .then chain. Subclassed/patched promises and other objects fall through.
-        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->structure() == globalObject->promiseStructure())
+        // A vanilla JSPromise with an unpatched .then needs no wrapper: the caller uses
+        // performPromiseThenWithContext (internal reactions), so skipping promiseResolvedWith's
+        // thenable adoption is unobservable. Subclasses / patched .then fall through.
+        if (auto* resultPromise = dynamicDowncast<JSC::JSPromise>(result); resultPromise && resultPromise->isThenFastAndNonObservable())
             return resultPromise;
         RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
     }

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -493,29 +493,24 @@ void readableStreamDefaultControllerCallPullIfNeeded(JSGlobalObject* globalObjec
         controller->m_pullAgain = true;
         return;
     }
-    // A pull() that returns a non-thenable (the overwhelmingly common case for a JS source)
-    // completes synchronously: loop the upon-fulfillment steps here instead of allocating a
-    // wrapper promise and a microtask per chunk. Every Bun chunkSteps arm defers its
-    // consumer continuation via a promise or queueReactionJob, so a re-read from inside
-    // enqueue() only sets m_pullAgain (the m_pulling guard holds) and the loop picks it up
-    // after the stack unwinds, keeping stack depth constant.
-    while (true) {
-        ASSERT(!controller->m_pullAgain);
-        controller->m_pulling = true;
-        JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (pullPromise) {
-            auto* runtime = JSStreamsRuntime::from(globalObject);
-            pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
-            return;
-        }
-        controller->m_pulling = false;
-        if (!controller->m_pullAgain)
-            return;
-        controller->m_pullAgain = false;
-        if (!readableStreamDefaultControllerShouldCallPull(controller))
-            return;
+    ASSERT(!controller->m_pullAgain);
+    controller->m_pulling = true;
+    JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
+    RETURN_IF_EXCEPTION(scope, void());
+    auto* runtime = JSStreamsRuntime::from(globalObject);
+    if (pullPromise) {
+        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
+        return;
     }
+    // A pull() that returned a non-thenable completed synchronously: skip the wrapper promise.
+    // When nothing during the pull set m_pullAgain, the upon-fulfillment steps are a no-op and
+    // can run inline. When m_pullAgain is set (enqueue()'s trailing callPullIfNeeded), defer
+    // the re-pull as its own microtask to preserve spec timing and bound stack depth.
+    if (!controller->m_pullAgain) {
+        controller->m_pulling = false;
+        return;
+    }
+    queueStreamsMicrotask(globalObject, runtime->onRSDefaultControllerPullFulfilled(), jsUndefined(), controller);
 }
 
 bool readableStreamDefaultControllerShouldCallPull(JSReadableStreamDefaultController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -53,7 +53,7 @@ static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalOb
 // The [[pullAlgorithm]] dispatch. ByteTeeBranch is byte-controller-only and CrossRealm sources
 // are never created (transferable streams are unimplemented); the switch is total over SourceKind.
 // Returns nullptr with no exception pending when the pull completed synchronously with a
-// non-thenable result: the caller runs the upon-fulfillment steps inline.
+// non-thenable result: the caller queues the upon-fulfillment handler without a wrapper promise.
 static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -68,10 +68,10 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
             JSC::throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
+        StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
         JSC::JSValue result;
         JSC::JSValue thrown;
         {
-            StreamAsyncContextScope asyncContextScope(globalObject, controller->m_stream.get());
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             auto callData = JSC::getCallData(pullMethod);
             ASSERT(callData.type != JSC::CallData::Type::None);
@@ -498,20 +498,13 @@ void readableStreamDefaultControllerCallPullIfNeeded(JSGlobalObject* globalObjec
     JSPromise* pullPromise = performDefaultControllerPullAlgorithm(vm, globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    if (pullPromise && pullPromise->status() != JSPromise::Status::Fulfilled) {
-        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
-        return;
-    }
     // A non-thenable return, or an already-fulfilled promise from an internal pull arm,
-    // completed synchronously: skip the performPromiseThen reactions. When nothing during
-    // the pull set m_pullAgain, the upon-fulfillment steps are just m_pulling = false and
-    // can run inline. When m_pullAgain is set (enqueue()'s trailing callPullIfNeeded), defer
-    // the re-pull as its own microtask to preserve spec timing and bound stack depth.
-    if (!controller->m_pullAgain) {
-        controller->m_pulling = false;
-        return;
-    }
-    queueStreamsMicrotask(globalObject, runtime->onRSDefaultControllerPullFulfilled(), jsUndefined(), controller);
+    // completed synchronously: queue the upon-fulfillment handler directly, saving the
+    // wrapper promise and performPromiseThen reactions while keeping the spec's microtask
+    // boundary (m_pulling stays set until then, so pull-call count is unchanged).
+    if (!pullPromise || pullPromise->status() == JSPromise::Status::Fulfilled)
+        return queueStreamsMicrotask(globalObject, runtime->onRSDefaultControllerPullFulfilled(), jsUndefined(), controller);
+    pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onRSDefaultControllerPullFulfilled(), runtime->onRSDefaultControllerPullRejected(), jsUndefined(), controller);
 }
 
 bool readableStreamDefaultControllerShouldCallPull(JSReadableStreamDefaultController* controller)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.h
@@ -53,13 +53,13 @@ public:
     // [[strategyHWM]]
     double m_strategyHWM { 1 };
     // [[started]]
-    bool m_started { false };
+    bool m_started : 1 { false };
     // [[pulling]]
-    bool m_pulling { false };
+    bool m_pulling : 1 { false };
     // [[pullAgain]]
-    bool m_pullAgain { false };
+    bool m_pullAgain : 1 { false };
     // [[closeRequested]]
-    bool m_closeRequested { false };
+    bool m_closeRequested : 1 { false };
 
     // The algorithm machinery — replaces [[pullAlgorithm]] and [[cancelAlgorithm]]; the
     // start algorithm is never stored. See SourceAlgorithmSlots (StreamQueue.h).

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -73,7 +73,7 @@ void readableStreamDefaultReaderErrorReadRequests(JSGlobalObject* globalObject, 
     MarkedArgumentBuffer readRequests;
     detachReadRequests(vm, globalObject, reader, readRequests);
     RETURN_IF_EXCEPTION(scope, void());
-    for (size_t i = 0; i < readRequests.size(); ++i) {
+    for (size_t i = 0, count = readRequests.size(); i < count; ++i) {
         uncheckedDowncast<WebCore::JSReadRequest>(readRequests.at(i))->errorSteps(globalObject, error);
         RETURN_IF_EXCEPTION(scope, void());
     }
@@ -103,9 +103,10 @@ void readableStreamDefaultReaderRead(JSGlobalObject* globalObject, JSReadableStr
     auto* stream = reader->m_stream.get();
     ASSERT(stream);
     stream->m_disturbed = true;
-    if (stream->m_state == ReadableStreamState::Closed)
+    const ReadableStreamState state = stream->m_state;
+    if (state == ReadableStreamState::Closed)
         RELEASE_AND_RETURN(scope, readRequest->closeSteps(globalObject));
-    if (stream->m_state == ReadableStreamState::Errored) {
+    if (state == ReadableStreamState::Errored) {
         JSValue storedError = stream->m_storedError.get();
         RELEASE_AND_RETURN(scope, readRequest->errorSteps(globalObject, storedError ? storedError : jsUndefined()));
     }
@@ -186,7 +187,7 @@ static JSObject* createReadManyResult(JSC::VM& vm, JSGlobalObject* globalObject,
 // Appends every queued chunk to `into` at `base`, runs the close-if-requested /
 // pull-if-needed step, resets the queue, and returns the PRE-drain [[queueTotalSize]]
 // (the pull decision runs against it, matching the readMany contract).
-static double drainQueueEntriesInto(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* stream, JSArray* into, unsigned base)
+static double drainQueueEntriesInto(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* __restrict stream, JSArray* __restrict into, unsigned base)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isByte = stream->m_controllerKind == ControllerKind::Byte;
@@ -376,16 +377,18 @@ JSValue readableStreamDefaultReaderReadMany(JSGlobalObject* globalObject, JSRead
         return {};
     }
     stream->m_disturbed = true;
-    if (stream->m_state == ReadableStreamState::Errored) {
+    const ReadableStreamState state = stream->m_state;
+    if (state == ReadableStreamState::Errored) {
         JSValue storedError = stream->m_storedError.get();
         throwException(globalObject, scope, storedError ? storedError : jsUndefined());
         return {};
     }
 
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    switch (stream->m_controllerKind) {
+    const ControllerKind controllerKind = stream->m_controllerKind;
+    switch (controllerKind) {
     case ControllerKind::Direct: {
-        if (stream->m_state == ReadableStreamState::Closed)
+        if (state == ReadableStreamState::Closed)
             break;
         auto* controller = uncheckedDowncast<WebCore::JSDirectStreamController>(stream->m_controller.get());
         JSValue pulled = controller->onPull(globalObject);
@@ -399,7 +402,7 @@ JSValue readableStreamDefaultReaderReadMany(JSGlobalObject* globalObject, JSRead
         return result;
     }
     case ControllerKind::None:
-        if (stream->m_state == ReadableStreamState::Closed)
+        if (state == ReadableStreamState::Closed)
             break;
         throwException(globalObject, scope, Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: This ReadableStream has no controller"_s));
         return {};
@@ -409,7 +412,7 @@ JSValue readableStreamDefaultReaderReadMany(JSGlobalObject* globalObject, JSRead
         return {};
     case ControllerKind::Default:
     case ControllerKind::Byte: {
-        bool isByte = stream->m_controllerKind == ControllerKind::Byte;
+        bool isByte = controllerKind == ControllerKind::Byte;
         bool queueIsEmpty = isByte ? byteControllerOf(stream)->m_queue.isEmpty() : defaultControllerOf(stream)->m_queue.isEmpty();
         if (!queueIsEmpty)
             RELEASE_AND_RETURN(scope, drainQueueForReadMany(vm, globalObject, stream, JSValue()));
@@ -678,7 +681,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_constructo
 
 JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_closed, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(JSValue::decode(thisValue));
+    const auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(JSValue::decode(thisValue));
     if (!reader) [[unlikely]]
         return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamDefaultReader"_s)));
     return JSValue::encode(reader->m_closedPromise.get());

--- a/src/jsc/bindings/webcore/streams/JSResumableSinkPumpOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSResumableSinkPumpOperation.h
@@ -43,9 +43,9 @@ public:
     // the sticky error, if any (gated by m_closed / emptiness).
     JSC::WriteBarrier<JSC::Unknown> m_error;
     // a drain loop is running (re-entrancy guard).
-    bool m_reading { false };
+    bool m_reading : 1 { false };
     // terminal.
-    bool m_closed { false };
+    bool m_closed : 1 { false };
 
 private:
     JSResumableSinkPumpOperation(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -219,7 +219,7 @@ static void performPipeShutdownAction(JSGlobalObject* globalObject, JSStreamPipe
 
 void JSStreamPipeToOperation::checkErrorsMustBePropagatedForward(JSGlobalObject* globalObject)
 {
-    auto* source = m_source.get();
+    const auto* source = m_source.get();
     if (source->m_state != ReadableStreamState::Errored)
         return;
     JSValue storedError = source->m_storedError.get();
@@ -233,7 +233,7 @@ void JSStreamPipeToOperation::checkErrorsMustBePropagatedForward(JSGlobalObject*
 
 void JSStreamPipeToOperation::checkErrorsMustBePropagatedBackward(JSGlobalObject* globalObject)
 {
-    auto* destination = m_destination.get();
+    const auto* destination = m_destination.get();
     if (destination->m_state != WritableStreamState::Errored)
         return;
     JSValue storedError = destination->m_storedError.get();
@@ -587,8 +587,8 @@ void startPipeToOperation(JSGlobalObject* globalObject, JSStreamPipeToOperation*
         op->m_abortAlgorithmId = WebCore::AbortSignal::addAbortAlgorithmToSignal(signal, WebCore::JSAbortAlgorithm::create(vm, boundAlgorithm));
     }
 
-    auto* reader = op->m_reader.get();
-    auto* writer = op->m_writer.get();
+    const auto* reader = op->m_reader.get();
+    const auto* writer = op->m_writer.get();
     WebCore::registerPipeReaction(globalObject, reader->m_closedPromise.get(), runtime->onPipeSourceClosedFulfilled(), runtime->onPipeSourceClosedRejected(), op);
     WebCore::registerPipeReaction(globalObject, writer->m_closedPromise.get(), runtime->onPipeDestClosedFulfilled(), runtime->onPipeDestClosedRejected(), op);
 
@@ -612,7 +612,7 @@ void pipeToReadRequestChunkSteps(JSGlobalObject* globalObject, JSStreamPipeToOpe
     op->m_readInFlight = false;
     if (op->m_finalized)
         return;
-    auto* writer = op->m_writer.get();
+    const auto* writer = op->m_writer.get();
     auto* runtime = JSStreamsRuntime::from(globalObject);
     // The sink write is deferred by one microtask so an enqueue() inside the source never
     // synchronously reenters the destination's write algorithm. m_currentWrite is the deferred

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.h
@@ -127,22 +127,22 @@ public:
     // The `originalError` / `error` handed to finalize; gated by m_hasShutdownError
     // (an error value of `undefined` is legal).
     JSC::WriteBarrier<JSC::Unknown> m_shutdownError;
-    bool m_hasShutdownError { false };
     // "shutdown with an action" wait-for-all latch: the number of action promises still
     // pending (AbortBoth registers two). The last settlement proceeds.
     uint8_t m_pendingShutdownActions { 0 };
     // The pending-abort action: which spec action shutdownWithAction is to perform once the
     // pending writes drain (onWritesFinishedForShutdown). No closures.
     ShutdownAction m_pendingShutdownAction { ShutdownAction::None };
+    bool m_hasShutdownError : 1 { false };
     // `shuttingDown`
-    bool m_shuttingDown { false };
+    bool m_shuttingDown : 1 { false };
     // set once "finalize" ran (back-edges cleared, abort algorithm removed).
-    bool m_finalized { false };
+    bool m_finalized : 1 { false };
     // a read has been issued and its read request has not settled yet.
-    bool m_readInFlight { false };
-    bool m_preventClose { false };
-    bool m_preventAbort { false };
-    bool m_preventCancel { false };
+    bool m_readInFlight : 1 { false };
+    bool m_preventClose : 1 { false };
+    bool m_preventAbort : 1 { false };
+    bool m_preventCancel : 1 { false };
 
 private:
     JSStreamPipeToOperation(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.h
@@ -50,17 +50,17 @@ public:
     JSC::WriteBarrier<JSC::Unknown> m_reason1;
     JSC::WriteBarrier<JSC::Unknown> m_reason2;
     // `reading`
-    bool m_reading { false };
+    bool m_reading : 1 { false };
     // default tee: `readAgain`; byte tee: `readAgainForBranch1`. (One flag, two spec names.)
-    bool m_readAgain1 { false };
+    bool m_readAgain1 : 1 { false };
     // byte tee only: `readAgainForBranch2`.
-    bool m_readAgain2 { false };
+    bool m_readAgain2 : 1 { false };
     // `canceled1` / `canceled2`
-    bool m_canceled1 { false };
-    bool m_canceled2 { false };
+    bool m_canceled1 : 1 { false };
+    bool m_canceled2 : 1 { false };
     // Bun: structured-clone branch2's chunks (Response.clone() passes true;
     // ReadableStream.prototype.tee() passes false). Default-tee chunkSteps only.
-    bool m_shouldClone { false };
+    bool m_shouldClone : 1 { false };
 
 private:
     JSStreamTeeState(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -278,7 +278,7 @@ static EncodedJSValue textDecoderStreamDelegatedGetter(JSGlobalObject* lexicalGl
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
+    const auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return throwThisTypeError(*lexicalGlobalObject, scope, "TextDecoderStream"_s, attributeName);
     RELEASE_AND_RETURN(scope, JSValue::encode(stream->m_decoder->get(lexicalGlobalObject, property)));
@@ -303,7 +303,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_readable, (JSGlobalO
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
+    const auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextDecoderStream"_s);
     return JSValue::encode(stream->m_transform->m_readable.get());
@@ -313,7 +313,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_writable, (JSGlobalO
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
+    const auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextDecoderStream"_s);
     return JSValue::encode(stream->m_transform->m_writable.get());

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -49,9 +49,9 @@ public:
     JSC::WriteBarrier<JSC::JSPromise> m_backpressureChangePromise;
     // [[backpressure]] — InitializeTransformStream sets it (to true) before anything reads it,
     // so the spec's initial "undefined" state needs no separate representation.
-    bool m_backpressure { false };
+    bool m_backpressure : 1 { false };
     // [[Detached]] (transferable streams are not implemented; the slot exists)
-    bool m_detached { false };
+    bool m_detached : 1 { false };
 
 private:
     JSTransformStream(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -32,7 +32,7 @@ using namespace JSC;
 // that teardown) can see a readable with no controller. A torn-down readable is terminal.
 static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
 {
-    auto* readable = stream->m_readable.get();
+    const auto* readable = stream->m_readable.get();
     if (readable->m_controllerKind != ControllerKind::Default)
         return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
@@ -262,7 +262,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSPerformTransformRejected, (JSGl
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue rejection = callFrame->argument(0);
-    auto* controller = uncheckedDowncast<JSTransformStreamDefaultController>(callFrame->argument(1));
+    const auto* controller = uncheckedDowncast<JSTransformStreamDefaultController>(callFrame->argument(1));
     transformStreamError(globalObject, controller->m_stream.get(), rejection);
     RETURN_IF_EXCEPTION(scope, {});
     throwException(globalObject, scope, rejection);
@@ -285,7 +285,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTransformStreamDefaultControllerPrototypeGetter_desir
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(JSValue::decode(thisValue));
+    const auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, globalObject, "TransformStreamDefaultController"_s);
     auto* readableController = transformReadableController(thisObject->m_stream.get());

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.h
@@ -85,9 +85,9 @@ public:
     // [[state]]
     WritableStreamState m_state { WritableStreamState::Writable };
     // [[backpressure]]
-    bool m_backpressure { false };
+    bool m_backpressure : 1 { false };
     // [[Detached]] (transferable streams are not implemented; the slot exists)
-    bool m_detached { false };
+    bool m_detached : 1 { false };
 
 private:
     JSWritableStream(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -319,7 +319,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onWSControllerStartFulfilled, (JSGl
     auto* controller = dynamicDowncast<JSWritableStreamDefaultController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    auto* stream = controller->m_stream.get();
+    const auto* stream = controller->m_stream.get();
     ASSERT(stream->m_state == WritableStreamState::Writable || stream->m_state == WritableStreamState::Erroring);
     UNUSED_PARAM(stream);
     controller->m_started = true;
@@ -347,7 +347,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onWSSinkCloseFulfilled, (JSGlobalOb
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* controller = dynamicDowncast<JSWritableStreamDefaultController>(callFrame->argument(1));
+    const auto* controller = dynamicDowncast<JSWritableStreamDefaultController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
     writableStreamFinishInFlightClose(globalObject, controller->m_stream.get());
@@ -359,7 +359,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onWSSinkCloseRejected, (JSGlobalObj
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* controller = dynamicDowncast<JSWritableStreamDefaultController>(callFrame->argument(1));
+    const auto* controller = dynamicDowncast<JSWritableStreamDefaultController>(callFrame->argument(1));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
     writableStreamFinishInFlightCloseWithError(globalObject, controller->m_stream.get(), callFrame->argument(0));
@@ -424,7 +424,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultControllerPrototypeGetter_signal
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(JSValue::decode(thisValue));
+    const auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, globalObject, "WritableStreamDefaultController"_s);
     auto* jsAbortController = uncheckedDowncast<JSAbortController>(thisObject->m_abortController.get());

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -97,7 +97,7 @@ void writableStreamDefaultWriterEnsureReadyPromiseRejected(JSGlobalObject* globa
 // Provably-non-throwing leaf: reads members and does queue arithmetic only.
 std::optional<double> writableStreamDefaultWriterGetDesiredSize(JSWritableStreamDefaultWriter* writer)
 {
-    auto* stream = writer->m_stream.get();
+    const auto* stream = writer->m_stream.get();
     switch (stream->m_state) {
     case WritableStreamState::Errored:
     case WritableStreamState::Erroring:
@@ -388,7 +388,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_constructo
 
 JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_closed, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
+    const auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
     if (!writer) [[unlikely]]
         return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a WritableStreamDefaultWriter"_s)));
     return JSValue::encode(writer->m_closedPromise.get());
@@ -411,7 +411,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_desiredSiz
 
 JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_ready, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))
 {
-    auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
+    const auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
     if (!writer) [[unlikely]]
         return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'ready' getter can only be used on a WritableStreamDefaultWriter"_s)));
     return JSValue::encode(writer->m_readyPromise.get());
@@ -455,7 +455,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototypeFunction_releaseL
     auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(callFrame->thisValue());
     if (!writer) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStreamDefaultWriter"_s);
-    auto* stream = writer->m_stream.get();
+    const auto* stream = writer->m_stream.get();
     if (!stream)
         return JSValue::encode(jsUndefined());
     ASSERT(stream->m_writer);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -274,7 +274,7 @@ void readableStreamClose(JSGlobalObject* globalObject, JSReadableStream* stream)
     MarkedArgumentBuffer readRequests;
     detachReadRequests(vm, globalObject, defaultReader, readRequests);
     RETURN_IF_EXCEPTION(scope, void());
-    for (size_t i = 0; i < readRequests.size(); ++i) {
+    for (size_t i = 0, count = readRequests.size(); i < count; ++i) {
         uncheckedDowncast<JSReadRequest>(readRequests.at(i))->closeSteps(globalObject);
         RETURN_IF_EXCEPTION(scope, void());
     }
@@ -359,9 +359,10 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     auto* runtime = JSStreamsRuntime::from(globalObject);
 
     stream->m_disturbed = true;
-    if (stream->m_state == ReadableStreamState::Closed)
+    const ReadableStreamState state = stream->m_state;
+    if (state == ReadableStreamState::Closed)
         RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
-    if (stream->m_state == ReadableStreamState::Errored)
+    if (state == ReadableStreamState::Errored)
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, stream->m_storedError.get()));
 
     readableStreamClose(globalObject, stream);
@@ -373,7 +374,7 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
         MarkedArgumentBuffer readIntoRequests;
         detachReadRequests(vm, globalObject, byobReader, readIntoRequests);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        for (size_t i = 0; i < readIntoRequests.size(); ++i) {
+        for (size_t i = 0, count = readIntoRequests.size(); i < count; ++i) {
             uncheckedDowncast<JSReadIntoRequest>(readIntoRequests.at(i))->closeSteps(globalObject, nullptr);
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
@@ -503,7 +504,7 @@ void readableStreamReaderGenericRelease(JSGlobalObject* globalObject, JSReadable
         controller->releaseSteps();
         // Bun: drop the native handle's event-loop ref when its consumer releases the lock.
         if (stream->m_nativePtr && controller->m_algorithms.kind == SourceKind::Native) {
-            auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
+            const auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
             if (auto* handle = adapter->m_handle.get()) {
                 JSValue updateRef = handle->getIfPropertyExists(globalObject, builtinNames(vm).updateRefPublicName());
                 RETURN_IF_EXCEPTION(scope, void());
@@ -589,7 +590,7 @@ JSReadableStreamBYOBReader* acquireReadableStreamBYOBReader(JSGlobalObject* glob
 
 // SetUpReadableStreamDefaultController steps 1-8. The caller populated the controller's
 // algorithm slots; the start reaction (steps 10-12) is registered by the caller.
-static void installDefaultController(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* stream, JSReadableStreamDefaultController* controller, double highWaterMark)
+static void installDefaultController(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* __restrict stream, JSReadableStreamDefaultController* __restrict controller, double highWaterMark)
 {
     ASSERT(stream->m_controllerKind == ControllerKind::None && !stream->m_controller);
     controller->m_stream.set(vm, controller, stream);
@@ -647,7 +648,7 @@ void setUpReadableStreamDefaultControllerFromUnderlyingSource(JSGlobalObject* gl
 }
 
 // SetUpReadableByteStreamController steps 1-13.
-static void installByteController(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* stream, JSReadableByteStreamController* controller, double highWaterMark, std::optional<uint64_t> autoAllocateChunkSize)
+static void installByteController(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* __restrict stream, JSReadableByteStreamController* __restrict controller, double highWaterMark, std::optional<uint64_t> autoAllocateChunkSize)
 {
     ASSERT(stream->m_controllerKind == ControllerKind::None && !stream->m_controller);
     if (autoAllocateChunkSize)
@@ -828,7 +829,7 @@ JSPromise* fromIterablePullAlgorithm(JSGlobalObject* globalObject, JSReadableStr
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
+    const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
     IterationRecord iteratorRecord { context->m_iterator.get(), context->m_nextMethod.get() };
 
     JSValue nextResult;
@@ -856,7 +857,7 @@ JSPromise* fromIterableCancelAlgorithm(JSGlobalObject* globalObject, JSReadableS
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
+    const auto* context = uncheckedDowncast<WebCore::JSStreamFromIterableContext>(controller->m_algorithms.algorithmContext.get());
     JSObject* iterator = context->m_iterator.get();
 
     JSValue returnMethod;
@@ -1162,7 +1163,7 @@ JSPromise* byteTeePullAlgorithm(JSGlobalObject* globalObject, JSStreamTeeState* 
     }
     teeState->m_reading = true;
     auto* branchStream = branch ? teeState->m_branch2.get() : teeState->m_branch1.get();
-    auto* byobRequest = readableByteStreamControllerGetBYOBRequest(globalObject, byteControllerOf(branchStream));
+    const auto* byobRequest = readableByteStreamControllerGetBYOBRequest(globalObject, byteControllerOf(branchStream));
     RETURN_IF_EXCEPTION(scope, nullptr);
     if (!byobRequest)
         byteTeePullWithDefaultReader(vm, globalObject, teeState);
@@ -1304,7 +1305,7 @@ static EncodedJSValue byteTeeReaderClosedRejected(JSGlobalObject* globalObject, 
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* teeState = uncheckedDowncast<JSStreamTeeState>(context->getInternalField(0));
+    const auto* teeState = uncheckedDowncast<JSStreamTeeState>(context->getInternalField(0));
     if (context->getInternalField(1) != teeState->m_reader.get())
         return JSValue::encode(jsUndefined());
     if (auto* controller1 = teeBranchByteController(teeState->m_branch1.get())) {

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -32,7 +32,7 @@ using WebCore::JSStreamsRuntime;
 // that teardown) can see a readable with no controller. A torn-down readable is terminal.
 static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
 {
-    auto* readable = stream->m_readable.get();
+    const auto* readable = stream->m_readable.get();
     if (readable->m_controllerKind != ControllerKind::Default)
         return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
@@ -313,10 +313,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkWriteBackpressureChangeFulf
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* context = uncheckedDowncast<InternalFieldTuple>(callFrame->argument(1));
-    auto* stream = uncheckedDowncast<JSTransformStream>(context->getInternalField(0));
+    const auto* stream = uncheckedDowncast<JSTransformStream>(context->getInternalField(0));
     JSValue chunk = context->getInternalField(1);
 
-    auto* writable = stream->m_writable.get();
+    const auto* writable = stream->m_writable.get();
     if (writable->m_state == WritableStreamState::Erroring) {
         throwException(globalObject, scope, writable->m_storedError.get());
         return {};
@@ -336,7 +336,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkAbortCancelFulfilled, (JSGl
     JSValue reason = context->getInternalField(1);
     auto* finishPromise = stream->m_controller->m_finishPromise.get();
 
-    auto* readable = stream->m_readable.get();
+    const auto* readable = stream->m_readable.get();
     if (readable->m_state == ReadableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
         return JSValue::encode(jsUndefined());
@@ -374,7 +374,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkCloseFlushFulfilled, (JSGlo
     auto* stream = uncheckedDowncast<JSTransformStream>(callFrame->argument(1));
     auto* finishPromise = stream->m_controller->m_finishPromise.get();
 
-    auto* readable = stream->m_readable.get();
+    const auto* readable = stream->m_readable.get();
     if (readable->m_state == ReadableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
         return JSValue::encode(jsUndefined());
@@ -414,7 +414,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSourceCancelFulfilled, (JSGloba
     JSValue reason = context->getInternalField(1);
     auto* finishPromise = stream->m_controller->m_finishPromise.get();
 
-    auto* writable = stream->m_writable.get();
+    const auto* writable = stream->m_writable.get();
     if (writable->m_state == WritableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, writable->m_storedError.get());
         return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -259,10 +259,10 @@ StreamAsyncContextScope::StreamAsyncContextScope(JSGlobalObject* globalObject, J
         return;
     auto* asyncContextData = globalObject->m_asyncContextData.get();
     JSValue current = asyncContextData->getInternalField(0);
-    if (snapshot == current)
-        return;
     m_asyncContextData = asyncContextData;
     m_previous = current;
+    if (snapshot == current)
+        return;
     asyncContextData->putInternalField(m_vm, 0, snapshot);
 }
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -257,9 +257,13 @@ StreamAsyncContextScope::StreamAsyncContextScope(JSGlobalObject* globalObject, J
     JSValue snapshot = stream->m_asyncContext.get();
     if (!snapshot || snapshot.isUndefinedOrNull())
         return;
-    m_asyncContextData = globalObject->m_asyncContextData.get();
-    m_previous = m_asyncContextData->getInternalField(0);
-    m_asyncContextData->putInternalField(m_vm, 0, snapshot);
+    auto* asyncContextData = globalObject->m_asyncContextData.get();
+    JSValue current = asyncContextData->getInternalField(0);
+    if (snapshot == current)
+        return;
+    m_asyncContextData = asyncContextData;
+    m_previous = current;
+    asyncContextData->putInternalField(m_vm, 0, snapshot);
 }
 
 StreamAsyncContextScope::~StreamAsyncContextScope()

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -448,7 +448,7 @@ JSPromise* webStreamClosedPromise(JSGlobalObject* globalObject, JSWritableStream
 // record" sites only. Empty return = a VM termination the caller must propagate.
 JSValue takeAbruptCompletion(JSGlobalObject*, TopExceptionScope& catchScope)
 {
-    JSC::Exception* exception = catchScope.exception();
+    const JSC::Exception* exception = catchScope.exception();
     ASSERT(exception);
     JSValue thrown = exception->value();
     if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]

--- a/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
@@ -35,7 +35,7 @@ static void clearPendingAbortRequest(JSWritableStream* stream)
 
 // SetUpWritableStreamDefaultController, minus reacting to the start result. The algorithm
 // slots and the size algorithm were already populated on `controller` by the caller.
-static void setUpWritableStreamDefaultControllerBeforeStart(JSC::VM& vm, JSGlobalObject* globalObject, JSWritableStream* stream, JSWritableStreamDefaultController* controller, double highWaterMark)
+static void setUpWritableStreamDefaultControllerBeforeStart(JSC::VM& vm, JSGlobalObject* globalObject, JSWritableStream* __restrict stream, JSWritableStreamDefaultController* __restrict controller, double highWaterMark)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -238,7 +238,7 @@ JSPromise* writableStreamClose(JSGlobalObject* globalObject, JSWritableStream* s
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     stream->m_closeRequest.set(vm, stream, promise);
 
-    auto* writer = stream->m_writer.get();
+    const auto* writer = stream->m_writer.get();
     if (writer && stream->m_backpressure && state == WritableStreamState::Writable) {
         resolvePromise(globalObject, writer->m_readyPromise.get(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -271,12 +271,13 @@ void writableStreamDealWithRejection(JSGlobalObject* globalObject, JSWritableStr
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (stream->m_state == WritableStreamState::Writable) {
+    const WritableStreamState state = stream->m_state;
+    if (state == WritableStreamState::Writable) {
         writableStreamStartErroring(globalObject, stream, error);
         RETURN_IF_EXCEPTION(scope, );
         return;
     }
-    ASSERT(stream->m_state == WritableStreamState::Erroring);
+    ASSERT(state == WritableStreamState::Erroring);
     RELEASE_AND_RETURN(scope, writableStreamFinishErroring(globalObject, stream));
 }
 
@@ -287,7 +288,7 @@ void writableStreamStartErroring(JSGlobalObject* globalObject, JSWritableStream*
 
     ASSERT(!stream->m_storedError);
     ASSERT(stream->m_state == WritableStreamState::Writable);
-    auto* controller = stream->m_controller.get();
+    const auto* controller = stream->m_controller.get();
     ASSERT(controller);
 
     stream->m_state = WritableStreamState::Erroring;
@@ -509,13 +510,14 @@ void setUpWritableStreamDefaultControllerFromUnderlyingSink(JSGlobalObject* glob
     RETURN_IF_EXCEPTION(scope, );
 
     JSValue startResult = jsUndefined();
-    if (underlyingSinkDict.start) {
+    const JSValue start = underlyingSinkDict.start;
+    if (start) {
         MarkedArgumentBuffer args;
         args.append(controller);
         ASSERT(!args.hasOverflowed());
-        auto callData = JSC::getCallData(underlyingSinkDict.start);
+        auto callData = JSC::getCallData(start);
         ASSERT(callData.type != CallData::Type::None);
-        startResult = JSC::call(globalObject, underlyingSinkDict.start, callData, underlyingSink, args);
+        startResult = JSC::call(globalObject, start, callData, underlyingSink, args);
         RETURN_IF_EXCEPTION(scope, );
     }
     RELEASE_AND_RETURN(scope, reactToWritableControllerStart(vm, globalObject, controller, startResult));

--- a/test/js/web/streams/sync-pull-fast-path.test.ts
+++ b/test/js/web/streams/sync-pull-fast-path.test.ts
@@ -1,88 +1,78 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// A JS-backed ReadableStream whose pull() returns undefined (the common case) used to route
-// every pull through promiseResolvedWith(result) + performPromiseThenWithContext, allocating a
-// JSPromise (plus its PromiseReactions) per chunk on the read/pull hot loop. This test proves
-// that overhead is gone by counting live Promise cells across a stretch of pull-driven reads.
-test("pull() returning undefined does not allocate a wrapper promise per chunk", async () => {
-  const src = `
-    const { heapStats } = require("bun:jsc");
+// A JS pull() that returns undefined used to go through promiseResolvedWith + performPromiseThen,
+// allocating a wrapper JSPromise per chunk. callPullIfNeeded now queues the fulfilled handler
+// directly, so only reader.read()'s own result promise remains per chunk.
+describe.each(["default", "bytes"] as const)("pull() sync fast path (%s controller)", kind => {
+  test("no wrapper promise allocated per chunk", async () => {
+    const src = `
+      const { heapStats } = require("bun:jsc");
+      const READS = 4000;
+      async function drain() {
+        let i = 0;
+        const rs = new ReadableStream({
+          ${kind === "bytes" ? 'type: "bytes",' : ""}
+          pull(c) {
+            if (i++ < READS) c.enqueue(new Uint8Array(1));
+            else c.close();
+          },
+        });
+        const reader = rs.getReader();
+        while (!(await reader.read()).done) {}
+      }
+      await drain();
+      Bun.gc(true);
+      const before = heapStats().objectTypeCounts.Promise || 0;
+      await drain();
+      const after = heapStats().objectTypeCounts.Promise || 0;
+      console.log(JSON.stringify({ delta: after - before, reads: READS }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const { delta, reads } = JSON.parse(stdout.trim());
+    // Old path: ~2*reads (wrapper + its resolve-chain). Fast path: ~1*reads (read()'s own).
+    expect({ belowThreshold: delta < reads * 1.5, stderr, exitCode }).toEqual({
+      belowThreshold: true,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 
-    const READS = 4000;
-    const chunk = new Uint8Array(1);
-
-    async function drain() {
+  test("many-chunk Response(stream).arrayBuffer() does not overflow the stack", async () => {
+    const N = 20000;
+    const src = `
       let i = 0;
-      const rs = new ReadableStream({
+      const stream = new ReadableStream({
+        ${kind === "bytes" ? 'type: "bytes",' : ""}
         pull(c) {
-          if (i++ < READS) c.enqueue(chunk);
+          if (i++ < ${N}) c.enqueue(new Uint8Array([1]));
           else c.close();
         },
       });
+      console.log((await new Response(stream).arrayBuffer()).byteLength);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: String(N), stderr: "", exitCode: 0 });
+  });
+
+  // callPullIfNeeded must not spin synchronously: a pull() that always enqueues would pin
+  // a sync re-pull loop at 100% CPU and never return from read(). The microtask-deferred
+  // re-pull lets read() resolve, then cancel() stops the fill and the process exits.
+  test("re-pull after a sync enqueue is not a synchronous loop", async () => {
+    const src = `
+      const rs = new ReadableStream({
+        ${kind === "bytes" ? 'type: "bytes",' : ""}
+        pull(c) { c.enqueue(new Uint8Array(1)); },
+      });
       const reader = rs.getReader();
-      while (!(await reader.read()).done) {}
-    }
-
-    // Warm up the machinery and settle any one-off allocations.
-    await drain();
-    Bun.gc(true);
-
-    const before = heapStats().objectTypeCounts.Promise || 0;
-    await drain();
-    const after = heapStats().objectTypeCounts.Promise || 0;
-
-    // Without the fast path each of the READS pulls allocates a wrapper promise, so
-    // (after - before) sits in the thousands until a GC. With the fast path the only
-    // promises are the per-read ones the await already drains.
-    console.log(JSON.stringify({ before, after, delta: after - before, reads: READS }));
-  `;
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+      const { done } = await reader.read();
+      await reader.cancel();
+      console.log(done ? "bad" : "ok");
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  const { delta, reads } = JSON.parse(stdout.trim());
-  // reader.read()'s own result promise is one per read and unavoidable; the old path
-  // additionally allocated a wrapper promise (promiseResolvedWith) per pull plus its
-  // resolve-chain promise, landing around 3*reads. Bound at 1.5*reads: fails on the
-  // old path, passes on the fast path.
-  expect(delta).toBeLessThan(reads * 1.5);
-  expect(exitCode).toBe(0);
-});
-
-// Regression guard for the synchronous-re-pull recursion pitfall: a pump-based consumer
-// (Response body collection) over a JS-source stream with many sync-pull chunks must not
-// overflow the stack. The m_pullAgain re-pull is deferred as a microtask, so stack depth
-// stays constant.
-test("Response(stream).arrayBuffer() over many sync-pull chunks does not overflow", async () => {
-  const N = 30000;
-  const src = `
-    let i = 0;
-    const stream = new ReadableStream({
-      pull(c) {
-        if (i++ < ${N}) c.enqueue(new Uint8Array([1]));
-        else c.close();
-      },
-    });
-    const buf = await new Response(stream).arrayBuffer();
-    console.log(buf.byteLength);
-  `;
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe(String(N));
-  expect(exitCode).toBe(0);
 });

--- a/test/js/web/streams/sync-pull-fast-path.test.ts
+++ b/test/js/web/streams/sync-pull-fast-path.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A JS-backed ReadableStream whose pull() returns undefined (the common case) used to route
+// every pull through promiseResolvedWith(result) + performPromiseThenWithContext, allocating a
+// JSPromise (plus its PromiseReactions) per chunk on the read/pull hot loop. This test proves
+// that overhead is gone by counting live Promise cells across a stretch of pull-driven reads.
+test("pull() returning undefined does not allocate a wrapper promise per chunk", async () => {
+  const src = `
+    const { heapStats } = require("bun:jsc");
+
+    const READS = 4000;
+    const chunk = new Uint8Array(1);
+
+    async function drain() {
+      let i = 0;
+      const rs = new ReadableStream({
+        pull(c) {
+          if (i++ < READS) c.enqueue(chunk);
+          else c.close();
+        },
+      });
+      const reader = rs.getReader();
+      while (!(await reader.read()).done) {}
+    }
+
+    // Warm up the machinery and settle any one-off allocations.
+    await drain();
+    Bun.gc(true);
+
+    const before = heapStats().objectTypeCounts.Promise || 0;
+    await drain();
+    const after = heapStats().objectTypeCounts.Promise || 0;
+
+    // Without the fast path each of the READS pulls allocates a wrapper promise, so
+    // (after - before) sits in the thousands until a GC. With the fast path the only
+    // promises are the per-read ones the await already drains.
+    console.log(JSON.stringify({ before, after, delta: after - before, reads: READS }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { delta, reads } = JSON.parse(stdout.trim());
+  // reader.read()'s own result promise is one per read and unavoidable; the old path
+  // additionally allocated a wrapper promise (promiseResolvedWith) per pull plus its
+  // resolve-chain promise, landing around 3*reads. Bound at 1.5*reads: fails on the
+  // old path, passes on the fast path.
+  expect(delta).toBeLessThan(reads * 1.5);
+  expect(exitCode).toBe(0);
+});
+
+// Regression guard for the synchronous-re-pull recursion pitfall: a pump-based consumer
+// (Response body collection) over a JS-source stream with many sync-pull chunks must not
+// overflow the stack. The m_pullAgain re-pull is deferred as a microtask, so stack depth
+// stays constant.
+test("Response(stream).arrayBuffer() over many sync-pull chunks does not overflow", async () => {
+  const N = 30000;
+  const src = `
+    let i = 0;
+    const stream = new ReadableStream({
+      pull(c) {
+        if (i++ < ${N}) c.enqueue(new Uint8Array([1]));
+        else c.close();
+      },
+    });
+    const buf = await new Response(stream).arrayBuffer();
+    console.log(buf.byteLength);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(String(N));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Three independent changes to the native WebStreams implementation in `src/jsc/bindings/webcore/streams/`.

### Synchronous pull() fast path

Every pull() of a JS-backed ReadableStream controller was routed through `promiseResolvedWith(result)` + `performPromiseThenWithContext`, even when `pull()` returned `undefined` (the overwhelmingly common case for `pull(c) { c.enqueue(x); }`). That's a JSPromise allocation and two PromiseReaction allocations on the read/pull hot loop per chunk.

`perform{Default,Byte}ControllerPullAlgorithm` now:
- returns `nullptr` when the JS pull() returned a non-object or when the source kind is `Nothing`;
- returns the JS pull() result directly when it is a vanilla JSPromise (`isThenFastAndNonObservable()`), skipping `promiseResolvedWith`'s wrapper promise and its thenable `.then` chain. Subclassed/patched promises and other objects still go through `promiseResolvedWith`.

`callPullIfNeeded` treats a `nullptr` or an already-fulfilled promise as synchronous completion: it queues the existing `onRS*ControllerPullFulfilled` handler directly via `queueStreamsMicrotask`, saving the `performPromiseThen` reactions while keeping the spec's microtask boundary (`m_pulling` stays set until then, so pull-call count is unchanged).

A thrown pull() still becomes a rejected promise so error handling is unchanged. `StreamAsyncContextScope` stays live over `promiseResolvedWith` so a thenable's `Get(result, "then")` sees the stream's construction-time async-context snapshot, matching the cancel path.

### Bitfield packing

Boolean members on the stream/controller/tee/pipe cells are packed as `bool m : 1`. On `JSReadableStream` the five bools were also reordered next to the three uint8_t enum members (8 bytes total, down from 16 with the previous interleaving around `m_nativeType`). None of these flags are address-taken or reached via offsetof.

### Code-quality cleanup in the .cpp helpers

- hoist repeated `foo->m_bar` / `foo->m_bar.get()` reads into a const local where no intervening call can mutate them
- `__restrict` on the static controller-install helpers where the two pointer parameters are distinct JSCell-derived types
- hoist `MarkedArgumentBuffer::size()` out of loop conditions that don't mutate the buffer
- `const T*` on a handful of pointee-read-only locals

### Benchmarks

linux-x64, 200k × 16-byte chunks, best of 5 per workload in each of 3 interleaved runs, release build of the same base commit with only `src/jsc/bindings/webcore/streams/` reverted for the `main` column.

| pull() shape | workload | main | this PR | delta |
| --- | --- | --- | --- | --- |
| `pull(c){...}` | `reader.read()` | 3.69M/s | 3.90M/s | +6% |
| `pull(c){...}` | `for await` | 3.06M/s | 3.64M/s | +19% |
| `async pull(c){...}` | `reader.read()` | 2.95M/s | 3.76M/s | +27% |
| `async pull(c){...}` | `for await` | 2.53M/s | 3.42M/s | +35% |
| `type:"bytes"` sync | `reader.read()` | 1.44M/s | 1.51M/s | +5% |
| `type:"bytes"` sync | `for await` | 1.25M/s | 1.34M/s | +7% |

Promise cells per read (heapStats, 4000 reads so no mid-run GC):

| pull() shape | main | this PR |
| --- | --- | --- |
| `pull(c){...}` | 2.00 | 1.00 |
| `async pull(c){...}` | 3.00 | 2.00 |
| `type:"bytes"` sync | 2.00 | 1.00 |

### Tests

`test/js/third_party/wpt-streams/wpt-streams.test.ts`: 1175 pass / 0 fail.

`test/js/web/streams/sync-pull-fast-path.test.ts` (new, `describe.each` over default + `type: "bytes"`):
- Promise allocation regression (fails on main at 2 cells/read vs threshold 1.5, passes here at 1)
- 20k-chunk `Response(new ReadableStream({ pull })).arrayBuffer()` stack-depth guard
- `pull(c) { c.enqueue(...) }` + read() + cancel() exits (re-pull is not a synchronous loop)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 32 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/sync-pull-fast-path.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (987f0000a)

test/js/web/streams/sync-pull-fast-path.test.ts:
30 |     `;
31 |     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
32 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 |     const { delta, reads } = JSON.parse(stdout.trim());
34 |     // Old path: ~2*reads (wrapper + its resolve-chain). Fast path: ~1*reads (read()'s own).
35 |     expect({ belowThreshold: delta < reads * 1.5, stderr, exitCode }).toEqual({
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "belowThreshold": true,
+   "belowThreshold": fal
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (374fb0d99)

test/js/web/streams/sync-pull-fast-path.test.ts:
(pass) pull() sync fast path (default controller) > no wrapper promise allocated per chunk [18.80ms]
(pass) pull() sync fast path (default controller) > many-chunk Response(stream).arrayBuffer() does not overflow the stack [25.33ms]
(pass) pull() sync fast path (default controller) > re-pull after a sync enqueue is not a synchronous loop [12.28ms]
(pass) pull() sync fast path (bytes controller) > no wrapper promise allocated per chunk [20.90ms]
(pass) pull() sync fast path (bytes controller) > many-chunk Response(stream).arrayBuffer() does not overflow the stack [36.46ms]
(pass) pull() sync fast path (bytes controller) > re-pull after a sync enqueue is not a synchronous loop [11.80ms]

 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [277.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/sync-pull-fast-path.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (987f0000a)

test/js/web/streams/sync-pull-fast-path.test.ts:
(pass) pull() sync fast path (default controller) > no wrapper promise allocated per chunk [1332.21ms]
(pass) pull() sync fast path (default controller) > many-chunk Response(stream).arrayBuffer() does not overflow the stack [2620.61ms]
(pass) pull() sync fast path (default controller) > re-pull after a sync enqueue is not a synchronous loop [507.07ms]
(pass) pull() sync fast path (bytes controller) > no wrapper promise allocated per chunk [1769.13ms]
(pass) pull() sync fast path (bytes controller) > many-chunk Response(stream).arrayBuffer() does not overflow the stack [3391.59ms]
(pass) pull() sync fast path (bytes controller) > re-pull after a sync enqueue 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/36] gen cpp.rs (cppbind)
[1/36] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         | 49 ++++++++------
 .../bindings/webcore/streams/BunStreamSource.cpp   | 12 ++--
 src/jsc/bindings/webcore/streams/BunStreamSource.h |  4 +-
 .../streams/JSAsyncIteratorSourceOperation.h       |  8 +--
 .../webcore/streams/JSDirectStreamController.cpp   | 18 +++--
 .../webcore/streams/JSDirectStreamController.h     | 22 +++---
 .../bindings/webcore/streams/JSOneShotDirectSink.h |  4 +-
 .../streams/JSReadStreamIntoSinkOperation.h        |  6 +-
 .../streams/JSReadableByteStreamController.cpp     | 74 ++++++++++++++------
 .../streams/JSReadableByteStreamController.h       |  8 +--
 .../bindings/webcore/streams/JSReadableStream.cpp  |  8 +--
 .../bindings/webcore/streams/JSReadableStream.h    | 22 +++---
 .../streams/JSReadableStreamAsyncIterator.h        |  4 +-
 .../webcore/streams/JSReadableStreamBYOBReader.cpp |  4 +-
 .../streams/JSReadableStreamDefaultController.cpp  | 35 +++++++++-
 .../streams/JSReadableStreamDefaultController.h    |  8 +--
 .../streams/JSReadableStreamDefaultReader.cpp      | 23 ++++---
 .../webcore/streams/JSResumableSinkPumpOperation.h |  4 +-
 .../webcore/streams/JSStreamPipeToOperation.cpp    | 10 +--
 .../webcore/streams/JSStreamPipeToOperation.h      | 14 ++--
 .../bindings/webcore/streams/JSStreamTeeState.h    | 12 ++--
 .../webcore/streams/JSTextDecoderStream.cpp        |  6 +-
 .../bindings/webcore/streams/JSTransformStream.h   |  4 +-
 .../streams/JSTransformStreamDefaultController.cpp |  6 +-
 .../bindings/webcore/streams/JSWritableStream.h    |  4 +-
 .../streams/JSWritableStreamDefaultController.cpp  |  8 +--
 .../streams/JSWritableStreamDefaultWriter.cpp      |  8 +--
 .../webcore/streams/ReadableStreamOperations.cpp   | 23 ++++---
 .../webcore/streams/TransformStreamOperations.cpp  | 12 ++--
 .../bindings/webcore/streams/WebStreamsMisc.cpp    | 12 ++--
 .../webcore/streams/WritableStreamOperations.cpp   | 18 ++---
 test/js/web/streams/sync-pull-fast-path.test.
... (truncated)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp       0      0      0
src/jsc/bindings/webcore/streams/BunStreamSource.cpp          1      0      0
src/jsc/bindings/webcore/streams/BunStreamSource.h            2      1      0
…ndings/webcore/streams/JSAsyncIteratorSourceOperation.h      1      1      0
…c/bindings/webcore/streams/JSDirectStreamController.cpp      0      0      0
…jsc/bindings/webcore/streams/JSDirectStreamController.h      1      2      0
src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h        2      1      0
…indings/webcore/streams/JSReadStreamIntoSinkOperation.h      1      1      0
…ings/webcore/streams/JSReadableByteStreamController.cpp      9     12      0
…ndings/webcore/streams/JSReadableByteStreamController.h      1      1      0
src/jsc/bindings/webcore/streams/JSReadableStream.cpp         0      0      0
src/jsc/bindings/webcore/streams/JSReadableStream.h           1      1      0
…indings/webcore/streams/JSReadableStreamAsyncIterator.h      1      1      0
…bindings/webcore/streams/JSReadableStreamBYOBReader.cpp      0      0      0
…s/webcore/streams/JSReadableStreamDefaultController.cpp      9     16      0
…ngs/webcore/streams/JSReadableStreamDefaultController.h      1      1      0
(+ 16 more files)
```

</details>

<!-- robobun:evidence:end -->