### PR TITLE
node:vm: honor import phase (defer) in SourceTextModule

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -398,8 +398,7 @@ class SourceTextModule extends Module {
 
     // Parse eagerly so a SyntaxError surfaces from the constructor and
     // moduleRequests is available immediately, matching Node where ModuleWrap
-    // compiles the module during construction. JSC has no source-phase
-    // imports, so every request is an evaluation-phase request.
+    // compiles the module during construction.
     const requests = this[kNative].createModuleRecord();
     this.#moduleRequests = ObjectFreeze(
       ArrayPrototypeMap.$call(requests, request =>
@@ -407,7 +406,7 @@ class SourceTextModule extends Module {
           __proto__: null,
           specifier: request.specifier,
           attributes: request.attributes,
-          phase: "evaluation",
+          phase: request.phase ?? "evaluation",
         }),
       ),
     );
@@ -619,9 +618,8 @@ function isModule(object) {
 
 function importModuleDynamicallyWrap(importModuleDynamically) {
   const importModuleDynamicallyWrapper = async (specifier, referrer, attributes, phase) => {
-    // JSC has no source-phase imports, so every dynamic import is an
-    // evaluation-phase request (Node passes the phase name as 4th argument).
-    const m: any = await importModuleDynamically.$call(this, specifier, referrer, attributes, phase ?? "evaluation");
+    phase ??= "evaluation";
+    const m: any = await importModuleDynamically.$call(this, specifier, referrer, attributes, phase);
     if (isModuleNamespaceObject(m)) {
       return m;
     }
@@ -630,6 +628,12 @@ function importModuleDynamicallyWrap(importModuleDynamically) {
     }
     if (m.status === "errored") {
       throw m.error;
+    }
+    if (phase === "defer") {
+      if (m[kNative].getStatusCode() < kLinked) {
+        throw $ERR_VM_MODULE_STATUS("must not be unlinked or linking");
+      }
+      return m[kNative].getDeferredNamespace();
     }
     return m.namespace;
   };

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -70,11 +70,11 @@
 namespace Bun {
 using namespace WebCore;
 
-static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin);
+static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin, bool deferred);
 
 namespace NodeVM {
 
-static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, JSValue dynamicImportCallback, JSValue owner);
+static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, JSValue dynamicImportCallback, JSValue owner, bool deferred);
 
 static JSValue scriptFetchParametersToImportAttributes(JSGlobalObject* globalObject, JSC::ScriptFetchParameters* params)
 {
@@ -261,7 +261,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     return function;
 }
 
-JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin)
+JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, bool deferred)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -270,7 +270,7 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefP
         if (!sourceOrigin.url().isEmpty()) {
             if (auto* nodeVmGlobalObject = dynamicDowncast<NodeVMGlobalObject>(globalObject)) {
                 if (nodeVmGlobalObject->dynamicImportCallback()) {
-                    RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, globalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin));
+                    RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, globalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, deferred));
                 }
             }
         }
@@ -288,16 +288,16 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefP
     if (isUseMainContextDefaultLoaderConstant(globalObject, dynamicImportCallback)) {
         auto defer = fetcher->temporarilyUseDefaultLoader();
         Zig::GlobalObject* zigGlobalObject = defaultGlobalObject(globalObject);
-        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, false));
+        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, deferred));
     } else if (!dynamicImportCallback || !dynamicImportCallback.isCallable()) {
         throwException(globalObject, scope, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));
         return nullptr;
     }
 
-    RELEASE_AND_RETURN(scope, importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, dynamicImportCallback, fetcher->owner()));
+    RELEASE_AND_RETURN(scope, importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, dynamicImportCallback, fetcher->owner(), deferred));
 }
 
-static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, JSValue dynamicImportCallback, JSValue owner)
+static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, JSValue dynamicImportCallback, JSValue owner, bool deferred)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -318,9 +318,8 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
         args.append(jsUndefined());
     }
     args.append(importAttributes);
-    // Node passes the import phase name as the 4th argument; JSC has no
-    // source-phase imports, so it is always the evaluation phase.
-    args.append(jsString(vm, String("evaluation"_s)));
+    // Node passes the import phase name as the 4th argument.
+    args.append(jsString(vm, String(deferred ? "defer"_s : "evaluation"_s)));
 
     JSValue result = AsyncContextFrame::call(globalObject, dynamicImportCallback, jsUndefined(), args);
 
