### PR TITLE
test/docker: bake mysql+postgres data dirs so cold start is ~2-3s, stop healthcheck wedge

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 37
+# Version: 38
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.

--- a/test/docker/Dockerfile.mysql-native-password
+++ b/test/docker/Dockerfile.mysql-native-password
@@ -11,7 +11,7 @@ RUN set -e; \
     docker-entrypoint.sh mysqld \
         --datadir=/var/lib/mysql-init \
         --default-authentication-plugin=mysql_native_password & pid=$!; \
-    for i in $(seq 60); do \
+    for i in $(seq 180); do \
         mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1' >/dev/null 2>&1 && break; \
         sleep 1; \
     done; \

--- a/test/docker/Dockerfile.mysql-native-password
+++ b/test/docker/Dockerfile.mysql-native-password
@@ -1,0 +1,22 @@
+FROM mysql:8.0
+
+# See Dockerfile.mysql-plain for the rationale. This variant pins mysql:8.0 and
+# the mysql_native_password auth plugin to cover the legacy-auth code path.
+ENV MYSQL_ROOT_PASSWORD=bun \
+    MYSQL_DATABASE=bun_sql_test \
+    MYSQL_ROOT_HOST=% \
+    MYSQL_INITDB_SKIP_TZINFO=1
+
+RUN set -e; \
+    docker-entrypoint.sh mysqld \
+        --datadir=/var/lib/mysql-init \
+        --default-authentication-plugin=mysql_native_password & pid=$!; \
+    for i in $(seq 60); do \
+        mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1' >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1'; \
+    mysqladmin -h127.0.0.1 -uroot -pbun shutdown; \
+    wait "$pid"
+
+CMD ["mysqld", "--datadir=/var/lib/mysql-init", "--default-authentication-plugin=mysql_native_password"]

--- a/test/docker/Dockerfile.mysql-plain
+++ b/test/docker/Dockerfile.mysql-plain
@@ -1,0 +1,24 @@
+FROM mysql:8.4
+
+# Bake a fully initialized data directory into the image so cold container
+# start skips `mysqld --initialize` and the temp-server dance entirely and is
+# just `exec mysqld` (~2-3s instead of ~60s). The base image declares
+# `VOLUME /var/lib/mysql`, which discards build-time writes there, so
+# initialize into a sibling path and point mysqld at it via CMD; at runtime the
+# entrypoint sees `$DATADIR/mysql` exists and goes straight to exec. tzinfo
+# loading is skipped since no test uses MySQL's named-timezone tables.
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    MYSQL_DATABASE=bun_sql_test \
+    MYSQL_INITDB_SKIP_TZINFO=1
+
+RUN set -e; \
+    docker-entrypoint.sh mysqld --datadir=/var/lib/mysql-init & pid=$!; \
+    for i in $(seq 60); do \
+        mysql -h127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    mysql -h127.0.0.1 -uroot -e 'SELECT 1'; \
+    mysqladmin -h127.0.0.1 -uroot shutdown; \
+    wait "$pid"
+
+CMD ["mysqld", "--datadir=/var/lib/mysql-init"]

--- a/test/docker/Dockerfile.mysql-plain
+++ b/test/docker/Dockerfile.mysql-plain
@@ -13,7 +13,7 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 
 RUN set -e; \
     docker-entrypoint.sh mysqld --datadir=/var/lib/mysql-init & pid=$!; \
-    for i in $(seq 60); do \
+    for i in $(seq 180); do \
         mysql -h127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1 && break; \
         sleep 1; \
     done; \

--- a/test/docker/Dockerfile.mysql-plain
+++ b/test/docker/Dockerfile.mysql-plain
@@ -5,8 +5,10 @@ FROM mysql:8.4
 # just `exec mysqld` (~2-3s instead of ~60s). The base image declares
 # `VOLUME /var/lib/mysql`, which discards build-time writes there, so
 # initialize into a sibling path and point mysqld at it via CMD; at runtime the
