### PR TITLE
Bun.connect: enforce rejectUnauthorized on client TLS sockets

### DIFF
--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -489,7 +489,7 @@ impl SocketConfig {
     }
 
     pub fn from_generated(
-        _vm: &'static VirtualMachine,
+        vm: &'static VirtualMachine,
         global: &JSGlobalObject,
         generated: &GeneratedSocketConfig,
         mode: SocketMode,
@@ -499,7 +499,11 @@ impl SocketConfig {
                 GeneratedTls::None => None,
                 GeneratedTls::Boolean(b) => {
                     if *b {
-                        Some(SSLConfig::zero())
+                        let mut cfg = SSLConfig::zero();
+                        if !mode.is_server() {
+                            cfg.reject_unauthorized = vm.get_tls_reject_unauthorized() as i32;
+                        }
+                        Some(cfg)
                     } else {
                         None
                     }

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1116,6 +1116,16 @@ impl Listener {
                         })
                     };
                     let tls_ref = tls;
+                    {
+                        let mut f = tls_ref.flags.get();
+                        f.set(
+                            SocketFlags::REJECT_UNAUTHORIZED,
+                            ssl_taken
+                                .as_ref()
+                                .is_some_and(|s| s.reject_unauthorized != 0),
+                        );
+                        tls_ref.flags.set(f);
+                    }
                     TLSSocket::data_set_cached(
                         tls_ref.get_this_value(global),
                         global,
@@ -1454,6 +1464,10 @@ fn connect_finish<const IS_SSL: bool>(
     {
         let mut f = socket_ref.flags.get();
         f.set(SocketFlags::ALLOW_HALF_OPEN, allow_half_open);
+        f.set(
+            SocketFlags::REJECT_UNAUTHORIZED,
+            IS_SSL && ssl.as_deref().is_some_and(|s| s.reject_unauthorized != 0),
+        );
         socket_ref.flags.set(f);
     }
     // Note: `do_connect` reads `self.connection` directly so no second

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3369,6 +3369,13 @@ impl<const SSL: bool> NewSocket<SSL> {
         let owned_ctx_taken = owned_ctx.map(|c| c.into_raw());
 
         let cfg = ssl_opts.as_ref();
+        // A bare `secureContext` leaves `ssl_opts` as None; clients still get
+        // the NODE_TLS_REJECT_UNAUTHORIZED-aware default instead of fail-open.
+        let reject_unauthorized = !is_server
+            && cfg.map_or_else(
+                || vm.get_tls_reject_unauthorized(),
+                |c| c.reject_unauthorized != 0,
+            );
         let tls: bun_ptr::ThisPtr<TLSSocket> = TLSSocket::new(TLSSocket {
             ref_count: bun_ptr::RefCount::init(),
             handlers: JsCell::new(Some(handlers)),
@@ -3380,13 +3387,11 @@ impl<const SSL: bool> NewSocket<SSL> {
             server_name: JsCell::new(
                 cfg.and_then(|c| c.server_name_bytes().map(Box::<[u8]>::from)),
             ),
-            flags: Cell::new(
-                if !is_server && cfg.is_some_and(|c| c.reject_unauthorized != 0) {
-                    Flags::default() | Flags::REJECT_UNAUTHORIZED
-                } else {
-                    Flags::default()
-                },
-            ),
+            flags: Cell::new(if reject_unauthorized {
+                Flags::default() | Flags::REJECT_UNAUTHORIZED
+            } else {
+                Flags::default()
+            }),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
             ref_pollref_on_connect: Cell::new(true),
@@ -4317,6 +4322,13 @@ pub fn js_upgrade_duplex_to_tls(
         default_data.ensure_still_alive();
     }
 
+    // A bare `secureContext` leaves `ssl_opts` as None; clients still get
+    // the NODE_TLS_REJECT_UNAUTHORIZED-aware default instead of fail-open.
+    let reject_unauthorized = !is_server
+        && socket_config.map_or_else(
+            || handlers.vm.get_tls_reject_unauthorized(),
+            |cfg| cfg.reject_unauthorized != 0,
+        );
     let tls = TLSSocket::new(TLSSocket {
         ref_count: bun_ptr::RefCount::init(),
         handlers: JsCell::new(Some(handlers)),
@@ -4330,13 +4342,11 @@ pub fn js_upgrade_duplex_to_tls(
         server_name: JsCell::new(
             socket_config.and_then(|cfg| cfg.server_name_bytes().map(Box::<[u8]>::from)),
         ),
-        flags: Cell::new(
-            if !is_server && socket_config.is_some_and(|cfg| cfg.reject_unauthorized != 0) {
-                Flags::default() | Flags::REJECT_UNAUTHORIZED
-            } else {
-                Flags::default()
-            },
-        ),
+        flags: Cell::new(if reject_unauthorized {
+            Flags::default() | Flags::REJECT_UNAUTHORIZED
+        } else {
+            Flags::default()
+        }),
         this_value: JsCell::new(JsRef::empty()),
         poll_ref: JsCell::new(KeepAlive::init()),
         ref_pollref_on_connect: Cell::new(true),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1653,10 +1653,27 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
         }
 
+        // `socket.authorized` must reflect peer-certificate verification, not
+        // just handshake completion. The callback's second argument stays raw:
+        // callers learn the verify verdict from its error argument and the
+        // `authorized` getter.
+        let authorized_flag = authorized && (!SSL || ssl_error.error_no == 0);
+
         this.update_flags(|f| {
-            f.set(Flags::AUTHORIZED, authorized);
+            f.set(Flags::AUTHORIZED, authorized_flag);
             f.set(Flags::HOSTNAME_MISMATCH, hostname_mismatch);
         });
+
+        // A client must not keep a connection whose peer certificate failed
+        // chain verification when the resolved `rejectUnauthorized` is true
+        // (the documented default). The callback observes the handshake
+        // first; node:tls destroys the socket there itself, making the
+        // close below a no-op. Server-side mTLS enforcement is separate.
+        let reject_unauthorized = SSL
+            && success == 1
+            && ssl_error.error_no != 0
+            && !handlers.mode.is_server()
+            && this.flags.get().contains(Flags::REJECT_UNAUTHORIZED);
 
         let mut callback = handlers.on_handshake();
         let mut is_open = false;
@@ -1669,6 +1686,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         if callback.is_empty() {
             callback = handlers.on_open();
             if callback.is_empty() {
+                if reject_unauthorized {
+                    this.reject_unauthorized_connection();
+                }
                 return Ok(());
             }
             is_open = true;
@@ -1708,6 +1728,10 @@ impl<const SSL: bool> NewSocket<SSL> {
                         // `Scope` has no Drop — balance event_loop().enter() and
                         // active_connections before propagating.
                         this.exit_scope(scope);
+                        // Fail closed: this exit is also past a failed verify.
+                        if reject_unauthorized {
+                            this.reject_unauthorized_connection();
+                        }
                         return Err(e);
                     }
                 }
@@ -1727,7 +1751,28 @@ impl<const SSL: bool> NewSocket<SSL> {
             let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
         }
         this.exit_scope(scope);
+        if reject_unauthorized {
+            this.reject_unauthorized_connection();
+        }
         Ok(())
+    }
+
+    /// Closes a TLS connection whose peer certificate failed verification
+    /// while the resolved `rejectUnauthorized` is true. Runs after the
+    /// handshake callback so JS observes the handshake first; the close
+    /// dispatches `on_close` synchronously, so no `data` event can follow.
+    fn reject_unauthorized_connection(&self) {
+        let socket = self.socket.get();
+        if socket.is_detached() || socket.is_closed() {
+            // The handshake callback already tore the connection down.
+            return;
+        }
+        // Hold a ref across the synchronous `on_close` dispatch; the matching
+        // deref below may be the one that frees `self`, so nothing touches
+        // `self` after it.
+        self.ref_();
+        self.close_and_detach(uws::CloseCode::FastShutdown);
+        self.deref();
     }
 
     /// A new resumable TLS session arrived (the peer's NewSessionTicket was
@@ -3263,7 +3308,12 @@ impl<const SSL: bool> NewSocket<SSL> {
                     tls_js,
                 )?;
             } else if tls_js.to_boolean() {
-                ssl_opts = Some(SSLConfig::default());
+                let mut default_cfg = SSLConfig::default();
+                if !is_server {
+                    default_cfg.reject_unauthorized =
+                        handlers.vm.get_tls_reject_unauthorized() as i32;
+                }
+                ssl_opts = Some(default_cfg);
             }
             let cfg = ssl_opts
                 .as_mut()
@@ -3330,7 +3380,13 @@ impl<const SSL: bool> NewSocket<SSL> {
             server_name: JsCell::new(
                 cfg.and_then(|c| c.server_name_bytes().map(Box::<[u8]>::from)),
             ),
-            flags: Cell::new(Flags::default()),
+            flags: Cell::new(
+                if !is_server && cfg.is_some_and(|c| c.reject_unauthorized != 0) {
+                    Flags::default() | Flags::REJECT_UNAUTHORIZED
+                } else {
+                    Flags::default()
+                },
+            ),
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::init()),
             ref_pollref_on_connect: Cell::new(true),
@@ -3832,6 +3888,10 @@ bitflags::bitflags! {
         /// pre-handshake bytes / read the underlying TCP stream.
         const BYPASS_TLS           = 1 << 9;
         const HOSTNAME_MISMATCH    = 1 << 11;
+        /// Resolved `rejectUnauthorized` for a client TLS socket: a peer
+        /// certificate that fails chain verification closes the connection
+        /// after the handshake callback runs (see `on_handshake`).
+        const REJECT_UNAUTHORIZED  = 1 << 12;
     }
 }
 
@@ -4239,7 +4299,11 @@ pub fn js_upgrade_duplex_to_tls(
         if !tls.is_boolean() {
             ssl_opts = SSLConfig::from_js(VirtualMachine::get().as_mut(), global, tls)?;
         } else if tls.to_boolean() {
-            ssl_opts = Some(SSLConfig::default());
+            let mut default_cfg = SSLConfig::default();
+            if !is_server {
+                default_cfg.reject_unauthorized = handlers.vm.get_tls_reject_unauthorized() as i32;
+            }
+            ssl_opts = Some(default_cfg);
         }
     }
     if owned_ctx.is_none() && ssl_opts.is_none() {
@@ -4266,7 +4330,13 @@ pub fn js_upgrade_duplex_to_tls(
         server_name: JsCell::new(
             socket_config.and_then(|cfg| cfg.server_name_bytes().map(Box::<[u8]>::from)),
         ),
-        flags: Cell::new(Flags::default()),
+        flags: Cell::new(
+            if !is_server && socket_config.is_some_and(|cfg| cfg.reject_unauthorized != 0) {
+                Flags::default() | Flags::REJECT_UNAUTHORIZED
+            } else {
+                Flags::default()
+            },
+        ),
         this_value: JsCell::new(JsRef::empty()),
         poll_ref: JsCell::new(KeepAlive::init()),
         ref_pollref_on_connect: Cell::new(true),

--- a/test/js/bun/http/bun-connect-x509.test.ts
+++ b/test/js/bun/http/bun-connect-x509.test.ts
@@ -44,7 +44,7 @@ describe("bun.connect", () => {
     await Bun.connect({
       hostname: listener.hostname,
       port: listener.port,
-      tls: harness.tls,
+      tls: { ca: harness.tls.cert },
       socket: {
         open(socket: Socket) {},
         close() {},

--- a/test/js/bun/net/socket-retention.test.ts
+++ b/test/js/bun/net/socket-retention.test.ts
@@ -159,7 +159,7 @@ test.skipIf(isWindows)("upgradeTLS raw + tls wrappers are both collectable after
         },
       });
       const [raw, tls] = socket.upgradeTLS({
-        tls: tlsCert,
+        tls: { ...tlsCert, ca: tlsCert.cert },
         socket: {
           drain(s) {
             s.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1100,7 +1100,7 @@ it("TLS client: flush() after end() does not double-teardown before deferred onC
       const client = await Bun.connect({
         hostname: "127.0.0.1",
         port: server.port,
-        tls,
+        tls: { ...tls, ca: tls.cert },
         socket: {
           handshake() { onHandshook(); },
           data() {},

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3,6 +3,7 @@ import { connect, fileURLToPath, SocketHandler, spawn } from "bun";
 import { createSocketPair } from "bun:internal-for-testing";
 import { describe, expect, it, jest } from "bun:test";
 import { closeSync } from "fs";
+import { createSecureContext } from "node:tls";
 import { bunEnv, bunExe, expectMaxObjectTypeCount, getMaxFD, isWindows, tempDir, tls } from "harness";
 describe.concurrent("socket", () => {
   it("should throw when a socket from a file descriptor has a bad file descriptor", async () => {
@@ -2160,6 +2161,60 @@ Reo=
     t.client.write("ping");
     await t.echoed.promise;
     expect(t.received.join("")).toContain("hello-from-server\n");
+  });
+
+  it("closes an untrusted connection upgraded with only a secureContext", async () => {
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { key: ROGUE_KEY, cert: ROGUE_CRT },
+      socket: {
+        open() {},
+        handshake(socket) {
+          socket.write("hello-from-server\n");
+        },
+        data(socket, data) {
+          socket.write(data);
+        },
+        close() {},
+        error() {},
+      },
+    });
+
+    const received: string[] = [];
+    const handshake = Promise.withResolvers<{ authorized: boolean; error: string | null }>();
+    const closed = Promise.withResolvers<void>();
+
+    using tcp = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: { data() {}, close() {}, error() {} },
+    });
+    const { context } = createSecureContext({ ca: CA_CRT }) as any;
+    const [raw, secure] = tcp.upgradeTLS({
+      secureContext: context,
+      socket: {
+        handshake(socket: Socket, _success: boolean, authorizationError: Error | null) {
+          handshake.resolve({
+            authorized: socket.authorized,
+            error: authorizationError?.message ?? null,
+          });
+        },
+        data(_socket: Socket, data: Buffer) {
+          received.push(data.toString());
+        },
+        close() {
+          closed.resolve();
+        },
+        error() {},
+      },
+    } as any);
+    using _raw = raw;
+    using _secure = secure;
+
+    expect(await handshake.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE });
+    await closed.promise;
+    expect(received).toEqual([]);
   });
 
   it("keeps a connection whose server certificate is trusted", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -717,7 +717,7 @@ describe.concurrent("socket", () => {
         });
         const result = socket.upgradeTLS({
           data: Buffer.from("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"),
-          tls,
+          tls: { ...tls, ca: tls.cert },
           socket: {
             data(socket, data) {
               body += data.toString("utf8");
@@ -1903,4 +1903,275 @@ it("socket handler validation errors don't steal GC protection from live sockets
   expect(stdout).toBe("errors=8\nreceived=hello\ndone\n");
   expect(exitCode).toBe(0);
   void stderr;
+});
+
+// https://github.com/oven-sh/bun/issues/33846
+// Bun.connect with rejectUnauthorized at its documented default (true) must
+// not exchange application data with a server whose certificate fails chain
+// verification, and socket.authorized must reflect the verification result.
+// Certs generated once with openssl: a trusted CA, a "localhost" server cert
+// signed by it, and another "localhost" server cert (same SANs) signed by a
+// different CA, so chain verification is the only difference between them.
+describe("Bun.connect TLS server-certificate authorization", () => {
+  const CA_CRT = `-----BEGIN CERTIFICATE-----
+MIIDHTCCAgWgAwIBAgIUdYbBJxXcjPYUU84754Rvyby/Wl8wDQYJKoZIhvcNAQEL
+BQAwHjEcMBoGA1UEAwwTQnVuLVRlc3QtVHJ1c3RlZC1DQTAeFw0yNjA3MDkxMzA5
+NTFaFw0zNjA3MDYxMzA5NTFaMB4xHDAaBgNVBAMME0J1bi1UZXN0LVRydXN0ZWQt
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTEqxdtRmWWEJejm0F
+ZpClpYe2/xnRA1YV/aH/mEeDF47MjYHYwN3htbjd6B0JFk9UhWKoiKuHyLlr6Pu9
+H1f2H4gAaqdkjbRJApXTk1AkDrJE2jZ+0CkMeycplpyjiQRqn0iUrUlbfNm97Wj/
+rx98s0VIS62YYx7z5svBkrxdCmTo8eVZHBgGRcMy9npqJC2t9DdYBWbqjeZCyQsb
+DRrJ46EF5anE1VkNtF6lX13rkjHY7syB+fVKfLFWcGgQCDyd14Ltb3myrfYdKsnZ
+z1wtUDgw1AE80MmatcH3N6ev7bOu68OAsZb3D9i5Ngfs0hUdqhTtUQztkfK3J63m
+5fVZAgMBAAGjUzBRMB0GA1UdDgQWBBQ+Ub20vshUFo+vQrymr9MLIh2NQDAfBgNV
+HSMEGDAWgBQ+Ub20vshUFo+vQrymr9MLIh2NQDAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQBzuL3k1AeP6WIsZp1ZsYWeC0VItwJXDKWItV5QlsX+
+JysjqMmEmJk55f54gpDdwdovgtqHNSZ6tXMBCLEqm7EQAT17IeUP5jhMy2vhePbp
+WU6KmAGYdack4r9oBk0bEUty/MfeH+poXDCBbZ6i010SEczDZt3X4NnmHHc50dMu
+wNApO7EeiZVjHOzVLpUqM7YMtRiz4QdI5dydNZeB7R6oIM2o0Hx43tE9mZzFOuKb
+KsbVnnD+mVj0e399Y+XxJ58eEvj/QVpYciLKBEvS9fREGbJ9EV7Pf3hy32WY26An
+X9IuLMOkTY4boCoNf5Azw3IPnOCAt1tavdI2ChtYc4fF
+-----END CERTIFICATE-----`;
+
+  const SERVER_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCf80SxHGevvLZP
+ft7aHBHugflXvvX8ieCaVUtn/f8vhDuhs5UyZDrI64xW4ij5eBSteK7JbPY3BGgU
+tzjzsZVR8v0W7Fsqbkd0NL08HKp7jaHcVhgMjNKWHIqzgr/f9lRnLdXfzrr2JG//
+WApHevnNF1TpJJJ604uKkk5HmZcpqdwXgdJeBG1ZEc1pEe6EDUmQQXh4f4J8rmsu
+8CvTVQXeKunZnawhVsY7dKkvH27wBKfOwuafM3q2SnrVqVJfaWN0sdRi7H75PrMl
+Y358AGuxs/AeZ1IUV2XxpYjNI7gEtlK7Dv0kOxSTpJuVLd1J4Z9Sn6pr3MAUEHUz
+nMCtYNP1AgMBAAECggEABNH49PltKn+eYuDo6FvGMpDaKcnIcfbZvOzrG9Qst4rd
+nS7jRSR+HQX0Mb4ZDAORY/TqF4ngFaJdXJp07eshG9odxG4VBT9Tie348fHPNW/8
+O76gdOhdhEaR63z6OU6cFovsERWSzs4kTeaiUKslEggs9+WxQGBVqTRlhYTcaFX4
+39ad0B0MF1bWDFyHhhzzDRMlIEAiIDNs00sTPEPcCFlWBSsuF2MdzO+bWtS76mhI
+JXJJlZe5SeteiudJXjDkpGzpDF32MHRj1Io591o7eYM97NuibxubKngnVArrOb2U
+pBbrFptvhZOdpQ+4vUVnzM3EBjOND05h0wmP9b8xdQKBgQDaOHESKhT9CssLMCEp
+kOehOLS8ZhsJdTH4GK8iQYAbshZ7T1d0AP+rkN2vs9f0eHqWngFCvDtatixfYFJj
+DVW9EgHUVGhvg09PtUJPa3e8lgnx8kr5+4/Pgh3Rs3qBQZFFJf7Z4RKyDjUz9j8O
+mL5YihOP5xVp4goCMYH/U5LrjwKBgQC7pEipjejuYE2UDVAvSOT0r2gn3VgcLYXo
+jzPgkMhNkFus0nJi09Zd7reZ5Qmur4J6N9RNL6ob5hu21nKCP4HZSPN4kU0orsNp
+BVCwWb5ehG8WqFgPrCcVEJtQamHjVLvAgEBVW3Vc0PxnJOml/fvc20TVsc/bl9l0
+QANLWzXWOwKBgQCJ96Ntg5OvhJJpKW3eFNKNuQd0Ee5IJYOJQzn/I4B2gjr6jWhS
+XItJEpdGjiMcWsvOzGkpo063hHQ7fO+51mV925OyhgddcZzEXWpmQiD657Wz9ad3
+s5fx72cg/SOX8zeAi4w8frPORXNXvfmSJfo6ilnh4o1EW3hOeLSjFFjQewKBgQCM
+qFbLuxQb9NbSn7Q27darUP2rvHG7Fajmrso9kWqFMix2fX6/dHqiCTtaQmWiq/AL
+++PKRGuo5DJsOY628jI9FkFkZM9JKtBS3mgg+fUJVw8LFgCFJxBY6wzyF/zu82qW
+n80Z7ygn/oTmMLZw9tYhNcEAy3y76LVaPk355BKUVwKBgAdhDA9DIFzpvIygaZId
+5vbz7dRYQ5MnLT48DxUko33q7+qPQagZltFl+ICBPhVQ10FP1wpNJwPs0ap/XVlB
++wDT5l7WNe2r/XqkI9cwQtZHy+TLwFRygb9ko44wLoNKdYgPEHordKeyGXQQlt3Y
+q7gf9VyYyWX6rkRsx/MV6hLf
+-----END PRIVATE KEY-----`;
+
+  const SERVER_CRT = `-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIULV6Pt6CN+GC7Hhr9gkO1wFmEeIAwDQYJKoZIhvcNAQEL
+BQAwHjEcMBoGA1UEAwwTQnVuLVRlc3QtVHJ1c3RlZC1DQTAeFw0yNjA3MDkxMzA5
+NTFaFw0zNjA3MDYxMzA5NTFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ/zRLEcZ6+8tk9+3tocEe6B+Ve+9fyJ
+4JpVS2f9/y+EO6GzlTJkOsjrjFbiKPl4FK14rsls9jcEaBS3OPOxlVHy/RbsWypu
+R3Q0vTwcqnuNodxWGAyM0pYcirOCv9/2VGct1d/OuvYkb/9YCkd6+c0XVOkkknrT
+i4qSTkeZlymp3BeB0l4EbVkRzWkR7oQNSZBBeHh/gnyuay7wK9NVBd4q6dmdrCFW
+xjt0qS8fbvAEp87C5p8zerZKetWpUl9pY3Sx1GLsfvk+syVjfnwAa7Gz8B5nUhRX
+ZfGliM0juAS2UrsO/SQ7FJOkm5Ut3Unhn1KfqmvcwBQQdTOcwK1g0/UCAwEAAaNw
+MG4wLAYDVR0RBCUwI4IJbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAAB
+MB0GA1UdDgQWBBTfIEZmI/+0PcpH+jHkfBQc9jNOVzAfBgNVHSMEGDAWgBQ+Ub20
+vshUFo+vQrymr9MLIh2NQDANBgkqhkiG9w0BAQsFAAOCAQEADLkbKVP3W+RYFYIg
+A0bfgJrQ1MhebrYk4W95BktNKRHuYE+22Nao8ZJcWXASNAoj++8Z03Be3fY0jHVn
+rY7Fd4p0u0J/IpNfOBbzeT17HvrXQ9cUi7CtaStBKmDpkl1NVmoJNBzwpUISDH/T
+mlWKKg3D5qG0H+RTOAgxDKmc6+fZWt5v/TgQq5hc1NB2WoZAk52uhRD0V7hhfmPy
+ZMdsndROjusArt/+ACRYcGN8g+aoON1RUq1lYeefb2uGtWk3AKd9+nsqTUQsPB/V
+aJSYfdU6MExCjVaib8zV8hjA0hCU0kQ0PlVvPrQkMn3RPhPwRzixLWrIuI4hz9sB
+sm8N1g==
+-----END CERTIFICATE-----`;
+
+  const ROGUE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQCN6OeCnDUVF9dC
+ouDNaM8hhpuK4NBm51XN+nm79zEAKTYjoW1j8zFZYfb03dCuYqVQ0rxlvHUFrEm1
+/oOmcDbKHm0VjGN9xkhvfcTRvMcoKW52r3WwRCSLFkYFw+SvFFrtvC9zxpojtFLx
+YY1rfBrnOeCsC34B9Jjb50ioyQcP+aMAy8AUFbBd2+gpslkDuMzFigLkWxXV/6dP
+ta1ZjUOsAjbebGlZ78tSfhVEWpXudnH73y1Wj6hCIg9gdggfDwLqOu0mZa8/+3M7
+TvR5hDstzUOx7I+Q48I7g/du/BIn8CNDRWqWbtz1jPNIJc8g7OnuMsvvZqWgQG7a
+5bxBWUHtAgMBAAECggEAEo+wGElOOCASK8kaFkPrM7tjhNq653rColpsqcU/R4Ic
+brSiljws7EAACS8qKGUGsned5MCtnbxXN9K+bXqn7+/i3LqsGLtiphKRN821Tu98
+X1G71v5SuU6EgiSJOM00x3uhyUbkyl6/qorT8IcfDbdoR5iJNsBDbh/mRQ1mOxR9
+9hoIv5UGsKTYqzm2v4y/W0MITpfp9NyrmExrvg52q20fAQJsGzLhY6mv/HpAbiWx
+dhXuKKDK2kYiv4/5CRgZxDsVbBODTDlwlRTQibZuzFGUxbOjdXJiFS/CxuiggL5L
+x6OgQxLCmlx3gJSWyd1y2YQUfqwio2IvROkMJgYngQKBgQDFE6af59JwfKAZfQjj
+1/CWmg/nvbJId+kCBeRReDPEG4PZVn/iMYQ9U8HMtIGJmR1qPkS479zIhmt3loM8
+LEqLmAB+MUhLBr9w0Ww6E1NOvZYl188DKCHlkyWIgZxLulqcOgpaetZZ1LJGADDJ
+MOtHMih0f14M2lcIPcvvDClPCQKBgQC4Vr8kbNY8PwXF1RZYV/8x/Q4/avuwrJ0k
+e6Gxk9/eHolIcU276QSQTut66KiFVUjLqNXwFX+FsHRh3L3bzfCzKP1XNdVgaKMy
+mYIJpPAK0XF/1F5/1WjhFyvnQws3Ro6VUDT5Nefm9lrM6AdwTUvq6yObU9KP8pCQ
+VPAyxn/wxQKBgG3K39ZQEWYHmC37AZvlrqxIUjoZ7Zv/6bjtzWAx5i0H4zGOxhoe
+2fxMkDhaC5y7x65r2F9rigXRFUf/e0dnqXQRj5y+GfdqX/cbRP8pywygBGk6zKKG
+ljPPAWcGRivOOzK0BxaXPpm3LEZhTsyXS0xTvkQAvUXN0hTOULHxhYX5An8qe9OR
+kYPOXrf14CZGNgGag7fE5eMb1KxivBuH0YzGpEL/bx17MTjcCVQ7/2LXV9BvH3ou
+2sWJCiHIbBdVkSDoKYo5jy6eCX+TKc3OazTnSV3fGBKvY3/IYI69vbXYB2rU/qc2
+yDWqBRzoHJGaUDYu7gJGygq9IiovGWRCT30tAoGAZQsZvzJnXtHwuSOqvAdKbddX
+2skPfTcFExiX1IB5mGO3hflMWIOSN3hHyR59QxKWKbDqecfa3MJBkUGhrmNZD2Sj
+/5X6E7YRbJWdP9yYSc39/2KOQMM1vKYuS6ggQcgdKWcLlrRP1VXI7xX/BEZ/K2hw
+TEdUSMbWShRVjPciMwU=
+-----END PRIVATE KEY-----`;
+
+  const ROGUE_CRT = `-----BEGIN CERTIFICATE-----
+MIIDLjCCAhagAwIBAgIUCD6d9Di7zLh2+19ZFKkuuU/oxMgwDQYJKoZIhvcNAQEL
+BQAwHDEaMBgGA1UEAwwRQnVuLVRlc3QtUm9ndWUtQ0EwHhcNMjYwNzA5MTMwOTUx
+WhcNMzYwNzA2MTMwOTUxWjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCN6OeCnDUVF9dCouDNaM8hhpuK4NBm51XN
++nm79zEAKTYjoW1j8zFZYfb03dCuYqVQ0rxlvHUFrEm1/oOmcDbKHm0VjGN9xkhv
+fcTRvMcoKW52r3WwRCSLFkYFw+SvFFrtvC9zxpojtFLxYY1rfBrnOeCsC34B9Jjb
+50ioyQcP+aMAy8AUFbBd2+gpslkDuMzFigLkWxXV/6dPta1ZjUOsAjbebGlZ78tS
+fhVEWpXudnH73y1Wj6hCIg9gdggfDwLqOu0mZa8/+3M7TvR5hDstzUOx7I+Q48I7
+g/du/BIn8CNDRWqWbtz1jPNIJc8g7OnuMsvvZqWgQG7a5bxBWUHtAgMBAAGjcDBu
+MCwGA1UdEQQlMCOCCWxvY2FsaG9zdIcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATAd
+BgNVHQ4EFgQUl5rCgVO/Wjb8QhyZnBLOwGvPZwYwHwYDVR0jBBgwFoAUimhDnL/h
+FghNe5jeHKjRB6WbMF0wDQYJKoZIhvcNAQELBQADggEBAAVb8clHFZpkZF72j2u0
+ulIQksCH4gSa5zamjsisnSlEh8j6jG4h8C5hGmGEh/zzHYKirR+Hqs8aiLA4BHlJ
+mq2rP5gsSMPO1wkeu6ZOFIXsPKA7Tb2ZhNzL0W+xz4e9bbAXE9vSZQggQ2KstokV
+uNg9oyZD5BBxvUGt3ZHSUu2k14HDhSyMnAEADTOAk4u28QxLaPcI7tyZ56Qy1Byf
+UqDL36Xlwc8WG6xdgc3sU3oxGpqNx5Gb/nK2Oql+P8QDXBj2Ak2r5FtyuvzD0JZ4
+ijlBfSKvj17k9aaZj8NI7cU/f1DhdxDutQgxZyikanCO3hOzoaNc6CiSQacYgEOm
+Reo=
+-----END CERTIFICATE-----`;
+
+  const UNTRUSTED_MESSAGE = "unable to verify the first certificate";
+
+  async function connectTo(
+    serverTls: { key: string; cert: string },
+    clientTls: Record<string, unknown> | boolean,
+  ) {
+    const received: string[] = [];
+    const handshake = Promise.withResolvers<{
+      authorizedArg: boolean;
+      authorizedGetter: boolean;
+      callbackError: string | null;
+      getterError: string | null;
+    }>();
+    const closed = Promise.withResolvers<void>();
+    const echoed = Promise.withResolvers<void>();
+
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: serverTls,
+      socket: {
+        open() {},
+        handshake(socket) {
+          socket.write("hello-from-server\n");
+        },
+        data(socket, data) {
+          socket.write(data);
+        },
+        close() {},
+        error() {},
+      },
+    });
+
+    const client = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      tls: clientTls as Bun.TLSOptions,
+      socket: {
+        open() {},
+        handshake(socket, authorized, authorizationError) {
+          handshake.resolve({
+            authorizedArg: authorized,
+            authorizedGetter: socket.authorized,
+            callbackError: authorizationError?.message ?? null,
+            getterError: socket.getAuthorizationError()?.message ?? null,
+          });
+        },
+        data(_socket, data) {
+          received.push(data.toString());
+          echoed.resolve();
+        },
+        close() {
+          closed.resolve();
+        },
+        error(_socket, err) {
+          handshake.reject(err);
+          echoed.reject(err);
+        },
+        connectError(_socket, err) {
+          handshake.reject(err);
+          closed.reject(err);
+          echoed.reject(err);
+        },
+      },
+    });
+
+    return {
+      server,
+      client,
+      received,
+      handshake,
+      closed,
+      echoed,
+      [Symbol.dispose]() {
+        client.end();
+        server.stop(true);
+      },
+    };
+  }
+
+  it("closes a connection whose server certificate is not trusted", async () => {
+    using t = await connectTo(
+      { key: ROGUE_KEY, cert: ROGUE_CRT },
+      { ca: CA_CRT }, // rejectUnauthorized left at its documented default (true)
+    );
+    // The callback's second argument stays the raw handshake result; the
+    // verification verdict is the authorized getter / error argument.
+    expect(await t.handshake.promise).toEqual({
+      authorizedArg: true,
+      authorizedGetter: false,
+      callbackError: UNTRUSTED_MESSAGE,
+      getterError: UNTRUSTED_MESSAGE,
+    });
+    await t.closed.promise;
+    expect(t.received).toEqual([]);
+  });
+
+  it("closes an untrusted connection with tls: true", async () => {
+    using t = await connectTo({ key: ROGUE_KEY, cert: ROGUE_CRT }, true);
+    // The callback's second argument stays the raw handshake result; the
+    // verification verdict is the authorized getter / error argument.
+    expect(await t.handshake.promise).toEqual({
+      authorizedArg: true,
+      authorizedGetter: false,
+      callbackError: UNTRUSTED_MESSAGE,
+      getterError: UNTRUSTED_MESSAGE,
+    });
+    await t.closed.promise;
+    expect(t.received).toEqual([]);
+  });
+
+  it("reports authorized=false but keeps the connection with rejectUnauthorized: false", async () => {
+    using t = await connectTo(
+      { key: ROGUE_KEY, cert: ROGUE_CRT },
+      { ca: CA_CRT, rejectUnauthorized: false },
+    );
+    // The callback's second argument stays the raw handshake result; the
+    // verification verdict is the authorized getter / error argument.
+    expect(await t.handshake.promise).toEqual({
+      authorizedArg: true,
+      authorizedGetter: false,
+      callbackError: UNTRUSTED_MESSAGE,
+      getterError: UNTRUSTED_MESSAGE,
+    });
+    t.client.write("ping");
+    await t.echoed.promise;
+    expect(t.received.join("")).toContain("hello-from-server\n");
+  });
+
+  it("keeps a connection whose server certificate is trusted", async () => {
+    using t = await connectTo({ key: SERVER_KEY, cert: SERVER_CRT }, { ca: CA_CRT });
+    expect(await t.handshake.promise).toEqual({
+      authorizedArg: true,
+      authorizedGetter: true,
+      callbackError: null,
+      getterError: null,
+    });
+    t.client.write("ping");
+    await t.echoed.promise;
+    expect(t.received.join("")).toContain("hello-from-server\n");
+  });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3,8 +3,8 @@ import { connect, fileURLToPath, SocketHandler, spawn } from "bun";
 import { createSocketPair } from "bun:internal-for-testing";
 import { describe, expect, it, jest } from "bun:test";
 import { closeSync } from "fs";
-import { createSecureContext } from "node:tls";
 import { bunEnv, bunExe, expectMaxObjectTypeCount, getMaxFD, isWindows, tempDir, tls } from "harness";
+import { createSecureContext } from "node:tls";
 describe.concurrent("socket", () => {
   it("should throw when a socket from a file descriptor has a bad file descriptor", async () => {
     const open = jest.fn();

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2063,38 +2063,44 @@ Reo=
       },
     });
 
-    const client = await Bun.connect({
-      hostname: "127.0.0.1",
-      port: server.port,
-      tls: clientTls as Bun.TLSOptions,
-      socket: {
-        open() {},
-        handshake(socket, authorized, authorizationError) {
-          handshake.resolve({
-            authorizedArg: authorized,
-            authorizedGetter: socket.authorized,
-            callbackError: authorizationError?.message ?? null,
-            getterError: socket.getAuthorizationError()?.message ?? null,
-          });
+    let client: Bun.Socket;
+    try {
+      client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: clientTls as Bun.TLSOptions,
+        socket: {
+          open() {},
+          handshake(socket, authorized, authorizationError) {
+            handshake.resolve({
+              authorizedArg: authorized,
+              authorizedGetter: socket.authorized,
+              callbackError: authorizationError?.message ?? null,
+              getterError: socket.getAuthorizationError()?.message ?? null,
+            });
+          },
+          data(_socket, data) {
+            received.push(data.toString());
+            echoed.resolve();
+          },
+          close() {
+            closed.resolve();
+          },
+          error(_socket, err) {
+            handshake.reject(err);
+            echoed.reject(err);
+          },
+          connectError(_socket, err) {
+            handshake.reject(err);
+            closed.reject(err);
+            echoed.reject(err);
+          },
         },
-        data(_socket, data) {
-          received.push(data.toString());
-          echoed.resolve();
-        },
-        close() {
-          closed.resolve();
-        },
-        error(_socket, err) {
-          handshake.reject(err);
-          echoed.reject(err);
-        },
-        connectError(_socket, err) {
-          handshake.reject(err);
-          closed.reject(err);
-          echoed.reject(err);
-        },
-      },
-    });
+      });
+    } catch (e) {
+      server.stop(true);
+      throw e;
+    }
 
     return {
       server,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2035,10 +2035,7 @@ Reo=
 
   const UNTRUSTED_MESSAGE = "unable to verify the first certificate";
 
-  async function connectTo(
-    serverTls: { key: string; cert: string },
-    clientTls: Record<string, unknown> | boolean,
-  ) {
+  async function connectTo(serverTls: { key: string; cert: string }, clientTls: Record<string, unknown> | boolean) {
     const received: string[] = [];
     const handshake = Promise.withResolvers<{
       authorizedArg: boolean;
@@ -2145,10 +2142,7 @@ Reo=
   });
 
   it("reports authorized=false but keeps the connection with rejectUnauthorized: false", async () => {
-    using t = await connectTo(
-      { key: ROGUE_KEY, cert: ROGUE_CRT },
-      { ca: CA_CRT, rejectUnauthorized: false },
-    );
+    using t = await connectTo({ key: ROGUE_KEY, cert: ROGUE_CRT }, { ca: CA_CRT, rejectUnauthorized: false });
     // The callback's second argument stays the raw handshake result; the
     // verification verdict is the authorized getter / error argument.
     expect(await t.handshake.promise).toEqual({

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -399,18 +399,16 @@ describe("tls.createServer events", () => {
 
     server.on("error", closeAndFail);
 
-    // First `Bun.connect({tls:true})` of the process triggers the once-only
-    // bundled-root-store build (`us_get_shared_default_ca_store`, ~150 ms in
-    // debug+ASAN) so SSL_get_verify_result is real instead of the false
-    // X509_V_OK VERIFY_NONE used to report. The condition assertion is the
-    // point; the old 100 ms was a perf claim that is now load-order-dependent.
+    // The client trusts the server's self-signed cert via `ca` so chain
+    // verification passes; with the default rejectUnauthorized (true) an
+    // untrusted chain would close the connection right after the handshake.
     timeout = setTimeout(closeAndFail, isDebug ? 2000 : 500);
 
     server.listen(
       mustCall(async () => {
         const address = server.address() as AddressInfo;
         client = await Bun.connect({
-          tls: true,
+          tls: { ca: COMMON_CERT.cert },
           hostname: address.address,
           port: address.port,
           socket: {
@@ -451,18 +449,16 @@ describe("tls.createServer events", () => {
     };
     server.on("error", closeAndFail);
 
-    // First `Bun.connect({tls:true})` of the process triggers the once-only
-    // bundled-root-store build (`us_get_shared_default_ca_store`, ~150 ms in
-    // debug+ASAN) so SSL_get_verify_result is real instead of the false
-    // X509_V_OK VERIFY_NONE used to report. The condition assertion is the
-    // point; the old 100 ms was a perf claim that is now load-order-dependent.
+    // The client trusts the server's self-signed cert via `ca` so chain
+    // verification passes; with the default rejectUnauthorized (true) an
+    // untrusted chain would close the connection right after the handshake.
     timeout = setTimeout(closeAndFail, isDebug ? 2000 : 500);
 
     server.listen(
       mustCall(async () => {
         const address = server.address() as AddressInfo;
         await Bun.connect({
-          tls: true,
+          tls: { ca: COMMON_CERT.cert },
           hostname: address.address,
           port: address.port,
           socket: {
@@ -529,7 +525,7 @@ describe("tls.createServer events", () => {
 
         async function spawnClient() {
           await Bun.connect({
-            tls: true,
+            tls: { ca: COMMON_CERT.cert },
             port: address?.port,
             hostname: address?.address,
             socket: {
@@ -607,18 +603,16 @@ describe("tls.createServer events", () => {
 
     server.on("error", closeAndFail);
 
-    // First `Bun.connect({tls:true})` of the process triggers the once-only
-    // bundled-root-store build (`us_get_shared_default_ca_store`, ~150 ms in
-    // debug+ASAN) so SSL_get_verify_result is real instead of the false
-    // X509_V_OK VERIFY_NONE used to report. The condition assertion is the
-    // point; the old 100 ms was a perf claim that is now load-order-dependent.
+    // The client trusts the server's self-signed cert via `ca` so chain
+    // verification passes; with the default rejectUnauthorized (true) an
+    // untrusted chain would close the connection right after the handshake.
     timeout = setTimeout(closeAndFail, isDebug ? 2000 : 500);
 
     server.listen(
       mustCall(async () => {
         const address = server.address() as AddressInfo;
         client = await Bun.connect({
-          tls: true,
+          tls: { ca: COMMON_CERT.cert },
           hostname: address.address,
           port: address.port,
           socket: {


### PR DESCRIPTION
Superseded in favor of https://github.com/oven-sh/bun/pull/33755

----


### What does this PR do?

Fixes #33846. Client-side counterpart of #33754 / #33755.

A `Bun.connect()` TLS client with `rejectUnauthorized` left at its documented default (`true`), connecting to a server whose certificate has the right hostname but is signed by an untrusted CA, completed the handshake, reported `socket.authorized === true` while `getAuthorizationError()` was simultaneously non-null ("unable to verify the first certificate"), and kept exchanging application data:

```
client: handshake() success = true
client: socket.authorized = true
client: authorizationError = unable to verify the first certificate

data received from malicious server: "SECRET-DATA-FROM-MALICIOUS-SERVER\n"
```

Cause: in `on_handshake` (src/runtime/socket/socket_body.rs), `authorized` was `success == 1` adjusted only by the hostname check; the chain-verification result (`ssl_error.error_no`) was never consulted. `SSLConfig` resolves `reject_unauthorized` correctly (default true), but nothing stored it anywhere the client handshake path could reach.

The fix:

- Store the resolved `rejectUnauthorized` in a new socket flag at every client TLS creation site: `Bun.connect` (fresh and reconnect), the Windows named-pipe connect path, `upgradeTLS`, the duplex upgrade, the `tls: true` boolean form, and the bare-`secureContext` upgrade form (the last two previously produced no config and now resolve the `NODE_TLS_REJECT_UNAUTHORIZED`-aware default for clients).
- Fold the verify result into the stored `authorized` flag, so `socket.authorized` and `getAuthorizationError()` agree. The handshake callback's second argument stays the raw handshake result (same decision as the server-side fix in #33755); callers read the verdict from the error argument and the getter.
- When verification failed and the resolved `rejectUnauthorized` is true, close the connection right after the handshake callback returns (mirroring #33755's server-side enforcement). Bytes the callback itself writes can still flush before the close, the same way Node allows writes queued before `'secureConnect'`; nothing the untrusted peer sends is ever delivered.

node:tls clients ride this same native path but always pass `rejectUnauthorized` explicitly and enforce it in JS (net.ts destroys the socket from its handshake handler with the proper Node error), so the native close is a no-op there; with `rejectUnauthorized: false` the flag is unset and behavior is unchanged. A hostname mismatch keeps its current behavior (`authorized` false, no forced close) because node:tls's `checkServerIdentity` override must be able to accept such connections; chain verification has no equivalent override.

Adopts the approach from #31419, which targeted this gap but predates the socket module refactor. The server-side twin #33755 is still open; the `authorized`-flag hunk is written identically so whichever lands second rebases trivially.

### How did you verify your code works?

- New `Bun.connect TLS server-certificate authorization` block in test/js/bun/net/socket.test.ts (certs generated once with openssl, embedded): untrusted CA with default `rejectUnauthorized` closes with `authorized === false` and no data delivered (the `ca:` object form, `tls: true`, and `upgradeTLS` with only a `secureContext`); `rejectUnauthorized: false` keeps the connection but now reports `authorized === false`; a trusted chain stays connected with `authorized === true`. The enforcement and flag tests fail on current main.
- Updated tests that relied on the old behavior: `bun-connect-x509.test.ts`, the `upgradeTLS` tests, the flush-after-end fixture, and the `Bun.connect({tls: true})` clients in `node-tls-server.test.ts` now have the client trust the server's CA instead of depending on unverified connections staying open.
- The issue's PoC now prints `socket.authorized = false`, fires `close()`, and exits 0 with no data received.
- node:tls and node:http2 suites pass locally with the debug build.
