### PR TITLE
bundler: let explicit `define` win over `env`-derived process.env.X

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -100,8 +100,9 @@ fn env_string_store_put(
 /// dispatching through a vtable — it only reads `loader.map.map.{keys,values}()`,
 /// all of which are public.
 ///
-/// `to_json` is the framework-defaults `RawDefines` map; `to_string` is the
-/// per-env `UserDefinesArray`.
+/// `to_json` is the caller's explicit-`define` `RawDefines` map (framework
+/// defaults are appended into it at the end); `to_string` is the per-env
+/// `UserDefinesArray`.
 pub fn copy_env_for_define(
     env: &bun_dotenv::Loader<'_>,
     to_json: &mut RawDefines,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -295,12 +295,18 @@ impl DefineExt for Define {
 
         // Step 4. Load environment data into hash tables.
         // These are only strings. We do not parse them as JSON.
+        // Skip keys the user already provided via `define` so the explicit
+        // option wins over the env-derived shorthand.
         if let Some(string_defines_) = &string_defines {
             define.insert_from_iterator(
                 string_defines_
                     .keys()
                     .iter()
                     .zip(string_defines_.values().iter())
+                    .filter(|(k, _)| match &_user_defines {
+                        Some(ud) => !ud.contains_key(k.as_ref()),
+                        None => true,
+                    })
                     .map(|(k, v)| (k.as_ref(), v)),
             )?;
         }

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -162,24 +162,32 @@ pub fn copy_env_for_define(
                         key_buf.clear();
                         key_buf.extend_from_slice(PROCESS_ENV);
                         key_buf.extend_from_slice(k);
-                        env_string_store_put(to_string, bump, &key_buf, value)?;
+                        // Explicit user `define` beats the env-derived
+                        // shorthand; `to_json` holds only explicit defines here.
+                        if !to_json.contains_key(&key_buf) {
+                            env_string_store_put(to_string, bump, &key_buf, value)?;
+                        }
                     } else {
                         let hash = bun_wyhash::hash(k);
                         debug_assert!(hash != INVALID_HASH);
                         if let Some(key_i) = string_map_hashes.iter().position(|&h| h == hash) {
-                            env_string_store_put(
-                                to_string,
-                                bump,
-                                framework_defaults_keys[key_i],
-                                value,
-                            )?;
+                            if !to_json.contains_key(framework_defaults_keys[key_i]) {
+                                env_string_store_put(
+                                    to_string,
+                                    bump,
+                                    framework_defaults_keys[key_i],
+                                    value,
+                                )?;
+                            }
                         }
                     }
                 } else {
                     key_buf.clear();
                     key_buf.extend_from_slice(PROCESS_ENV);
                     key_buf.extend_from_slice(k);
-                    env_string_store_put(to_string, bump, &key_buf, value)?;
+                    if !to_json.contains_key(&key_buf) {
+                        env_string_store_put(to_string, bump, &key_buf, value)?;
+                    }
                 }
             }
         }
@@ -295,18 +303,12 @@ impl DefineExt for Define {
 
         // Step 4. Load environment data into hash tables.
         // These are only strings. We do not parse them as JSON.
-        // Skip keys the user already provided via `define` so the explicit
-        // option wins over the env-derived shorthand.
         if let Some(string_defines_) = &string_defines {
             define.insert_from_iterator(
                 string_defines_
                     .keys()
                     .iter()
                     .zip(string_defines_.values().iter())
-                    .filter(|(k, _)| match &_user_defines {
-                        Some(ud) => !ud.contains_key(k.as_ref()),
-                        None => true,
-                    })
                     .map(|(k, v)| (k.as_ref(), v)),
             )?;
         }

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
@@ -89,6 +89,73 @@ for (let backend of ["api", "cli"] as const) {
             PUBLIC_BAR: "BAD_BAR",
           },
           stdout: "public_value\nanother_public\nundefined\n",
+        },
+      });
+
+    // An explicit `define` entry for process.env.X must win over the
+    // env-option-derived entry for the same X, even when X is set in the
+    // build environment.
+    if (backend === "cli")
+      for (const target of ["browser", "node", "bun"] as const) {
+        itBundled(`env/inline-define-precedence-${target}`, {
+          env: {
+            APP_MODE: "fromenv",
+          },
+          backend,
+          target,
+          dotenv: "inline",
+          define: {
+            "process.env.APP_MODE": '"FROMDEFINE"',
+          },
+          files: {
+            "/a.js": `
+          console.log(process.env.APP_MODE);
+        `,
+          },
+          onAfterBundle(api) {
+            const out = api.readFile("out.js");
+            expect(out).toContain('"FROMDEFINE"');
+            expect(out).not.toContain("fromenv");
+          },
+          run: {
+            env: {
+              APP_MODE: "runtime",
+            },
+            stdout: "FROMDEFINE\n",
+          },
+        });
+      }
+
+    if (backend === "cli")
+      itBundled("env/prefix-define-precedence", {
+        env: {
+          APP_MODE: "fromenv",
+          APP_OTHER: "other_fromenv",
+        },
+        backend,
+        target: "node",
+        dotenv: "APP_*",
+        define: {
+          "process.env.APP_MODE": '"FROMDEFINE"',
+        },
+        files: {
+          "/a.js": `
+        console.log(process.env.APP_MODE);
+        console.log(process.env.APP_OTHER);
+      `,
+        },
+        onAfterBundle(api) {
+          const out = api.readFile("out.js");
+          expect(out).toContain('"FROMDEFINE"');
+          expect(out).not.toContain('"fromenv"');
+          expect(out).toContain('"other_fromenv"');
+        },
+        run: {
+          env: {
+            APP_MODE: "runtime",
+            APP_OTHER: "runtime_other",
+          },
+          stdout: "FROMDEFINE\nother_fromenv\n",
         },
       });
 


