### PR TITLE
fetch: implement Body.textStream()

### DIFF
--- a/packages/bun-types/fetch.d.ts
+++ b/packages/bun-types/fetch.d.ts
@@ -71,10 +71,26 @@ declare module "bun" {
 
     interface BunRequestOverride extends LibOrFallbackRequest {
       headers: BunHeadersOverride;
+      /**
+       * Returns a {@link ReadableStream} of the body decoded as UTF-8 text.
+       *
+       * Multi-byte characters split across chunk boundaries are joined
+       * correctly. Throws a {@link TypeError} if the body has already been
+       * consumed or is locked.
+       */
+      textStream(): ReadableStream<string>;
     }
 
     interface BunResponseOverride extends LibOrFallbackResponse {
       headers: BunHeadersOverride;
+      /**
+       * Returns a {@link ReadableStream} of the body decoded as UTF-8 text.
+       *
+       * Multi-byte characters split across chunk boundaries are joined
+       * correctly. Throws a {@link TypeError} if the body has already been
+       * consumed or is locked.
+       */
+      textStream(): ReadableStream<string>;
     }
   }
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -876,6 +876,8 @@ JSValue tryUseReadableStreamBufferedFastPath(JSGlobalObject* globalObject, WebCo
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    if (stream->m_nativeTextMode)
+        return {};
     JSValue nativePtr = stream->nativePtrForJS();
     if (!nativePtr || !nativePtr.isCell())
         return {};

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -876,8 +876,6 @@ JSValue tryUseReadableStreamBufferedFastPath(JSGlobalObject* globalObject, WebCo
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (stream->m_nativeTextMode)
-        return {};
     JSValue nativePtr = stream->nativePtrForJS();
     if (!nativePtr || !nativePtr.isCell())
         return {};

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -493,28 +493,34 @@ static JSValue nativeDecodePullResult(JSC::VM& vm, JSGlobalObject* globalObject,
         double written = result.asNumber();
         if (!isClosed)
             nativeAdjustChunkSize(adapter, written > 0 ? static_cast<size_t>(written) : 0);
+        if (adapter->m_textMode) {
+            if (written > 0 && view) {
+                size_t count = std::min(static_cast<size_t>(written), static_cast<size_t>(view->length()));
+                nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, view->span().first(count), /* flush */ false);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+            if (isClosed) {
+                scheduleNativeSourceCallClose(globalObject, adapter);
+                return jsUndefined();
+            }
+            // The whole view is free to reuse next pull (bytes were copied out).
+            return view ? JSValue(view) : jsUndefined();
+        }
         JSValue newView = view ? JSValue(view) : jsUndefined();
         if (written > 0 && view) {
             size_t count = std::min(static_cast<size_t>(written), static_cast<size_t>(view->length()));
-            if (adapter->m_textMode) {
-                nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, view->span().first(count), /* flush */ false);
+            JSC::JSArrayBufferView* toEnqueue = view;
+            if (view->length() - count > 0) {
+                toEnqueue = uint8Subarray(globalObject, view, 0, count);
                 RETURN_IF_EXCEPTION(scope, {});
-                // The whole view is free to reuse next pull (bytes were copied out).
-                newView = view;
-            } else {
-                JSC::JSArrayBufferView* toEnqueue = view;
-                if (view->length() - count > 0) {
-                    toEnqueue = uint8Subarray(globalObject, view, 0, count);
-                    RETURN_IF_EXCEPTION(scope, {});
-                    auto* tail = uint8Subarray(globalObject, view, count, view->length() - count);
-                    RETURN_IF_EXCEPTION(scope, {});
-                    newView = tail;
-                } else
-                    newView = jsUndefined();
-                if (controller) {
-                    readableStreamDefaultControllerEnqueue(globalObject, controller, toEnqueue);
-                    RETURN_IF_EXCEPTION(scope, {});
-                }
+                auto* tail = uint8Subarray(globalObject, view, count, view->length() - count);
+                RETURN_IF_EXCEPTION(scope, {});
+                newView = tail;
+            } else
+                newView = jsUndefined();
+            if (controller) {
+                readableStreamDefaultControllerEnqueue(globalObject, controller, toEnqueue);
+                RETURN_IF_EXCEPTION(scope, {});
             }
         }
         if (isClosed) {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -386,6 +386,19 @@ static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* ada
         adapter->m_pendingView.clear();
 }
 
+// Text mode: decode `bytes` via the adapter's streaming UTF-8 state and enqueue the
+// resulting string (empty strings are skipped).
+static void nativeEnqueueTextChunk(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSReadableStreamDefaultController* controller, std::span<const uint8_t> bytes, bool flush)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    WTF::String decoded = streamingUTF8Decode(bytes, adapter->m_textState, flush);
+    if (decoded.isEmpty() || !controller)
+        return;
+    JSString* chunk = jsString(vm, WTF::move(decoded));
+    readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+    RETURN_IF_EXCEPTION(scope, void());
+}
+
 static bool nativeCloserFlag(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -422,7 +435,10 @@ static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSN
     auto* controller = adapter->m_controller.get();
     if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        readableStreamDefaultControllerClose(globalObject, controller);
+        if (adapter->m_textMode)
+            nativeEnqueueTextChunk(vm, globalObject, adapter, controller, {}, /* flush */ true);
+        if (!catchScope.exception())
+            readableStreamDefaultControllerClose(globalObject, controller);
         if (catchScope.exception()) [[unlikely]] {
             JSValue thrown = takeAbruptCompletion(globalObject, catchScope);
             if (thrown.isEmpty())
@@ -480,18 +496,26 @@ static JSValue nativeDecodePullResult(JSC::VM& vm, JSGlobalObject* globalObject,
         JSValue newView = view ? JSValue(view) : jsUndefined();
         if (written > 0 && view) {
             size_t count = std::min(static_cast<size_t>(written), static_cast<size_t>(view->length()));
-            JSC::JSArrayBufferView* toEnqueue = view;
-            if (view->length() - count > 0) {
-                toEnqueue = uint8Subarray(globalObject, view, 0, count);
+            if (adapter->m_textMode) {
+                std::span<const uint8_t> bytes { view->typedVector(), count };
+                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
                 RETURN_IF_EXCEPTION(scope, {});
-                auto* tail = uint8Subarray(globalObject, view, count, view->length() - count);
-                RETURN_IF_EXCEPTION(scope, {});
-                newView = tail;
-            } else
-                newView = jsUndefined();
-            if (controller) {
-                readableStreamDefaultControllerEnqueue(globalObject, controller, toEnqueue);
-                RETURN_IF_EXCEPTION(scope, {});
+                // The whole view is free to reuse next pull (bytes were copied out).
+                newView = view;
+            } else {
+                JSC::JSArrayBufferView* toEnqueue = view;
+                if (view->length() - count > 0) {
+                    toEnqueue = uint8Subarray(globalObject, view, 0, count);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    auto* tail = uint8Subarray(globalObject, view, count, view->length() - count);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    newView = tail;
+                } else
+                    newView = jsUndefined();
+                if (controller) {
+                    readableStreamDefaultControllerEnqueue(globalObject, controller, toEnqueue);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
             }
         }
         if (isClosed) {
@@ -507,9 +531,15 @@ static JSValue nativeDecodePullResult(JSC::VM& vm, JSGlobalObject* globalObject,
     if (auto* chunk = dynamicDowncast<JSC::JSArrayBufferView>(result)) {
         if (!isClosed)
             nativeAdjustChunkSize(adapter, chunk->byteLength());
-        if (chunk->byteLength() > 0 && controller) {
-            readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
-            RETURN_IF_EXCEPTION(scope, {});
+        if (chunk->byteLength() > 0) {
+            if (adapter->m_textMode) {
+                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(chunk->vector()), chunk->byteLength() };
+                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
+                RETURN_IF_EXCEPTION(scope, {});
+            } else if (controller) {
+                readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
         }
         if (isClosed) {
             scheduleNativeSourceCallClose(globalObject, adapter);
@@ -562,8 +592,18 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
         RETURN_IF_EXCEPTION(scope, );
         auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue);
         if (drainView && drainView->byteLength() > 0) {
-            readableStreamDefaultControllerEnqueue(globalObject, controller, drainView);
-            RETURN_IF_EXCEPTION(scope, );
+            if (stream->m_nativeTextMode) {
+                StreamingUTF8DecodeState state;
+                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(drainView->vector()), drainView->byteLength() };
+                WTF::String decoded = streamingUTF8Decode(bytes, state, /* flush */ true);
+                if (!decoded.isEmpty()) {
+                    readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+                    RETURN_IF_EXCEPTION(scope, );
+                }
+            } else {
+                readableStreamDefaultControllerEnqueue(globalObject, controller, drainView);
+                RETURN_IF_EXCEPTION(scope, );
+            }
         }
         readableStreamDefaultControllerClose(globalObject, controller);
         RETURN_IF_EXCEPTION(scope, );
@@ -572,6 +612,7 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
 
     auto* adapter = WebCore::JSNativeStreamSourceAdapter::create(vm, runtime->nativeStreamSourceAdapterStructure(domGlobalObject));
     adapter->m_handle.set(vm, adapter, handle);
+    adapter->m_textMode = stream->m_nativeTextMode;
     adapter->m_chunkSize = std::max(static_cast<size_t>(chunkSize), autoAllocateChunkSize);
     auto* closer = JSC::constructEmptyArray(globalObject, nullptr, 1);
     RETURN_IF_EXCEPTION(scope, );
@@ -611,8 +652,16 @@ JSValue nativeSourceStart(JSGlobalObject* globalObject, JSReadableStreamDefaultC
         adapter->m_drainValue.clear();
         if (!adapter->m_controller)
             adapter->m_controller = JSC::Weak<JSReadableStreamDefaultController>(controller);
-        readableStreamDefaultControllerEnqueue(globalObject, controller, drainValue);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (adapter->m_textMode) {
+            if (auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue)) {
+                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(drainView->vector()), drainView->byteLength() };
+                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        } else {
+            readableStreamDefaultControllerEnqueue(globalObject, controller, drainValue);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
     }
     return jsUndefined();
 }
@@ -741,6 +790,14 @@ static void nativeSourceOnDrain(JSGlobalObject* globalObject, JSNativeStreamSour
     auto* controller = adapter->m_controller.get();
     if (!controller)
         return;
+    if (adapter->m_textMode) {
+        auto& vm = getVM(globalObject);
+        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
+            std::span<const uint8_t> bytes { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
+            nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
+        }
+        return;
+    }
     readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
 }
 

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -386,12 +386,12 @@ static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* ada
         adapter->m_pendingView.clear();
 }
 
-// Text mode: decode `bytes` via the adapter's streaming UTF-8 state and enqueue the
-// resulting string (empty strings are skipped).
-static void nativeEnqueueTextChunk(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSReadableStreamDefaultController* controller, std::span<const uint8_t> bytes, bool flush)
+// Text mode: decode `bytes` against `state` and enqueue the resulting string
+// (empty strings are skipped).
+static void nativeEnqueueTextChunk(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, StreamingUTF8DecodeState& state, std::span<const uint8_t> bytes, bool flush)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* decoded = streamingUTF8Decode(globalObject, bytes, adapter->m_textState, flush);
+    auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
+    auto* decoded = streamingUTF8Decode(globalObject, bytes, state, flush);
     RETURN_IF_EXCEPTION(scope, void());
     if (!decoded || !decoded->length() || !controller)
         return;
@@ -436,7 +436,7 @@ static void nativeSourceCallClose(JSC::VM& vm, JSGlobalObject* globalObject, JSN
     if (controller && readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (adapter->m_textMode)
-            nativeEnqueueTextChunk(vm, globalObject, adapter, controller, {}, /* flush */ true);
+            nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, {}, /* flush */ true);
         if (!catchScope.exception())
             readableStreamDefaultControllerClose(globalObject, controller);
         if (catchScope.exception()) [[unlikely]] {
@@ -497,8 +497,7 @@ static JSValue nativeDecodePullResult(JSC::VM& vm, JSGlobalObject* globalObject,
         if (written > 0 && view) {
             size_t count = std::min(static_cast<size_t>(written), static_cast<size_t>(view->length()));
             if (adapter->m_textMode) {
-                std::span<const uint8_t> bytes { view->typedVector(), count };
-                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
+                nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, view->span().first(count), /* flush */ false);
                 RETURN_IF_EXCEPTION(scope, {});
                 // The whole view is free to reuse next pull (bytes were copied out).
                 newView = view;
@@ -533,8 +532,7 @@ static JSValue nativeDecodePullResult(JSC::VM& vm, JSGlobalObject* globalObject,
             nativeAdjustChunkSize(adapter, chunk->byteLength());
         if (chunk->byteLength() > 0) {
             if (adapter->m_textMode) {
-                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(chunk->vector()), chunk->byteLength() };
-                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
+                nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, chunk->span(), /* flush */ false);
                 RETURN_IF_EXCEPTION(scope, {});
             } else if (controller) {
                 readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
@@ -594,17 +592,11 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
         if (drainView && drainView->byteLength() > 0) {
             if (stream->m_nativeTextMode) {
                 StreamingUTF8DecodeState state;
-                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(drainView->vector()), drainView->byteLength() };
-                auto* decoded = streamingUTF8Decode(globalObject, bytes, state, /* flush */ true);
-                RETURN_IF_EXCEPTION(scope, );
-                if (decoded && decoded->length()) {
-                    readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
-                    RETURN_IF_EXCEPTION(scope, );
-                }
+                nativeEnqueueTextChunk(globalObject, controller, state, drainView->span(), /* flush */ true);
             } else {
                 readableStreamDefaultControllerEnqueue(globalObject, controller, drainView);
-                RETURN_IF_EXCEPTION(scope, );
             }
+            RETURN_IF_EXCEPTION(scope, );
         }
         readableStreamDefaultControllerClose(globalObject, controller);
         RETURN_IF_EXCEPTION(scope, );
@@ -654,15 +646,12 @@ JSValue nativeSourceStart(JSGlobalObject* globalObject, JSReadableStreamDefaultC
         if (!adapter->m_controller)
             adapter->m_controller = JSC::Weak<JSReadableStreamDefaultController>(controller);
         if (adapter->m_textMode) {
-            if (auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue)) {
-                std::span<const uint8_t> bytes { static_cast<const uint8_t*>(drainView->vector()), drainView->byteLength() };
-                nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
-                RETURN_IF_EXCEPTION(scope, {});
-            }
+            if (auto* drainView = dynamicDowncast<JSC::JSArrayBufferView>(drainValue))
+                nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, drainView->span(), /* flush */ false);
         } else {
             readableStreamDefaultControllerEnqueue(globalObject, controller, drainValue);
-            RETURN_IF_EXCEPTION(scope, {});
         }
+        RETURN_IF_EXCEPTION(scope, {});
     }
     return jsUndefined();
 }
@@ -792,11 +781,8 @@ static void nativeSourceOnDrain(JSGlobalObject* globalObject, JSNativeStreamSour
     if (!controller)
         return;
     if (adapter->m_textMode) {
-        auto& vm = getVM(globalObject);
-        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-            std::span<const uint8_t> bytes { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
-            nativeEnqueueTextChunk(vm, globalObject, adapter, controller, bytes, /* flush */ false);
-        }
+        if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
+            nativeEnqueueTextChunk(globalObject, controller, adapter->m_textState, view->span(), /* flush */ false);
         return;
     }
     readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -391,11 +391,11 @@ static void nativeStorePendingView(JSC::VM& vm, JSNativeStreamSourceAdapter* ada
 static void nativeEnqueueTextChunk(JSC::VM& vm, JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSReadableStreamDefaultController* controller, std::span<const uint8_t> bytes, bool flush)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::String decoded = streamingUTF8Decode(bytes, adapter->m_textState, flush);
-    if (decoded.isEmpty() || !controller)
+    auto* decoded = streamingUTF8Decode(globalObject, bytes, adapter->m_textState, flush);
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!decoded || !decoded->length() || !controller)
         return;
-    JSString* chunk = jsString(vm, WTF::move(decoded));
-    readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+    readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
     RETURN_IF_EXCEPTION(scope, void());
 }
 
@@ -595,9 +595,10 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
             if (stream->m_nativeTextMode) {
                 StreamingUTF8DecodeState state;
                 std::span<const uint8_t> bytes { static_cast<const uint8_t*>(drainView->vector()), drainView->byteLength() };
-                WTF::String decoded = streamingUTF8Decode(bytes, state, /* flush */ true);
-                if (!decoded.isEmpty()) {
-                    readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+                auto* decoded = streamingUTF8Decode(globalObject, bytes, state, /* flush */ true);
+                RETURN_IF_EXCEPTION(scope, );
+                if (decoded && decoded->length()) {
+                    readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
                     RETURN_IF_EXCEPTION(scope, );
                 }
             } else {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -13,6 +13,7 @@
 #include "StreamsForward.h"
 
 #include "JSReadableStreamDefaultController.h"
+#include "WebStreamsInternals.h"
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/Weak.h>
 
@@ -62,6 +63,9 @@ public:
     bool m_hasResized : 1 { false };
     // #closed
     bool m_closed : 1 { false };
+    // Body.textStream(): each pulled byte span is UTF-8-decoded before enqueue.
+    bool m_textMode : 1 { false };
+    Bun::WebStreams::StreamingUTF8DecodeState m_textState;
 
 private:
     JSNativeStreamSourceAdapter(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -13,7 +13,6 @@
 #include "StreamsForward.h"
 
 #include "JSReadableStreamDefaultController.h"
-#include "WebStreamsInternals.h"
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/Weak.h>
 

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -143,6 +143,8 @@ void JSReadRequest::chunkSteps(JSGlobalObject* globalObject, JSValue chunk)
         queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorResolveMicrotask(), result, promise);
         return;
     }
+    case ReadRequestKind::TextDecode:
+        RELEASE_AND_RETURN(scope, textDecodeReadRequestChunkSteps(globalObject, uncheckedDowncast<JSReadableStreamDefaultController>(m_context.get()), chunk));
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -218,6 +220,8 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
         queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorResolveMicrotask(), result, promise);
         return;
     }
+    case ReadRequestKind::TextDecode:
+        RELEASE_AND_RETURN(scope, textDecodeReadRequestCloseSteps(globalObject, uncheckedDowncast<JSReadableStreamDefaultController>(m_context.get())));
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -249,6 +253,8 @@ void JSReadRequest::errorSteps(JSGlobalObject* globalObject, JSValue error)
         queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorRejectMicrotask(), error, promise);
         return;
     }
+    case ReadRequestKind::TextDecode:
+        RELEASE_AND_RETURN(scope, readableStreamDefaultControllerError(globalObject, uncheckedDowncast<JSReadableStreamDefaultController>(m_context.get()), error));
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -258,7 +258,7 @@ void JSReadRequest::errorSteps(JSGlobalObject* globalObject, JSValue error)
         auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
         readableStreamDefaultControllerError(globalObject, controller, error);
         RETURN_IF_EXCEPTION(scope, void());
-        if (reader) {
+        if (reader && reader->m_stream) {
             readableStreamDefaultReaderRelease(globalObject, reader);
             RETURN_IF_EXCEPTION(scope, void());
         }

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -253,8 +253,17 @@ void JSReadRequest::errorSteps(JSGlobalObject* globalObject, JSValue error)
         queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorRejectMicrotask(), error, promise);
         return;
     }
-    case ReadRequestKind::TextDecode:
-        RELEASE_AND_RETURN(scope, readableStreamDefaultControllerError(globalObject, uncheckedDowncast<JSReadableStreamDefaultController>(m_context.get()), error));
+    case ReadRequestKind::TextDecode: {
+        auto* controller = uncheckedDowncast<JSReadableStreamDefaultController>(m_context.get());
+        auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+        readableStreamDefaultControllerError(globalObject, controller, error);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (reader) {
+            readableStreamDefaultReaderRelease(globalObject, reader);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
+        return;
+    }
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -161,6 +161,7 @@ static JSC::JSPromise* performByteControllerPullAlgorithm(JSC::VM& vm, JSC::JSGl
     case SourceKind::FromIterable:
     case SourceKind::CrossRealm:
     case SourceKind::Native:
+    case SourceKind::TextDecode:
         break;
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -194,6 +195,7 @@ static JSC::JSPromise* performByteControllerCancelAlgorithm(JSC::VM& vm, JSC::JS
     case SourceKind::FromIterable:
     case SourceKind::CrossRealm:
     case SourceKind::Native:
+    case SourceKind::TextDecode:
         break;
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -50,9 +50,6 @@ public:
     ReadableStreamState m_state { ReadableStreamState::Readable };
     // The Bun lazy-start mode; tells materializeIfNeeded() what to do.
     BunStreamMode m_bunMode { BunStreamMode::Default };
-    // Body.textStream(): the native source adapter decodes each chunk as UTF-8
-    // text before enqueue.
-    bool m_nativeTextMode { false };
     // The tag for the ERASED m_controller below. Every switch over it is TOTAL.
     ControllerKind m_controllerKind { ControllerKind::None };
     // [[disturbed]]
@@ -66,6 +63,9 @@ public:
     bool m_transferred : 1 { false };
     // `typeof rawHighWaterMark === "number"` at construction time.
     bool m_bunHighWaterMarkIsNumber : 1 { false };
+    // Body.textStream(): the native source adapter decodes each chunk as UTF-8
+    // text before enqueue.
+    bool m_nativeTextMode : 1 { false };
     // `$bunNativeType`: write-only today, kept for the FFI ABI.
     int32_t m_nativeType { 0 };
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -109,6 +109,12 @@ public:
     {
         if (m_transferred)
             return JSC::jsNumber(-1);
+        // A text-mode native stream's handle wraps a raw byte source; hide it
+        // from JS-side native-transfer fast paths (Readable.fromWeb) so they
+        // fall back to a reader that sees decoded strings. ReadableStreamTag__tagged
+        // reads the raw slot, so the fetch/server push-side is unaffected.
+        if (m_nativeTextMode)
+            return {};
         return m_nativePtr.get(); // may be empty
     }
     bool nativeHandleDetached() const

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -50,6 +50,9 @@ public:
     ReadableStreamState m_state { ReadableStreamState::Readable };
     // The Bun lazy-start mode; tells materializeIfNeeded() what to do.
     BunStreamMode m_bunMode { BunStreamMode::Default };
+    // Body.textStream(): the native source adapter decodes each chunk as UTF-8
+    // text before enqueue.
+    bool m_nativeTextMode { false };
     // The tag for the ERASED m_controller below. Every switch over it is TOTAL.
     ControllerKind m_controllerKind { ControllerKind::None };
     // [[disturbed]]

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -105,6 +105,8 @@ static JSC::JSPromise* performDefaultControllerPullAlgorithm(JSC::VM& vm, JSC::J
         RELEASE_AND_RETURN(scope, fromIterablePullAlgorithm(globalObject, controller));
     case SourceKind::Native:
         RELEASE_AND_RETURN(scope, nativeSourcePull(globalObject, controller));
+    case SourceKind::TextDecode:
+        RELEASE_AND_RETURN(scope, textDecodePullAlgorithm(globalObject, controller));
     case SourceKind::ByteTeeBranch:
     case SourceKind::CrossRealm:
         break;
@@ -141,6 +143,8 @@ static JSC::JSPromise* performDefaultControllerCancelAlgorithm(JSC::VM& vm, JSC:
         RELEASE_AND_RETURN(scope, fromIterableCancelAlgorithm(globalObject, controller, reason));
     case SourceKind::Native:
         RELEASE_AND_RETURN(scope, nativeSourceCancel(globalObject, controller, reason));
+    case SourceKind::TextDecode:
+        RELEASE_AND_RETURN(scope, textDecodeCancelAlgorithm(globalObject, controller, reason));
     case SourceKind::ByteTeeBranch:
     case SourceKind::CrossRealm:
         break;

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1007,8 +1007,18 @@ JSPromise* textDecodePullAlgorithm(JSGlobalObject* globalObject, JSReadableStrea
     auto* runtime = JSStreamsRuntime::from(globalObject);
     auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
     auto* readRequest = WebCore::JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::TextDecode, controller);
-    readableStreamDefaultReaderRead(globalObject, reader, readRequest);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    JSValue thrown;
+    {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        readableStreamDefaultReaderRead(globalObject, reader, readRequest);
+        if (catchScope.exception()) [[unlikely]] {
+            thrown = takeAbruptCompletion(globalObject, catchScope);
+            if (thrown.isEmpty())
+                return nullptr;
+        }
+    }
+    if (!thrown.isEmpty())
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JSAsyncFromSyncIterator.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
+#include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
@@ -972,6 +973,110 @@ static EncodedJSValue fromIterableCancelFulfilled(JSGlobalObject* globalObject, 
     if (!iterResult.isObject())
         return throwVMTypeError(globalObject, scope, "The promise returned by the async iterator's return() method must fulfill with an object"_s);
     return JSValue::encode(jsUndefined());
+}
+
+// SourceKind::TextDecode — Body.textStream() over an existing byte ReadableStream. The
+// controller's algorithmContext is the source JSReadableStreamDefaultReader; underlyingObject
+// is a 4-byte Uint8Array holding the StreamingUTF8DecodeState verbatim.
+
+static constexpr size_t textDecodeStateSize = sizeof(StreamingUTF8DecodeState);
+static_assert(textDecodeStateSize == 4);
+
+static void textDecodeLoadState(JSC::JSUint8Array* stateView, StreamingUTF8DecodeState& state)
+{
+    memcpy(&state, stateView->typedVector(), textDecodeStateSize);
+}
+
+static void textDecodeStoreState(JSC::JSUint8Array* stateView, const StreamingUTF8DecodeState& state)
+{
+    memcpy(stateView->typedVector(), &state, textDecodeStateSize);
+}
+
+JSReadableStream* readableStreamTextDecodeFrom(JSGlobalObject* globalObject, JSReadableStream* source)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* domGlobalObject = defaultGlobalObject(globalObject);
+
+    source->materializeIfNeeded(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    auto* reader = acquireReadableStreamDefaultReader(globalObject, source);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    auto* stream = JSReadableStream::create(vm, WebCore::getDOMStructure<JSReadableStream>(vm, *domGlobalObject));
+    initializeReadableStream(stream);
+    auto* controller = JSReadableStreamDefaultController::create(vm, WebCore::getDOMStructure<JSReadableStreamDefaultController>(vm, *domGlobalObject));
+    controller->m_algorithms.kind = SourceKind::TextDecode;
+    controller->m_algorithms.algorithmContext.set(vm, controller, reader);
+    auto* stateView = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), textDecodeStateSize);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    controller->m_algorithms.underlyingObject.set(vm, controller, stateView);
+    setUpReadableStreamDefaultController(globalObject, stream, controller, jsUndefined(), /* highWaterMark */ 0);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return stream;
+}
+
+JSPromise* textDecodePullAlgorithm(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* runtime = JSStreamsRuntime::from(globalObject);
+    auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+    auto* readRequest = WebCore::JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::TextDecode, controller);
+    readableStreamDefaultReaderRead(globalObject, reader, readRequest);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+}
+
+JSPromise* textDecodeCancelAlgorithm(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue reason)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+    RELEASE_AND_RETURN(scope, readableStreamReaderGenericCancel(globalObject, reader, reason));
+}
+
+void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue chunk)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk);
+    if (!view || view->isDetached()) [[unlikely]] {
+        auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not an ArrayBufferView"_s);
+        RETURN_IF_EXCEPTION(scope, void());
+        readableStreamDefaultControllerError(globalObject, controller, error);
+        return;
+    }
+    auto* stateView = uncheckedDowncast<JSC::JSUint8Array>(controller->m_algorithms.underlyingObject.get().getObject());
+    StreamingUTF8DecodeState state;
+    textDecodeLoadState(stateView, state);
+    std::span<const uint8_t> bytes { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
+    WTF::String decoded = streamingUTF8Decode(bytes, state, /* flush */ false);
+    textDecodeStoreState(stateView, state);
+    if (decoded.isEmpty()) {
+        // No output from this chunk (held back as an incomplete sequence). Arm
+        // `m_pullAgain` so the controller re-pulls once this pull settles.
+        RELEASE_AND_RETURN(scope, readableStreamDefaultControllerCallPullIfNeeded(globalObject, controller));
+    }
+    readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+    RETURN_IF_EXCEPTION(scope, void());
+}
+
+void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stateView = uncheckedDowncast<JSC::JSUint8Array>(controller->m_algorithms.underlyingObject.get().getObject());
+    StreamingUTF8DecodeState state;
+    textDecodeLoadState(stateView, state);
+    WTF::String decoded = streamingUTF8Decode({}, state, /* flush */ true);
+    textDecodeStoreState(stateView, state);
+    if (!decoded.isEmpty()) {
+        readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+        RETURN_IF_EXCEPTION(scope, void());
+    }
+    readableStreamDefaultControllerClose(globalObject, controller);
+    RETURN_IF_EXCEPTION(scope, void());
 }
 
 // Bun: `$structuredCloneForStream(chunk)` — the shared native host function installed as a

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1050,10 +1050,10 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     std::span<const uint8_t> bytes;
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
         if (!view->isDetached())
-            bytes = std::span { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
+            bytes = view->span();
     } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
         if (buffer->impl() && !buffer->impl()->isDetached())
-            bytes = std::span { static_cast<const uint8_t*>(buffer->impl()->data()), buffer->impl()->byteLength() };
+            bytes = buffer->impl()->span();
     } else {
         auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
         RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -27,9 +27,9 @@
 #include <JavaScriptCore/InternalFieldTuple.h>
 #include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSAsyncFromSyncIterator.h>
+#include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
-#include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/Locker.h>
@@ -976,21 +976,8 @@ static EncodedJSValue fromIterableCancelFulfilled(JSGlobalObject* globalObject, 
 }
 
 // SourceKind::TextDecode — Body.textStream() over an existing byte ReadableStream. The
-// controller's algorithmContext is the source JSReadableStreamDefaultReader; underlyingObject
-// is a 4-byte Uint8Array holding the StreamingUTF8DecodeState verbatim.
-
-static constexpr size_t textDecodeStateSize = sizeof(StreamingUTF8DecodeState);
-static_assert(textDecodeStateSize == 4);
-
-static void textDecodeLoadState(JSC::JSUint8Array* stateView, StreamingUTF8DecodeState& state)
-{
-    memcpy(&state, stateView->typedVector(), textDecodeStateSize);
-}
-
-static void textDecodeStoreState(JSC::JSUint8Array* stateView, const StreamingUTF8DecodeState& state)
-{
-    memcpy(stateView->typedVector(), &state, textDecodeStateSize);
-}
+// controller's algorithmContext is the source JSReadableStreamDefaultReader; the
+// StreamingUTF8DecodeState is inline on m_algorithms.textDecodeState.
 
 JSReadableStream* readableStreamTextDecodeFrom(JSGlobalObject* globalObject, JSReadableStream* source)
 {
@@ -1008,9 +995,6 @@ JSReadableStream* readableStreamTextDecodeFrom(JSGlobalObject* globalObject, JSR
     auto* controller = JSReadableStreamDefaultController::create(vm, WebCore::getDOMStructure<JSReadableStreamDefaultController>(vm, *domGlobalObject));
     controller->m_algorithms.kind = SourceKind::TextDecode;
     controller->m_algorithms.algorithmContext.set(vm, controller, reader);
-    auto* stateView = JSC::JSUint8Array::create(globalObject, globalObject->typedArrayStructure(JSC::TypeUint8, false), textDecodeStateSize);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    controller->m_algorithms.underlyingObject.set(vm, controller, stateView);
     setUpReadableStreamDefaultController(globalObject, stream, controller, jsUndefined(), /* highWaterMark */ 0);
     RETURN_IF_EXCEPTION(scope, nullptr);
     return stream;
@@ -1040,9 +1024,15 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk);
-    if (!view || view->isDetached()) [[unlikely]] {
-        auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not an ArrayBufferView"_s);
+    if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
+        return;
+    std::span<const uint8_t> bytes;
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk); view && !view->isDetached()) {
+        bytes = std::span { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
+    } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk); buffer && buffer->impl() && !buffer->impl()->isDetached()) {
+        bytes = std::span { static_cast<const uint8_t*>(buffer->impl()->data()), buffer->impl()->byteLength() };
+    } else {
+        auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
         RETURN_IF_EXCEPTION(scope, void());
         if (auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get())) {
             auto* cancelResult = readableStreamReaderGenericCancel(globalObject, reader, error);
@@ -1051,14 +1041,10 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
                 markPromiseAsHandled(vm, cancelResult);
         }
         readableStreamDefaultControllerError(globalObject, controller, error);
+        RETURN_IF_EXCEPTION(scope, void());
         return;
     }
-    auto* stateView = uncheckedDowncast<JSC::JSUint8Array>(controller->m_algorithms.underlyingObject.get().getObject());
-    StreamingUTF8DecodeState state;
-    textDecodeLoadState(stateView, state);
-    std::span<const uint8_t> bytes { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
-    WTF::String decoded = streamingUTF8Decode(bytes, state, /* flush */ false);
-    textDecodeStoreState(stateView, state);
+    WTF::String decoded = streamingUTF8Decode(bytes, controller->m_algorithms.textDecodeState, /* flush */ false);
     if (decoded.isEmpty()) {
         // No output from this chunk (held back as an incomplete sequence). Arm
         // `m_pullAgain` so the controller re-pulls once this pull settles.
@@ -1072,11 +1058,9 @@ void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStr
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* stateView = uncheckedDowncast<JSC::JSUint8Array>(controller->m_algorithms.underlyingObject.get().getObject());
-    StreamingUTF8DecodeState state;
-    textDecodeLoadState(stateView, state);
-    WTF::String decoded = streamingUTF8Decode({}, state, /* flush */ true);
-    textDecodeStoreState(stateView, state);
+    if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
+        return;
+    WTF::String decoded = streamingUTF8Decode({}, controller->m_algorithms.textDecodeState, /* flush */ true);
     if (!decoded.isEmpty()) {
         readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
         RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1044,6 +1044,12 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     if (!view || view->isDetached()) [[unlikely]] {
         auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not an ArrayBufferView"_s);
         RETURN_IF_EXCEPTION(scope, void());
+        if (auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get())) {
+            auto* cancelResult = readableStreamReaderGenericCancel(globalObject, reader, error);
+            RETURN_IF_EXCEPTION(scope, void());
+            if (cancelResult)
+                markPromiseAsHandled(vm, cancelResult);
+        }
         readableStreamDefaultControllerError(globalObject, controller, error);
         return;
     }

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1044,13 +1044,14 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
         RETURN_IF_EXCEPTION(scope, void());
         return;
     }
-    WTF::String decoded = streamingUTF8Decode(bytes, controller->m_algorithms.textDecodeState, /* flush */ false);
-    if (decoded.isEmpty()) {
+    auto* decoded = streamingUTF8Decode(globalObject, bytes, controller->m_algorithms.textDecodeState, /* flush */ false);
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!decoded || !decoded->length()) {
         // No output from this chunk (held back as an incomplete sequence). Arm
         // `m_pullAgain` so the controller re-pulls once this pull settles.
         RELEASE_AND_RETURN(scope, readableStreamDefaultControllerCallPullIfNeeded(globalObject, controller));
     }
-    readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+    readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
     RETURN_IF_EXCEPTION(scope, void());
 }
 
@@ -1060,9 +1061,10 @@ void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStr
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
         return;
-    WTF::String decoded = streamingUTF8Decode({}, controller->m_algorithms.textDecodeState, /* flush */ true);
-    if (!decoded.isEmpty()) {
-        readableStreamDefaultControllerEnqueue(globalObject, controller, jsString(vm, WTF::move(decoded)));
+    auto* decoded = streamingUTF8Decode(globalObject, {}, controller->m_algorithms.textDecodeState, /* flush */ true);
+    RETURN_IF_EXCEPTION(scope, void());
+    if (decoded && decoded->length()) {
+        readableStreamDefaultControllerEnqueue(globalObject, controller, decoded);
         RETURN_IF_EXCEPTION(scope, void());
     }
     readableStreamDefaultControllerClose(globalObject, controller);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1068,8 +1068,10 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
             RETURN_IF_EXCEPTION(scope, void());
             if (cancelResult)
                 markPromiseAsHandled(vm, cancelResult);
-            readableStreamDefaultReaderRelease(globalObject, reader);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (reader->m_stream) {
+                readableStreamDefaultReaderRelease(globalObject, reader);
+                RETURN_IF_EXCEPTION(scope, void());
+            }
         }
         return;
     }