-# entrypoint sees `$DATADIR/mysql` exists and goes straight to exec. tzinfo
-# loading is skipped since no test uses MySQL's named-timezone tables.
+# entrypoint sees `$DATADIR/mysql` exists and goes straight to exec, so the
+# init-time MYSQL_* env vars below are build inputs only and runtime overrides
+# have no effect. tzinfo loading is skipped since no test uses MySQL's
+# named-timezone tables.
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes \
     MYSQL_DATABASE=bun_sql_test \
     MYSQL_INITDB_SKIP_TZINFO=1

--- a/test/docker/Dockerfile.postgres-auth
+++ b/test/docker/Dockerfile.postgres-auth
@@ -1,3 +1,20 @@
 FROM postgres:15
 COPY init-scripts/postgres-auth/ /docker-entrypoint-initdb.d/
 COPY config/pg_hba_auth.conf /etc/postgresql/pg_hba.conf
+
+# See Dockerfile.postgres-plain for the rationale. The custom hba_file and
+# connection-limit flags are supplied by the compose `command:` at runtime;
+# build-time init only needs the default local-trust hba to run its scripts.
+ENV POSTGRES_HOST_AUTH_METHOD=trust \
+    POSTGRES_USER=postgres \
+    PGDATA=/var/lib/postgresql/pgdata-init
+
+RUN set -e; \
+    docker-entrypoint.sh postgres & pid=$!; \
+    for i in $(seq 180); do \
+        pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    pg_isready -h 127.0.0.1 -U postgres; \
+    gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop; \
+    wait "$pid"

--- a/test/docker/Dockerfile.postgres-plain
+++ b/test/docker/Dockerfile.postgres-plain
@@ -1,2 +1,22 @@
 FROM postgres:15
 COPY init-scripts/postgres/ /docker-entrypoint-initdb.d/
