### PR TITLE
webstreams: fix five crash/hang/data-loss bugs in the C++ streams implementation

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -112,18 +112,6 @@ template<> void JSByteLengthQueuingStrategyConstructor::finishCreation(VM& vm, J
     m_instanceStructure.set(vm, this, getDOMStructure<JSByteLengthQueuingStrategy>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSByteLengthQueuingStrategyConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSByteLengthQueuingStrategy>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 // `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double` member.
 static double convertQueuingStrategyInit(JSC::VM& vm, JSGlobalObject* globalObject, JSValue init)
 {

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -112,18 +112,6 @@ template<> void JSCountQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMG
     m_instanceStructure.set(vm, this, getDOMStructure<JSCountQueuingStrategy>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSCountQueuingStrategyConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSCountQueuingStrategy>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 // `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double` member.
 static double convertQueuingStrategyInit(JSC::VM& vm, JSGlobalObject* globalObject, JSValue init)
 {

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -313,18 +313,6 @@ template<> void JSReadableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalO
     m_instanceStructure.set(vm, this, getDOMStructure<JSReadableStream>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSReadableStreamConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSReadableStream>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSReadableStreamConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
@@ -163,24 +163,39 @@ static JSPromise* runAsyncIteratorNextSteps(JSC::VM& vm, JSGlobalObject* globalO
 
     auto* reader = iterator->m_reader.get();
     ASSERT(reader);
+
+    // Publish the result promise as the ongoing promise BEFORE the user pull() can run
+    // below, so a reentrant next()/return() chains onto it — unless the current ongoing
+    // promise is still pending (it is already the guard; never rewind the chain tail).
+    auto* result = JSPromise::create(vm, globalObject->promiseStructure());
+    auto* currentOngoing = iterator->m_ongoingPromise.get();
+    if (!currentOngoing || currentOngoing->status() != JSPromise::Status::Pending)
+        iterator->m_ongoingPromise.set(vm, iterator, result);
+    auto clearOngoingIfOurs = [&]() -> JSPromise* {
+        if (iterator->m_ongoingPromise.get() == result)
+            iterator->m_ongoingPromise.clear();
+        return nullptr;
+    };
+
     // Queued chunk and nothing waiting: dequeue with no read request. The result promise
     // still settles in a microtask, as the spec's read-request chunk steps require.
     JSValue chunk = readableStreamDefaultReaderTryReadFromQueue(globalObject, reader);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (scope.exception()) [[unlikely]]
+        return clearOngoingIfOurs();
     if (chunk) {
-        auto* result = createIteratorResultObject(globalObject, chunk, false);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorResolveMicrotask(), result, promise);
-        return promise;
+        auto* resultObject = createIteratorResultObject(globalObject, chunk, false);
+        if (scope.exception()) [[unlikely]]
+            return clearOngoingIfOurs();
+        queueStreamsMicrotask(globalObject, JSStreamsRuntime::from(globalObject)->onAsyncIteratorResolveMicrotask(), resultObject, result);
+        return result;
     }
     auto* domGlobalObject = defaultGlobalObject(globalObject);
     auto* runtime = JSStreamsRuntime::from(globalObject);
-    auto* result = JSPromise::create(vm, globalObject->promiseStructure());
     auto* context = InternalFieldTuple::create(vm, domGlobalObject->internalFieldTupleStructure(), iterator, result);
     auto* readRequest = JSReadRequest::create(vm, runtime->readRequestStructure(domGlobalObject), ReadRequestKind::AsyncIterator, context);
     readableStreamDefaultReaderRead(globalObject, reader, readRequest);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (scope.exception()) [[unlikely]]
+        return clearOngoingIfOurs();
     return result;
 }
 
@@ -240,9 +255,10 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamAsyncIteratorPrototypeFunction_next, (J
         return JSValue::encode(chained);
     }
 
+    // The steps publish their result promise as m_ongoingPromise before running user JS;
+    // a reentrant caller may have chained past it — do NOT overwrite it here.
     auto* promise = runAsyncIteratorNextSteps(vm, globalObject, iterator);
     RETURN_IF_EXCEPTION(scope, {});
-    iterator->m_ongoingPromise.set(vm, iterator, promise);
     return JSValue::encode(promise);
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -232,18 +232,6 @@ template<> void JSReadableStreamBYOBReaderConstructor::finishCreation(VM& vm, JS
     m_instanceStructure.set(vm, this, getDOMStructure<JSReadableStreamBYOBReader>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSReadableStreamBYOBReaderConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSReadableStreamBYOBReader>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 // new ReadableStreamBYOBReader(stream): SetUpReadableStreamBYOBReader(this, stream), which
 // throws a TypeError when the stream is locked or is not a byte stream.
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSReadableStreamBYOBReaderConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -537,19 +537,6 @@ template<> void JSReadableStreamDefaultReaderConstructor::finishCreation(VM& vm,
     m_instanceStructure.set(vm, this, getDOMStructure<JSReadableStreamDefaultReader>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSReadableStreamDefaultReaderConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSReadableStreamDefaultReader>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 // new ReadableStreamDefaultReader(stream): SetUpReadableStreamDefaultReader(this, stream).
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSReadableStreamDefaultReaderConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
@@ -564,7 +551,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSReadableStreamDefaultR
     // Same as getReader(): a lazy native/direct stream materializes before it is locked.
     stream->materializeIfNeeded(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto* structure = structureForNewTarget(constructor, lexicalGlobalObject, asObject(callFrame->newTarget()));
+    auto* structure = structureForNewTarget(vm, constructor, lexicalGlobalObject, asObject(callFrame->newTarget()));
     RETURN_IF_EXCEPTION(scope, {});
     auto* reader = JSReadableStreamDefaultReader::create(vm, structure);
     setUpReadableStreamDefaultReader(lexicalGlobalObject, reader, stream);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -181,14 +181,9 @@ static JSObject* createReadManyResult(JSC::VM& vm, JSGlobalObject* globalObject,
     return result;
 }
 
-// Drains the whole queue (after an optional already-read head chunk) into a fresh array,
-// runs the close-if-requested / pull-if-needed step, resets the queue, and returns the
-// `{value, size, done: false}` result. `size` is the PRE-drain [[queueTotalSize]], and the
-// pull decision runs against it (the drain leaves [[queueTotalSize]] untouched until the
-// final ResetQueue), matching the readMany contract.
-// Appends every queued chunk to `into` at `base`, runs the close-if-requested /
-// pull-if-needed step, resets the queue, and returns the PRE-drain [[queueTotalSize]]
-// (the pull decision runs against it, matching the readMany contract).
+// Appends every queued chunk to `into` at `base`, resets the queue, THEN runs the
+// close/pull step; returns the PRE-drain [[queueTotalSize]]. Reset must precede the step:
+// its user JS may reentrantly enqueue (must survive) or close() (must see an empty queue).
 static double drainQueueEntriesInto(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStream* __restrict stream, JSArray* __restrict into, unsigned base)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -227,22 +222,27 @@ static double drainQueueEntriesInto(JSC::VM& vm, JSGlobalObject* globalObject, J
         RETURN_IF_EXCEPTION(scope, size);
     }
 
-    if (stream->m_state != ReadableStreamState::Closed) {
-        bool closeRequested = isByte ? byteController->m_closeRequested : defaultController->m_closeRequested;
-        if (closeRequested)
-            readableStreamCloseIfPossible(globalObject, stream);
-        else if (isByte)
-            readableByteStreamControllerCallPullIfNeeded(globalObject, byteController);
-        else
-            readableStreamDefaultControllerCallPullIfNeeded(globalObject, defaultController);
-        RETURN_IF_EXCEPTION(scope, size);
-    }
     if (isByte) {
         WTF::Locker locker { byteController->cellLock() };
         byteController->m_queue.resetQueue(locker);
     } else {
         WTF::Locker locker { defaultController->cellLock() };
         defaultController->m_queue.resetQueue(locker);
+    }
+    if (stream->m_state != ReadableStreamState::Closed) {
+        bool closeRequested = isByte ? byteController->m_closeRequested : defaultController->m_closeRequested;
+        // Pull DECISION against the PRE-drain total (readMany cadence: a full batch defers
+        // the next pull to the next wake); the queue is already reset, so reentrant enqueues survive.
+        double hwm = isByte ? byteController->m_strategyHWM : defaultController->m_strategyHWM;
+        if (closeRequested)
+            readableStreamCloseIfPossible(globalObject, stream);
+        else if (hwm - size > 0) {
+            if (isByte)
+                readableByteStreamControllerCallPullIfNeeded(globalObject, byteController);
+            else
+                readableStreamDefaultControllerCallPullIfNeeded(globalObject, defaultController);
+        }
+        RETURN_IF_EXCEPTION(scope, size);
     }
     return size;
 }

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -354,8 +354,8 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSTextDecoderStream;
 
-// `decoder.decode(input, { stream })` on the wrapped TextDecoder. Runs no user JS: the
-// method lives on the TextDecoder's internal prototype. Empty return = it threw.
+// `decoder.decode(input, { stream })` on the wrapped TextDecoder. Runs user JS: `decode`
+// is looked up on the public TextDecoder.prototype. Empty return = it threw.
 static JSValue invokeDecode(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* decoder, JSValue input, bool streaming)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -378,30 +378,27 @@ static JSValue invokeDecode(JSC::VM& vm, JSGlobalObject* globalObject, JSObject*
     RELEASE_AND_RETURN(scope, call(globalObject, method, callData, decoder, args));
 }
 
-// Decodes, then enqueues the decoded string if non-empty; an abrupt decode completion
-// becomes a rejected promise. Shared by the transform and flush arms.
+// Decodes, then enqueues the non-empty result; abrupt decode OR enqueue completions become
+// a rejected promise (a transform algorithm must never throw synchronously into
+// ProcessWrite — the in-flight write would never settle). Shared by transform and flush.
 static JSPromise* decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, JSValue input, bool streaming)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue decoded;
     JSValue thrown;
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        decoded = invokeDecode(vm, globalObject, stream->m_decoder.get(), input, streaming);
+        JSValue decoded = invokeDecode(vm, globalObject, stream->m_decoder.get(), input, streaming);
+        if (!catchScope.exception() && decoded.isString() && asString(decoded)->length())
+            transformStreamDefaultControllerEnqueue(globalObject, controller, decoded);
         if (catchScope.exception()) [[unlikely]]
             thrown = takeAbruptCompletion(globalObject, catchScope);
     }
+    // takeAbruptCompletion leaves a VM termination pending and returns the empty value.
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (!thrown.isEmpty())
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (decoded.isEmpty())
-        return nullptr;
-
-    if (decoded.isString() && asString(decoded)->length()) {
-        transformStreamDefaultControllerEnqueue(globalObject, controller, decoded);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-    }
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -121,18 +121,6 @@ template<> void JSTextDecoderStreamConstructor::finishCreation(VM& vm, JSDOMGlob
     m_instanceStructure.set(vm, this, getDOMStructure<JSTextDecoderStream>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSTextDecoderStreamConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSTextDecoderStream>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTextDecoderStreamConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -119,18 +119,6 @@ template<> void JSTextEncoderStreamConstructor::finishCreation(VM& vm, JSDOMGlob
     m_instanceStructure.set(vm, this, getDOMStructure<JSTextEncoderStream>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSTextEncoderStreamConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSTextEncoderStream>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTextEncoderStreamConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -303,8 +303,8 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSTextEncoderStream;
 
-// `encoder.encode(chunk)` / `encoder.flush()` on the TextEncoderStreamEncoder cell. Runs no
-// user JS: the method lives on the encoder's internal prototype. Empty return = it threw.
+// `encoder.encode(chunk)` / `encoder.flush()` on the TextEncoderStreamEncoder cell. The
+// encode arm runs user JS (ToString of the chunk). Empty return = it threw.
 static JSValue invokeEncoderMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* encoder, const Identifier& methodName, const MarkedArgumentBuffer& args)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -326,44 +326,42 @@ static void enqueueIfNonEmptyView(JSGlobalObject* globalObject, JSTransformStrea
     transformStreamDefaultControllerEnqueue(globalObject, controller, buffer);
 }
 
-JSPromise* textEncoderStreamTransform(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
+// An abrupt encode OR enqueue completion becomes a rejected promise (a transform algorithm
+// must never throw synchronously into ProcessWrite/ProcessClose — the in-flight operation
+// would never settle). Shared by the transform and flush arms.
+static JSPromise* encodeAndEnqueue(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, const Identifier& methodName, const MarkedArgumentBuffer& args)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue buffer;
     JSValue thrown;
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        MarkedArgumentBuffer args;
-        args.append(chunk);
-        ASSERT(!args.hasOverflowed());
-        buffer = invokeEncoderMethod(vm, globalObject, stream->m_encoder.get(), builtinNames(vm).encodePublicName(), args);
+        JSValue buffer = invokeEncoderMethod(vm, globalObject, stream->m_encoder.get(), methodName, args);
+        if (!catchScope.exception() && !buffer.isEmpty())
+            enqueueIfNonEmptyView(globalObject, controller, buffer);
         if (catchScope.exception()) [[unlikely]]
             thrown = takeAbruptCompletion(globalObject, catchScope);
     }
+    // takeAbruptCompletion leaves a VM termination pending and returns the empty value.
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (!thrown.isEmpty())
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (buffer.isEmpty())
-        return nullptr;
-
-    enqueueIfNonEmptyView(globalObject, controller, buffer);
-    RETURN_IF_EXCEPTION(scope, nullptr);
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+}
+
+JSPromise* textEncoderStreamTransform(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
+{
+    MarkedArgumentBuffer args;
+    args.append(chunk);
+    ASSERT(!args.hasOverflowed());
+    return encodeAndEnqueue(globalObject, stream, controller, builtinNames(getVM(globalObject)).encodePublicName(), args);
 }
 
 JSPromise* textEncoderStreamFlush(JSGlobalObject* globalObject, JSTextEncoderStream* stream, JSTransformStreamDefaultController* controller)
 {
-    auto& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
     MarkedArgumentBuffer noArguments;
-    JSValue buffer = invokeEncoderMethod(vm, globalObject, stream->m_encoder.get(), builtinNames(vm).flushPublicName(), noArguments);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    enqueueIfNonEmptyView(globalObject, controller, buffer);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    return encodeAndEnqueue(globalObject, stream, controller, builtinNames(getVM(globalObject)).flushPublicName(), noArguments);
 }
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -121,18 +121,6 @@ template<> void JSTransformStreamConstructor::finishCreation(VM& vm, JSDOMGlobal
     m_instanceStructure.set(vm, this, getDOMStructure<JSTransformStream>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSTransformStreamConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSTransformStream>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTransformStreamConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -122,18 +122,6 @@ template<> void JSWritableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalO
     m_instanceStructure.set(vm, this, getDOMStructure<JSWritableStream>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSWritableStreamConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSWritableStream>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWritableStreamConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -257,18 +257,6 @@ template<> void JSWritableStreamDefaultWriterConstructor::finishCreation(VM& vm,
     m_instanceStructure.set(vm, this, getDOMStructure<JSWritableStreamDefaultWriter>(vm, globalObject));
 }
 
-static Structure* structureForNewTarget(JSC::VM& vm, JSWritableStreamDefaultWriterConstructor* constructor, JSGlobalObject* lexicalGlobalObject, JSObject* newTarget)
-{
-    if (newTarget == constructor) [[likely]]
-        return constructor->instanceStructure();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* baseStructure = getDOMStructure<JSWritableStreamDefaultWriter>(vm, *uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject));
-    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWritableStreamDefaultWriterConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/StreamConstructor.h
+++ b/src/jsc/bindings/webcore/streams/StreamConstructor.h
@@ -7,6 +7,9 @@
 
 #include "JSDOMConstructorBase.h"
 #include "ErrorCode.h"
+#include "JSDOMWrapperCache.h"
+#include <JavaScriptCore/InternalFunction.h>
+#include <JavaScriptCore/ThrowScope.h>
 #include <JavaScriptCore/WriteBarrier.h>
 
 namespace WebCore {
@@ -62,5 +65,23 @@ private:
 
     JSC::WriteBarrier<JSC::Structure> m_instanceStructure;
 };
+
+// The shared `construct` slow path for a subclass/foreign newTarget. newTarget's realm may
+// be a non-Zig global (a node:vm context) with no DOM structure caches, so it must NOT be
+// downcast to JSDOMGlobalObject; fall back to the constructor's own realm's cached Structure.
+template<typename JSClass, Bun::ErrorCode errorCodeIfCalled>
+JSC::Structure* structureForNewTarget(JSC::VM& vm, JSStreamConstructor<JSClass, errorCodeIfCalled>* constructor, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* newTarget)
+{
+    if (newTarget == constructor) [[likely]]
+        return constructor->instanceStructure();
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* newTargetGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    JSC::Structure* baseStructure = constructor->instanceStructure();
+    if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(newTargetGlobalObject)) [[likely]]
+        baseStructure = getDOMStructure<JSClass>(vm, *domGlobalObject);
+    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure));
+}
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -73,10 +73,9 @@ bool canTransferArrayBuffer(JSC::ArrayBuffer& buffer)
     return !buffer.isDetached() && buffer.isDetachable();
 }
 
-// spec TransferArrayBuffer(O) at the impl level: detach O (and every view over it) and
-// return a fresh ArrayBuffer over the same block. No JSArrayBuffer wrapper is created —
-// callers hand out views over the impl, and JSC materializes a wrapper only if user code
-// reads `.buffer`.
+// spec TransferArrayBuffer(O) = ArrayBufferCopyAndDetach(O, undefined, fixed-length):
+// resizability must NOT survive the transfer, or a later user resize() invalidates every
+// byte length the byte controller recorded. No JSArrayBuffer wrapper cell is created.
 RefPtr<JSC::ArrayBuffer> transferArrayBufferImpl(JSGlobalObject* globalObject, JSC::ArrayBuffer& buffer)
 {
     auto& vm = getVM(globalObject);
@@ -85,6 +84,19 @@ RefPtr<JSC::ArrayBuffer> transferArrayBufferImpl(JSGlobalObject* globalObject, J
     if (!buffer.isDetachable()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Cannot transfer an ArrayBuffer that is not detachable"_s);
         return nullptr;
+    }
+    if (buffer.isResizableNonShared()) [[unlikely]] {
+        // Same shape as JSC's arrayBufferCopyAndDetach FixedLength slow path: copy into a
+        // fixed-length block, then detach the original.
+        RefPtr<JSC::ArrayBuffer> copy = JSC::ArrayBuffer::tryCreate(buffer.span());
+        if (!copy) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return nullptr;
+        }
+        JSC::ArrayBufferContents droppedContents;
+        bool detached = buffer.transferTo(vm, droppedContents);
+        ASSERT_UNUSED(detached, detached);
+        return copy;
     }
     JSC::ArrayBufferContents contents;
     bool transferred = buffer.transferTo(vm, contents);

--- a/test/js/web/encoding/text-decoder-stream.test.ts
+++ b/test/js/web/encoding/text-decoder-stream.test.ts
@@ -190,3 +190,52 @@ test("TextDecoderStream accepts undefined and null options", () => {
   }
   expect(new TextDecoderStream("utf-8", { fatal: true }).fatal).toBe(true);
 });
+
+// https://github.com/oven-sh/bun/pull/33193 — a transform/flush failure must reject the
+// write/close promise, not throw synchronously or leave the in-flight op unsettled.
+test("cancelling the readable inside a patched decode() rejects the write instead of throwing", async () => {
+  const original = TextDecoder.prototype.decode;
+  try {
+    const stream = new TextDecoderStream();
+    const reader = stream.readable.getReader();
+    const writer = stream.writable.getWriter();
+    reader.read();
+    await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+
+    TextDecoder.prototype.decode = function (...args) {
+      TextDecoder.prototype.decode = original;
+      reader.cancel();
+      return "x";
+    };
+    const writePromise = writer.write(new Uint8Array([120])); // must NOT throw synchronously
+    expect(writePromise).toBeInstanceOf(Promise);
+    await expect(writePromise).rejects.toBeInstanceOf(TypeError);
+    await writer.abort("bye"); // must settle
+  } finally {
+    TextDecoder.prototype.decode = original;
+  }
+});
+
+test("cancelling the readable inside a patched decode() during flush rejects close()", async () => {
+  const original = TextDecoder.prototype.decode;
+  try {
+    const stream = new TextDecoderStream();
+    const reader = stream.readable.getReader();
+    const writer = stream.writable.getWriter();
+    reader.read();
+    await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+
+    TextDecoder.prototype.decode = function (...args) {
+      TextDecoder.prototype.decode = original;
+      // cancel() during an in-flight close returns the finish promise, which rejects
+      // together with the flush — handle it so it isn't an unhandled rejection.
+      reader.cancel().catch(() => {});
+      return "tail";
+    };
+    const closePromise = writer.close(); // flush runs the patched decode; must NOT throw synchronously
+    expect(closePromise).toBeInstanceOf(Promise);
+    await expect(closePromise).rejects.toBeInstanceOf(TypeError);
+  } finally {
+    TextDecoder.prototype.decode = original;
+  }
+});

--- a/test/js/web/encoding/text-decoder-stream.test.ts
+++ b/test/js/web/encoding/text-decoder-stream.test.ts
@@ -200,7 +200,7 @@ test("cancelling the readable inside a patched decode() rejects the write instea
     const reader = stream.readable.getReader();
     const writer = stream.writable.getWriter();
     reader.read();
-    await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+    (await null, await null, await null); // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
 
     TextDecoder.prototype.decode = function (...args) {
       TextDecoder.prototype.decode = original;
@@ -223,7 +223,7 @@ test("cancelling the readable inside a patched decode() during flush rejects clo
     const reader = stream.readable.getReader();
     const writer = stream.writable.getWriter();
     reader.read();
-    await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+    (await null, await null, await null); // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
 
     TextDecoder.prototype.decode = function (...args) {
       TextDecoder.prototype.decode = original;

--- a/test/js/web/encoding/text-encoder-stream.test.ts
+++ b/test/js/web/encoding/text-encoder-stream.test.ts
@@ -143,3 +143,23 @@ for (const { input, output, description } of testCases) {
     }
   });
 }
+
+// https://github.com/oven-sh/bun/pull/33193 — a transform failure must reject the write
+// promise, not throw synchronously or leave the in-flight write unsettled (abort() hang).
+test("cancelling the readable inside the chunk's toString() rejects the write instead of throwing", async () => {
+  const stream = new TextEncoderStream();
+  const reader = stream.readable.getReader();
+  const writer = stream.writable.getWriter();
+  reader.read();
+  await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+
+  const writePromise = writer.write({
+    toString() {
+      reader.cancel();
+      return "x";
+    },
+  }); // must NOT throw synchronously
+  expect(writePromise).toBeInstanceOf(Promise);
+  await expect(writePromise).rejects.toBeInstanceOf(TypeError);
+  await writer.abort("bye"); // must settle
+});

--- a/test/js/web/encoding/text-encoder-stream.test.ts
+++ b/test/js/web/encoding/text-encoder-stream.test.ts
@@ -151,7 +151,7 @@ test("cancelling the readable inside the chunk's toString() rejects the write in
   const reader = stream.readable.getReader();
   const writer = stream.writable.getWriter();
   reader.read();
-  await null, await null, await null; // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
+  (await null, await null, await null); // open the synchronous-transform window (backpressure cleared, write runs the transform inline)
 
   const writePromise = writer.write({
     toString() {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2342,3 +2342,47 @@ it("TransformStreamDefaultController survives after a native sink tears down its
     signalCode: null,
   });
 });
+
+// https://github.com/oven-sh/bun/pull/33193 — constructing any stream class with a newTarget
+// from a non-Zig realm (a node:vm context) must not downcast that realm's global object.
+test("streams constructors survive a foreign-realm (node:vm) newTarget", async () => {
+  const script = `
+    const vm = require("node:vm");
+    const context = vm.createContext({});
+    const foreign = vm.runInContext("(function F(){})", context);
+    const byteStream = () => new ReadableStream({ type: "bytes" });
+    const readerCtor = Object.getPrototypeOf(new ReadableStream().getReader()).constructor;
+    const byobCtor = Object.getPrototypeOf(byteStream().getReader({ mode: "byob" })).constructor;
+    const writerCtor = Object.getPrototypeOf(new WritableStream().getWriter()).constructor;
+    const cases = [
+      [CountQueuingStrategy, [{ highWaterMark: 1 }]],
+      [ByteLengthQueuingStrategy, [{ highWaterMark: 1 }]],
+      [ReadableStream, []],
+      [WritableStream, []],
+      [TransformStream, []],
+      [TextEncoderStream, []],
+      [TextDecoderStream, []],
+      [readerCtor, [new ReadableStream()]],
+      [byobCtor, [byteStream()]],
+      [writerCtor, [new WritableStream()]],
+    ];
+    for (const [C, args] of cases) {
+      const constructed = Reflect.construct(C, args, foreign);
+      if (Object.getPrototypeOf(constructed) !== foreign.prototype) throw new Error(C.name + ": wrong prototype");
+    }
+    // A non-object foreign prototype falls back to the constructor realm's structure.
+    const bare = vm.runInContext("(function G(){})", context);
+    bare.prototype = 5;
+    const fallback = Reflect.construct(CountQueuingStrategy, [{ highWaterMark: 2 }], bare);
+    if (!(fallback instanceof CountQueuingStrategy)) throw new Error("fallback: wrong prototype");
+    if (fallback.highWaterMark !== 2) throw new Error("fallback: object broken");
+    console.log("OK");
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "OK",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2386,3 +2386,63 @@ test("streams constructors survive a foreign-realm (node:vm) newTarget", async (
     signalCode: null,
   });
 });
+
+// https://github.com/oven-sh/bun/pull/33193 — TransferArrayBuffer must produce a
+// fixed-length buffer, or user resize() invalidates the byte controller's recorded sizes.
+test("byte streams transfer resizable ArrayBuffers to fixed-length", async () => {
+  const script = `
+    // BYOB read: the pull-into descriptor's transferred buffer must be fixed-length.
+    {
+      let resizeError = null;
+      const rs = new ReadableStream({
+        type: "bytes",
+        pull(c) {
+          const view = c.byobRequest.view;
+          if (view.buffer.resizable) throw new Error("byobRequest view buffer is resizable");
+          try { view.buffer.resize(0); } catch (e) { resizeError = e; }
+          c.byobRequest.respond(view.byteLength);
+        },
+      });
+      const rab = new ArrayBuffer(8, { maxByteLength: 64 });
+      const { value } = await rs.getReader({ mode: "byob" }).read(new Uint8Array(rab));
+      if (!(resizeError instanceof TypeError)) throw new Error("resize() unexpectedly succeeded");
+      if (value.byteLength !== 8) throw new Error("wrong read length: " + value.byteLength);
+      if (rab.byteLength !== 0) throw new Error("source buffer not detached");
+    }
+    // enqueue: a resizable-backed chunk is delivered over a fixed-length buffer.
+    {
+      const rab = new ArrayBuffer(8, { maxByteLength: 64 });
+      new Uint8Array(rab).set([1, 2, 3, 4, 5, 6, 7, 8]);
+      const rs = new ReadableStream({ type: "bytes", start(c) { c.enqueue(new Uint8Array(rab)); } });
+      const { value } = await rs.getReader().read();
+      if (value.buffer.resizable) throw new Error("delivered chunk buffer is resizable");
+      if (String(new Uint8Array(value.buffer)) !== "1,2,3,4,5,6,7,8") throw new Error("wrong bytes");
+      if (rab.byteLength !== 0) throw new Error("chunk buffer not detached");
+    }
+    // resize-then-enqueue inside pull must reject the read, not abort the process.
+    {
+      const rs = new ReadableStream({
+        type: "bytes",
+        pull(c) {
+          c.byobRequest.view.buffer.resize(0);
+          c.enqueue(new Uint8Array(10));
+        },
+      });
+      let rejection = null;
+      try {
+        await rs.getReader({ mode: "byob" }).read(new Uint8Array(new ArrayBuffer(64, { maxByteLength: 1024 })));
+      } catch (e) {
+        rejection = e;
+      }
+      if (!(rejection instanceof TypeError)) throw new Error("expected read() to reject with TypeError");
+    }
+    console.log("OK");
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "OK",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2453,7 +2453,9 @@ describe("bulk drain runs the user pull() against the already-reset queue", () =
   const makeSource = enqueue => {
     let pulls = 0;
     return {
-      start(c) { c.enqueue(enqueue("A")); },
+      start(c) {
+        c.enqueue(enqueue("A"));
+      },
       pull(c) {
         if (++pulls >= 2) {
           c.enqueue(enqueue("B"));
@@ -2464,7 +2466,10 @@ describe("bulk drain runs the user pull() against the already-reset queue", () =
   };
 
   test("text() keeps a chunk enqueued during the drain and settles on close()", async () => {
-    const rs = new ReadableStream(makeSource(s => s), { highWaterMark: 2 });
+    const rs = new ReadableStream(
+      makeSource(s => s),
+      { highWaterMark: 2 },
+    );
     await Bun.sleep(0); // let start + the initial pull settle so pull #2 fires inside the drain
     expect(await rs.text()).toBe("AB");
   });
@@ -2477,7 +2482,10 @@ describe("bulk drain runs the user pull() against the already-reset queue", () =
   });
 
   test("readMany() leaves the reentrantly-enqueued chunk readable and the stream closable", async () => {
-    const rs = new ReadableStream(makeSource(s => s), { highWaterMark: 2 });
+    const rs = new ReadableStream(
+      makeSource(s => s),
+      { highWaterMark: 2 },
+    );
     await Bun.sleep(0);
     const reader = rs.getReader();
     const first = await reader.readMany();
@@ -2546,7 +2554,11 @@ describe("ReadableStream async iterator reentrancy", () => {
 
   test("queued next() calls resolve in call order as chunks arrive", async () => {
     let controller;
-    const rs = new ReadableStream({ start(c) { controller = c; } });
+    const rs = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
     const it = rs.values();
     const p1 = it.next();
     const p2 = it.next();

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2446,3 +2446,44 @@ test("byte streams transfer resizable ArrayBuffers to fixed-length", async () =>
     signalCode: null,
   });
 });
+
+// https://github.com/oven-sh/bun/pull/33193 — the bulk drain must reset the queue BEFORE
+// the user pull(): reentrant enqueues must survive and a reentrant close() must take effect.
+describe("bulk drain runs the user pull() against the already-reset queue", () => {
+  const makeSource = enqueue => {
+    let pulls = 0;
+    return {
+      start(c) { c.enqueue(enqueue("A")); },
+      pull(c) {
+        if (++pulls >= 2) {
+          c.enqueue(enqueue("B"));
+          c.close();
+        }
+      },
+    };
+  };
+
+  test("text() keeps a chunk enqueued during the drain and settles on close()", async () => {
+    const rs = new ReadableStream(makeSource(s => s), { highWaterMark: 2 });
+    await Bun.sleep(0); // let start + the initial pull settle so pull #2 fires inside the drain
+    expect(await rs.text()).toBe("AB");
+  });
+
+  test("text() on a byte stream keeps a chunk enqueued during the drain", async () => {
+    const encoder = new TextEncoder();
+    const rs = new ReadableStream({ type: "bytes", ...makeSource(s => encoder.encode(s)) }, { highWaterMark: 2 });
+    await Bun.sleep(0);
+    expect(await rs.text()).toBe("AB");
+  });
+
+  test("readMany() leaves the reentrantly-enqueued chunk readable and the stream closable", async () => {
+    const rs = new ReadableStream(makeSource(s => s), { highWaterMark: 2 });
+    await Bun.sleep(0);
+    const reader = rs.getReader();
+    const first = await reader.readMany();
+    expect(first).toEqual({ value: ["A"], size: 1, done: false });
+    expect(await reader.read()).toEqual({ value: "B", done: false });
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+    await reader.closed;
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2487,3 +2487,82 @@ describe("bulk drain runs the user pull() against the already-reset queue", () =
     await reader.closed;
   });
 });
+
+// https://github.com/oven-sh/bun/pull/33193 — a reentrant next()/return() from a
+// synchronous pull() must chain onto the in-flight iteration instead of racing it.
+describe("ReadableStream async iterator reentrancy", () => {
+  test("return() from inside a synchronous pull() does not crash", async () => {
+    const script = `
+      let it, phase = 0;
+      const rs = new ReadableStream(
+        {
+          pull(c) {
+            if (++phase === 2) {
+              it.return("bye");
+              return new Promise(() => {});
+            }
+          },
+        },
+        { highWaterMark: 1 },
+      );
+      it = rs.values();
+      await null; await null; await null; // let start + the initial pull settle
+      it.next(); // fires pull #2 synchronously, which reenters via it.return()
+      await Bun.sleep(10);
+      console.log("SURVIVED");
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "SURVIVED",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("return() from inside a dequeueing pull() settles after the ongoing next()", async () => {
+    let it,
+      phase = 0,
+      returnPromise;
+    const rs = new ReadableStream(
+      {
+        pull(c) {
+          if (++phase === 2) {
+            returnPromise = it.return("bye");
+            c.enqueue("x");
+          } else {
+            c.enqueue("first");
+          }
+        },
+      },
+      { highWaterMark: 1 },
+    );
+    it = rs.values();
+    const r1 = await it.next(); // pull #2 fires inside this next()'s dequeue
+    expect(r1).toEqual({ value: "first", done: false });
+    expect(await returnPromise).toEqual({ value: "bye", done: true });
+    expect(await it.next()).toEqual({ value: undefined, done: true });
+  });
+
+  test("queued next() calls resolve in call order as chunks arrive", async () => {
+    let controller;
+    const rs = new ReadableStream({ start(c) { controller = c; } });
+    const it = rs.values();
+    const p1 = it.next();
+    const p2 = it.next();
+    const p3 = it.next();
+    controller.enqueue("a");
+    controller.enqueue("b");
+    controller.enqueue("c");
+    const p4 = it.next(); // must chain after p3, not after whichever promise settled last
+    controller.enqueue("d");
+    controller.close();
+    expect(await Promise.all([p1, p2, p3, p4])).toEqual([
+      { value: "a", done: false },
+      { value: "b", done: false },
+      { value: "c", done: false },
+      { value: "d", done: false },
+    ]);
+    expect(await it.next()).toEqual({ value: undefined, done: true });
+  });
+});


### PR DESCRIPTION
### What

Five self-contained fixes (one commit each) for bugs in the C++ WebStreams implementation introduced by #33193, found while auditing the rewrite. Two are memory-safety issues reachable from a few lines of user JS in release builds; three are hangs/data loss via reentrancy. Each commit ships regression tests verified to fail before the fix and pass after.

---

### 1. Foreign-realm `newTarget` type-confuses the global object (all 10 constructors)

Every stream constructor's subclass slow path did `uncheckedDowncast<JSDOMGlobalObject>(newTargetGlobalObject)`. A `node:vm` context's global is a *sibling* class, so the downcast is an invalid `static_cast` in release builds — `getDOMStructure` then reads and writes structure caches past the end of the smaller allocation.

```js
const vm = require("node:vm");
const foreignFn = vm.runInContext("(function F(){})", vm.createContext({}));
Reflect.construct(ReadableStream, [], foreignFn); // asserts in debug; heap type confusion in release
```

The ten copy-pasted `structureForNewTarget` statics are replaced with one shared template in `StreamConstructor.h` that `dynamicDowncast`s and falls back to the constructor's own realm's cached Structure (per-VM correct, unlike a process-global fallback).

### 2. `TransferArrayBuffer` left transferred buffers resizable

The spec defines TransferArrayBuffer as `ArrayBufferCopyAndDetach(O, undefined, fixed-length)`, but `transferArrayBufferImpl` used `ArrayBuffer::transferTo`, which carries `maxByteLength` across the transfer. User JS reaching the stream-internal buffer through `byobRequest.view.buffer` could `resize()` it, invalidating every byte length the controller recorded:

```js
const rs = new ReadableStream({
  type: "bytes",
  pull(c) {
    c.byobRequest.view.buffer.resize(0); // succeeded; must throw TypeError
    c.enqueue(new Uint8Array(10));       // RELEASE_ASSERT → process abort, release builds included
  },
});
await rs.getReader({ mode: "byob" }).read(
  new Uint8Array(new ArrayBuffer(64, { maxByteLength: 1024 })),
);
```

A second variant (`resize(2)` + `respond()` with a remainder) made the remainder-clone path `subspan` past the live length — an out-of-bounds heap read whose bytes were delivered to a subsequent `read()`. Fix mirrors JSC's own `arrayBufferCopyAndDetach` FixedLength slow path: resizable sources are copied into a fixed-length block, then detached; non-resizable buffers keep the zero-copy transfer. (The WPT streams suite has no resizable-ArrayBuffer coverage, so tests are added.)

### 3. Bulk drain ran the user `pull()` before `ResetQueue`

`drainQueueEntriesInto` — behind `reader.readMany()` and the buffered consumers (`text()`, `bytes()`, `Bun.readableStreamTo*`) — removed every queue entry, ran the close/pull step, and only then reset the queue. A chunk enqueued synchronously by that pull landed in the still-live queue and was wiped by the reset; a `close()` in the same pull saw a momentarily non-empty queue and never re-evaluated:

```js
let pulls = 0;
const rs = new ReadableStream({
  start(c) { c.enqueue("A"); },
  pull(c) { if (++pulls >= 2) { c.enqueue("B"); c.close(); } },
}, { highWaterMark: 2 });
await Bun.sleep(0);
await rs.text(); // hung forever (and "B" was silently destroyed); now resolves "AB"
```

The queue is now reset before the close/pull step. The pull *decision* still runs against the pre-drain `[[queueTotalSize]]`, preserving the existing readMany batching cadence (the `readMany batches the pipelined pull's chunk` test still passes byte-for-byte).

### 4. Async iterator: reentrant `next()`/`return()` from a synchronous `pull()`

The iterator published `m_ongoingPromise` only *after* running steps that invoke the user `pull()` synchronously. A `return()` called from inside that pull saw a stale non-pending ongoing promise, skipped the chaining path, and released the reader under an in-flight read (`ASSERT(reader->m_readRequests.isEmpty())` in debug):

```js
let it, phase = 0;
const rs = new ReadableStream({
  pull(c) {
    if (++phase === 2) { it.return("bye"); return new Promise(() => {}); }
  },
}, { highWaterMark: 1 });
it = rs.values();
await null; await null; await null;
it.next(); // pull #2 fires synchronously and reenters via it.return() → assert/double release
```

The result promise is now published before any user JS can run — but only when the current ongoing promise is not pending, so ongoing-settled reactions never rewind the chain tail (queued `next()` calls still resolve in call order; tests cover both properties).

### 5. `TextEncoderStream`/`TextDecoderStream` let transform failures escape synchronously

The codec transform/flush algorithms wrapped only the encode/decode call in the completion-record catch. Both run user JS (`ToString` of the chunk; the patchable `TextDecoder.prototype.decode`), which can cancel the readable mid-transform — the subsequent enqueue's TypeError then escaped synchronously out of `writer.write()`/`writer.close()`, and the in-flight operation never settled:

```js
const tes = new TextEncoderStream();
const reader = tes.readable.getReader();
const writer = tes.writable.getWriter();
reader.read();
await null; await null; await null;
try {
  writer.write({ toString() { reader.cancel(); return "x"; } }); // threw synchronously (spec: never throws)
} catch {}
await writer.abort("bye"); // never settled — wedged forever
```

The catch now covers the enqueue at all sites (encoder transform+flush unified into one helper, mirroring the decoder), converting abrupt completions into rejected promises that flow through `transformStreamError` — write rejects, abort settles, matching Node.

---

### Test notes

- All 9 regression tests fail on the unfixed implementation (crash / 5s-timeout hang / sync throw) and pass with the fixes; verified by reverting `src/jsc/bindings/webcore/streams/` to main and re-running.
- Full `test/js/web/streams/` + WPT streams + encoding suites: 1,421 tests, no regressions (the one pre-existing failure, `streams-leak` absolute-RSS floor under ASAN, fails identically on main with a negative RSS delta).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->