### PR TITLE
Wire up HeapAnalyzer for Web Streams cell classes

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1538,19 +1538,20 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
   } = obj;
   const name = className(typeName);
 
+  // analyzeHeap reports every cached value as a named property edge; appendHidden
+  // marks for GC without emitting a duplicate anonymous internal edge.
   let DEFINE_VISIT_CHILDREN_LIST = [...Object.entries(fields), ...Object.entries(proto)]
     .filter(([name, { cache = false }]) => cache === true)
-    .map(([name]) => `visitor.append(thisObject->m_${name});`)
+    .map(([name]) => `visitor.appendHidden(thisObject->m_${name});`)
     .join("\n");
 
   for (const name in callbacks) {
-    // Use appendHidden so it doesn't show up in the heap snapshot twice.
     DEFINE_VISIT_CHILDREN_LIST += "\n" + `    visitor.appendHidden(thisObject->m_callback_${name});`;
   }
 
   const values = (obj.values || [])
     .map(val => {
-      return `visitor.append(thisObject->m_${val});`;
+      return `visitor.appendHidden(thisObject->m_${val});`;
     })
     .join("\n");
   var DEFINE_VISIT_CHILDREN = "";

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3954,8 +3954,7 @@ pub mod formatter {
                     C,
                 )
             })?;
-            // Strings are printed directly, otherwise we recurse. It is
-            // possible to end up in an infinite loop.
+            // Strings are printed directly, otherwise we recurse.
             if result.is_string() {
                 if writer_
                     .write_fmt(format_args!("{}", result.fmt_string(self.global_this)))
@@ -3964,12 +3963,15 @@ pub mod formatter {
                     self.failed = true;
                 }
             } else {
-                self.format::<C>(
-                    Tag::get(result, self.global_this)?,
-                    writer_,
-                    result,
-                    self.global_this,
-                )?;
+                // A custom inspector that returns its own `this` would recurse
+                // forever; re-tag without the custom hook so it falls through to
+                // default formatting (mirrors util.inspect's `ret !== context`).
+                let tag = if result == self.custom_formatted_object.this {
+                    Tag::get_advanced(result, self.global_this, TagOptions::DISABLE_INSPECT_CUSTOM)?
+                } else {
+                    Tag::get(result, self.global_this)?
+                };
+                self.format::<C>(tag, writer_, result, self.global_this)?;
             }
             Ok(())
         }

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -13,6 +13,7 @@
 #include "JSReadableStream.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 
@@ -76,6 +77,16 @@ void JSAsyncIteratorSourceOperation::visitChildrenImpl(JSCell* cell, Visitor& vi
 }
 
 DEFINE_VISIT_CHILDREN(JSAsyncIteratorSourceOperation);
+
+void JSAsyncIteratorSourceOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSAsyncIteratorSourceOperation>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_iterator, "iterator"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pullPromise, "pullPromise"_s);
+}
 
 static void driveAsyncIterator(JSGlobalObject*, JSAsyncIteratorSourceOperation*);
 static void asyncIterReturnIteratorAndSettle(JSGlobalObject*, JSAsyncIteratorSourceOperation*);

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -71,9 +71,9 @@ void JSAsyncIteratorSourceOperation::visitChildrenImpl(JSCell* cell, Visitor& vi
     auto* thisObject = uncheckedDowncast<JSAsyncIteratorSourceOperation>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_iterator);
-    visitor.append(thisObject->m_controller);
-    visitor.append(thisObject->m_pullPromise);
+    visitor.appendHidden(thisObject->m_iterator);
+    visitor.appendHidden(thisObject->m_controller);
+    visitor.appendHidden(thisObject->m_pullPromise);
 }
 
 DEFINE_VISIT_CHILDREN(JSAsyncIteratorSourceOperation);

--- a/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
+++ b/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
@@ -11,6 +11,7 @@
 #include "root.h"
 #include "StreamsForward.h"
 
+#include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/WriteBarrier.h>
@@ -59,6 +60,17 @@ struct BunTextAccumulator {
     {
         for (auto& piece : pieces)
             visitor.append(piece);
+    }
+
+    // Reports every barrier in `pieces` as an index edge for heap-snapshot retainers.
+    // Called from the OWNING cell's analyzeHeap, inside that cell's single cellLock() scope.
+    void analyzeHeap(const WTF::AbstractLocker&, JSC::JSCell* from, JSC::HeapAnalyzer& analyzer)
+    {
+        for (uint32_t i = 0; i < pieces.size(); ++i) {
+            JSC::JSValue v = pieces[i].get();
+            if (v && v.isCell())
+                analyzer.analyzeIndexEdge(from, v.asCell(), i);
+        }
     }
 };
 

--- a/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
+++ b/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
@@ -81,6 +81,7 @@ public:
     // visitChildrenImpl MUST visit the barrier container m_accumulator.pieces (via
     // m_accumulator.visit(locker, visitor) inside ONE `Locker { cellLock() }` scope).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
+++ b/src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h
@@ -59,7 +59,7 @@ struct BunTextAccumulator {
     void visit(const WTF::AbstractLocker&, Visitor& visitor)
     {
         for (auto& piece : pieces)
-            visitor.append(piece);
+            visitor.appendHidden(piece);
     }
 
     // Reports every barrier in `pieces` as an index edge for heap-snapshot retainers.

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -155,10 +155,10 @@ void JSOneShotDirectSink::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSOneShotDirectSink>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_arrayBufferSink);
-    visitor.append(thisObject->m_capabilityPromise);
-    visitor.append(thisObject->m_closeFunction);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_arrayBufferSink);
+    visitor.appendHidden(thisObject->m_capabilityPromise);
+    visitor.appendHidden(thisObject->m_closeFunction);
 }
 
 void JSOneShotDirectSink::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
@@ -220,9 +220,9 @@ void JSReadableStreamIntoArrayOperation::visitChildrenImpl(JSCell* cell, Visitor
     auto* thisObject = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_chunks);
-    visitor.append(thisObject->m_result);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_chunks);
+    visitor.appendHidden(thisObject->m_result);
 }
 
 void JSReadableStreamIntoArrayOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -107,12 +107,7 @@ void JSBunStandaloneTextSink::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     auto* thisObject = uncheckedDowncast<JSBunStandaloneTextSink>(cell);
     Base::analyzeHeap(cell, analyzer);
     WTF::Locker locker { thisObject->cellLock() };
-    auto& pieces = thisObject->m_accumulator.pieces;
-    for (uint32_t i = 0; i < pieces.size(); ++i) {
-        JSValue v = pieces[i].get();
-        if (v && v.isCell())
-            analyzer.analyzeIndexEdge(cell, v.asCell(), i);
-    }
+    thisObject->m_accumulator.analyzeHeap(locker, cell, analyzer);
 }
 
 // JSOneShotDirectSink — consumeDirectStreamToArrayBuffer's throwaway controller cell.

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -18,6 +18,7 @@
 #include "JSReadableStream.h"
 #include "JSReadableStreamDefaultReader.h"
 #include "JSStreamsRuntime.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/ArrayBuffer.h>
@@ -43,6 +44,7 @@
 namespace WebCore {
 
 using namespace JSC;
+using Bun::WebStreams::analyzeBarrierEdge;
 
 // JSBunStandaloneTextSink — the GENERIC toText accumulator cell (BunStandaloneTextSink.h).
 
@@ -100,6 +102,19 @@ void JSBunStandaloneTextSink::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_accumulator.visit(locker, visitor);
 }
 
+void JSBunStandaloneTextSink::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSBunStandaloneTextSink>(cell);
+    Base::analyzeHeap(cell, analyzer);
+    WTF::Locker locker { thisObject->cellLock() };
+    auto& pieces = thisObject->m_accumulator.pieces;
+    for (uint32_t i = 0; i < pieces.size(); ++i) {
+        JSValue v = pieces[i].get();
+        if (v && v.isCell())
+            analyzer.analyzeIndexEdge(cell, v.asCell(), i);
+    }
+}
+
 // JSOneShotDirectSink — consumeDirectStreamToArrayBuffer's throwaway controller cell.
 
 const ClassInfo JSOneShotDirectSink::s_info = { "OneShotDirectSink"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSOneShotDirectSink) };
@@ -149,6 +164,17 @@ void JSOneShotDirectSink::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_arrayBufferSink);
     visitor.append(thisObject->m_capabilityPromise);
     visitor.append(thisObject->m_closeFunction);
+}
+
+void JSOneShotDirectSink::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSOneShotDirectSink>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_arrayBufferSink, "arrayBufferSink"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_capabilityPromise, "capabilityPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closeFunction, "closeFunction"_s);
 }
 
 // JSReadableStreamIntoArrayOperation — the queue-backed array pump's persistent state.
@@ -202,6 +228,16 @@ void JSReadableStreamIntoArrayOperation::visitChildrenImpl(JSCell* cell, Visitor
     visitor.append(thisObject->m_reader);
     visitor.append(thisObject->m_chunks);
     visitor.append(thisObject->m_result);
+}
+
+void JSReadableStreamIntoArrayOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamIntoArrayOperation>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_chunks, "chunks"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_result, "result"_s);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -18,6 +18,7 @@
 #include "JSResumableSinkPumpOperation.h"
 #include "JSSink.h"
 #include "JSStreamsRuntime.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/AggregateError.h>
@@ -43,6 +44,7 @@
 namespace WebCore {
 
 using namespace JSC;
+using Bun::WebStreams::analyzeBarrierEdge;
 
 const ClassInfo JSNativeStreamSourceAdapter::s_info = { "NativeStreamSourceAdapter"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSNativeStreamSourceAdapter) };
 
@@ -100,6 +102,17 @@ void JSNativeStreamSourceAdapter::visitChildrenImpl(JSCell* cell, Visitor& visit
 
 DEFINE_VISIT_CHILDREN(JSNativeStreamSourceAdapter);
 
+void JSNativeStreamSourceAdapter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSNativeStreamSourceAdapter>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_handle, "handle"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingView, "pendingView"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closer, "closer"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_drainValue, "drainValue"_s);
+}
+
 const ClassInfo JSDirectSinkCloseState::s_info = { "DirectSinkCloseState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDirectSinkCloseState) };
 
 JSDirectSinkCloseState::JSDirectSinkCloseState(VM& vm, Structure* structure)
@@ -147,6 +160,16 @@ void JSDirectSinkCloseState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 }
 
 DEFINE_VISIT_CHILDREN(JSDirectSinkCloseState);
+
+void JSDirectSinkCloseState::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSDirectSinkCloseState>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_underlyingSource, "underlyingSource"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_sinkController, "sinkController"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closePromise, "closePromise"_s);
+}
 
 const ClassInfo JSReadStreamIntoSinkOperation::s_info = { "ReadStreamIntoSinkOperation"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadStreamIntoSinkOperation) };
 
@@ -197,6 +220,17 @@ void JSReadStreamIntoSinkOperation::visitChildrenImpl(JSCell* cell, Visitor& vis
 
 DEFINE_VISIT_CHILDREN(JSReadStreamIntoSinkOperation);
 
+void JSReadStreamIntoSinkOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadStreamIntoSinkOperation>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_sink, "sink"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_result, "result"_s);
+}
+
 const ClassInfo JSResumableSinkPumpOperation::s_info = { "ResumableSinkPumpOperation"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSResumableSinkPumpOperation) };
 
 JSResumableSinkPumpOperation::JSResumableSinkPumpOperation(VM& vm, Structure* structure)
