### PR TITLE
MessagePort: define node-style emitter methods on the prototype itself

### DIFF
--- a/src/js/builtins/MessagePort.ts
+++ b/src/js/builtins/MessagePort.ts
@@ -1,0 +1,61 @@
+// Node.js MessagePort inherits from NodeEventTarget. These are bootstrap stubs:
+// the first call to any of them loads internal/worker/messageport_emitter, which
+// installs the real methods on an intermediate prototype and deletes these
+// own-property stubs so subsequent lookups hit the inherited implementations.
+// Without them, `port.on(...)` throws TypeError until something in the process
+// happens to load node:worker_threads.
+
+export function on(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.on.$apply(this, arguments);
+}
+
+export function off(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.off.$apply(this, arguments);
+}
+
+export function once(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.once.$apply(this, arguments);
+}
+
+export function emit(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.emit.$apply(this, arguments);
+}
+
+export function addListener(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.addListener.$apply(this, arguments);
+}
+
+export function removeListener(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.removeListener.$apply(this, arguments);
+}
+
+export function listenerCount(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.listenerCount.$apply(this, arguments);
+}
+
+export function eventNames(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.eventNames.$apply(this, arguments);
+}
+
+export function removeAllListeners(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.removeAllListeners.$apply(this, arguments);
+}
+
+export function setMaxListeners(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.setMaxListeners.$apply(this, arguments);
+}
+
+export function getMaxListeners(this: MessagePort) {
+  require("internal/worker/messageport_emitter");
+  return this.getMaxListeners.$apply(this, arguments);
+}