@@ -339,7 +338,7 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
 
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    auto* transformer = JSNativeStdFunction::create(vm, globalObject, 1, {}, [](JSGlobalObject* globalObject, CallFrame* callFrame) -> JSC::EncodedJSValue {
+    auto* transformer = JSNativeStdFunction::create(vm, globalObject, 1, {}, [deferred](JSGlobalObject* globalObject, CallFrame* callFrame) -> JSC::EncodedJSValue {
         VM& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -349,6 +348,10 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
             JSValue result = object->get(globalObject, JSC::Identifier::fromString(vm, "namespace"_s));
             RETURN_IF_EXCEPTION(scope, {});
             if (!result.isUndefinedOrNull()) {
+                if (deferred) {
+                    if (auto* ns = dynamicDowncast<JSModuleNamespaceObject>(result))
+                        RELEASE_AND_RETURN(scope, JSValue::encode(ns->moduleRecord()->getModuleNamespace(globalObject, AbstractModuleRecord::ModulePhase::Defer)));
+                }
                 return JSValue::encode(result);
             }
         }
@@ -1682,7 +1685,7 @@ bool NodeVMGlobalObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObje
     return Base::deleteProperty(cell, globalObject, propertyName, slot);
 }
 
-static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin)
+static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin, bool deferred)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1691,7 +1694,7 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
 
     if (sourceOrigin.fetcher() == nullptr && sourceOrigin.url().isEmpty()) {
         if (globalObject->dynamicImportCallback().isCallable()) {
-            return NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {});
+            return NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {}, deferred);
         }
 
         promise->reject(vm, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));
@@ -1709,12 +1712,11 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
 
 JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin, bool deferred)
 {
-    UNUSED_PARAM(deferred);
     auto* nodeVmGlobalObject = static_cast<NodeVMGlobalObject*>(globalObject);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSPromise* result = NodeVM::importModule(nodeVmGlobalObject, moduleName, parameters, sourceOrigin);
+    JSPromise* result = NodeVM::importModule(nodeVmGlobalObject, moduleName, parameters, sourceOrigin, deferred);
     // importModule runs the user's dynamic-import callback, which can throw
     // and leave a null result; surface that as a rejected promise instead of
     // falling through with the exception pending.
@@ -1726,7 +1728,7 @@ JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalOb
         return result;
     }
 
-    RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin));
+    RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin, deferred));
 }
 
 void NodeVMGlobalObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject* globalObject, JSC::PropertyNameArrayBuilder& propertyNames, JSC::DontEnumPropertiesMode mode)

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -31,7 +31,7 @@ NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSV
 JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value);
 // For vm.compileFunction we need to return an anonymous function expression. This code is adapted from/inspired by JSC::constructFunction, which is used for function declarations.
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope);
-JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
+JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, bool deferred);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -598,6 +598,15 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmModuleGetDeferredNamespace, (JSC::JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (auto* thisObject = dynamicDowncast<NodeVMModule>(callFrame->thisValue())) {
+        // EvaluateModuleSync (triggered by first property access on the
+        // deferred namespace) runs the JSC record directly with no reference
+        // to the wrapper's initializeImportMeta or a SyntheticModule's
+        // evaluateCallback; perform those wrapper-side steps for the whole
+        // subgraph first, mirroring the static `import defer` path in
+        // evaluateDependencies().
+        UncheckedKeyHashSet<NodeVMModule*> visited;
+        thisObject->prepareDeferredSubgraph(globalObject, visited, 0, false);
+        RETURN_IF_EXCEPTION(scope, {});
         AbstractModuleRecord* amr = thisObject->moduleRecord(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         RELEASE_AND_RETURN(scope, JSValue::encode(amr->getModuleNamespace(globalObject, AbstractModuleRecord::ModulePhase::Defer)));

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -54,7 +54,11 @@ void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeou
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
-    if (m_status != Status::Evaluating)
+    // Evaluating: a top-level-await module whose async machinery finishes
+    // after evaluate() returned. Linked: a deferred dependency whose body was
+    // run via EvaluateModuleSync on first namespace access, bypassing this
+    // wrapper's evaluate().
+    if (m_status != Status::Evaluating && m_status != Status::Linked)
         return;
 
     auto* sourceTextThis = dynamicDowncast<NodeVMSourceTextModule>(this);
@@ -307,6 +311,12 @@ void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractMo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     for (const auto& request : record->requestedModules()) {
+        // `import defer` dependencies are left unevaluated here; the
+        // spec-level Evaluate() (innerModuleEvaluation) already handles the
+        // Defer phase correctly, and the deferred namespace's first property
+        // access triggers EvaluateModuleSync on the dependency's record.
+        if (request.m_phase == AbstractModuleRecord::ModulePhase::Defer)
+            continue;
         if (auto iter = m_resolveCache.find(request.m_specifier.string()); iter != m_resolveCache.end()) {
             auto* dependency = uncheckedDowncast<NodeVMModule>(iter->value.get());
             RELEASE_ASSERT(dependency != nullptr);
@@ -401,6 +411,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsNodeVmModuleGetterIdentifier);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleGetStatusCode);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleGetStatus);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleGetNamespace);
+JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleGetDeferredNamespace);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleGetError);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleInstantiate);
 JSC_DECLARE_HOST_FUNCTION(jsNodeVmModuleEvaluate);
