### PR TITLE
test_runner: clear pending exception when diff formatting fails

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,31 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+            {
+                global_this.clear_exception_except_termination();
+            }
 
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+            {
+                global_this.clear_exception_except_termination();
+            }
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/test/js/bun/test/expect-diff-proxy-throw.test.ts
+++ b/test/js/bun/test/expect-diff-proxy-throw.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect diff does not crash when prototype has trap throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const handler = { has() { throw new Error("trap threw"); } };
+      const received = { a: 1 };
+      Object.setPrototypeOf(received, new Proxy(Object.prototype, handler));
+      const { expect } = Bun.jest("x");
+      let msg = "";
+      try { expect(received).toEqual({}); } catch (e) { msg = e.message; }
+      if (!msg.includes("toEqual")) throw new Error("wrong error: " + msg);
+      try { expect(received).toStrictEqual({}); } catch (e) { msg = e.message; }
+      if (!msg.includes("toStrictEqual")) throw new Error("wrong error: " + msg);
+      console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "ok",
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/test/expect-diff-proxy-throw.test.ts
+++ b/test/js/bun/test/expect-diff-proxy-throw.test.ts
@@ -23,11 +23,7 @@ test("expect diff does not crash when prototype has trap throws", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
     stdout: "ok",


### PR DESCRIPTION
Fuzzilli found a debug assertion crash (fingerprint `d127caecba2b9edd`) in `ExceptionScope::assertNoExceptionExceptTermination` triggered through `expect().toEqual()` / `toStrictEqual()`.

`DiffFormatter` is a `fmt::Display` impl so it cannot propagate `JsError`; it discards the `JsResult` from `JestPrettyFormat::format` with `let _ = ...`. When formatting the received value triggers a throwing proxy trap (the repro installs a throwing `has` trap on the prototype, hit while resolving `Symbol.toStringTag`), the VM exception stays pending. The second format call (or any later host entry that asserts no pending exception) then aborts in debug builds. In release builds the stale exception surfaces in place of the matcher failure message, so the user sees the proxy trap error instead of `expect(received).toEqual(expected)`.

Repro:
```js
const received = { a: 1 };
Object.setPrototypeOf(received, new Proxy(Object.prototype, { has() { throw new Error("boom"); } }));
Bun.jest("x").expect(received).toEqual({});
```

Fix: clear any pending non-termination exception when the format call fails, matching the existing intent to swallow formatting errors here.