### PR TITLE
sql: purify NaN before boxing binary float8/double values from the wire

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -152,7 +152,7 @@ static JSC::JSValue toJS(JSC::VM& vm, JSC::JSGlobalObject* globalObject, DataCel
         return jsEmptyString(vm);
     }
     case DataCellTag::Double:
-        return jsNumber(cell.value.number);
+        return jsNumber(purifyNaN(cell.value.number));
         break;
     case DataCellTag::Integer:
         return jsNumber(cell.value.integer);

--- a/test/js/sql/postgres-binary-float-nan-box.test.ts
+++ b/test/js/sql/postgres-binary-float-nan-box.test.ts
@@ -1,0 +1,78 @@
+// A malicious or compromised server controls the raw 8 bytes of a binary
+// float8 column. SQLClient.cpp boxes that double into a JSValue; without
+// purifyNaN() a non-canonical NaN bit pattern collides with JSC's JSVALUE64
+// tag ranges, so the server can forge an arbitrary JSValue (boolean,
+// undefined, a cell pointer) out of a column typed `double precision`.
+// A numeric column must always come back as a number. See issue #33823.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const FLOAT8_OID = 701;
+
+// Each of these IEEE-754 bit patterns is a NaN whose payload, once jsNumber()
+// adds DoubleEncodeOffset, used to decode as a forged immediate JSValue:
+//   fffe000000000007 -> boolean true
+//   fffe00000000000a -> undefined
+//   fffc000012345678 -> int32 0x12345678
+// After purifyNaN() every NaN collapses to the canonical NaN, so all three
+// must come back as the number NaN.
+const forgedNaNBits = ["fffe000000000007", "fffe00000000000a", "fffc000012345678"];
+
+async function selectForgedFloat8(rawBitsHex: string): Promise<unknown> {
+  const columnBytes = Buffer.from(rawBitsHex, "hex");
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    socket.on("data", () => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      socket.write(
+        Buffer.concat([
+          pgRowDescription([{ name: "n", typeOid: FLOAT8_OID, format: 1 }]),
+          pgDataRow([columnBytes]),
+          pgCommandComplete("SELECT 1"),
+          pgReadyForQuery(),
+        ]),
+      );
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({
+      url: `postgres://u@127.0.0.1:${port}/db`,
+      max: 1,
+      idleTimeout: 5,
+      connectionTimeout: 5,
+    });
+    const [row]: any = await sql`select x`.simple();
+    return row.n;
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test.each(forgedNaNBits)("binary float8 NaN payload 0x%s comes back as number, not a forged JSValue", async bits => {
+  const value = await selectForgedFloat8(bits);
+  expect(typeof value).toBe("number");
+  expect(Number.isNaN(value as number)).toBe(true);
+});
+
+test("binary float8 decodes an ordinary double", async () => {
+  // 3.5 as big-endian IEEE-754 bits: not a NaN, must survive untouched.
+  const bits = Buffer.alloc(8);
+  bits.writeDoubleBE(3.5, 0);
+  const value = await selectForgedFloat8(bits.toString("hex"));
+  expect(value).toBe(3.5);
+});


### PR DESCRIPTION
Fixes #33823

### Problem

`bun:sql` boxes the raw 8 bytes of a binary `float8`/`DOUBLE` column straight into a JSValue. A tagged-template or parameterized query automatically requests binary result format for numeric columns, so the bytes come from whatever sits on the other end of the socket (the database, a proxy, or a MITM on a plaintext connection).

`jsNumber(double)` NaN-boxes by adding `DoubleEncodeOffset`. JSC's JSVALUE64 encoding is only sound when the boxed double is a non-NaN or the single canonical purified NaN. Any other NaN bit pattern collides with the tag ranges JSC uses for booleans, `undefined`, Int32, and cell pointers, so a server can make a `double precision` column come back as an arbitrary forged JSValue, or crash the process with a forged cell pointer.

This is the same root cause already fixed for `bun:ffi`/N-API in #32787 and for `v8::Number::New` in #33072; that first PR explicitly called out the SQL decoders as a known, deferred gap.

```
panic(main thread): Segmentation fault at address 0x1234567D
```

### Cause

`src/jsc/bindings/SQLClient.cpp`, `DataCellTag::Double`:

```cpp
return jsNumber(cell.value.number);
```

`cell.value.number` is produced by `f64::from_bits(...)` over the raw wire bytes (Postgres `parse_binary_float8`, MySQL `MYSQL_TYPE_DOUBLE`/`FLOAT`), with no validation or purification in between. Both producers feed this one sink.

### Fix

Purify the NaN at the sink, mirroring `napi_create_double`:

```cpp
return jsNumber(purifyNaN(cell.value.number));
```

Purifying at the sink covers every `DataCellTag::Double` producer (Postgres and MySQL, `float8` and `float4`). Non-NaN doubles are untouched; any NaN bit pattern collapses to the canonical NaN.

### Verification

New test `test/js/sql/postgres-binary-float-nan-box.test.ts` stands up a mock TCP server speaking the real Postgres v3 wire protocol and returns a binary `float8` column with forged bit patterns that previously decoded as `boolean true`, `undefined`, and an int32. With the fix each comes back as the number `NaN`; an ordinary double (`3.5`) round-trips unchanged.

- Without the fix (`USE_SYSTEM_BUN=1`): the forged columns return `boolean`/`undefined`, assertions fail.
- With the fix (`bun bd test`): 4 pass.