@@ -417,6 +428,7 @@ static const HashTableValue NodeVMModulePrototypeTableValues[] = {
     { "getStatusCode"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleGetStatusCode, 0 } },
     { "getStatus"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleGetStatus, 0 } },
     { "getNamespace"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleGetNamespace, 0 } },
+    { "getDeferredNamespace"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleGetDeferredNamespace, 0 } },
     { "getError"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleGetError, 0 } },
     { "instantiate"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleInstantiate, 0 } },
     { "evaluate"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsNodeVmModuleEvaluate, 2 } },
@@ -520,6 +532,21 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmModuleGetNamespace, (JSC::JSGlobalObject * glob
 
     if (auto* thisObject = dynamicDowncast<NodeVMModule>(callFrame->thisValue())) {
         RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->namespaceObject(globalObject)));
+    }
+
+    throwTypeError(globalObject, scope, "This function must be called on a SourceTextModule or SyntheticModule"_s);
+    return {};
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsNodeVmModuleGetDeferredNamespace, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (auto* thisObject = dynamicDowncast<NodeVMModule>(callFrame->thisValue())) {
+        AbstractModuleRecord* amr = thisObject->moduleRecord(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        RELEASE_AND_RETURN(scope, JSValue::encode(amr->getModuleNamespace(globalObject, AbstractModuleRecord::ModulePhase::Defer)));
     }
 
     throwTypeError(globalObject, scope, "This function must be called on a SourceTextModule or SyntheticModule"_s);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -311,35 +311,88 @@ void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractMo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    UncheckedKeyHashSet<NodeVMModule*> deferVisited;
+
     for (const auto& request : record->requestedModules()) {
-        // `import defer` dependencies are left unevaluated here; the
-        // spec-level Evaluate() (innerModuleEvaluation) already handles the
-        // Defer phase correctly, and the deferred namespace's first property
-        // access triggers EvaluateModuleSync on the dependency's record.
-        if (request.m_phase == AbstractModuleRecord::ModulePhase::Defer)
+        auto iter = m_resolveCache.find(request.m_specifier.string());
+        if (iter == m_resolveCache.end())
             continue;
-        if (auto iter = m_resolveCache.find(request.m_specifier.string()); iter != m_resolveCache.end()) {
-            auto* dependency = uncheckedDowncast<NodeVMModule>(iter->value.get());
-            RELEASE_ASSERT(dependency != nullptr);
+        auto* dependency = uncheckedDowncast<NodeVMModule>(iter->value.get());
+        RELEASE_ASSERT(dependency != nullptr);
 
-            if (dependency->status() == Status::Unlinked) {
-                if (auto* syntheticDependency = dynamicDowncast<NodeVMSyntheticModule>(dependency)) {
-                    syntheticDependency->link(globalObject, nullptr, nullptr, jsUndefined());
-                    RETURN_IF_EXCEPTION(scope, );
-                }
-            }
+        // `import defer` dependencies must not run their SourceTextModule body
+        // here; the spec-level Evaluate() (innerModuleEvaluation) handles the
+        // Defer phase and the deferred namespace's first property access runs
+        // EvaluateModuleSync on the dependency's record. That JSC-level path
+        // has no reference to the wrapper's initializeImportMeta or a
+        // SyntheticModule's evaluateCallback, so perform those wrapper-side
+        // steps for the whole deferred subgraph now.
+        if (request.m_phase == AbstractModuleRecord::ModulePhase::Defer) {
+            dependency->prepareDeferredSubgraph(globalObject, deferVisited, timeout, breakOnSigint);
+            RETURN_IF_EXCEPTION(scope, );
+            continue;
+        }
 
-            if (dependency->status() == Status::Linked) {
-                JSValue dependencyResult = dependency->evaluate(globalObject, timeout, breakOnSigint);
+        if (dependency->status() == Status::Unlinked) {
+            if (auto* syntheticDependency = dynamicDowncast<NodeVMSyntheticModule>(dependency)) {
+                syntheticDependency->link(globalObject, nullptr, nullptr, jsUndefined());
                 RETURN_IF_EXCEPTION(scope, );
-                // Source text dependencies evaluate via the spec-style
-                // Evaluate() and return a capability promise. A still-pending
-                // promise means the dependency uses top-level await; the
-                // root record's evaluate() drives the async machinery to
-                // completion and the wrapper status reconciles lazily
-                // (reconcileEvaluationState), so a pending result is fine
-                // here.
-                UNUSED_PARAM(dependencyResult);
+            }
+        }
+
+        if (dependency->status() == Status::Linked) {
+            JSValue dependencyResult = dependency->evaluate(globalObject, timeout, breakOnSigint);
+            RETURN_IF_EXCEPTION(scope, );
+            // Source text dependencies evaluate via the spec-style
+            // Evaluate() and return a capability promise. A still-pending
+            // promise means the dependency uses top-level await; the
+            // root record's evaluate() drives the async machinery to
+            // completion and the wrapper status reconciles lazily
+            // (reconcileEvaluationState), so a pending result is fine
+            // here.
+            UNUSED_PARAM(dependencyResult);
+        }
+    }
+}
+
+void NodeVMModule::prepareDeferredSubgraph(JSGlobalObject* globalObject, UncheckedKeyHashSet<NodeVMModule*>& visited, uint32_t timeout, bool breakOnSigint)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    WTF::Vector<NodeVMModule*, 8> stack;
+    stack.append(this);
+    while (!stack.isEmpty()) {
+        NodeVMModule* module = stack.takeLast();
+        if (!visited.add(module).isNewEntry)
+            continue;
+
+        if (module->status() == Status::Unlinked) {
+            if (auto* syntheticModule = dynamicDowncast<NodeVMSyntheticModule>(module)) {
+                syntheticModule->link(globalObject, nullptr, nullptr, jsUndefined());
+                RETURN_IF_EXCEPTION(scope, );
+            }
+        }
+
+        if (dynamicDowncast<NodeVMSyntheticModule>(module)) {
+            if (module->status() == Status::Linked) {
+                module->evaluate(globalObject, timeout, breakOnSigint);
+                RETURN_IF_EXCEPTION(scope, );
+            }
+            continue;
+        }
+
+        auto* sourceTextModule = dynamicDowncast<NodeVMSourceTextModule>(module);
+        if (!sourceTextModule || module->status() != Status::Linked)
+            continue;
+
+        sourceTextModule->initializeImportMeta(globalObject);
+        RETURN_IF_EXCEPTION(scope, );
+
+        if (auto* depRecord = sourceTextModule->moduleRecordIfExists()) {
+            for (const auto& request : depRecord->requestedModules()) {
+                if (auto iter = module->m_resolveCache.find(request.m_specifier.string()); iter != module->m_resolveCache.end())
+                    stack.append(uncheckedDowncast<NodeVMModule>(iter->value.get()));
             }
         }
     }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -121,7 +121,8 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 return {};
             }
         }