@@ -245,6 +279,17 @@ void JSResumableSinkPumpOperation::visitChildrenImpl(JSCell* cell, Visitor& visi
 }
 
 DEFINE_VISIT_CHILDREN(JSResumableSinkPumpOperation);
+
+void JSResumableSinkPumpOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSResumableSinkPumpOperation>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_sink, "sink"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_error, "error"_s);
+}
 
 } // namespace WebCore
 

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -94,10 +94,10 @@ void JSNativeStreamSourceAdapter::visitChildrenImpl(JSCell* cell, Visitor& visit
     auto* thisObject = uncheckedDowncast<JSNativeStreamSourceAdapter>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_handle);
-    visitor.append(thisObject->m_pendingView);
-    visitor.append(thisObject->m_closer);
-    visitor.append(thisObject->m_drainValue);
+    visitor.appendHidden(thisObject->m_handle);
+    visitor.appendHidden(thisObject->m_pendingView);
+    visitor.appendHidden(thisObject->m_closer);
+    visitor.appendHidden(thisObject->m_drainValue);
 }
 
 DEFINE_VISIT_CHILDREN(JSNativeStreamSourceAdapter);
@@ -154,9 +154,9 @@ void JSDirectSinkCloseState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSDirectSinkCloseState>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_underlyingSource);
-    visitor.append(thisObject->m_sinkController);
-    visitor.append(thisObject->m_closePromise);
+    visitor.appendHidden(thisObject->m_underlyingSource);
+    visitor.appendHidden(thisObject->m_sinkController);
+    visitor.appendHidden(thisObject->m_closePromise);
 }
 
 DEFINE_VISIT_CHILDREN(JSDirectSinkCloseState);
@@ -212,10 +212,10 @@ void JSReadStreamIntoSinkOperation::visitChildrenImpl(JSCell* cell, Visitor& vis
     auto* thisObject = uncheckedDowncast<JSReadStreamIntoSinkOperation>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_sink);
-    visitor.append(thisObject->m_result);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_sink);
+    visitor.appendHidden(thisObject->m_result);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadStreamIntoSinkOperation);
@@ -272,10 +272,10 @@ void JSResumableSinkPumpOperation::visitChildrenImpl(JSCell* cell, Visitor& visi
     auto* thisObject = uncheckedDowncast<JSResumableSinkPumpOperation>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_sink);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_error);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_sink);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_error);
 }
 
 DEFINE_VISIT_CHILDREN(JSResumableSinkPumpOperation);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.h
@@ -32,6 +32,7 @@ public:
     // visitChildrenImpl MUST visit: m_handle, m_pendingView, m_closer, m_drainValue.
     // m_controller is a JSC::Weak and MUST NOT be visited (that is the whole point).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSAsyncIteratorSourceOperation.h
@@ -23,6 +23,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_iterator, m_controller, m_pullPromise.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -8,11 +8,13 @@
 #include "JSDOMWrapperCache.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -24,6 +26,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_constructor);
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_highWaterMark);
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_size);
+static JSC_DECLARE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom);
 
 class JSByteLengthQueuingStrategyPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -170,10 +173,24 @@ static const HashTableValue JSByteLengthQueuingStrategyPrototypeTableValues[] = 
 
 const ClassInfo JSByteLengthQueuingStrategyPrototype::s_info = { "ByteLengthQueuingStrategy"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSByteLengthQueuingStrategyPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSByteLengthQueuingStrategy>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ByteLengthQueuingStrategy"_s, data));
+}
+
 void JSByteLengthQueuingStrategyPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSByteLengthQueuingStrategy::info(), JSByteLengthQueuingStrategyPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsByteLengthQueuingStrategyPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -8,11 +8,13 @@
 #include "JSDOMWrapperCache.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -24,6 +26,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_constructor);
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_highWaterMark);
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_size);
+static JSC_DECLARE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom);
 
 class JSCountQueuingStrategyPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -170,10 +173,24 @@ static const HashTableValue JSCountQueuingStrategyPrototypeTableValues[] = {
 
 const ClassInfo JSCountQueuingStrategyPrototype::s_info = { "CountQueuingStrategy"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCountQueuingStrategyPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSCountQueuingStrategy>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "CountQueuingStrategy"_s, data));
+}
+
 void JSCountQueuingStrategyPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSCountQueuingStrategy::info(), JSCountQueuingStrategyPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsCountQueuingStrategyPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
@@ -61,10 +61,10 @@ void JSCrossRealmTransformState::visitChildrenImpl(JSCell* cell, Visitor& visito
     auto* thisObject = uncheckedDowncast<JSCrossRealmTransformState>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_port);
-    visitor.append(thisObject->m_backpressurePromise);
-    visitor.append(thisObject->m_readableController);
-    visitor.append(thisObject->m_writableController);
+    visitor.appendHidden(thisObject->m_port);
+    visitor.appendHidden(thisObject->m_backpressurePromise);
+    visitor.appendHidden(thisObject->m_readableController);
+    visitor.appendHidden(thisObject->m_writableController);
 }
 
 void JSCrossRealmTransformState::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
@@ -7,6 +7,7 @@
 #include "JSDOMGlobalObject.h"
 #include "JSReadableStreamDefaultController.h"
 #include "JSWritableStreamDefaultController.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
@@ -15,6 +16,7 @@
 namespace WebCore {
 
 using namespace JSC;
+using Bun::WebStreams::analyzeBarrierEdge;
 
 const ClassInfo JSCrossRealmTransformState::s_info = { "CrossRealmTransformState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCrossRealmTransformState) };
 
@@ -63,6 +65,17 @@ void JSCrossRealmTransformState::visitChildrenImpl(JSCell* cell, Visitor& visito
     visitor.append(thisObject->m_backpressurePromise);
     visitor.append(thisObject->m_readableController);
     visitor.append(thisObject->m_writableController);
+}
+
+void JSCrossRealmTransformState::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSCrossRealmTransformState>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_port, "port"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_backpressurePromise, "backpressurePromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_readableController, "readableController"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_writableController, "writableController"_s);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.h
+++ b/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.h
@@ -28,6 +28,7 @@ public:
     // visitChildrenImpl MUST visit: m_port, m_backpressurePromise, m_readableController,
     // m_writableController.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSDirectSinkCloseState.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectSinkCloseState.h
@@ -25,6 +25,7 @@ public:
     // m_closePromise. (An unvisited m_closePromise is a premature collection of the
     // promise handed to Rust.)
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -126,6 +126,8 @@ void JSDirectStreamController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_array, "array"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closingPromise, "closingPromise"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_finalChunk, "finalChunk"_s);
+    WTF::Locker locker { thisObject->cellLock() };
+    thisObject->m_textAccumulator.analyzeHeap(locker, cell, analyzer);
 }
 
 static size_t byteLengthOf(JSValue value)

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -99,15 +99,15 @@ void JSDirectStreamController::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSDirectStreamController>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_underlyingSource);
-    visitor.append(thisObject->m_pull);
-    visitor.append(thisObject->m_pendingRead);
-    visitor.append(thisObject->m_deferCloseReason);
-    visitor.append(thisObject->m_arrayBufferSink);
-    visitor.append(thisObject->m_array);
-    visitor.append(thisObject->m_closingPromise);
-    visitor.append(thisObject->m_finalChunk);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_underlyingSource);
+    visitor.appendHidden(thisObject->m_pull);
+    visitor.appendHidden(thisObject->m_pendingRead);
+    visitor.appendHidden(thisObject->m_deferCloseReason);
+    visitor.appendHidden(thisObject->m_arrayBufferSink);
+    visitor.appendHidden(thisObject->m_array);
+    visitor.appendHidden(thisObject->m_closingPromise);
+    visitor.appendHidden(thisObject->m_finalChunk);
     Locker locker { thisObject->cellLock() };
     thisObject->m_textAccumulator.visit(locker, visitor);
 }

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -11,6 +11,7 @@
 #include "JSReadableStreamDefaultReader.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 
@@ -109,6 +110,22 @@ void JSDirectStreamController::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_finalChunk);
     Locker locker { thisObject->cellLock() };
     thisObject->m_textAccumulator.visit(locker, visitor);
+}
+
+void JSDirectStreamController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSDirectStreamController>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_underlyingSource, "underlyingSource"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pull, "pull"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingRead, "pendingRead"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_deferCloseReason, "deferCloseReason"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_arrayBufferSink, "arrayBufferSink"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_array, "array"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closingPromise, "closingPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_finalChunk, "finalChunk"_s);
 }
 
 static size_t byteLengthOf(JSValue value)

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -37,6 +37,7 @@ public:
     // m_textAccumulator.visit(locker, visitor) inside ONE `Locker { cellLock() }` scope
     // taken by THIS visitChildrenImpl — cellLock() is non-recursive; see StreamQueue.h).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h
+++ b/src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h
@@ -37,6 +37,7 @@ public:
     // visitChildrenImpl MUST visit ALL FOUR barriers: m_stream, m_arrayBufferSink,
     // m_capabilityPromise, m_closeFunction. No barrier container ⇒ no cellLock needed.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -13,6 +13,7 @@
 #include "JSStreamPipeToOperation.h"
 #include "JSStreamTeeState.h"
 #include "JSStreamsRuntime.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include <JavaScriptCore/InternalFieldTuple.h>
 #include <JavaScriptCore/IteratorOperations.h>
@@ -102,6 +103,14 @@ void JSReadRequest::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_context);
+}
+
+void JSReadRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadRequest>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_context, "context"_s);
 }
 
 void JSReadRequest::chunkSteps(JSGlobalObject* globalObject, JSValue chunk)
@@ -278,6 +287,14 @@ void JSReadIntoRequest::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_context);
+}
+
+void JSReadIntoRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadIntoRequest>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_context, "context"_s);
 }
 
 void JSReadIntoRequest::chunkSteps(JSGlobalObject* globalObject, JSArrayBufferView* chunk)

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -102,7 +102,7 @@ void JSReadRequest::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSReadRequest>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_context);
+    visitor.appendHidden(thisObject->m_context);
 }
 
 void JSReadRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
@@ -286,7 +286,7 @@ void JSReadIntoRequest::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSReadIntoRequest>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_context);
+    visitor.appendHidden(thisObject->m_context);
 }
 
 void JSReadIntoRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.h
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.h
@@ -24,6 +24,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_context.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
@@ -71,6 +72,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_context.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadStreamIntoSinkOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSReadStreamIntoSinkOperation.h
@@ -26,6 +26,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit ALL FOUR barriers: m_stream, m_reader, m_sink, m_result.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -14,6 +14,7 @@
 #include "JSStreamTeeState.h"
 #include "JSStreamsRuntime.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 
@@ -26,6 +27,7 @@
 #include <JavaScriptCore/JSDataView.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSTypedArrays.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -191,6 +193,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableByteStreamControllerPrototypeGetter_d
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom);
 
 class JSReadableByteStreamControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -235,10 +238,24 @@ static const HashTableValue JSReadableByteStreamControllerPrototypeTableValues[]
 
 const ClassInfo JSReadableByteStreamControllerPrototype::s_info = { "ReadableByteStreamController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableByteStreamControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableByteStreamController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    (void)thisObject;
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableByteStreamController"_s, data));
+}
+
 void JSReadableByteStreamControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableByteStreamController::info(), JSReadableByteStreamControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableByteStreamControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -324,17 +324,17 @@ void JSReadableByteStreamController::visitChildrenImpl(JSCell* cell, Visitor& vi
     auto* thisObject = uncheckedDowncast<JSReadableByteStreamController>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_byobRequest);