@@ -1099,7 +1101,10 @@ void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStr
     }
     readableStreamDefaultControllerClose(globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
-    if (reader) {
+    // The flush enqueue above can tail-call callPullIfNeeded and re-enter
+    // closeSteps (source is already Closed), whose inner call releases the
+    // reader; guard against a second release on an already-released reader.
+    if (reader && reader->m_stream) {
         readableStreamDefaultReaderRelease(globalObject, reader);
         RETURN_IF_EXCEPTION(scope, void());
     }

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1027,7 +1027,11 @@ JSPromise* textDecodeCancelAlgorithm(JSGlobalObject* globalObject, JSReadableStr
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
-    RELEASE_AND_RETURN(scope, readableStreamReaderGenericCancel(globalObject, reader, reason));
+    auto* result = readableStreamReaderGenericCancel(globalObject, reader, reason);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    readableStreamDefaultReaderRelease(globalObject, reader);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return result;
 }
 
 void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStreamDefaultController* controller, JSValue chunk)
@@ -1059,6 +1063,8 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
             RETURN_IF_EXCEPTION(scope, void());
             if (cancelResult)
                 markPromiseAsHandled(vm, cancelResult);
+            readableStreamDefaultReaderRelease(globalObject, reader);
+            RETURN_IF_EXCEPTION(scope, void());
         }
         return;
     }