--- a/src/js/internal/worker/messageport_emitter.ts
+++ b/src/js/internal/worker/messageport_emitter.ts
@@ -1,0 +1,207 @@
+// Installs node's NodeEventTarget emitter surface on MessagePort. Lives in its
+// own module so it runs on the first emitter-method access (via the MessagePort
+// prototype bootstraps in src/js/builtins/MessagePort.ts) rather than only when
+// node:worker_threads happens to be loaded.
+
+const { SafeMap } = require("internal/primordials");
+
+const emitterMethodNames = [
+  "on",
+  "off",
+  "once",
+  "emit",
+  "addListener",
+  "removeListener",
+  "listenerCount",
+  "eventNames",
+  "removeAllListeners",
+  "setMaxListeners",
+  "getMaxListeners",
+] as const;
+
+function injectFakeEmitter(Class) {
+  // Per-instance registry mapping each event to (user listener -> wrapper), so
+  // listenerCount/eventNames/removeAllListeners work over EventTarget's opaque
+  // internal map and off() can find the wrapper a given listener registered.
+  // SafeMap: its prototype is a frozen, null-proto snapshot of Map.prototype, so
+  // .get/.set/.size/.values()/iteration all bypass a user-replaced Map.prototype.
+  // (It has no @get/@set private names, so the $-intrinsics don't apply to it.)
+  // Keyed by a module-local symbol, not a WeakMap — WeakMap has neither defence.
+  const kListenerRegistry = Symbol("listenerRegistry");
+  function registryFor(target, create) {
+    let map = target[kListenerRegistry];
+    if (!map && create) target[kListenerRegistry] = map = new SafeMap();
+    return map;
+  }
+
+  function messageEventHandler(event: MessageEvent) {
+    return event.data;
+  }
+
+  function errorEventHandler(event: ErrorEvent) {
+    return event.error;
+  }
+
+  function customEventHandler(event) {
+    return event.detail;
+  }
+
+  function wrapped(run, listener) {
+    return function (event) {
+      return listener(run(event));
+    };
+  }
+
+  function functionForEventType(event, listener) {
+    switch (event) {
+      case "error":
+      case "messageerror": {
+        return wrapped(errorEventHandler, listener);
+      }
+
+      case "message": {
+        return wrapped(messageEventHandler, listener);
+      }
+
+      default: {
+        return wrapped(customEventHandler, listener);
+      }
+    }
+  }
+
+  function EventClass(eventName) {
+    if (eventName === "error" || eventName === "messageerror") {
+      return ErrorEvent;
+    }
+
+    return MessageEvent;
+  }
+
+  // EventTarget dedupes on (type, callback), so in node the FIRST registration of
+  // a listener wins outright -- including its once-ness -- and later adds of the
+  // same function are no-ops. Keying wrappers per listener reproduces that.
+  function register(target, event, listener, wrapper, options) {
+    const map = registryFor(target, true)!;
+    let byListener = map.get(event);
+    if (!byListener) map.set(event, (byListener = new SafeMap()));
+    if (byListener.has(listener)) return false;
+    target.addEventListener(event, wrapper, options);
+    byListener.set(listener, wrapper);
+    return true;
+  }
+
+  function on(event, listener) {
+    register(this, event, listener, functionForEventType(event, listener), undefined);
+    return this;
+  }
+
+  function off(event, listener) {
+    if (listener) {
+      const byListener = registryFor(this, false)?.get(event);
+      const wrapper = byListener?.get(listener) ?? listener;
+      this.removeEventListener(event, wrapper);
+      byListener?.delete(listener);
+    } else {
+      this.removeEventListener(event);
+    }
+    return this;
+  }
+
+  function once(event, listener) {
+    const wrapper = functionForEventType(event, listener);
+    const target = this;
+    // EventTarget drops a {once:true} listener natively, without telling the
+    // registry — so purge it here or listenerCount()/eventNames() keep counting
+    // a listener that already fired.
+    function onceWrapper(ev) {
+      registryFor(target, false)?.get(event)?.delete(listener);
+      return wrapper(ev);
+    }
+    register(this, event, listener, onceWrapper, { once: true });
+    return this;
+  }
+
+  function emit(event, ...args) {
+    switch (event) {
+      case "error":
+      case "messageerror":
+      case "message":
+        this.dispatchEvent(new (EventClass(event))(event, ...args));
+        break;
+      default:
+        // Non-standard events surface as CustomEvent (detail = first arg) to
+        // addEventListener and as the raw argument to .on(), matching node.
+        this.dispatchEvent(new CustomEvent(event, { detail: args[0] }));
+        break;
+    }
+    return this;
+  }
+
+  const kMaxListeners = Symbol("kMaxListeners");
+  function setMaxListeners(n) {
+    this[kMaxListeners] = n;
+    return this;
+  }
+  function getMaxListeners() {
+    return this[kMaxListeners] ?? 10;
+  }
+  function listenerCount(type) {
+    return registryFor(this, false)?.get(type)?.size ?? 0;
+  }
+  function eventNames() {
+    const map = registryFor(this, false);
+    if (!map) return [];
+    const out: string[] = [];
+    for (const [k, v] of map) if (v.size > 0) out.push(k);
+    return out;
+  }
+  function removeAllListeners(type) {
+    const map = registryFor(this, false);
+    if (!map) return this;
+    const removeType = t => {
+      const byListener = map.get(t);
+      if (byListener) {
+        for (const w of byListener.values()) this.removeEventListener(t, w);
+        map.delete(t);
+      }
+    };
+    if (arguments.length === 0) {
+      // removeType only deletes `t`, and a Map iterator tolerates deleting the
+      // entry it just yielded — so no snapshot copy is needed here.
+      for (const t of map.keys()) removeType(t);
+    } else {
+      removeType(type);
+    }
+    return this;
+  }
+
+  // node inherits these from NodeEventTarget.prototype (a curated subset of
+  // EventEmitter, not EventEmitter itself); use an intermediate prototype so
+  // Object.getOwnPropertyNames(MessagePort.prototype) matches node.
+  const proto = Class.prototype;
+  const inherited = Object.create(Object.getPrototypeOf(proto));
+  const emitterMethods: [string, Function][] = [
+    ["on", on],
+    ["off", off],
+    ["once", once],
+    ["emit", emit],
+    ["addListener", on],
+    ["removeListener", off],
+    ["listenerCount", listenerCount],
+    ["eventNames", eventNames],
+    ["removeAllListeners", removeAllListeners],
+    ["setMaxListeners", setMaxListeners],
+    ["getMaxListeners", getMaxListeners],
+  ];
+  for (const [methodName, value] of emitterMethods) {
+    Object.defineProperty(inherited, methodName, { value, writable: true, enumerable: false, configurable: true });
+  }
+  // Remove the bootstrap own-properties JSMessagePort.cpp put on the prototype
+  // so subsequent lookups fall through to `inherited`.
+  for (const methodName of emitterMethodNames) delete proto[methodName];
+  Object.setPrototypeOf(proto, inherited);
+}
+
+injectFakeEmitter(globalThis.MessagePort);
+
+export default {};

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -4,7 +4,6 @@ declare const self: typeof globalThis;
 type WebWorker = InstanceType<typeof globalThis.Worker>;
 
 const EventEmitter = require("node:events");
