### PR TITLE
Bun.serve: don't truncate error()'s streaming body when async handler rejects

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -981,10 +981,17 @@ where
             return;
         }
 
+        // run_error_handler() may have started a streaming body (ReadableStream
+        // sink, ByteStream pipe, or sendfile). Those paths take a ref and arm
+        // their own completion without setting has_marked_pending; ending the
+        // exchange here would truncate the body mid-stream and orphan the sink.
         // SAFETY: FFI handle
         if !resp.has_responded()
             && !ctx.flags.has_marked_pending()
             && !ctx.flags.is_error_promise_pending()
+            && !ctx.flags.has_sendfile_ctx()
+            && ctx.sink.is_none()
+            && ctx.byte_stream.is_none()
         {
             ctx.render_missing();
             return;

--- a/test/js/bun/http/serve-error-handler-stream.test.ts
+++ b/test/js/bun/http/serve-error-handler-stream.test.ts
@@ -1,0 +1,202 @@
+// When an async fetch handler rejects and error() returns a Response whose
+// body is a ReadableStream, the stream must be allowed to finish.
+// Previously handle_reject() fell through to render_missing() while the sink
+// was still pumping, which force-ended the exchange after the first
+// synchronous chunk (or with an empty Content-Length: 0 body if the stream's
+// first pull awaited before enqueuing).
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const CHUNK = Buffer.alloc(64, "P").toString();
+const CHUNKS = 12;
+const FULL = Buffer.alloc(64 * CHUNKS, "P").toString();
+
+function chunkedBody() {
+  let i = 0;
+  return new ReadableStream({
+    async pull(c) {
+      if (i++ < CHUNKS) {
+        c.enqueue(CHUNK);
+        await Bun.sleep(4);
+      } else {
+        c.close();
+      }
+    },
+  });
+}
+
+function lazyBody() {
+  return new ReadableStream({
+    async pull(c) {
+      await Bun.sleep(10);
+      c.enqueue(CHUNK);
+      c.close();
+    },
+  });
+}
+
+function directBody() {
+  return new ReadableStream({
+    type: "direct",
+    async pull(c) {
+      for (let i = 0; i < CHUNKS; i++) {
+        c.write(CHUNK);
+        await c.flush();
+        await Bun.sleep(4);
+      }
+      await c.end();
+    },
+  } as any);
+}
+
+async function* iteratorBody() {
+  for (let i = 0; i < CHUNKS; i++) {
+    yield CHUNK;
+    await Bun.sleep(4);
+  }
+}
+
+describe("Bun.serve error() returning a streaming Response", () => {
+  const routes: Record<string, (req: Request) => Response | Promise<Response>> = {
+    // Control: sync throw from the handler (was already correct).
+    "/sync": () => {
+      throw new Error("boom");
+    },
+    // The bug: async handler rejects.
+    "/async": () =>
+      (async () => {
+        throw new Error("boom");
+      })(),
+    "/reject": () => Promise.reject(new Error("boom")),
+    // A stream whose first pull awaits before its first enqueue. Without the
+    // fix the client received `Content-Length: 0` and an empty body.
+    "/lazy": () =>
+      (async () => {
+        throw new Error("lazy");
+      })(),
+    "/direct": () =>
+      (async () => {
+        throw new Error("direct");
+      })(),
+    "/iter": () =>
+      (async () => {
+        throw new Error("iter");
+      })(),
+  };
+
+  async function run(path: string) {
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        const u = new URL(req.url);
+        const handler = routes[u.pathname];
+        if (handler) return handler(req);
+        return new Response(chunkedBody(), { status: 200 });
+      },
+      error(e) {
+        const msg = String((e as Error).message);
+        if (msg === "lazy") return new Response(lazyBody(), { status: 597 });
+        if (msg === "direct") return new Response(directBody(), { status: 597 });
+        if (msg === "iter") return new Response(iteratorBody() as any, { status: 597 });
+        return new Response(chunkedBody(), {
+          status: 597,
+          headers: { "x-err": msg },
+        });
+      },
+    });
+
+    const res = await fetch(`http://127.0.0.1:${server.port}${path}`);
+    const body = await res.text();
+    return { status: res.status, body, headers: Object.fromEntries(res.headers) };
+  }
+
+  test.concurrent("control: plain streaming response completes", async () => {
+    const r = await run("/plain");
+    expect({ status: r.status, body: r.body }).toEqual({ status: 200, body: FULL });
+  });
+
+  test.concurrent("control: sync throw -> error() stream completes", async () => {
+    const r = await run("/sync");
+    expect({ status: r.status, body: r.body, xerr: r.headers["x-err"] }).toEqual({
+      status: 597,
+      body: FULL,
+      xerr: "boom",
+    });
+  });
+
+  test.concurrent("async reject -> error() stream completes (pull ReadableStream)", async () => {
+    const r = await run("/async");
+    expect({ status: r.status, body: r.body, xerr: r.headers["x-err"] }).toEqual({
+      status: 597,
+      body: FULL,
+      xerr: "boom",
+    });
+  });
+
+  test.concurrent("Promise.reject -> error() stream completes", async () => {
+    const r = await run("/reject");
+    expect({ status: r.status, body: r.body, xerr: r.headers["x-err"] }).toEqual({
+      status: 597,
+      body: FULL,
+      xerr: "boom",
+    });
+  });
+
+  test.concurrent("async reject -> error() stream whose first pull awaits is not emptied", async () => {
+    const r = await run("/lazy");
+    expect({ status: r.status, body: r.body }).toEqual({ status: 597, body: CHUNK });
+  });
+
+  test.concurrent("async reject -> error() direct stream completes", async () => {
+    const r = await run("/direct");
+    expect({ status: r.status, body: r.body }).toEqual({ status: 597, body: FULL });
+  });
+
+  test.concurrent("async reject -> error() async-iterator body completes", async () => {
+    const r = await run("/iter");
+    expect({ status: r.status, body: r.body }).toEqual({ status: 597, body: FULL });
+  });
+
+  // With Connection: close the premature end frees the socket while the
+  // orphaned stream keeps writing. Under ASAN this is a heap-use-after-free in
+  // uws_res_has_responded. Run in a subprocess so a crash is observable.
+  test.concurrent("async reject + Connection: close does not crash the server", async () => {
+    const src = /* js */ `
+      const CHUNK = Buffer.alloc(64, "P").toString();
+      const CHUNKS = 12;
+      function body() {
+        let i = 0;
+        return new ReadableStream({
+          async pull(c) { if (i++ < CHUNKS) { c.enqueue(CHUNK); await Bun.sleep(4); } else c.close(); },
+        });
+      }
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        fetch: async () => { throw new Error("boom"); },
+        error: () => new Response(body(), { status: 597 }),
+      });
+      const res = await fetch("http://127.0.0.1:" + server.port + "/x", {
+        headers: { Connection: "close" },
+      });
+      const text = await res.text();
+      process.stdout.write(JSON.stringify({ status: res.status, len: text.length }));
+      // Give the orphaned producer (pre-fix) time to write to the freed socket.
+      await Bun.sleep(100);
+      server.stop(true);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, Malloc: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: stdout, exitCode, stderr }).toEqual({
+      out: JSON.stringify({ status: 597, len: 64 * CHUNKS }),
+      exitCode: 0,
+      stderr: "",
+    });
+  });
+});

--- a/test/js/bun/http/serve-error-handler-stream.test.ts
+++ b/test/js/bun/http/serve-error-handler-stream.test.ts
@@ -193,10 +193,11 @@ describe("Bun.serve error() returning a streaming Response", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ out: stdout, exitCode, stderr }).toEqual({
+    // stderr intentionally not asserted empty: debug/ASAN builds may emit
+    // benign warnings. A crash is observed via exitCode and the missing body.
+    expect({ out: stdout, exitCode }, stderr).toEqual({
       out: JSON.stringify({ status: 597, len: 64 * CHUNKS }),
       exitCode: 0,
-      stderr: "",
     });
   });
 });


### PR DESCRIPTION
## Reproduction

```ts
const CHUNK = Buffer.alloc(64, 'P').toString();
const body = () => { let i = 0; return new ReadableStream({
  async pull(c) { if (i++ < 12) { c.enqueue(CHUNK); await Bun.sleep(4); } else c.close(); } }); };

Bun.serve({
  port: 0, development: false,
  fetch: async () => { throw new Error('boom'); },
  error: () => new Response(body(), { status: 597 }),
});
```

A single request to this server receives status 597 with a 1-chunk (64-byte) body framed as a complete chunked response. The same `error()` body returned from a **sync** throw streams all 12 chunks. If the stream's first pull `await`s before enqueuing, the client gets `Content-Length: 0` and an empty body.

With `Connection: close` on a debug/ASAN build, that one request also kills the server:

```
AddressSanitizer: heap-use-after-free READ of size 1
  uWS::HttpResponse<false>::hasResponded()
  <- HTTPServerWritable::write_latin1 (streams.rs) <- js_write (Sink.rs)
freed by: us_internal_free_closed_sockets (bun-usockets/loop.c:308)
```

## Cause

`RequestContext::handle_reject()` runs `run_error_handler()`, then falls through to:

```rust
if !resp.has_responded()
    && !ctx.flags.has_marked_pending()
    && !ctx.flags.is_error_promise_pending()
{
    ctx.render_missing();
}
```

When `error()` returns a streaming `Response`, `do_render_stream`'s pending branch sets `ctx.sink`, takes a ref, and attaches `ON_RESOLVE_STREAM`/`ON_REJECT_STREAM`, but sets none of the flags above. `render_missing()` then sees `has_written_status` already set and does `ctx.end(b"", ...)`, ending the exchange over its own still-pumping sink. The orphaned stream's next write finds a closed (and with `Connection: close`, freed) socket.

The sync-throw path never re-enters `handle_reject`; the resolve path (`handle_resolve`) returns after `render()` without a fallback. Only async-reject hits this.

## Fix

Skip `render_missing()` when a body render is already in flight: `ctx.sink` (ReadableStream / direct / async-iterator), `ctx.byte_stream` (Bytes pipe), or `has_sendfile_ctx()` (file body). These are the pending-render states that arm their own completion without setting `has_marked_pending`.

## Verification

New test `test/js/bun/http/serve-error-handler-stream.test.ts` covers pull/direct/async-iterator bodies, `Promise.reject`, a first-pull-awaits body, and a subprocess `Connection: close` crash repro.

Without the fix under `bun bd` (ASAN) the suite crashes the runner with the heap-use-after-free above; under release bun 1.4.0 the five async-reject cases fail with truncated bodies while the two controls pass. With the fix all 8 pass.