### PR TITLE
fs: honor encoding option in mkdtemp

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1162,12 +1162,6 @@ mod _async_tasks {
             Ok(crate::node::types::FdJsc::to_js(*self, global))
         }
     }
-    impl FsReturn for ZigString {
-        #[inline]
-        fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
-            Ok(bun_jsc::ZigStringJsc::to_js(self, global))
-        }
-    }
     impl FsReturn for StringOrBuffer {
         #[inline]
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -4615,7 +4609,7 @@ pub mod ret {
     pub type Link = ();
     pub type Lstat = StatOrNotFound;
     pub type Mkdir = StringOrUndefined;
-    pub type Mkdtemp = ZigString;
+    pub type Mkdtemp = StringOrBuffer;
     pub type Open = FD;
     pub type WriteFile = ();
     pub type Readv = Read;
@@ -4809,6 +4803,25 @@ impl Default for NodeFS {
 // containing module level instead so `NodeFS::ReturnType::Foo` callers (none
 // yet in-tree) keep working via `node::fs::ReturnType::Foo`.
 pub use ret as ReturnType;
+
+/// Encode a path returned by the OS (`mkdtemp`/`readlink`/`realpath`) using the
+/// caller's `encoding` option, matching Node.js: `"buffer"` yields a `Buffer`
+/// of the raw bytes, any other encoding is `Buffer.from(bytes).toString(enc)`.
+fn encode_path_result(bytes: &[u8], encoding: Encoding) -> StringOrBuffer {
+    match encoding {
+        Encoding::Buffer => {
+            StringOrBuffer::Buffer(Buffer::from_string(bytes).expect("unreachable"))
+        }
+        Encoding::Utf8 => StringOrBuffer::String(node::SliceWithUnderlyingString {
+            underlying: BunString::clone_utf8(bytes),
+            ..Default::default()
+        }),
+        enc => StringOrBuffer::String(node::SliceWithUnderlyingString {
+            underlying: webcore::encoding::to_bun_string(bytes, enc),
+            ..Default::default()
+        }),
+    }
+}
 
 impl NodeFS {
     pub fn access(&mut self, args: &args::Access, _: Flavor) -> Maybe<ret::Access> {
@@ -6074,10 +6087,8 @@ impl NodeFS {
             // SAFETY: on success libuv populates `req.path` with a NUL-terminated
             // UTF-8 string owned by the request; `UvFsReq::drop` runs
             // `uv_fs_req_cleanup` in place after we've copied the bytes out.
-            return Ok(
-                ZigString::dupe_for_js(unsafe { bun_core::ffi::cstr(req.path) }.to_bytes())
-                    .expect("oom"),
-            );
+            let bytes = unsafe { bun_core::ffi::cstr(req.path) }.to_bytes();
+            return Ok(encode_path_result(bytes, args.encoding));
         }
 
         #[cfg(not(windows))]
@@ -6089,7 +6100,7 @@ impl NodeFS {
                 // SAFETY: `rc` is non-null and points back into `prefix_buf`, which is
                 // NUL-terminated and outlives this borrow.
                 let bytes = unsafe { bun_core::ffi::cstr(rc) }.to_bytes();
-                return Ok(ZigString::dupe_for_js(bytes).expect("oom"));
+                return Ok(encode_path_result(bytes, args.encoding));
             }
 
             let errno = sys::last_errno();
@@ -7561,22 +7572,14 @@ impl NodeFS {
             Ok(result) => result,
         };
         let link_path: &[u8] = &outbuf[..link_len];
-        Ok(match args.encoding {
-            Encoding::Buffer => {
-                StringOrBuffer::Buffer(Buffer::from_string(link_path).expect("unreachable"))
-            }
-            _ => {
-                if let PathLike::SliceWithUnderlyingString(s) = &args.path {
-                    if strings::eql_long(s.slice(), link_path, true) {
-                        return Ok(StringOrBuffer::String(s.dupe_ref()));
-                    }
+        if args.encoding == Encoding::Utf8 {
+            if let PathLike::SliceWithUnderlyingString(s) = &args.path {
+                if strings::eql_long(s.slice(), link_path, true) {
+                    return Ok(StringOrBuffer::String(s.dupe_ref()));
                 }
-                StringOrBuffer::String(node::SliceWithUnderlyingString {
-                    underlying: BunString::clone_utf8(link_path),
-                    ..Default::default()
-                })
             }
-        })
+        }
+        Ok(encode_path_result(link_path, args.encoding))
     }
 
     pub fn realpath_non_native(
@@ -7659,26 +7662,14 @@ impl NodeFS {
                     buf = &buf[..buf.len() - 1];
                 }
             }
-            return Ok(match args.encoding {
-                Encoding::Buffer => {
-                    StringOrBuffer::Buffer(Buffer::from_string(buf).expect("unreachable"))
-                }
-                Encoding::Utf8 => {
-                    if let PathLike::SliceWithUnderlyingString(s) = &args.path {
-                        if strings::eql_long(s.slice(), buf, true) {
-                            return Ok(StringOrBuffer::String(s.dupe_ref()));
-                        }
+            if args.encoding == Encoding::Utf8 {
+                if let PathLike::SliceWithUnderlyingString(s) = &args.path {
+                    if strings::eql_long(s.slice(), buf, true) {
+                        return Ok(StringOrBuffer::String(s.dupe_ref()));
                     }
-                    StringOrBuffer::String(node::SliceWithUnderlyingString {
-                        underlying: BunString::clone_utf8(buf),
-                        ..Default::default()
-                    })
                 }
-                enc => StringOrBuffer::String(node::SliceWithUnderlyingString {
-                    underlying: webcore::encoding::to_bun_string(buf, enc),
-                    ..Default::default()
-                }),
-            });
+            }
+            return Ok(encode_path_result(buf, args.encoding));
         }
 
         #[cfg(not(windows))]
@@ -7724,26 +7715,14 @@ impl NodeFS {
             };
 
             let _ = variant;
-            Ok(match args.encoding {
-                Encoding::Buffer => {
-                    StringOrBuffer::Buffer(Buffer::from_string(buf).expect("unreachable"))
-                }
-                Encoding::Utf8 => {
-                    if let PathLike::SliceWithUnderlyingString(s) = &args.path {
-                        if strings::eql_long(s.slice(), buf, true) {
-                            return Ok(StringOrBuffer::String(s.dupe_ref()));
-                        }
+            if args.encoding == Encoding::Utf8 {
+                if let PathLike::SliceWithUnderlyingString(s) = &args.path {
+                    if strings::eql_long(s.slice(), buf, true) {
+                        return Ok(StringOrBuffer::String(s.dupe_ref()));
                     }
-                    StringOrBuffer::String(node::SliceWithUnderlyingString {
-                        underlying: BunString::clone_utf8(buf),
-                        ..Default::default()
-                    })
                 }
-                enc => StringOrBuffer::String(node::SliceWithUnderlyingString {
-                    underlying: webcore::encoding::to_bun_string(buf, enc),
-                    ..Default::default()
-                }),
-            })
+            }
+            Ok(encode_path_result(buf, args.encoding))
         }
     }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1410,28 +1410,21 @@ it("mkdtemp() non-exist dir #2568", done => {
 });
 
 describe("mkdtemp encoding option", () => {
-  const prefix = join(tmpdir(), "mkenc-dé-");
+  const base = tmpdirSync();
+  const prefix = join(base, "mkenc-dé-");
   const prefixBytes = Buffer.from(prefix, "utf8");
 
   it("sync: 'buffer' returns a Buffer of the path bytes", () => {
     const result = mkdtempSync(prefix, { encoding: "buffer" });
-    try {
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect(result.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
-      expect(result.length).toBe(prefixBytes.length + 6);
-      expect(existsSync(result)).toBe(true);
-    } finally {
-      rmSync(result, { recursive: true, force: true });
-    }
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(result.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
+    expect(result.length).toBe(prefixBytes.length + 6);
+    expect(existsSync(result)).toBe(true);
   });
 
   it("sync: string shorthand 'buffer'", () => {
     const result = mkdtempSync(prefix, "buffer");
-    try {
-      expect(Buffer.isBuffer(result)).toBe(true);
-    } finally {
-      rmSync(result, { recursive: true, force: true });
-    }
+    expect(Buffer.isBuffer(result)).toBe(true);
   });
 
   it.each(["hex", "base64", "base64url", "latin1"] as const)("sync: '%s' re-encodes the path", encoding => {
@@ -1441,30 +1434,21 @@ describe("mkdtemp encoding option", () => {
     expect(decoded.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
     expect(decoded.length).toBe(prefixBytes.length + 6);
     expect(existsSync(decoded)).toBe(true);
-    rmSync(decoded, { recursive: true, force: true });
   });
 
   it("sync: default utf8 still returns a string", () => {
     const result = mkdtempSync(prefix);
-    try {
-      expect(typeof result).toBe("string");
-      expect(result.startsWith(prefix)).toBe(true);
-      expect(existsSync(result)).toBe(true);
-    } finally {
-      rmSync(result, { recursive: true, force: true });
-    }
+    expect(typeof result).toBe("string");
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(existsSync(result)).toBe(true);
   });
 
   it("callback: 'buffer' returns a Buffer", async () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     mkdtemp(prefix, { encoding: "buffer" }, (err, folder) => (err ? reject(err) : resolve(folder)));
     const result = await promise;
-    try {
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect(existsSync(result)).toBe(true);
-    } finally {
-      rmSync(result, { recursive: true, force: true });
-    }
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(existsSync(result)).toBe(true);
   });
 
   it("promises: 'hex' re-encodes the path", async () => {
@@ -1473,17 +1457,12 @@ describe("mkdtemp encoding option", () => {
     const decoded = Buffer.from(result, "hex");
     expect(decoded.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
     expect(existsSync(decoded)).toBe(true);
-    rmSync(decoded, { recursive: true, force: true });
   });
 
   it("promises: 'buffer' returns a Buffer", async () => {
     const result = await promises.mkdtemp(prefix, { encoding: "buffer" });
-    try {
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect(existsSync(result)).toBe(true);
-    } finally {
-      rmSync(result, { recursive: true, force: true });
-    }
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(existsSync(result)).toBe(true);
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1409,6 +1409,86 @@ it("mkdtemp() non-exist dir #2568", done => {
   });
 });
 
+describe("mkdtemp encoding option", () => {
+  const prefix = join(tmpdir(), "mkenc-dé-");
+  const prefixBytes = Buffer.from(prefix, "utf8");
+
+  it("sync: 'buffer' returns a Buffer of the path bytes", () => {
+    const result = mkdtempSync(prefix, { encoding: "buffer" });
+    try {
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
+      expect(result.length).toBe(prefixBytes.length + 6);
+      expect(existsSync(result)).toBe(true);
+    } finally {
+      rmSync(result, { recursive: true, force: true });
+    }
+  });
+
+  it("sync: string shorthand 'buffer'", () => {
+    const result = mkdtempSync(prefix, "buffer");
+    try {
+      expect(Buffer.isBuffer(result)).toBe(true);
+    } finally {
+      rmSync(result, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["hex", "base64", "base64url", "latin1"] as const)("sync: '%s' re-encodes the path", encoding => {
+    const result = mkdtempSync(prefix, { encoding });
+    expect(typeof result).toBe("string");
+    const decoded = Buffer.from(result, encoding);
+    expect(decoded.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
+    expect(decoded.length).toBe(prefixBytes.length + 6);
+    expect(existsSync(decoded)).toBe(true);
+    rmSync(decoded, { recursive: true, force: true });
+  });
+
+  it("sync: default utf8 still returns a string", () => {
+    const result = mkdtempSync(prefix);
+    try {
+      expect(typeof result).toBe("string");
+      expect(result.startsWith(prefix)).toBe(true);
+      expect(existsSync(result)).toBe(true);
+    } finally {
+      rmSync(result, { recursive: true, force: true });
+    }
+  });
+
+  it("callback: 'buffer' returns a Buffer", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    mkdtemp(prefix, { encoding: "buffer" }, (err, folder) => (err ? reject(err) : resolve(folder)));
+    const result = await promise;
+    try {
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(existsSync(result)).toBe(true);
+    } finally {
+      rmSync(result, { recursive: true, force: true });
+    }
+  });
+
+  it("promises: 'hex' re-encodes the path", async () => {
+    const result = await promises.mkdtemp(prefix, "hex");
+    expect(typeof result).toBe("string");
+    const decoded = Buffer.from(result, "hex");
+    expect(decoded.subarray(0, prefixBytes.length).equals(prefixBytes)).toBe(true);
+    expect(existsSync(decoded)).toBe(true);
+    rmSync(decoded, { recursive: true, force: true });
+  });
+
+  it("promises: 'buffer' returns a Buffer", async () => {
+    const result = await promises.mkdtemp(prefix, { encoding: "buffer" });
+    try {
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(existsSync(result)).toBe(true);
+    } finally {
+      rmSync(result, { recursive: true, force: true });
+    }
+  });
+});
+
+
+
 it("readdirSync on import.meta.dir with trailing slash", () => {
   const dirs = readdirSync(import.meta.dir + "/");
   expect(dirs.length > 0).toBe(true);
@@ -2363,6 +2443,30 @@ it("readlink", () => {
   symlinkSync(import.meta.path, actual);
 
   expect(readlinkSync(actual)).toBe(realpathSync(import.meta.path));
+});
+
+describe("readlink encoding option", () => {
+  const base = tmpdirSync();
+  const link = join(base, "lnk");
+  symlinkSync(join(base, "tgt-dé"), link);
+  const targetBytes = readlinkSync(link, { encoding: "buffer" }) as Buffer;
+
+  it("'buffer' returns a Buffer", () => {
+    expect(Buffer.isBuffer(targetBytes)).toBe(true);
+    expect(targetBytes.includes(Buffer.from("tgt-dé", "utf8"))).toBe(true);
+  });
+
+  it.each(["hex", "base64", "base64url", "latin1"] as const)("'%s' re-encodes the target", encoding => {
+    const result = readlinkSync(link, { encoding });
+    expect(typeof result).toBe("string");
+    expect(result).toBe(targetBytes.toString(encoding));
+  });
+
+  it("default utf8 still returns a string", () => {
+    const result = readlinkSync(link);
+    expect(typeof result).toBe("string");
+    expect(result).toBe(targetBytes.toString("utf8"));
+  });
 });
 
 // On FUSE / some network filesystems a symlink target can exceed PATH_MAX,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1487,8 +1487,6 @@ describe("mkdtemp encoding option", () => {
   });
 });
 
-
-
 it("readdirSync on import.meta.dir with trailing slash", () => {
   const dirs = readdirSync(import.meta.dir + "/");
   expect(dirs.length > 0).toBe(true);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { beforeAll, describe, expect, it, spyOn } from "bun:test";
 import {
   bunEnv,
   bunExe,
@@ -2425,8 +2425,11 @@ it("readlink", () => {
 describe("readlink encoding option", () => {
   const base = tmpdirSync();
   const link = join(base, "lnk");
-  symlinkSync(join(base, "tgt-dé"), link);
-  const targetBytes = readlinkSync(link, { encoding: "buffer" }) as Buffer;
+  let targetBytes: Buffer;
+  beforeAll(() => {
+    symlinkSync(join(base, "tgt-dé"), link);
+    targetBytes = readlinkSync(link, { encoding: "buffer" }) as Buffer;
+  });
 
   it("'buffer' returns a Buffer", () => {
     expect(Buffer.isBuffer(targetBytes)).toBe(true);


### PR DESCRIPTION
`fs.mkdtemp` / `fs.mkdtempSync` / `fs.promises.mkdtemp` parsed the `encoding` option into `args::MkdirTemp.encoding` but never read it. The function unconditionally built a `ZigString` from the created path's bytes, so `{encoding:"buffer"}` returned a string (a type break versus Node's `Buffer`), and every string encoding (`"hex"`, `"base64"`, `"latin1"`, ...) returned the raw `prefix + XXXXXX` unchanged instead of re-encoding the path's bytes.

## Repro

```js
import { mkdtempSync, promises as fsp } from "node:fs";
import { tmpdir } from "node:os"; import { join } from "node:path";
const pfx = join(tmpdir(), "mkenc-dé-");
console.log(mkdtempSync(pfx, { encoding: "buffer" }));
// node : <Buffer 2f 74 6d 70 2f 6d 6b 65 6e 63 2d 64 c3 a9 2d ...>
// bun  : "/tmp/mkenc-dé-AAkoTt"   (a string, not a Buffer)
console.log(mkdtempSync(pfx, "hex"));
// node : "2f746d702f6d6b656e632d64c3a92d..."
// bun  : "/tmp/mkenc-dé-4yD4Pi"   (not hex; the raw path)
console.log(await fsp.mkdtemp(pfx, "base64"));
// node : "L3RtcC9ta2VuYy1kw6kt..."
// bun  : "/tmp/mkenc-dé-2THu5T"
```

The directory is created correctly in both runtimes; only the returned value ignores the encoding.

## Fix

`realpath_inner` already had the right match (`Buffer` / `Utf8` via `clone_utf8` / other via `webcore::encoding::to_bun_string`). Extract it into a small `encode_path_result(bytes, encoding) -> StringOrBuffer` helper, change `ret::Mkdtemp` from `ZigString` to `StringOrBuffer`, and route both `mkdtemp` arms (POSIX `libc::mkdtemp` and Windows `uv_fs_mkdtemp`) through it.

`readlink` had the adjacent gap: it handled `"buffer"` but treated every other encoding as utf8. It now uses the same helper, with its path-reuse fast path restricted to the `Utf8` case only. `realpath_inner` (Windows + POSIX) is refactored onto the helper with no behavior change.

The now-unused `impl FsReturn for ZigString` is removed.

The `readlink` portion overlaps with #33841; this PR goes further by extracting the shared helper and fixing `mkdtemp` through it.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "mkdtemp encoding"
 1 pass
 9 fail

bun bd test test/js/node/fs/fs.test.ts -t "mkdtemp encoding"
 10 pass
 0 fail

USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "readlink encoding option"
 2 pass
 4 fail

bun bd test test/js/node/fs/fs.test.ts -t "readlink encoding option"
 6 pass
 0 fail
```

Full `fs.test.ts` (398 pass / 0 fail), the node parallel `test-fs-mkdtemp*.js` files, and `bun run rust:check-all` (10/10 targets) are clean.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->