### PR TITLE
usockets: make us_create_loop fallible instead of aborting on EMFILE

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -165,6 +165,10 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
 #ifdef LIBUS_USE_EPOLL
     loop->fd = epoll_create1(EPOLL_CLOEXEC);
+    if (UNLIKELY(loop->fd == -1)) {
+        us_free(loop);
+        return NULL;
+    }
 
     if (has_epoll_pwait2 == -1) {
         if (Bun__isEpollPwait2SupportedOnLinuxKernel() == 0) {
@@ -174,9 +178,17 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
 #else
     loop->fd = kqueue();
+    if (UNLIKELY(loop->fd == -1)) {
+        us_free(loop);
+        return NULL;
+    }
 #endif
 
-    us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
+    if (UNLIKELY(us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb) != 0)) {
+        close(loop->fd);
+        us_free(loop);
+        return NULL;
+    }
     return loop;
 }
 
@@ -611,10 +623,11 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 
     int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (efd == -1) {
-        // eventfd only fails on EMFILE/ENFILE — the loop is unusable without
-        // wakeup_async, and the sole caller doesn't NULL-check. Crash loudly
-        // rather than NULL-deref or store -1 as a poll fd.
-        BUN_PANIC("eventfd() failed during loop init (out of file descriptors?)");
+        if (!fallthrough) {
+            loop->num_polls--;
+        }
+        us_free(p);
+        return NULL;
     }
     us_poll_init(p, efd, POLL_TYPE_CALLBACK);
 

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -175,7 +175,7 @@ struct us_loop_t *us_create_loop(void *hint,
   loop->uv_check->data = loop;
 
   // here we create two unreffed handles - timer and async
-  us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
+  (void) us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
 
   // if we do not own this loop, we need to integrate and set up timer
   if (hint) {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -164,10 +164,10 @@ void us_internal_group_maybe_unlink(struct us_socket_group_t *group);
  * SSL path calls _raw once it's actually time to drop the fd. */
 struct us_socket_t *us_internal_socket_close_raw(us_socket_r s, int code, void *reason);
 struct us_socket_t *us_internal_ssl_close(us_socket_r s, int code, void *reason);
-void us_internal_loop_data_init(struct us_loop_t *loop,
-                                void (*wakeup_cb)(us_loop_r loop),
-                                void (*pre_cb)(us_loop_r loop),
-                                void (*post_cb)(us_loop_r loop));
+int us_internal_loop_data_init(struct us_loop_t *loop,
+                               void (*wakeup_cb)(us_loop_r loop),
+                               void (*pre_cb)(us_loop_r loop),
+                               void (*post_cb)(us_loop_r loop));
 void us_internal_loop_data_free(us_loop_r loop);
 void us_internal_loop_pre(us_loop_r loop);
 void us_internal_loop_post(us_loop_r loop);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -117,7 +117,9 @@ void us_internal_sweep_if_due(struct us_loop_t *loop) {
 #endif
 
 
-void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
+/* Returns 0 on success, -1 on fd exhaustion (EMFILE/ENFILE from eventfd on
+ * Linux); on failure nothing is left allocated in loop->data. */
+int us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
     void (*pre_cb)(struct us_loop_t *loop), void (*post_cb)(struct us_loop_t *loop)) {
     // We allocate with calloc, so we only need to initialize the specific fields in use.
 #ifdef LIBUS_USE_LIBUV
@@ -134,12 +136,21 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.pre_cb = pre_cb;
     loop->data.post_cb = post_cb;
     loop->data.wakeup_async = us_internal_create_async(loop, 1, 0);
+    if (!loop->data.wakeup_async) {
+        free(loop->data.recv_buf);
+        free(loop->data.send_buf);
+#ifdef LIBUS_USE_LIBUV
+        us_timer_close(loop->data.sweep_timer, 0);
+#endif
+        return -1;
+    }
     us_internal_async_set(loop->data.wakeup_async, (void (*)(struct us_internal_async *)) wakeup_cb);
 #if ASSERT_ENABLED
     if (Bun__lock__size != sizeof(loop->data.mutex)) {
         BUN_PANIC("The size of the mutex must match the size of the lock");
     }
 #endif
+    return 0;
 }
 
 void us_internal_loop_data_free(struct us_loop_t *loop) {

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -84,8 +84,11 @@ private:
     }
 
     static Loop *create(void *hint) {
-        Loop *loop = ((Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData)))->init();
-        return loop;
+        Loop *loop = (Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData));
+        if (!loop) {
+            return nullptr;
+        }
+        return loop->init();
     }
 
     /* What to do with loops created with existingNativeLoop? */