-        return m_evaluationResult.get();
+        JSValue cached = m_evaluationResult.get();
+        return cached ? cached : jsUndefined();
     }
 
     auto* sourceTextThis = dynamicDowncast<NodeVMSourceTextModule>(this);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -306,6 +306,14 @@ NodeVMModule::NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String i
 {
 }
 
+static void linkIfUnlinkedSynthetic(JSGlobalObject* globalObject, NodeVMModule* module)
+{
+    if (module->status() != NodeVMModule::Status::Unlinked)
+        return;
+    if (auto* syntheticModule = dynamicDowncast<NodeVMSyntheticModule>(module))
+        syntheticModule->link(globalObject, nullptr, nullptr, jsUndefined());
+}
+
 void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractModuleRecord* record, uint32_t timeout, bool breakOnSigint)
 {
     VM& vm = globalObject->vm();
@@ -333,12 +341,8 @@ void NodeVMModule::evaluateDependencies(JSGlobalObject* globalObject, AbstractMo
             continue;
         }
 
-        if (dependency->status() == Status::Unlinked) {
-            if (auto* syntheticDependency = dynamicDowncast<NodeVMSyntheticModule>(dependency)) {
-                syntheticDependency->link(globalObject, nullptr, nullptr, jsUndefined());
-                RETURN_IF_EXCEPTION(scope, );
-            }
-        }
+        linkIfUnlinkedSynthetic(globalObject, dependency);
+        RETURN_IF_EXCEPTION(scope, );
 
         if (dependency->status() == Status::Linked) {
             JSValue dependencyResult = dependency->evaluate(globalObject, timeout, breakOnSigint);
@@ -367,12 +371,8 @@ void NodeVMModule::prepareDeferredSubgraph(JSGlobalObject* globalObject, Uncheck
         if (!visited.add(module).isNewEntry)
             continue;
 
-        if (module->status() == Status::Unlinked) {
-            if (auto* syntheticModule = dynamicDowncast<NodeVMSyntheticModule>(module)) {
-                syntheticModule->link(globalObject, nullptr, nullptr, jsUndefined());
-                RETURN_IF_EXCEPTION(scope, );
-            }
-        }
+        linkIfUnlinkedSynthetic(globalObject, module);
+        RETURN_IF_EXCEPTION(scope, );
 
         if (dynamicDowncast<NodeVMSyntheticModule>(module)) {
             if (module->status() == Status::Linked) {

--- a/src/jsc/bindings/NodeVMModule.h
+++ b/src/jsc/bindings/NodeVMModule.h
@@ -90,6 +90,7 @@ protected:
     NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String identifier, JSValue context, JSValue moduleWrapper);
 
     void evaluateDependencies(JSGlobalObject* globalObject, AbstractModuleRecord* record, uint32_t timeout, bool breakOnSigint);
+    void prepareDeferredSubgraph(JSGlobalObject* globalObject, UncheckedKeyHashSet<NodeVMModule*>& visited, uint32_t timeout, bool breakOnSigint);
 
     DECLARE_EXPORT_INFO;
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/NodeVMModule.h
+++ b/src/jsc/bindings/NodeVMModule.h
@@ -76,6 +76,8 @@ public:
 
     JSC::Exception* evaluationException() const { return m_evaluationException.get(); }
 
+    void prepareDeferredSubgraph(JSGlobalObject* globalObject, UncheckedKeyHashSet<NodeVMModule*>& visited, uint32_t timeout, bool breakOnSigint);
+
 protected:
     WTF::String m_identifier;
     Status m_status = Status::Unlinked;
@@ -90,7 +92,6 @@ protected:
     NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String identifier, JSValue context, JSValue moduleWrapper);
 
     void evaluateDependencies(JSGlobalObject* globalObject, AbstractModuleRecord* record, uint32_t timeout, bool breakOnSigint);
-    void prepareDeferredSubgraph(JSGlobalObject* globalObject, UncheckedKeyHashSet<NodeVMModule*>& visited, uint32_t timeout, bool breakOnSigint);
 
     DECLARE_EXPORT_INFO;
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -215,6 +215,9 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
     const Identifier& specifierIdentifier = builtinNames.specifierPublicName();
     const Identifier& attributesIdentifier = builtinNames.attributesPublicName();
     const Identifier& hostDefinedImportTypeIdentifier = builtinNames.hostDefinedImportTypePublicName();
+    const Identifier phaseIdentifier = Identifier::fromString(vm, "phase"_s);
+    JSString* evaluationPhase = jsString(vm, String("evaluation"_s));
+    JSString* deferPhase = jsString(vm, String("defer"_s));
 
     WTF::Vector<ImportAttributesListNode*, 8> attributesNodes;
     attributesNodes.reserveInitialCapacity(requests.size());
@@ -293,6 +296,7 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         }
 
         requestObject->putDirect(vm, attributesIdentifier, attributesObject);
+        requestObject->putDirect(vm, phaseIdentifier, request.m_phase == AbstractModuleRecord::ModulePhase::Defer ? deferPhase : evaluationPhase);
         addModuleRequest({ request.m_specifier.string(), WTF::move(attributeMap) });
         requestsArray->putDirectIndex(globalObject, i, requestObject);
     }

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -539,13 +539,16 @@ void NodeVMSourceTextModule::initializeImportMeta(JSGlobalObject* globalObject)
         return;
     }
 