@@ -1079,6 +1085,7 @@ void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStr
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
         return;
+    auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
     auto* decoded = streamingUTF8Decode(globalObject, {}, controller->m_algorithms.textDecodeState, /* flush */ true);
     RETURN_IF_EXCEPTION(scope, void());
     if (decoded && decoded->length()) {
@@ -1087,6 +1094,10 @@ void textDecodeReadRequestCloseSteps(JSGlobalObject* globalObject, JSReadableStr
     }
     readableStreamDefaultControllerClose(globalObject, controller);
     RETURN_IF_EXCEPTION(scope, void());
+    if (reader) {
+        readableStreamDefaultReaderRelease(globalObject, reader);
+        RETURN_IF_EXCEPTION(scope, void());
+    }
 }
 
 // Bun: `$structuredCloneForStream(chunk)` — the shared native host function installed as a

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1026,7 +1026,12 @@ JSPromise* textDecodeCancelAlgorithm(JSGlobalObject* globalObject, JSReadableStr
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* reader = uncheckedDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+    // closeSteps may have already released the source reader while the output
+    // still has a queued chunk (ClearAlgorithms didn't run); in that state the
+    // source is already terminal, so cancel becomes a no-op.
+    auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+    if (!reader || !reader->m_stream)
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
     auto* result = readableStreamReaderGenericCancel(globalObject, reader, reason);
     RETURN_IF_EXCEPTION(scope, nullptr);
     readableStreamDefaultReaderRelease(globalObject, reader);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1034,14 +1034,18 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     } else {
         auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
         RETURN_IF_EXCEPTION(scope, void());
-        if (auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get())) {
+        // Error the output first so any second pending TextDecode read request's
+        // closeSteps (fired by cancelling the source) no-ops on canCloseOrEnqueue.
+        // Grab the reader before erroring: ClearAlgorithms nulls algorithmContext.
+        auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(controller->m_algorithms.algorithmContext.get());
+        readableStreamDefaultControllerError(globalObject, controller, error);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (reader) {
             auto* cancelResult = readableStreamReaderGenericCancel(globalObject, reader, error);
             RETURN_IF_EXCEPTION(scope, void());
             if (cancelResult)
                 markPromiseAsHandled(vm, cancelResult);
         }
-        readableStreamDefaultControllerError(globalObject, controller, error);
-        RETURN_IF_EXCEPTION(scope, void());
         return;
     }
     auto* decoded = streamingUTF8Decode(globalObject, bytes, controller->m_algorithms.textDecodeState, /* flush */ false);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1026,11 +1026,15 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
         return;
+    // WebIDL "get a copy of the bytes held by the buffer source": a detached
+    // buffer is still a BufferSource whose bytes are the empty sequence.
     std::span<const uint8_t> bytes;
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk); view && !view->isDetached()) {
-        bytes = std::span { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
-    } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk); buffer && buffer->impl() && !buffer->impl()->isDetached()) {
-        bytes = std::span { static_cast<const uint8_t*>(buffer->impl()->data()), buffer->impl()->byteLength() };
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
+        if (!view->isDetached())
+            bytes = std::span { static_cast<const uint8_t*>(view->vector()), view->byteLength() };
+    } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
+        if (buffer->impl() && !buffer->impl()->isDetached())
+            bytes = std::span { static_cast<const uint8_t*>(buffer->impl()->data()), buffer->impl()->byteLength() };
     } else {
         auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
         RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/webcore/streams/StreamQueue.h
+++ b/src/jsc/bindings/webcore/streams/StreamQueue.h
@@ -70,6 +70,8 @@ struct SourceAlgorithmSlots {
     SourceKind kind { SourceKind::Nothing };
     // TeeBranch / ByteTeeBranch only: which branch this controller is (0 or 1).
     uint8_t teeBranchIndex { 0 };
+    // TextDecode kind only: the inline streaming-UTF-8 decode state.
+    StreamingUTF8DecodeState textDecodeState;
     // JavaScript kind only: the user underlyingSource object (the call `this`).
     JSC::WriteBarrier<JSC::Unknown> underlyingObject;
     // JavaScript kind only: the converted `pull` method ([[pullAlgorithm]]);

--- a/src/jsc/bindings/webcore/streams/StreamsForward.h
+++ b/src/jsc/bindings/webcore/streams/StreamsForward.h
@@ -116,6 +116,8 @@ enum class SourceKind : uint8_t {
     CrossRealm, // receiving end of a postMessage transfer (context = JSCrossRealmTransformState)
     Native, // Bun: lazily-materialized native source on a DEFAULT controller
             // (context = JSNativeStreamSourceAdapter)
+    TextDecode, // Body.textStream() reading from an existing byte stream
+                // (context = InternalFieldTuple{reader, 4-byte Uint8Array pending buffer})
 };
 
 // Which arm runs a writable controller's write/close/abort algorithms.
@@ -174,6 +176,9 @@ enum class ReadRequestKind : uint8_t {
     AsyncIterator, // context = InternalFieldTuple{asyncIterator, the next() result promise}
     ReadStreamIntoSink, // Bun: readStreamIntoSink pump read (context = JSReadStreamIntoSinkOperation)
     ResumableSinkPump, // Bun: ResumableSink pump read (context = JSResumableSinkPumpOperation)
+    TextDecode, // Body.textStream()'s per-pull read: context = the output
+                // JSReadableStreamDefaultController (its algorithmContext is the
+                // JSStreamTextDecodeContext holding the decoder)
 };
 
 // JSReadIntoRequest::m_kind (the BYOB parallel of ReadRequestKind).

--- a/src/jsc/bindings/webcore/streams/StreamsForward.h
+++ b/src/jsc/bindings/webcore/streams/StreamsForward.h
@@ -117,7 +117,8 @@ enum class SourceKind : uint8_t {
     Native, // Bun: lazily-materialized native source on a DEFAULT controller
             // (context = JSNativeStreamSourceAdapter)
     TextDecode, // Body.textStream() reading from an existing byte stream
-                // (context = InternalFieldTuple{reader, 4-byte Uint8Array pending buffer})
+                // (algorithmContext = source JSReadableStreamDefaultReader;
+                // underlyingObject = 4-byte state Uint8Array)
 };
 
 // Which arm runs a writable controller's write/close/abort algorithms.
@@ -178,7 +179,7 @@ enum class ReadRequestKind : uint8_t {
     ResumableSinkPump, // Bun: ResumableSink pump read (context = JSResumableSinkPumpOperation)
     TextDecode, // Body.textStream()'s per-pull read: context = the output
                 // JSReadableStreamDefaultController (its algorithmContext is the
-                // JSStreamTextDecodeContext holding the decoder)
+                // source reader; underlyingObject is the 4-byte state Uint8Array)
 };
 
 // JSReadIntoRequest::m_kind (the BYOB parallel of ReadRequestKind).

--- a/src/jsc/bindings/webcore/streams/StreamsForward.h
+++ b/src/jsc/bindings/webcore/streams/StreamsForward.h
@@ -118,7 +118,7 @@ enum class SourceKind : uint8_t {
             // (context = JSNativeStreamSourceAdapter)
     TextDecode, // Body.textStream() reading from an existing byte stream
                 // (algorithmContext = source JSReadableStreamDefaultReader;
-                // underlyingObject = 4-byte state Uint8Array)
+                // decode state inline on m_algorithms.textDecodeState)
 };
 
 // Which arm runs a writable controller's write/close/abort algorithms.
@@ -179,7 +179,7 @@ enum class ReadRequestKind : uint8_t {
     ResumableSinkPump, // Bun: ResumableSink pump read (context = JSResumableSinkPumpOperation)
     TextDecode, // Body.textStream()'s per-pull read: context = the output
                 // JSReadableStreamDefaultController (its algorithmContext is the
-                // source reader; underlyingObject is the 4-byte state Uint8Array)
+                // source reader; decode state inline on m_algorithms.textDecodeState)
 };
 
 // JSReadIntoRequest::m_kind (the BYOB parallel of ReadRequestKind).
@@ -196,6 +196,26 @@ enum class DirectSinkKind : uint8_t {
     Text, // the rope + pieces accumulator
     Array, // chunks pushed into a JSArray
 };
+
+// Body.textStream() streaming UTF-8 decode state: the partial trailing sequence carried
+// across chunk boundaries plus the once-per-stream BOM decision. Held-back bytes are
+// always [lead(>=0xC0), cont*(0x80..0xBF)], never zero, so pendingLen is the index of
+// the first zero in `pending` (0..3). Embedded inline on JSNativeStreamSourceAdapter and
+// on SourceAlgorithmSlots (for SourceKind::TextDecode).
+struct StreamingUTF8DecodeState {
+    uint8_t pending[3] { 0, 0, 0 };
+    bool bomSeen { false };
+
+    unsigned pendingLen() const { return (pending[0] != 0) + (pending[0] != 0 && pending[1] != 0) + (pending[0] != 0 && pending[1] != 0 && pending[2] != 0); }
+    void clearPending() { pending[0] = pending[1] = pending[2] = 0; }
+    void setPending(const uint8_t* src, unsigned len)
+    {
+        clearPending();
+        for (unsigned i = 0; i < len; ++i)
+            pending[i] = src[i];
+    }
+};
+static_assert(sizeof(StreamingUTF8DecodeState) == 4);
 
 // WebIDL enums & small closed sets
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -7,6 +7,7 @@
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapperCache.h"
 #include "JSReadableStream.h"
+#include "JSReadableStreamDefaultController.h"
 #include "WebCoreJSBuiltins.h"
 #include "ZigGeneratedClasses.h"
 #include "ZigGlobalObject.h"
@@ -221,6 +222,48 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__createNativeReadableStream(Zig::
     // Nothing native runs until a consumer materializes the stream.
     stream->m_bunMode = BunStreamMode::NativePending;
     stream->m_nativePtr.set(vm, stream, JSValue::decode(nativePtr));
+    return JSValue::encode(stream);
+}
+
+extern "C" JSC::EncodedJSValue ZigGlobalObject__createNativeTextReadableStream(Zig::GlobalObject* globalObject, JSC::EncodedJSValue nativePtr)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stream = JSReadableStream::create(vm, WebCore::getDOMStructure<JSReadableStream>(vm, *globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
+    initializeReadableStream(stream);
+    stream->m_bunMode = BunStreamMode::NativePending;
+    stream->m_nativeTextMode = true;
+    stream->m_nativePtr.set(vm, stream, JSValue::decode(nativePtr));
+    return JSValue::encode(stream);
+}
+
+extern "C" JSC::EncodedJSValue ReadableStream__fromDecodedText(Zig::GlobalObject* globalObject, JSC::EncodedJSValue string)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stream = createReadableStream(globalObject, SourceKind::Nothing, nullptr, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, {});
+    auto* controller = uncheckedDowncast<JSReadableStreamDefaultController>(stream->m_controller.get());
+    JSValue chunk = JSValue::decode(string);
+    if (chunk.isString() && asString(chunk)->length()) {
+        readableStreamDefaultControllerEnqueue(globalObject, controller, chunk);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    readableStreamDefaultControllerClose(globalObject, controller);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(stream);
+}
+
+extern "C" JSC::EncodedJSValue ReadableStream__textDecodeFrom(Zig::GlobalObject* globalObject, JSC::EncodedJSValue sourceValue)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* source = dynamicDowncast<JSReadableStream>(JSValue::decode(sourceValue));
+    if (!source) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Expected a ReadableStream"_s);
+    auto* stream = readableStreamTextDecodeFrom(globalObject, source);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(stream);
 }
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -193,9 +193,11 @@ void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSVa
 JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&); // userJS: no — WebStreamsMisc.cpp
 
 // Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds
-// back a trailing incomplete sequence (unless `flush`), and returns the decoded span with
-// invalid sequences replaced by U+FFFD. The returned string may be empty.
-WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8DecodeState&, bool flush); // userJS: no — WebStreamsMisc.cpp
+// back a trailing incomplete sequence (unless `flush`), and decodes the remaining span via
+// Bun's simdutf-backed UTF-8 path (invalid sequences replaced by U+FFFD). Returns nullptr
+// when no complete code points were produced (callers skip the enqueue), or on a decode
+// throw (check the scope).
+JSC::JSString* streamingUTF8Decode(JSC::JSGlobalObject*, std::span<const uint8_t> chunk, StreamingUTF8DecodeState&, bool flush); // userJS: no — WebStreamsMisc.cpp
 
 // ReadableStreamOperations.cpp — stream-level RS ops, reader set-up, controller set-up,
 // tee, from-iterable.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -192,26 +192,6 @@ void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSVa
 // clearException() anywhere in the subsystem.
 JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&); // userJS: no — WebStreamsMisc.cpp
 