@@ -119,7 +122,13 @@ public:
                 getLazyLoop().loop = create(existingNativeLoop);
                 /* We cannot register automatic free here, must be manually done */
             } else {
-                getLazyLoop().loop = create(nullptr);
+                Loop *loop = create(nullptr);
+                if (!loop) {
+                    /* fd exhaustion (EMFILE). Leave lazyLoop null so a later
+                     * get() retries once descriptors are available. */
+                    return nullptr;
+                }
+                getLazyLoop().loop = loop;
                 getLazyLoop().cleanMe = true;
             }
         }

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -604,7 +604,7 @@ impl AsyncHTTP<'static> {
     /// # Safety
     /// `http` must be a live JS-thread-owned `AsyncHTTP` popped from
     /// `HttpThread::queued_tasks`.
-    pub unsafe fn fail_before_start(http: NonNull<AsyncHTTP<'static>>, err: bun_core::Error) {
+    pub unsafe fn fail_before_start(http: NonNull<AsyncHTTP<'static>>, err: crate::Error) {
         // Callbacks (e.g. `FetchTasklet::callback`) borrow both the JS-side
         // `AsyncHTTP` and the `async_http` arg. Mirror `start_queued_task`: a
         // bitwise stack copy supplies the arg; it is forgotten afterwards as

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -613,6 +613,7 @@ impl AsyncHTTP<'static> {
         // SAFETY: caller guarantees `http` is live and exclusively owned by
         // this thread (popped from the MPSC queue).
         let mut copy = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(http) });
+        copy.real = NonNull::new(http);
         copy.err = Some(err);
         copy.state.store(State::Fail, Ordering::Relaxed);
         let callback = copy.result_callback;

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -596,22 +596,16 @@ impl<'a> AsyncHTTP<'a> {
 }
 
 impl AsyncHTTP<'static> {
-    /// Fail a queued request that was never handed to `start_queued_task`.
-    /// Runs the caller's `result_callback` with `fail = err` so the owning
-    /// `fetch()` promise (or install NetworkTask) rejects. Used when the HTTP
-    /// thread cannot create its event loop under fd exhaustion.
+    /// Fail a queued-but-never-started request via its `result_callback` so
+    /// the owning fetch/NetworkTask rejects (HTTP-thread loop init failed).
     ///
     /// # Safety
-    /// `http` must be a live JS-thread-owned `AsyncHTTP` popped from
-    /// `HttpThread::queued_tasks`.
+    /// `http` must be live and just popped from `HttpThread::queued_tasks`.
     pub unsafe fn fail_before_start(http: NonNull<AsyncHTTP<'static>>, err: crate::Error) {
-        // Callbacks (e.g. `FetchTasklet::callback`) borrow both the JS-side
-        // `AsyncHTTP` and the `async_http` arg. Mirror `start_queued_task`: a
-        // bitwise stack copy supplies the arg; it is forgotten afterwards as
-        // every owned field still belongs to the original.
+        // Callbacks borrow both the JS-side original and the `async_http` arg,
+        // so pass an undropped stack copy (mirrors `start_queued_task`).
         let http = http.as_ptr();
-        // SAFETY: caller guarantees `http` is live and exclusively owned by
-        // this thread (popped from the MPSC queue).
+        // SAFETY: MPSC pop — `http` is live and exclusively owned here.
         let mut copy = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(http) });
         copy.real = NonNull::new(http);
         copy.err = Some(err);

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -595,6 +595,36 @@ impl<'a> AsyncHTTP<'a> {
     }
 }
 
