### PR TITLE
spawnSync: drain piped stdio to EOF after the direct child exits

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1848,6 +1848,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         }
 
         let has_user_timespec = !user_timespec.eql(&Timespec::EPOCH);
+        let mut bun_test_fired = false;
 
         // SAFETY: jsc_vm_ptr is the live thread VM; re-borrowed for the nested arg.
         let sync_loop = unsafe { &mut *jsc_vm_ptr }
@@ -1856,12 +1857,13 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
 
         while subprocess.compute_has_pending_activity() {
             // Re-evaluate this at each iteration of the loop since it may change between iterations.
-            let bun_test_timeout: Timespec =
-                if let Some(runner) = crate::test_runner::jest::Jest::runner() {
-                    runner.get_active_timeout()
-                } else {
-                    Timespec::EPOCH
-                };
+            let bun_test_timeout: Timespec = if bun_test_fired {
+                Timespec::EPOCH
+            } else if let Some(runner) = crate::test_runner::jest::Jest::runner() {
+                runner.get_active_timeout()
+            } else {
+                Timespec::EPOCH
+            };
             let has_bun_test_timeout = !bun_test_timeout.eql(&Timespec::EPOCH);
 
             if has_bun_test_timeout {
@@ -1913,6 +1915,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                     // different test fails, and that SHOULD be okay.
                     if has_bun_test_timeout {
                         if bun_test_timeout.order(&now) == core::cmp::Ordering::Less {
+                            bun_test_fired = true;
                             let mut active_file_strong = crate::test_runner::jest::Jest::runner()
                                 .unwrap()
                                 .bun_test_root
@@ -1938,23 +1941,19 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                                 // SAFETY: jsc_vm_ptr is the live thread VM.
                                 unsafe { &*jsc_vm_ptr },
                             );
-                            if !has_user_timespec {
-                                // No user deadline, and the bun:test timer is
-                                // now EPOCH: stop draining so the loop can
-                                // exit instead of blocking with no timeout.
-                                let _ = subprocess.try_kill(subprocess.kill_signal);
-                                subprocess.close_readable_pipes();
-                            }
+                            // The direct child may already be reaped (and
+                            // gone from the auto-killer), so kill it here too.
+                            let _ = subprocess.try_kill(subprocess.kill_signal);
                             // active_file_strong / taken_active_file drop here (was `defer .deinit()`).
                         }
                     }
                 }
             }
 
-            // Once the wait is being terminated (timeout, maxBuffer), stop
-            // waiting on pipe EOF; a grandchild may still hold the write end.
-            // Matches Node.js SyncProcessRunner::Kill() closing stdio pipes.
-            if did_timeout || subprocess.exited_due_to_maxbuf.get().is_some() {
+            // Once the wait is being terminated (timeout, maxBuffer, bun:test
+            // per-test timeout), stop waiting on pipe EOF; a grandchild may
+            // still hold the write end (Node.js SyncProcessRunner::Kill()).
+            if did_timeout || bun_test_fired || subprocess.exited_due_to_maxbuf.get().is_some() {
                 subprocess.close_readable_pipes();
             }
         }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -908,7 +908,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let _ = &inherited_env_storage;
 
     for fd_index in 0..stdio.len() {
-        if stdio[fd_index].can_use_memfd(IS_SYNC, fd_index > 0 && max_buffer.is_some()) {
+        if stdio[fd_index].can_use_memfd() {
             if stdio[fd_index].use_memfd(fd_index as u32) {
                 jsc_vm.counters.mark(jsc::counters::Field::SpawnMemfd);
             }
@@ -1942,6 +1942,13 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                         }
                     }
                 }
+            }
+
+            // Once the wait is being terminated (timeout, maxBuffer), stop
+            // waiting on pipe EOF; a grandchild may still hold the write end.
+            // Matches Node.js SyncProcessRunner::Kill() closing stdio pipes.
+            if did_timeout || subprocess.exited_due_to_maxbuf.get().is_some() {
+                subprocess.close_readable_pipes();
             }
         }
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1938,6 +1938,13 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                                 // SAFETY: jsc_vm_ptr is the live thread VM.
                                 unsafe { &*jsc_vm_ptr },
                             );
