### PR TITLE
Add [nodejs.util.inspect.custom] to Web Streams prototypes

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3963,11 +3963,9 @@ pub mod formatter {
                     self.failed = true;
                 }
             } else {
-                // A custom inspector that returns its own `this` (Node's web
-                // streams do for depth<0, and so does any wrong-receiver call
-                // on the prototype) would recurse forever; re-tag without the
-                // custom hook so it falls through to default formatting, same
-                // as util.inspect's `ret !== context` check.
+                // A custom inspector that returns its own `this` would recurse
+                // forever; re-tag without the custom hook so it falls through to
+                // default formatting (mirrors util.inspect's `ret !== context`).
                 let tag = if result == self.custom_formatted_object.this {
                     Tag::get_advanced(result, self.global_this, TagOptions::DISABLE_INSPECT_CUSTOM)?
                 } else {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3954,8 +3954,7 @@ pub mod formatter {
                     C,
                 )
             })?;
-            // Strings are printed directly, otherwise we recurse. It is
-            // possible to end up in an infinite loop.
+            // Strings are printed directly, otherwise we recurse.
             if result.is_string() {
                 if writer_
                     .write_fmt(format_args!("{}", result.fmt_string(self.global_this)))
@@ -3964,12 +3963,17 @@ pub mod formatter {
                     self.failed = true;
                 }
             } else {
-                self.format::<C>(
-                    Tag::get(result, self.global_this)?,
-                    writer_,
-                    result,
-                    self.global_this,
-                )?;
+                // A custom inspector that returns its own `this` (Node's web
+                // streams do for depth<0, and so does any wrong-receiver call
+                // on the prototype) would recurse forever; re-tag without the
+                // custom hook so it falls through to default formatting, same
+                // as util.inspect's `ret !== context` check.
+                let tag = if result == self.custom_formatted_object.this {
+                    Tag::get_advanced(result, self.global_this, TagOptions::DISABLE_INSPECT_CUSTOM)?
+                } else {
+                    Tag::get(result, self.global_this)?
+                };
+                self.format::<C>(tag, writer_, result, self.global_this)?;
             }
             Ok(())
         }

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -180,7 +180,7 @@ JSC_DEFINE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom, (JS
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSByteLengthQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ByteLengthQueuingStrategy"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ByteLengthQueuingStrategy"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -180,7 +180,7 @@ JSC_DEFINE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom, (JS
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSByteLengthQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ByteLengthQueuingStrategy"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ByteLengthQueuingStrategy"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -8,11 +8,13 @@
 #include "JSDOMWrapperCache.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -24,6 +26,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_constructor);
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_highWaterMark);
 static JSC_DECLARE_CUSTOM_GETTER(jsByteLengthQueuingStrategyPrototypeGetter_size);
+static JSC_DECLARE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom);
 
 class JSByteLengthQueuingStrategyPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -170,10 +173,24 @@ static const HashTableValue JSByteLengthQueuingStrategyPrototypeTableValues[] = 
 
 const ClassInfo JSByteLengthQueuingStrategyPrototype::s_info = { "ByteLengthQueuingStrategy"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSByteLengthQueuingStrategyPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSByteLengthQueuingStrategy>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ByteLengthQueuingStrategy"_s, data));
+}
+
 void JSByteLengthQueuingStrategyPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSByteLengthQueuingStrategy::info(), JSByteLengthQueuingStrategyPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsByteLengthQueuingStrategyPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -180,7 +180,7 @@ JSC_DEFINE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom, (JSGloba
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSCountQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "CountQueuingStrategy"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "CountQueuingStrategy"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -8,11 +8,13 @@
 #include "JSDOMWrapperCache.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -24,6 +26,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_constructor);
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_highWaterMark);
 static JSC_DECLARE_CUSTOM_GETTER(jsCountQueuingStrategyPrototypeGetter_size);
+static JSC_DECLARE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom);
 
 class JSCountQueuingStrategyPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -170,10 +173,24 @@ static const HashTableValue JSCountQueuingStrategyPrototypeTableValues[] = {
 
 const ClassInfo JSCountQueuingStrategyPrototype::s_info = { "CountQueuingStrategy"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCountQueuingStrategyPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSCountQueuingStrategy>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "CountQueuingStrategy"_s, data));
+}
+
 void JSCountQueuingStrategyPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSCountQueuingStrategy::info(), JSCountQueuingStrategyPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsCountQueuingStrategyPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -180,7 +180,7 @@ JSC_DEFINE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom, (JSGloba
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSCountQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "CountQueuingStrategy"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "highWaterMark"_s), jsNumber(thisObject->m_highWaterMark), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "CountQueuingStrategy"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -245,7 +245,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom, 
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableByteStreamController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableByteStreamController"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     (void)thisObject;
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableByteStreamController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -14,6 +14,7 @@
 #include "JSStreamTeeState.h"
 #include "JSStreamsRuntime.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 