+
+# Bake a fully initialized data directory into the image so cold container
+# start skips initdb + the temp-server init-script pass and is just
+# `exec postgres` (~1-2s instead of ~5-8s). The base image declares
+# `VOLUME /var/lib/postgresql/data`, which discards build-time writes there,
+# so point PGDATA at a sibling path; the entrypoint reads PGDATA and sees it
+# is already populated at runtime, so it goes straight to exec.
+ENV POSTGRES_HOST_AUTH_METHOD=trust \
+    POSTGRES_USER=postgres \
+    PGDATA=/var/lib/postgresql/pgdata-init
+
+RUN set -e; \
+    docker-entrypoint.sh postgres & pid=$!; \
+    for i in $(seq 180); do \
+        pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    pg_isready -h 127.0.0.1 -U postgres; \
+    gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop; \
+    wait "$pid"

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -171,8 +171,8 @@ test("wait for service to be healthy", async () => {
 ```
 test/docker/
 ├── docker-compose.yml       # Service definitions
-├── Dockerfile.postgres-plain # postgres_plain image (bakes in init-scripts)
-├── Dockerfile.postgres-auth  # postgres_auth image (init-scripts + pg_hba)
+├── Dockerfile.postgres-plain # postgres_plain image (baked PGDATA + init-scripts)
+├── Dockerfile.postgres-auth  # postgres_auth image (baked PGDATA + init-scripts + pg_hba)
 ├── Dockerfile.mysql-plain           # mysql_plain image (baked data dir)
 ├── Dockerfile.mysql-native-password # mysql_native_password image (baked data dir, legacy auth)
 ├── Dockerfile.autobahn       # autobahn image (fuzzingserver.json)

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -173,10 +173,12 @@ test/docker/
 ├── docker-compose.yml       # Service definitions
 ├── Dockerfile.postgres-plain # postgres_plain image (bakes in init-scripts)
 ├── Dockerfile.postgres-auth  # postgres_auth image (init-scripts + pg_hba)
+├── Dockerfile.mysql-plain           # mysql_plain image (baked data dir)
+├── Dockerfile.mysql-native-password # mysql_native_password image (baked data dir, legacy auth)
 ├── Dockerfile.autobahn       # autobahn image (fuzzingserver.json)
 ├── Dockerfile.squid          # squid image (squid.conf)
 ├── index.ts                # TypeScript API
-├── prepare-ci.sh          # CI/CD setup script
+├── prepare-ci.ts          # CI/CD setup script
 ├── README.md              # This file
 ├── config/                # Service configurations
 │   ├── fuzzingserver.json # Autobahn config

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,19 +1,18 @@
 services:
   # PostgreSQL Services
+  # These images bake a pre-initialized PGDATA (initdb + init scripts) into the
+  # image so cold container start is `exec postgres` (~1-2s) instead of the
+  # stock entrypoint's first-boot init. State lives on the container's CoW
+  # layer, so a fresh container is still a fresh cluster.
   postgres_plain:
     build:
       context: .
       dockerfile: Dockerfile.postgres-plain
     image: bun-postgres-plain:local
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: postgres
     ports:
       - target: 5432
         published: 0
         protocol: tcp
-    tmpfs:
-      - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -39,8 +38,6 @@ services:
       -c ssl_key_file=/etc/postgresql/ssl/server.key
       -c max_prepared_transactions=1000
       -c max_connections=2000
-    tmpfs:
-      - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -54,9 +51,6 @@ services:
       context: .
       dockerfile: Dockerfile.postgres-auth
     image: bun-postgres-auth:local
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: postgres
     ports:
       - target: 5432
         published: 0
@@ -66,8 +60,6 @@ services:
       -c hba_file=/etc/postgresql/pg_hba.conf
       -c max_prepared_transactions=1000
       -c max_connections=2000
-    tmpfs:
-      - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s
@@ -43,7 +43,7 @@ services:
       - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s
@@ -70,7 +70,7 @@ services:
       - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s
@@ -94,10 +94,16 @@ services:
       # passes the check before the real TCP listener exists. Auth + SELECT 1
       # so we don't go healthy until the real server is accepting connections.
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-e", "SELECT 1"]
-      interval: 1h # Effectively disable after startup
+      # Once start_period elapses the engine probes at `interval`, not
+      # `start_interval`, so a long interval wedges health at "starting" if
+      # init overshoots the window. MySQL 8.4 first-boot init (timezone load +
+      # temp server) has been observed at ~65s on loaded CI hosts, hence 180s
+      # here; interval stays short so overshooting any service's start_period
+      # recovers within one probe instead of freezing `compose up --wait`.
+      interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 60s
+      start_period: 180s
       start_interval: 1s
 
   mysql_native_password:
@@ -115,10 +121,10 @@ services:
       - /var/lib/mysql
     healthcheck:
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-pbun", "-e", "SELECT 1"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 60s
+      start_period: 180s
       start_interval: 1s
 
   mysql_tls:
@@ -139,10 +145,10 @@ services:
       - /var/lib/mysql
     healthcheck:
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-pbun", "-e", "SELECT 1"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 60s
+      start_period: 180s
       start_interval: 1s
 
   # Redis/Valkey Services
@@ -195,7 +201,7 @@ services:
       - /data
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 1h # Effectively disable after startup
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s
@@ -220,7 +226,7 @@ services:
       # healthcheck `up --wait` returns at "running" and the test's
       # /getCaseCount fetch can hit before the listener exists.
       test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 9002), 1).close()"]
-      interval: 1h
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s
@@ -241,7 +247,7 @@ services:
       - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD-SHELL", "pgrep squid > /dev/null"]
-      interval: 1h
+      interval: 5s
       timeout: 5s
       retries: 30
       start_period: 60s

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -77,17 +77,20 @@ services:
       start_interval: 1s
 
   # MySQL Services
+  # These images bake a pre-initialized data dir so cold container start is
+  # `exec mysqld` (~2-3s) instead of the stock entrypoint's first-boot init
+  # (`mysqld --initialize` + temp server + tzinfo load, ~60s on loaded CI
+  # hosts). State lives on the container's CoW layer, so a fresh container is a
+  # fresh database.
   mysql_plain:
-    image: mysql:8.4
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_DATABASE: bun_sql_test
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql-plain
+    image: bun-mysql-plain:local
     ports:
       - target: 3306
         published: 0
         protocol: tcp
-    tmpfs:
-      - /var/lib/mysql
     healthcheck:
       # 127.0.0.1 (not localhost) forces TCP — `localhost` would use the unix
       # socket, which is up during the entrypoint's temporary init server and
@@ -95,36 +98,30 @@ services:
       # so we don't go healthy until the real server is accepting connections.
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-e", "SELECT 1"]
       # Once start_period elapses the engine probes at `interval`, not
-      # `start_interval`, so a long interval wedges health at "starting" if
-      # init overshoots the window. MySQL 8.4 first-boot init (timezone load +
-      # temp server) has been observed at ~65s on loaded CI hosts, hence 180s
-      # here; interval stays short so overshooting any service's start_period
-      # recovers within one probe instead of freezing `compose up --wait`.
+      # `start_interval`, so a long interval would wedge health at "starting"
+      # if init overshot the window; keep interval short so an overshoot on any
+      # service recovers within one probe.
       interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 180s
+      start_period: 60s
       start_interval: 1s
 
   mysql_native_password:
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: bun
-      MYSQL_DATABASE: bun_sql_test
-      MYSQL_ROOT_HOST: "%"
-    command: --default-authentication-plugin=mysql_native_password
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql-native-password
+    image: bun-mysql-native-password:local
     ports:
       - target: 3306
         published: 0
         protocol: tcp
-    tmpfs:
-      - /var/lib/mysql
     healthcheck:
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-pbun", "-e", "SELECT 1"]
       interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 180s
+      start_period: 60s
       start_interval: 1s
 
   mysql_tls:
@@ -134,21 +131,16 @@ services:
       args:
         MYSQL_VERSION: 8.4
     image: bun-mysql-tls:local
-    environment:
-      MYSQL_ROOT_PASSWORD: bun
-      MYSQL_DATABASE: bun_sql_test
     ports:
       - target: 3306
         published: 0
         protocol: tcp
-    tmpfs:
-      - /var/lib/mysql
     healthcheck:
       test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-pbun", "-e", "SELECT 1"]
       interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 180s
+      start_period: 60s
       start_interval: 1s
 
   # Redis/Valkey Services

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -238,11 +238,12 @@ class DockerComposeHelper {
     }
 
     // Start the service and wait for it to be healthy.
-    // --wait-timeout bounds how long `--wait` blocks for a health transition;
-    // 180 covers the slowest observed cold start (mysql 8.4 first-boot init on
-    // a loaded CI host, with three mysqld containers contending for the same
-    // tmpfs, has been seen at ~65s) with headroom, and matches the longest
-    // start_period in docker-compose.yml.
+    // --wait-timeout bounds how long `--wait` blocks for a health transition.
+    // All services are expected to go healthy within a few seconds (mysql
+    // images bake a pre-initialized data dir so first boot is just `exec
+    // mysqld`); 180 is generous headroom so a slow host or a service whose
+    // init regresses surfaces as a single diagnosable failure here rather than
+    // cascading through every test file that asks for it.
     const { exitCode, stderr } = await this.exec(["up", "-d", "--wait", "--wait-timeout", "180", service]);
 
     if (exitCode !== 0) {

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -238,11 +238,12 @@ class DockerComposeHelper {
     }
 
     // Start the service and wait for it to be healthy.
-    // --wait-timeout: without it `--wait` blocks until the engine reports
-    // healthy, which with `interval: 1h` and an engine that doesn't honor the
-    // 5s start_interval default means "hang until the test's beforeAll times
-    // out with no error message". 60 covers cold mysql init on tmpfs.
-    const { exitCode, stderr } = await this.exec(["up", "-d", "--wait", "--wait-timeout", "60", service]);
+    // --wait-timeout bounds how long `--wait` blocks for a health transition;
+    // 180 covers the slowest observed cold start (mysql 8.4 first-boot init on
+    // a loaded CI host, with three mysqld containers contending for the same
+    // tmpfs, has been seen at ~65s) with headroom, and matches the longest
+    // start_period in docker-compose.yml.
+    const { exitCode, stderr } = await this.exec(["up", "-d", "--wait", "--wait-timeout", "180", service]);
 
     if (exitCode !== 0) {
       const ps = await this.exec(["ps", "-a", service]);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1190,11 +1190,11 @@ export async function describeWithContainer(
       _port = info.ports[servicePort];
       console.log(`Container ready via docker-compose: ${image} at ${_host}:${_port}`);
       readyResolver!();
-      // Cold container start is bounded by `compose up --wait-timeout 60` plus
+      // Cold container start is bounded by `compose up --wait-timeout 180` plus
       // a `compose build` step; the default 5s hook timeout fires first and the
       // runner's auto-killer then SIGTERMs the in-flight compose subprocesses,
       // surfacing as bogus `Failed to start service X: ... Creating` errors.
-    }, 120_000);
+    }, 240_000);
 
     fn(containerDescriptor);
   });