+impl AsyncHTTP<'static> {
+    /// Fail a queued request that was never handed to `start_queued_task`.
+    /// Runs the caller's `result_callback` with `fail = err` so the owning
+    /// `fetch()` promise (or install NetworkTask) rejects. Used when the HTTP
+    /// thread cannot create its event loop under fd exhaustion.
+    ///
+    /// # Safety
+    /// `http` must be a live JS-thread-owned `AsyncHTTP` popped from
+    /// `HttpThread::queued_tasks`.
+    pub unsafe fn fail_before_start(http: NonNull<AsyncHTTP<'static>>, err: bun_core::Error) {
+        // Callbacks (e.g. `FetchTasklet::callback`) borrow both the JS-side
+        // `AsyncHTTP` and the `async_http` arg. Mirror `start_queued_task`: a
+        // bitwise stack copy supplies the arg; it is forgotten afterwards as
+        // every owned field still belongs to the original.
+        let http = http.as_ptr();
+        // SAFETY: caller guarantees `http` is live and exclusively owned by
+        // this thread (popped from the MPSC queue).
+        let mut copy = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(http) });
+        copy.err = Some(err);
+        copy.state.store(State::Fail, Ordering::Relaxed);
+        let callback = copy.result_callback;
+        let result = HTTPClientResult {
+            fail: Some(err),
+            has_more: false,
+            ..Default::default()
+        };
+        callback.run(core::ptr::from_mut(&mut *copy), result);
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // send_sync
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1283,7 +1283,7 @@ mod _event_loop_draft {
                 // live until its `result_callback` runs (the owner holds a
                 // ref for the in-flight callback).
                 unsafe {
-                    AsyncHttp::fail_before_start(http, bun_core::err!("FailedToOpenSocket"));
+                    AsyncHttp::fail_before_start(http, crate::Error::FailedToOpenSocket);
                 }
             }
             std::thread::sleep(core::time::Duration::from_millis(50));

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1271,6 +1271,24 @@ mod _event_loop_draft {
             core::sync::atomic::Ordering::Relaxed,
         );
 
+        // Ensure this thread's uSockets loop exists before `init_global`
+        // derefs it. `uws::Loop::get()` returns null if epoll_create1 /
+        // timerfd_create / eventfd fail (EMFILE). Rather than aborting the
+        // process, reject every queued fetch with `FailedToOpenSocket` and
+        // retry once fds free up — the next `get()` re-attempts creation.
+        while uws::Loop::get().is_null() {
+            let thread = crate::http_thread_mut();
+            while let Some(http) = NonNull::new(thread.queued_tasks.pop()) {
+                // SAFETY: `http` was pushed by `HttpThread::schedule` and is
+                // live until its `result_callback` runs (the owner holds a
+                // ref for the in-flight callback).
+                unsafe {
+                    AsyncHttp::fail_before_start(http, bun_core::err!("FailedToOpenSocket"));
+                }
+            }
+            std::thread::sleep(core::time::Duration::from_millis(50));
+        }
+
         // Critical side effect: `init_global` calls
         // `internal_loop_data.set_parent_raw(2 /* mini */, mini_ptr)` on this
         // thread's uSockets loop. Without it, the macOS DNS cache-miss path

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1271,11 +1271,8 @@ mod _event_loop_draft {
             core::sync::atomic::Ordering::Relaxed,
         );
 