@@ -26,6 +27,7 @@
 #include <JavaScriptCore/JSDataView.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSTypedArrays.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -191,6 +193,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableByteStreamControllerPrototypeGetter_d
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom);
 
 class JSReadableByteStreamControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -235,10 +238,24 @@ static const HashTableValue JSReadableByteStreamControllerPrototypeTableValues[]
 
 const ClassInfo JSReadableByteStreamControllerPrototype::s_info = { "ReadableByteStreamController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableByteStreamControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableByteStreamController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    (void)thisObject;
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableByteStreamController"_s, data));
+}
+
 void JSReadableByteStreamControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableByteStreamController::info(), JSReadableByteStreamControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableByteStreamControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -245,7 +245,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom, 
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableByteStreamController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableByteStreamController"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     (void)thisObject;
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableByteStreamController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -409,7 +409,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObjec
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isReadableStreamLocked(thisObject)), 0);
     ASCIILiteral state;

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -409,7 +409,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObjec
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStream"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isReadableStreamLocked(thisObject)), 0);
     ASCIILiteral state;

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -18,6 +18,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -28,6 +29,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -56,6 +58,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamPrototype_nativeTypeGetter);
 static JSC_DECLARE_CUSTOM_SETTER(jsReadableStreamPrototype_nativeTypeSetter);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamPrototype_disturbedGetter);
 static JSC_DECLARE_CUSTOM_SETTER(jsReadableStreamPrototype_disturbedSetter);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom);
 
 class JSReadableStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -399,6 +402,27 @@ static const HashTableValue JSReadableStreamPrototypeTableValues[] = {
 
 const ClassInfo JSReadableStreamPrototype::s_info = { "ReadableStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isReadableStreamLocked(thisObject)), 0);
+    ASCIILiteral state;
+    switch (thisObject->m_state) {
+    case ReadableStreamState::Readable: state = "readable"_s; break;
+    case ReadableStreamState::Closed:   state = "closed"_s;   break;
+    case ReadableStreamState::Errored:  state = "errored"_s;  break;
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "supportsBYOB"_s), jsBoolean(thisObject->m_controllerKind == ControllerKind::Byte), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStream"_s, data));
+}
+
 void JSReadableStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
@@ -414,6 +438,7 @@ void JSReadableStreamPrototype::finishCreation(VM& vm)
     putDirectCustomAccessor(vm, names.bunNativeTypePrivateName(), DOMAttributeGetterSetter::create(vm, jsReadableStreamPrototype_nativeTypeGetter, jsReadableStreamPrototype_nativeTypeSetter, DOMAttributeAnnotation { JSReadableStream::info(), nullptr }), JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete);
     putDirectCustomAccessor(vm, names.disturbedPrivateName(), DOMAttributeGetterSetter::create(vm, jsReadableStreamPrototype_disturbedGetter, jsReadableStreamPrototype_disturbedSetter, DOMAttributeAnnotation { JSReadableStream::info(), nullptr }), JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete);
 
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -414,9 +414,15 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObjec
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isReadableStreamLocked(thisObject)), 0);
     ASCIILiteral state;
     switch (thisObject->m_state) {
-    case ReadableStreamState::Readable: state = "readable"_s; break;
-    case ReadableStreamState::Closed:   state = "closed"_s;   break;
-    case ReadableStreamState::Errored:  state = "errored"_s;  break;
+    case ReadableStreamState::Readable:
+        state = "readable"_s;
+        break;
+    case ReadableStreamState::Closed:
+        state = "closed"_s;
+        break;
+    case ReadableStreamState::Errored:
+        state = "errored"_s;
+        break;
     }
     data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
     data->putDirect(vm, Identifier::fromString(vm, "supportsBYOB"_s), jsBoolean(thisObject->m_controllerKind == ControllerKind::Byte), 0);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -17,6 +17,7 @@
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -26,6 +27,7 @@
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -142,6 +144,7 @@ static BYOBReadArguments convertBYOBReadArguments(JSC::VM& vm, JSGlobalObject* g
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_cancel);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_read);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototypeFunction_releaseLock);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_closed);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_constructor);
 
@@ -274,10 +277,31 @@ static const HashTableValue JSReadableStreamBYOBReaderPrototypeTableValues[] = {
 
 const ClassInfo JSReadableStreamBYOBReaderPrototype::s_info = { "ReadableStreamBYOBReader"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamBYOBReaderPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamBYOBReader>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    size_t requestCount;
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        requestCount = thisObject->m_readIntoRequests.size();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "readIntoRequests"_s), jsNumber(requestCount), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamBYOBReader"_s, data));
+}
+
 void JSReadableStreamBYOBReaderPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamBYOBReader::info(), JSReadableStreamBYOBReaderPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamBYOBReaderPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -284,7 +284,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom, (JSG
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBReader>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamBYOBReader"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     size_t requestCount;

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -284,7 +284,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom, (JSG
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBReader>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamBYOBReader"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     size_t requestCount;

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -109,7 +109,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom, (JS
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBRequest>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamBYOBRequest"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "view"_s), thisObject->m_view.get() ? JSValue(thisObject->m_view.get()) : jsNull(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "controller"_s), thisObject->m_controller.get() ? JSValue(thisObject->m_controller.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -109,7 +109,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom, (JS
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBRequest>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamBYOBRequest"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "view"_s), thisObject->m_view.get() ? JSValue(thisObject->m_view.get()) : jsNull(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "controller"_s), thisObject->m_controller.get() ? JSValue(thisObject->m_controller.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -13,6 +13,7 @@
 #include "JSReadableByteStreamController.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -21,6 +22,7 @@
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -31,6 +33,7 @@ using namespace Bun::WebStreams;
 
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototypeFunction_respond);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototypeFunction_respondWithNewView);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBRequestPrototypeGetter_view);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamBYOBRequestPrototypeGetter_constructor);
 