-    visitor.append(thisObject->m_algorithms.underlyingObject);
-    visitor.append(thisObject->m_algorithms.method1);
-    visitor.append(thisObject->m_algorithms.method2);
-    visitor.append(thisObject->m_algorithms.algorithmContext);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_byobRequest);
+    visitor.appendHidden(thisObject->m_algorithms.underlyingObject);
+    visitor.appendHidden(thisObject->m_algorithms.method1);
+    visitor.appendHidden(thisObject->m_algorithms.method2);
+    visitor.appendHidden(thisObject->m_algorithms.algorithmContext);
     // ONE non-recursive cellLock scope covers BOTH barrier containers (StreamQueue.h).
     WTF::Locker locker { thisObject->cellLock() };
     thisObject->m_queue.visit(locker, visitor);
     for (auto& descriptor : thisObject->m_pendingPullIntos)
-        visitor.append(descriptor);
+        visitor.appendHidden(descriptor);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableByteStreamController);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -13,6 +13,7 @@
 #include "JSReadableStreamDefaultReader.h"
 #include "JSStreamTeeState.h"
 #include "JSStreamsRuntime.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 
@@ -337,6 +338,28 @@ void JSReadableByteStreamController::visitChildrenImpl(JSCell* cell, Visitor& vi
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableByteStreamController);
+
+void JSReadableByteStreamController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableByteStreamController>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_byobRequest, "byobRequest"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.underlyingObject, "underlyingSource"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method1, "pullAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method2, "cancelAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.algorithmContext, "algorithmContext"_s);
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        uint32_t i = 0;
+        for (auto& entry : thisObject->m_pendingPullIntos) {
+            if (auto* descriptor = entry.get())
+                analyzer.analyzeIndexEdge(cell, descriptor, i);
+            ++i;
+        }
+    }
+}
 
 // [[CancelSteps]](reason)
 JSPromise* JSReadableByteStreamController::cancelSteps(JSGlobalObject* globalObject, JSValue reason)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.h
@@ -39,6 +39,7 @@ public:
     //   never re-acquires the lock). Never visit either container outside that scope, and
     //   never take a second Locker. Mutating ops that touch BOTH containers do the same.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -17,6 +17,7 @@
 #include "JSReadableStreamDefaultReader.h"
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -488,6 +489,20 @@ void JSReadableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_directUnderlyingSource);
     visitor.append(thisObject->m_asyncContext);
     visitor.append(thisObject->m_closedPromise);
+}
+
+void JSReadableStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStream>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_storedError, "storedError"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_nativePtr, "bunNativePtr"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_directUnderlyingSource, "underlyingSource"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_asyncContext, "asyncContext"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closedPromise, "closedPromise"_s);
 }
 
 void JSReadableStream::materializeIfNeeded(JSGlobalObject* globalObject)

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -482,13 +482,13 @@ void JSReadableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSReadableStream>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_storedError);
-    visitor.append(thisObject->m_controller);
-    visitor.append(thisObject->m_nativePtr);
-    visitor.append(thisObject->m_directUnderlyingSource);
-    visitor.append(thisObject->m_asyncContext);
-    visitor.append(thisObject->m_closedPromise);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_storedError);
+    visitor.appendHidden(thisObject->m_controller);
+    visitor.appendHidden(thisObject->m_nativePtr);
+    visitor.appendHidden(thisObject->m_directUnderlyingSource);
+    visitor.appendHidden(thisObject->m_asyncContext);
+    visitor.appendHidden(thisObject->m_closedPromise);
 }
 
 void JSReadableStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -18,6 +18,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -28,6 +29,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -56,6 +58,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamPrototype_nativeTypeGetter);
 static JSC_DECLARE_CUSTOM_SETTER(jsReadableStreamPrototype_nativeTypeSetter);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamPrototype_disturbedGetter);
 static JSC_DECLARE_CUSTOM_SETTER(jsReadableStreamPrototype_disturbedSetter);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom);
 
 class JSReadableStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -399,6 +402,33 @@ static const HashTableValue JSReadableStreamPrototypeTableValues[] = {
 
 const ClassInfo JSReadableStreamPrototype::s_info = { "ReadableStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isReadableStreamLocked(thisObject)), 0);
+    ASCIILiteral state;
+    switch (thisObject->m_state) {
+    case ReadableStreamState::Readable:
+        state = "readable"_s;
+        break;
+    case ReadableStreamState::Closed:
+        state = "closed"_s;
+        break;
+    case ReadableStreamState::Errored:
+        state = "errored"_s;
+        break;
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "supportsBYOB"_s), jsBoolean(thisObject->m_controllerKind == ControllerKind::Byte), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStream"_s, data));
+}
+
 void JSReadableStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
@@ -414,6 +444,7 @@ void JSReadableStreamPrototype::finishCreation(VM& vm)
     putDirectCustomAccessor(vm, names.bunNativeTypePrivateName(), DOMAttributeGetterSetter::create(vm, jsReadableStreamPrototype_nativeTypeGetter, jsReadableStreamPrototype_nativeTypeSetter, DOMAttributeAnnotation { JSReadableStream::info(), nullptr }), JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete);
     putDirectCustomAccessor(vm, names.disturbedPrivateName(), DOMAttributeGetterSetter::create(vm, jsReadableStreamPrototype_disturbedGetter, jsReadableStreamPrototype_disturbedSetter, DOMAttributeAnnotation { JSReadableStream::info(), nullptr }), JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete);
 
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -33,6 +33,7 @@ public:
     // m_directUnderlyingSource, m_asyncContext, m_closedPromise. No barrier container ⇒ no
     // cellLock needed.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
@@ -136,8 +136,8 @@ void JSReadableStreamAsyncIterator::visitChildrenImpl(JSCell* cell, Visitor& vis
     auto* thisObject = uncheckedDowncast<JSReadableStreamAsyncIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_ongoingPromise);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_ongoingPromise);
 }
 
 void JSReadableStreamAsyncIterator::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
@@ -12,6 +12,7 @@
 #include "JSReadableStreamDefaultReader.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/AsyncIteratorPrototype.h>
@@ -137,6 +138,15 @@ void JSReadableStreamAsyncIterator::visitChildrenImpl(JSCell* cell, Visitor& vis
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_reader);
     visitor.append(thisObject->m_ongoingPromise);
+}
+
+void JSReadableStreamAsyncIterator::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamAsyncIterator>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_ongoingPromise, "ongoingPromise"_s);
 }
 
 // "Get the next iteration result": the read request's chunk/close/error steps

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.h
@@ -30,6 +30,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_reader, m_ongoingPromise.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -17,6 +17,7 @@
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -26,6 +27,7 @@
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -142,6 +144,7 @@ static BYOBReadArguments convertBYOBReadArguments(JSC::VM& vm, JSGlobalObject* g
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_cancel);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_read);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_releaseLock);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_closed);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_constructor);
 
@@ -274,10 +277,31 @@ static const HashTableValue JSReadableStreamBYOBReaderPrototypeTableValues[] = {
 
 const ClassInfo JSReadableStreamBYOBReaderPrototype::s_info = { "ReadableStreamBYOBReader"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamBYOBReaderPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamBYOBReader>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    size_t requestCount;
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        requestCount = thisObject->m_readIntoRequests.size();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "readIntoRequests"_s), jsNumber(requestCount), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamBYOBReader"_s, data));
+}
+
 void JSReadableStreamBYOBReaderPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamBYOBReader::info(), JSReadableStreamBYOBReaderPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamBYOBReaderPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -16,6 +16,7 @@
 #include "JSReadableStream.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -354,6 +355,24 @@ void JSReadableStreamBYOBReader::visitChildrenImpl(JSCell* cell, Visitor& visito
     WTF::Locker locker { thisObject->cellLock() };
     for (auto& request : thisObject->m_readIntoRequests)
         visitor.append(request);
+}
+
+void JSReadableStreamBYOBReader::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamBYOBReader>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closedPromise, "closedPromise"_s);
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        uint32_t i = 0;
+        for (auto& entry : thisObject->m_readIntoRequests) {
+            if (auto* request = entry.get())
+                analyzer.analyzeIndexEdge(cell, request, i);
+            ++i;
+        }
+    }
 }
 
 // Prototype accessors and host functions

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -350,11 +350,11 @@ void JSReadableStreamBYOBReader::visitChildrenImpl(JSCell* cell, Visitor& visito
     auto* thisObject = uncheckedDowncast<JSReadableStreamBYOBReader>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_closedPromise);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_closedPromise);
     WTF::Locker locker { thisObject->cellLock() };
     for (auto& request : thisObject->m_readIntoRequests)
-        visitor.append(request);
+        visitor.appendHidden(request);
 }
 
 void JSReadableStreamBYOBReader::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.h
@@ -31,6 +31,7 @@ public:
     // visitChildrenImpl MUST visit: m_stream + m_closedPromise (from the base) and
     // m_readIntoRequests (a barrier container: UNDER cellLock()).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -13,6 +13,7 @@
 #include "JSReadableByteStreamController.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -21,6 +22,7 @@
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -31,6 +33,7 @@ using namespace Bun::WebStreams;
 
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototypeFunction_respond);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototypeFunction_respondWithNewView);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBRequestPrototypeGetter_view);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBRequestPrototypeGetter_constructor);
 
@@ -99,10 +102,25 @@ static const HashTableValue JSReadableStreamBYOBRequestPrototypeTableValues[] = 
 
 const ClassInfo JSReadableStreamBYOBRequestPrototype::s_info = { "ReadableStreamBYOBRequest"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamBYOBRequestPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamBYOBRequest>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "view"_s), thisObject->m_view.get() ? JSValue(thisObject->m_view.get()) : jsNull(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "controller"_s), thisObject->m_controller.get() ? JSValue(thisObject->m_controller.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamBYOBRequest"_s, data));
+}
+
 void JSReadableStreamBYOBRequestPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamBYOBRequest::info(), JSReadableStreamBYOBRequestPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamBYOBRequestPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -12,6 +12,7 @@
 #include "JSDOMWrapperCache.h"
 #include "JSReadableByteStreamController.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -169,6 +170,15 @@ void JSReadableStreamBYOBRequest::visitChildrenImpl(JSCell* cell, Visitor& visit
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_controller);
     visitor.append(thisObject->m_view);
+}
+
+void JSReadableStreamBYOBRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamBYOBRequest>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_view, "view"_s);
 }
 
 // Prototype host functions

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -168,8 +168,8 @@ void JSReadableStreamBYOBRequest::visitChildrenImpl(JSCell* cell, Visitor& visit
     auto* thisObject = uncheckedDowncast<JSReadableStreamBYOBRequest>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_controller);
-    visitor.append(thisObject->m_view);
+    visitor.appendHidden(thisObject->m_controller);
+    visitor.appendHidden(thisObject->m_view);
 }
 
 void JSReadableStreamBYOBRequest::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.h