-const { SafeMap } = require("internal/primordials");
 const Readable = require("internal/streams/readable");
 const Writable = require("internal/streams/writable");
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
@@ -101,190 +100,14 @@ type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
 // after their Worker exits
 let urlRevokeRegistry: FinalizationRegistry<string> | undefined = undefined;
 
-function injectFakeEmitter(Class) {
-  // Per-instance registry mapping each event to (user listener -> wrapper), so
-  // listenerCount/eventNames/removeAllListeners work over EventTarget's opaque
-  // internal map and off() can find the wrapper a given listener registered.
-  // SafeMap: its prototype is a frozen, null-proto snapshot of Map.prototype, so
-  // .get/.set/.size/.values()/iteration all bypass a user-replaced Map.prototype.
-  // (It has no @get/@set private names, so the $-intrinsics don't apply to it.)
-  // Keyed by a module-local symbol, not a WeakMap — WeakMap has neither defence.
-  const kListenerRegistry = Symbol("listenerRegistry");
-  function registryFor(target, create) {
-    let map = target[kListenerRegistry];
-    if (!map && create) target[kListenerRegistry] = map = new SafeMap();
-    return map;
-  }
+// Installs the NodeEventTarget emitter surface on MessagePort (on/once/off/emit
+// and friends). MessagePort.prototype has self-replacing bootstraps for these
+// that load the module on first access, so this require is a no-op if any
+// emitter method has already been touched; evaluating it here keeps the old
+// "loaded by worker_threads" timing for code that depended on it.
+require("internal/worker/messageport_emitter");
 
-  function messageEventHandler(event: MessageEvent) {
-    return event.data;
-  }
-
-  function errorEventHandler(event: ErrorEvent) {
-    return event.error;
-  }
-
-  function customEventHandler(event) {
-    return event.detail;
-  }
-
-  function wrapped(run, listener) {
-    return function (event) {
-      return listener(run(event));
-    };
-  }
-
-  function functionForEventType(event, listener) {
-    switch (event) {
-      case "error":
-      case "messageerror": {
-        return wrapped(errorEventHandler, listener);
-      }
-
-      case "message": {
-        return wrapped(messageEventHandler, listener);
-      }
-
-      default: {
-        return wrapped(customEventHandler, listener);
-      }
-    }
-  }
-
-  function EventClass(eventName) {
-    if (eventName === "error" || eventName === "messageerror") {
-      return ErrorEvent;
-    }
-
-    return MessageEvent;
-  }
-
-  // EventTarget dedupes on (type, callback), so in node the FIRST registration of
-  // a listener wins outright -- including its once-ness -- and later adds of the
-  // same function are no-ops. Keying wrappers per listener reproduces that.
-  function register(target, event, listener, wrapper, options) {
-    const map = registryFor(target, true)!;
-    let byListener = map.get(event);
-    if (!byListener) map.set(event, (byListener = new SafeMap()));
-    if (byListener.has(listener)) return false;
-    target.addEventListener(event, wrapper, options);
-    byListener.set(listener, wrapper);
-    return true;
-  }
-
-  function on(event, listener) {
-    register(this, event, listener, functionForEventType(event, listener), undefined);
-    return this;
-  }
-
-  function off(event, listener) {
-    if (listener) {
-      const byListener = registryFor(this, false)?.get(event);
-      const wrapper = byListener?.get(listener) ?? listener;
-      this.removeEventListener(event, wrapper);
-      byListener?.delete(listener);
-    } else {
-      this.removeEventListener(event);
-    }
-    return this;
-  }
-
-  function once(event, listener) {
-    const wrapper = functionForEventType(event, listener);
-    const target = this;
-    // EventTarget drops a {once:true} listener natively, without telling the
-    // registry — so purge it here or listenerCount()/eventNames() keep counting
-    // a listener that already fired.
-    function onceWrapper(ev) {
-      registryFor(target, false)?.get(event)?.delete(listener);
-      return wrapper(ev);
-    }
-    register(this, event, listener, onceWrapper, { once: true });
-    return this;
-  }
-
-  function emit(event, ...args) {
-    switch (event) {
-      case "error":
-      case "messageerror":
-      case "message":
-        this.dispatchEvent(new (EventClass(event))(event, ...args));
-        break;
-      default:
-        // Non-standard events surface as CustomEvent (detail = first arg) to
-        // addEventListener and as the raw argument to .on(), matching node.
-        this.dispatchEvent(new CustomEvent(event, { detail: args[0] }));
-        break;
-    }
-    return this;
-  }
-
-  const kMaxListeners = Symbol("kMaxListeners");
-  function setMaxListeners(n) {
-    this[kMaxListeners] = n;
-    return this;
-  }
-  function getMaxListeners() {
-    return this[kMaxListeners] ?? 10;
-  }
-  function listenerCount(type) {
-    return registryFor(this, false)?.get(type)?.size ?? 0;
-  }
-  function eventNames() {
-    const map = registryFor(this, false);
-    if (!map) return [];
-    const out: string[] = [];
-    for (const [k, v] of map) if (v.size > 0) out.push(k);
-    return out;
-  }
-  function removeAllListeners(type) {
-    const map = registryFor(this, false);
-    if (!map) return this;
-    const removeType = t => {
-      const byListener = map.get(t);
-      if (byListener) {
-        for (const w of byListener.values()) this.removeEventListener(t, w);
-        map.delete(t);
-      }
-    };
-    if (arguments.length === 0) {
-      // removeType only deletes `t`, and a Map iterator tolerates deleting the
-      // entry it just yielded — so no snapshot copy is needed here.
-      for (const t of map.keys()) removeType(t);
-    } else {
-      removeType(type);
-    }
-    return this;
-  }
-
-  // node inherits these from NodeEventTarget.prototype (a curated subset of
-  // EventEmitter, not EventEmitter itself); use an intermediate prototype so
-  // Object.getOwnPropertyNames(MessagePort.prototype) matches node.
-  const proto = Class.prototype;
-  const inherited = Object.create(Object.getPrototypeOf(proto));
-  const emitterMethods: [string, Function][] = [
-    ["on", on],
-    ["off", off],
-    ["once", once],
-    ["emit", emit],
-    ["addListener", on],
-    ["removeListener", off],
-    ["listenerCount", listenerCount],
-    ["eventNames", eventNames],
-    ["removeAllListeners", removeAllListeners],
-    ["setMaxListeners", setMaxListeners],
-    ["getMaxListeners", getMaxListeners],
-  ];
-  for (const [methodName, value] of emitterMethods) {
-    Object.defineProperty(inherited, methodName, { value, writable: true, enumerable: false, configurable: true });
-  }
-  Object.setPrototypeOf(proto, inherited);
-}
-
-const _MessagePort = globalThis.MessagePort;
-injectFakeEmitter(_MessagePort);
-
-const MessagePort = _MessagePort;
+const MessagePort = globalThis.MessagePort;
 
 // node's close(cb) registers cb as a one-time "close" listener before the native close.
 // closedMessagePorts lets moveMessagePortToContext report ERR_CLOSED_MESSAGE_PORT.
