### PR TITLE
scripts/build.ts: fix TDZ ReferenceError on --help

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -51,16 +51,6 @@ import { interactive, nameColor, status } from "./build/tty.ts";
 // Main
 // ───────────────────────────────────────────────────────────────────────────
 
-try {
-  await main();
-} catch (err) {
-  if (err instanceof BuildError) {
-    process.stderr.write(err.format());
-    process.exit(1);
-  }
-  throw err;
-}
-
 async function main(): Promise<void> {
   // Windows: re-exec inside the VS dev shell if not already there.
   // The shell provides PATH (mt.exe, rc.exe, cl.exe), INCLUDE, LIB,
@@ -589,3 +579,15 @@ Examples:
   bun scripts/build.ts --target=bun-rust
   bun scripts/build.ts --configure-only
 `;
+
+// Entry point — must run after all module-level declarations (USAGE) are
+// initialized, otherwise parseArgs hits a TDZ ReferenceError on --help.
+try {
+  await main();
+} catch (err) {
+  if (err instanceof BuildError) {
+    process.stderr.write(err.format());
+    process.exit(1);
+  }
+  throw err;
+}


### PR DESCRIPTION
## Repro

```
$ bun bd --help
ReferenceError: Cannot access 'USAGE' before initialization.
      at parseArgs (scripts/build.ts:491:33)
```

## Cause

`await main()` runs at the top of the module (line 55), before `const USAGE` is declared at line 558. `parseArgs()` reads `USAGE` while it is still in the temporal dead zone. This is spec-correct ESM behavior (Node throws the same error) and reproduces back to Bun 1.2.0, so it is not a runtime regression; `--help` has been broken since this file was introduced in 2192edcbe8.

## Fix

Move the `try { await main() }` entry block to the end of the file so every module-level binding is initialized before `main()` runs.

## Verification

```
$ bun scripts/build.ts --help
Usage: bun scripts/build.ts [options] [exec-args...]
...
$ echo $?
0
```

`--configure-only` still works unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->