@@ -28,6 +28,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_controller, m_view.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -292,6 +292,8 @@ void JSReadableStreamDefaultController::analyzeHeap(JSCell* cell, HeapAnalyzer& 
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method1, "pullAlgorithm"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method2, "cancelAlgorithm"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.algorithmContext, "algorithmContext"_s);
+    WTF::Locker locker { thisObject->cellLock() };
+    thisObject->m_queue.analyzeHeap(locker, cell, analyzer);
 }
 
 // [[CancelSteps]](reason)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -12,12 +12,14 @@
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -137,6 +139,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultControllerPrototypeGette
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCustom);
 
 class JSReadableStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -180,10 +183,24 @@ static const HashTableValue JSReadableStreamDefaultControllerPrototypeTableValue
 
 const ClassInfo JSReadableStreamDefaultControllerPrototype::s_info = { "ReadableStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    (void)thisObject;
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultController"_s, data));
+}
+
 void JSReadableStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamDefaultController::info(), JSReadableStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -269,12 +269,12 @@ void JSReadableStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor&
     auto* thisObject = uncheckedDowncast<JSReadableStreamDefaultController>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_algorithms.underlyingObject);
-    visitor.append(thisObject->m_algorithms.method1);
-    visitor.append(thisObject->m_algorithms.method2);
-    visitor.append(thisObject->m_algorithms.algorithmContext);
-    visitor.append(thisObject->m_strategySizeAlgorithm);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_algorithms.underlyingObject);
+    visitor.appendHidden(thisObject->m_algorithms.method1);
+    visitor.appendHidden(thisObject->m_algorithms.method2);
+    visitor.appendHidden(thisObject->m_algorithms.algorithmContext);
+    visitor.appendHidden(thisObject->m_strategySizeAlgorithm);
     WTF::Locker locker { thisObject->cellLock() };
     thisObject->m_queue.visit(locker, visitor);
 }

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -11,6 +11,7 @@
 #include "JSStreamTeeState.h"
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
@@ -279,6 +280,19 @@ void JSReadableStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor&
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamDefaultController);
+
+void JSReadableStreamDefaultController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamDefaultController>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_strategySizeAlgorithm, "strategySizeAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.underlyingObject, "underlyingSource"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method1, "pullAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method2, "cancelAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.algorithmContext, "algorithmContext"_s);
+}
 
 // [[CancelSteps]](reason)
 JSPromise* JSReadableStreamDefaultController::cancelSteps(JSGlobalObject* globalObject, JSValue reason)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.h
@@ -34,6 +34,7 @@ public:
     // m_queue.visit(locker, visitor) inside ONE `Locker { cellLock() }` scope taken by THIS
     // visitChildrenImpl — cellLock() is non-recursive; see StreamQueue.h).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -17,6 +17,7 @@
 #include "JSReadableStreamDefaultController.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -662,6 +663,25 @@ void JSReadableStreamDefaultReader::visitChildrenImpl(JSCell* cell, Visitor& vis
     WTF::Locker locker { thisObject->cellLock() };
     for (auto& request : thisObject->m_readRequests)
         visitor.append(request);
+}
+
+void JSReadableStreamDefaultReader::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSReadableStreamDefaultReader>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closedPromise, "closedPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pipeOperation, "pipeOperation"_s);
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        uint32_t i = 0;
+        for (auto& entry : thisObject->m_readRequests) {
+            if (auto* request = entry.get())
+                analyzer.analyzeIndexEdge(cell, request, i);
+            ++i;
+        }
+    }
 }
 
 // Prototype accessors and host functions

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -657,12 +657,12 @@ void JSReadableStreamDefaultReader::visitChildrenImpl(JSCell* cell, Visitor& vis
     auto* thisObject = uncheckedDowncast<JSReadableStreamDefaultReader>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_closedPromise);
-    visitor.append(thisObject->m_pipeOperation);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_closedPromise);
+    visitor.appendHidden(thisObject->m_pipeOperation);
     WTF::Locker locker { thisObject->cellLock() };
     for (auto& request : thisObject->m_readRequests)
-        visitor.append(request);
+        visitor.appendHidden(request);
 }
 
 void JSReadableStreamDefaultReader::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -18,6 +18,7 @@
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -445,6 +446,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_read);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_readMany);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_releaseLock);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_closed);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_constructor);
 
@@ -581,10 +583,31 @@ static const HashTableValue JSReadableStreamDefaultReaderPrototypeTableValues[] 
 
 const ClassInfo JSReadableStreamDefaultReaderPrototype::s_info = { "ReadableStreamDefaultReader"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamDefaultReaderPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamDefaultReader>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    size_t requestCount;
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        requestCount = thisObject->m_readRequests.size();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "readRequests"_s), jsNumber(requestCount), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultReader"_s, data));
+}
+
 void JSReadableStreamDefaultReaderPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamDefaultReader::info(), JSReadableStreamDefaultReaderPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamDefaultReaderPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.h
@@ -31,6 +31,7 @@ public:
     // visitChildrenImpl MUST visit: m_stream + m_closedPromise (from the base),
     // m_pipeOperation, and m_readRequests (a barrier container: UNDER cellLock()).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSC::JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamIntoArrayOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamIntoArrayOperation.h
@@ -26,6 +26,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_reader, m_chunks, m_result.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSResumableSinkPumpOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSResumableSinkPumpOperation.h
@@ -25,6 +25,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit all four barriers: m_stream, m_sink, m_reader, m_error.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "JSStreamAlgorithmContexts.h"
 
+#include "WebStreamsHeapAnalyzer.h"
 #include "DOMClientIsoSubspaces.h"
 #include "DOMIsoSubspaces.h"
 #include "JSDOMBinding.h"
@@ -13,6 +14,7 @@
 namespace WebCore {
 
 using namespace JSC;
+using Bun::WebStreams::analyzeBarrierEdge;
 
 const ClassInfo JSStreamFromIterableContext::s_info = { "StreamFromIterableContext"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStreamFromIterableContext) };
 
@@ -59,6 +61,15 @@ void JSStreamFromIterableContext::visitChildrenImpl(JSCell* cell, Visitor& visit
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_iterator);
     visitor.append(thisObject->m_nextMethod);
+}
+
+void JSStreamFromIterableContext::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSStreamFromIterableContext>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_iterator, "iterator"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_nextMethod, "nextMethod"_s);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
@@ -59,8 +59,8 @@ void JSStreamFromIterableContext::visitChildrenImpl(JSCell* cell, Visitor& visit
     auto* thisObject = uncheckedDowncast<JSStreamFromIterableContext>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_iterator);
-    visitor.append(thisObject->m_nextMethod);
+    visitor.appendHidden(thisObject->m_iterator);
+    visitor.appendHidden(thisObject->m_nextMethod);
 }
 
 void JSStreamFromIterableContext::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.h
@@ -26,6 +26,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_iterator, m_nextMethod.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -79,15 +79,15 @@ void JSStreamPipeToOperation::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSStreamPipeToOperation>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_source);
-    visitor.append(thisObject->m_destination);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_writer);
-    visitor.append(thisObject->m_signal);
-    visitor.append(thisObject->m_promise);
-    visitor.append(thisObject->m_currentWrite);
-    visitor.append(thisObject->m_shutdownActionPromise);
-    visitor.append(thisObject->m_shutdownError);
+    visitor.appendHidden(thisObject->m_source);
+    visitor.appendHidden(thisObject->m_destination);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_writer);
+    visitor.appendHidden(thisObject->m_signal);
+    visitor.appendHidden(thisObject->m_promise);
+    visitor.appendHidden(thisObject->m_currentWrite);
+    visitor.appendHidden(thisObject->m_shutdownActionPromise);
+    visitor.appendHidden(thisObject->m_shutdownError);
 }
 
 void JSStreamPipeToOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -14,6 +14,7 @@
 #include "JSStreamsRuntime.h"
 #include "JSWritableStream.h"
 #include "JSWritableStreamDefaultWriter.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -87,6 +88,22 @@ void JSStreamPipeToOperation::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_currentWrite);
     visitor.append(thisObject->m_shutdownActionPromise);
     visitor.append(thisObject->m_shutdownError);
+}
+
+void JSStreamPipeToOperation::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSStreamPipeToOperation>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_source, "source"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_destination, "destination"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_writer, "writer"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_signal, "signal"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_promise, "promise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_currentWrite, "currentWrite"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_shutdownActionPromise, "shutdownActionPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_shutdownError, "shutdownError"_s);
 }
 
 static JSValue pipeShutdownError(JSStreamPipeToOperation* op)

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.h
@@ -40,6 +40,7 @@ public:
     // visitChildrenImpl MUST visit: m_source, m_destination, m_reader, m_writer, m_signal,
     // m_promise, m_currentWrite, m_shutdownActionPromise, m_shutdownError.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
@@ -60,13 +60,13 @@ void JSStreamTeeState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSStreamTeeState>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_reader);
-    visitor.append(thisObject->m_branch1);
-    visitor.append(thisObject->m_branch2);
-    visitor.append(thisObject->m_cancelPromise);
-    visitor.append(thisObject->m_reason1);
-    visitor.append(thisObject->m_reason2);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_reader);
+    visitor.appendHidden(thisObject->m_branch1);
+    visitor.appendHidden(thisObject->m_branch2);
+    visitor.appendHidden(thisObject->m_cancelPromise);
+    visitor.appendHidden(thisObject->m_reason1);
+    visitor.appendHidden(thisObject->m_reason2);
 }
 
 void JSStreamTeeState::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
@@ -6,6 +6,7 @@
 #include "JSDOMBinding.h"
 #include "JSDOMGlobalObject.h"
 #include "JSReadableStream.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
@@ -14,6 +15,7 @@
 namespace WebCore {
 
 using namespace JSC;
+using Bun::WebStreams::analyzeBarrierEdge;
 
 const ClassInfo JSStreamTeeState::s_info = { "StreamTeeState"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStreamTeeState) };
 
@@ -65,6 +67,20 @@ void JSStreamTeeState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_cancelPromise);
     visitor.append(thisObject->m_reason1);
     visitor.append(thisObject->m_reason2);
+}
+
+void JSStreamTeeState::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSStreamTeeState>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reader, "reader"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_branch1, "branch1"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_branch2, "branch2"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_cancelPromise, "cancelPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reason1, "reason1"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_reason2, "reason2"_s);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.h
@@ -26,6 +26,7 @@ public:
     // visitChildrenImpl MUST visit: m_stream, m_reader, m_branch1, m_branch2,
     // m_cancelPromise, m_reason1, m_reason2.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
@@ -141,7 +141,7 @@ void JSStreamsRuntime::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     {
         WTF::Locker locker { thisObject->cellLock() };
         for (auto& controller : thisObject->m_endOfTickFlushes)
-            visitor.append(controller);
+            visitor.appendHidden(controller);
     }
 }
 

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
@@ -21,6 +21,7 @@
 #include "JSStreamPipeToOperation.h"
 #include "JSStreamTeeState.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/JSCInlines.h>
@@ -141,6 +142,19 @@ void JSStreamsRuntime::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         WTF::Locker locker { thisObject->cellLock() };
         for (auto& controller : thisObject->m_endOfTickFlushes)
             visitor.append(controller);
+    }
+}
+
+void JSStreamsRuntime::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSStreamsRuntime>(cell);
+    Base::analyzeHeap(cell, analyzer);
+    WTF::Locker locker { thisObject->cellLock() };
+    uint32_t i = 0;
+    for (auto& entry : thisObject->m_endOfTickFlushes) {
+        if (auto* controller = entry.get())
+            analyzer.analyzeIndexEdge(cell, controller, i);
+        ++i;
     }
 }
 

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -355,6 +355,7 @@ public:
     // two size-function LazyProperties, and every LazyProperty in
     // FOR_EACH_WEB_STREAMS_INTERNAL_STRUCTURE.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -258,8 +258,8 @@ void JSTextDecoderStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSTextDecoderStream>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_transform);
