### PR TITLE
spawn: inherit parent cwd when no explicit cwd option is given

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -372,6 +372,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let jsc_vm: &mut jsc::VirtualMachineRef = global_this.bun_vm().as_mut();
 
     let mut cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let mut user_specified_cwd = false;
 
     let mut stdio: [Stdio; 3] = [Stdio::Ignore, Stdio::Pipe, Stdio::Inherit];
 
@@ -475,6 +476,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                     // `cwd_owned` is never mutated again, so this borrow is valid
                     // for every read of `cwd` below.
                     cwd = cwd_owned.as_bytes();
+                    user_specified_cwd = true;
                 }
             }
         }
@@ -1086,7 +1088,14 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let loop_handle = EventLoopHandle::init(event_loop.cast::<()>());
 
     let mut spawn_options = SpawnOptions {
-        cwd: cwd.to_vec().into_boxed_slice(),
+        // Empty means "inherit the parent's working directory". Only chdir
+        // when the user asked for it: the stored cwd path string can be stale
+        // if the directory was renamed out from under the process (#33819).
+        cwd: if user_specified_cwd {
+            cwd.to_vec().into_boxed_slice()
+        } else {
+            Box::default()
+        },
         detached,
         uid,
         gid,

--- a/test/js/bun/spawn/spawn-renamed-cwd.test.ts
+++ b/test/js/bun/spawn/spawn-renamed-cwd.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/33819
+// Spawning without an explicit `cwd` must inherit the parent's working
+// directory instead of chdir'ing to a stored path string, which is stale
+// after the cwd directory is renamed.
+test.skipIf(isWindows)("spawn without explicit cwd works after the parent's cwd is renamed", async () => {
+  using dir = tempDir("spawn-renamed-cwd", {
+    "fixture.ts": `
+      import { mkdirSync, renameSync, realpathSync } from "fs";
+      import { execFileSync } from "child_process";
+      import { join } from "path";
+
+      const root = process.cwd();
+      const installDir = join(root, "install");
+      const renamedDir = join(root, "renamed");
+      mkdirSync(installDir);
+      process.chdir(installDir);
+
+      // Rename the process's own cwd out from under it.
+      renameSync(installDir, renamedDir);
+
+      const sync = Bun.spawnSync(["/bin/echo", "sync-ok"]);
+      console.log(sync.stdout.toString().trim());
+
+      const proc = Bun.spawn(["/bin/echo", "async-ok"], { stdout: "pipe" });
+      console.log((await proc.stdout.text()).trim());
+      await proc.exited;
+
+      console.log(execFileSync("/bin/echo", ["execFileSync-ok"]).toString().trim());
+
+      // The child must inherit the parent's (renamed) working directory.
+      const pwd = Bun.spawnSync([process.execPath, "-e", "console.log(process.cwd())"]);
+      const childCwd = pwd.stdout.toString().trim();
+      console.log(childCwd === realpathSync(renamedDir) ? "cwd-inherited" : "cwd-mismatch: " + childCwd);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim(), stderr).toBe("sync-ok\nasync-ok\nexecFileSync-ok\ncwd-inherited");
+  expect(exitCode).toBe(0);
+});
+
+// An explicit `cwd` option must still chdir the child.
+test.skipIf(isWindows)("spawn with explicit cwd still changes the child's directory", async () => {
+  using dir = tempDir("spawn-explicit-cwd", { "sub/.keep": "" });
+  const sub = join(String(dir), "sub");
+
+  const sync = Bun.spawnSync({
+    cmd: [bunExe(), "-e", "console.log(process.cwd())"],
+    env: bunEnv,
+    cwd: sub,
+  });
+  expect(sync.stdout.toString().trim()).toBe(realpathSync(sub));
+  expect(sync.success).toBe(true);
+});


### PR DESCRIPTION
Fixes #33819

### Problem

When a Bun process's working directory is renamed out from under it (e.g. a self-updating CLI doing an atomic swap of its own install directory), every subsequent `Bun.spawn`/`Bun.spawnSync`/`child_process.execFileSync` call fails:

```
ENOENT: no such file or directory, posix_spawn '/bin/mv'
```

even though the executable exists. Reproduced on Linux and macOS with the script from the issue:

```ts
process.chdir(installRoot);
Bun.spawnSync(["/bin/mv", installRoot, backup]);        // renames the parent's cwd
Bun.spawnSync(["/bin/mv", staged, installRoot]);        // ENOENT posix_spawn '/bin/mv'
```

Node succeeds in the same scenario because it only chdirs the child when `options.cwd` is set.

### Cause

`spawn_maybe_sync` in `src/runtime/api/bun/js_bun_spawn_bindings.rs` defaulted `cwd` to `FileSystem::get().top_level_dir` and always passed it to `SpawnOptions`, so `spawn_process` always added a `posix_spawn_file_actions_addchdir_np` action with that path string. After the directory is renamed the stored path no longer exists, the chdir action fails with ENOENT inside posix_spawn, and the error is attributed to the executable path. The directory inode itself is still alive, so inheriting the parent's cwd (what Node does) works fine.

### Fix

Only populate `SpawnOptions.cwd` when the caller supplied a `cwd` option. An empty cwd already means "inherit the parent's working directory" in both spawn layers: the posix path skips the chdir action, and the Windows path passes NULL to `uv_process_options.cwd`. `node:child_process` routes through the same binding and only forwards a user-supplied `cwd`, so `execFileSync` is covered as well. Explicit `cwd` behavior is unchanged.

### Tests

`test/js/bun/spawn/spawn-renamed-cwd.test.ts`:
- spawns a fixture that chdirs into a directory, renames it, then runs `Bun.spawnSync`, `Bun.spawn`, and `execFileSync`, and verifies a spawned child inherits the renamed cwd
- verifies an explicit `cwd` option still changes the child's directory

Fails on bun 1.4.0-canary (ENOENT posix_spawn at the first spawnSync), passes with this change. Existing spawn suites (`spawn.test.ts`, `spawnSync.test.ts`, `spawn-path.test.ts`) pass; the two `child_process.test.ts` failures in my environment (missing `$SHELL`, GC pipe timeout in debug) reproduce identically on unmodified main.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-renamed-cwd.test.ts

<!-- robobun:evidence:end -->