-    CallData callData = JSC::getCallData(m_initializeImportMeta.get());
+    JSValue callback = m_initializeImportMeta.get();
+    m_initializeImportMeta.clear();
+
+    CallData callData = JSC::getCallData(callback);
 
     MarkedArgumentBuffer args;
     args.append(metaValue);
     args.append(m_moduleWrapper.get());
 
-    JSC::call(globalObject, m_initializeImportMeta.get(), callData, jsUndefined(), args);
+    JSC::call(globalObject, callback, callData, jsUndefined(), args);
     scope.release();
 }
 

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -245,7 +245,7 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
 
         JSString* specifierValue = JSC::jsString(vm, request.m_specifier.string());
 
-        JSObject* requestObject = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
+        JSObject* requestObject = constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
         requestObject->putDirect(vm, specifierIdentifier, specifierValue);
 
         WTF::String attributesTypeString = "unknown"_str;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3471,14 +3471,13 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     const SourceOrigin& sourceOrigin,
     bool deferred)
 {
-    UNUSED_PARAM(deferred);
     auto* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
 
     VM& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     {
-        JSC::JSPromise* result = NodeVM::importModule(globalObject, moduleNameValue, parameters, sourceOrigin);
+        JSC::JSPromise* result = NodeVM::importModule(globalObject, moduleNameValue, parameters, sourceOrigin, deferred);
         RETURN_IF_EXCEPTION(scope, nullptr);
         if (result) {
             return result;
@@ -3513,7 +3512,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
-            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
+            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, deferred, referrerAsyncOrder);
             if (scope.exception()) [[unlikely]] {
                 return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
             }
@@ -3573,7 +3572,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
-        JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
+        JSC::Identifier(), WTF::move(parameters), nullptr, deferred, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1290,6 +1290,60 @@ describe("node:vm SourceTextModule import defer", () => {
     expect(metaCalls).toBe(1);
   });
 
+  test("dynamic `import.defer()` of a SyntheticModule still runs its evaluation steps", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SyntheticModule(
+      ["x"],
+      function () {
+        ctx.LOG.push("SYNTH");
+        this.setExport("x", 42);
+      },
+      { context: ctx, identifier: "dep" },
+    );
+    const root = new vm.SourceTextModule("export const p = import.defer('d');", {
+      context: ctx,
+      identifier: "root",
+      importModuleDynamically: () => dep,
+    });
+    await root.link(() => {
+      throw new Error("no deps");
+    });
+    await root.evaluate();
+
+    const ns = await root.namespace.p;
+    expect(ns.x).toBe(42);
+    expect(ctx.LOG).toContain("SYNTH");
+    expect(dep.status).toBe("evaluated");
+  });
+
+  test("dynamic `import.defer()` of a SourceTextModule still runs initializeImportMeta", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SourceTextModule("LOG.push('DEP'); export const u = import.meta.url;", {
+      context: ctx,
+      identifier: "dep",
+      initializeImportMeta(meta: any) {
+        meta.url = "file:///dep.js";
+      },
+    });
+    await dep.link(() => {
+      throw new Error("no deps");
+    });
+    const root = new vm.SourceTextModule("export const p = import.defer('d');", {
+      context: ctx,
+      identifier: "root",
+      importModuleDynamically: () => dep,
+    });
+    await root.link(() => {
+      throw new Error("no deps");
+    });
+    await root.evaluate();
+
+    const ns = await root.namespace.p;
+    expect(ctx.LOG.join("|")).toBe("");
+    expect(ns.u).toBe("file:///dep.js");
+    expect(ctx.LOG.join("|")).toBe("DEP");
+  });
+
   test("a throwing deferred dependency surfaces the error and reports errored status", async () => {
     const ctx = vm.createContext({ LOG: [] });
     const dep = new vm.SourceTextModule("LOG.push('DEP'); throw new Error('boom'); export const a = 1;", {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1251,10 +1251,10 @@ describe("node:vm SourceTextModule import defer", () => {
       },
       { context: ctx, identifier: "dep" },
     );
-    const root = new vm.SourceTextModule(
-      "import defer * as N from 'dep'; LOG.push('ROOT'); export const v = N.x;",
-      { context: ctx, identifier: "root" },
-    );
+    const root = new vm.SourceTextModule("import defer * as N from 'dep'; LOG.push('ROOT'); export const v = N.x;", {
+      context: ctx,
+      identifier: "root",
+    });
     await root.link(() => dep);
     await root.evaluate();
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1241,6 +1241,55 @@ describe("node:vm SourceTextModule import defer", () => {
     expect(seenPhase).toBe("defer");
   });
 
+  test("`import defer` of a SyntheticModule still runs its evaluation steps", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SyntheticModule(
+      ["x"],
+      function () {
+        ctx.LOG.push("SYNTH");
+        this.setExport("x", 42);
+      },
+      { context: ctx, identifier: "dep" },
+    );
+    const root = new vm.SourceTextModule(
+      "import defer * as N from 'dep'; LOG.push('ROOT'); export const v = N.x;",
+      { context: ctx, identifier: "root" },
+    );
+    await root.link(() => dep);
+    await root.evaluate();
+
+    // The JSC SyntheticModuleRecord has no reference to the wrapper's
+    // evaluateCallback, so the wrapper must evaluate synthetic dependencies
+    // itself even for a defer-phase request.
+    expect(root.namespace.v).toBe(42);
+    expect(ctx.LOG).toContain("SYNTH");
+    expect(dep.status).toBe("evaluated");
+  });
+
+  test("`import defer` of a SourceTextModule still runs initializeImportMeta", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    let metaCalls = 0;
+    const dep = new vm.SourceTextModule("LOG.push('DEP'); export const u = import.meta.url;", {
+      context: ctx,
+      identifier: "dep",
+      initializeImportMeta(meta: any) {
+        metaCalls++;
+        meta.url = "file:///dep.js";
+      },
+    });
+    const root = new vm.SourceTextModule(
+      "import defer * as N from 'dep'; LOG.push('ROOT'); export const before = LOG.join('|'); export const u = N.u;",
+      { context: ctx, identifier: "root" },
+    );
+    await root.link(() => dep);
+    await root.evaluate();
+
+    expect(root.namespace.before).toBe("ROOT");
+    expect(root.namespace.u).toBe("file:///dep.js");
+    expect(ctx.LOG.join("|")).toBe("ROOT|DEP");
+    expect(metaCalls).toBe(1);
+  });
+
   test("`import.defer()` and `import()` from the same module report distinct phases", async () => {
     const ctx = vm.createContext({});
     const dep = new vm.SourceTextModule("export const v = 1;", { identifier: "dep", context: ctx });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1177,3 +1177,94 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("node:vm SourceTextModule import defer", () => {
+  const vm = require("node:vm");
+
+  test("static `import defer` leaves the dependency unevaluated until first namespace access", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SourceTextModule("LOG.push('DEP-EVAL'); export const a = 41;", {
+      identifier: "dep",
+      context: ctx,
+    });
+    const root = new vm.SourceTextModule(
+      "import defer * as N from 'dep';\n" +
+        "LOG.push('ROOT');\n" +
+        "export const before = LOG.join('|');\n" +
+        "export const v = N.a + 1;\n" +
+        "export const after = LOG.join('|');",
+      { identifier: "root", context: ctx },
+    );
+
+    await root.link(() => dep);
+    await root.evaluate();
+
+    // Bun previously evaluated the deferred dependency eagerly, giving
+    // before === "DEP-EVAL|ROOT".
+    expect({ ...root.namespace }).toEqual({ before: "ROOT", v: 42, after: "ROOT|DEP-EVAL" });
+    expect(dep.status).toBe("evaluated");
+    expect(root.moduleRequests).toEqual([{ specifier: "dep", attributes: {}, phase: "defer" }]);
+  });
+
+  test("dynamic `import.defer()` returns a deferred namespace that evaluates on first access", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SourceTextModule("LOG.push('D2'); export const z = 7;", {
+      identifier: "d2",
+      context: ctx,
+    });
+    await dep.link(() => {
+      throw new Error("no deps");
+    });
+
+    let seenPhase: string | undefined;
+    const root = new vm.SourceTextModule("export const p = import.defer('x');", {
+      identifier: "r2",
+      context: ctx,
+      importModuleDynamically: (_spec: string, _ref: unknown, _attrs: unknown, phase: string) => {
+        seenPhase = phase;
+        return dep;
+      },
+    });
+    await root.link(() => {
+      throw new Error("no deps");
+    });
+    await root.evaluate();
+
+    const ns = await root.namespace.p;
+    // Bun previously dropped the deferred flag and handed back the regular
+    // (un-evaluated) namespace, so every property read TDZ-threw and the
+    // dependency body never ran.
+    expect(ctx.LOG.join("|")).toBe("");
+    expect(ns.z).toBe(7);
+    expect(ctx.LOG.join("|")).toBe("D2");
+    expect(dep.status).toBe("evaluated");
+    expect(seenPhase).toBe("defer");
+  });
+
+  test("`import.defer()` and `import()` from the same module report distinct phases", async () => {
+    const ctx = vm.createContext({});
+    const dep = new vm.SourceTextModule("export const v = 1;", { identifier: "dep", context: ctx });
+    await dep.link(() => {
+      throw new Error("no deps");
+    });
+    await dep.evaluate();
+
+    const phases: string[] = [];
+    const root = new vm.SourceTextModule("export const a = import('x'); export const b = import.defer('y');", {
+      identifier: "root",
+      context: ctx,
+      importModuleDynamically: (_s: string, _r: unknown, _a: unknown, phase: string) => {
+        phases.push(phase);
+        return dep;
+      },
+    });
+    await root.link(() => {
+      throw new Error("no deps");
+    });
+    await root.evaluate();
+    await root.namespace.a;
+    await root.namespace.b;
+
+    expect(phases).toEqual(["evaluation", "defer"]);
+  });
+});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1290,6 +1290,26 @@ describe("node:vm SourceTextModule import defer", () => {
     expect(metaCalls).toBe(1);
   });
 
+  test("a throwing deferred dependency surfaces the error and reports errored status", async () => {
+    const ctx = vm.createContext({ LOG: [] });
+    const dep = new vm.SourceTextModule("LOG.push('DEP'); throw new Error('boom'); export const a = 1;", {
+      identifier: "dep",
+      context: ctx,
+    });
+    const root = new vm.SourceTextModule(
+      "import defer * as N from 'dep'; LOG.push('ROOT'); export let caught; try { N.a; } catch (e) { caught = String(e); }",
+      { identifier: "root", context: ctx },
+    );
+    await root.link(() => dep);
+    await root.evaluate();
+
+    expect(root.namespace.caught).toBe("Error: boom");
+    expect(ctx.LOG.join("|")).toBe("ROOT|DEP");
+    expect(dep.status).toBe("errored");
+    expect(String(dep.error)).toBe("Error: boom");
+    expect(root.status).toBe("evaluated");
+  });
+
   test("`import.defer()` and `import()` from the same module report distinct phases", async () => {
     const ctx = vm.createContext({});
     const dep = new vm.SourceTextModule("export const v = 1;", { identifier: "dep", context: ctx });


### PR DESCRIPTION
### Repro

```js
import * as vm from "node:vm";

const ctx = vm.createContext({ LOG: [] });
const dep  = new vm.SourceTextModule("LOG.push('DEP-EVAL'); export const a = 41;", { identifier: "dep", context: ctx });
const root = new vm.SourceTextModule(
  "import defer * as N from 'dep';\n" +
  "LOG.push('ROOT');\n" +
  "export const before = LOG.join('|');\n" +
  "export const v = N.a + 1;\n" +
  "export const after = LOG.join('|');",
  { identifier: "root", context: ctx });
await root.link(() => dep); await root.evaluate();
console.log(root.namespace.before);   // DEP-EVAL|ROOT  (should be ROOT)

const c2 = vm.createContext({ LOG: [] });
const d2 = new vm.SourceTextModule("LOG.push('D2'); export const z = 7;", { identifier: "d2", context: c2 });
await d2.link(() => { throw 0; });
const r2 = new vm.SourceTextModule("export const p = import.defer('x');",
  { identifier: "r2", context: c2, importModuleDynamically: () => d2 });
await r2.link(() => { throw 0; }); await r2.evaluate();
const ns = await r2.namespace.p;
ns.z;   // ReferenceError: Cannot access 'z' before initialization.
```

The same two-module graph loaded through Bun's file-based ESM loader defers correctly; only the `vm.SourceTextModule` driver is wrong.

### Cause

* `NodeVMModule::evaluateDependencies` iterates `record->requestedModules()` and calls `evaluate()` on every dependency without looking at `request.m_phase`, so `import defer` requests are evaluated eagerly before the importer's body runs.
* `NodeVMGlobalObject::moduleLoaderImportModule` and `Zig::GlobalObject::moduleLoaderImportModule` discard the `deferred` argument JSC passes. `importModuleDynamically` is always called with `phase === "evaluation"` and the wrapper returns the regular (un-evaluated) namespace, so `import.defer()` resolves to a namespace whose bindings are permanently in TDZ and the dependency body never runs.
* `createModuleRecord` never reads `request.m_phase`, so `SourceTextModule#moduleRequests[i].phase` is hardcoded to `"evaluation"`.

### Fix

* Skip `ModulePhase::Defer` requests in `evaluateDependencies`. JSC's `innerModuleEvaluation` (called right after) already implements the spec's Defer handling, and the deferred namespace's first property access runs `EvaluateModuleSync` on the dependency's record.
* Extend `reconcileEvaluationState` to also reconcile Linked -> Evaluated so a deferred dependency's wrapper status reflects its record after the namespace triggers evaluation.
* Thread `deferred` through `NodeVM::importModule` / `importModuleInner` and both `moduleLoaderImportModule` overrides. The `importModuleDynamically` callback now receives `"defer"` as the phase, and the JS wrapper returns `record.getModuleNamespace(Defer)` via a new native `getDeferredNamespace()` method. The native transformer (used by `vm.Script` / `vm.compileFunction`) does the same conversion.
* Surface `request.m_phase` as the `phase` property on the module-requests array.

### Verification

New tests in `test/js/node/vm/vm.test.ts` cover the static form (side-effect ordering `ROOT` then `DEP-EVAL`, `moduleRequests[0].phase === "defer"`), the dynamic form (`ns.z` reads the value and triggers evaluation on first access), and that `import()` vs `import.defer()` report distinct phases. All existing `test-vm-module-*.js` parallel tests and `test/js/bun/resolve/import-defer.test.ts` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (525614b48)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [19.78ms]
(pass) vm > runInContext() > can return a value [14.32ms]
(pass) vm > runInContext() > can return a complex value [14.61ms]
(pass) vm > runInContext() > can return the last value [14.30ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.83ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.15ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.98ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [14.83ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.76ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release without fix: 68 skipped
bun test v1.4.0-canary.1 (74c3aacce)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.39ms]
(pass) vm > runInContext() > can return a value [0.20ms]
(pass) vm > runInContext() > can return a complex value [0.20ms]
(pass) vm > runInContext() > can return the last value [0.22ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.43ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (525614b48)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [20.19ms]
(pass) vm > runInContext() > can return a value [14.40ms]
(pass) vm > runInContext() > can return a complex value [14.45ms]
(pass) vm > runInContext() > can return the last value [14.23ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.27ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.10ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [14.64ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [14.90ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [14.62ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release with fix: 68 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (6384ms)
Bundle modules (45ms)
Postprocesss modules (145ms)
Bundle Functions (715ms)
Generate Code (88ms)

[7.39s] Bundled "src/js" for production
  1889 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/vm.ts                           |  16 ++-
 src/jsc/bindings/NodeVM.cpp                 |  34 ++---
 src/jsc/bindings/NodeVM.h                   |   2 +-
 src/jsc/bindings/NodeVMModule.cpp           | 134 ++++++++++++++---
 src/jsc/bindings/NodeVMModule.h             |   2 +
 src/jsc/bindings/NodeVMSourceTextModule.cpp |  13 +-
 src/jsc/bindings/ZigGlobalObject.cpp        |   7 +-
 test/js/node/vm/vm.test.ts                  | 214 ++++++++++++++++++++++++++++
 8 files changed, 370 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/node/vm.ts                                4      1      0
src/jsc/bindings/NodeVM.cpp                      4      4      0
src/jsc/bindings/NodeVM.h                        1      1      0
src/jsc/bindings/NodeVMModule.cpp                7      8      0
src/jsc/bindings/NodeVMModule.h                  3      2      0
src/jsc/bindings/NodeVMSourceTextModule.cpp      4      5      0
src/jsc/bindings/ZigGlobalObject.cpp             1      1      0
test/js/node/vm/vm.test.ts                       2      5      0
```

</details>

<!-- robobun:evidence:end -->