-    visitor.append(thisObject->m_decoder);
+    visitor.appendHidden(thisObject->m_transform);
+    visitor.appendHidden(thisObject->m_decoder);
 }
 
 void JSTextDecoderStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -13,6 +13,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -34,6 +35,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_fatal);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_ignoreBOM);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_writable);
+static JSC_DECLARE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom);
 
 class JSTextDecoderStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -189,10 +191,37 @@ static const HashTableValue JSTextDecoderStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTextDecoderStreamPrototype::s_info = { "TextDecoderStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTextDecoderStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTextDecoderStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    // encoding/fatal/ignoreBOM live on the TextDecoder held by m_decoder; read them via the
+    // public prototype getters this class already exposes so no extra coupling is introduced.
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    JSValue encoding = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "encoding"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), encoding, 0);
+    JSValue fatal = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "fatal"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "fatal"_s), fatal, 0);
+    JSValue ignoreBOM = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "ignoreBOM"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "ignoreBOM"_s), ignoreBOM, 0);
+    auto* transform = thisObject->m_transform.get();
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), transform && transform->m_readable.get() ? JSValue(transform->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), transform && transform->m_writable.get() ? JSValue(transform->m_writable.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextDecoderStream"_s, data));
+}
+
 void JSTextDecoderStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTextDecoderStream::info(), JSTextDecoderStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTextDecoderStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -12,6 +12,7 @@
 #include "JSTransformStreamDefaultController.h"
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -259,6 +260,15 @@ void JSTextDecoderStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_transform);
     visitor.append(thisObject->m_decoder);
+}
+
+void JSTextDecoderStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSTextDecoderStream>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_transform, "transform"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_decoder, "decoder"_s);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.h
@@ -30,6 +30,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_transform, m_decoder.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -12,6 +12,7 @@
 #include "JSTransformStreamDefaultController.h"
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -233,6 +234,15 @@ void JSTextEncoderStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_transform);
     visitor.append(thisObject->m_encoder);
+}
+
+void JSTextEncoderStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSTextEncoderStream>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_transform, "transform"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_encoder, "encoder"_s);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -232,8 +232,8 @@ void JSTextEncoderStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSTextEncoderStream>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_transform);
-    visitor.append(thisObject->m_encoder);
+    visitor.appendHidden(thisObject->m_transform);
+    visitor.appendHidden(thisObject->m_encoder);
 }
 
 void JSTextEncoderStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -13,11 +13,13 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -31,6 +33,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_constructor)
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_encoding);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_writable);
+static JSC_DECLARE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom);
 
 class JSTextEncoderStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -163,10 +166,27 @@ static const HashTableValue JSTextEncoderStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTextEncoderStreamPrototype::s_info = { "TextEncoderStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTextEncoderStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTextEncoderStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), jsNontrivialString(vm, "utf-8"_s), 0);
+    auto* transform = thisObject->m_transform.get();
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), transform && transform->m_readable.get() ? JSValue(transform->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), transform && transform->m_writable.get() ? JSValue(transform->m_writable.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextEncoderStream"_s, data));
+}
+
 void JSTextEncoderStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTextEncoderStream::info(), JSTextEncoderStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTextEncoderStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.h
@@ -29,6 +29,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_transform, m_encoder.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -14,6 +14,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -22,6 +23,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -33,6 +35,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_writable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom);
 
 class JSTransformStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -201,10 +204,26 @@ static const HashTableValue JSTransformStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTransformStreamPrototype::s_info = { "TransformStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTransformStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTransformStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "backpressure"_s), jsBoolean(thisObject->m_backpressure), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStream"_s, data));
+}
+
 void JSTransformStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTransformStream::info(), JSTransformStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTransformStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -13,6 +13,7 @@
 #include "JSTransformStreamDefaultController.h"
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -273,6 +274,17 @@ void JSTransformStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_writable);
     visitor.append(thisObject->m_controller);
     visitor.append(thisObject->m_backpressureChangePromise);
+}
+
+void JSTransformStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSTransformStream>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_readable, "readable"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_writable, "writable"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_backpressureChangePromise, "backpressureChangePromise"_s);
 }
 
 // Prototype host functions

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -270,10 +270,10 @@ void JSTransformStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSTransformStream>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_readable);
-    visitor.append(thisObject->m_writable);
-    visitor.append(thisObject->m_controller);
-    visitor.append(thisObject->m_backpressureChangePromise);
+    visitor.appendHidden(thisObject->m_readable);
+    visitor.appendHidden(thisObject->m_writable);
+    visitor.appendHidden(thisObject->m_controller);
+    visitor.appendHidden(thisObject->m_backpressureChangePromise);
 }
 
 void JSTransformStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -29,6 +29,7 @@ public:
     // visitChildrenImpl MUST visit: m_readable, m_writable, m_controller,
     // m_backpressureChangePromise.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -12,6 +12,7 @@
 #include "JSTextDecoderStream.h"
 #include "JSTextEncoderStream.h"
 #include "JSTransformStream.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
@@ -254,6 +255,20 @@ void JSTransformStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor
 }
 
 DEFINE_VISIT_CHILDREN(JSTransformStreamDefaultController);
+
+void JSTransformStreamDefaultController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSTransformStreamDefaultController>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_finishPromise, "finishPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_transformer, "transformer"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_transformMethod, "transformAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_flushMethod, "flushAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_cancelMethod, "cancelAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithmContext, "algorithmContext"_s);
+}
 
 // [reaction-convention]: handler(resolutionValue, contextCell).
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -13,12 +13,14 @@
 #include "JSTextEncoderStream.h"
 #include "JSTransformStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -120,6 +122,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamDefaultControllerPrototypeGett
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_error);
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_terminate);
+static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCustom);
 
 class JSTransformStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -163,10 +166,24 @@ static const HashTableValue JSTransformStreamDefaultControllerPrototypeTableValu
 
 const ClassInfo JSTransformStreamDefaultControllerPrototype::s_info = { "TransformStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTransformStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStreamDefaultController"_s, data));
+}
+
 void JSTransformStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTransformStreamDefaultController::info(), JSTransformStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTransformStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -245,13 +245,13 @@ void JSTransformStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor
     auto* thisObject = uncheckedDowncast<JSTransformStreamDefaultController>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_finishPromise);
-    visitor.append(thisObject->m_transformer);
-    visitor.append(thisObject->m_transformMethod);
-    visitor.append(thisObject->m_flushMethod);
-    visitor.append(thisObject->m_cancelMethod);
-    visitor.append(thisObject->m_algorithmContext);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_finishPromise);
+    visitor.appendHidden(thisObject->m_transformer);
+    visitor.appendHidden(thisObject->m_transformMethod);
+    visitor.appendHidden(thisObject->m_flushMethod);
+    visitor.appendHidden(thisObject->m_cancelMethod);
+    visitor.appendHidden(thisObject->m_algorithmContext);
 }
 
 DEFINE_VISIT_CHILDREN(JSTransformStreamDefaultController);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.h
@@ -31,6 +31,7 @@ public:
     // visitChildrenImpl MUST visit: m_stream, m_finishPromise, m_transformer,
     // m_transformMethod, m_flushMethod, m_cancelMethod, m_algorithmContext.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -255,19 +255,19 @@ void JSWritableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto* thisObject = uncheckedDowncast<JSWritableStream>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_controller);
-    visitor.append(thisObject->m_writer);
-    visitor.append(thisObject->m_storedError);
-    visitor.append(thisObject->m_closeRequest);
-    visitor.append(thisObject->m_inFlightWriteRequest);
-    visitor.append(thisObject->m_inFlightCloseRequest);
-    visitor.append(thisObject->m_closedPromise);
-    visitor.append(thisObject->m_pendingAbortRequest.promise);
-    visitor.append(thisObject->m_pendingAbortRequest.reason);
+    visitor.appendHidden(thisObject->m_controller);
+    visitor.appendHidden(thisObject->m_writer);
+    visitor.appendHidden(thisObject->m_storedError);
+    visitor.appendHidden(thisObject->m_closeRequest);
+    visitor.appendHidden(thisObject->m_inFlightWriteRequest);
+    visitor.appendHidden(thisObject->m_inFlightCloseRequest);
+    visitor.appendHidden(thisObject->m_closedPromise);
+    visitor.appendHidden(thisObject->m_pendingAbortRequest.promise);
+    visitor.appendHidden(thisObject->m_pendingAbortRequest.reason);
     {
         WTF::Locker locker { thisObject->cellLock() };
         for (auto& writeRequest : thisObject->m_writeRequests)
-            visitor.append(writeRequest);
+            visitor.appendHidden(writeRequest);
     }
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -12,6 +12,7 @@
 #include "JSWritableStreamDefaultController.h"
 #include "JSWritableStreamDefaultWriter.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -267,6 +268,31 @@ void JSWritableStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         WTF::Locker locker { thisObject->cellLock() };
         for (auto& writeRequest : thisObject->m_writeRequests)
             visitor.append(writeRequest);
+    }
+}
+
+void JSWritableStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSWritableStream>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_controller, "controller"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_writer, "writer"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_storedError, "storedError"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closeRequest, "closeRequest"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_inFlightWriteRequest, "inFlightWriteRequest"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_inFlightCloseRequest, "inFlightCloseRequest"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closedPromise, "closedPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingAbortRequest.promise, "pendingAbortRequestPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pendingAbortRequest.reason, "pendingAbortRequestReason"_s);
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        uint32_t i = 0;
+        for (auto& entry : thisObject->m_writeRequests) {
+            if (auto* value = entry.get())
+                analyzer.analyzeIndexEdge(cell, value, i);
+            ++i;
+        }
     }
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -13,6 +13,7 @@
 #include "JSWritableStreamDefaultWriter.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -21,6 +22,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -34,6 +36,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototypeFunction_getWriter);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamPrototypeGetter_locked);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom);
 
 class JSWritableStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -179,10 +182,40 @@ static const HashTableValue JSWritableStreamPrototypeTableValues[] = {
 
 const ClassInfo JSWritableStreamPrototype::s_info = { "WritableStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isWritableStreamLocked(thisObject)), 0);
+    ASCIILiteral state;
+    switch (thisObject->m_state) {
+    case WritableStreamState::Writable:
+        state = "writable"_s;
+        break;
+    case WritableStreamState::Erroring:
+        state = "erroring"_s;
+        break;
+    case WritableStreamState::Errored:
+        state = "errored"_s;
+        break;
+    case WritableStreamState::Closed:
+        state = "closed"_s;
+        break;
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStream"_s, data));
+}
+
 void JSWritableStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStream::info(), JSWritableStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.h
@@ -50,6 +50,7 @@ public:
     // m_pendingAbortRequest.{promise,reason}, and m_writeRequests (a barrier container: UNDER
     // cellLock()).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSC::JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -12,12 +12,14 @@
 #include "JSTransformStream.h"
 #include "JSWritableStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -147,6 +149,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultControllerConstructorGetter);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultControllerPrototypeGetter_signal);
 static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCustom);
 
 class JSWritableStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -188,10 +191,24 @@ static const HashTableValue JSWritableStreamDefaultControllerPrototypeTableValue
 
 const ClassInfo JSWritableStreamDefaultControllerPrototype::s_info = { "WritableStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultController"_s, data));
