### PR TITLE
bun_core::String: map zero-length WTFStringImpl to the Empty tag

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -458,10 +458,12 @@ impl String {
     }
     /// `bun.String.init(WTFStringImpl)` / `WTFString.adopt` — wrap a raw
     /// `*mut WTFStringImplStruct`, **adopting** the existing +1 ref (no inc).
-    /// Inverse of [`leak_wtf_impl`]. Null → `String::EMPTY`.
+    /// Inverse of [`leak_wtf_impl`]. Null / zero-length → `String::EMPTY`.
     #[inline]
     pub fn adopt_wtf_impl(wtf: WTFStringImpl) -> Self {
-        if wtf.is_null() {
+        // SAFETY: `wtf` is either null or a live `WTF::StringImpl*` per the
+        // caller contract; we only read `m_length` here.
+        if wtf.is_null() || unsafe { (*wtf).length() } == 0 {
             return Self::EMPTY;
         }
         Self(bun_alloc::String {
@@ -1198,6 +1200,12 @@ impl From<WTFStringImpl> for String {
     #[inline]
     fn from(wtf: WTFStringImpl) -> Self {
         debug_assert!(!wtf.is_null());
+        // `Bun::toJS(BunString)` asserts a `WTFStringImpl`-tagged string is
+        // never empty; mirror the C++ `Bun::toString(StringImpl*)` guard.
+        // SAFETY: caller guarantees non-null (debug-asserted above).
+        if unsafe { (*wtf).length() } == 0 {
+            return Self::EMPTY;
+        }
         Self(bun_alloc::String {
             tag: Tag::WTFStringImpl,
             value: StringImpl {

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -461,9 +461,13 @@ impl String {
     /// Inverse of [`leak_wtf_impl`]. Null / zero-length → `String::EMPTY`.
     #[inline]
     pub fn adopt_wtf_impl(wtf: WTFStringImpl) -> Self {
-        // SAFETY: `wtf` is either null or a live `WTF::StringImpl*` per the
-        // caller contract; we only read `m_length` here.
-        if wtf.is_null() || unsafe { (*wtf).length() } == 0 {
+        if wtf.is_null() {
+            return Self::EMPTY;
+        }
+        // SAFETY: non-null per the guard above.
+        if unsafe { (*wtf).length() } == 0 {
+            // Release the adopted +1; no-op on WTF's static empty singleton.
+            unsafe { (*wtf).deref() };
             return Self::EMPTY;
         }
         Self(bun_alloc::String {

--- a/test/js/node/worker_threads/worker-argv-empty-string.test.ts
+++ b/test/js/node/worker_threads/worker-argv-empty-string.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A zero-length WTF::StringImpl must surface as BunStringTag::Empty; debug
+// builds assert on a WTFStringImpl-tagged empty string in Bun::toJS.
+test("argv/execArgv options accept empty-string elements", async () => {
+  const script = `
+    const { Worker } = require("node:worker_threads");
+    const w = new Worker(
+      'require("node:worker_threads").parentPort.postMessage({ argv: process.argv.slice(2), execArgv: process.execArgv })',
+      { eval: true, argv: ["", "a", ""], execArgv: [""] },
+    );
+    w.on("message", m => { console.log(JSON.stringify(m)); });
+    w.on("error", e => { console.error(String(e)); process.exitCode = 1; });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ argv: ["", "a", ""], execArgv: [""] }),
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -280,6 +280,31 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
+test("argv/execArgv options accept empty-string elements", async () => {
+  // A zero-length WTF::StringImpl must surface as BunStringTag::Empty; debug
+  // builds assert on a WTFStringImpl-tagged empty string in Bun::toJS.
+  const script = `
+    const { Worker } = require("node:worker_threads");
+    const w = new Worker(
+      'require("node:worker_threads").parentPort.postMessage({ argv: process.argv.slice(2), execArgv: process.execArgv })',
+      { eval: true, argv: ["", "a", ""], execArgv: [""] },
+    );
+    w.on("message", m => { console.log(JSON.stringify(m)); });
+    w.on("error", e => { console.error(String(e)); process.exitCode = 1; });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ argv: ["", "a", ""], execArgv: [""] }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -280,31 +280,6 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
-test("argv/execArgv options accept empty-string elements", async () => {
-  // A zero-length WTF::StringImpl must surface as BunStringTag::Empty; debug
-  // builds assert on a WTFStringImpl-tagged empty string in Bun::toJS.
-  const script = `
-    const { Worker } = require("node:worker_threads");
-    const w = new Worker(
-      'require("node:worker_threads").parentPort.postMessage({ argv: process.argv.slice(2), execArgv: process.execArgv })',
-      { eval: true, argv: ["", "a", ""], execArgv: [""] },
-    );
-    w.on("message", m => { console.log(JSON.stringify(m)); });
-    w.on("error", e => { console.error(String(e)); process.exitCode = 1; });
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: JSON.stringify({ argv: ["", "a", ""], execArgv: [""] }),
-    stderr: "",
-    exitCode: 0,
-  });
-});
-
 test("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],


### PR DESCRIPTION
## Repro

```js
import { Worker } from "node:worker_threads";
new Worker(
  'require("node:worker_threads").parentPort.postMessage(process.argv.slice(2))',
  { eval: true, argv: [""] },
).on("message", m => console.log(JSON.stringify(m)));
```

Under any assert-enabled build (`bun-debug`, `-DENABLE_ASSERTS`):

```
ASSERTION FAILED: bunString.impl.wtf->hasAtLeastOneRef() && !bunString.impl.wtf->isEmpty()
src/jsc/bindings/BunString.cpp(185) : JSC::JSString *Bun::toJS(JSC::JSGlobalObject *, BunString)
SIGABRT (exit 134)
```

Release builds skip the assert and happen to print `[""]`. Node prints `[""]`.

## Cause

`Bun::toJS(BunString)` asserts that a `WTFStringImpl`-tagged `BunString` is never empty; `BunStringTag::Empty` exists for that case, and every C++ constructor (`Bun::fromJS`, `Bun::toString(StringImpl*)`, `Bun::toStringRef`) checks `isEmpty()` and returns the `Empty` tag.

The Rust `From<WTFStringImpl> for bun_core::String` (what `BunString::init(wtf)` dispatches to) wrapped the pointer as `Tag::WTFStringImpl` unconditionally. The Worker `argv` / `execArgv` option path stores each element as a `WTF::String` in `WorkerOptions`, hands the backing `StringImpl*` array to Rust, and the worker-side `process.argv` / `process.execArgv` getter wraps each element via `BunString::init(wtf)`. A `""` element is the zero-length `StringImpl::empty()` singleton, so the assert fires on first access.

## Fix

`From<WTFStringImpl>` and `adopt_wtf_impl` now return `String::EMPTY` when the impl has zero length, matching the C++ `Bun::toString(StringImpl*)` guard. This upholds the invariant at the one place a raw `WTF::StringImpl*` enters the tagged union on the Rust side.

## Verification

Added a test to `test/js/node/worker_threads/worker_threads.test.ts` that spawns a worker with `argv: ["", "a", ""]` and `execArgv: [""]` and asserts the worker's `process.argv.slice(2)` / `process.execArgv` round-trip exactly.

```
# bun bd, src/ stashed
(fail) argv/execArgv options accept empty-string elements
  stderr: ASSERTION FAILED: bunString.impl.wtf->hasAtLeastOneRef() && !bunString.impl.wtf->isEmpty()
  exitCode: 134

# bun bd, with fix
(pass) argv/execArgv options accept empty-string elements
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-argv-empty-string.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (02432b651)

test/js/node/worker_threads/worker-argv-empty-string.test.ts:
17 |     cmd: [bunExe(), "-e", script],
18 |     env: bunEnv,
19 |     stderr: "pipe",
20 |   });
21 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
22 |   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": "{"argv":["","a",""],"execArgv":[""]}",
+   "exitCode": 134,
+   "stderr": 
+ "ASSERTION FAILED: bunString.impl.wtf-hasAtLeastOneRef() && !bunString.impl.wtf-isEmpty()
+ unified/../../../src/jsc/bind
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (fa626d0ba)

test/js/node/worker_threads/worker-argv-empty-string.test.ts:
(pass) argv/execArgv options accept empty-string elements [29.54ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [181.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-argv-empty-string.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (02432b651)

test/js/node/worker_threads/worker-argv-empty-string.test.ts:
(pass) argv/execArgv options accept empty-string elements [1392.89ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [3.33s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/string/mod.rs                         | 14 ++++++++++-
 .../worker-argv-empty-string.test.ts               | 27 ++++++++++++++++++++++
 2 files changed, 40 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_core/string/mod.rs                                    3      3      0
…js/node/worker_threads/worker-argv-empty-string.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->