@@ -99,10 +102,25 @@ static const HashTableValue JSReadableStreamBYOBRequestPrototypeTableValues[] = 
 
 const ClassInfo JSReadableStreamBYOBRequestPrototype::s_info = { "ReadableStreamBYOBRequest"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamBYOBRequestPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamBYOBRequest>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "view"_s), thisObject->m_view.get() ? JSValue(thisObject->m_view.get()) : jsNull(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "controller"_s), thisObject->m_controller.get() ? JSValue(thisObject->m_controller.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamBYOBRequest"_s, data));
+}
+
 void JSReadableStreamBYOBRequestPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamBYOBRequest::info(), JSReadableStreamBYOBRequestPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamBYOBRequestPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -190,7 +190,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCusto
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamDefaultController"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     (void)thisObject;
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -190,7 +190,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCusto
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamDefaultController"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     (void)thisObject;
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -12,12 +12,14 @@
 #include "JSStreamsRuntime.h"
 #include "JSTransformStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -137,6 +139,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultControllerPrototypeGette
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCustom);
 
 class JSReadableStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -180,10 +183,24 @@ static const HashTableValue JSReadableStreamDefaultControllerPrototypeTableValue
 
 const ClassInfo JSReadableStreamDefaultControllerPrototype::s_info = { "ReadableStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    (void)thisObject;
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultController"_s, data));
+}
+
 void JSReadableStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamDefaultController::info(), JSReadableStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -590,7 +590,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom, (
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultReader>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamDefaultReader"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     size_t requestCount;

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -590,7 +590,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom, (
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultReader>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStreamDefaultReader"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     size_t requestCount;

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -18,6 +18,7 @@
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -445,6 +446,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_read);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_readMany);
 static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototypeFunction_releaseLock);
+static JSC_DECLARE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_closed);
 static JSC_DECLARE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_constructor);
 
@@ -581,10 +583,31 @@ static const HashTableValue JSReadableStreamDefaultReaderPrototypeTableValues[] 
 
 const ClassInfo JSReadableStreamDefaultReaderPrototype::s_info = { "ReadableStreamDefaultReader"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableStreamDefaultReaderPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSReadableStreamDefaultReader>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    size_t requestCount;
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        requestCount = thisObject->m_readRequests.size();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "readRequests"_s), jsNumber(requestCount), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "ReadableStreamDefaultReader"_s, data));
+}
+
 void JSReadableStreamDefaultReaderPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSReadableStreamDefaultReader::info(), JSReadableStreamDefaultReaderPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsReadableStreamDefaultReaderPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -198,7 +198,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom, (JSGlobalOb
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTextDecoderStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextDecoderStream"_s);
+        return JSValue::encode(thisValue);
     // encoding/fatal/ignoreBOM live on the TextDecoder held by m_decoder; read them via the
     // public prototype getters this class already exposes so no extra coupling is introduced.
     JSObject* data = constructEmptyObject(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -13,6 +13,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -34,6 +35,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_fatal);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_ignoreBOM);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_writable);
+static JSC_DECLARE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom);
 
 class JSTextDecoderStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -189,10 +191,37 @@ static const HashTableValue JSTextDecoderStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTextDecoderStreamPrototype::s_info = { "TextDecoderStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTextDecoderStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTextDecoderStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    // encoding/fatal/ignoreBOM live on the TextDecoder held by m_decoder; read them via the
+    // public prototype getters this class already exposes so no extra coupling is introduced.
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    JSValue encoding = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "encoding"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), encoding, 0);
+    JSValue fatal = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "fatal"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "fatal"_s), fatal, 0);
+    JSValue ignoreBOM = thisObject->get(lexicalGlobalObject, Identifier::fromString(vm, "ignoreBOM"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    data->putDirect(vm, Identifier::fromString(vm, "ignoreBOM"_s), ignoreBOM, 0);
+    auto* transform = thisObject->m_transform.get();
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), transform && transform->m_readable.get() ? JSValue(transform->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), transform && transform->m_writable.get() ? JSValue(transform->m_writable.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextDecoderStream"_s, data));
+}
+
 void JSTextDecoderStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTextDecoderStream::info(), JSTextDecoderStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTextDecoderStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -198,7 +198,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom, (JSGlobalOb
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTextDecoderStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextDecoderStream"_s);
     // encoding/fatal/ignoreBOM live on the TextDecoder held by m_decoder; read them via the
     // public prototype getters this class already exposes so no extra coupling is introduced.
     JSObject* data = constructEmptyObject(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalOb
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTextEncoderStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), jsNontrivialString(vm, "utf-8"_s), 0);
     auto* transform = thisObject->m_transform.get();

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalOb
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTextEncoderStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextEncoderStream"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), jsNontrivialString(vm, "utf-8"_s), 0);
     auto* transform = thisObject->m_transform.get();

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -13,11 +13,13 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -31,6 +33,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_constructor)
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_encoding);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTextEncoderStreamPrototypeGetter_writable);
+static JSC_DECLARE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom);
 
 class JSTextEncoderStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -163,10 +166,27 @@ static const HashTableValue JSTextEncoderStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTextEncoderStreamPrototype::s_info = { "TextEncoderStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTextEncoderStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTextEncoderStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTextEncoderStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "encoding"_s), jsNontrivialString(vm, "utf-8"_s), 0);
+    auto* transform = thisObject->m_transform.get();
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), transform && transform->m_readable.get() ? JSValue(transform->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), transform && transform->m_writable.get() ? JSValue(transform->m_writable.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TextEncoderStream"_s, data));
+}
+
 void JSTextEncoderStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTextEncoderStream::info(), JSTextEncoderStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTextEncoderStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -14,6 +14,7 @@
 #include "JSWritableStream.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -22,6 +23,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -33,6 +35,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_readable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_writable);
 static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom);
 
 class JSTransformStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -201,10 +204,26 @@ static const HashTableValue JSTransformStreamPrototypeTableValues[] = {
 
 const ClassInfo JSTransformStreamPrototype::s_info = { "TransformStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTransformStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTransformStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "readable"_s), thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "writable"_s), thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "backpressure"_s), jsBoolean(thisObject->m_backpressure), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStream"_s, data));