+}
+
 void JSWritableStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStreamDefaultController::info(), JSWritableStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -305,6 +305,8 @@ void JSWritableStreamDefaultController::analyzeHeap(JSCell* cell, HeapAnalyzer& 
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method2, "closeAlgorithm"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method3, "abortAlgorithm"_s);
     analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.algorithmContext, "algorithmContext"_s);
+    WTF::Locker locker { thisObject->cellLock() };
+    thisObject->m_queue.analyzeHeap(locker, cell, analyzer);
 }
 
 // [[AbortSteps]](reason)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -277,14 +277,14 @@ void JSWritableStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor&
     auto* thisObject = uncheckedDowncast<JSWritableStreamDefaultController>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_abortController);
-    visitor.append(thisObject->m_algorithms.underlyingObject);
-    visitor.append(thisObject->m_algorithms.method1);
-    visitor.append(thisObject->m_algorithms.method2);
-    visitor.append(thisObject->m_algorithms.method3);
-    visitor.append(thisObject->m_algorithms.algorithmContext);
-    visitor.append(thisObject->m_strategySizeAlgorithm);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_abortController);
+    visitor.appendHidden(thisObject->m_algorithms.underlyingObject);
+    visitor.appendHidden(thisObject->m_algorithms.method1);
+    visitor.appendHidden(thisObject->m_algorithms.method2);
+    visitor.appendHidden(thisObject->m_algorithms.method3);
+    visitor.appendHidden(thisObject->m_algorithms.algorithmContext);
+    visitor.appendHidden(thisObject->m_strategySizeAlgorithm);
     // ONE non-recursive cellLock scope covers the barrier container (StreamQueue.h).
     WTF::Locker locker { thisObject->cellLock() };
     thisObject->m_queue.visit(locker, visitor);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -11,6 +11,7 @@
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
 #include "JSWritableStream.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
@@ -290,6 +291,21 @@ void JSWritableStreamDefaultController::visitChildrenImpl(JSCell* cell, Visitor&
 }
 
 DEFINE_VISIT_CHILDREN(JSWritableStreamDefaultController);
+
+void JSWritableStreamDefaultController::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSWritableStreamDefaultController>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_abortController, "abortController"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_strategySizeAlgorithm, "strategySizeAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.underlyingObject, "underlyingSink"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method1, "writeAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method2, "closeAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.method3, "abortAlgorithm"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_algorithms.algorithmContext, "algorithmContext"_s);
+}
 
 // [[AbortSteps]](reason)
 JSPromise* JSWritableStreamDefaultController::abortSteps(JSGlobalObject* globalObject, JSValue reason)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.h
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.h
@@ -33,6 +33,7 @@ public:
     // m_queue.visit(locker, visitor) inside ONE `Locker { cellLock() }` scope taken by THIS
     // visitChildrenImpl — cellLock() is non-recursive; see StreamQueue.h).
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSC::JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -369,10 +369,10 @@ void JSWritableStreamDefaultWriter::visitChildrenImpl(JSCell* cell, Visitor& vis
     auto* thisObject = uncheckedDowncast<JSWritableStreamDefaultWriter>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_stream);
-    visitor.append(thisObject->m_closedPromise);
-    visitor.append(thisObject->m_readyPromise);
-    visitor.append(thisObject->m_pipeOperation);
+    visitor.appendHidden(thisObject->m_stream);
+    visitor.appendHidden(thisObject->m_closedPromise);
+    visitor.appendHidden(thisObject->m_readyPromise);
+    visitor.appendHidden(thisObject->m_pipeOperation);
 }
 
 void JSWritableStreamDefaultWriter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -15,6 +15,7 @@
 #include "JSWritableStreamDefaultController.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -22,6 +23,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -169,6 +171,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_cl
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_desiredSize);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_ready);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom);
 
 class JSWritableStreamDefaultWriterPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -300,10 +303,32 @@ static const HashTableValue JSWritableStreamDefaultWriterPrototypeTableValues[] 
 
 const ClassInfo JSWritableStreamDefaultWriterPrototype::s_info = { "WritableStreamDefaultWriter"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamDefaultWriterPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStreamDefaultWriter>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "ready"_s), thisObject->m_readyPromise.get() ? JSValue(thisObject->m_readyPromise.get()) : jsUndefined(), 0);
+    JSValue desiredSizeValue = jsNull();
+    if (thisObject->m_stream.get()) {
+        auto desiredSize = writableStreamDefaultWriterGetDesiredSize(thisObject);
+        desiredSizeValue = desiredSize ? jsNumber(*desiredSize) : jsNull();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "desiredSize"_s), desiredSizeValue, 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultWriter"_s, data));
+}
+
 void JSWritableStreamDefaultWriterPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStreamDefaultWriter::info(), JSWritableStreamDefaultWriterPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamDefaultWriterPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -14,6 +14,7 @@
 #include "JSWritableStream.h"
 #include "JSWritableStreamDefaultController.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsHeapAnalyzer.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -372,6 +373,17 @@ void JSWritableStreamDefaultWriter::visitChildrenImpl(JSCell* cell, Visitor& vis
     visitor.append(thisObject->m_closedPromise);
     visitor.append(thisObject->m_readyPromise);
     visitor.append(thisObject->m_pipeOperation);
+}
+
+void JSWritableStreamDefaultWriter::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
+{
+    auto* thisObject = uncheckedDowncast<JSWritableStreamDefaultWriter>(cell);
+    auto& vm = cell->vm();
+    Base::analyzeHeap(cell, analyzer);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_stream, "stream"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_closedPromise, "closedPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_readyPromise, "readyPromise"_s);
+    analyzeBarrierEdge(vm, analyzer, cell, thisObject->m_pipeOperation, "pipeOperation"_s);
 }
 
 // Prototype accessors and host functions

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.h
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.h
@@ -29,6 +29,7 @@ public:
     DECLARE_INFO;
     // visitChildrenImpl MUST visit: m_stream, m_closedPromise, m_readyPromise, m_pipeOperation.
     DECLARE_VISIT_CHILDREN;
+    static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/streams/StreamQueue.h
+++ b/src/jsc/bindings/webcore/streams/StreamQueue.h
@@ -219,7 +219,7 @@ private:
     static void analyzeEntry(JSC::JSCell*, JSC::HeapAnalyzer&, ByteQueueEntry&, uint32_t) {}
 
     template<typename Visitor>
-    static void visitEntry(Visitor& visitor, ValueWithSize& entry) { visitor.append(entry.value); }
+    static void visitEntry(Visitor& visitor, ValueWithSize& entry) { visitor.appendHidden(entry.value); }
     template<typename Visitor>
     static void visitEntry(Visitor&, ByteQueueEntry&) {} // RefPtr impl: nothing for the GC
 

--- a/src/jsc/bindings/webcore/streams/StreamQueue.h
+++ b/src/jsc/bindings/webcore/streams/StreamQueue.h
@@ -30,6 +30,7 @@
 
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -197,7 +198,26 @@ public:
             visitEntry(visitor, entry);
     }
 
+    // HeapAnalyzer: called from the owner's analyzeHeap, under the same cellLock() scope
+    // as visit(). Reports each queued value as an index edge for heap-snapshot retainers.
+    void analyzeHeap(const WTF::AbstractLocker&, JSC::JSCell* from, JSC::HeapAnalyzer& analyzer)
+    {
+        uint32_t i = 0;
+        for (auto& entry : m_queue) {
+            analyzeEntry(from, analyzer, entry, i);
+            ++i;
+        }
+    }
+
 private:
+    static void analyzeEntry(JSC::JSCell* from, JSC::HeapAnalyzer& analyzer, ValueWithSize& entry, uint32_t i)
+    {
+        JSC::JSValue v = entry.value.get();
+        if (v && v.isCell())
+            analyzer.analyzeIndexEdge(from, v.asCell(), i);
+    }
+    static void analyzeEntry(JSC::JSCell*, JSC::HeapAnalyzer&, ByteQueueEntry&, uint32_t) {}
+
     template<typename Visitor>
     static void visitEntry(Visitor& visitor, ValueWithSize& entry) { visitor.append(entry.value); }
     template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/WebStreamsHeapAnalyzer.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsHeapAnalyzer.h
@@ -1,0 +1,35 @@
+// WebStreamsHeapAnalyzer.h — the one helper every Web Streams cell's analyzeHeap() uses to
+// report its WriteBarrier members as NAMED edges to the heap snapshot builder, so retained
+// paths in a snapshot read `ReadableStream --controller--> ReadableStreamDefaultController`
+// instead of an anonymous internal edge.
+#pragma once
+
+#include "root.h"
+
+#include <JavaScriptCore/HeapAnalyzer.h>
+#include <JavaScriptCore/Identifier.h>
+#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCell.h>
+#include <JavaScriptCore/WriteBarrier.h>
+
+namespace Bun {
+namespace WebStreams {
+
+// WriteBarrier<T> where T : JSCell — .get() is a T*.
+template<typename T>
+ALWAYS_INLINE void analyzeBarrierEdge(JSC::VM& vm, JSC::HeapAnalyzer& analyzer, JSC::JSCell* from, const JSC::WriteBarrier<T>& barrier, ASCIILiteral name)
+{
+    if (JSC::JSCell* to = barrier.get())
+        analyzer.analyzePropertyNameEdge(from, to, JSC::Identifier::fromString(vm, name).impl());
+}
+
+// WriteBarrier<Unknown> — .get() is a JSValue.
+ALWAYS_INLINE void analyzeBarrierEdge(JSC::VM& vm, JSC::HeapAnalyzer& analyzer, JSC::JSCell* from, const JSC::WriteBarrier<JSC::Unknown>& barrier, ASCIILiteral name)
+{
+    JSC::JSValue value = barrier.get();
+    if (value && value.isCell())
+        analyzer.analyzePropertyNameEdge(from, value.asCell(), JSC::Identifier::fromString(vm, name).impl());
+}
+
+} // namespace WebStreams
+} // namespace Bun

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -1,0 +1,81 @@
+#include "config.h"
+#include "WebStreamsInspectCustom.h"
+
+#include "BunClientData.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include <wtf/text/MakeString.h>
+
+namespace Bun {
+namespace WebStreams {
+
+using namespace JSC;
+
+EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSValue thisValue, ASCIILiteral name, JSObject* data)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue depthValue = callFrame->argument(0);
+    JSValue optionsValue = callFrame->argument(1);
+
+    double depth = depthValue.toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (depth < 0)
+        return JSValue::encode(thisValue);
+
+    // opts = { ...options, depth: options.depth == null ? null : options.depth - 1 }
+    JSObject* opts = constructEmptyObject(lexicalGlobalObject);
+    JSValue childDepth = jsNull();
+    if (optionsValue.isObject()) {
+        JSObject* options = asObject(optionsValue);
+        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+        options->getPropertyNames(lexicalGlobalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(scope, {});
+        for (size_t i = 0; i < names.size(); ++i) {
+            JSValue v = options->get(lexicalGlobalObject, names[i]);
+            RETURN_IF_EXCEPTION(scope, {});
+            opts->putDirect(vm, names[i], v, 0);
+        }
+        JSValue optionsDepth = options->get(lexicalGlobalObject, Identifier::fromString(vm, "depth"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!optionsDepth.isUndefinedOrNull()) {
+            double d = optionsDepth.toNumber(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            childDepth = jsNumber(d - 1);
+        }
+    }
+    opts->putDirect(vm, Identifier::fromString(vm, "depth"_s), childDepth, 0);
+
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, {});
+    auto callData = JSC::getCallData(utilInspect);
+    MarkedArgumentBuffer arguments;
+    arguments.append(data);
+    arguments.append(opts);
+    ASSERT(!arguments.hasOverflowed());
+
+    JSValue inspected = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, utilInspect, callData, jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto* inspectedString = inspected.toString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto view = inspectedString->view(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(jsString(vm, makeString(name, " "_s, view.data)));
+}
+
+void installInspectCustom(VM& vm, JSObject* prototype, NativeFunction nativeFunction)
+{
+    auto* globalObject = prototype->globalObject();
+    prototype->putDirectNativeFunction(vm, globalObject, WebCore::builtinNames(vm).inspectCustomPublicName(), 2,
+        nativeFunction, ImplementationVisibility::Public, NoIntrinsic,
+        static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum));
+}
+
+} // namespace WebStreams
+} // namespace Bun

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -1,0 +1,21 @@
+// WebStreamsInspectCustom.h — the one shared helper every Web Streams prototype's
+// [Symbol.for("nodejs.util.inspect.custom")] host function routes through, so
+// `console.log(stream)` matches Node's output shape: `ClassName { field: value, ... }`.
+#pragma once
+
+#include "root.h"
+
+#include <JavaScriptCore/JSObject.h>
+
+namespace Bun {
+namespace WebStreams {
+
+// Node's `customInspect(depth, options, name, data)` (lib/internal/webstreams/util.js):
+// depth < 0 returns `thisValue`; otherwise `${name} ${inspect(data, {...options, depth-1})}`.
+JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
+
+// Installs the host function on a prototype under Symbol.for("nodejs.util.inspect.custom").
+void installInspectCustom(JSC::VM&, JSC::JSObject* prototype, JSC::NativeFunction);
+
+} // namespace WebStreams
+} // namespace Bun

