### PR TITLE
bundler: keep console.METHOD.bind() callable under --drop=console

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1423,6 +1423,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
         );
 
+        // "console.log.bind(x)" => "(() => {}).bind(x)" when `console` is
+        // dropped, so the bound function stays callable instead of the whole
+        // expression collapsing to `undefined` and throwing when invoked.
+        if p.method_call_must_be_replaced_with_undefined && e_.name == b"bind" {
+            e_.target = p.new_expr(E::Arrow::NOOP_RETURN_UNDEFINED, e_.target.loc);
+            p.method_call_must_be_replaced_with_undefined = false;
+        }
+
         // 'require.resolve' -> .e_require_resolve_call_target
         if matches!(e_.target.data, Data::ERequireCallTarget) && e_.name == b"resolve" {
             // we do not need to call p.recordUsageOfRuntimeRequire(); because `require`

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1424,12 +1424,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
         );
 
-        // "console.log.bind(x)" => "(() => {}).bind(x)" when `console` is
-        // dropped, so the bound function stays callable instead of the whole
-        // expression collapsing to `undefined` and throwing when invoked.
-        // Only applies when this `.bind` is the direct call target and the
-        // flag was set by the target visit rather than by this EDot's own
-        // dot-define match (e.g. `drop: ["Mousetrap.bind"]`).
+        // "console.log.bind(x)" => "(() => {}).bind(x)" so the result stays callable.
+        // Gate on is_call_target and a false->true flag transition so drop paths that
+        // themselves end in .bind (`drop: ["Mousetrap.bind"]`) still collapse to undefined.
         if is_call_target
             && !drop_flag_before_target_visit
             && p.method_call_must_be_replaced_with_undefined

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1414,6 +1414,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        let drop_flag_before_target_visit = p.method_call_must_be_replaced_with_undefined;
         p.visit_expr_in_out(
             &mut e_.target,
             ExprIn {
@@ -1426,7 +1427,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // "console.log.bind(x)" => "(() => {}).bind(x)" when `console` is
         // dropped, so the bound function stays callable instead of the whole
         // expression collapsing to `undefined` and throwing when invoked.
-        if p.method_call_must_be_replaced_with_undefined && e_.name == b"bind" {
+        // Only applies when this `.bind` is the direct call target and the
+        // flag was set by the target visit rather than by this EDot's own
+        // dot-define match (e.g. `drop: ["Mousetrap.bind"]`).
+        if is_call_target
+            && !drop_flag_before_target_visit
+            && p.method_call_must_be_replaced_with_undefined
+            && e_.name == b"bind"
+        {
             e_.target = p.new_expr(E::Arrow::NOOP_RETURN_UNDEFINED, e_.target.loc);
             p.method_call_must_be_replaced_with_undefined = false;
         }

--- a/test/bundler/bundler_drop.test.ts
+++ b/test/bundler/bundler_drop.test.ts
@@ -164,4 +164,30 @@ describe("bundler", () => {
     backend: "api",
     run: { stdout: "undefined\nundefined" },
   });
+  itBundled("drop/BindNotCallTargetStillDropped", {
+    files: {
+      "/a.js": `globalThis.console.log(console.log.bind.call(console.log, console));`,
+    },
+    drop: ["console"],
+    backend: "api",
+    run: { stdout: "undefined" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("() => {");
+    },
+  });
+  itBundled("drop/DotDefineEndingInBindStillDropped", {
+    files: {
+      "/a.js": `
+        globalThis.handler = () => "SHOULD NOT RUN";
+        globalThis.console.log(typeof Mousetrap.bind('ctrl+s', handler));
+      `,
+    },
+    drop: ["Mousetrap.bind"],
+    backend: "api",
+    run: { stdout: "undefined" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("() => {");
+      api.expectFile("out.js").not.toContain("handler)");
+    },
+  });
 });

--- a/test/bundler/bundler_drop.test.ts
+++ b/test/bundler/bundler_drop.test.ts
@@ -114,4 +114,54 @@ describe("bundler", () => {
     drop: ["ASSERT"],
     backend: "api",
   });
+  itBundled("drop/BindStaysCallable", {
+    files: {
+      "/a.js": `
+        const log = console.log.bind(console);
+        log("hello");
+        process.stdout.write("ALIVE\\n");
+      `,
+    },
+    drop: ["console"],
+    backend: "api",
+    run: { stdout: "ALIVE" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain("() => {");
+      api.expectFile("out.js").not.toContain("= undefined");
+    },
+  });
+  itBundled("drop/BindImmediateCall", {
+    files: {
+      "/a.js": `
+        console.log.bind(console)("immediate");
+        process.stdout.write("ALIVE\\n");
+      `,
+    },
+    drop: ["console"],
+    backend: "api",
+    run: { stdout: "ALIVE" },
+  });
+  itBundled("drop/BindDotDefine", {
+    files: {
+      "/a.js": `
+        const f = my.logger.bind(null);
+        f("hello");
+        process.stdout.write("ALIVE\\n");
+      `,
+    },
+    drop: ["my.logger"],
+    backend: "api",
+    run: { stdout: "ALIVE" },
+  });
+  itBundled("drop/CallApplyStillDropped", {
+    files: {
+      "/a.js": `
+        globalThis.console.log(console.log.call(console, "x"));
+        globalThis.console.log(console.log.apply(console, ["y"]));
+      `,
+    },
+    drop: ["console"],
+    backend: "api",
+    run: { stdout: "undefined\nundefined" },
+  });
 });