-// Body.textStream() streaming UTF-8 decode state: the partial trailing sequence carried
-// across chunk boundaries plus the once-per-stream BOM decision. Held-back bytes are
-// always [lead(>=0xC0), cont*(0x80..0xBF)], never zero, so pendingLen is the index of
-// the first zero in `pending` (0..3). Embedded inline (native adapter) or marshalled
-// to/from a 4-byte Uint8Array (the SourceKind::TextDecode context).
-struct StreamingUTF8DecodeState {
-    uint8_t pending[3] { 0, 0, 0 };
-    bool bomSeen { false };
-
-    unsigned pendingLen() const { return (pending[0] != 0) + (pending[0] != 0 && pending[1] != 0) + (pending[0] != 0 && pending[1] != 0 && pending[2] != 0); }
-    void clearPending() { pending[0] = pending[1] = pending[2] = 0; }
-    void setPending(const uint8_t* src, unsigned len)
-    {
-        ASSERT(len <= 3);
-        clearPending();
-        for (unsigned i = 0; i < len; ++i)
-            pending[i] = src[i];
-    }
-};
-static_assert(sizeof(StreamingUTF8DecodeState) == 4);
 // Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds
 // back a trailing incomplete sequence (unless `flush`), and returns the decoded span with
 // invalid sequences replaced by U+FFFD. The returned string may be empty.
@@ -279,8 +259,8 @@ JSC::JSPromise* byteTeeCancelAlgorithm(JSC::JSGlobalObject*, JSStreamTeeState*, 
 JSC::JSPromise* fromIterablePullAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: yes (iterator `next`) — ReadableStreamOperations.cpp
 JSC::JSPromise* fromIterableCancelAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue reason); // userJS: yes (iterator `return`) — ReadableStreamOperations.cpp
 // TextDecode (Body.textStream() reading from an existing byte ReadableStream; the
-// controller's algorithmContext is the source reader, underlyingObject is the state
-// Uint8Array):
+// controller's algorithmContext is the source reader, decode state inline on
+// m_algorithms.textDecodeState):
 JSC::JSPromise* textDecodePullAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: yes (source pull) — ReadableStreamOperations.cpp
 JSC::JSPromise* textDecodeCancelAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue reason); // userJS: yes — ReadableStreamOperations.cpp
 void textDecodeReadRequestChunkSteps(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue chunk); // userJS: yes — ReadableStreamOperations.cpp

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -192,6 +192,31 @@ void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSVa
 // clearException() anywhere in the subsystem.
 JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&); // userJS: no — WebStreamsMisc.cpp
 
+// Body.textStream() streaming UTF-8 decode state: the partial trailing sequence carried
+// across chunk boundaries plus the once-per-stream BOM decision. Held-back bytes are
+// always [lead(>=0xC0), cont*(0x80..0xBF)], never zero, so pendingLen is the index of
+// the first zero in `pending` (0..3). Embedded inline (native adapter) or marshalled
+// to/from a 4-byte Uint8Array (the SourceKind::TextDecode context).
+struct StreamingUTF8DecodeState {
+    uint8_t pending[3] { 0, 0, 0 };
+    bool bomSeen { false };
+
+    unsigned pendingLen() const { return (pending[0] != 0) + (pending[0] != 0 && pending[1] != 0) + (pending[0] != 0 && pending[1] != 0 && pending[2] != 0); }
+    void clearPending() { pending[0] = pending[1] = pending[2] = 0; }
+    void setPending(const uint8_t* src, unsigned len)
+    {
+        ASSERT(len <= 3);
+        clearPending();
+        for (unsigned i = 0; i < len; ++i)
+            pending[i] = src[i];
+    }
+};
+static_assert(sizeof(StreamingUTF8DecodeState) == 4);
+// Joins any pending bytes, strips a single leading BOM per stream (ignoreBOM=false), holds
+// back a trailing incomplete sequence (unless `flush`), and returns the decoded span with
+// invalid sequences replaced by U+FFFD. The returned string may be empty.
+WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8DecodeState&, bool flush); // userJS: no — WebStreamsMisc.cpp
+
 // ReadableStreamOperations.cpp — stream-level RS ops, reader set-up, controller set-up,
 // tee, from-iterable.
 
@@ -236,6 +261,9 @@ std::pair<JSReadableStream*, JSReadableStream*> readableStreamDefaultTee(JSC::JS
 std::pair<JSReadableStream*, JSReadableStream*> readableByteStreamTee(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — ReadableStreamOperations.cpp
 // spec ReadableStreamFromIterable(asyncIterable) — `ReadableStream.from`.
 JSReadableStream* readableStreamFromIterable(JSC::JSGlobalObject*, JSC::JSValue asyncIterable); // userJS: yes — ReadableStreamOperations.cpp
+// Body.textStream() over an existing byte ReadableStream: locks a default reader on
+// `source` and returns a SourceKind::TextDecode stream that UTF-8-decodes each chunk.
+JSReadableStream* readableStreamTextDecodeFrom(JSC::JSGlobalObject*, JSReadableStream* source); // userJS: yes — ReadableStreamOperations.cpp
 
 // Non-JavaScript SourceKind algorithm ARMS owned by THIS file. The controller's pull/cancel
 // dispatch is a TOTAL `switch (m_algorithms.kind)` in JSReadableStreamDefaultController.cpp /
@@ -250,6 +278,13 @@ JSC::JSPromise* byteTeeCancelAlgorithm(JSC::JSGlobalObject*, JSStreamTeeState*, 
 // FromIterable (the controller's algorithmContext is the JSStreamFromIterableContext):
 JSC::JSPromise* fromIterablePullAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: yes (iterator `next`) — ReadableStreamOperations.cpp
 JSC::JSPromise* fromIterableCancelAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue reason); // userJS: yes (iterator `return`) — ReadableStreamOperations.cpp
+// TextDecode (Body.textStream() reading from an existing byte ReadableStream; the
+// controller's algorithmContext is the source reader, underlyingObject is the state
+// Uint8Array):
+JSC::JSPromise* textDecodePullAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: yes (source pull) — ReadableStreamOperations.cpp
+JSC::JSPromise* textDecodeCancelAlgorithm(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue reason); // userJS: yes — ReadableStreamOperations.cpp
+void textDecodeReadRequestChunkSteps(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue chunk); // userJS: yes — ReadableStreamOperations.cpp
+void textDecodeReadRequestCloseSteps(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: yes — ReadableStreamOperations.cpp
 // (The Transform arm's cross-file targets are transformStreamDefaultSource{Pull,Cancel}Algorithm
 // below; the Native arm's are nativeSource{Start,Pull,Cancel} in the BunStreamSource.cpp
 // section; the CrossRealm arms are with the rest of CrossRealmTransform.cpp.)
@@ -595,7 +630,10 @@ void ReadableStream__detach(JSC::EncodedJSValue possibleReadableStream, Zig::Glo
 JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__errored(Zig::GlobalObject*, JSC::EncodedJSValue reason); // userJS: no
+JSC::EncodedJSValue ReadableStream__fromDecodedText(Zig::GlobalObject*, JSC::EncodedJSValue string); // userJS: no
+JSC::EncodedJSValue ReadableStream__textDecodeFrom(Zig::GlobalObject*, JSC::EncodedJSValue source); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__createNativeReadableStream(Zig::GlobalObject*, JSC::EncodedJSValue nativePtr); // userJS: no
+JSC::EncodedJSValue ZigGlobalObject__createNativeTextReadableStream(Zig::GlobalObject*, JSC::EncodedJSValue nativePtr); // userJS: no
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBuffer(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -51,8 +51,10 @@ JSObject* extractSizeAlgorithm(const QueuingStrategyDict& strategy)
     return asObject(strategy.size);
 }
 
-// How many bytes at the tail of `data` form an incomplete UTF-8 sequence (1..3), or 0 if
-// it ends on a boundary (or the tail is definitely invalid and should be replaced now).
+// How many bytes at the tail of `data` form a valid incomplete UTF-8 sequence (1..3),
+// or 0 if it ends on a boundary (or the tail is definitely invalid and should be
+// replaced now). Applies the WHATWG UTF-8 decoder's per-lead second-byte ranges so a
+// surrogate / overlong / out-of-range prefix is not held back.
 static size_t incompleteTrailingUTF8(std::span<const uint8_t> data)
 {
     size_t len = data.size();
@@ -61,17 +63,33 @@ static size_t incompleteTrailingUTF8(std::span<const uint8_t> data)
         if ((b & 0xC0) == 0x80)
             continue;
         size_t need;
+        uint8_t secondMin = 0x80, secondMax = 0xBF;
         if (b < 0x80)
             need = 1;
-        else if ((b & 0xE0) == 0xC0)
+        else if (b >= 0xC2 && b <= 0xDF)
             need = 2;
-        else if ((b & 0xF0) == 0xE0)
+        else if (b >= 0xE0 && b <= 0xEF) {
             need = 3;
-        else if ((b & 0xF8) == 0xF0)
+            if (b == 0xE0)
+                secondMin = 0xA0;
+            else if (b == 0xED)
+                secondMax = 0x9F;
+        } else if (b >= 0xF0 && b <= 0xF4) {
             need = 4;
-        else
+            if (b == 0xF0)
+                secondMin = 0x90;
+            else if (b == 0xF4)
+                secondMax = 0x8F;
+        } else
             return 0;
-        return back < need ? back : 0;
+        if (back >= need)
+            return 0;
+        if (back >= 2) {
+            uint8_t second = data[len - back + 1];
+            if (second < secondMin || second > secondMax)
+                return 0;
+        }
+        return back;
     }
     return 0;
 }

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -7,6 +7,7 @@
 #include "JSWritableStream.h"
 
 #include "BunClientData.h"
+#include "JSBuffer.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSStreamsRuntime.h"
 #include <JavaScriptCore/ArrayBuffer.h>
@@ -75,7 +76,7 @@ static size_t incompleteTrailingUTF8(std::span<const uint8_t> data)
     return 0;
 }
 
-WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8DecodeState& state, bool flush)
+JSC::JSString* streamingUTF8Decode(JSGlobalObject* globalObject, std::span<const uint8_t> chunk, StreamingUTF8DecodeState& state, bool flush)
 {
     WTF::Vector<uint8_t> joinedStorage;
     std::span<const uint8_t> joined = chunk;
@@ -95,7 +96,7 @@ WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8Dec
         } else if (!flush && joined.size() < 3 && !memcmp(joined.data(), bom, joined.size())) {
             // Still a possible BOM prefix; carry it to the next chunk.
             state.setPending(joined.data(), static_cast<unsigned>(joined.size()));
-            return emptyString();
+            return nullptr;
         } else if (!joined.empty())
             state.bomSeen = true;
     }
@@ -105,8 +106,18 @@ WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8Dec
         state.setPending(joined.data() + (joined.size() - holdBack), static_cast<unsigned>(holdBack));
     auto toDecode = joined.first(joined.size() - holdBack);
     if (toDecode.empty())
-        return emptyString();
-    return WTF::String::fromUTF8ReplacingInvalidSequences(toDecode);
+        return nullptr;
+
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // Bun's simdutf-backed Buffer.toString('utf8') path: SIMD ASCII check,
+    // external UTF-16 for non-ASCII, replacement chars for invalid sequences.
+    // Small chunks avoid the FFI round-trip.
+    if (toDecode.size() < 64)
+        return jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences(toDecode));
+    JSValue decoded = JSValue::decode(Bun__encoding__toStringUTF8(toDecode.data(), toDecode.size(), globalObject));
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return asString(decoded);
 }
 
 // spec IsNonNegativeNumber(v). Non-throwing leaf: pure type + range test, no coercion.

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -50,6 +50,65 @@ JSObject* extractSizeAlgorithm(const QueuingStrategyDict& strategy)
     return asObject(strategy.size);
 }
 