--- a/test/js/sql/docker-tls/Dockerfile
+++ b/test/js/sql/docker-tls/Dockerfile
@@ -75,8 +75,24 @@ RUN mkdir -p /docker-entrypoint-initdb.d && \
     echo "ALTER SYSTEM SET ssl_key_file = '/etc/postgresql/ssl/server.key';" >> /docker-entrypoint-initdb.d/configure-postgres.sql
 
 # Set environment variables
-ENV POSTGRES_HOST_AUTH_METHOD=trust
-ENV POSTGRES_USER=postgres
+ENV POSTGRES_HOST_AUTH_METHOD=trust \
+    POSTGRES_USER=postgres \
+    PGDATA=/var/lib/postgresql/pgdata-init
+
+# Bake a fully initialized data directory into the image so cold container
+# start is just `exec postgres` (~1-2s). See test/docker/Dockerfile.postgres-plain
+# for the rationale. Runs with the default (trust) hba so the init scripts can
+# connect on the local socket; the compose `command:` points postgres at the
+# hostssl-only /etc/postgresql/pg_hba.conf at runtime.
+RUN set -e; \
+    docker-entrypoint.sh postgres & pid=$!; \
+    for i in $(seq 180); do \
+        pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    pg_isready -h 127.0.0.1 -U postgres; \
+    gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop; \
+    wait "$pid"
 
 # Expose PostgreSQL port
 EXPOSE 5432