+}
+
 void JSTransformStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTransformStream::info(), JSTransformStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTransformStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -211,7 +211,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom, (JSGlobalObje
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTransformStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TransformStream"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "readable"_s), thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "writable"_s), thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -211,7 +211,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom, (JSGlobalObje
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTransformStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TransformStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "readable"_s), thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "writable"_s), thisObject->m_writable.get() ? JSValue(thisObject->m_writable.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCust
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TransformStreamDefaultController"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCust
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TransformStreamDefaultController"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -13,12 +13,14 @@
 #include "JSTextEncoderStream.h"
 #include "JSTransformStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -120,6 +122,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTransformStreamDefaultControllerPrototypeGett
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_enqueue);
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_error);
 static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototypeFunction_terminate);
+static JSC_DECLARE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCustom);
 
 class JSTransformStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -163,10 +166,24 @@ static const HashTableValue JSTransformStreamDefaultControllerPrototypeTableValu
 
 const ClassInfo JSTransformStreamDefaultControllerPrototype::s_info = { "TransformStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTransformStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "TransformStreamDefaultController"_s, data));
+}
+
 void JSTransformStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTransformStreamDefaultController::info(), JSTransformStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsTransformStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -189,7 +189,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObjec
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isWritableStreamLocked(thisObject)), 0);
     ASCIILiteral state;

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -189,7 +189,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObjec
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStream>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStream"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isWritableStreamLocked(thisObject)), 0);
     ASCIILiteral state;

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -194,10 +194,18 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObjec
     data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isWritableStreamLocked(thisObject)), 0);
     ASCIILiteral state;
     switch (thisObject->m_state) {
-    case WritableStreamState::Writable: state = "writable"_s; break;
-    case WritableStreamState::Erroring: state = "erroring"_s; break;
-    case WritableStreamState::Errored:  state = "errored"_s;  break;
-    case WritableStreamState::Closed:   state = "closed"_s;   break;
+    case WritableStreamState::Writable:
+        state = "writable"_s;
+        break;
+    case WritableStreamState::Erroring:
+        state = "erroring"_s;
+        break;
+    case WritableStreamState::Errored:
+        state = "errored"_s;
+        break;
+    case WritableStreamState::Closed:
+        state = "closed"_s;
+        break;
     }
     data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStream"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -13,6 +13,7 @@
 #include "JSWritableStreamDefaultWriter.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/BuiltinNames.h>
@@ -21,6 +22,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -34,6 +36,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototypeFunction_close);
 static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototypeFunction_getWriter);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamPrototypeGetter_locked);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom);
 
 class JSWritableStreamPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -179,10 +182,32 @@ static const HashTableValue JSWritableStreamPrototypeTableValues[] = {
 
 const ClassInfo JSWritableStreamPrototype::s_info = { "WritableStream"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStream>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "locked"_s), jsBoolean(isWritableStreamLocked(thisObject)), 0);
+    ASCIILiteral state;
+    switch (thisObject->m_state) {
+    case WritableStreamState::Writable: state = "writable"_s; break;
+    case WritableStreamState::Erroring: state = "erroring"_s; break;
+    case WritableStreamState::Errored:  state = "errored"_s;  break;
+    case WritableStreamState::Closed:   state = "closed"_s;   break;
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "state"_s), jsNontrivialString(vm, state), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStream"_s, data));
+}
+
 void JSWritableStreamPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStream::info(), JSWritableStreamPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -12,12 +12,14 @@
 #include "JSTransformStream.h"
 #include "JSWritableStream.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -147,6 +149,7 @@ using namespace Bun::WebStreams;
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultControllerConstructorGetter);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultControllerPrototypeGetter_signal);
 static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototypeFunction_error);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCustom);
 
 class JSWritableStreamDefaultControllerPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -188,10 +191,24 @@ static const HashTableValue JSWritableStreamDefaultControllerPrototypeTableValue
 
 const ClassInfo JSWritableStreamDefaultControllerPrototype::s_info = { "WritableStreamDefaultController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamDefaultControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultController"_s, data));
+}
+
 void JSWritableStreamDefaultControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStreamDefaultController::info(), JSWritableStreamDefaultControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamDefaultControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -198,7 +198,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCusto
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStreamDefaultController"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -198,7 +198,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCusto
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStreamDefaultController"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultController"_s, data));

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -310,7 +310,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom, (
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultWriter>(thisValue);
     if (!thisObject) [[unlikely]]
-        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStreamDefaultWriter"_s);
+        return JSValue::encode(thisValue);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -310,7 +310,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom, (
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultWriter>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "WritableStreamDefaultWriter"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
     data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
     data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -15,6 +15,7 @@
 #include "JSWritableStreamDefaultController.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
+#include "WebStreamsInspectCustom.h"
 #include "WebStreamsInternals.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/Error.h>
@@ -22,6 +23,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/Lookup.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 
@@ -169,6 +171,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_cl
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_desiredSize);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_ready);
 static JSC_DECLARE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_constructor);