+// How many bytes at the tail of `data` form an incomplete UTF-8 sequence (1..3), or 0 if
+// it ends on a boundary (or the tail is definitely invalid and should be replaced now).
+static size_t incompleteTrailingUTF8(std::span<const uint8_t> data)
+{
+    size_t len = data.size();
+    for (size_t back = 1; back <= std::min<size_t>(3, len); ++back) {
+        uint8_t b = data[len - back];
+        if ((b & 0xC0) == 0x80)
+            continue;
+        size_t need;
+        if (b < 0x80)
+            need = 1;
+        else if ((b & 0xE0) == 0xC0)
+            need = 2;
+        else if ((b & 0xF0) == 0xE0)
+            need = 3;
+        else if ((b & 0xF8) == 0xF0)
+            need = 4;
+        else
+            return 0;
+        return back < need ? back : 0;
+    }
+    return 0;
+}
+
+WTF::String streamingUTF8Decode(std::span<const uint8_t> chunk, StreamingUTF8DecodeState& state, bool flush)
+{
+    WTF::Vector<uint8_t> joinedStorage;
+    std::span<const uint8_t> joined = chunk;
+    if (unsigned pendingLen = state.pendingLen()) {
+        joinedStorage.reserveInitialCapacity(pendingLen + chunk.size());
+        joinedStorage.append(std::span<const uint8_t> { state.pending, pendingLen });
+        joinedStorage.append(chunk);
+        joined = joinedStorage.span();
+        state.clearPending();
+    }
+
+    if (!state.bomSeen) {
+        static constexpr uint8_t bom[] = { 0xEF, 0xBB, 0xBF };
+        if (joined.size() >= 3 && !memcmp(joined.data(), bom, 3)) {
+            joined = joined.subspan(3);
+            state.bomSeen = true;
+        } else if (!flush && joined.size() < 3 && !memcmp(joined.data(), bom, joined.size())) {
+            // Still a possible BOM prefix; carry it to the next chunk.
+            state.setPending(joined.data(), static_cast<unsigned>(joined.size()));
+            return emptyString();
+        } else if (!joined.empty())
+            state.bomSeen = true;
+    }
+
+    size_t holdBack = flush ? 0 : incompleteTrailingUTF8(joined);
+    if (holdBack)
+        state.setPending(joined.data() + (joined.size() - holdBack), static_cast<unsigned>(holdBack));
+    auto toDecode = joined.first(joined.size() - holdBack);
+    if (toDecode.empty())
+        return emptyString();
+    return WTF::String::fromUTF8ReplacingInvalidSequences(toDecode);
+}
+
 // spec IsNonNegativeNumber(v). Non-throwing leaf: pure type + range test, no coercion.
 bool isNonNegativeNumber(JSValue value)
 {

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -116,9 +116,6 @@ JSC::JSString* streamingUTF8Decode(JSGlobalObject* globalObject, std::span<const
     }
     // Bun's simdutf-backed Buffer.toString('utf8') path: SIMD ASCII check,
     // external UTF-16 for non-ASCII, replacement chars for invalid sequences.
-    // Small chunks avoid the FFI round-trip.
-    if (toDecode.size() < 64)
-        return jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences(toDecode));
     JSValue decoded = JSValue::decode(Bun__encoding__toStringUTF8(toDecode.data(), toDecode.size(), globalObject));
     RETURN_IF_EXCEPTION(scope, nullptr);
     return asString(decoded);

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -111,7 +111,7 @@ JSC::JSString* streamingUTF8Decode(JSGlobalObject* globalObject, std::span<const
         if (joined.size() >= 3 && !memcmp(joined.data(), bom, 3)) {
             joined = joined.subspan(3);
             state.bomSeen = true;
-        } else if (!flush && joined.size() < 3 && !memcmp(joined.data(), bom, joined.size())) {
+        } else if (!flush && !joined.empty() && joined.size() < 3 && !memcmp(joined.data(), bom, joined.size())) {
             // Still a possible BOM prefix; carry it to the next chunk.
             state.setPending(joined.data(), static_cast<unsigned>(joined.size()));
             return nullptr;

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -110,6 +110,10 @@ JSC::JSString* streamingUTF8Decode(JSGlobalObject* globalObject, std::span<const
 
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    if (exceedsStringLimit(toDecode.size())) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
     // Bun's simdutf-backed Buffer.toString('utf8') path: SIMD ASCII check,
     // external UTF-16 for non-ASCII, replacement chars for invalid sequences.
     // Small chunks avoid the FFI round-trip.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2418,9 +2418,8 @@ where
             if let Some(readable) = strong.get(&global_this) {
                 readable.value.ensure_still_alive();
                 if let Some(bytes) = readable.ptr.bytes() {
-                    let mut err = Body::ValueError::AbortReason(
-                        jsc::CommonAbortReason::ConnectionClosed,
-                    );
+                    let mut err =
+                        Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed);
                     bytes.on_data(WebCore::streams::Result::Err(
                         err.to_stream_error(global_this),
                     ))?;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2415,7 +2415,7 @@ where
         if self.request_body_readable_stream_ref.has() {
             let global_this = self.server().global_this();
             let strong = core::mem::take(&mut self.request_body_readable_stream_ref);
-            if let Some(readable) = strong.get(&global_this) {
+            if let Some(readable) = strong.get(global_this) {
                 readable.value.ensure_still_alive();
                 if let Some(bytes) = readable.ptr.bytes() {
                     let mut err =

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2408,6 +2408,28 @@ where
                 return Ok(true);
             }
         }
+
+        // `req.textStream()` transitions the body to `Value::Used`, so the
+        // Locked check above falls through. Error the ByteStream via our own
+        // strong ref instead so a pending read rejects rather than hanging.
+        if self.request_body_readable_stream_ref.has() {
+            let global_this = self.server().global_this();
+            let strong = core::mem::take(&mut self.request_body_readable_stream_ref);
+            if let Some(readable) = strong.get(&global_this) {
+                readable.value.ensure_still_alive();
+                if let Some(bytes) = readable.ptr.bytes() {
+                    let mut err = Body::ValueError::AbortReason(
+                        jsc::CommonAbortReason::ConnectionClosed,
+                    );
+                    bytes.on_data(WebCore::streams::Result::Err(
+                        err.to_stream_error(global_this),
+                    ))?;
+                    err.reset();
+                    return Ok(true);
+                }
+            }
+        }
+
         Ok(false)
     }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -839,78 +839,7 @@ impl Value {
                 if let Some(readable) = locked.readable.get(global_this) {
                     return Ok(readable.value);
                 }
-                if locked.promise.is_some() || !locked.action.is_none() {
-                    return ReadableStream::used(global_this);
-                }
-                let mut drain_result = DrainResult::EstimatedSize(0);
-
-                if let Some(drain) = locked.on_start_streaming.take() {
-                    drain_result = drain(locked.task.unwrap());
-                }
-
-                if matches!(drain_result, DrainResult::Empty | DrainResult::Aborted) {
-                    *self = Value::Null;
-                    return ReadableStream::empty(global_this);
-                }
-
-                // `new_mut` centralises the post-allocation deref; ownership of the
-                // heap `NewSource` transfers to the JS wrapper's `m_ctx` in
-                // `to_readable_stream()` below (freed by the GC finalizer).
-                let reader = webcore::readable_stream::NewSource::<ByteStream>::new_mut(
-                    webcore::readable_stream::NewSource {
-                        // `ByteStream::default()` is the post-setup state.
-                        context: ByteStream::default(),
-                        global_this: Some(bun_ptr::BackRef::new(global_this)),
-                        ..Default::default()
-                    },
-                );
-
-                if let Some(task) = locked.task {
-                    if let Some(on_cancelled) = locked.on_stream_cancelled {
-                        reader.cancel_handler.set(Some(on_cancelled));
-                        reader.cancel_ctx.set(Some(task));
-                    }
-                    if let Some(on_drained) = locked.on_stream_drained {
-                        reader.drain_handler.set(Some(on_drained));
-                        reader.drain_ctx.set(Some(task));
-                    }
-                }
-
-                reader.context.setup();
-
-                match drain_result {
-                    DrainResult::EstimatedSize(estimated_size) => {
-                        reader.context.high_water_mark = estimated_size as blob::SizeType;
-                        reader
-                            .context
-                            .size_hint
-                            .set(estimated_size as blob::SizeType);
-                    }
-                    DrainResult::Owned { list, size_hint } => {
-                        reader.context.buffer.set(list);
-                        reader.context.size_hint.set(size_hint as blob::SizeType);
-                    }
-                    _ => {}
-                }
-
-                let context_ptr: *mut ByteStream = &raw mut reader.context;
-                locked.readable = webcore::readable_stream::Strong::init(
-                    ReadableStream {
-                        ptr: webcore::readable_stream::Source::Bytes(context_ptr),
-                        value: reader.to_readable_stream(global_this)?,
-                    },
-                    global_this,
-                );
-
-                if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
-                    on_readable_stream_available(
-                        locked.task.unwrap(),
-                        global_this,
-                        locked.readable.get(global_this).unwrap(),
-                    );
-                }
-
-                Ok(locked.readable.get(global_this).unwrap().value)
+                self.locked_to_native_stream(global_this, false)
             }
             Value::Error(err) => {
                 // Leave `self` as `Error` so the promise-returning readers
@@ -958,82 +887,103 @@ impl Value {
                 *self = Value::Used;
                 Ok(stream)
             }
-            Value::Locked(locked) => {
-                if locked.promise.is_some() || !locked.action.is_none() {
-                    return ReadableStream::used(global_this);
-                }
-                let mut drain_result = DrainResult::EstimatedSize(0);
-
-                if let Some(drain) = locked.on_start_streaming.take() {
-                    drain_result = drain(locked.task.unwrap());
-                }
-
-                if matches!(drain_result, DrainResult::Empty | DrainResult::Aborted) {
-                    *self = Value::Null;
-                    return ReadableStream::empty(global_this);
-                }
-
-                let reader = webcore::readable_stream::NewSource::<ByteStream>::new_mut(
-                    webcore::readable_stream::NewSource {
-                        context: ByteStream::default(),
-                        global_this: Some(bun_ptr::BackRef::new(global_this)),
-                        ..Default::default()
-                    },
-                );
-
-                if let Some(task) = locked.task {
-                    if let Some(on_cancelled) = locked.on_stream_cancelled {
-                        reader.cancel_handler.set(Some(on_cancelled));
-                        reader.cancel_ctx.set(Some(task));
-                    }
-                    if let Some(on_drained) = locked.on_stream_drained {
-                        reader.drain_handler.set(Some(on_drained));
-                        reader.drain_ctx.set(Some(task));
-                    }
-                }
-
-                reader.context.setup();
-
-                match drain_result {
-                    DrainResult::EstimatedSize(estimated_size) => {
-                        reader.context.high_water_mark = estimated_size as blob::SizeType;
-                        reader
-                            .context
-                            .size_hint
-                            .set(estimated_size as blob::SizeType);
-                    }
-                    DrainResult::Owned { list, size_hint } => {
-                        reader.context.buffer.set(list);
-                        reader.context.size_hint.set(size_hint as blob::SizeType);
-                    }
-                    _ => {}
-                }
-
-                let context_ptr: *mut ByteStream = &raw mut reader.context;
-                let stream_value = reader.to_text_readable_stream(global_this)?;
-                locked.readable = webcore::readable_stream::Strong::init(
-                    ReadableStream {
-                        ptr: webcore::readable_stream::Source::Bytes(context_ptr),
-                        value: stream_value,
-                    },
-                    global_this,
-                );
-
-                if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
-                    on_readable_stream_available(
-                        locked.task.unwrap(),
-                        global_this,
-                        locked.readable.get(global_this).unwrap(),
-                    );
-                }
-
-                Ok(stream_value)
-            }
+            Value::Locked(_) => self.locked_to_native_stream(global_this, true),
             Value::Error(err) => {
                 let reason = err.to_js(global_this);
                 ReadableStream::errored(global_this, reason)
             }
         }
+    }
+
+    /// Materialize a `Value::Locked` body (no readable yet) as a
+    /// `NewSource<ByteStream>`-backed native `ReadableStream` and wire up the
+    /// HTTP-client callbacks. Shared tail of [`to_readable_stream`] and
+    /// [`to_text_readable_stream`].
+    fn locked_to_native_stream(
+        &mut self,
+        global_this: &JSGlobalObject,
+        text_mode: bool,
+    ) -> JsResult<JSValue> {
+        let Value::Locked(locked) = self else {
+            unreachable!("locked_to_native_stream on non-Locked Value");
+        };
+        if locked.promise.is_some() || !locked.action.is_none() {
+            return ReadableStream::used(global_this);
+        }
+        let mut drain_result = DrainResult::EstimatedSize(0);
+
+        if let Some(drain) = locked.on_start_streaming.take() {
+            drain_result = drain(locked.task.unwrap());
+        }
+
+        if matches!(drain_result, DrainResult::Empty | DrainResult::Aborted) {
+            *self = Value::Null;
+            return ReadableStream::empty(global_this);
+        }
+
+        // `new_mut` centralises the post-allocation deref; ownership of the
+        // heap `NewSource` transfers to the JS wrapper's `m_ctx` in
+        // `to_readable_stream()` below (freed by the GC finalizer).
+        let reader = webcore::readable_stream::NewSource::<ByteStream>::new_mut(
+            webcore::readable_stream::NewSource {
+                // `ByteStream::default()` is the post-setup state.
+                context: ByteStream::default(),
+                global_this: Some(bun_ptr::BackRef::new(global_this)),
+                ..Default::default()
+            },
+        );
+
+        if let Some(task) = locked.task {
+            if let Some(on_cancelled) = locked.on_stream_cancelled {
+                reader.cancel_handler.set(Some(on_cancelled));
+                reader.cancel_ctx.set(Some(task));
+            }
+            if let Some(on_drained) = locked.on_stream_drained {
+                reader.drain_handler.set(Some(on_drained));
+                reader.drain_ctx.set(Some(task));
+            }
+        }
+
+        reader.context.setup();
+
+        match drain_result {
+            DrainResult::EstimatedSize(estimated_size) => {
+                reader.context.high_water_mark = estimated_size as blob::SizeType;
+                reader
+                    .context
+                    .size_hint
+                    .set(estimated_size as blob::SizeType);
+            }
+            DrainResult::Owned { list, size_hint } => {
+                reader.context.buffer.set(list);
+                reader.context.size_hint.set(size_hint as blob::SizeType);
+            }
+            _ => {}
+        }
+
+        let context_ptr: *mut ByteStream = &raw mut reader.context;
+        let stream_value = if text_mode {
+            reader.to_text_readable_stream(global_this)?
+        } else {
+            reader.to_readable_stream(global_this)?
+        };
+        locked.readable = webcore::readable_stream::Strong::init(
+            ReadableStream {
+                ptr: webcore::readable_stream::Source::Bytes(context_ptr),
+                value: stream_value,
+            },
+            global_this,
+        );
+
+        if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
+            on_readable_stream_available(
+                locked.task.unwrap(),
+                global_this,
+                locked.readable.get(global_this).unwrap(),
+            );
+        }
+
+        Ok(stream_value)
     }
 
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Value> {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -967,13 +967,11 @@ impl Value {
         } else {
             reader.to_readable_stream(global_this)?
         };
-        locked.readable = webcore::readable_stream::Strong::init(
-            ReadableStream {
-                ptr: webcore::readable_stream::Source::Bytes(context_ptr),
-                value: stream_value,
-            },
-            global_this,
-        );
+        let readable = ReadableStream {
+            ptr: webcore::readable_stream::Source::Bytes(context_ptr),
+            value: stream_value,
+        };
+        locked.readable = webcore::readable_stream::Strong::init(readable, global_this);
 
         if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
             on_readable_stream_available(
@@ -981,6 +979,13 @@ impl Value {
                 global_this,
                 locked.readable.get(global_this).unwrap(),
             );
+        }
+
+        // In text mode the returned stream emits strings, so it must not be
+        // cached as the body's byte stream (consulted by `.body`, `bodyUsed`,
+        // and `throw_if_body_unusable`). Mark the body consumed instead.
+        if text_mode {
+            *self = Value::Used;
         }
 
         Ok(stream_value)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -921,6 +921,121 @@ impl Value {
         }
     }
 
+    /// `Body.textStream()`: a `ReadableStream<string>` of the body's UTF-8
+    /// content, decoded directly from the body's backing bytes without
+    /// materializing a separate byte `ReadableStream` for native-backed bodies.
+    /// Returns `NULL` for `Null` (caller substitutes an empty stream).
+    pub fn to_text_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        jsc::mark_binding();
+
+        match self {
+            Value::Used => ReadableStream::used(global_this),
+            Value::Null => Ok(JSValue::NULL),
+            Value::Empty => {
+                *self = Value::Used;
+                ReadableStream::empty(global_this)
+            }
+            Value::InternalBlob(_) | Value::WTFStringImpl(_) => {
+                let mut blob = self.use_as_any_blob_allow_non_utf8_string();
+                let string = blob.to_string(global_this, Lifetime::Transfer);
+                blob.detach();
+                ReadableStream::from_decoded_text(global_this, string?)
+            }
+            Value::Blob(_) => {
+                let stream = {
+                    let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
+                    blob.resolve_size();
+                    if blob.needs_to_read_file() || blob.is_s3() {
+                        let blob_size = blob.size.get();
+                        let bytes =
+                            ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
+                        ReadableStream::text_decode_from(global_this, bytes)?
+                    } else {
+                        let string = blob.to_string(global_this, Lifetime::Transfer)?;
+                        ReadableStream::from_decoded_text(global_this, string)?
+                    }
+                };
+                *self = Value::Used;
+                Ok(stream)
+            }
+            Value::Locked(locked) => {
+                if locked.promise.is_some() || !locked.action.is_none() {
+                    return ReadableStream::used(global_this);
+                }
+                let mut drain_result = DrainResult::EstimatedSize(0);
+
+                if let Some(drain) = locked.on_start_streaming.take() {
+                    drain_result = drain(locked.task.unwrap());
+                }
+
+                if matches!(drain_result, DrainResult::Empty | DrainResult::Aborted) {
+                    *self = Value::Null;
+                    return ReadableStream::empty(global_this);
+                }
+
+                let reader = webcore::readable_stream::NewSource::<ByteStream>::new_mut(
+                    webcore::readable_stream::NewSource {
+                        context: ByteStream::default(),
+                        global_this: Some(bun_ptr::BackRef::new(global_this)),
+                        ..Default::default()
+                    },
+                );
+
+                if let Some(task) = locked.task {
+                    if let Some(on_cancelled) = locked.on_stream_cancelled {
+                        reader.cancel_handler.set(Some(on_cancelled));
+                        reader.cancel_ctx.set(Some(task));
+                    }
+                    if let Some(on_drained) = locked.on_stream_drained {
+                        reader.drain_handler.set(Some(on_drained));
+                        reader.drain_ctx.set(Some(task));
+                    }
+                }
+
+                reader.context.setup();
+
+                match drain_result {
+                    DrainResult::EstimatedSize(estimated_size) => {
+                        reader.context.high_water_mark = estimated_size as blob::SizeType;
+                        reader
+                            .context
+                            .size_hint
+                            .set(estimated_size as blob::SizeType);
+                    }
+                    DrainResult::Owned { list, size_hint } => {
+                        reader.context.buffer.set(list);
+                        reader.context.size_hint.set(size_hint as blob::SizeType);
+                    }
+                    _ => {}
+                }
+
+                let context_ptr: *mut ByteStream = &raw mut reader.context;
+                let stream_value = reader.to_text_readable_stream(global_this)?;
+                locked.readable = webcore::readable_stream::Strong::init(
+                    ReadableStream {
+                        ptr: webcore::readable_stream::Source::Bytes(context_ptr),
+                        value: stream_value,
+                    },
+                    global_this,
+                );
+
+                if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
+                    on_readable_stream_available(
+                        locked.task.unwrap(),
+                        global_this,
+                        locked.readable.get(global_this).unwrap(),
+                    );
+                }
+
+                Ok(stream_value)
+            }
+            Value::Error(err) => {
+                let reason = err.to_js(global_this);
+                ReadableStream::errored(global_this, reason)
+            }
+        }
+    }
+
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Value> {
         value.ensure_still_alive();
 
@@ -1827,6 +1942,38 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
         self.get_body_value().to_readable_stream(global_this)
+    }
+
+    /// <https://fetch.spec.whatwg.org/#dom-body-textstream>
+    fn get_text_stream(
+        &self,
+        global_this: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        // Step 1: If this is unusable, throw a TypeError.
+        self.throw_if_body_unusable(global_this)?;
+
+        // A `Locked` body whose stream is already materialized (user-provided
+        // ReadableStream, or `.body` was accessed first) is decoded via a reader
+        // on that existing stream.
+        if matches!(self.get_body_value(), Value::Locked(_)) {
+            if let Some(readable) = self.get_body_readable_stream(global_this) {
+                let text = ReadableStream::text_decode_from(global_this, readable.value)?;
+                self.detach_readable_stream(global_this);
+                *self.get_body_value() = Value::Used;
+                return Ok(text);
+            }
+        }
+
+        // Step 2: null body → a new empty closed ReadableStream.
+        // Steps 3-6: decode directly from the body's backing bytes.
+        let stream = self
+            .get_body_value()
+            .to_text_readable_stream(global_this)?;
+        if stream.is_null() {
+            return ReadableStream::empty(global_this);
+        }
+        Ok(stream)
     }
 
     /// `Used` / in-flight-read bodies are unconditionally `true`; otherwise

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1967,9 +1967,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         // Step 2: null body → a new empty closed ReadableStream.
         // Steps 3-6: decode directly from the body's backing bytes.