--- a/test/js/sql/mysql-tls/Dockerfile
+++ b/test/js/sql/mysql-tls/Dockerfile
@@ -1,6 +1,24 @@
-# Dockerfile
 ARG MYSQL_VERSION=8.4
 FROM mysql:${MYSQL_VERSION}
+
+# Bake a fully initialized data directory into the image so cold container
+# start is just `exec mysqld` (~2-3s instead of ~60s); see
+# test/docker/Dockerfile.mysql-plain for the rationale. This runs before the
+# TLS config is copied in so the readiness poll can use plain TCP (the runtime
+# config sets require_secure_transport=ON, which would reject it).
+ENV MYSQL_ROOT_PASSWORD=bun \
+    MYSQL_DATABASE=bun_sql_test \
+    MYSQL_INITDB_SKIP_TZINFO=1
+
+RUN set -e; \
+    docker-entrypoint.sh mysqld --datadir=/var/lib/mysql-init & pid=$!; \
+    for i in $(seq 60); do \
+        mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1' >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1'; \
+    mysqladmin -h127.0.0.1 -uroot -pbun shutdown; \
+    wait "$pid"
 
 # Copy TLS materials + config
 # Expect these in the build context:
@@ -17,6 +35,8 @@ RUN chown -R mysql:mysql /etc/mysql/ssl /etc/mysql/conf.d \
  && chmod 600 /etc/mysql/ssl/server-key.pem \
  && find /etc/mysql/ssl -type f -name "*.pem" -exec chmod 640 {} \; \
  && printf "[mysqld]\nrequire_secure_transport=ON\n" > /etc/mysql/conf.d/force_tls.cnf