+                            if !has_user_timespec {
+                                // No user deadline, and the bun:test timer is
+                                // now EPOCH: stop draining so the loop can
+                                // exit instead of blocking with no timeout.
+                                let _ = subprocess.try_kill(subprocess.kill_signal);
+                                subprocess.close_readable_pipes();
+                            }
                             // active_file_strong / taken_active_file drop here (was `defer .deinit()`).
                         }
                     }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -114,10 +114,9 @@ impl Stdio {
         }
     }
 
-    pub fn can_use_memfd(&self, is_sync: bool, has_max_buffer: bool) -> bool {
+    pub fn can_use_memfd(&self) -> bool {
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
-            let _ = (is_sync, has_max_buffer);
             return false;
         }
 
@@ -125,7 +124,8 @@ impl Stdio {
         match self {
             Self::Blob(blob) => !blob.needs_to_read_file(),
             Self::Memfd(_) | Self::ArrayBuffer(_) => true,
-            Self::Pipe => is_sync && !has_max_buffer,
+            // `Self::Pipe` is never memfd: a memfd has no EOF signal, so a
+            // grandchild still writing after the child exits would be lost.
             _ => false,
         }
     }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -680,6 +680,18 @@ impl Subprocess<'_> {
         let _ = self.try_kill(self.kill_signal);
     }
 
