### PR TITLE
process: keep a worker's process.title assignment thread-local, lock umask

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -772,9 +772,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     return JSValue::encode(resultValue);
 }
 
-// The no-arg "read" is a umask(0)+umask(old) pair, so serialize every
-// process.umask call to keep a worker's read from interleaving with a
-// main-thread write (node: per_process::umask_mutex).
+// The no-arg read below is umask(0)+umask(old), so it must not interleave with a writer.
 static WTF::Lock umaskLock;
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -772,9 +772,15 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     return JSValue::encode(resultValue);
 }
 
+// The no-arg "read" is a umask(0)+umask(old) pair, so serialize every
+// process.umask call to keep a worker's read from interleaving with a
+// main-thread write (node: per_process::umask_mutex).
+static WTF::Lock umaskLock;
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     if (callFrame->argumentCount() == 0 || callFrame->argument(0).isUndefined()) {
+        Locker<Lock> locker(umaskLock);
         mode_t currentMask = umask(0);
         umask(currentMask);
         return JSValue::encode(jsNumber(currentMask));
@@ -797,6 +803,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
         newUmask = value.toUInt32(globalObject);
     }
 
+    Locker<Lock> locker(umaskLock);
     return JSC::JSValue::encode(JSC::jsNumber(umask(newUmask)));
 }
 
@@ -3674,6 +3681,7 @@ void Process::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_uncaughtExceptionCaptureCallback);
     visitor.append(thisObject->m_nextTickFunction);
     visitor.append(thisObject->m_cachedCwd);
+    visitor.append(thisObject->m_workerThreadTitle);
     visitor.append(thisObject->m_argv);
     visitor.append(thisObject->m_execArgv);
     visitor.append(thisObject->m_onWarning);