-        let stream = self
-            .get_body_value()
-            .to_text_readable_stream(global_this)?;
+        let stream = self.get_body_value().to_text_readable_stream(global_this)?;
         if stream.is_null() {
             return ReadableStream::empty(global_this);
         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -974,11 +974,7 @@ impl Value {
         locked.readable = webcore::readable_stream::Strong::init(readable, global_this);
 
         if let Some(on_readable_stream_available) = locked.on_readable_stream_available {
-            on_readable_stream_available(
-                locked.task.unwrap(),
-                global_this,
-                locked.readable.get(global_this).unwrap(),
-            );
+            on_readable_stream_available(locked.task.unwrap(), global_this, readable);
         }
 
         // In text mode the returned stream emits strings, so it must not be

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -110,6 +110,8 @@ unsafe extern "C" {
     safe fn ReadableStream__empty(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__used(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__errored(global: &JSGlobalObject, reason: JSValue) -> JSValue;
+    safe fn ReadableStream__fromDecodedText(global: &JSGlobalObject, string: JSValue) -> JSValue;
+    safe fn ReadableStream__textDecodeFrom(global: &JSGlobalObject, source: JSValue) -> JSValue;
     safe fn ReadableStream__cancel(stream: JSValue, global: &JSGlobalObject);
     safe fn ReadableStream__cancelWithReason(
         stream: JSValue,
@@ -118,6 +120,10 @@ unsafe extern "C" {
     );
     safe fn ReadableStream__detach(stream: JSValue, global: &JSGlobalObject);
     safe fn ZigGlobalObject__createNativeReadableStream(
+        global: &JSGlobalObject,
+        native_ptr: JSValue,
+    ) -> JSValue;
+    safe fn ZigGlobalObject__createNativeTextReadableStream(
         global: &JSGlobalObject,
         native_ptr: JSValue,
     ) -> JSValue;
@@ -310,6 +316,30 @@ impl ReadableStream {
     pub fn from_native(global_this: &JSGlobalObject, native: JSValue) -> JsResult<JSValue> {
         bun_jsc::from_js_host_call(global_this, || {
             ZigGlobalObject__createNativeReadableStream(global_this, native)
+        })
+    }
+
+    /// Same as [`from_native`] but the native source adapter UTF-8-decodes each
+    /// chunk to a string before enqueue (Body.textStream()).
+    pub fn from_native_text(global_this: &JSGlobalObject, native: JSValue) -> JsResult<JSValue> {
+        bun_jsc::from_js_host_call(global_this, || {
+            ZigGlobalObject__createNativeTextReadableStream(global_this, native)
+        })
+    }
+
+    /// A closed stream with `string` (a JS string) as its only chunk. An empty
+    /// string produces an empty closed stream.
+    pub fn from_decoded_text(global_this: &JSGlobalObject, string: JSValue) -> JsResult<JSValue> {
+        bun_jsc::from_js_host_call(global_this, || {
+            ReadableStream__fromDecodedText(global_this, string)
+        })
+    }
+
+    /// Locks a default reader on `source` and returns a stream that
+    /// UTF-8-decodes each chunk from it to a string.
+    pub fn text_decode_from(global_this: &JSGlobalObject, source: JSValue) -> JsResult<JSValue> {
+        bun_jsc::from_js_host_call(global_this, || {
+            ReadableStream__textDecodeFrom(global_this, source)
         })
     }
 
@@ -1021,6 +1051,19 @@ impl<C: SourceContext> NewSource<C> {
             self.this_jsvalue = jsc::JsRef::init_weak(out_value);
         }
         ReadableStream::from_native(global_this, out_value)
+    }
+
+    pub fn to_text_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        let out_value = if let Some(v) = self.this_jsvalue.try_get() {
+            v
+        } else {
+            <Self as NewSourceCodegen>::to_js(self, global_this)
+        };
+        out_value.ensure_still_alive();
+        if self.this_jsvalue.is_empty() {
+            self.this_jsvalue = jsc::JsRef::init_weak(out_value);
+        }
+        ReadableStream::from_native_text(global_this, out_value)
     }
 
     pub fn set_raw_mode_from_js(

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -1040,7 +1040,11 @@ impl<C: SourceContext> NewSource<C> {
         self.context.drain_internal_buffer()
     }
 
-    pub fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+    fn to_readable_stream_with(
+        &mut self,
+        global_this: &JSGlobalObject,
+        from_native: fn(&JSGlobalObject, JSValue) -> JsResult<JSValue>,
+    ) -> JsResult<JSValue> {
         let out_value = if let Some(v) = self.this_jsvalue.try_get() {
             v
         } else {
@@ -1050,20 +1054,15 @@ impl<C: SourceContext> NewSource<C> {
         if self.this_jsvalue.is_empty() {
             self.this_jsvalue = jsc::JsRef::init_weak(out_value);
         }
-        ReadableStream::from_native(global_this, out_value)
+        from_native(global_this, out_value)
+    }
+
+    pub fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        self.to_readable_stream_with(global_this, ReadableStream::from_native)
     }
 
     pub fn to_text_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        let out_value = if let Some(v) = self.this_jsvalue.try_get() {
-            v
-        } else {
-            <Self as NewSourceCodegen>::to_js(self, global_this)
-        };
-        out_value.ensure_still_alive();
-        if self.this_jsvalue.is_empty() {
-            self.this_jsvalue = jsc::JsRef::init_weak(out_value);
-        }
-        ReadableStream::from_native_text(global_this, out_value)
+        self.to_readable_stream_with(global_this, ReadableStream::from_native_text)
     }
 
     pub fn set_raw_mode_from_js(

--- a/src/runtime/webcore/response.classes.ts
+++ b/src/runtime/webcore/response.classes.ts
@@ -18,6 +18,7 @@ export default [
     values: ["stream"],
     proto: {
       text: { fn: "getText", async: true },
+      textStream: { fn: "getTextStream" },
       json: { fn: "getJSON", async: true },
       bytes: { fn: "getBytes", async: true },
       body: { getter: "getBody", cache: true },
@@ -101,6 +102,7 @@ export default [
       body: { getter: "getBody", cache: true },
 
       text: { fn: "getText", async: true },
+      textStream: { fn: "getTextStream" },
       json: { fn: "getJSON", async: true },
       bytes: { fn: "getBytes", async: true },
       arrayBuffer: { fn: "getArrayBuffer", async: true },

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -468,6 +468,15 @@ for (const { body, fn } of bodyTypes) {
         const out = (await Array.fromAsync(stream)).join("");
         expect(out).toBe("hello world 🫠");
       });
+      test("Bun's ReadableStream.text() on a fetch textStream() yields decoded text", async () => {
+        await using server = Bun.serve({
+          port: 0,
+          fetch: () => new Response(new Uint8Array([0xef, 0xbb, 0xbf, 0x61, 0xff, 0x62])),
+        });
+        const res = await fetch(server.url);
+        // The native-handle buffered fast path must not bypass the decode.
+        expect(await res.textStream().text()).toBe("a\ufffdb");
+      });
       test("streams an incoming request body server-side", async () => {
         const { promise, resolve, reject } = Promise.withResolvers<{
           chunks: string[];

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -338,6 +338,30 @@ for (const { body, fn } of bodyTypes) {
         expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("a\ufffdb");
       });
       test.each([
+        ["surrogate lead + second byte", [0xed, 0xa0]],
+        ["overlong 4-byte lead + second byte", [0xf0, 0x80]],
+        ["out-of-range 4-byte lead + second byte", [0xf4, 0x90]],
+        ["0xF5 (never a valid lead)", [0xf5]],
+        ["0xC0 (overlong 2-byte lead)", [0xc0]],
+      ])("does not hold back a definitely-invalid trailing prefix: %s", async (_, trailing) => {
+        // An invalid prefix at the end of a chunk should be replaced
+        // immediately (the WHATWG decoder emits U+FFFD), not held back to the
+        // next chunk. Assert via observable chunk timing: the first read of
+        // the output stream must not be empty.
+        let sc!: ReadableStreamDefaultController;
+        const input = new ReadableStream({
+          start(c) {
+            sc = c;
+            c.enqueue(new Uint8Array([0x61, ...trailing]));
+          },
+        });
+        const reader = fn(input).textStream().getReader();
+        const first = await reader.read();
+        expect(first.done).toBe(false);
+        expect(first.value!.startsWith("a\ufffd")).toBe(true);
+        sc.close();
+      });
+      test.each([
         ["ascii", Buffer.alloc(1000, "abcd").toString()],
         ["mixed", Buffer.alloc(1000, "hello 🫠 ").toString()],
       ])("decodes a large %s chunk from a ReadableStream body", async (_, big) => {
@@ -374,7 +398,7 @@ for (const { body, fn } of bodyTypes) {
         const ts = r.textStream();
         expect(stream.locked).toBe(true);
         expect(() => stream.getReader()).toThrow(TypeError);
-        expect(stream.cancel()).rejects.toBeInstanceOf(TypeError);
+        await expect(stream.cancel()).rejects.toBeInstanceOf(TypeError);
         expect((await Array.fromAsync(ts)).join("")).toBe("hello");
       });
       test("second textStream() call throws", () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -542,6 +542,28 @@ for (const { body, fn } of bodyTypes) {
         await reader.cancel();
         expect(source.locked).toBe(false);
       });
+      test("re-entrant closeSteps via flush enqueue does not double-release", async () => {
+        let sc!: ReadableStreamDefaultController;
+        const source = new ReadableStream({
+          start(c) {
+            sc = c;
+          },
+        });
+        const reader = fn(source).textStream().getReader();
+        await Promise.resolve();
+        const p1 = reader.read();
+        const p2 = reader.read();
+        await Promise.resolve();
+        await Promise.resolve();
+        // 0xC2 is held back; the chunk-step's callPullIfNeeded queues a third
+        // TextDecode read on the source reader.
+        sc.enqueue(new Uint8Array([0xc2]));
+        await Promise.resolve();
+        sc.close();
+        expect((await p1).value).toBe("\ufffd");
+        expect((await p2).done).toBe(true);
+        expect(source.locked).toBe(false);
+      });
       if (body === Response) {
         test("streams a fetch response body", async () => {
           await using server = Bun.serve({

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -519,108 +519,112 @@ for (const { body, fn } of bodyTypes) {
         expect(await p1).toEqual({ value: undefined, done: true });
         expect(await p2).toEqual({ value: undefined, done: true });
       });
-      test("streams a fetch response body", async () => {
-        await using server = Bun.serve({
-          port: 0,
-          fetch() {
-            const chunks = ["hello ", "world 🫠"];
-            return new Response(
-              new ReadableStream({
-                start(controller) {
-                  for (const c of chunks) controller.enqueue(new TextEncoder().encode(c));
-                  controller.close();
-                },
-              }),
-            );
-          },
-        });
-        const res = await fetch(server.url);
-        const stream = res.textStream();
-        expect(res.bodyUsed).toBe(true);
-        expect(() => res.textStream()).toThrow(TypeError);
-        const out = (await Array.fromAsync(stream)).join("");
-        expect(out).toBe("hello world 🫠");
-      });
-      test("Bun's ReadableStream.text() on a fetch textStream() yields decoded text", async () => {
-        await using server = Bun.serve({
-          port: 0,
-          fetch: () => new Response(new Uint8Array([0xef, 0xbb, 0xbf, 0x61, 0xff, 0x62])),
-        });
-        const res = await fetch(server.url);
-        // The native-handle buffered fast path must not bypass the decode.
-        expect(await res.textStream().text()).toBe("a\ufffdb");
-      });
-      test("streams an incoming request body server-side", async () => {
-        const { promise, resolve, reject } = Promise.withResolvers<{
-          chunks: string[];
-          bodyUsedAfter: boolean;
-          secondCallThrew: boolean;
-        }>();
-        await using server = Bun.serve({
-          port: 0,
-          async fetch(req) {
-            try {
-              const stream = req.textStream();
-              const chunks = await Array.fromAsync(stream);
-              let secondCallThrew = false;
-              try {
-                req.textStream();
-              } catch (e) {
-                secondCallThrew = e instanceof TypeError;
-              }
-              resolve({ chunks, bodyUsedAfter: req.bodyUsed, secondCallThrew });
-            } catch (e) {
-              reject(e);
-            }
-            return new Response("ok");
-          },
-        });
-        await fetch(server.url, {
-          method: "POST",
-          body: new ReadableStream({
-            start(c) {
-              for (const s of ["hello ", "world 🫠"]) c.enqueue(new TextEncoder().encode(s));
-              c.close();
+      if (body === Response) {
+        test("streams a fetch response body", async () => {
+          await using server = Bun.serve({
+            port: 0,
+            fetch() {
+              const chunks = ["hello ", "world 🫠"];
+              return new Response(
+                new ReadableStream({
+                  start(controller) {
+                    for (const c of chunks) controller.enqueue(new TextEncoder().encode(c));
+                    controller.close();
+                  },
+                }),
+              );
             },
-          }),
+          });
+          const res = await fetch(server.url);
+          const stream = res.textStream();
+          expect(res.bodyUsed).toBe(true);
+          expect(() => res.textStream()).toThrow(TypeError);
+          const out = (await Array.fromAsync(stream)).join("");
+          expect(out).toBe("hello world 🫠");
         });
-        const result = await promise;
-        for (const chunk of result.chunks) {
-          expect(typeof chunk).toBe("string");
-        }
-        expect(result.chunks.join("")).toBe("hello world 🫠");
-        expect(result.bodyUsedAfter).toBe(true);
-        expect(result.secondCallThrew).toBe(true);
-      });
-      test("rejects when the client aborts mid-upload server-side", async () => {
-        const firstChunk = Promise.withResolvers<void>();
-        const done = Promise.withResolvers<{ name: string; received: string }>();
-        await using server = Bun.serve({
-          port: 0,
-          async fetch(req) {
-            const received: string[] = [];
-            try {
-              for await (const c of req.textStream()) {
-                received.push(c);
-                firstChunk.resolve();
+        test("Bun's ReadableStream.text() on a fetch textStream() yields decoded text", async () => {
+          await using server = Bun.serve({
+            port: 0,
+            fetch: () => new Response(new Uint8Array([0xef, 0xbb, 0xbf, 0x61, 0xff, 0x62])),
+          });
+          const res = await fetch(server.url);
+          // The native-handle buffered fast path must not bypass the decode.
+          expect(await res.textStream().text()).toBe("a\ufffdb");
+        });
+      }
+      if (body === Request) {
+        test("streams an incoming request body server-side", async () => {
+          const { promise, resolve, reject } = Promise.withResolvers<{
+            chunks: string[];
+            bodyUsedAfter: boolean;
+            secondCallThrew: boolean;
+          }>();
+          await using server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+              try {
+                const stream = req.textStream();
+                const chunks = await Array.fromAsync(stream);
+                let secondCallThrew = false;
+                try {
+                  req.textStream();
+                } catch (e) {
+                  secondCallThrew = e instanceof TypeError;
+                }
+                resolve({ chunks, bodyUsedAfter: req.bodyUsed, secondCallThrew });
+              } catch (e) {
+                reject(e);
               }
-              done.resolve({ name: "<no error>", received: received.join("") });
-            } catch (e: any) {
-              done.resolve({ name: e?.name, received: received.join("") });
-            }
-            return new Response("ok");
-          },
+              return new Response("ok");
+            },
+          });
+          await fetch(server.url, {
+            method: "POST",
+            body: new ReadableStream({
+              start(c) {
+                for (const s of ["hello ", "world 🫠"]) c.enqueue(new TextEncoder().encode(s));
+                c.close();
+              },
+            }),
+          });
+          const result = await promise;
+          for (const chunk of result.chunks) {
+            expect(typeof chunk).toBe("string");
+          }
+          expect(result.chunks.join("")).toBe("hello world 🫠");
+          expect(result.bodyUsedAfter).toBe(true);
+          expect(result.secondCallThrew).toBe(true);
         });
-        const connected = Promise.withResolvers<void>();
-        const sock = net.connect(server.port, "127.0.0.1", () => connected.resolve());
-        sock.on("error", () => {});
-        await connected.promise;
-        sock.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 1000\r\n\r\nhello");
-        await firstChunk.promise;
-        sock.destroy();
-        const result = await done.promise;
-        expect(result).toEqual({ name: "AbortError", received: "hello" });
-      });
+        test("rejects when the client aborts mid-upload server-side", async () => {
+          const firstChunk = Promise.withResolvers<void>();
+          const done = Promise.withResolvers<{ name: string; received: string }>();
+          await using server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+              const received: string[] = [];
+              try {
+                for await (const c of req.textStream()) {
+                  received.push(c);
+                  firstChunk.resolve();
+                }
+                done.resolve({ name: "<no error>", received: received.join("") });
+              } catch (e: any) {
+                done.resolve({ name: e?.name, received: received.join("") });
+              }
+              return new Response("ok");
+            },
+          });
+          const connected = Promise.withResolvers<void>();
+          const sock = net.connect(server.port, "127.0.0.1", () => connected.resolve());
+          sock.on("error", () => {});
+          await connected.promise;
+          sock.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 1000\r\n\r\nhello");
+          await firstChunk.promise;
+          sock.destroy();
+          const result = await done.promise;
+          expect(result).toEqual({ name: "AbortError", received: "hello" });
+        });
+      }
     });
     describe("json()", () => {
       const validTests: [string, unknown][] = [

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -446,7 +446,7 @@ for (const { body, fn } of bodyTypes) {
           },
         });
         const stream = fn(input).textStream();
-        expect(async () => {
+        await expect(async () => {
           for await (const _ of stream) {
           }
         }).toThrow("boom");
@@ -476,7 +476,7 @@ for (const { body, fn } of bodyTypes) {
           },
         });
         const stream = fn(input).textStream();
-        expect(async () => {
+        await expect(async () => {
           for await (const _ of stream) {
           }
         }).toThrow(TypeError);

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -422,6 +422,18 @@ for (const { body, fn } of bodyTypes) {
         }).toThrow(TypeError);
         expect(cancelled).toBeInstanceOf(TypeError);
       });
+      test("treats a detached BufferSource chunk as empty", async () => {
+        const view = new Uint8Array([0x68, 0x69]);
+        structuredClone(view, { transfer: [view.buffer] });
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(view);
+            controller.enqueue(new Uint8Array([0x21]));
+            controller.close();
+          },
+        });
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("!");
+      });
       test("accepts raw ArrayBuffer chunks from a ReadableStream body", async () => {
         const input = new ReadableStream({
           start(controller) {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -400,6 +400,32 @@ for (const { body, fn } of bodyTypes) {
         expect(() => stream.getReader()).toThrow(TypeError);
         await expect(stream.cancel()).rejects.toBeInstanceOf(TypeError);
         expect((await Array.fromAsync(ts)).join("")).toBe("hello");
+        expect(stream.locked).toBe(false);
+      });
+      test("releases the source stream on close and cancel", async () => {
+        {
+          const source = new ReadableStream({
+            start(c) {
+              c.enqueue(new Uint8Array([65]));
+              c.close();
+            },
+          });
+          const ts = fn(source).textStream();
+          expect(source.locked).toBe(true);
+          expect((await Array.fromAsync(ts)).join("")).toBe("A");
+          expect(source.locked).toBe(false);
+        }
+        {
+          const source = new ReadableStream({
+            pull(c) {
+              c.enqueue(new Uint8Array([65]));
+            },
+          });
+          const ts = fn(source).textStream();
+          expect(source.locked).toBe(true);
+          await ts.cancel();
+          expect(source.locked).toBe(false);
+        }
       });
       test("second textStream() call throws", () => {
         const r = fn("hello");

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -273,7 +273,147 @@ for (const { body, fn } of bodyTypes) {
           expect(await fn(buffer).text()).toBe(string);
         });
       });
+      describe("textStream()", () => {
+        test("undefined", async () => {
+          const stream = fn().textStream();
+          expect(stream instanceof ReadableStream).toBe(true);
+          expect(await Array.fromAsync(stream)).toEqual([]);
+        });
+        test("null", async () => {
+          const stream = fn(null).textStream();
+          expect(stream instanceof ReadableStream).toBe(true);
+          expect(await Array.fromAsync(stream)).toEqual([]);
+        });
+        test(`"${string}" (string body)`, async () => {
+          const stream = fn(string).textStream();
+          expect(stream instanceof ReadableStream).toBe(true);
+          expect((await Array.fromAsync(stream)).join("")).toBe(string);
+        });
+        test(`"${string}" (buffer body)`, async () => {
+          const stream = fn(buffer).textStream();
+          expect(stream instanceof ReadableStream).toBe(true);
+          const chunks = await Array.fromAsync(stream);
+          for (const chunk of chunks) {
+            expect(typeof chunk).toBe("string");
+          }
+          expect(chunks.join("")).toBe(string);
+        });
+      });
     }
+    describe("textStream()", () => {
+      test("yields string chunks from a ReadableStream body", async () => {
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello "));
+            controller.enqueue(new TextEncoder().encode("world"));
+            controller.close();
+          },
+        });
+        const stream = fn(input).textStream();
+        const chunks = await Array.fromAsync(stream);
+        for (const chunk of chunks) {
+          expect(typeof chunk).toBe("string");
+        }
+        expect(chunks.join("")).toBe("hello world");
+      });
+      test("joins multi-byte characters split across chunks", async () => {
+        // "🫠" is F0 9F AB A0
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0xf0, 0x9f]));
+            controller.enqueue(new Uint8Array([0xab]));
+            controller.enqueue(new Uint8Array([0xa0]));
+            controller.close();
+          },
+        });
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("🫠");
+      });
+      test("strips a leading UTF-8 BOM", async () => {
+        const input = new Uint8Array([0xef, 0xbb, 0xbf, 0x68, 0x69]);
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("hi");
+      });
+      test("replaces invalid sequences with U+FFFD", async () => {
+        const input = new Uint8Array([0x61, 0xff, 0x62]);
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("a\ufffdb");
+      });
+      test("marks body as used", async () => {
+        const r = fn("hello");
+        expect(r.bodyUsed).toBe(false);
+        const stream = r.textStream();
+        expect(r.bodyUsed).toBe(true);
+        expect((await Array.fromAsync(stream)).join("")).toBe("hello");
+      });
+      test("throws TypeError synchronously when body is unusable", async () => {
+        const r = fn("hello");
+        await r.text();
+        expect(r.bodyUsed).toBe(true);
+        expect(() => r.textStream()).toThrow(TypeError);
+      });
+      test("throws TypeError when body stream is locked", () => {
+        const r = fn("hello");
+        r.body!.getReader();
+        expect(() => r.textStream()).toThrow(TypeError);
+      });
+      test("second textStream() call throws", () => {
+        const r = fn("hello");
+        r.textStream();
+        expect(() => r.textStream()).toThrow(TypeError);
+      });
+      test("ignores Content-Type charset", async () => {
+        const result = fn(new Uint8Array([0xf0, 0x9f, 0xab, 0xa0]), {
+          "Content-Type": "text/plain; charset=iso-8859-1",
+        });
+        expect((await Array.fromAsync(result.textStream())).join("")).toBe("🫠");
+      });
+      test("propagates errors from a ReadableStream body", async () => {
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello"));
+            controller.error(new Error("boom"));
+          },
+        });
+        const stream = fn(input).textStream();
+        expect(async () => {
+          for await (const _ of stream) {
+          }
+        }).toThrow("boom");
+      });
+      test("cancel propagates to the source stream", async () => {
+        let cancelled: unknown;
+        const input = new ReadableStream({
+          pull(controller) {
+            controller.enqueue(new TextEncoder().encode("x"));
+          },
+          cancel(reason) {
+            cancelled = reason;
+          },
+        });
+        const stream = fn(input).textStream();
+        await stream.cancel("stop");
+        expect(cancelled).toBe("stop");
+      });
+      test("streams a fetch response body", async () => {
+        await using server = Bun.serve({
+          port: 0,
+          fetch() {
+            const chunks = ["hello ", "world 🫠"];
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  for (const c of chunks) controller.enqueue(new TextEncoder().encode(c));
+                  controller.close();
+                },
+              }),
+            );
+          },
+        });
+        const res = await fetch(server.url);
+        const stream = res.textStream();
+        const out = (await Array.fromAsync(stream)).join("");
+        expect(out).toBe("hello world 🫠");
+        expect(res.bodyUsed).toBe(true);
+      });
+    });
     describe("json()", () => {
       const validTests: [string, unknown][] = [
         ["true", true],

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -367,6 +367,16 @@ for (const { body, fn } of bodyTypes) {
         r.body!.getReader();
         expect(() => r.textStream()).toThrow(TypeError);
       });
+      test("locks a previously-accessed .body stream", async () => {
+        const r = fn("hello");
+        const stream = r.body!;
+        expect(stream.locked).toBe(false);
+        const ts = r.textStream();
+        expect(stream.locked).toBe(true);
+        expect(() => stream.getReader()).toThrow(TypeError);
+        expect(stream.cancel()).rejects.toBeInstanceOf(TypeError);
+        expect((await Array.fromAsync(ts)).join("")).toBe("hello");
+      });
       test("second textStream() call throws", () => {
         const r = fn("hello");
         r.textStream();

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -519,6 +519,29 @@ for (const { body, fn } of bodyTypes) {
         expect(await p1).toEqual({ value: undefined, done: true });
         expect(await p2).toEqual({ value: undefined, done: true });
       });
+      test("cancel after source close with a queued flush chunk", async () => {
+        // closeSteps' flush enqueues a replacement char into the output queue
+        // and releases the source reader; a subsequent output cancel() must
+        // tolerate the already-released reader.
+        let sc!: ReadableStreamDefaultController;
+        const source = new ReadableStream({
+          start(c) {
+            sc = c;
+          },
+        });
+        const reader = fn(source).textStream().getReader();
+        await Promise.resolve();
+        reader.read();
+        await Promise.resolve();
+        reader.read();
+        await Promise.resolve();
+        sc.enqueue(new Uint8Array([0x41, 0xc2]));
+        sc.enqueue(new Uint8Array([0xa9, 0xc2]));
+        sc.close();
+        await Promise.resolve();
+        await reader.cancel();
+        expect(source.locked).toBe(false);
+      });
       if (body === Response) {
         test("streams a fetch response body", async () => {
           await using server = Bun.serve({

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,7 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite } from "harness";
+import net from "net";
 
 const exampleServer = exampleSite("http");
 
@@ -518,6 +519,35 @@ for (const { body, fn } of bodyTypes) {
         expect(result.chunks.join("")).toBe("hello world 🫠");
         expect(result.bodyUsedAfter).toBe(true);
         expect(result.secondCallThrew).toBe(true);
+      });
+      test("rejects when the client aborts mid-upload server-side", async () => {
+        const firstChunk = Promise.withResolvers<void>();
+        const done = Promise.withResolvers<{ name: string; received: string }>();
+        await using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            const received: string[] = [];
+            try {
+              for await (const c of req.textStream()) {
+                received.push(c);
+                firstChunk.resolve();
+              }
+              done.resolve({ name: "<no error>", received: received.join("") });
+            } catch (e: any) {
+              done.resolve({ name: e?.name, received: received.join("") });
+            }
+            return new Response("ok");
+          },
+        });
+        const connected = Promise.withResolvers<void>();
+        const sock = net.connect(server.port, "127.0.0.1", () => connected.resolve());
+        sock.on("error", () => {});
+        await connected.promise;
+        sock.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 1000\r\n\r\nhello");
+        await firstChunk.promise;
+        sock.destroy();
+        const result = await done.promise;
+        expect(result).toEqual({ name: "AbortError", received: "hello" });
       });
     });
     describe("json()", () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -392,6 +392,23 @@ for (const { body, fn } of bodyTypes) {
         await stream.cancel("stop");
         expect(cancelled).toBe("stop");
       });
+      test("cancels the source stream when it produces a non-ArrayBufferView chunk", async () => {
+        let cancelled: unknown;
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue("oops");
+          },
+          cancel(reason) {
+            cancelled = reason;
+          },
+        });
+        const stream = fn(input).textStream();
+        expect(async () => {
+          for await (const _ of stream) {
+          }
+        }).toThrow(TypeError);
+        expect(cancelled).toBeInstanceOf(TypeError);
+      });
       test("streams a fetch response body", async () => {
         await using server = Bun.serve({
           port: 0,
@@ -412,6 +429,48 @@ for (const { body, fn } of bodyTypes) {
         const out = (await Array.fromAsync(stream)).join("");
         expect(out).toBe("hello world 🫠");
         expect(res.bodyUsed).toBe(true);
+      });
+      test("streams an incoming request body server-side", async () => {
+        const { promise, resolve, reject } = Promise.withResolvers<{
+          chunks: string[];
+          bodyUsedAfter: boolean;
+          secondCallThrew: boolean;
+        }>();
+        await using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            try {
+              const stream = req.textStream();
+              const chunks = await Array.fromAsync(stream);
+              let secondCallThrew = false;
+              try {
+                req.textStream();
+              } catch (e) {
+                secondCallThrew = e instanceof TypeError;
+              }
+              resolve({ chunks, bodyUsedAfter: req.bodyUsed, secondCallThrew });
+            } catch (e) {
+              reject(e);
+            }
+            return new Response("ok");
+          },
+        });
+        await fetch(server.url, {
+          method: "POST",
+          body: new ReadableStream({
+            start(c) {
+              for (const s of ["hello ", "world 🫠"]) c.enqueue(new TextEncoder().encode(s));
+              c.close();
+            },
+          }),
+        });
+        const result = await promise;
+        for (const chunk of result.chunks) {
+          expect(typeof chunk).toBe("string");
+        }
+        expect(result.chunks.join("")).toBe("hello world 🫠");
+        expect(result.bodyUsedAfter).toBe(true);
+        expect(result.secondCallThrew).toBe(true);
       });
     });
     describe("json()", () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -392,7 +392,7 @@ for (const { body, fn } of bodyTypes) {
         await stream.cancel("stop");
         expect(cancelled).toBe("stop");
       });
