### PR TITLE
uws: do not abort on us_create_timer NULL (timerfd_create EMFILE) during Worker init

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -607,7 +607,14 @@ struct us_timer_t *us_create_timer(struct us_loop_t *loop, int fallthrough, unsi
     memset(p, 0, sizeof(struct us_internal_callback_t) + ext_size);
     int timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
     if (timerfd == -1) {
-      return NULL;
+        /* Undo us_create_poll: free the allocation and the num_polls bump it
+         * took for non-fallthrough timers. The caller handles NULL. */
+        if (fallthrough) {
+            us_free(p);
+        } else {
+            us_poll_free(p, loop);
+        }
+        return NULL;
     }
     us_poll_init(p, timerfd, POLL_TYPE_CALLBACK);
 

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -110,15 +110,19 @@ impl GarbageCollectionController {
     pub fn init(&mut self, vm: &mut VirtualMachine) {
         // SAFETY: uws::Loop::get() returns the live process-global loop.
         let actual = unsafe { &mut *uws::Loop::get() };
-        self.gc_timer = Some(uws::Timer::create_fallthrough(
-            actual,
-            std::ptr::from_mut::<Self>(self),
-        ));
-        self.gc_repeating_timer = Some(uws::Timer::create_fallthrough(
-            actual,
-            std::ptr::from_mut::<Self>(self),
-        ));
+        self.gc_timer =
+            uws::Timer::create_fallthrough(actual, std::ptr::from_mut::<Self>(self));
+        self.gc_repeating_timer =
+            uws::Timer::create_fallthrough(actual, std::ptr::from_mut::<Self>(self));
         actual.internal_loop_data.jsc_vm = vm.jsc_vm.cast();
+
+        // timerfd_create can fail with EMFILE/ENFILE (Linux) when a Worker is
+        // spawned near RLIMIT_NOFILE; disable the controller and free any fd
+        // that was acquired rather than aborting the process.
+        let timers_unavailable = self.gc_timer.is_none() || self.gc_repeating_timer.is_none();
+        if timers_unavailable {
+            self.deinit();
+        }
 
         // `Transpiler::init` is deferred to the high-tier
         // `init_runtime_state` hook (which runs *after* `ensure_waker` →
@@ -148,7 +152,7 @@ impl GarbageCollectionController {
             }
         }
 
-        self.disabled = env.is_some_and(|e| e.has(b"BUN_GC_TIMER_DISABLE"));
+        self.disabled = timers_unavailable || env.is_some_and(|e| e.has(b"BUN_GC_TIMER_DISABLE"));
 
         if !self.disabled {
             let ext = std::ptr::from_mut::<Self>(self);

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -110,8 +110,7 @@ impl GarbageCollectionController {
     pub fn init(&mut self, vm: &mut VirtualMachine) {
         // SAFETY: uws::Loop::get() returns the live process-global loop.
         let actual = unsafe { &mut *uws::Loop::get() };
-        self.gc_timer =
-            uws::Timer::create_fallthrough(actual, std::ptr::from_mut::<Self>(self));
+        self.gc_timer = uws::Timer::create_fallthrough(actual, std::ptr::from_mut::<Self>(self));
         self.gc_repeating_timer =
             uws::Timer::create_fallthrough(actual, std::ptr::from_mut::<Self>(self));
         actual.internal_loop_data.jsc_vm = vm.jsc_vm.cast();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1066,20 +1066,21 @@ impl EventLoop {
 
         if !loop_.is_active() {
             if self.forever_timer.is_none() {
-                let mut t = uws::Timer::create(
+                if let Some(mut t) = uws::Timer::create(
                     loop_,
                     std::ptr::from_mut::<EventLoop>(self).cast::<core::ffi::c_void>(),
-                );
-                // SAFETY: t is a fresh non-null timer handle
-                unsafe {
-                    t.as_mut().set(
-                        std::ptr::from_mut::<EventLoop>(self).cast::<core::ffi::c_void>(),
-                        Some(noop_forever_timer),
-                        1000 * 60 * 4,
-                        1000 * 60 * 4,
-                    )
-                };
-                self.forever_timer = Some(t);
+                ) {
+                    // SAFETY: t is a fresh non-null timer handle
+                    unsafe {
+                        t.as_mut().set(
+                            std::ptr::from_mut::<EventLoop>(self).cast::<core::ffi::c_void>(),
+                            Some(noop_forever_timer),
+                            1000 * 60 * 4,
+                            1000 * 60 * 4,
+                        )
+                    };
+                    self.forever_timer = Some(t);
+                }
             }
         }
 

--- a/src/uws_sys/Timer.rs
+++ b/src/uws_sys/Timer.rs
@@ -17,7 +17,9 @@ bun_core::declare_scope!(uws, visible);
 bun_opaque::opaque_ffi! { pub struct Timer; }
 
 impl Timer {
-    pub fn create<T>(loop_: &mut Loop, _ptr: T) -> NonNull<Timer> {
+    // None when the C layer returns NULL (timerfd_create EMFILE/ENFILE on
+    // Linux). Callers must degrade gracefully rather than abort the process.
+    pub fn create<T>(loop_: &mut Loop, _ptr: T) -> Option<NonNull<Timer>> {
         // never fallthrough poll
         // the problem is uSockets hardcodes it on the other end
         // so we can never free non-fallthrough polls
@@ -29,15 +31,10 @@ impl Timer {
                 c_uint::try_from(size_of::<T>()).expect("int cast"),
             )
         };
-        NonNull::new(t).unwrap_or_else(|| {
-            panic!(
-                "us_create_timer: returned null: {}",
-                std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
-            )
-        })
+        NonNull::new(t)
     }
 
-    pub fn create_fallthrough<T>(loop_: &mut Loop, _ptr: T) -> NonNull<Timer> {
+    pub fn create_fallthrough<T>(loop_: &mut Loop, _ptr: T) -> Option<NonNull<Timer>> {
         // never fallthrough poll
         // the problem is uSockets hardcodes it on the other end
         // so we can never free non-fallthrough polls
@@ -49,12 +46,7 @@ impl Timer {
                 c_uint::try_from(size_of::<T>()).expect("int cast"),
             )
         };
-        NonNull::new(t).unwrap_or_else(|| {
-            panic!(
-                "us_create_timer: returned null: {}",
-                std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
-            )
-        })
+        NonNull::new(t)
     }
 
     pub fn set<T>(

--- a/test/js/web/workers/worker-fd-limit.test.ts
+++ b/test/js/web/workers/worker-fd-limit.test.ts
@@ -44,11 +44,7 @@ test.skipIf(!isLinux)(
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // The Worker may either run to completion (message:42) or surface a
     // catchable error for a later fd-consuming open (error:...). Either is

--- a/test/js/web/workers/worker-fd-limit.test.ts
+++ b/test/js/web/workers/worker-fd-limit.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// On Linux, a Worker's event loop consumes an epoll fd, a timerfd (sweep timer)
+// and an eventfd (wakeup async), and then the per-VM GC controller lazily
+// creates two more timerfds. When the process is near RLIMIT_NOFILE,
+// timerfd_create(2) for those GC timers returns EMFILE. Previously the Rust
+// wrapper around us_create_timer would panic on the documented NULL return,
+// aborting the whole process. The GC controller is an optimisation, so it
+// should disable itself and let the Worker proceed (or fail later with a
+// catchable error event) instead of taking the process down.
+//
+// Linux-only: on kqueue and libuv, us_create_timer does not allocate an fd.
+//
+// With 4 spare fds: loop init (3 fds) succeeds, the first GC timerfd succeeds,
+// and the second GC timerfd hits EMFILE. With the fix, the controller frees the
+// first timerfd and disables itself, leaving one fd for the Worker to open its
+// script with.
+test.skipIf(!isLinux)(
+  "new Worker() does not abort the process on timerfd_create EMFILE near RLIMIT_NOFILE",
+  async () => {
+    using dir = tempDir("worker-fd-limit", {
+      "worker.mjs": `postMessage(42)\n`,
+      "main.mjs": `
+        import * as fs from "node:fs";
+        const held = [];
+        for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+        for (let i = 0; i < 4; i++) { const fd = held.pop(); if (fd !== undefined) fs.closeSync(fd); }
+        const { promise, resolve } = Promise.withResolvers();
+        const w = new Worker(new URL("./worker.mjs", import.meta.url));
+        w.onerror = e => resolve("error:" + (e?.message ?? e));
+        w.onmessage = e => resolve("message:" + e.data);
+        const outcome = await promise;
+        for (const fd of held) fs.closeSync(fd);
+        process.stdout.write("SURVIVED " + outcome + "\\n");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -n 256 && exec "$@"`, "sh", bunExe(), "main.mjs"],
+      env: { ...bunEnv, BUN_ENABLE_CRASH_REPORTING: "0" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // The Worker may either run to completion (message:42) or surface a
+    // catchable error for a later fd-consuming open (error:...). Either is
+    // fine; what must not happen is a panic/SIGABRT.
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: expect.stringMatching(/^SURVIVED (message:42|error:.+)\n$/),
+      stderr: expect.any(String),
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);


### PR DESCRIPTION
## Repro

```js
// sh -c 'ulimit -n 256; exec bun main.mjs'
import * as fs from "node:fs";
const held = [];
for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
for (let i = 0; i < 4; i++) fs.closeSync(held.pop());   // 4 spare fds
new Worker(new URL("./worker.mjs", import.meta.url));    // worker.mjs: postMessage(42)
```

Before:
```
panic: us_create_timer: returned null: 24
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```
SIGABRT, exit 134. Node at the same limit surfaces `ERR_WORKER_INIT_FAILED` on that one worker and keeps running.

## Cause

On Linux, `us_create_timer` returns NULL when `timerfd_create(2)` fails (EMFILE/ENFILE). The Rust wrapper `uws_sys::Timer::create` / `create_fallthrough` turned that documented NULL back into `panic!`. A Worker's `GarbageCollectionController::init` calls `create_fallthrough` twice during VM setup, so spawning a Worker with 3-4 spare descriptors (enough for the loop's epoll + sweep timerfd + wakeup eventfd, but not the GC controller's two timerfds) aborted the whole process.

## Fix

- `Timer::create` / `Timer::create_fallthrough` return `Option<NonNull<Timer>>`.
- `GarbageCollectionController::init`: when either timer cannot be created, close whichever one did get created (returning its fd to the budget) and set `disabled = true`. The controller is an optimisation on top of JSC's own GC scheduling; the Worker proceeds without it.
- `EventLoop::tick_possibly_forever`: skip the keep-alive `forever_timer` on the same failure; it retries on the next call.
- `us_create_timer` (epoll): free the poll allocation and undo the `num_polls` bump when `timerfd_create` fails, instead of leaking both.

The 0-2 spare-fd variant (`eventfd() failed during loop init`) is a separate abort site in `epoll_kqueue.c` and is not addressed here.

Related: #33359 removes `us_timer_t` from epoll/kqueue entirely, which would also eliminate this path. This PR is the minimal fix in the meantime.

## Verification

`test/js/web/workers/worker-fd-limit.test.ts` (Linux-only) exhausts fds, frees 4, spawns a Worker, and asserts the process exits 0 with either a message from the worker or a catchable error event. Fails on `main` with SIGABRT and `panic: us_create_timer: returned null: 24`; passes with this change (`SURVIVED message:42`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-fd-limit.test.ts

<!-- robobun:evidence:end -->