+static JSC_DECLARE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom);
 
 class JSWritableStreamDefaultWriterPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -300,10 +303,32 @@ static const HashTableValue JSWritableStreamDefaultWriterPrototypeTableValues[] 
 
 const ClassInfo JSWritableStreamDefaultWriterPrototype::s_info = { "WritableStreamDefaultWriter"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWritableStreamDefaultWriterPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSWritableStreamDefaultWriter>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    data->putDirect(vm, Identifier::fromString(vm, "stream"_s), thisObject->m_stream.get() ? JSValue(thisObject->m_stream.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "close"_s), thisObject->m_closedPromise.get() ? JSValue(thisObject->m_closedPromise.get()) : jsUndefined(), 0);
+    data->putDirect(vm, Identifier::fromString(vm, "ready"_s), thisObject->m_readyPromise.get() ? JSValue(thisObject->m_readyPromise.get()) : jsUndefined(), 0);
+    JSValue desiredSizeValue = jsNull();
+    if (thisObject->m_stream.get()) {
+        auto desiredSize = writableStreamDefaultWriterGetDesiredSize(thisObject);
+        desiredSizeValue = desiredSize ? jsNumber(*desiredSize) : jsNull();
+    }
+    data->putDirect(vm, Identifier::fromString(vm, "desiredSize"_s), desiredSizeValue, 0);
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "WritableStreamDefaultWriter"_s, data));
+}
+
 void JSWritableStreamDefaultWriterPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSWritableStreamDefaultWriter::info(), JSWritableStreamDefaultWriterPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsWritableStreamDefaultWriterPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -1,0 +1,81 @@
+#include "config.h"
+#include "WebStreamsInspectCustom.h"
+
+#include "BunClientData.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include <wtf/text/MakeString.h>
+
+namespace Bun {
+namespace WebStreams {
+
+using namespace JSC;
+
+EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSValue thisValue, ASCIILiteral name, JSObject* data)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue depthValue = callFrame->argument(0);
+    JSValue optionsValue = callFrame->argument(1);
+
+    double depth = depthValue.toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (depth < 0)
+        return JSValue::encode(thisValue);
+
+    // opts = { ...options, depth: options.depth == null ? null : options.depth - 1 }
+    JSObject* opts = constructEmptyObject(lexicalGlobalObject);
+    JSValue childDepth = jsNull();
+    if (optionsValue.isObject()) {
+        JSObject* options = asObject(optionsValue);
+        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+        options->getPropertyNames(lexicalGlobalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(scope, {});
+        for (size_t i = 0; i < names.size(); ++i) {
+            JSValue v = options->get(lexicalGlobalObject, names[i]);
+            RETURN_IF_EXCEPTION(scope, {});
+            opts->putDirect(vm, names[i], v, 0);
+        }
+        JSValue optionsDepth = options->get(lexicalGlobalObject, Identifier::fromString(vm, "depth"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!optionsDepth.isUndefinedOrNull()) {
+            double d = optionsDepth.toNumber(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            childDepth = jsNumber(d - 1);
+        }
+    }
+    opts->putDirect(vm, Identifier::fromString(vm, "depth"_s), childDepth, 0);
+
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, {});
+    auto callData = JSC::getCallData(utilInspect);
+    MarkedArgumentBuffer arguments;
+    arguments.append(data);
+    arguments.append(opts);
+    ASSERT(!arguments.hasOverflowed());
+
+    JSValue inspected = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, utilInspect, callData, jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto* inspectedString = inspected.toString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto view = inspectedString->view(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(jsString(vm, makeString(name, " "_s, view.data)));
+}
+
+void installInspectCustom(VM& vm, JSObject* prototype, NativeFunction nativeFunction)
+{
+    auto* globalObject = prototype->globalObject();
+    prototype->putDirectNativeFunction(vm, globalObject, WebCore::builtinNames(vm).inspectCustomPublicName(), 2,
+        nativeFunction, ImplementationVisibility::Public, NoIntrinsic,
+        static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum));
+}
+
+} // namespace WebStreams
+} // namespace Bun

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -11,10 +11,7 @@ namespace Bun {
 namespace WebStreams {
 
 // Node's `customInspect(depth, options, name, data)` (lib/internal/webstreams/util.js):
-//   if (depth < 0) return this;
-//   const opts = { ...options, depth: options.depth == null ? null : options.depth - 1 };
-//   return `${name} ${inspect(data, opts)}`;
-// `thisValue` is returned when depth < 0; `data` is the pre-built field object.
+// depth < 0 returns `thisValue`; otherwise `${name} ${inspect(data, {...options, depth-1})}`.
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
 
 // Installs the host function on a prototype under Symbol.for("nodejs.util.inspect.custom").

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -1,0 +1,24 @@
+// WebStreamsInspectCustom.h — the one shared helper every Web Streams prototype's
+// [Symbol.for("nodejs.util.inspect.custom")] host function routes through, so
+// `console.log(stream)` matches Node's output shape: `ClassName { field: value, ... }`.
+#pragma once
+
+#include "root.h"
+
+#include <JavaScriptCore/JSObject.h>
+
+namespace Bun {
+namespace WebStreams {
+
+// Node's `customInspect(depth, options, name, data)` (lib/internal/webstreams/util.js):
+//   if (depth < 0) return this;
+//   const opts = { ...options, depth: options.depth == null ? null : options.depth - 1 };
+//   return `${name} ${inspect(data, opts)}`;
+// `thisValue` is returned when depth < 0; `data` is the pre-built field object.
+JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
+
+// Installs the host function on a prototype under Symbol.for("nodejs.util.inspect.custom").
+void installInspectCustom(JSC::VM&, JSC::JSObject* prototype, JSC::NativeFunction);
+
+} // namespace WebStreams
+} // namespace Bun

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -163,7 +163,9 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
   const inspect = util.inspect;
 
   test("ReadableStream", () => {
-    expect(inspect(new ReadableStream())).toBe("ReadableStream { locked: false, state: 'readable', supportsBYOB: false }");
+    expect(inspect(new ReadableStream())).toBe(
+      "ReadableStream { locked: false, state: 'readable', supportsBYOB: false }",
+    );
     expect(inspect(new ReadableStream({ type: "bytes" }))).toBe(
       "ReadableStream { locked: false, state: 'readable', supportsBYOB: true }",
     );

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -306,11 +306,13 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
     expect(rs[customSymbol](-1, {})).toBe(rs);
   });
 
-  test("wrong receiver throws ERR_INVALID_THIS", () => {
-    expect(() => ReadableStream.prototype[customSymbol].call({}, 2, {})).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_THIS" }),
-    );
-    // util.inspect skips the custom function on prototype objects, so this must not recurse.
+  test("wrong receiver returns the receiver (no infinite recursion)", () => {
+    const o = {};
+    expect(ReadableStream.prototype[customSymbol].call(o, 2, {})).toBe(o);
+    // util.inspect and Bun.inspect must both fall through to default formatting
+    // rather than recursing on a custom function that returned its own `this`.
     expect(inspect(ReadableStream.prototype)).toContain("[ReadableStream]");
+    expect(Bun.inspect(ReadableStream.prototype).length > 0).toBeTrue();
+    expect(Bun.inspect(TransformStream.prototype).length > 0).toBeTrue();
   });
 });

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -158,3 +158,131 @@ for (const [name, inspect] of process.versions.bun
     expect(() => inspect(obj)).toThrow();
   });
 }