-      test("cancels the source stream when it produces a non-ArrayBufferView chunk", async () => {
+      test("cancels the source stream when it produces a non-BufferSource chunk", async () => {
         let cancelled: unknown;
         const input = new ReadableStream({
           start(controller) {
@@ -408,6 +408,31 @@ for (const { body, fn } of bodyTypes) {
           }
         }).toThrow(TypeError);
         expect(cancelled).toBeInstanceOf(TypeError);
+      });
+      test("accepts raw ArrayBuffer chunks from a ReadableStream body", async () => {
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hi").buffer);
+            controller.close();
+          },
+        });
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("hi");
+      });
+      test("concurrent reads with a source that closes without enqueueing", async () => {
+        let sc!: ReadableStreamDefaultController;
+        const source = new ReadableStream({
+          start(c) {
+            sc = c;
+          },
+        });
+        const reader = fn(source).textStream().getReader();
+        await Promise.resolve();
+        const p1 = reader.read();
+        const p2 = reader.read();
+        await Promise.resolve();
+        sc.close();
+        expect(await p1).toEqual({ value: undefined, done: true });
+        expect(await p2).toEqual({ value: undefined, done: true });
       });
       test("streams a fetch response body", async () => {
         await using server = Bun.serve({
@@ -426,9 +451,10 @@ for (const { body, fn } of bodyTypes) {
         });
         const res = await fetch(server.url);
         const stream = res.textStream();
+        expect(res.bodyUsed).toBe(true);
+        expect(() => res.textStream()).toThrow(TypeError);
         const out = (await Array.fromAsync(stream)).join("");
         expect(out).toBe("hello world 🫠");
-        expect(res.bodyUsed).toBe(true);
       });
       test("streams an incoming request body server-side", async () => {
         const { promise, resolve, reject } = Promise.withResolvers<{

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -336,6 +336,18 @@ for (const { body, fn } of bodyTypes) {
         const input = new Uint8Array([0x61, 0xff, 0x62]);
         expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe("a\ufffdb");
       });
+      test.each([
+        ["ascii", Buffer.alloc(1000, "abcd").toString()],
+        ["mixed", Buffer.alloc(1000, "hello 🫠 ").toString()],
+      ])("decodes a large %s chunk from a ReadableStream body", async (_, big) => {
+        const input = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(big));
+            controller.close();
+          },
+        });
+        expect((await Array.fromAsync(fn(input).textStream())).join("")).toBe(big);
+      });
       test("marks body as used", async () => {
         const r = fn("hello");
         expect(r.bodyUsed).toBe(false);

--- a/test/js/web/fetch/wpt/textstream-wpt.test.ts
+++ b/test/js/web/fetch/wpt/textstream-wpt.test.ts
@@ -1,0 +1,32 @@
+// Runs the vendored Web Platform Tests fetch/api/body/textstream.any.js
+// against Bun's Body.textStream() implementation. The .any.js file is
+// byte-identical to upstream; this driver follows the
+// test/js/third_party/wpt-h2 pattern.
+//
+// Vendored from web-platform-tests/wpt:
+//   fetch/api/body/textstream.any.js
+
+import { test as bunTest } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { setRegistrar, wptTest } from "../../../third_party/wpt-testharness-shim";
+
+// WPT subtests that do not pass on the current implementation. Tests whose
+// names appear here are registered via test.todo so the suite stays green
+// while still surfacing the gap.
+const knownFailures = new Set<string>([]);
+
+setRegistrar((name, run) => {
+  if (knownFailures.has(name)) {
+    bunTest.todo(name);
+    return;
+  }
+  bunTest(name, run);
+});
+
+// bun:test injects its own `test` binding into every imported module, which
+// would shadow the WPT-style test(fn, name) global. Load the vendored file
+// as text and run it inside a Function whose `test` parameter is the shim.
+// All other testharness identifiers resolve via globalThis.
+const src = readFileSync(join(import.meta.dir, "textstream.any.js"), "utf8");
+new Function("test", src)(wptTest);

--- a/test/js/web/fetch/wpt/textstream.any.js
+++ b/test/js/web/fetch/wpt/textstream.any.js
@@ -1,0 +1,177 @@
+// META: global=window,worker
+
+async function readAllChunks(stream) {
+  const reader = stream.getReader();
+  const chunks = [];
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+test(() => {
+  assert_true('textStream' in Response.prototype, "textStream exists on Response.prototype");
+  assert_true('textStream' in Request.prototype, "textStream exists on Request.prototype");
+  assert_equals(typeof Response.prototype.textStream, "function", "Response.prototype.textStream is a function");
+  assert_equals(typeof Request.prototype.textStream, "function", "Request.prototype.textStream is a function");
+}, "textStream method existence");
+
+promise_test(async () => {
+  const response = new Response("hello world");
+  assert_false(response.bodyUsed, "bodyUsed is false initially");
+  const stream = response.textStream();
+  assert_true(stream instanceof ReadableStream, "textStream() returns a ReadableStream");
+  assert_true(response.bodyUsed, "bodyUsed becomes true immediately after calling textStream()");
+
+  const chunks = await readAllChunks(stream);
+  assert_greater_than(chunks.length, 0);
+  for (const chunk of chunks) {
+    assert_equals(typeof chunk, "string", "each chunk should be a string");
+  }
+  assert_equals(chunks.join(""), "hello world", "concatenated chunks match the body content");
+}, "Response.textStream() basic functionality");
+
+promise_test(async () => {
+  const request = new Request("https://example.com", {
+    method: "POST",
+    body: "hello world"
+  });
+  assert_false(request.bodyUsed, "bodyUsed is false initially");
+  const stream = request.textStream();
+  assert_true(stream instanceof ReadableStream, "textStream() returns a ReadableStream");
+  assert_true(request.bodyUsed, "bodyUsed becomes true immediately after calling textStream()");
+
+  const chunks = await readAllChunks(stream);
+  assert_greater_than(chunks.length, 0);
+  for (const chunk of chunks) {
+    assert_equals(typeof chunk, "string", "each chunk should be a string");
+  }
+  assert_equals(chunks.join(""), "hello world", "concatenated chunks match the body content");
+}, "Request.textStream() basic functionality");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("hello "));
+      controller.enqueue(new TextEncoder().encode("world"));
+      controller.close();
+    }
+  });
+  const response = new Response(stream);
+  const textStream = response.textStream();
+  const chunks = await readAllChunks(textStream);
+  assert_greater_than(chunks.length, 0);
+  for (const chunk of chunks) {
+    assert_equals(typeof chunk, "string");
+  }
+  assert_equals(chunks.join(""), "hello world");
+}, "textStream() handles chunked byte stream input");
+
+test(() => {
+  const response = new Response("hello");
+  response.text(); // consumes body
+  assert_throws_js(TypeError, () => response.textStream());
+}, "Response.textStream() on consumed body throws TypeError");
+
+test(() => {
+  const request = new Request("https://example.com", {
+    method: "POST",
+    body: "hello"
+  });
+  request.text(); // consumes body
+  assert_throws_js(TypeError, () => request.textStream());
+}, "Request.textStream() on consumed body throws TypeError");
+
+test(() => {
+  const response = new Response("hello");
+  const reader = response.body.getReader(); // locks body
+  assert_throws_js(TypeError, () => response.textStream());
+}, "Response.textStream() on locked body throws TypeError");
+
+test(() => {
+  const request = new Request("https://example.com", {
+    method: "POST",
+    body: "hello"
+  });
+  const reader = request.body.getReader(); // locks body
+  assert_throws_js(TypeError, () => request.textStream());
+}, "Request.textStream() on locked body throws TypeError");
+
+promise_test(async () => {
+  const response = new Response();
+  assert_equals(response.body, null);
+  assert_false(response.bodyUsed, "bodyUsed is false initially");
+  const stream1 = response.textStream();
+  assert_true(stream1 instanceof ReadableStream);
+  assert_false(response.bodyUsed, "bodyUsed remains false after first textStream()");
+  const stream2 = response.textStream();
+  assert_true(stream2 instanceof ReadableStream);
+  assert_false(response.bodyUsed, "bodyUsed remains false after second textStream()");
+  assert_not_equals(stream1, stream2, "multiple calls must return different stream objects");
+  const chunks1 = await readAllChunks(stream1);
+  assert_equals(chunks1.length, 0, "no chunks should be read from first null body textStream");
+  const chunks2 = await readAllChunks(stream2);
+  assert_equals(chunks2.length, 0, "no chunks should be read from second null body textStream");
+}, "Response.textStream() with null body");
+
+promise_test(async () => {
+  const request = new Request("https://example.com");
+  assert_equals(request.body, null);
+  assert_false(request.bodyUsed, "bodyUsed is false initially");
+  const stream1 = request.textStream();
+  assert_true(stream1 instanceof ReadableStream);
+  assert_false(request.bodyUsed, "bodyUsed remains false after first textStream()");
+  const stream2 = request.textStream();
+  assert_true(stream2 instanceof ReadableStream);
+  assert_false(request.bodyUsed, "bodyUsed remains false after second textStream()");
+  assert_not_equals(stream1, stream2, "multiple calls must return different stream objects");
+  const chunks1 = await readAllChunks(stream1);
+  assert_equals(chunks1.length, 0, "no chunks should be read from first null body textStream");
+  const chunks2 = await readAllChunks(stream2);
+  assert_equals(chunks2.length, 0, "no chunks should be read from second null body textStream");
+}, "Request.textStream() with null body");
+
+promise_test(async () => {
+  const response = new Response("");
+  assert_false(response.bodyUsed);
+  const stream = response.textStream();
+  assert_true(stream instanceof ReadableStream);
+  assert_true(response.bodyUsed);
+  const chunks = await readAllChunks(stream);
+  assert_equals(chunks.length, 0, "no chunks should be read from empty stream");
+}, "Response.textStream() with empty body");
+
+promise_test(async () => {
+  const buffer = new Uint8Array([0x68, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f, 0x00]); // "hello" in UTF-16LE
+  const response = new Response(buffer, {
+    headers: { "Content-Type": "text/plain; charset=utf-16le" }
+  });
+  const stream = response.textStream();
+  const chunks = await readAllChunks(stream);
+  assert_equals(chunks.join(""), "h\0e\0l\0l\0o\0", "ignores charset=utf-16le and decodes as UTF-8");
+}, "Response.textStream() ignores Content-Type charset (UTF-16LE)");
+
+promise_test(async () => {
+  const buffer = new Uint8Array([0x68, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f, 0x00]); // "hello" in UTF-16LE
+  const request = new Request("https://example.com", {
+    method: "POST",
+    body: buffer,
+    headers: { "Content-Type": "text/plain; charset=utf-16le" }
+  });
+  const stream = request.textStream();
+  const chunks = await readAllChunks(stream);
+  assert_equals(chunks.join(""), "h\0e\0l\0l\0o\0", "ignores charset=utf-16le and decodes as UTF-8");
+}, "Request.textStream() ignores Content-Type charset (UTF-16LE)");
+
+promise_test(async () => {
+  const response = new Response(new TextEncoder().encode("hello"), {
+    headers: { "Content-Type": "text/plain; charset=invalid-charset" }
+  });
+  const stream = response.textStream();
+  const chunks = await readAllChunks(stream);
+  assert_equals(chunks.join(""), "hello", "ignores invalid-charset and decodes as UTF-8");
+}, "Response.textStream() ignores invalid Content-Type charset (invalid-charset)");