+    /// Close any still-open stdout/stderr pipe readers so the sync wait loop
+    /// stops waiting for EOF after timeout/maxBuffer. Matches Node.js
+    /// `SyncProcessRunner::Kill()`. Called outside any reader callback.
+    pub fn close_readable_pipes(&self) {
+        if matches!(self.stdout.get(), Readable::Pipe(_)) {
+            self.stdout.with_mut(|s| s.close());
+        }
+        if matches!(self.stderr.get(), Readable::Pipe(_)) {
+            self.stderr.with_mut(|s| s.close());
+        }
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn kill(
         this: &Self,
@@ -964,28 +976,18 @@ impl Subprocess<'_> {
             crate::webcore::file_sink::JSSink::set_destroy_callback(existing_stdin_value, 0);
         }
 
-        if self.flags.get().contains(Flags::IS_SYNC) {
-            // This doesn't match Node.js' behavior, but for synchronous
-            // subprocesses the streams should not keep the timers going.
-            if matches!(self.stdout.get(), Readable::Pipe(_)) {
-                self.stdout.with_mut(|s| s.close());
+        // Node.js keeps reading stdout/stderr until EOF after the direct child
+        // is reaped (a grandchild may still be writing). Sync and async both
+        // resume reads here; timeout/maxBuffer bound the sync wait.
+        if let Readable::Pipe(pipe) = self.stdout.get() {
+            if !pipe.reader.is_done() {
+                Readable::pipe_reader_mut(pipe).reader.read();
             }
+        }
 
-            if matches!(self.stderr.get(), Readable::Pipe(_)) {
-                self.stderr.with_mut(|s| s.close());
-            }
-        } else {
-            // This matches Node.js behavior. Node calls resume() on the streams.
-            if let Readable::Pipe(pipe) = self.stdout.get() {
-                if !pipe.reader.is_done() {
-                    Readable::pipe_reader_mut(pipe).reader.read();
-                }
-            }
-
-            if let Readable::Pipe(pipe) = self.stderr.get() {
-                if !pipe.reader.is_done() {
-                    Readable::pipe_reader_mut(pipe).reader.read();
-                }
+        if let Readable::Pipe(pipe) = self.stderr.get() {
+            if !pipe.reader.is_done() {
+                Readable::pipe_reader_mut(pipe).reader.read();
             }
         }
 

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -89,6 +89,10 @@ pub struct Execution {
     /// the entries themselves are owned by BunTest, which owns Execution.
     pub sequences: Box<[ExecutionSequence]>,
     pub group_index: usize,
+    /// The entry whose callback is synchronously on the stack right now. Set
+    /// around `run_test_callback` so code re-entered from a test body (e.g.
+    /// spawnSync's wait loop) can read the calling entry's own deadline.
+    pub on_stack_entry: core::cell::Cell<Option<NonNull<ExecutionEntry>>>,
 }
 
 pub struct ConcurrentGroup {
@@ -285,6 +289,7 @@ impl Execution {
             groups: Box::default(),
             sequences: Box::default(),
             group_index: 0,
+            on_stack_entry: core::cell::Cell::new(None),
         }
     }
 
@@ -1014,6 +1019,14 @@ fn step_sequence_one(
             }),
         };
         group_log::log(format_args!("runSequence queued callback: {}", callback_data));
+
+        let prev_on_stack = this.on_stack_entry.replace(Some(next_item_ptr));
+        let on_stack_cell = &raw const this.on_stack_entry;
+        // SAFETY: `on_stack_cell` points into `buntest.execution`, which is
+        // never moved during execution (arena-owned BunTest behind an Rc).
+        let _restore = scopeguard::guard((), move |()| unsafe {
+            (*on_stack_cell).set(prev_on_stack);
+        });
 
         if BunTest::run_test_callback(
             buntest_strong,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -159,12 +159,28 @@ impl<'a> TestRunner<'a> {
         let Some(active_file) = self.bun_test_root.active_file.as_deref() else {
             return bun_core::Timespec::EPOCH;
         };
-        // Per-entry deadline of the callback synchronously on the stack (file
-        // timer only advances sooner and can be stale; `on_stack_entry` also
-        // never picks up a sibling test.concurrent deadline).
+        // Per-entry deadline, not the (only-advances-sooner) file timer.
+        // `on_stack_entry` pins the caller when still synchronously on stack;
+        // else take the latest running entry so a sibling never terminates early.
         if let Some(entry) = active_file.execution.on_stack_entry.get() {
             // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
             return unsafe { entry.as_ref() }.timespec;
+        }
+        if active_file.phase == bun_test::Phase::Execution {
+            if let Some(group) = active_file.execution.active_group_ref() {
+                let mut latest = bun_core::Timespec::EPOCH;
+                for seq in group.sequences_const(&active_file.execution) {
+                    let Some(entry) = seq.active_entry else { continue };
+                    // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+                    let ts = unsafe { entry.as_ref() }.timespec;
+                    if ts.order(&latest) == core::cmp::Ordering::Greater {
+                        latest = ts;
+                    }
+                }
+                if !latest.eql(&bun_core::Timespec::EPOCH) {
+                    return latest;
+                }
+            }
         }
         if active_file.timer.state != TimerState::ACTIVE
             || active_file.timer.next == ElTimespec::EPOCH

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -159,20 +159,12 @@ impl<'a> TestRunner<'a> {
         let Some(active_file) = self.bun_test_root.active_file.as_deref() else {
             return bun_core::Timespec::EPOCH;
         };
-        // Per-entry deadline, not the file timer (which only advances sooner
-        // and can be stale). Single-sequence gate mirrors Execution::handle_timeout
-        // so a sibling test.concurrent deadline never kills the caller's child.
-        if active_file.phase == bun_test::Phase::Execution {
-            if let Some(group) = active_file.execution.active_group_ref() {
-                let seqs = group.sequences_const(&active_file.execution);
-                if let [seq] = seqs {
-                    if let Some(entry) = seq.active_entry {
-                        // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-                        return unsafe { entry.as_ref() }.timespec;
-                    }
-                }
-                return bun_core::Timespec::EPOCH;
-            }
+        // Per-entry deadline of the callback synchronously on the stack (file
+        // timer only advances sooner and can be stale; `on_stack_entry` also
+        // never picks up a sibling test.concurrent deadline).
+        if let Some(entry) = active_file.execution.on_stack_entry.get() {
+            // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+            return unsafe { entry.as_ref() }.timespec;
         }
         if active_file.timer.state != TimerState::ACTIVE
             || active_file.timer.next == ElTimespec::EPOCH

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -168,16 +168,16 @@ impl<'a> TestRunner<'a> {
         }
         if active_file.phase == bun_test::Phase::Execution {
             if let Some(group) = active_file.execution.active_group_ref() {
-                let mut latest = bun_core::Timespec::EPOCH;
+                let mut latest: Option<bun_core::Timespec> = None;
                 for seq in group.sequences_const(&active_file.execution) {
                     let Some(entry) = seq.active_entry else { continue };
                     // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
                     let ts = unsafe { entry.as_ref() }.timespec;
-                    if ts.order(&latest) == core::cmp::Ordering::Greater {
-                        latest = ts;
+                    if latest.is_none_or(|l| ts.order(&l) == core::cmp::Ordering::Greater) {
+                        latest = Some(ts);
                     }
                 }
-                if !latest.eql(&bun_core::Timespec::EPOCH) {
+                if let Some(latest) = latest {
                     return latest;
                 }
             }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -159,6 +159,21 @@ impl<'a> TestRunner<'a> {
         let Some(active_file) = self.bun_test_root.active_file.as_deref() else {
             return bun_core::Timespec::EPOCH;
         };
+        // Return the soonest per-entry deadline rather than the file timer:
+        // `update_min_timeout` only advances `timer.next` to sooner values, so
+        // the file timer can be stale (earlier than any running entry).
+        if active_file.phase == bun_test::Phase::Execution {
+            if let Some(group) = active_file.execution.active_group_ref() {
+                let mut soonest = bun_core::Timespec::EPOCH;
+                for seq in group.sequences_const(&active_file.execution) {
+                    let Some(entry) = seq.active_entry else { continue };
+                    // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+                    let ts = unsafe { entry.as_ref() }.timespec;
+                    soonest = soonest.min_ignore_epoch(ts);
+                }
+                return soonest;
+            }
+        }
         if active_file.timer.state != TimerState::ACTIVE
             || active_file.timer.next == ElTimespec::EPOCH
         {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -159,19 +159,19 @@ impl<'a> TestRunner<'a> {
         let Some(active_file) = self.bun_test_root.active_file.as_deref() else {
             return bun_core::Timespec::EPOCH;
         };
-        // Return the soonest per-entry deadline rather than the file timer:
-        // `update_min_timeout` only advances `timer.next` to sooner values, so
-        // the file timer can be stale (earlier than any running entry).
+        // Per-entry deadline, not the file timer (which only advances sooner
+        // and can be stale). Single-sequence gate mirrors Execution::handle_timeout
+        // so a sibling test.concurrent deadline never kills the caller's child.
         if active_file.phase == bun_test::Phase::Execution {
             if let Some(group) = active_file.execution.active_group_ref() {
-                let mut soonest = bun_core::Timespec::EPOCH;
-                for seq in group.sequences_const(&active_file.execution) {
-                    let Some(entry) = seq.active_entry else { continue };
-                    // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-                    let ts = unsafe { entry.as_ref() }.timespec;
-                    soonest = soonest.min_ignore_epoch(ts);
+                let seqs = group.sequences_const(&active_file.execution);
+                if let [seq] = seqs {
+                    if let Some(entry) = seq.active_entry {
+                        // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+                        return unsafe { entry.as_ref() }.timespec;
+                    }
                 }
-                return soonest;
+                return bun_core::Timespec::EPOCH;
             }
         }
         if active_file.timer.state != TimerState::ACTIVE

--- a/test/js/bun/spawn/spawnSync-counters-fixture.ts
+++ b/test/js/bun/spawn/spawnSync-counters-fixture.ts
@@ -4,7 +4,7 @@ import { getCounters } from "bun:internal-for-testing";
 const before = getCounters();
 const result = spawnSync({
   cmd: ["sleep", "0.00001"],
-  stdout: process.platform === "linux" ? "pipe" : "inherit",
+  stdout: "inherit",
   stderr: "inherit",
   stdin: "inherit",
 });
@@ -12,8 +12,4 @@ const after = getCounters();
 
 if (!(after.spawnSync_blocking > before.spawnSync_blocking)) {
   throw new Error("spawnSync_blocking should have been incremented");
-}
-
-if (process.platform === "linux" && !(after.spawn_memfd > before.spawn_memfd)) {
-  throw new Error("spawn_memfd should have been incremented");
 }

--- a/test/js/bun/spawn/spawnSync-memfd-fixture.ts
+++ b/test/js/bun/spawn/spawnSync-memfd-fixture.ts
@@ -5,8 +5,8 @@ const before = getCounters();
 const result = spawnSync({
   cmd: ["sleep", "0.00001"],
   stdout: "inherit",
-  stderr: "pipe",
-  stdin: "pipe",
+  stderr: "inherit",
+  stdin: new Uint8Array([104, 105]),
 });
 const after = getCounters();
 

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -40,6 +40,43 @@ describe("spawnSync", () => {
   it.skipIf(!isPosix)("should use spawnSync optimizations when possible", () => {
     expect([join(import.meta.dir, "spawnSync-counters-fixture.ts")]).toRun();
   });
+
+  describe.skipIf(!isPosix)("drains piped stdio to EOF after the direct child exits", () => {
+    // Grandchild inherits the pipe and writes after the direct child has exited.
+    const sh = (fd: number) => [
+      "/bin/sh",
+      "-c",
+      `printf A >&${fd}; ( sleep 0.3; printf B >&${fd}; sleep 0.1; printf C >&${fd} ) & exit 0`,
+    ];
+    for (const maxBuffer of [undefined, 1024 * 1024]) {
+      it(`stdout (maxBuffer=${maxBuffer})`, () => {
+        const { stdout, exitCode } = Bun.spawnSync({
+          cmd: sh(1),
+          stdio: ["ignore", "pipe", "ignore"],
+          maxBuffer,
+        });
+        expect({ stdout: stdout.toString(), exitCode }).toEqual({ stdout: "ABC", exitCode: 0 });
+      });
+      it(`stderr (maxBuffer=${maxBuffer})`, () => {
+        const { stderr, exitCode } = Bun.spawnSync({
+          cmd: sh(2),
+          stdio: ["ignore", "ignore", "pipe"],
+          maxBuffer,
+        });
+        expect({ stderr: stderr.toString(), exitCode }).toEqual({ stderr: "ABC", exitCode: 0 });
+      });
+    }
+
+    it("timeout still bounds the wait when a grandchild never closes the pipe", () => {
+      const { stdout, exitedDueToTimeout } = Bun.spawnSync({
+        cmd: ["/bin/sh", "-c", "printf A; sleep 5 & exit 0"],
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 500,
+      });
+      // The grandchild holds the pipe open and writes nothing; timeout must fire.
+      expect({ stdout: stdout.toString(), exitedDueToTimeout }).toEqual({ stdout: "A", exitedDueToTimeout: true });
+    });
+  });
 });
 
 describe("uid/gid", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -440,9 +440,14 @@ describe("spawnSync()", () => {
     // Node.js documents spawnSync as not returning until the child process has
     // fully closed, i.e. every pipe has been read to EOF even when a grandchild
     // that inherited the pipe is still writing after the direct child exited.
-    const cmd = ["-c", `printf A; ( sleep 0.3; printf B ) & exit 0`];
-    const { stdout, status, signal } = spawnSync("/bin/sh", cmd, { stdio: ["ignore", "pipe", "ignore"] });
-    expect({ stdout: String(stdout), status, signal }).toEqual({ stdout: "AB", status: 0, signal: null });
+    const cmd = ["-c", `printf A; printf C >&2; ( sleep 0.3; printf B; printf D >&2 ) & exit 0`];
+    const { stdout, stderr, status, signal } = spawnSync("/bin/sh", cmd, { stdio: ["ignore", "pipe", "pipe"] });
+    expect({ stdout: String(stdout), stderr: String(stderr), status, signal }).toEqual({
+      stdout: "AB",
+      stderr: "CD",
+      status: 0,
+      signal: null,
+    });
   });
 });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -435,6 +435,15 @@ describe("spawnSync()", () => {
     expect(detachedPgid).toMatch(/^\d+$/);
     expect(detachedPgid).not.toBe(parentPgid);
   });
+
+  it.skipIf(isWindows)("drains piped stdio to EOF after the direct child exits", () => {
+    // Node.js documents spawnSync as not returning until the child process has
+    // fully closed, i.e. every pipe has been read to EOF even when a grandchild
+    // that inherited the pipe is still writing after the direct child exited.
+    const cmd = ["-c", `printf A; ( sleep 0.3; printf B ) & exit 0`];
+    const { stdout, status, signal } = spawnSync("/bin/sh", cmd, { stdio: ["ignore", "pipe", "ignore"] });
+    expect({ stdout: String(stdout), status, signal }).toEqual({ stdout: "AB", status: 0, signal: null });
+  });
 });
 
 describe("execFileSync()", () => {


### PR DESCRIPTION
## Reproduction

```js
import { spawnSync } from "node:child_process";
const CMD = ["-c", 'printf A; ( sleep 0.3; printf B ) & exit 0'];
const r = spawnSync("/bin/sh", CMD, { stdio: ["ignore", "pipe", "ignore"] });
console.log(String(r.stdout));
// node : "AB"
// bun  : "A"   <- "B" written by the grandchild after the direct child exited is lost
```

The same happens for `Bun.spawnSync`. `status` is 0 and nothing signals the truncation. The async `child_process.spawn` path already delivers `"AB"` on `close`, so this is specifically the sync path's EOF contract.

## Cause

`Subprocess::on_process_exit` closed the stdout/stderr pipe readers on the `IS_SYNC` path the moment the direct child was reaped (the existing comment there already noted it did not match Node.js). The sync wait loop in `spawn_maybe_sync` then observed no pending stdio activity and returned.

On Linux, `Bun.spawnSync` with `stdio: "pipe"` and no `maxBuffer` also replaced the pipe with a memfd; a memfd is a file with no EOF signal when the last writer closes, so bytes written by a surviving grandchild after the memfd was read back were unobservable regardless of the `on_process_exit` behaviour.

## Fix

* `on_process_exit` now resumes reads on stdout/stderr for both sync and async, the same way the async path already did. The sync wait loop already keys off `has_pending_activity_stdio()`, so it keeps ticking until every pipe reaches EOF. This is how Node's `SyncProcessRunner` works: `OnExit()` does not close stdio; `uv_run` returns once every pipe has EOF'd.
* When the sync wait is being terminated early (user `timeout`, `maxBuffer`), the pipe readers are closed from the wait loop after the tick so a grandchild holding the write end cannot keep the wait alive. This mirrors Node's `SyncProcessRunner::Kill()`, which closes stdio pipes after sending the kill signal.
* `Stdio::can_use_memfd` no longer upgrades `"pipe"` to a memfd; memfd is still used for `ArrayBuffer`/`Blob` stdin. The two `spawn_memfd` / `spawnSync_blocking` counter fixtures are updated to keep asserting what is still true (memfd for a `Uint8Array` stdin, blocking fast path with no piped stdio).

Node's drain-to-EOF also means `spawnSync` of a command whose grandchild never closes the pipe will block until `timeout` / `maxBuffer`; that is Node's documented behaviour and is now Bun's as well.

## Verification

```
# before
$ bun test/repro.mjs
{"cpSync":"A","bunSync":"A","cpAsyncAtClose":"AB"}

# after
$ bun bd test/repro.mjs
{"cpSync":"AB","bunSync":"AB","cpAsyncAtClose":"AB"}
```

New tests in `test/js/bun/spawn/spawnSync.test.ts` cover stdout/stderr with and without `maxBuffer`, and that `timeout` still bounds the wait when a grandchild never closes the pipe; a matching `node:child_process` `spawnSync` test lives in `test/js/node/child_process/child_process.test.ts`. The Node `parallel/test-child-process-spawnsync*` suite continues to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawnSync.test.ts test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->