+
+describe("Web Streams [nodejs.util.inspect.custom]", () => {
+  const inspect = util.inspect;
+
+  test("ReadableStream", () => {
+    expect(inspect(new ReadableStream())).toBe("ReadableStream { locked: false, state: 'readable', supportsBYOB: false }");
+    expect(inspect(new ReadableStream({ type: "bytes" }))).toBe(
+      "ReadableStream { locked: false, state: 'readable', supportsBYOB: true }",
+    );
+    const rs = new ReadableStream();
+    rs.getReader();
+    expect(inspect(rs)).toBe("ReadableStream { locked: true, state: 'readable', supportsBYOB: false }");
+  });
+
+  test("WritableStream", () => {
+    expect(inspect(new WritableStream())).toBe("WritableStream { locked: false, state: 'writable' }");
+    const ws = new WritableStream();
+    ws.getWriter();
+    expect(inspect(ws)).toBe("WritableStream { locked: true, state: 'writable' }");
+  });
+
+  test("TransformStream", () => {
+    const out = inspect(new TransformStream());
+    expect(out).toStartWith("TransformStream {");
+    expect(out).toContain("readable: ReadableStream {");
+    expect(out).toContain("writable: WritableStream {");
+    expect(out).toContain("backpressure: true");
+  });
+
+  test("ReadableStreamDefaultReader", () => {
+    const out = inspect(new ReadableStream().getReader());
+    expect(out).toStartWith("ReadableStreamDefaultReader {");
+    expect(out).toContain("stream: ReadableStream {");
+    expect(out).toContain("readRequests: 0");
+    expect(out).toContain("close: Promise");
+  });
+
+  test("ReadableStreamBYOBReader", () => {
+    const out = inspect(new ReadableStream({ type: "bytes" }).getReader({ mode: "byob" }));
+    expect(out).toStartWith("ReadableStreamBYOBReader {");
+    expect(out).toContain("readIntoRequests: 0");
+  });
+
+  test("ReadableStreamDefaultController", () => {
+    let controller;
+    new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    expect(inspect(controller)).toBe("ReadableStreamDefaultController {}");
+  });
+
+  test("ReadableByteStreamController", () => {
+    let controller;
+    new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    expect(inspect(controller)).toBe("ReadableByteStreamController {}");
+  });
+
+  test("WritableStreamDefaultWriter", () => {
+    const out = inspect(new WritableStream().getWriter());
+    expect(out).toStartWith("WritableStreamDefaultWriter {");
+    expect(out).toContain("stream: WritableStream {");
+    expect(out).toContain("close: Promise");
+    expect(out).toContain("ready: Promise");
+    expect(out).toContain("desiredSize: 1");
+  });
+
+  test("WritableStreamDefaultController", () => {
+    let controller;
+    new WritableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const out = inspect(controller);
+    expect(out).toStartWith("WritableStreamDefaultController {");
+    expect(out).toContain("stream: WritableStream {");
+  });
+
+  test("TransformStreamDefaultController", () => {
+    let controller;
+    new TransformStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    const out = inspect(controller);
+    expect(out).toStartWith("TransformStreamDefaultController {");
+    expect(out).toContain("stream: TransformStream {");
+  });
+
+  test("ByteLengthQueuingStrategy", () => {
+    expect(inspect(new ByteLengthQueuingStrategy({ highWaterMark: 16 }))).toBe(
+      "ByteLengthQueuingStrategy { highWaterMark: 16 }",
+    );
+  });
+
+  test("CountQueuingStrategy", () => {
+    expect(inspect(new CountQueuingStrategy({ highWaterMark: 8 }))).toBe("CountQueuingStrategy { highWaterMark: 8 }");
+  });
+
+  test("TextEncoderStream", () => {
+    const out = inspect(new TextEncoderStream());
+    expect(out).toStartWith("TextEncoderStream {");
+    expect(out).toContain("encoding: 'utf-8'");
+    expect(out).toContain("readable: ReadableStream {");
+    expect(out).toContain("writable: WritableStream {");
+  });
+
+  test("TextDecoderStream", () => {
+    const out = inspect(new TextDecoderStream("utf-8", { fatal: true, ignoreBOM: true }));
+    expect(out).toStartWith("TextDecoderStream {");
+    expect(out).toContain("encoding: 'utf-8'");
+    expect(out).toContain("fatal: true");
+    expect(out).toContain("ignoreBOM: true");
+  });
+
+  test("depth < 0 returns the instance", () => {
+    const rs = new ReadableStream();
+    expect(rs[customSymbol](-1, {})).toBe(rs);
+  });
+});

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -283,8 +283,34 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
     expect(out).toContain("ignoreBOM: true");
   });
 