--- a/test/js/bun/util/v8-heap-snapshot-fixture.ts
+++ b/test/js/bun/util/v8-heap-snapshot-fixture.ts
@@ -103,6 +103,67 @@ switch (mode) {
     break;
   }
 
+  case "stream-edges": {
+    // Build a graph touching the main Web Streams cell classes and keep every
+    // handle live across the snapshot so analyzeHeap can see the edges.
+    const rs = new ReadableStream({ start() {} });
+    const reader = rs.getReader();
+    const ws = new WritableStream({ write() {} });
+    const writer = ws.getWriter();
+    const ts = new TransformStream({ transform() {} });
+    const pipePromise = ts.readable
+      .pipeTo(new WritableStream({ write() {} }))
+      .catch(() => {});
+
+    const json = JSON.parse(Bun.generateHeapSnapshot("v8"));
+    // Referenced after the snapshot so nothing above is dead before it runs.
+    void (rs, reader, ws, writer, ts, pipePromise);
+
+    const meta = json.snapshot.meta;
+    const nodeStride = meta.node_fields.length;
+    const edgeStride = meta.edge_fields.length;
+    const nameIdx = meta.node_fields.indexOf("name");
+    const edgeCountIdx = meta.node_fields.indexOf("edge_count");
+    const edgeTypeIdx = meta.edge_fields.indexOf("type");
+    const edgeNameIdx = meta.edge_fields.indexOf("name_or_index");
+    const propertyType = meta.edge_types[edgeTypeIdx].indexOf("property");
+
+    const wanted = new Set([
+      "ReadableStream",
+      "WritableStream",
+      "TransformStream",
+      "ReadableStreamDefaultController",
+      "ReadableStreamDefaultReader",
+      "WritableStreamDefaultController",
+      "WritableStreamDefaultWriter",
+      "TransformStreamDefaultController",
+      "StreamPipeToOperation",
+    ]);
+    const edgesByClass: Record<string, string[]> = {};
+    for (const name of wanted) edgesByClass[name] = [];
+
+    let e = 0;
+    for (let n = 0; n < json.nodes.length; n += nodeStride) {
+      const className = json.strings[json.nodes[n + nameIdx]];
+      const edgeCount = json.nodes[n + edgeCountIdx];
+      if (wanted.has(className)) {
+        for (let k = 0; k < edgeCount; k++) {
+          const base = e + k * edgeStride;
+          if (json.edges[base + edgeTypeIdx] === propertyType) {
+            const edgeName = json.strings[json.edges[base + edgeNameIdx]];
+            if (!edgesByClass[className].includes(edgeName)) {
+              edgesByClass[className].push(edgeName);
+            }
+          }
+        }
+      }
+      e += edgeCount * edgeStride;
+    }
+    for (const name of wanted) edgesByClass[name].sort();
+    result = edgesByClass;
+    break;
+  }
+
   default:
     throw new Error(`Unknown mode: ${mode}`);
 }

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -100,7 +100,9 @@ test("v8 heap snapshot labels Web Streams internal edges", async () => {
   expect(edges.WritableStreamDefaultController).toEqual(
     expect.arrayContaining(["stream", "underlyingSink", "writeAlgorithm", "abortController"]),
   );
-  expect(edges.WritableStreamDefaultWriter).toEqual(expect.arrayContaining(["stream", "closedPromise", "readyPromise"]));
+  expect(edges.WritableStreamDefaultWriter).toEqual(
+    expect.arrayContaining(["stream", "closedPromise", "readyPromise"]),
+  );
   expect(edges.TransformStream).toEqual(expect.arrayContaining(["readable", "writable", "controller"]));
   expect(edges.TransformStreamDefaultController).toEqual(
     expect.arrayContaining(["stream", "transformer", "transformAlgorithm"]),

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -88,3 +88,24 @@ test("v8.writeHeapSnapshot() with path", async () => {
   const path = join(String(dir), "test.heapsnapshot");
   expect(await runFixture("write-path", { args: [path] })).toEqual({ returnedPath: path, ...structure });
 });
+
+test("v8 heap snapshot labels Web Streams internal edges", async () => {
+  const edges = await runFixture("stream-edges");
+  // Every WriteBarrier member reported by analyzeHeap shows up as a named
+  // property edge in the snapshot, so retainer paths are readable.
+  expect(edges.ReadableStream).toEqual(expect.arrayContaining(["controller", "reader"]));
+  expect(edges.ReadableStreamDefaultController).toEqual(expect.arrayContaining(["stream", "underlyingSource"]));
+  expect(edges.ReadableStreamDefaultReader).toEqual(expect.arrayContaining(["stream", "closedPromise"]));
+  expect(edges.WritableStream).toEqual(expect.arrayContaining(["controller", "writer"]));
+  expect(edges.WritableStreamDefaultController).toEqual(
+    expect.arrayContaining(["stream", "underlyingSink", "writeAlgorithm", "abortController"]),
+  );
+  expect(edges.WritableStreamDefaultWriter).toEqual(expect.arrayContaining(["stream", "closedPromise", "readyPromise"]));
+  expect(edges.TransformStream).toEqual(expect.arrayContaining(["readable", "writable", "controller"]));
+  expect(edges.TransformStreamDefaultController).toEqual(
+    expect.arrayContaining(["stream", "transformer", "transformAlgorithm"]),
+  );
+  expect(edges.StreamPipeToOperation).toEqual(
+    expect.arrayContaining(["source", "destination", "reader", "writer", "promise"]),
+  );
+});

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -158,3 +158,161 @@ for (const [name, inspect] of process.versions.bun
     expect(() => inspect(obj)).toThrow();
   });
 }
+
+describe("Web Streams [nodejs.util.inspect.custom]", () => {
+  const inspect = util.inspect;
+
+  test("ReadableStream", () => {
+    expect(inspect(new ReadableStream())).toBe(
+      "ReadableStream { locked: false, state: 'readable', supportsBYOB: false }",
+    );
+    expect(inspect(new ReadableStream({ type: "bytes" }))).toBe(
+      "ReadableStream { locked: false, state: 'readable', supportsBYOB: true }",
+    );
+    const rs = new ReadableStream();
+    rs.getReader();
+    expect(inspect(rs)).toBe("ReadableStream { locked: true, state: 'readable', supportsBYOB: false }");
+  });
+
+  test("WritableStream", () => {
+    expect(inspect(new WritableStream())).toBe("WritableStream { locked: false, state: 'writable' }");
+    const ws = new WritableStream();
+    ws.getWriter();
+    expect(inspect(ws)).toBe("WritableStream { locked: true, state: 'writable' }");
+  });
+
+  test("TransformStream", () => {
+    const out = inspect(new TransformStream());
+    expect(out).toStartWith("TransformStream {");
+    expect(out).toContain("readable: ReadableStream {");
+    expect(out).toContain("writable: WritableStream {");
+    expect(out).toContain("backpressure: true");
+  });
+
+  test("ReadableStreamDefaultReader", () => {
+    const out = inspect(new ReadableStream().getReader());
+    expect(out).toStartWith("ReadableStreamDefaultReader {");
+    expect(out).toContain("stream: ReadableStream {");
+    expect(out).toContain("readRequests: 0");
+    expect(out).toContain("close: Promise");
+  });
+
+  test("ReadableStreamBYOBReader", () => {
+    const out = inspect(new ReadableStream({ type: "bytes" }).getReader({ mode: "byob" }));
+    expect(out).toStartWith("ReadableStreamBYOBReader {");
+    expect(out).toContain("readIntoRequests: 0");
+  });
+
+  test("ReadableStreamDefaultController", () => {
+    let controller;
+    new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    expect(inspect(controller)).toBe("ReadableStreamDefaultController {}");
+  });
+
+  test("ReadableByteStreamController", () => {
+    let controller;
+    new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    expect(inspect(controller)).toBe("ReadableByteStreamController {}");
+  });
+
+  test("WritableStreamDefaultWriter", () => {
+    const out = inspect(new WritableStream().getWriter());
+    expect(out).toStartWith("WritableStreamDefaultWriter {");
+    expect(out).toContain("stream: WritableStream {");
+    expect(out).toContain("close: Promise");
+    expect(out).toContain("ready: Promise");
+    expect(out).toContain("desiredSize: 1");
+  });
+
+  test("WritableStreamDefaultController", () => {
+    let controller;
+    new WritableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const out = inspect(controller);
+    expect(out).toStartWith("WritableStreamDefaultController {");
+    expect(out).toContain("stream: WritableStream {");
+  });
+
+  test("TransformStreamDefaultController", () => {
+    let controller;
+    new TransformStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const out = inspect(controller);
+    expect(out).toStartWith("TransformStreamDefaultController {");
+    expect(out).toContain("stream: TransformStream {");
+  });
+
+  test("ByteLengthQueuingStrategy", () => {
+    expect(inspect(new ByteLengthQueuingStrategy({ highWaterMark: 16 }))).toBe(
+      "ByteLengthQueuingStrategy { highWaterMark: 16 }",
+    );
+  });
+
+  test("CountQueuingStrategy", () => {
+    expect(inspect(new CountQueuingStrategy({ highWaterMark: 8 }))).toBe("CountQueuingStrategy { highWaterMark: 8 }");
+  });
+
+  test("TextEncoderStream", () => {
+    const out = inspect(new TextEncoderStream());
+    expect(out).toStartWith("TextEncoderStream {");
+    expect(out).toContain("encoding: 'utf-8'");
+    expect(out).toContain("readable: ReadableStream {");
+    expect(out).toContain("writable: WritableStream {");
+  });
+
+  test("TextDecoderStream", () => {
+    const out = inspect(new TextDecoderStream("utf-8", { fatal: true, ignoreBOM: true }));
+    expect(out).toStartWith("TextDecoderStream {");
+    expect(out).toContain("encoding: 'utf-8'");
+    expect(out).toContain("fatal: true");
+    expect(out).toContain("ignoreBOM: true");
+  });
+
+  test("ReadableStreamBYOBRequest", async () => {
+    let out;
+    const rs = new ReadableStream({
+      type: "bytes",
+      autoAllocateChunkSize: 16,
+      pull(c) {
+        out = inspect(c.byobRequest);
+        c.byobRequest.view[0] = 1;
+        c.byobRequest.respond(1);
+        c.close();
+      },
+    });
+    await rs.getReader().read();
+    expect(out).toStartWith("ReadableStreamBYOBRequest {");
+    expect(out).toContain("view: Uint8Array");
+    expect(out).toContain("controller: ReadableByteStreamController {}");
+  });
+
+  test("depth < 0 returns the instance", () => {
+    const rs = new ReadableStream();
+    expect(rs[customSymbol](-1, {})).toBe(rs);
+  });
+
+  test("wrong receiver returns the receiver (no infinite recursion)", () => {
+    const o = {};
+    expect(ReadableStream.prototype[customSymbol].call(o, 2, {})).toBe(o);
+    // util.inspect and Bun.inspect must both fall through to default formatting
+    // rather than recursing on a custom function that returned its own `this`.
+    expect(inspect(ReadableStream.prototype)).toContain("[ReadableStream]");
+    expect(Bun.inspect(ReadableStream.prototype).length > 0).toBeTrue();
+    expect(Bun.inspect(TransformStream.prototype).length > 0).toBeTrue();
+  });
+});


### PR DESCRIPTION
## What

Adds `analyzeHeap(JSCell*, HeapAnalyzer&)` to every JS cell class in `src/jsc/bindings/webcore/streams/` so that V8 heap snapshots show **labeled** property edges for each `WriteBarrier` member instead of anonymous internal references.

Before this change, a `ReadableStream` retaining its controller looked like an unnamed internal edge in a heap snapshot; now the retainer path reads `ReadableStream --controller--> ReadableStreamDefaultController --stream--> ReadableStream`, which makes leak hunting in DevTools actually useful.

## How

- New `src/jsc/bindings/webcore/streams/WebStreamsHeapAnalyzer.h` with a small `analyzeBarrierEdge(vm, analyzer, from, barrier, "label"_s)` helper handling both `WriteBarrier<T>` and `WriteBarrier<Unknown>`.
- Each class's `analyzeHeap` reports every `WriteBarrier` member by name (matching its spec internal-slot name where one exists) and every `Deque`/`Vector` barrier container by index under the owning cell's `cellLock()`, mirroring `visitChildrenImpl`.
- Embedded algorithm-slot structs (`SourceAlgorithmSlots`, `SinkAlgorithmSlots`, `PendingAbortRequest`) have their barrier members reported individually (`underlyingSource`, `pullAlgorithm`, `writeAlgorithm`, ...).

### Classes covered (30)

`JSReadableStream`, `JSWritableStream`, `JSTransformStream`, `JSReadableStreamDefaultController`, `JSReadableByteStreamController`, `JSWritableStreamDefaultController`, `JSTransformStreamDefaultController`, `JSReadableStreamDefaultReader`, `JSReadableStreamBYOBReader`, `JSWritableStreamDefaultWriter`, `JSReadableStreamBYOBRequest`, `JSReadableStreamAsyncIterator`, `JSStreamPipeToOperation`, `JSStreamTeeState`, `JSCrossRealmTransformState`, `JSDirectStreamController`, `JSTextDecoderStream`, `JSTextEncoderStream`, `JSReadRequest`, `JSReadIntoRequest`, `JSStreamFromIterableContext`, `JSAsyncIteratorSourceOperation`, `JSDirectSinkCloseState`, `JSReadStreamIntoSinkOperation`, `JSResumableSinkPumpOperation`, `JSNativeStreamSourceAdapter`, `JSOneShotDirectSink`, `JSReadableStreamIntoArrayOperation`, `JSBunStandaloneTextSink`, `JSStreamsRuntime`.

Not touched: `JSByteLengthQueuingStrategy`, `JSCountQueuingStrategy`, `JSPullIntoDescriptor` (no `WriteBarrier` members), `JSReadableStreamReaderBase` (no own `ClassInfo`; concrete readers report its slots).

## Verification

New test in `test/js/bun/util/v8-heap-snapshot.test.ts` (`stream-edges` fixture mode) builds a graph of live stream objects, takes a V8 heap snapshot, walks it, and asserts the named edges appear on each class.

Before this change the fixture reports no internal-slot edges on any of these classes:
```
"StreamPipeToOperation": []
"ReadableStreamDefaultController": ["Symbol.toStringTag","close","constructor","desiredSize","enqueue","error"]
```
After:
```
"StreamPipeToOperation": ["destination","promise","reader","source","writer"]
"ReadableStreamDefaultController": [...,"algorithmContext","stream","underlyingSource"]
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 58 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/v8-heap-snapshot.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b16a6c889)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [3492.03ms]
(pass) v8 heap snapshot arraybuffer [3014.70ms]
(pass) v8 heap snapshot arraybuffer matches string output [1476.49ms]
(pass) v8.getHeapSnapshot() [3507.44ms]
(pass) v8.writeHeapSnapshot() [3782.22ms]
(pass) v8.writeHeapSnapshot() with path [3113.97ms]
91 | 
92 | test("v8 heap snapshot labels Web Streams internal edges", async () => {
93 |   const edges = await runFixture("stream-edges");
94 |   // Every WriteBarrier member reported by analyzeHeap shows up as a named
95 |   // property edge in the snapshot, so retainer paths are readable.
96 |   expect(edges.ReadableStream).toEqual(expect.arrayContaining(["controller", "reader"]));
  
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3fd5a5f1b)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [63.35ms]
(pass) v8 heap snapshot arraybuffer [76.76ms]
(pass) v8 heap snapshot arraybuffer matches string output [29.19ms]
(pass) v8.getHeapSnapshot() [52.04ms]
(pass) v8.writeHeapSnapshot() [69.40ms]
(pass) v8.writeHeapSnapshot() with path [56.23ms]
(pass) v8 heap snapshot labels Web Streams internal edges [25.64ms]

 7 pass
 0 fail
 18 expect() calls
Ran 7 tests across 1 file. [536.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/v8-heap-snapshot.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b16a6c889)

test/js/bun/util/v8-heap-snapshot.test.ts:
(pass) v8 heap snapshot [3431.73ms]
(pass) v8 heap snapshot arraybuffer [2906.35ms]
(pass) v8 heap snapshot arraybuffer matches string output [1408.34ms]
(pass) v8.getHeapSnapshot() [3340.21ms]
(pass) v8.writeHeapSnapshot() [3900.98ms]
(pass) v8.writeHeapSnapshot() with path [3168.58ms]
(pass) v8 heap snapshot labels Web Streams internal edges [1415.98ms]

 7 pass
 0 fail
 18 expect() calls
Ran 7 tests across 1 file. [21.62s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 790ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/63] gen cpp.rs (cppbind)
[2/63] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/ap
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/generate-classes.ts                    |  7 +-
 .../webcore/streams/BunAsyncIterableSource.cpp     | 17 ++++-
 .../webcore/streams/BunStandaloneTextSink.h        | 15 ++++-
 .../webcore/streams/BunStreamConsumers.cpp         | 45 +++++++++++--
 .../bindings/webcore/streams/BunStreamSource.cpp   | 75 +++++++++++++++++-----
 src/jsc/bindings/webcore/streams/BunStreamSource.h |  1 +
 .../streams/JSAsyncIteratorSourceOperation.h       |  1 +
 .../webcore/streams/JSCrossRealmTransformState.cpp | 21 ++++--
 .../webcore/streams/JSCrossRealmTransformState.h   |  1 +
 .../webcore/streams/JSDirectSinkCloseState.h       |  1 +
 .../webcore/streams/JSDirectStreamController.cpp   | 37 ++++++++---
 .../webcore/streams/JSDirectStreamController.h     |  1 +
 .../bindings/webcore/streams/JSOneShotDirectSink.h |  1 +
 src/jsc/bindings/webcore/streams/JSReadRequest.cpp | 21 +++++-
 src/jsc/bindings/webcore/streams/JSReadRequest.h   |  2 +
 .../streams/JSReadStreamIntoSinkOperation.h        |  1 +
 .../streams/JSReadableByteStreamController.cpp     | 37 +++++++++--
 .../streams/JSReadableByteStreamController.h       |  1 +
 .../bindings/webcore/streams/JSReadableStream.cpp  | 29 +++++++--
 .../bindings/webcore/streams/JSReadableStream.h    |  1 +
 .../streams/JSReadableStreamAsyncIterator.cpp      | 14 +++-
 .../streams/JSReadableStreamAsyncIterator.h        |  1 +
 .../webcore/streams/JSReadableStreamBYOBReader.cpp | 25 +++++++-
 .../webcore/streams/JSReadableStreamBYOBReader.h   |  1 +
 .../streams/JSReadableStreamBYOBRequest.cpp        | 14 +++-
 .../webcore/streams/JSReadableStreamBYOBRequest.h  |  1 +
 .../streams/JSReadableStreamDefaultController.cpp  | 28 ++++++--
 .../streams/JSReadableStreamDefaultController.h    |  1 +
 .../streams/JSReadableStreamDefaultReader.cpp      | 28 ++++++--
 .../streams/JSReadableStreamDefaultReader.h        |  1 +
 .../streams/JSReadableStreamIntoArrayOperation.h   |  1 +
 .../webcore/streams/JSResumableSinkPumpOperation
... (truncated)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/codegen/generate-classes.ts                               1      1      0
…jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp      0      0      0
src/jsc/bindings/webcore/streams/BunStandaloneTextSink.h      1      2      0
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp       2      3      0
src/jsc/bindings/webcore/streams/BunStreamSource.cpp          0      0      0
src/jsc/bindings/webcore/streams/BunStreamSource.h            0      0      0
…ndings/webcore/streams/JSAsyncIteratorSourceOperation.h      0      0      0
…bindings/webcore/streams/JSCrossRealmTransformState.cpp      0      0      0
…c/bindings/webcore/streams/JSCrossRealmTransformState.h      0      0      0
…c/jsc/bindings/webcore/streams/JSDirectSinkCloseState.h      0      0      0
…c/bindings/webcore/streams/JSDirectStreamController.cpp      1      1      0
…jsc/bindings/webcore/streams/JSDirectStreamController.h      0      0      0
src/jsc/bindings/webcore/streams/JSOneShotDirectSink.h        0      0      0
src/jsc/bindings/webcore/streams/JSReadRequest.cpp            0      0      0
src/jsc/bindings/webcore/streams/JSReadRequest.h              0      0      0
…indings/webcore/streams/JSReadStreamIntoSinkOperation.h      0      0      0
(+ 42 more files)
```

</details>

<!-- robobun:evidence:end -->