### PR TITLE
node:vm SourceTextModule.evaluate(): return the same capability promise on repeat calls

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -48,6 +48,7 @@ const {
   compileFunction,
   isModuleNamespaceObject,
   kLinked,
+  kEvaluating,
   kEvaluated,
   kErrored,
   DONT_CONTEXTIFY,
@@ -305,18 +306,18 @@ class Module {
       const { breakOnSigint = false } = options;
       validateBoolean(breakOnSigint, "options.breakOnSigint");
       const status = this[kNative].getStatusCode();
-      if (status !== kLinked && status !== kEvaluated && status !== kErrored) {
+      // kEvaluating passes through: native returns the cached capability
+      // promise for TLA in flight, or throws ERR_VM_MODULE_STATUS for a
+      // synchronous re-entrant call from inside the module body.
+      if (status !== kLinked && status !== kEvaluating && status !== kEvaluated && status !== kErrored) {
         throw $ERR_VM_MODULE_STATUS("must be one of linked, evaluated, or errored");
       }
       // Always call into native, even when already evaluated: Node re-enters
       // ModuleWrap::Evaluate, which performs the afterEvaluate microtask
-      // checkpoint for contexts with their own microtask queue.
+      // checkpoint for contexts with their own microtask queue. The cached
+      // capability promise is returned as-is so repeated evaluate() calls
+      // observe the SAME promise object (ES2024 Evaluate() step 2/4).
       const result = this[kNative].evaluate(timeout, breakOnSigint);
-      if (status === kEvaluated) {
-        // Re-evaluating a settled module resolves synchronously with
-        // undefined (a then-chain on the cached promise would be pending).
-        return PromiseResolve(undefined);
-      }
       if ($isPromise(result)) {
         // Spec-style module evaluation capability: already settled (with
         // undefined) for synchronous modules, pending for top-level await.

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -84,19 +84,17 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // ES2024 Evaluate() step 2: for evaluating-async, return the cached
     // [[TopLevelCapability]] promise. m_evaluationResult is set only after the
     // first evaluate() returned, so Evaluating-without-result is sync re-entry.
-    if (m_status == Status::Evaluating && m_evaluationResult) {
-        return m_evaluationResult.get();
-    }
+    const bool evaluatingAsync = m_status == Status::Evaluating && m_evaluationResult;
 
-    if (m_status != Status::Linked && m_status != Status::Evaluated && m_status != Status::Errored) {
+    if (!evaluatingAsync && m_status != Status::Linked && m_status != Status::Evaluated && m_status != Status::Errored) {
         throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_STATUS, "Module status must be one of linked, evaluated, or errored"_s);
         return {};
     }
 
-    if (m_status == Status::Evaluated) {
-        // Node re-enters ModuleWrap::Evaluate even for already-evaluated
-        // modules; for microtaskMode "afterEvaluate" contexts that performs a
-        // microtask checkpoint on the context's own queue.
+    if (m_status == Status::Evaluated || evaluatingAsync) {
+        // Node re-enters ModuleWrap::Evaluate for both evaluated and
+        // evaluating-async; for microtaskMode "afterEvaluate" contexts that
+        // performs a microtask checkpoint on the context's own queue.
         NodeVMGlobalObject* nodeVmGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
         RETURN_IF_EXCEPTION(scope, {});
         if (nodeVmGlobalObject && nodeVmGlobalObject->hasOwnMicrotaskQueue()) {

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -81,8 +81,15 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
 
     reconcileEvaluationState(vm);
 
+    // ES2024 Evaluate() step 2: for evaluating-async, return the cached
+    // [[TopLevelCapability]] promise. m_evaluationResult is set only after the
+    // first evaluate() returned, so Evaluating-without-result is sync re-entry.
+    if (m_status == Status::Evaluating && m_evaluationResult) {
+        return m_evaluationResult.get();
+    }
+
     if (m_status != Status::Linked && m_status != Status::Evaluated && m_status != Status::Errored) {
-        throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_STATUS, "Module must be linked, evaluated or errored before evaluating"_s);
+        throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_STATUS, "Module status must be one of linked, evaluated, or errored"_s);
         return {};
     }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1181,7 +1181,7 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
 // ES2024 Evaluate() steps 2/4: for evaluating-async or evaluated, return
 // module.[[TopLevelCapability]].[[Promise]] (same object every call). Bun used
 // to reject the in-flight TLA case and mint a fresh promise per settled call.
-describe("node:vm SourceTextModule evaluate() is idempotent", () => {
+describe.concurrent("node:vm SourceTextModule evaluate() is idempotent", () => {
   test("TLA in a dependency: second evaluate() returns the same pending promise", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,121 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// ES2024 Evaluate() steps 2/4: for evaluating-async or evaluated, return
+// module.[[TopLevelCapability]].[[Promise]] (same object every call). Bun used
+// to reject the in-flight TLA case and mint a fresh promise per settled call.
+describe("node:vm SourceTextModule evaluate() is idempotent", () => {
+  test("TLA in a dependency: second evaluate() returns the same pending promise", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          const leaf = new vm.SourceTextModule("export const v = await Promise.resolve(7);", { identifier: "leaf" });
+          const root = new vm.SourceTextModule("import {v} from 'l'; export const r = v;", { identifier: "root" });
+          await root.link(() => leaf);
+
+          const p1 = root.evaluate();
+          const p2 = root.evaluate();
+          const out = { same12: p1 === p2, settled: await p2.then(() => "fulfilled", e => "rejected:" + e.code) };
+          await p1;
+          const p3 = root.evaluate(), p4 = root.evaluate();
+          out.same34 = p3 === p4;
+          out.same13 = p1 === p3;
+          out.r = root.namespace.r;
+          console.log(JSON.stringify(out));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ same12: true, settled: "fulfilled", same34: true, same13: true, r: 7 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("TLA in the root module itself: same capability promise each call", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          const m = new vm.SourceTextModule("export const v = await Promise.resolve(42);");
+          await m.link(() => { throw new Error("no deps"); });
+
+          const p1 = m.evaluate();
+          const p2 = m.evaluate();
+          await p1;
+          const p3 = m.evaluate();
+          console.log(JSON.stringify({ same12: p1 === p2, same13: p1 === p3, v: m.namespace.v }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ same12: true, same13: true, v: 42 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("settled non-TLA module: repeated evaluate() returns the same fulfilled promise", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          const m = new vm.SourceTextModule("export const x = 1;");
+          await m.link(() => { throw new Error("no deps"); });
+
+          const p1 = m.evaluate();
+          const p2 = m.evaluate();
+          const p3 = m.evaluate();
+          console.log(JSON.stringify({ same12: p1 === p2, same23: p2 === p3, v: await p1 }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ same12: true, same23: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test("synchronously re-entrant evaluate() from inside the module body still rejects", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          let inner;
+          globalThis.reenter = () => { inner = m.evaluate(); };
+          const m = new vm.SourceTextModule("globalThis.reenter(); export const x = 1;");
+          await m.link(() => { throw new Error("no deps"); });
+          await m.evaluate();
+          await inner.then(
+            () => console.log("FAIL: inner fulfilled"),
+            e => console.log("code=" + e.code),
+          );
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("code=ERR_VM_MODULE_STATUS");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`vm.SourceTextModule#evaluate()` is supposed to be idempotent: per ES2024 `Evaluate()` steps 2 and 4, a module whose cyclic record is `evaluating-async` or `evaluated` returns `module.[[TopLevelCapability]].[[Promise]]`, the same promise object every call. Node matches the spec via ModuleWrap's cached promise.

Bun did not:

```js
import * as vm from "node:vm";

const leaf = new vm.SourceTextModule("export const v = await Promise.resolve(7);");
const root = new vm.SourceTextModule("import {v} from 'l'; export const r = v;");
await root.link(() => leaf);

const p1 = root.evaluate();
const p2 = root.evaluate();
console.log(p1 === p2, await p2.then(() => "fulfilled", e => "rejected: " + e));
//   node:  true fulfilled
//   bun:   false rejected: Error [ERR_VM_MODULE_STATUS]: Module status must be one of linked, evaluated, or errored

await p1;
const p3 = root.evaluate(), p4 = root.evaluate();
console.log("settled: same promise?", p3 === p4);
//   node:  settled: same promise? true
//   bun:   settled: same promise? false
```

Two halves of one cause. `NodeVMModule` already caches the capability promise in `m_evaluationResult` on first evaluation, but:

1. While a TLA graph is in flight the wrapper status is `Evaluating`, and both the JS-layer and native-layer status gates rejected that outright instead of returning the cached promise.
2. For a settled module the JS layer discarded the cached result and returned a fresh `Promise.resolve(undefined)` per call.

## How did you verify your code works?

New tests in `test/js/node/vm/vm.test.ts` covering: TLA in a dependency, TLA in the root module, a settled non-TLA module, and that a synchronous re-entrant `evaluate()` from inside the module body still rejects with `ERR_VM_MODULE_STATUS`.

All 21 `test/js/node/test/parallel/test-vm-module-*` Node compat tests and the full `vm.test.ts` suite continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (760125fec)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [20.23ms]
(pass) vm > runInContext() > can return a value [14.57ms]
(pass) vm > runInContext() > can return a complex value [14.76ms]
(pass) vm > runInContext() > can return the last value [14.31ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.77ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.79ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [14.79ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.80ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release without fix: 68 skipped
bun test v1.4.0-canary.1 (db1bbb4bb)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.37ms]
(pass) vm > runInContext() > can return a value [0.23ms]
(pass) vm > runInContext() > can return a complex value [0.24ms]
(pass) vm > runInContext() > can return the last value [0.20ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.22ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (760125fec)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [32.18ms]
(pass) vm > runInContext() > can return a value [21.03ms]
(pass) vm > runInContext() > can return a complex value [14.82ms]
(pass) vm > runInContext() > can return the last value [14.38ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.58ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.31ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.13ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.23ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.35ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release with fix: 68 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 660ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (9041ms)
Bundle modules (31ms)
Postprocesss modules (36ms)
Bundle Functions (957ms)
Generate Code (118ms)

[10.20s] Bundled "src/js" for production
  1888 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/vm.ts                 |  15 ++---
 src/jsc/bindings/NodeVMModule.cpp |  17 ++++--
 test/js/node/vm/vm.test.ts        | 118 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 137 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js/node/vm.ts                      4      3      0
src/jsc/bindings/NodeVMModule.cpp      4      3      0
test/js/node/vm/vm.test.ts             2      3      0
```

</details>

<!-- robobun:evidence:end -->