@@ -572,7 +395,7 @@ function packJSTransferables(options: NodeWorkerOptions): NodeWorkerOptions {
       item !== null &&
       typeof item === "object" &&
       !(item instanceof ArrayBuffer) &&
-      !(item instanceof _MessagePort) &&
+      !(item instanceof MessagePort) &&
       !$isTypedArrayView(item)
     ) {
       hasCandidate = true;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -628,16 +628,6 @@ function fakeParentPort() {
     value: self.removeEventListener.bind(self),
   });
 
-  Object.defineProperty(fake, "removeListener", {
-    value: self.removeEventListener.bind(self),
-    enumerable: false,
-  });
-
-  Object.defineProperty(fake, "addListener", {
-    value: self.addEventListener.bind(self),
-    enumerable: false,
-  });
-
   return fake;
 }
 let parentPort: MessagePort | null = isMainThread ? null : fakeParentPort();

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -41,6 +41,7 @@
 #include "JSEventListener.h"
 #include "JSStructuredSerializeOptions.h"
 #include "ScriptExecutionContext.h"
+#include "WebCoreJSBuiltins.h"
 #include "WebCoreJSClientData.h"
 // #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
@@ -136,6 +137,21 @@ static const HashTableValue JSMessagePortPrototypeTableValues[] = {
     { "ref"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_ref, 0 } },
     { "unref"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_unref, 0 } },
     { "hasRef"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_hasRef, 0 } },