### PR DESCRIPTION
## Reproduction

```js
// in.mjs
const log = console.log.bind(console);
log("hello");
process.stdout.write("ALIVE\n");
```

```
$ bun build --drop=console in.mjs
var log = undefined;
log("hello");                // TypeError: log is not a function
process.stdout.write(...);   // never reached
```

The build succeeds silently and the bundle throws at module load. `const log = console.log.bind(console)` is a very common idiom (logger locals, shims, older TS emit), so enabling the documented log-stripping option breaks the program outright.

## Cause

In `visit_expr.rs`, `e_call` marks its target visit with `property_access_for_method_call_maybe_should_replace_with_undefined = true`, and `e_dot` propagates that flag down through every intermediate property access. When the leaf `console` identifier matches the drop define it sets `p.method_call_must_be_replaced_with_undefined`, and the enclosing `e_call` then rewrites the whole call to `EUndefined`. For `console.log.bind(console)` that outer call is `.bind(...)`, whose result is a function the program calls later, so the substitution yields `undefined(...)`.

## Fix

After `e_dot` visits its target, if the drop flag is set and the accessor name is `bind`, replace the target with an empty arrow `() => {}` and clear the flag. The outer `.bind(...)` call is preserved and returns a no-op function:

```
var log = (() => {}).bind(console);
log("hello");                // no-op
process.stdout.write(...);   // ALIVE
```

This matches esbuild's `--drop:console` output for the same input. `.call`/`.apply` and deeper property chains (`Bun.inspect.table()` with `drop: ["Bun"]`) continue to collapse to `undefined` exactly as before.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bundler_drop.test.ts
 15 pass
 3 fail   # BindStaysCallable, BindImmediateCall, BindDotDefine

$ bun bd test test/bundler/bundler_drop.test.ts
 18 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_drop.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ce1c67f25)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [890.06ms]
(pass) bundler > drop/DebuggerStmt [101.82ms]
(pass) bundler > drop/NoDisableDebugger [82.01ms]
(pass) bundler > drop/RemovesSideEffects [509.85ms]
(pass) bundler > drop/ReassignKeepsOutput [500.83ms]
(pass) bundler > drop/AssignKeepsOutput [504.97ms]
(pass) bundler > drop/UnaryExpression [500.14ms]
(pass) bundler > drop/0Args [492.99ms]
(pass) bundler > drop/BecomesUndefined [514.51ms]
(pass) bundler > drop/BecomesUndefinedNested1 [509.98ms]
(pass) bundler > drop/BecomesUndefinedNested2 [512.09ms]
(pass) bundler > drop/AssignTarget [512.12ms]
(pass) bundler > drop/DeleteAssignTarget [938.03ms]
(pass) bundler > drop/IdentifierCall [579.89ms]
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6d4828a43)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [31.88ms]
(pass) bundler > drop/DebuggerStmt [4.48ms]
(pass) bundler > drop/NoDisableDebugger [2.83ms]
(pass) bundler > drop/RemovesSideEffects [15.37ms]
(pass) bundler > drop/ReassignKeepsOutput [16.35ms]
(pass) bundler > drop/AssignKeepsOutput [15.09ms]
(pass) bundler > drop/UnaryExpression [15.12ms]
(pass) bundler > drop/0Args [14.84ms]
(pass) bundler > drop/BecomesUndefined [14.86ms]
(pass) bundler > drop/BecomesUndefinedNested1 [14.41ms]
(pass) bundler > drop/BecomesUndefinedNested2 [14.20ms]
(pass) bundler > drop/AssignTarget [20.82ms]
(pass) bundler > drop/DeleteAssignTarget [15.36ms]
(pass) bundler > drop/IdentifierCall [14.33ms]
(pass) bundler > drop/BindStaysCallable [29.16ms]
(pass) bundler > drop/BindImmediateCall [29.08ms]
(pass) bundler > drop/BindDotDefine [28.16ms]
(pass) bundler > drop/CallApplyStillDropped [15.15ms]
(pass) bundler > drop/BindNotCallTargetStillDropped [14.90ms]
(pass) bundler > drop/DotDefineEndingInBindStillDropped [14.72ms]

 20 pass
 0 fail
 25 expect() calls
Ran 20 tests across 1 file. [533.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_drop.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ce1c67f25)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [956.35ms]
(pass) bundler > drop/DebuggerStmt [105.72ms]
(pass) bundler > drop/NoDisableDebugger [91.75ms]
(pass) bundler > drop/RemovesSideEffects [567.80ms]
(pass) bundler > drop/ReassignKeepsOutput [492.52ms]
(pass) bundler > drop/AssignKeepsOutput [500.02ms]
(pass) bundler > drop/UnaryExpression [493.55ms]
(pass) bundler > drop/0Args [486.14ms]
(pass) bundler > drop/BecomesUndefined [501.59ms]
(pass) bundler > drop/BecomesUndefinedNested1 [566.67ms]
(pass) bundler > drop/BecomesUndefinedNested2 [509.03ms]
(pass) bundler > drop/AssignTarget [504.26ms]
(pass) bundler > drop/DeleteAssignTarget [874.20ms]
(pass) bundler > drop/IdentifierCall [490.83ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 722ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_expr.rs | 13 +++++++
 test/bundler/bundler_drop.test.ts | 76 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 89 insertions(+)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js_parser/visit/visit_expr.rs      6      4      0
test/bundler/bundler_drop.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->