+
+CMD ["mysqld", "--datadir=/var/lib/mysql-init"]
 
 # Expose MySQL
 EXPOSE 3306

--- a/test/js/sql/mysql-tls/Dockerfile
+++ b/test/js/sql/mysql-tls/Dockerfile
@@ -12,7 +12,7 @@ ENV MYSQL_ROOT_PASSWORD=bun \
 
 RUN set -e; \
     docker-entrypoint.sh mysqld --datadir=/var/lib/mysql-init & pid=$!; \
-    for i in $(seq 60); do \
+    for i in $(seq 180); do \
         mysql -h127.0.0.1 -uroot -pbun -e 'SELECT 1' >/dev/null 2>&1 && break; \
         sleep 1; \
     done; \

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -441,10 +441,10 @@ if (isEnabled) {
     // if (!context.initialized) {
     //   console.warn("Test initialization failed - tests may be skipped");
     // }
-    // Cold container start is bounded by `compose up --wait-timeout 60` plus
+    // Cold container start is bounded by `compose up --wait-timeout 180` plus
     // a `compose build` step; the default 5s hook timeout fires long before
     // that on a cold cache.
-  }, 120_000);
+  }, 240_000);
 }
 
 if (isEnabled) {

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -27,9 +27,9 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         ctx.redis = createClient(connectionType);
       }
       // setupDockerContainer() may cold-start the redis_unified container
-      // (compose up --wait-timeout 60); shielded by the file-level beforeAll's
+      // (compose up --wait-timeout 180); shielded by the file-level beforeAll's
       // cached promise once that has run, but match its timeout for safety.