-        // Ensure this thread's uSockets loop exists before `init_global`
-        // derefs it. `uws::Loop::get()` returns null if epoll_create1 /
-        // timerfd_create / eventfd fail (EMFILE). Rather than aborting the
-        // process, reject every queued fetch with `FailedToOpenSocket` and
-        // retry once fds free up — the next `get()` re-attempts creation.
+        // `uws::Loop::get()` is null on EMFILE (epoll/eventfd); reject every
+        // queued fetch and retry so `init_global` never derefs a null loop.
         while uws::Loop::get().is_null() {
             let thread = crate::http_thread_mut();
             while let Some(http) = NonNull::new(thread.queued_tasks.pop()) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1995,7 +1995,7 @@ impl VirtualMachine {
         // null. Check before allocating anything so the worker's null-vm
         // `shutdown()` path has nothing to reclaim.
         if uws::Loop::get().is_null() {
-            return Err(bun_core::err!("EMFILE"));
+            return Err(bun_errno::SystemErrno::EMFILE.into());
         }
 
         let log: *mut bun_ast::Log = match opts.log {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1990,10 +1990,8 @@ impl VirtualMachine {
     pub fn init(mut opts: InitOptions) -> crate::CrateResult<*mut VirtualMachine> {
         jsc::mark_binding();
 
-        // `uws::Loop::get()` lazily creates the per-thread uSockets loop; on
-        // fd exhaustion (epoll_create1/timerfd/eventfd → EMFILE) it returns
-        // null. Check before allocating anything so the worker's null-vm
-        // `shutdown()` path has nothing to reclaim.
+        // `uws::Loop::get()` returns null on EMFILE; bail before allocating
+        // so the worker's null-vm `shutdown()` has nothing to reclaim.
         if uws::Loop::get().is_null() {
             return Err(bun_errno::SystemErrno::EMFILE.into());
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1990,6 +1990,14 @@ impl VirtualMachine {
     pub fn init(mut opts: InitOptions) -> crate::CrateResult<*mut VirtualMachine> {
         jsc::mark_binding();
 
+        // `uws::Loop::get()` lazily creates the per-thread uSockets loop; on
+        // fd exhaustion (epoll_create1/timerfd/eventfd → EMFILE) it returns
+        // null. Check before allocating anything so the worker's null-vm
+        // `shutdown()` path has nothing to reclaim.
+        if uws::Loop::get().is_null() {
+            return Err(bun_core::err!("EMFILE"));
+        }
+
         let log: *mut bun_ast::Log = match opts.log {
             Some(l) => l.as_ptr(),
             None => bun_core::heap::into_raw(Box::new(bun_ast::Log::default())),
@@ -2153,13 +2161,6 @@ impl VirtualMachine {
         }
 
         // JSGlobalObject creation. `ensure_waker()` must run before the FFI.
-        // `uws::Loop::get()` lazily creates the per-thread uSockets loop; on
-        // fd exhaustion (epoll_create1/timerfd/eventfd → EMFILE) it returns
-        // null. Fail the VM init instead of letting `ensure_waker` deref null,
-        // so a worker thread can surface an `error` event rather than abort.
-        if uws::Loop::get().is_null() {
-            return Err(bun_core::err!("EMFILE"));
-        }
         // SAFETY: `vm` is the unique live VM on this thread; raw-ptr deref so
         // no `&mut` is held across the FFI re-entry (`Bun__getVM()` —
         // ZigGlobalObject.cpp:473/961).

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2153,6 +2153,13 @@ impl VirtualMachine {
         }
 
         // JSGlobalObject creation. `ensure_waker()` must run before the FFI.
+        // `uws::Loop::get()` lazily creates the per-thread uSockets loop; on
+        // fd exhaustion (epoll_create1/timerfd/eventfd → EMFILE) it returns
+        // null. Fail the VM init instead of letting `ensure_waker` deref null,
+        // so a worker thread can surface an `error` event rather than abort.
+        if uws::Loop::get().is_null() {
+            return Err(bun_core::err!("EMFILE"));
+        }
         // SAFETY: `vm` is the unique live VM on this thread; raw-ptr deref so
         // no `&mut` is held across the FFI re-entry (`Bun__getVM()` —
         // ZigGlobalObject.cpp:473/961).

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -681,6 +681,11 @@ extern "C" void WebWorker__dispatchExit(Worker* worker, int32_t exitCode)
     worker->dispatchExit(exitCode);
 }
 
+extern "C" void WebWorker__dispatchErrorMessage(Worker* worker, BunString* message)
+{
+    worker->dispatchErrorWithMessage(message->transferToWTFString());
+}
+
 // The entry module just finished (or failed) its top-level evaluation. Flush
 // the worker_threads hub's deferred cross-thread deliveries: node's bootstrap
 // runs the synchronous CJS main before any port delivery, so a routed message

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -181,6 +181,10 @@ pub struct WebWorker {
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
     /// producing `&mut WebWorker` while another thread holds `&WebWorker` is UB).
     exit_called: AtomicBool,
+    /// Exit code `shutdown()` posts when the VM never came up. Set to 1 by
+    /// `thread_main` on `start_vm()` failure so the parent's close/exit event
+    /// reflects abnormal exit (Node's ERR_WORKER_INIT_FAILED gives code 1).
+    init_fail_exit_code: Cell<i32>,
 }
 
 #[repr(u8)]
@@ -567,6 +571,7 @@ impl WebWorker {
             worker_env_map: Cell::new(core::ptr::null_mut()),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
             exit_called: AtomicBool::new(false),
+            init_fail_exit_code: Cell::new(0),
         }));
         // `worker` is non-null (just heap-allocated). Wrap once for the safe
         // shared reborrows below; the raw `worker` is still used for
@@ -790,6 +795,7 @@ impl WebWorker {
                     format!("Worker initialization failed: {}", err.name()).as_bytes(),
                 );
                 WebWorker__dispatchErrorMessage(self.cpp_worker, &mut msg);
+                self.init_fail_exit_code.set(1);
                 self.shutdown();
                 return;
             }
@@ -1247,7 +1253,7 @@ impl WebWorker {
         }
 
         // ---- 2. User exit handlers -----------------------------------------
-        let mut exit_code: i32 = 0;
+        let mut exit_code: i32 = self.init_fail_exit_code.get();
         let mut global_object: Option<*const JSGlobalObject> = None;
         if !vm_ptr.is_null() {
             // SAFETY: vm_ptr valid; unpublished above under vm_lock, so no

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -210,6 +210,7 @@ unsafe extern "C" {
     // `ctx`. `&JSGlobalObject` is the non-null handle proof; remaining args are
     // by-value scalars/`#[repr(C)]` PODs.
     safe fn WebWorker__dispatchExit(cpp_worker: *mut c_void, exit_code: i32);
+    safe fn WebWorker__dispatchErrorMessage(cpp_worker: *mut c_void, message: &mut BunString);
     // Re-declared here (also private in VM.rs) so `thread_main` can take the
     // API lock as a raw FFI call with NO RAII guard — see the note there.
     safe fn JSC__VM__getAPILock(vm: &jsc::VM);
@@ -780,10 +781,17 @@ impl WebWorker {
         let vm_ptr = match self.start_vm() {
             Ok(vm) => vm,
             Err(err) => {
-                bun_core::output::panic(format_args!(
-                    "An unhandled error occurred while starting a worker: {}\n",
-                    err.name()
-                ));
+                // VM init failed before a JSGlobalObject exists (e.g. EMFILE
+                // from the per-thread uSockets loop, or getcwd ENOENT from
+                // the transpiler hook). Surface it as a Worker `error` event
+                // on the parent and tear down this thread cleanly, matching
+                // Node's ERR_WORKER_INIT_FAILED behaviour.
+                let mut msg = BunString::clone_utf8(
+                    format!("Worker initialization failed: {}", err.name()).as_bytes(),
+                );
+                WebWorker__dispatchErrorMessage(self.cpp_worker, &mut msg);
+                self.shutdown();
+                return;
             }
         };
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -786,11 +786,9 @@ impl WebWorker {
         let vm_ptr = match self.start_vm() {
             Ok(vm) => vm,
             Err(err) => {
-                // VM init failed before a JSGlobalObject exists (e.g. EMFILE
-                // from the per-thread uSockets loop, or getcwd ENOENT from
-                // the transpiler hook). Surface it as a Worker `error` event
-                // on the parent and tear down this thread cleanly, matching
-                // Node's ERR_WORKER_INIT_FAILED behaviour.
+                // VM init failed before a JSGlobalObject exists (e.g. EMFILE on
+                // the per-thread loop). Fire a Worker `error` event on the
+                // parent and shut down, matching Node's ERR_WORKER_INIT_FAILED.
                 let mut msg = BunString::clone_utf8(
                     format!("Worker initialization failed: {}", err.name()).as_bytes(),
                 );

--- a/test/js/bun/util/emfile-loop-init.test.ts
+++ b/test/js/bun/util/emfile-loop-init.test.ts
@@ -41,6 +41,7 @@ const workerFixture = /* js */ `
     w.onmessage = () => { console.error("UNEXPECTED: worker message"); resolve(); };
   });
   for (const fd of held) fs.closeSync(fd);
+  fs.unlinkSync(W);
   console.error("SURVIVED");
 `;
 

--- a/test/js/bun/util/emfile-loop-init.test.ts
+++ b/test/js/bun/util/emfile-loop-init.test.ts
@@ -1,0 +1,80 @@
+// The first fetch() and the first new Worker() lazily create a per-thread
+// uSockets event loop (epoll_create1 + timerfd_create + eventfd on Linux,
+// kqueue on macOS). Under fd exhaustion those syscalls fail with EMFILE. The
+// process must not abort: the one operation should fail and, once fds are
+// freed, a retry should succeed.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+
+const fixture = /* js */ `
+  import * as fs from "node:fs";
+  const held = [];
+  for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+  // First use of the lazily-created HTTP-client event loop: must reject, not abort.
+  await fetch("http://127.0.0.1:1/").then(
+    () => { console.error("UNEXPECTED: fetch resolved"); process.exit(1); },
+    e => console.error("rejected:", e?.code ?? String(e)),
+  );
+  for (const fd of held) fs.closeSync(fd);
+  // With fds freed, the HTTP thread's loop should come up and a retry should
+  // reach a normal connect failure (ECONNREFUSED to 127.0.0.1:1), not abort.
+  await fetch("http://127.0.0.1:1/").then(
+    () => console.error("retry resolved"),
+    e => console.error("retry rejected:", e?.code ?? String(e)),
+  );
+  console.error("SURVIVED");
+`;
+
+const workerFixture = /* js */ `
+  import * as fs from "node:fs";
+  import * as os from "node:os";
+  const W = os.tmpdir() + "/w-" + process.pid + ".mjs";
+  fs.writeFileSync(W, "postMessage(42)\\n");
+  // Warm lazy builtin loads (debug builds read internal:fixed_queue from disk
+  // on the first nextTick, which new Worker()'s close-event dispatch triggers).
+  process.nextTick(() => {});
+  const held = [];
+  for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+  await new Promise(resolve => {
+    const w = new Worker(W);
+    w.onerror = ev => { console.error("worker error:", ev?.message ?? "error"); resolve(); };
+    w.onmessage = () => { console.error("UNEXPECTED: worker message"); resolve(); };
+  });
+  for (const fd of held) fs.closeSync(fd);
+  console.error("SURVIVED");
+`;
+
+describe.skipIf(!isPosix)("lazy event-loop creation under EMFILE", () => {
+  test.concurrent("first fetch() rejects instead of aborting the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -n 512 && exec "$1" --no-install -e "$2"`, "sh", bunExe(), fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("SURVIVED"),
+      exitCode: 0,
+    });
+    expect(stderr).toContain("rejected:");
+    expect(stderr).toContain("retry rejected:");
+  });
+
+  test.concurrent("first new Worker() fires an error event instead of aborting the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -n 512 && exec "$1" --no-install -e "$2"`, "sh", bunExe(), workerFixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("SURVIVED"),
+      exitCode: 0,
+    });
+    expect(stderr).toContain("worker error:");
+  });
+});

--- a/test/js/bun/util/emfile-loop-init.test.ts
+++ b/test/js/bun/util/emfile-loop-init.test.ts
@@ -34,14 +34,17 @@ const workerFixture = /* js */ `
   // on the first nextTick, which new Worker()'s close-event dispatch triggers).
   process.nextTick(() => {});
   const held = [];
-  for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
-  await new Promise(resolve => {
-    const w = new Worker(W);
-    w.onerror = ev => { console.error("worker error:", ev?.message ?? "error"); resolve(); };
-    w.onmessage = () => { console.error("UNEXPECTED: worker message"); resolve(); };
-  });
-  for (const fd of held) fs.closeSync(fd);
-  fs.unlinkSync(W);
+  try {
+    for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+    await new Promise(resolve => {
+      const w = new Worker(W);
+      w.onerror = ev => { console.error("worker error:", ev?.message ?? "error"); resolve(); };
+      w.onmessage = () => { console.error("UNEXPECTED: worker message"); resolve(); };
+    });
+  } finally {
+    for (const fd of held) fs.closeSync(fd);
+    fs.unlinkSync(W);
+  }
   console.error("SURVIVED");
 `;
 
@@ -59,8 +62,10 @@ describe.skipIf(!isPosix)("lazy event-loop creation under EMFILE", () => {
       stderr: expect.stringContaining("SURVIVED"),
       exitCode: 0,
     });
-    expect(stderr).toContain("rejected:");
-    expect(stderr).toContain("retry rejected:");
+    expect(stderr).toContain("rejected: FailedToOpenSocket");
+    // The retry must reach the normal connect path (loop recovered), not
+    // another FailedToOpenSocket.
+    expect(stderr).toContain("retry rejected: ConnectionRefused");
   });
 
   test.concurrent("first new Worker() fires an error event instead of aborting the process", async () => {
@@ -76,6 +81,6 @@ describe.skipIf(!isPosix)("lazy event-loop creation under EMFILE", () => {
       stderr: expect.stringContaining("SURVIVED"),
       exitCode: 0,
     });
-    expect(stderr).toContain("worker error:");
+    expect(stderr).toContain("worker error: Worker initialization failed: EMFILE");
   });
 });


### PR DESCRIPTION
## Repro

```js
// sh -c 'ulimit -n 512; exec bun repro.ts'
import * as fs from "node:fs";
const held = [];
for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
await fetch("http://127.0.0.1:1/").catch(e => console.error("rejected:", e.code));
for (const fd of held) fs.closeSync(fd);
console.error("SURVIVED");
```

Before (both `fetch` and `new Worker()` at the fd limit):
```
panic: eventfd() failed during loop init (out of file descriptors?)
```
SIGABRT, exit 134. Node at the same limit rejects that one fetch (TypeError: fetch failed) / fires `ERR_WORKER_INIT_FAILED` on that one Worker, then recovers.

## Cause

On Linux, `us_create_loop` acquires three fds: `epoll_create1`, `timerfd_create` for the sweep timer, and `eventfd` for the wakeup async. The eventfd failure was a deliberate `BUN_PANIC`; the other two were never checked. The first `fetch()` spawns the HTTP-client thread and the first `new Worker()` spawns a worker thread; both lazily create their own per-thread uSockets loop via `uWS::Loop::get()`, which reached the panic and took the whole process down.

## Fix

`us_create_loop` now returns NULL when any of the init syscalls fail, cleaning up whatever was acquired. `us_internal_loop_data_init` returns `int` so the caller can unwind. `uWS::Loop::get()` returns nullptr and leaves the per-thread lazy slot empty so a later call retries.

Callers:

- `VirtualMachine::init` returns `Err(EMFILE)` before `ensure_waker` would dereference a null loop.
- `WebWorker::thread_main` turns `start_vm()` Err into an `error` event on the parent Worker (new `WebWorker__dispatchErrorMessage` shim that only needs the parent-side `Worker*`) plus the existing null-vm `shutdown()`, instead of `Output::panic`.
- HTTP client `on_start` checks `uws::Loop::get()` before `init_global`; while null it rejects every queued fetch with `FailedToOpenSocket` (via new `AsyncHTTP::fail_before_start`) and retries, so a later fetch succeeds once fds free up.

Also fixes the pre-existing leak of the poll allocation when `timerfd_create` or `eventfd` fails.

Related: #33848 handles the adjacent case where the loop itself comes up but the GC controller's `us_create_timer` fails (3-4 spare fds). This PR is the 0-spare-fd variant that #33848 explicitly scoped out.

## Verification

`test/js/bun/util/emfile-loop-init.test.ts` (POSIX-only) runs both scenarios under `ulimit -n 512`: fills the fd table, issues the first `fetch()` / `new Worker()`, asserts the process exits 0 with `SURVIVED` and the per-operation error. Fails on main with exit 134 / `panic: eventfd() failed during loop init`; passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/emfile-loop-init.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f29437aca)