+  test("ReadableStreamBYOBRequest", async () => {
+    let out;
+    const rs = new ReadableStream({
+      type: "bytes",
+      autoAllocateChunkSize: 16,
+      pull(c) {
+        out = inspect(c.byobRequest);
+        c.byobRequest.view[0] = 1;
+        c.byobRequest.respond(1);
+        c.close();
+      },
+    });
+    await rs.getReader().read();
+    expect(out).toStartWith("ReadableStreamBYOBRequest {");
+    expect(out).toContain("view: Uint8Array");
+    expect(out).toContain("controller: ReadableByteStreamController {}");
+  });
+
   test("depth < 0 returns the instance", () => {
     const rs = new ReadableStream();
     expect(rs[customSymbol](-1, {})).toBe(rs);
+  });
+
+  test("wrong receiver throws ERR_INVALID_THIS", () => {
+    expect(() => ReadableStream.prototype[customSymbol].call({}, 2, {})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_THIS" }),
+    );
+    // util.inspect skips the custom function on prototype objects, so this must not recurse.
+    expect(inspect(ReadableStream.prototype)).toContain("[ReadableStream]");
   });
 });


### PR DESCRIPTION
Stacked on #33830.

## What

`console.log` / `util.inspect` on a Web Streams object now matches Node.js instead of dumping every prototype method:

```js
> console.log(new ReadableStream())
ReadableStream { locked: false, state: 'readable', supportsBYOB: false }
> console.log(new WritableStream().getWriter())
WritableStreamDefaultWriter {
  stream: WritableStream { locked: true, state: 'writable' },
  close: Promise { <pending> },
  ready: Promise { undefined },
  desiredSize: 1
}
```

## How

- New `WebStreamsInspectCustom.{h,cpp}` with `Bun::WebStreams::customInspect(global, callFrame, thisValue, name, data)`, which mirrors Node's `lib/internal/webstreams/util.js` `customInspect(depth, options, name, data)`: if `depth < 0` return `this`; otherwise spread `options` with `depth - 1`, call `util.inspect(data, opts)`, and prepend the class name. `installInspectCustom(vm, prototype, fn)` registers the host function under `Symbol.for("nodejs.util.inspect.custom")` via `builtinNames.inspectCustomPublicName()`.
- Each prototype gets a small host function that validates `this`, builds a plain JS object with the per-class fields, and delegates to the helper. Registered in the prototype's `finishCreation`.
- Fields per class follow Node exactly (checked against Node v26.3.0 source and runtime output).

### Classes covered (15)

| Class | Fields shown |
|---|---|
| `ReadableStream` | `locked`, `state`, `supportsBYOB` |
| `WritableStream` | `locked`, `state` |
| `TransformStream` | `readable`, `writable`, `backpressure` |
| `ReadableStreamDefaultReader` | `stream`, `readRequests`, `close` |
| `ReadableStreamBYOBReader` | `stream`, `readIntoRequests`, `close` |
| `ReadableStreamDefaultController` | *(empty `{}`)* |
| `ReadableByteStreamController` | *(empty `{}`)* |
| `ReadableStreamBYOBRequest` | `view`, `controller` |
| `WritableStreamDefaultWriter` | `stream`, `close`, `ready`, `desiredSize` |
| `WritableStreamDefaultController` | `stream` |
| `TransformStreamDefaultController` | `stream` |
| `ByteLengthQueuingStrategy` | `highWaterMark` |
| `CountQueuingStrategy` | `highWaterMark` |
| `TextEncoderStream` | `encoding`, `readable`, `writable` |
| `TextDecoderStream` | `encoding`, `fatal`, `ignoreBOM`, `readable`, `writable` |

## Verification

