### PR TITLE
fs: honor string encoding option in readlink

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7565,7 +7565,7 @@ impl NodeFS {
             Encoding::Buffer => {
                 StringOrBuffer::Buffer(Buffer::from_string(link_path).expect("unreachable"))
             }
-            _ => {
+            Encoding::Utf8 => {
                 if let PathLike::SliceWithUnderlyingString(s) = &args.path {
                     if strings::eql_long(s.slice(), link_path, true) {
                         return Ok(StringOrBuffer::String(s.dupe_ref()));
@@ -7576,6 +7576,10 @@ impl NodeFS {
                     ..Default::default()
                 })
             }
+            enc => StringOrBuffer::String(node::SliceWithUnderlyingString {
+                underlying: webcore::encoding::to_bun_string(link_path, enc),
+                ..Default::default()
+            }),
         })
     }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2397,6 +2397,39 @@ it.skipIf(isWindows)("readlink with PATH_MAX-1 target", () => {
   expect(readlinkSync(link)).toBe(target);
 });
 
+describe.skipIf(isWindows)("readlink encoding option", () => {
+  const readlinkCb = promisify(fs.readlink);
+  // A symlink target on POSIX is an arbitrary byte string. `readlink(path, enc)`
+  // must encode those raw bytes with `enc` (Buffer.toString semantics), not
+  // UTF-8-decode them first.
+  it.each(["latin1", "ascii", "hex", "base64", "base64url", "ucs2", "utf16le"] as const)(
+    "honors %p for the link target bytes (sync/callback/promises)",
+    async enc => {
+      const dir = tmpdirSync();
+      const link = join(dir, "a");
+      symlinkSync("tést-ü", link);
+      const want = readlinkSync(link, "buffer").toString(enc);
+      expect({
+        positional: readlinkSync(link, enc),
+        object: readlinkSync(link, { encoding: enc }),
+        callback: await readlinkCb(link, enc),
+        promises: await promises.readlink(link, enc),
+      }).toEqual({ positional: want, object: want, callback: want, promises: want });
+    },
+  );
+
+  it("latin1 round-trips a non-UTF-8 link target losslessly", async () => {
+    const dir = tmpdirSync();
+    const link = join(dir, "b");
+    symlinkSync(Buffer.from([0x66, 0xff, 0x62]), link);
+    expect({
+      sync: readlinkSync(link, "latin1"),
+      promises: await promises.readlink(link, { encoding: "latin1" }),
+      hex: readlinkSync(link, "hex"),
+    }).toEqual({ sync: "f\u00ffb", promises: "f\u00ffb", hex: "66ff62" });
+  });
+});
+
 it.if(isWindows)("symlink on windows with forward slashes", async () => {
   const r = tmpdirSync();
   await fs.promises.rm(join(r, "files/2024"), { recursive: true, force: true });


### PR DESCRIPTION
`fs.readlink` / `readlinkSync` / `fs.promises.readlink` accepted an `encoding` option but only branched on `Encoding::Buffer`; every other string encoding fell through to `BunString::clone_utf8`, so the link target's raw bytes were UTF-8-decoded regardless of what was requested. `"latin1"` / `"hex"` / `"base64"` / `"ucs2"` all returned the same UTF-8 string, and a non-UTF-8 link target came back with U+FFFD replacement characters in every string form.

## Repro

```js
import { symlinkSync, readlinkSync, mkdtempSync } from "node:fs";
import { tmpdir } from "node:os"; import { join } from "node:path";
const d = mkdtempSync(join(tmpdir(), "rl-"));
const link = join(d, "b");
symlinkSync(Buffer.from([0x66, 0xff, 0x62]), link); // non-UTF-8 target
console.log(readlinkSync(link, "latin1")); // bun: "f�b"   node: "fÿb"
console.log(readlinkSync(link, "hex"));    // bun: "f�b"   node: "66ff62"
```

On Linux a symlink target is an arbitrary byte string, and `readlink(path, "latin1")` is the documented lossless escape hatch for reading one as a string. Bun ran the raw bytes through its UTF-8 decoder regardless of the requested encoding, so the data was silently destroyed.

## Fix

Add a third match arm in `NodeFS::readlink` that routes the raw bytes through `webcore::encoding::to_bun_string` with the requested encoding, exactly as `realpath_inner()` already does a few lines below. The `Utf8` arm keeps the existing path-reuse fast path. All three JS forms (sync, callback, promises) go through this one native function, so they are all fixed.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "readlink encoding option"
 0 pass
 8 fail

bun bd test test/js/node/fs/fs.test.ts -t "readlink encoding option"
 8 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->