test/js/bun/util/emfile-loop-init.test.ts:
(fail) lazy event-loop creation under EMFILE > first fetch() rejects instead of aborting the process [5007.72ms]
  ^ this test timed out after 5000ms.
(fail) lazy event-loop creation under EMFILE > first new Worker() fires an error event instead of aborting the process [5006.11ms]
  ^ this test timed out after 5000ms.

 0 pass
 2 fail
Ran 2 tests across 1 file. [7.01s]
error: script "bd" exited with code 1
__F:2:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (2b4acd612)

test/js/bun/util/emfile-loop-init.test.ts:
(pass) lazy event-loop creation under EMFILE > first new Worker() fires an error event instead of aborting the process [28.27ms]
(pass) lazy event-loop creation under EMFILE > first fetch() rejects instead of aborting the process [76.79ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [227.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/emfile-loop-init.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f29437aca)

test/js/bun/util/emfile-loop-init.test.ts:
(pass) lazy event-loop creation under EMFILE > first new Worker() fires an error event instead of aborting the process [1364.96ms]
(pass) lazy event-loop creation under EMFILE > first fetch() rejects instead of aborting the process [1415.06ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [3.40s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] cc obj/packages/bun-usockets/src/context.c.o
[2/26] cc obj/packages/bun-usockets/src/bsd.c.o
[3/26] cc obj/packages/bun-usockets/src/fault_inject.c.o
[4/26] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/26] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[6/26] cc obj/packages/bun-usockets/src/loop.c.o
[7/26] cc obj/packages/bun-usockets/src/socket.c.o
[8/26] cc obj/packages/bun-usockets/src/udp.c.o
[9/26] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[10/26] cc obj/packages/bun-usockets/src/quic.c.o
[11/26] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[12/26] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[13/26] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[14/26] cxx obj/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/eventing/epoll_kqueue.c | 23 ++++--
 packages/bun-usockets/src/eventing/libuv.c        |  2 +-
 packages/bun-usockets/src/internal/internal.h     |  8 +--
 packages/bun-usockets/src/loop.c                  | 13 +++-
 packages/bun-uws/src/Loop.h                       | 15 +++-
 src/http/AsyncHTTP.rs                             | 25 +++++++
 src/http/HTTPThread.rs                            | 15 ++++
 src/jsc/VirtualMachine.rs                         |  6 ++
 src/jsc/bindings/webcore/Worker.cpp               |  5 ++
 src/jsc/web_worker.rs                             | 22 ++++--
 test/js/bun/util/emfile-loop-init.test.ts         | 86 +++++++++++++++++++++++
 11 files changed, 201 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
packages/bun-usockets/src/eventing/epoll_kqueue.c      5      5      0
packages/bun-usockets/src/eventing/libuv.c             2      1      0
packages/bun-usockets/src/internal/internal.h          1      1      0
packages/bun-usockets/src/loop.c                       3      3      0
packages/bun-uws/src/Loop.h                            1      2      0
src/http/AsyncHTTP.rs                                  8      5      0
src/http/HTTPThread.rs                                 7      3      0
src/jsc/VirtualMachine.rs                              6      5      0
src/jsc/bindings/webcore/Worker.cpp                    2      2      0
src/jsc/web_worker.rs                                  6      8      0
test/js/bun/util/emfile-loop-init.test.ts              2      9      0
```

</details>

<!-- robobun:evidence:end -->