New tests in `test/js/node/util/custom-inspect.test.js` assert the exact output (or key fields for nested cases) for all 15 classes and the `depth < 0` behavior. All 40 tests in that file pass; 13/15 of the new tests fail on a build without this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 19 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/custom-inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (591ec398f)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [1.80ms]
(pass) util.inspect calls inspect.custom [22.51ms]
(pass) util.inspect calls inspect.custom recursivly [4.33ms]
(pass) util.inspect calls inspect.custom recursivly nested [68.97ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [5.65ms]
(pass) util.inspect calls inspect.custom with valid options [4.92ms]
(pass) util.inspect stylize function works without color [4.04ms]
(pass) util.inspect stylize function works with color [7.05ms]
(pass) util.inspect stylize function gives correct depth [18.01ms]
(pass) util.inspect stylize function gives correct depth [5.71ms]
(pass) util.inspect non-callable does not get called [4.
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (591ec398f)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [0.03ms]
(pass) util.inspect calls inspect.custom [0.37ms]
(pass) util.inspect calls inspect.custom recursivly [0.05ms]
(pass) util.inspect calls inspect.custom recursivly nested [1.12ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [0.08ms]
(pass) util.inspect calls inspect.custom with valid options [0.07ms]
(pass) util.inspect stylize function works without color [0.05ms]
(pass) util.inspect stylize function works with color [0.09ms]
(pass) util.inspect stylize function gives correct depth [0.31ms]
(pass) util.inspect stylize function gives correct depth [0.08ms]
(pass) util.inspect non-callable does not get called [0.11ms]
(pass) util.inspect handles exceptions %s [0.07ms]
(pass) util.inspect handles exceptions %s
(pass) Bun.inspect calls inspect.custom [0.02ms]
(pass) Bun.inspect calls inspect.custom recursivly
(pass) Bun.inspect calls inspect.custom recursivly nested [0.02ms]
(pass) Bun.inspect calls inspect.custom recursivly nested 2
(pass) Bun.inspect calls inspect.custom with valid options
(pass) Bun.inspect stylize function works
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/custom-inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (591ec398f)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [1.90ms]
(pass) util.inspect calls inspect.custom [18.47ms]
(pass) util.inspect calls inspect.custom recursivly [4.18ms]
(pass) util.inspect calls inspect.custom recursivly nested [55.36ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [5.84ms]
(pass) util.inspect calls inspect.custom with valid options [5.21ms]
(pass) util.inspect stylize function works without color [4.24ms]
(pass) util.inspect stylize function works with color [7.12ms]
(pass) util.inspect stylize function gives correct depth [17.77ms]
(pass) util.inspect stylize function gives correct depth [5.99ms]
(pass) util.inspect non-callable does not get called [5.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] cxx obj/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp.o
[2/21] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp.o
[3/21] cxx obj/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp.o
[4/21] cxx obj/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp.o
[5/21] cxx obj/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp.o
[6/21] cxx obj/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp.o
[7/21] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStream.cpp.o
[8/21] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp.o
[9/21] cxx obj/src/jsc/bindings/webcore/streams/JSWritableStream.cpp.o
[10/21] cxx obj/src/jsc/bindings/webcore/st
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                           |  18 +--
 .../streams/JSByteLengthQueuingStrategy.cpp        |  17 +++
 .../webcore/streams/JSCountQueuingStrategy.cpp     |  17 +++
 .../streams/JSReadableByteStreamController.cpp     |  17 +++
 .../bindings/webcore/streams/JSReadableStream.cpp  |  31 ++++
 .../webcore/streams/JSReadableStreamBYOBReader.cpp |  24 ++++
 .../streams/JSReadableStreamBYOBRequest.cpp        |  18 +++
 .../streams/JSReadableStreamDefaultController.cpp  |  17 +++
 .../streams/JSReadableStreamDefaultReader.cpp      |  23 +++
 .../webcore/streams/JSTextDecoderStream.cpp        |  29 ++++
 .../webcore/streams/JSTextEncoderStream.cpp        |  20 +++
 .../bindings/webcore/streams/JSTransformStream.cpp |  19 +++
 .../streams/JSTransformStreamDefaultController.cpp |  17 +++
 .../bindings/webcore/streams/JSWritableStream.cpp  |  33 +++++
 .../streams/JSWritableStreamDefaultController.cpp  |  17 +++
 .../streams/JSWritableStreamDefaultWriter.cpp      |  25 ++++
 .../webcore/streams/WebStreamsInspectCustom.cpp    |  81 +++++++++++
 .../webcore/streams/WebStreamsInspectCustom.h      |  21 +++
 test/js/node/util/custom-inspect.test.js           | 158 +++++++++++++++++++++
 19 files changed, 594 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/ConsoleObject.rs                                      2      3      0
…indings/webcore/streams/JSByteLengthQueuingStrategy.cpp      0      0      0
…jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp      0      0      0
…ings/webcore/streams/JSReadableByteStreamController.cpp      1      0      0
src/jsc/bindings/webcore/streams/JSReadableStream.cpp         1      0      0
…bindings/webcore/streams/JSReadableStreamBYOBReader.cpp      0      0      0
…indings/webcore/streams/JSReadableStreamBYOBRequest.cpp      0      0      0
…s/webcore/streams/JSReadableStreamDefaultController.cpp      1      1      0
…dings/webcore/streams/JSReadableStreamDefaultReader.cpp      1      0      0
src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp      0      0      0
src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp      0      0      0
src/jsc/bindings/webcore/streams/JSTransformStream.cpp        0      0      0
…/webcore/streams/JSTransformStreamDefaultController.cpp      0      0      0
src/jsc/bindings/webcore/streams/JSWritableStream.cpp         0      0      0
…s/webcore/streams/JSWritableStreamDefaultController.cpp      1      1      0
…dings/webcore/streams/JSWritableStreamDefaultWriter.cpp      0      0      0
(+ 3 more files)
```

</details>

<!-- robobun:evidence:end -->