### PR DESCRIPTION
Implements the [`textStream()`](https://fetch.spec.whatwg.org/#dom-body-textstream) method on the Body mixin (Request and Response), returning a `ReadableStream<string>` of the body decoded as UTF-8 text.

## Approach

Rather than materializing a byte `ReadableStream` and piping it through a `TextDecoderStream`, each body backing decodes directly:

- **In-memory bodies** (string, bytes, Blob-with-bytes) decode once and enqueue a single string chunk into a closed stream (`ReadableStream__fromDecodedText`).
- **Native byte sources** (fetch response `ByteStream`, file loader) run in a text-mode `JSNativeStreamSourceAdapter` that UTF-8-decodes each pulled span before enqueueing. The streaming-decode state (3 held-back bytes + BOM-seen) lives inline on the adapter; no extra GC cells.
- **Bodies that already have a materialized byte stream** (user-provided `ReadableStream`, or `.body` was accessed first) use a new `SourceKind::TextDecode` whose pull issues a `ReadRequestKind::TextDecode` read on the source reader; chunk steps decode and enqueue strings. The decode state is a 4-byte `Uint8Array` stored in the controller's existing `underlyingObject` slot.

`streamingUTF8Decode` (WebStreamsMisc.cpp) joins held-back bytes from a previous chunk, strips a single leading BOM per stream, holds back a trailing incomplete sequence, and decodes via `WTF::String::fromUTF8ReplacingInvalidSequences`. Held-back bytes are always `[lead(>=0xC0), cont*(0x80..0xBF)]` so the length is derived from the first zero byte.

## Verification

```
$ bun bd test test/js/web/fetch/body.test.ts -t textStream
56 pass, 0 fail
```

Covers: string/buffer/null/undefined bodies, user ReadableStream bodies, multi-byte characters split across chunks, leading BOM stripping, invalid-sequence replacement, fetch response bodies (native ByteStream path), body-unusable/locked error handling, error propagation, cancel propagation, Content-Type charset is ignored.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 14 · 20 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 94 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts test/js/web/fetch/wpt/textstream-wpt.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6b1404cce)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [4.97ms]
(pass) Request > constructor > null [3.59ms]
(pass) Request > constructor > string > "" [6.00ms]
(pass) Request > constructor > string > "Hello world" [1.97ms]
(pass) Request > constructor > string > "🫠" [1.55ms]
(pass) Request > constructor > string > "⁉️" [1.27ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [8.73ms]
(pass) Request > constructor > ArrayBuffer > small buffer [3.63ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.60ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.85ms]
(pass) Request > constructor > SharedArrayBuffer > small b
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (40453587f)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [0.07ms]
(pass) Request > constructor > null [0.03ms]
(pass) Request > constructor > string > "" [0.12ms]
(pass) Request > constructor > string > "Hello world" [0.01ms]
(pass) Request > constructor > string > "🫠" [0.01ms]
(pass) Request > constructor > string > "⁉️"
(pass) Request > constructor > ArrayBuffer > empty buffer [0.11ms]
(pass) Request > constructor > ArrayBuffer > small buffer [0.08ms]
(pass) Request > constructor > ArrayBuffer > large buffer [1.72ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [0.03ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [0.03ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [1.95ms]
(pass) Request > constructor > Buffer > empty buffer [0.02ms]
(pass) Request > constructor > Buffer > small buffer [0.01ms]
(pass) Request > constructor > Buffer > large buffer [1.59ms]
(pass) Request > constructor > Uint8Array > empty buffer [0.01ms]
(pass) Request > constructor > Uint8Array > small buffer [0.03ms]
(pass) Request > constructor > Uint8Array > large buffer [1.4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body.test.ts test/js/web/fetch/wpt/textstream-wpt.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6b1404cce)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [5.01ms]
(pass) Request > constructor > null [3.42ms]
(pass) Request > constructor > string > "" [5.91ms]
(pass) Request > constructor > string > "Hello world" [1.54ms]
(pass) Request > constructor > string > "🫠" [1.77ms]
(pass) Request > constructor > string > "⁉️" [1.19ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [8.63ms]
(pass) Request > constructor > ArrayBuffer > small buffer [3.50ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.37ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.79ms]
(pass) Request > constructor > SharedArrayBuffer > small b
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6b1404cced
  features     (none)

22 deps, 106 codegen, 1169 objects in 674ms

ninja: Entering directory `/workspace/bun/build/release'
[1/59] gen cpp.rs (cppbind)
[2/59] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/59] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/fetch.d.ts                      |  16 +
 .../bindings/webcore/streams/BunStreamSource.cpp   |  62 +++-
 src/jsc/bindings/webcore/streams/BunStreamSource.h |   3 +
 src/jsc/bindings/webcore/streams/JSReadRequest.cpp |  15 +
 .../streams/JSReadableByteStreamController.cpp     |   2 +
 .../bindings/webcore/streams/JSReadableStream.h    |   9 +
 .../streams/JSReadableStreamDefaultController.cpp  |   4 +
 .../webcore/streams/ReadableStreamOperations.cpp   | 136 +++++++
 src/jsc/bindings/webcore/streams/StreamQueue.h     |   2 +
 src/jsc/bindings/webcore/streams/StreamsForward.h  |  26 ++
 .../bindings/webcore/streams/WebStreamsExports.cpp |  43 +++
 .../bindings/webcore/streams/WebStreamsInternals.h |  20 ++
 .../bindings/webcore/streams/WebStreamsMisc.cpp    |  89 +++++
 src/runtime/server/RequestContext.rs               |  21 ++
 src/runtime/webcore/Body.rs                        | 232 ++++++++----
 src/runtime/webcore/ReadableStream.rs              |  46 ++-
 src/runtime/webcore/response.classes.ts            |   2 +
 test/js/web/fetch/body.test.ts                     | 397 +++++++++++++++++++++
 test/js/web/fetch/wpt/textstream-wpt.test.ts       |  32 ++
 test/js/web/fetch/wpt/textstream.any.js            | 177 +++++++++
 20 files changed, 1258 insertions(+), 76 deletions(-)
```

</details>

**gate history** · 17 passed · 0 rejected · iteration 14

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-types/fetch.d.ts                                 2      2      0
src/jsc/bindings/webcore/streams/BunStreamSource.cpp         11     17      0
src/jsc/bindings/webcore/streams/BunStreamSource.h            5      5      0
src/jsc/bindings/webcore/streams/JSReadRequest.cpp            3      5      0
…ings/webcore/streams/JSReadableByteStreamController.cpp      1      2      0
src/jsc/bindings/webcore/streams/JSReadableStream.h           4      4      0
…s/webcore/streams/JSReadableStreamDefaultController.cpp      2      3      0
…c/bindings/webcore/streams/ReadableStreamOperations.cpp     14     22      0
src/jsc/bindings/webcore/streams/StreamQueue.h                2      1      0
src/jsc/bindings/webcore/streams/StreamsForward.h             7     11      0
src/jsc/bindings/webcore/streams/WebStreamsExports.cpp        4      8      0
src/jsc/bindings/webcore/streams/WebStreamsInternals.h        6     11      0
src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp           6     10      0
src/runtime/server/RequestContext.rs                          5      2      0
src/runtime/webcore/Body.rs                                  14     10      0
src/runtime/webcore/ReadableStream.rs                         3      8      0
(+ 4 more files)
```

</details>

<!-- robobun:evidence:end -->