@@ -4545,6 +4553,12 @@ JSC_DEFINE_CUSTOM_GETTER(processTitle, (JSC::JSGlobalObject * globalObject, JSC:
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!Bun__isMainThreadVM()) {
+        auto* processObject = defaultGlobalObject(globalObject)->processObject();
+        if (auto* cached = processObject->workerThreadTitle()) {
+            RELEASE_AND_RETURN(scope, JSValue::encode(cached));
+        }
+    }
 #if !OS(WINDOWS)
     BunString str;
     Bun__Process__getTitle(globalObject, &str);
@@ -4586,6 +4600,11 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessTitle, (JSC::JSGlobalObject * globalObject, J
     JSC::JSString* jsString = dynamicDowncast<JSC::JSString>(JSValue::decode(value));
     if (!thisObject || !jsString) {
         return false;
+    }
+    if (!Bun__isMainThreadVM()) {
+        auto* processObject = defaultGlobalObject(globalObject)->processObject();
+        processObject->setWorkerThreadTitle(vm, jsString);
+        return true;
     }
 #if !OS(WINDOWS)
     BunString str = Bun::toStringRef(globalObject, jsString);

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -30,6 +30,9 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116
     WriteBarrier<JSString> m_cachedCwd;
+    // Workers cannot change the OS process title; the setter stores here so the
+    // assignment round-trips without leaking into the process-wide title.
+    WriteBarrier<JSString> m_workerThreadTitle;
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;
     // The JS warning printer (ProcessObjectInternals createOnWarning), built on the first warning.
@@ -88,6 +91,9 @@ public:
     JSString* cachedCwd() { return m_cachedCwd.get(); }
     void setCachedCwd(JSC::VM& vm, JSString* cwd) { m_cachedCwd.set(vm, this, cwd); }
     void clearCachedCwd() { m_cachedCwd.clear(); }
+
+    JSString* workerThreadTitle() { return m_workerThreadTitle.get(); }
+    void setWorkerThreadTitle(JSC::VM& vm, JSString* title) { m_workerThreadTitle.set(vm, this, title); }
 
     JSValue getArgv(JSGlobalObject* globalObject);
     void setArgv(JSGlobalObject* globalObject, JSValue argv);

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -30,8 +30,7 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116
     WriteBarrier<JSString> m_cachedCwd;
-    // Workers cannot change the OS process title; the setter stores here so the
-    // assignment round-trips without leaking into the process-wide title.
+    // process.title as assigned inside a worker; never written to the OS title.
     WriteBarrier<JSString> m_workerThreadTitle;
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;

--- a/test/js/node/worker_threads/worker-process-state.test.ts
+++ b/test/js/node/worker_threads/worker-process-state.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("process.title assigned in a Worker is thread-local and does not change the main thread's title", async () => {
-  using dir = tempDir("worker-process-title", {
-    "index.js": `
+test.concurrent(
+  "process.title assigned in a Worker is thread-local and does not change the main thread's title",
+  async () => {
+    using dir = tempDir("worker-process-title", {
+      "index.js": `
       const { Worker, isMainThread, parentPort } = require("node:worker_threads");
       if (isMainThread) {
         process.title = "MAIN-TITLE";
@@ -20,27 +22,28 @@ test("process.title assigned in a Worker is thread-local and does not change the
         parentPort.postMessage({ before, after: process.title });
       }
     `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("WORKER_ERROR");
-  expect(JSON.parse(stdout.trim())).toEqual({
-    // the worker starts with the parent's title and its own assignment round-trips locally
-    worker: { before: "MAIN-TITLE", after: "WORKER-TITLE" },
-    // the process-wide title the main thread sees is untouched
-    mainAfter: "MAIN-TITLE",
-  });
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("WORKER_ERROR");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      // the worker starts with the parent's title and its own assignment round-trips locally
+      worker: { before: "MAIN-TITLE", after: "WORKER-TITLE" },
+      // the process-wide title the main thread sees is untouched
+      mainAfter: "MAIN-TITLE",
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
-test("a Web Worker cannot change the main thread's process.title either", async () => {
+test.concurrent("a Web Worker cannot change the main thread's process.title either", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -48,6 +51,7 @@ test("a Web Worker cannot change the main thread's process.title either", async 
       `
         process.title = "MAIN-TITLE";
         const w = new Worker(new URL("data:text/javascript," + encodeURIComponent('process.title = "WEB-WORKER-TITLE"; postMessage(process.title);')));
+        w.onerror = e => { console.error("WORKER_ERROR:" + (e && e.message)); process.exitCode = 1; w.terminate(); };
         w.onmessage = e => {
           console.log(JSON.stringify({ worker: e.data, mainAfter: process.title }));
           w.terminate();
@@ -59,7 +63,7 @@ test("a Web Worker cannot change the main thread's process.title either", async 
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  expect(stderr).not.toContain("WORKER_ERROR");
   expect(JSON.parse(stdout.trim())).toEqual({ worker: "WEB-WORKER-TITLE", mainAfter: "MAIN-TITLE" });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/worker_threads/worker-process-state.test.ts
+++ b/test/js/node/worker_threads/worker-process-state.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("process.title assigned in a Worker is thread-local and does not change the main thread's title", async () => {
+  using dir = tempDir("worker-process-title", {
+    "index.js": `
+      const { Worker, isMainThread, parentPort } = require("node:worker_threads");
+      if (isMainThread) {
+        process.title = "MAIN-TITLE";
+        const w = new Worker(__filename);
+        let result;
+        w.on("message", m => { result = m; });
+        w.on("error", e => { console.error("WORKER_ERROR:" + (e && e.message)); process.exitCode = 1; });
+        w.on("exit", () => {
+          console.log(JSON.stringify({ worker: result, mainAfter: process.title }));
+        });
+      } else {
+        const before = process.title;
+        process.title = "WORKER-TITLE";
+        parentPort.postMessage({ before, after: process.title });
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("WORKER_ERROR");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    // the worker starts with the parent's title and its own assignment round-trips locally
+    worker: { before: "MAIN-TITLE", after: "WORKER-TITLE" },
+    // the process-wide title the main thread sees is untouched
+    mainAfter: "MAIN-TITLE",
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("a Web Worker cannot change the main thread's process.title either", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        process.title = "MAIN-TITLE";
+        const w = new Worker(new URL("data:text/javascript," + encodeURIComponent('process.title = "WEB-WORKER-TITLE"; postMessage(process.title);')));
+        w.onmessage = e => {
+          console.log(JSON.stringify({ worker: e.data, mainAfter: process.title }));
+          w.terminate();
+        };
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ worker: "WEB-WORKER-TITLE", mainAfter: "MAIN-TITLE" });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- A Worker that assigns `process.title` overwrites the process-wide title. The main thread's `process.title` and `ps` both change. Node keeps the assignment local to the worker. This happens for `node:worker_threads` workers and for Web Workers.
- The setter in `src/jsc/bindings/BunProcess.cpp` (`setProcessTitle`) writes straight to the global title store from any thread.
- `process.umask()` with no argument is `umask(0)` then `umask(old)`. A worker's read can interleave with a main-thread `process.umask(mask)` and restore the old mask over it.

### Fix
- Add `m_workerThreadTitle` to `Process`. Off the main thread, the setter stores there and the getter returns it once set. The worker still sees its own assignment round-trip. The OS title is never written from a worker.
- Take a `WTF::Lock` around both `umask()` paths, after argument validation, so the lock never spans code that can throw. Node does the same with `per_process::umask_mutex`.
- Verified: `test/js/node/worker_threads/worker-process-state.test.ts` (2 tests, both fail on main) covers the title change. The umask lock has no test. The race window is two adjacent syscalls, so a test for it would be flaky. Both locked paths still run under `process.test.js`. Node's `test-worker-unsupported-things.js` also passes.

### Background
- `Process` is the C++ object behind the `process` global. Each thread (main, each worker) has its own instance, so a `WriteBarrier` field on it is per-thread state.
- `Bun__isMainThreadVM()` is the existing check `process.execve` uses to reject workers.
- #31216 landed while this PR was open. It stubs `chdir`, `umask(mask)`, `setuid` and friends in `node:worker_threads` workers from JS (`applyWorkerProcessOverrides` in `src/js/node/worker_threads.ts`). This PR originally added the same guards natively. After the rebase it keeps only the two pieces main still lacks.

<details><summary>Notes</summary>

Original report: a worker could `chdir`, `umask(mask)`, `setuid`, and set `title`, and all of it landed on the whole process. After `chdir` the main thread's `process.cwd()` cache was also stale. On current main plus this PR the repro matches Node: `chdir` and `umask(mask)` throw `ERR_WORKER_UNSUPPORTED_OPERATION` (from #31216), the worker's title assignment round-trips locally, and the main thread's cwd, umask and title are unchanged.

Web Workers (`new globalThis.Worker`) can still call `process.chdir()` and friends. #31216 deliberately applies its stubs only to `node:worker_threads` workers. Whether Web Workers should be restricted too is a separate decision, so this PR does not change it. The title isolation here does apply to Web Workers, since there is no case where a worker of either kind should rename the process.

Node v26.3.0 keeps a worker's title assignment readable from that worker (`test-worker-unsupported-things.js` asserts the round-trip), which is why the value is stored rather than dropped.

Earlier revisions of this PR added native `ERR_WORKER_UNSUPPORTED_OPERATION` guards to `chdir`, `umask(mask)`, `setuid`, `seteuid`, `setgid`, `setegid` and `setgroups`. Those are removed after rebasing onto #31216.

</details>