+    // NodeEventTarget emitter surface: these are self-replacing bootstraps (see
+    // src/js/builtins/MessagePort.ts). The first call loads
+    // internal/worker/messageport_emitter, which installs the real methods on an
+    // intermediate prototype and deletes these own-properties.
+    { "on"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortOnCodeGenerator, 2 } },
+    { "off"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortOffCodeGenerator, 2 } },
+    { "once"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortOnceCodeGenerator, 2 } },
+    { "emit"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortEmitCodeGenerator, 1 } },
+    { "addListener"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortAddListenerCodeGenerator, 2 } },
+    { "removeListener"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortRemoveListenerCodeGenerator, 2 } },
+    { "listenerCount"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortListenerCountCodeGenerator, 1 } },
+    { "eventNames"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortEventNamesCodeGenerator, 0 } },
+    { "removeAllListeners"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortRemoveAllListenersCodeGenerator, 0 } },
+    { "setMaxListeners"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortSetMaxListenersCodeGenerator, 1 } },
+    { "getMaxListeners"_s, static_cast<unsigned>(JSC::PropertyAttribute::Builtin), NoIntrinsic, { HashTableValue::BuiltinGeneratorType, messagePortGetMaxListenersCodeGenerator, 0 } },
 };
 
 const ClassInfo JSMessagePortPrototype::s_info = { "MessagePort"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSMessagePortPrototype) };

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -1,3 +1,6 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
 test("simple usage", done => {
   const channel = new MessageChannel();
   const port1 = channel.port1;
@@ -452,4 +455,119 @@ test("transferring a port from inside peerClosed()'s flush preserves the remaini
   await done.promise;
   // m1 delivered to the old owner; m2/m3 buffered for the new owner.
   expect(seen).toEqual(["old:m1", "new:m2", "new:m3"]);
+});
+
+test.concurrent("MessagePort node-style emitter methods exist without loading node:worker_threads", async () => {
+  // Regression: the NodeEventTarget emitter surface used to be installed on
+  // MessagePort.prototype as a side effect of evaluating node:worker_threads,
+  // so `new MessageChannel().port1.on(...)` threw TypeError unless that module
+  // had been loaded somewhere in the process.
+  const src = `
+    if (Object.keys(require.cache).some(k => k.includes("worker_threads"))) {
+      throw new Error("precondition: worker_threads is already loaded");
+    }
+    const names = [
+      "on", "off", "once", "emit", "addListener", "removeListener",
+      "listenerCount", "eventNames", "removeAllListeners", "setMaxListeners", "getMaxListeners",
+    ];
+    const { port1, port2 } = new MessageChannel();
+    const shape = {};
+    for (const n of names) shape[n] = typeof port1[n];
+
+    let onGot = [], onceGot, onceCount = 0;
+    port1.once("message", m => { onceGot = m; onceCount++; });
+
+    let offGot = 0;
+    const offListener = () => { offGot++; };
+    port1.on("message", offListener);
+    port1.off("message", offListener);
+
+    let removeGot = 0;
+    const removeListener = () => { removeGot++; };
+    port1.addListener("message", removeListener);
+    port1.removeListener("message", removeListener);
+
+    port1.on("message", m => {
+      onGot.push(m);
+      if (onGot.length === 2) {
+        const listenerCount = port1.listenerCount("message");
+        console.log(JSON.stringify({ shape, onGot, onceGot, onceCount, offGot, removeGot, listenerCount }));
+        port1.close();
+        port2.close();
+      }
+    });
+
+    port2.postMessage("a");
+    port2.postMessage("b");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    shape: {
+      on: "function",
+      off: "function",
+      once: "function",
+      emit: "function",
+      addListener: "function",
+      removeListener: "function",
+      listenerCount: "function",
+      eventNames: "function",
+      removeAllListeners: "function",
+      setMaxListeners: "function",
+      getMaxListeners: "function",
+    },
+    onGot: ["a", "b"],
+    onceGot: "a",
+    onceCount: 1,
+    offGot: 0,
+    removeGot: 0,
+    listenerCount: 1,
+  });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("events.once(port, ...) takes the emitter path symmetrically", async () => {
+  // events.once's add side duck-types on `.on`, its remove side on
+  // `.removeListener`; MessagePort must provide both so the wrapper registered
+  // on add is the one removed on abort/resolve.
+  const src = `
+    const { once } = require("node:events");
+    if (Object.keys(require.cache).some(k => k.includes("worker_threads"))) {
+      throw new Error("precondition: worker_threads is already loaded");
+    }
+    const { port1, port2 } = new MessageChannel();
+    port1.start();
+
+    port2.postMessage({ x: 1 });
+    const [got] = await once(port1, "message");
+
+    const ac = new AbortController();
+    const p = once(port1, "message", { signal: ac.signal }).then(
+      () => "resolved",
+      e => e.name,
+    );
+    ac.abort();
+    const aborted = await p;
+
+    console.log(JSON.stringify({ got, aborted }));
+    port1.close();
+    port2.close();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // Node resolves events.once on a MessagePort with the payload, not the event.
+  expect(JSON.parse(stdout)).toEqual({ got: { x: 1 }, aborted: "AbortError" });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
// No import of node:worker_threads anywhere in the process.
const { port1, port2 } = new MessageChannel();
port1.on("message", m => console.log(m));  // textbook node code
port2.postMessage(42);
```

```
$ bun repro.mjs
TypeError: port1.on is not a function
```

Importing `node:worker_threads` anywhere (even transitively, even after the port is constructed) retroactively makes the same port work:

```
$ IMPORT_WT=1 bun repro.mjs
before-import on=undefined once=undefined off=undefined emit=undefined
after-import  on=function once=function off=function emit=function
port.on delivered: 42
```

Node has these methods on the class from the start.

## Cause

`src/js/node/worker_threads.ts` calls `injectFakeEmitter(globalThis.MessagePort)` at module top level, so the NodeEventTarget emitter surface (`on`/`once`/`off`/`emit`/`addListener`/`removeListener`/`listenerCount`/`eventNames`/`removeAllListeners`/`setMaxListeners`/`getMaxListeners`) only appears on `MessagePort`'s prototype chain once `node:worker_threads` is first evaluated. A port from the global `new MessageChannel()` has none of them until something else in the dependency graph loads that module. In node, `MessagePort`'s prototype chain runs through `NodeEventTarget`, so the methods are always present.

## Fix

Move `injectFakeEmitter` into `internal/worker/messageport_emitter` and put self-replacing bootstrap stubs for each emitter method name on `JSMessagePortPrototype` (via `src/js/builtins/MessagePort.ts`). The first call to any stub requires the internal module, which inserts the real methods on the intermediate prototype (same as before) and deletes the stubs so subsequent lookups hit the inherited implementations directly. `worker_threads.ts` now just requires the same module; the module cache makes that idempotent.

The emitter implementation itself is unchanged from `main`; only where and when it is installed changes.

## Verification

New tests in `test/js/web/workers/message-channel.test.ts` spawn subprocesses that assert `node:worker_threads` is not in `require.cache`, then check the prototype shape and exercise `on`/`once`/`off`/`addListener`/`removeListener`/`listenerCount` end to end, plus `events.once(port, 'message')` (which now resolves with the payload, matching Node).

```
# fail-before (main src)
TypeError: port1.once is not a function
got: {"isTrusted": true}   # events.once takes the EventTarget path

# pass-after
2 pass, 0 fail
```

Existing coverage stays green: `test/js/web/workers/`, `test/js/node/worker_threads/worker_threads.test.ts` (all MessagePort/NodeEventTarget/listener-registry tests), and the `test-worker-message-port*` / `test-messagechannel*` node-compat tests.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (beb068b55)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [12.84ms]
(pass) transfer message port [10.39ms]
(pass) transfer array buffer [5.16ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:61:10)

(pass) non-transferable [38.38ms]
(pass) transfer message ports and post messages [14.72ms]
(pass) message channel created on main thread [143.37ms]
(pass) message channel created on other thread [145.85ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <an
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a7accad24)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [4.83ms]
(pass) transfer message port [0.22ms]
(pass) transfer array buffer [0.13ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:61:10)

(pass) non-transferable [2.94ms]
(pass) transfer message ports and post messages [0.21ms]
(pass) message channel created on main thread [4.05ms]
(pass) message channel created on other thread [4.44ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:152:25)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:153:12)

(pass) many message channels [0.89ms]
(pass) gc [0.81ms]
(pass) cloneable and transferable equals [6.83ms]
(pass) cloneable and non-transferable equals (BunFile) [0.84ms]
(pass) cloneable and non-transferable equals (net.BlockList) [5.41ms]
(pass) a pending close eve
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (beb068b55)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [16.92ms]
(pass) transfer message port [10.65ms]
(pass) transfer array buffer [4.80ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:60:19)
      at <anonymous> (/workspace/bun/test/js/web/workers/message-channel.test.ts:61:10)

(pass) non-transferable [38.20ms]
(pass) transfer message ports and post messages [14.96ms]
(pass) message channel created on main thread [147.55ms]
(pass) message channel created on other thread [153.95ms]
Warning: The target port was posted to itself, and the communication channel was lost
      at <an
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 735ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (6584ms)
Bundle modules (43ms)
Postprocesss modules (141ms)
Bundle Functions (787ms)
Generate Code (105ms)

[7.68s] Bundled "src/js" for production
  1914 kb
  163 internal modules
  12 native modules
  101 internal functions across 20 files
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/MessagePort.ts                |  61 ++++++++
 src/js/internal/worker/messageport_emitter.ts | 207 ++++++++++++++++++++++++++
 src/js/node/worker_threads.ts                 | 203 +------------------------
 src/jsc/bindings/webcore/JSMessagePort.cpp    |  16 ++
 test/js/web/workers/message-channel.test.ts   | 118 +++++++++++++++
 5 files changed, 410 insertions(+), 195 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js/builtins/MessagePort.ts                     1      3      0
src/js/internal/worker/messageport_emitter.ts      0      1      0
src/js/node/worker_threads.ts                      8      8      0
src/jsc/bindings/webcore/JSMessagePort.cpp         4      6      0
test/js/web/workers/message-channel.test.ts        4     11      0
```

</details>

<!-- robobun:evidence:end -->