### PR TITLE
crypto: fix generatePrime hangs with add/rem and with small safe sizes

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -547,6 +547,61 @@ bool BignumPointer::generate(const PrimeConfig& params,
             },
             &innerCb);
     }
+
+    // BoringSSL's probable_prime_dh() (the non-safe add/rem path inside
+    // BN_generate_prime_ex) applies the safe-prime trial-division criterion
+    // `rnd mod p <= 1` instead of `== 0`, and never re-randomizes or re-clamps
+    // the candidate to the requested bit range. For any odd prime q dividing
+    // `add`, `rnd mod q` is invariant across steps of `add`, so a start with
+    // `rnd mod q == 1` loops forever; and for small sizes the walk can return
+    // values well above the requested bit length. Implement OpenSSL's
+    // bn_probable_prime_dh semantics here and let BN_is_prime_fasttest_ex do
+    // the (correct) trial division.
+    if (params.add.get() != nullptr && !params.safe && params.bits >= 2) {
+        BignumCtxPointer ctx(BN_CTX_new());
+        BignumPointer t1(BN_new());
+        if (!ctx || !t1) [[unlikely]]
+            return false;
+        BIGNUM* rnd = get();
+        const BIGNUM* add = params.add.get();
+        const BIGNUM* rem = params.rem.get();
+        const unsigned bits = static_cast<unsigned>(params.bits);
+        int c1 = 0;
+        for (;;) {
+            if (!BN_rand(rnd, bits, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD))
+                return false;
+            // we need (rnd - rem) % add == 0
+            if (!BN_mod(t1.get(), rnd, add, ctx.get()))
+                return false;
+            if (!BN_sub(rnd, rnd, t1.get()))
+                return false;
+            if (rem == nullptr) {
+                if (!BN_add_word(rnd, 1))
+                    return false;
+            } else {
+                if (!BN_add(rnd, rnd, rem))
+                    return false;
+            }
+            if (BN_num_bits(rnd) < bits || BN_cmp_word(rnd, 3) < 0) {
+                if (!BN_add(rnd, rnd, add))
+                    return false;
+            }
+            for (;;) {
+                if (BN_num_bits(rnd) != bits)
+                    break;
+                if (!BN_GENCB_call(cb.get(), BN_GENCB_GENERATED, c1++))
+                    return false;
+                int r = BN_is_prime_fasttest_ex(rnd, BN_prime_checks_for_generation, ctx.get(), 1, cb.get());
+                if (r < 0)
+                    return false;
+                if (r == 1)
+                    return true;
+                if (!BN_add(rnd, rnd, add))
+                    return false;
+            }
+        }
+    }
+
     if (BN_generate_prime_ex(get(),
             params.bits,
             params.safe ? 1 : 0,

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -531,8 +531,7 @@ BignumPointer BignumPointer::NewPrime(const PrimeConfig& params,
 bool BignumPointer::generate(const PrimeConfig& params,
     PrimeCheckCallback innerCb) const
 {
-    // Same check as OpenSSL's BN_generate_prime_ex2: the only safe prime
-    // BoringSSL can reach below 6 bits is 7, so sizes 4 and 5 never terminate.
+    // Input check from OpenSSL's BN_generate_prime_ex2.
     if (params.safe && params.add.get() == nullptr && params.bits < 6 && params.bits != 3) {
         ERR_put_error(ERR_LIB_BN, 0, BN_R_BITS_TOO_SMALL, __FILE__, __LINE__);
         return false;
@@ -555,9 +554,7 @@ bool BignumPointer::generate(const PrimeConfig& params,
             &innerCb);
     }
 
-    // OpenSSL's bn_probable_prime_dh. BoringSSL's probable_prime_dh() rejects
-    // candidates with `rnd mod p <= 1`, which never terminates once a prime
-    // factor of `add` divides rnd - 1, and it never re-clamps rnd to `bits`.
+    // OpenSSL's bn_probable_prime_dh, in place of BoringSSL's probable_prime_dh.
     if (params.add.get() != nullptr && !params.safe && params.bits >= 2) {
         BignumCtxPointer ctx(BN_CTX_new());
         BignumPointer t1(BN_new());

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -531,10 +531,8 @@ BignumPointer BignumPointer::NewPrime(const PrimeConfig& params,
 bool BignumPointer::generate(const PrimeConfig& params,
     PrimeCheckCallback innerCb) const
 {
-    // BN_generate_prime_ex draws safe-prime candidates with the top two bits
-    // set, so below 6 bits the only safe prime it can reach is 7 (3 bits); 11
-    // and 23 are unreachable and sizes 4 and 5 loop forever. OpenSSL rejects
-    // these sizes up front (BN_generate_prime_ex2); BoringSSL only rejects 2.
+    // Same check as OpenSSL's BN_generate_prime_ex2: the only safe prime
+    // BoringSSL can reach below 6 bits is 7, so sizes 4 and 5 never terminate.
     if (params.safe && params.add.get() == nullptr && params.bits < 6 && params.bits != 3) {
         ERR_put_error(ERR_LIB_BN, 0, BN_R_BITS_TOO_SMALL, __FILE__, __LINE__);
         return false;
@@ -557,15 +555,9 @@ bool BignumPointer::generate(const PrimeConfig& params,
             &innerCb);
     }
 
-    // BoringSSL's probable_prime_dh() (the non-safe add/rem path inside
-    // BN_generate_prime_ex) applies the safe-prime trial-division criterion
-    // `rnd mod p <= 1` instead of `== 0`, and never re-randomizes or re-clamps
-    // the candidate to the requested bit range. For any odd prime q dividing
-    // `add`, `rnd mod q` is invariant across steps of `add`, so a start with
-    // `rnd mod q == 1` loops forever; and for small sizes the walk can return
-    // values well above the requested bit length. Implement OpenSSL's
-    // bn_probable_prime_dh semantics here and let BN_is_prime_fasttest_ex do
-    // the (correct) trial division.
+    // OpenSSL's bn_probable_prime_dh. BoringSSL's probable_prime_dh() rejects
+    // candidates with `rnd mod p <= 1`, which never terminates once a prime
+    // factor of `add` divides rnd - 1, and it never re-clamps rnd to `bits`.
     if (params.add.get() != nullptr && !params.safe && params.bits >= 2) {
         BignumCtxPointer ctx(BN_CTX_new());
         BignumPointer t1(BN_new());

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -531,6 +531,15 @@ BignumPointer BignumPointer::NewPrime(const PrimeConfig& params,
 bool BignumPointer::generate(const PrimeConfig& params,
     PrimeCheckCallback innerCb) const
 {
+    // BN_generate_prime_ex draws safe-prime candidates with the top two bits
+    // set, so below 6 bits the only safe prime it can reach is 7 (3 bits); 11
+    // and 23 are unreachable and sizes 4 and 5 loop forever. OpenSSL rejects
+    // these sizes up front (BN_generate_prime_ex2); BoringSSL only rejects 2.
+    if (params.safe && params.add.get() == nullptr && params.bits < 6 && params.bits != 3) {
+        ERR_put_error(ERR_LIB_BN, 0, BN_R_BITS_TOO_SMALL, __FILE__, __LINE__);
+        return false;
+    }
+
     // BN_generate_prime_ex() calls RAND_bytes_ex() internally.
     // Make sure the CSPRNG is properly seeded.
     std::ignore = CSPRNG(nullptr, 0);

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { checkPrime, checkPrimeSync, generatePrime, generatePrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
+import {
+  checkPrime,
+  checkPrimeSync,
+  generatePrime,
+  generatePrimeSync,
+  randomBytes,
+  randomFill,
+  randomFillSync,
+  randomInt,
+} from "crypto";
 import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
 import { join } from "path";
 
@@ -232,11 +241,24 @@ describe("generatePrime with add/rem", () => {
   `;
 
   function checkResults(
-    results: Array<{ bits: number; add: string; rem?: string; p: string; numBits: number; mod: string; isPrime: boolean }>,
+    results: Array<{
+      bits: number;
+      add: string;
+      rem?: string;
+      p: string;
+      numBits: number;
+      mod: string;
+      isPrime: boolean;
+    }>,
   ) {
     expect(results).toHaveLength(cases.length);
     for (const r of results) {
-      expect({ case: `${r.bits} add=${r.add} rem=${r.rem}`, numBits: r.numBits, mod: r.mod, isPrime: r.isPrime }).toEqual({
+      expect({
+        case: `${r.bits} add=${r.add} rem=${r.rem}`,
+        numBits: r.numBits,
+        mod: r.mod,
+        isPrime: r.isPrime,
+      }).toEqual({
         case: `${r.bits} add=${r.add} rem=${r.rem}`,
         numBits: r.bits,
         mod: r.rem ?? "1",

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { checkPrime, checkPrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
+import { checkPrime, checkPrimeSync, generatePrime, generatePrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
 import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
 import { join } from "path";
 
@@ -187,6 +187,162 @@ describe("randomFill default size with multi-byte typed arrays", () => {
       if (bytes.subarray(744, 800).some(b => b !== 0)) tailFilled = true;
     }
     expect(tailFilled).toBe(true);
+  });
+});
+
+describe("generatePrime with add/rem", () => {
+  // BoringSSL's probable_prime_dh() applies the safe-prime trial-division
+  // criterion (rnd mod p <= 1) to the non-safe search and never re-randomizes,
+  // so for any odd prime q dividing `add` a start with rnd mod q == 1 loops
+  // forever. It also doesn't clamp the walk to the requested bit length. Bun
+  // implements OpenSSL's search in BignumPointer::generate() instead.
+
+  const cases: Array<[number, { add: bigint; rem?: bigint }]> = [
+    [16, { add: 3n, rem: 1n }],
+    [64, { add: 30n }],
+    [64, { add: 30n, rem: 7n }],
+    [8, { add: 11n, rem: 4n }],
+    [8, { add: 7n, rem: 3n }],
+    [32, { add: 12n, rem: 5n }],
+    // Cases that already worked previously:
+    [64, { add: 4n, rem: 3n }],
+    [64, { add: 2n }],
+  ];
+  const fixture = `
+    const { generatePrimeSync, checkPrimeSync } = require("crypto");
+    const cases = ${JSON.stringify(cases, (_, v) => (typeof v === "bigint" ? "BIGINT:" + v : v))};
+    const revive = o => Object.fromEntries(
+      Object.entries(o).map(([k, v]) => [k, typeof v === "string" && v.startsWith("BIGINT:") ? BigInt(v.slice(7)) : v]),
+    );
+    const out = [];
+    for (const [bits, rawOpts] of cases) {
+      const opts = revive(rawOpts);
+      const p = generatePrimeSync(bits, { ...opts, bigint: true });
+      out.push({
+        bits,
+        add: String(opts.add),
+        rem: opts.rem !== undefined ? String(opts.rem) : undefined,
+        p: String(p),
+        numBits: p.toString(2).length,
+        mod: String(p % opts.add),
+        isPrime: checkPrimeSync(p),
+      });
+    }
+    process.stdout.write(JSON.stringify(out));
+  `;
+
+  function checkResults(
+    results: Array<{ bits: number; add: string; rem?: string; p: string; numBits: number; mod: string; isPrime: boolean }>,
+  ) {
+    expect(results).toHaveLength(cases.length);
+    for (const r of results) {
+      expect({ case: `${r.bits} add=${r.add} rem=${r.rem}`, numBits: r.numBits, mod: r.mod, isPrime: r.isPrime }).toEqual({
+        case: `${r.bits} add=${r.add} rem=${r.rem}`,
+        numBits: r.bits,
+        mod: r.rem ?? "1",
+        isPrime: true,
+      });
+    }
+  }
+
+  it("generatePrimeSync terminates and honors the requested bit length", async () => {
+    // Run in a subprocess with a kill guard: before the fix these inputs loop
+    // forever at 100% CPU and the sync form wedges the whole process.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 4500,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, signalCode: proc.signalCode }).toEqual({ stderr: "", signalCode: null });
+    expect(exitCode).toBe(0);
+    checkResults(JSON.parse(stdout));
+  });
+
+  it("generatePrime (async) calls back for add/rem inputs that previously hung", async () => {
+    // Run in a subprocess: before the fix each call permanently consumes a
+    // threadpool thread at 100% CPU and the callback never fires, so an
+    // in-process test would leave spinning threads behind for the rest of the
+    // suite even after timing out.
+    const asyncFixture = `
+      const { generatePrime, checkPrimeSync } = require("crypto");
+      const cases = ${JSON.stringify(cases, (_, v) => (typeof v === "bigint" ? "BIGINT:" + v : v))};
+      const revive = o => Object.fromEntries(
+        Object.entries(o).map(([k, v]) => [k, typeof v === "string" && v.startsWith("BIGINT:") ? BigInt(v.slice(7)) : v]),
+      );
+      Promise.all(cases.map(([bits, rawOpts]) => new Promise((resolve, reject) => {
+        const opts = revive(rawOpts);
+        generatePrime(bits, { ...opts, bigint: true }, (err, p) => {
+          if (err) return reject(err);
+          resolve({
+            bits,
+            add: String(opts.add),
+            rem: opts.rem !== undefined ? String(opts.rem) : undefined,
+            p: String(p),
+            numBits: p.toString(2).length,
+            mod: String(p % opts.add),
+            isPrime: checkPrimeSync(p),
+          });
+        });
+      }))).then(out => process.stdout.write(JSON.stringify(out)), err => { console.error(err); process.exit(1); });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", asyncFixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 4500,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, signalCode: proc.signalCode }).toEqual({ stderr: "", signalCode: null });
+    expect(exitCode).toBe(0);
+    checkResults(JSON.parse(stdout));
+  });
+
+  it("generatePrimeSync returns fresh values on repeated calls", async () => {
+    // Before the fix, size=8 add=7 rem=3 returned 7703 (13 bits) on every call
+    // in every process. 8-bit primes that are 3 (mod 7): 17 of them, so 64
+    // independent draws collapsing to one value has probability < 17^-63.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { generatePrimeSync } = require("crypto");
+         const seen = new Set();
+         for (let i = 0; i < 64; i++) {
+           const p = generatePrimeSync(8, { add: 7n, rem: 3n, bigint: true });
+           seen.add(String(p));
+           if (p.toString(2).length !== 8) { console.log("BADBITS:" + p); process.exit(1); }
+         }
+         process.stdout.write(String(seen.size));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 4500,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout, signalCode: proc.signalCode }).toEqual({
+      stderr: "",
+      stdout: expect.stringMatching(/^\d+$/),
+      signalCode: null,
+    });
+    expect(Number(stdout)).toBeGreaterThan(1);
+    expect(exitCode).toBe(0);
+  });
+
+  it("generatePrime without add still works", async () => {
+    const p = generatePrimeSync(64, { bigint: true });
+    expect(p.toString(2).length).toBe(64);
+    expect(checkPrimeSync(p)).toBe(true);
+
+    const q = await new Promise<bigint>((resolve, reject) => {
+      generatePrime(64, { bigint: true }, (err, p) => (err ? reject(err) : resolve(p as bigint)));
+    });
+    expect(q.toString(2).length).toBe(64);
+    expect(checkPrimeSync(q)).toBe(true);
   });
 });
 

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -368,6 +368,61 @@ describe("generatePrime with add/rem", () => {
   });
 });
 
+describe("generatePrime with safe and small sizes", () => {
+  // BN_generate_prime_ex draws safe-prime candidates with the top two bits set,
+  // so below 6 bits the only safe prime it can reach is 7 (size 3): sizes 4 and
+  // 5 used to spin forever (11 and 23 are unreachable), the sync form wedging
+  // the process and the async form never calling back. BoringSSL itself already
+  // rejects size 2 with BN_R_BITS_TOO_SMALL; sizes 4 and 5 must now be rejected
+  // the same way, whatever form the binding surfaces that rejection in.
+  const fixture = `
+    const { generatePrime, generatePrimeSync } = require("crypto");
+    const outcome = fn => {
+      try { return "value:" + String(fn()); } catch (e) { return "error:" + e.code; }
+    };
+    const sync = {};
+    for (const bits of [2, 4, 5]) sync[bits] = outcome(() => generatePrimeSync(bits, { safe: true, bigint: true }));
+    const reachable = {};
+    for (const bits of [3, 6, 7]) reachable[bits] = String(generatePrimeSync(bits, { safe: true, bigint: true }));
+    Promise.all(
+      [2, 4, 5].map(bits => new Promise(resolve => {
+        generatePrime(bits, { safe: true, bigint: true }, (err, p) => resolve(err ? "error:" + err.code : "value:" + String(p)));
+      })),
+    ).then(([two, four, five]) => {
+      process.stdout.write(JSON.stringify({ sync, async: { 2: two, 4: four, 5: five }, reachable }));
+    });
+  `;
+
+  it("rejects sizes 4 and 5 the same way as size 2 instead of looping forever", async () => {
+    // Subprocess with a kill guard: before the fix generatePrimeSync(4) never returns.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 4500,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, signalCode: proc.signalCode }).toEqual({ stderr: "", signalCode: null });
+    expect(exitCode).toBe(0);
+
+    const result: {
+      sync: Record<string, string>;
+      async: Record<string, string>;
+      reachable: Record<string, string>;
+    } = JSON.parse(stdout);
+    expect(result).toEqual({
+      sync: { 2: result.sync[2], 4: result.sync[2], 5: result.sync[2] },
+      async: { 2: result.async[2], 4: result.async[2], 5: result.async[2] },
+      // The only safe prime with the top two bits set at each of these sizes.
+      reachable: { 3: "7", 6: "59", 7: "107" },
+    });
+    // Whatever size 2 produces, it is a rejection, not a prime.
+    expect(result.sync[2]).not.toMatch(/^value:[1-9]/);
+    expect(result.async[2]).not.toMatch(/^value:[1-9]/);
+  });
+});
+
 describe("checkPrime candidate handling", () => {
   it("checkPrimeSync uses the candidate bytes provided at call time", () => {
     expect(checkPrimeSync(Buffer.from([7]), { checks: 1 })).toBe(true);


### PR DESCRIPTION
### Problem

Two ways `crypto.generatePrime` / `generatePrimeSync` loop forever at 100% CPU on valid input (the sync form wedges the process; the async form never calls back and pins a threadpool thread per call), plus one wrong-output face:

```js
import crypto from "node:crypto";

// 1. add/rem (non-safe). Every one of these hangs; node answers each in <15ms.
crypto.generatePrimeSync(16, { add: 3n, rem: 1n, bigint: true });
crypto.generatePrimeSync(64, { add: 30n, bigint: true });
crypto.generatePrimeSync(64, { add: 30n, rem: 7n, bigint: true });
crypto.generatePrimeSync(8,  { add: 11n, rem: 4n, bigint: true });

// 2. add/rem at small sizes: returns 7703n (13 bits) on every call in every
//    process. Node returns a fresh 8-bit prime each time.
crypto.generatePrimeSync(8, { add: 7n, rem: 3n, bigint: true });

// 3. safe without add at sizes 4 and 5: hangs. Node throws
//    ERR_OSSL_BN_BITS_TOO_SMALL. Sizes 3, 6, 7 return 7, 59, 107 on both.
crypto.generatePrimeSync(4, { safe: true, bigint: true });
crypto.generatePrimeSync(5, { safe: true, bigint: true });
```

Anywhere `size`, `add` or `rem` come from configuration or request data this is a one-line DoS.

### Cause

Both are in the vendored BoringSSL (`crypto/fipsmodule/bn/prime.cc.inc`), which is fetched at build time, so the fix lives in bun's wrapper, `ncrypto::BignumPointer::generate()` (`src/jsc/bindings/ncrypto.cpp`).

- Faces 1 and 2: `probable_prime_dh()` (the non-safe `add`/`rem` path of `BN_generate_prime_ex`) rejects a candidate when `rnd mod p <= 1` for any small prime `p`. That is the safe-prime criterion; OpenSSL's non-safe path uses `== 0`. The candidate only ever steps by `add`, so `rnd mod q` is invariant for every odd prime `q | add`, and a start with `rnd mod q == 1` is rejected forever. Omitting `rem` defaults it to 1, which is why plain `{add: 30n}` hangs. The walk also never checks the bit length, so at small sizes it runs off the end of the range and stops on the same value every time (7703 for size 8 / add 7 / rem 3).
- Face 3: `BN_generate_prime_ex` draws safe-prime candidates with the top two bits set, so below 6 bits the only safe prime it can reach is 7 (size 3); 11 and 23 are unreachable. OpenSSL's `BN_generate_prime_ex2` rejects `safe && add == NULL && bits < 6 && bits != 3` with `BN_R_BITS_TOO_SMALL` up front. BoringSSL only rejects size 2.

### Fix

- Non-safe `add`/`rem`: implement OpenSSL's `bn_probable_prime_dh` search in `generate()`: random start, snap onto the progression, walk by `add`, re-randomize whenever the candidate leaves the requested bit length, and use `BN_is_prime_fasttest_ex` (correct `== 0` trial division plus Miller-Rabin) for the test.
- Safe without `add`: the same input check OpenSSL applies, pushing `BN_R_BITS_TOO_SMALL` on the error queue so it fails exactly like size 2 already does. Today the binding turns that into `0n`; #33837 (separate, open) makes it a thrown `ERR_OSSL_BN_BITS_TOO_SMALL`, at which point sizes 4 and 5 match node with no further change here. #33837 also fixes the `return -1` in this function, so that line is left alone to avoid overlapping it.
- The no-`add` and `safe`+`add` paths still delegate to `BN_generate_prime_ex` unchanged. (`safe`+`add` has a small-size oversized-output face of its own in `probable_prime_dh_safe`, e.g. 13-bit results for an 8-bit request; it does not hang and is tracked separately.)

Verification, all in `test/js/node/crypto/crypto-random.test.ts` (subprocesses with a kill guard so the unfixed build fails instead of hanging the runner):

- `generatePrime with add/rem`: each formerly hanging input, sync and async, asserting bit length, residue and primality; the size 8 case asserting fresh values across 64 calls; controls for the unaffected paths.
- `generatePrime with safe and small sizes`: sizes 4 and 5 must produce exactly what size 2 produces, sync and async (holds before and after #33837), and sizes 3, 6, 7 must return 7, 59, 107.

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/crypto/crypto-random.test.ts -t generatePrime
  4 fail (3 SIGTERM on the hangs, 1 BADBITS:7703), 1 pass (control)
$ bun bd test test/js/node/crypto/crypto-random.test.ts
  27 pass, 0 fail
```

`test/js/node/test/parallel/test-crypto-prime.js` still passes.

### Background

- `generatePrime(size, {add, rem})` asks for a prime `p` with `p % add == rem` (DH-style parameter generation). `safe: true` asks for `p` such that `(p-1)/2` is also prime.
- Prime search works by picking a random candidate, rejecting it quickly by trial division against small primes, then running Miller-Rabin on survivors. With `add`/`rem` the candidates are not independent draws but an arithmetic progression, which is why a wrong rejection rule turns into a non-terminating loop rather than just a slower search.
- `BN_GENCB` is the progress callback OpenSSL/BoringSSL invoke during generation; bun always passes one, and the new loop calls it at the same points `BN_generate_prime_ex` would.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/crypto/crypto-random.test.ts

<!-- robobun:evidence:end -->