-    }, 120_000);
+    }, 240_000);
 
     beforeEach(async () => {
       if (!ctx.redis) {

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -42,10 +42,10 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
     wsOptions = process.env.BUN_AUTOBAHN_HOST_HEADER
       ? { headers: { Host: process.env.BUN_AUTOBAHN_HOST_HEADER } }
       : undefined;
-    // Cold container start is bounded by `compose up --wait-timeout 60` plus
+    // Cold container start is bounded by `compose up --wait-timeout 180` plus
     // a `compose build` step; the default 5s hook timeout fires long before
     // that on a cold cache.
-  }, 120_000);
+  }, 240_000);
 
   function getCaseStatus(testID: number) {
     return new Promise((resolve, reject) => {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -600,7 +600,7 @@ describe.skipIf(!isDockerEnabled())("WebSocket through Squid proxy (Docker)", ()
     console.log("Starting squid proxy container...");
     squidInfo = await dockerCompose.ensure("squid");
     console.log(`Squid proxy ready at: ${squidInfo.host}:${squidInfo.ports[3128]}`);
-  }, 120_000);
+  }, 240_000);
 
   afterAll(async () => {
     if (!process.env.BUN_KEEP_DOCKER) {


### PR DESCRIPTION
## What

Fixes the recurring `application not healthy after 1m0s` flake that takes out every mysql-backed test file on alpine shards (26030, 24850, 26063, 28632, sql-mysql.*, integration/mysql2), by baking pre-initialized data directories into the mysql and postgres test images so cold container start is ~2-3s instead of ~60s, and by removing the healthcheck configuration that turned a slow start into a permanent wedge.

- `Dockerfile.mysql-plain`, `Dockerfile.mysql-native-password`, and the mysql-tls Dockerfile run the stock entrypoint once at `docker build` time with `MYSQL_INITDB_SKIP_TZINFO=1` against a sibling datadir (the base image's `VOLUME /var/lib/mysql` discards build-time writes there). At container start the entrypoint sees the datadir is populated and `exec`s `mysqld` directly.
- `Dockerfile.postgres-plain`, `Dockerfile.postgres-auth`, and the postgres-tls Dockerfile do the same against a `PGDATA` outside `VOLUME /var/lib/postgresql/data`.
- Every healthcheck's `interval` drops from `1h` to `5s`.
- `compose up --wait-timeout` goes from 60 to 180 and the container `beforeAll` hook timeouts go to 240s.
- `scripts/bootstrap.sh` bumped to v38 so the next Linux AMI bake runs `prepare-ci.ts` against the new compose file and pre-builds `bun-mysql-*:local` / `bun-postgres-*:local` into the runner. Until the v38 AMIs are published each shard still pays one image build under parallel prestart; afterwards it is just `docker run` (~2-3s).

## Why

The ~62s mysql cold start breaks down as: ~39s loading `/usr/share/zoneinfo` into `mysql.time_zone_*` via `mysql_tzinfo_to_sql`, ~15s `mysqld --initialize-insecure`, and ~8s of entrypoint setup plus the temp-server bounce. No test touches MySQL's named-timezone tables (the datetime-roundtrip test only varies the **process** `TZ`, not the MySQL session `time_zone`), so the tzinfo load is dead weight, and the rest is deterministic and can run at image-build time instead of every container start. Postgres's own init (initdb + temp server + init scripts) is ~5-8s, but on alpine shards it queued behind the three parallel mysql builds and was observed at 130-220s ensure-to-ready.

On alpine 3.23 CI hosts, mysql's ~62s overshot `start_period: 60s`, and once start_period elapses Docker's health monitor switches from `start_interval: 1s` to `interval: 1h`. So the container sat at `health: starting` for an hour even though mysqld was accepting TCP connections two seconds later, and every `compose up --wait --wait-timeout 60` timed out from then on. Each affected test file was retried four times at 60s apiece.

From [build 70876's alpine x64-baseline shard](https://buildkite.com/bun/bun/builds/70876#019f457d-d9ef-494b-ae4a-06c08a13acb8):

```
mysql_plain-1  | 2026-07-09 06:38:49 [Entrypoint]: Entrypoint script ... started.
...
mysql_plain-1  | 2026-07-09T06:39:51 [MY-010931] ... ready for connections. ... port: 3306
```

62s from entrypoint to ready, yet `docker compose ps` two minutes later still shows:

```
bun-test-services-mysql_plain-1 ... Up 2 minutes (health: starting)
```

because the next probe is scheduled for ~07:39.

Sampling the last 30 failed `:alpine: 3.23` test-bun jobs, **20** were this exact error (x64, x64-baseline, aarch64). **0** of 20 sampled debian/ubuntu failures were.

`tmpfs` is dropped for both: the baked data dir lives on the container's CoW layer, so a fresh container is still a fresh database/cluster and the light test workloads don't need RAM-backed I/O. `interval: 5s` everywhere means that even if some future service overshoots its `start_period`, it recovers within one probe instead of freezing `compose up --wait` for an hour; a `SELECT 1` / `pg_isready` every 5s is negligible and would need 30 consecutive failures (150s) to mark a running container unhealthy.

## Verification

- [build 70904](https://buildkite.com/bun/bun/builds/70904) (mysql pre-bake, old AMIs): all 60 alpine shards pass; a solo mysql_plain `compose build` + `up --wait` on alpine completes in ~15s, debian completes all three in parallel in ~91s.
- This commit carries `[build linux images]` so CI bakes throwaway v38 AMIs with the new images pre-built and runs the suite on them. Once green the subject can be switched to `[publish images]` per the bootstrap header.