### PR DESCRIPTION
## What

When both an explicit `define: { "process.env.X": ... }` and `env: "inline"` (or `env: "PREFIX_*"`) are passed to `Bun.build` / `bun build`, and `X` happens to be set in the build environment, the env-derived entry silently overrode the explicit `define`. The explicit option should win.

## Repro

```sh
$ echo 'console.log(process.env.APP_MODE); export {};' > in.mjs
$ APP_MODE=fromenv bun build ./in.mjs \
    --define 'process.env.APP_MODE="FROMDEFINE"' --env inline --target=node
// before: console.log("fromenv");
// after:  console.log("FROMDEFINE");
```

Same for the JS API (`Bun.build({ define, env: "inline" })`) and for `env: "APP_*"`. Remove `APP_MODE` from the build environment and the explicit define is honored, so the behaviour depended on what the host happened to export.

The existing implicit `process.env.NODE_ENV` auto-define already has the correct precedence (explicit `define` wins) via `get_or_put_value` in `options.rs`, so this was internally inconsistent.

## Cause

`Define::init` (src/bundler/defines.rs) loads user defines (step 3) and then env-derived string defines (step 4) into the same `dots`/`identifiers` tables. On a key collision `Define::insert` calls `DefineData::merge(&existing, new)`, which keeps the *new* value, so the env entry landed after and beat the user's.

## Fix

In step 4, skip env-derived keys that already appear in the user define map, mirroring the insert-only-if-absent treatment `NODE_ENV` gets in `options.rs`.

## Tests

Added `env/inline-define-precedence-{browser,node,bun}` and `env/prefix-define-precedence` to `test/bundler/bundler_env.test.ts`. Each asserts on the bundle contents (`"FROMDEFINE"` present, `fromenv` absent) and on runtime stdout. All four fail on main and pass with the fix; the existing `env/*` tests continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_env.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (369edac62)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [1231.42ms]
(pass) bundler/api > env/disable [589.22ms]
(pass) bundler/cli > env/inline [924.07ms]
(pass) bundler/cli > env/inline system [1055.65ms]
(pass) bundler/cli > env/disable [916.46ms]
(pass) bundler/cli > env/pattern-matching [905.46ms]
112 |           console.log(process.env.APP_MODE);
113 |         `,
114 |           },
115 |           onAfterBundle(api) {
116 |             const out = api.readFile("out.js");
117 |             expect(out).toContain('"FROMDEFINE"');
                              ^
error: expect(received).toContain(expected)

Expected to contain: "\"FROMDEFINE\""
Received: "// a.js\nconsole.log(\"fromenv\");\n"

      at on
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d3c4544ef)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [36.32ms]
(pass) bundler/api > env/disable [29.82ms]
(pass) bundler/cli > env/inline [29.17ms]
(pass) bundler/cli > env/inline system [19.09ms]
(pass) bundler/cli > env/disable [26.20ms]
(pass) bundler/cli > env/pattern-matching [30.68ms]
(pass) bundler/cli > env/inline-define-precedence-browser [21.09ms]
(pass) bundler/cli > env/inline-define-precedence-node [19.92ms]
(pass) bundler/cli > env/inline-define-precedence-bun [23.53ms]
(pass) bundler/cli > env/prefix-define-precedence [22.38ms]
(pass) bundler/cli > nested-refs [26.45ms]

 11 pass
 0 fail
 20 expect() calls
Ran 11 tests across 1 file. [514.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_env.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (369edac62)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline system [1127.28ms]
(pass) bundler/api > env/disable [548.00ms]
(pass) bundler/cli > env/inline [933.17ms]
(pass) bundler/cli > env/inline system [924.12ms]
(pass) bundler/cli > env/disable [756.53ms]
(pass) bundler/cli > env/pattern-matching [1036.74ms]
(pass) bundler/cli > env/inline-define-precedence-browser [1112.61ms]
(pass) bundler/cli > env/inline-define-precedence-node [1100.27ms]
(pass) bundler/cli > env/inline-define-precedence-bun [1051.69ms]
(pass) bundler/cli > env/prefix-define-precedence [891.12ms]
(pass) bundler/cli > nested-refs [1111.52ms]

 11 pass
 0 fail
 20 expect() calls
Ran 11 tests across 1 file. [13.74s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 855ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/defines.rs           | 29 +++++++++++------
 test/bundler/bundler_env.test.ts | 69 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 87 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/bundler/defines.rs                4      6      0
test/bundler/bundler_env.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->