### PR TITLE
Bun.serve: evaluate If-Modified-Since on static Response routes

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5186,9 +5186,9 @@ pub(crate) fn __bun_get_vm_ctx(kind: bun_io::AllocatorType) -> bun_io::EventLoop
 
 /// `dateForHeader`: wrap the header bytes in a
 /// `bun.String`, call `String.parseDate(&s, vm.global)`, return the integer
-/// value if finite and non-negative, else `None`. Lives in this crate (sole
-/// caller is `server::FileRoute::on`) so `bun_uws_sys` (T0) has no upward
-/// hook into `bun_jsc`.
+/// value if finite and non-negative, else `None`. Lives in this crate (callers
+/// are `server::FileRoute` / `server::StaticRoute`) so `bun_uws_sys` (T0) has
+/// no upward hook into `bun_jsc`.
 pub fn parse_http_date(value: &[u8]) -> Option<u64> {
     let vm = bun_jsc::virtual_machine::VirtualMachine::get();
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -267,9 +267,9 @@ impl StaticRoute {
     pub unsafe fn on_head_request(this: *mut Self, mut req: AnyRequest, resp: AnyResponse) {
         // SAFETY: caller contract.
         unsafe {
-            // Check If-None-Match for HEAD requests with 200 status
+            // Evaluate conditional request preconditions for HEAD with 200 status
             if (*this).status_code == 200 {
-                if Self::render_304_not_modified_if_none_match(this, &mut req, resp) {
+                if Self::render_304_if_not_modified(this, &mut req, resp) {
                     return;
                 }
             }
@@ -334,9 +334,9 @@ impl StaticRoute {
     pub unsafe fn on_get(this: *mut Self, mut req: AnyRequest, resp: AnyResponse) {
         // SAFETY: caller contract.
         unsafe {
-            // Check If-None-Match for GET requests with 200 status
+            // Evaluate conditional request preconditions for GET with 200 status
             if (*this).status_code == 200 {
-                if Self::render_304_not_modified_if_none_match(this, &mut req, resp) {
+                if Self::render_304_if_not_modified(this, &mut req, resp) {
                     return;
                 }
             }
@@ -532,24 +532,41 @@ impl StaticRoute {
     /// # Safety
     /// See [`on_head_request`]. May free `*this` via `on_response_complete` when it
     /// returns `true`.
-    unsafe fn render_304_not_modified_if_none_match(
+    unsafe fn render_304_if_not_modified(
         this: *mut Self,
         req: &mut AnyRequest,
         resp: AnyResponse,
     ) -> bool {
         // SAFETY: caller contract.
         unsafe {
-            let Some(if_none_match) = req.header(b"if-none-match") else {
-                return false;
+            // RFC 9110 §13.2.2: If-None-Match takes precedence; If-Modified-Since
+            // is evaluated only when If-None-Match is absent.
+            let not_modified = if let Some(if_none_match) = req.header(b"if-none-match") {
+                match (*this).headers.get(b"etag") {
+                    Some(etag) if !if_none_match.is_empty() && !etag.is_empty() => {
+                        ETag::if_none_match(etag, if_none_match)
+                    }
+                    _ => false,
+                }
+            } else if let Some(ims) = req
+                .header(b"if-modified-since")
+                .and_then(crate::jsc_hooks::parse_http_date)
+            {
+                // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
+                // is second-granular, so compare at second precision.
+                match (*this)
+                    .headers
+                    .get(b"last-modified")
+                    .and_then(crate::jsc_hooks::parse_http_date)
+                {
+                    Some(last_modified) => last_modified / 1000 <= ims / 1000,
+                    None => false,
+                }
+            } else {
+                false
             };
-            let Some(etag) = (*this).headers.get(b"etag") else {
-                return false;
-            };
-            if if_none_match.is_empty() || etag.is_empty() {
-                return false;
-            }
 
-            if !ETag::if_none_match(etag, if_none_match) {
+            if !not_modified {
                 return false;
             }
 

--- a/test/js/bun/http/serve-if-none-match.test.ts
+++ b/test/js/bun/http/serve-if-none-match.test.ts
@@ -284,6 +284,109 @@ describe("If-None-Match Support", () => {
     });
   });
 
+  // RFC 9110 §13.2.2 step 4 / §13.1.3: when If-None-Match is absent, an origin
+  // MUST evaluate If-Modified-Since against the selected representation's
+  // Last-Modified and MUST answer 304 when Last-Modified <= the field date.
+  describe("If-Modified-Since Evaluation", () => {
+    const LM = "Wed, 01 Jan 2020 00:00:00 GMT";
+    const EARLIER = "Tue, 01 Jan 2019 00:00:00 GMT";
+    const LATER = "Fri, 01 Jan 2027 00:00:00 GMT";
+    let imsServer: Server;
+
+    beforeAll(() => {
+      imsServer = Bun.serve({
+        port: 0,
+        development: false,
+        static: {
+          "/lm": new Response("hello static route", {
+            headers: { "Content-Type": "text/plain", "Last-Modified": LM },
+          }),
+          "/no-lm": new Response("no last-modified", {
+            headers: { "Content-Type": "text/plain" },
+          }),
+        },
+        fetch: () => new Response("Not Found", { status: 404 }),
+      });
+      imsServer.unref();
+    });
+
+    afterAll(() => {
+      imsServer.stop(true);
+    });
+
+    it("should return 304 when If-Modified-Since equals Last-Modified (GET)", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        headers: { "If-Modified-Since": LM },
+      });
+      expect(res.status).toBe(304);
+      expect(res.headers.get("Last-Modified")).toBe(LM);
+      expect(await res.text()).toBe("");
+    });
+
+    it("should return 304 when If-Modified-Since is later than Last-Modified (GET)", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        headers: { "If-Modified-Since": LATER },
+      });
+      expect(res.status).toBe(304);
+      expect(await res.text()).toBe("");
+    });
+
+    it("should return 200 when If-Modified-Since is earlier than Last-Modified", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        headers: { "If-Modified-Since": EARLIER },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello static route");
+    });
+
+    it("should return 304 when If-Modified-Since equals Last-Modified (HEAD)", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        method: "HEAD",
+        headers: { "If-Modified-Since": LM },
+      });
+      expect(res.status).toBe(304);
+      expect(await res.text()).toBe("");
+    });
+
+    it("should ignore If-Modified-Since when If-None-Match is present (RFC 9110 §13.1.3)", async () => {
+      // If-None-Match takes precedence; a non-matching ETag with a satisfying
+      // If-Modified-Since must still return 200.
+      const res = await fetch(`${imsServer.url}lm`, {
+        headers: {
+          "If-None-Match": '"does-not-match"',
+          "If-Modified-Since": LM,
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello static route");
+    });
+
+    it("should return 200 for an unparsable If-Modified-Since date", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        headers: { "If-Modified-Since": "not a date" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello static route");
+    });
+
+    it("should return 200 when the route has no Last-Modified header", async () => {
+      const res = await fetch(`${imsServer.url}no-lm`, {
+        headers: { "If-Modified-Since": LATER },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("no last-modified");
+    });
+
+    it("should not apply If-Modified-Since to POST requests", async () => {
+      const res = await fetch(`${imsServer.url}lm`, {
+        method: "POST",
+        headers: { "If-Modified-Since": LM },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello static route");
+    });
+  });
+
   describe("Other HTTP Methods", () => {
     it("should not apply If-None-Match to POST requests", async () => {
       const res = await fetch(`${server.url}basic`, {


### PR DESCRIPTION
## What does this PR do?

RFC 9110 section 13.2.2 step 4 requires an origin server to evaluate `If-Modified-Since` against the selected representation's `Last-Modified` for GET/HEAD when `If-None-Match` is absent, and to answer 304 when `Last-Modified` is earlier than or equal to the field date (section 13.1.3).

`StaticRoute` (a `new Response(...)` entry in `Bun.serve({ routes })`) only implemented the `If-None-Match` precondition. A client presenting only a date validator (`curl -z`, `wget -N`, HTTP/1.0-era caches, intermediaries that stored `Last-Modified` but not the `ETag`) re-downloaded the full body on every request.

This is the mirror of the `FileRoute` situation: in one `routes` table, `Bun.file(p)` honours `If-Modified-Since` but not `If-None-Match` (#33620), while `new Response(blob)` honours `If-None-Match` but not `If-Modified-Since`. The same conditional request produced opposite answers depending only on which spelling the app used.

### Reproduction

```js
const LM = "Wed, 01 Jan 2020 00:00:00 GMT";
using s = Bun.serve({
  port: 0,
  development: false,
  routes: {
    "/static": new Response("hello", { headers: { "last-modified": LM } }),
  },
  fetch: () => new Response("nf", { status: 404 }),
});
const r = await fetch(`${s.url}static`, { headers: { "if-modified-since": LM } });
console.log(r.status); // 200 before, 304 after
```

### Fix

`render_304_if_not_modified` now evaluates `If-Modified-Since` against the stored `last-modified` response header when `If-None-Match` is absent, reusing `parse_http_date` (already used by `FileRoute`) and comparing at second precision (HTTP-date is second-granular). When `If-None-Match` is present it still takes precedence per RFC 9110 section 13.2.2.

## How did you verify your code works?

New tests in `test/js/bun/http/serve-if-none-match.test.ts` cover GET/HEAD with equal, earlier, and later `If-Modified-Since` dates, an unparsable date, a route with no `Last-Modified`, the `If-None-Match` precedence rule, and POST being exempt. All 28 tests in the file pass with the debug build; the three new 304 cases fail with `USE_SYSTEM_BUN=1`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-if-none-match.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ee0894bf0)

test/js/bun/http/serve-if-none-match.test.ts:
(pass) If-None-Match Support > ETag Generation > should automatically generate ETag for static responses [16.56ms]
(pass) If-None-Match Support > ETag Generation > should preserve existing ETag headers [7.08ms]
(pass) If-None-Match Support > ETag Generation > should preserve weak ETag headers [11.16ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches ETag [9.49ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches custom ETag [11.72ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 for weak ETag comparison [7.69ms]
(pass) If-None-Ma
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0b27a4ad0)

test/js/bun/http/serve-if-none-match.test.ts:
(pass) If-None-Match Support > ETag Generation > should automatically generate ETag for static responses [0.82ms]
(pass) If-None-Match Support > ETag Generation > should preserve existing ETag headers [0.17ms]
(pass) If-None-Match Support > ETag Generation > should preserve weak ETag headers [0.13ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches ETag [0.24ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches custom ETag [0.14ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 for weak ETag comparison [0.13ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when comparing strong vs weak ETags [0.12ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 for '*' wildcard [0.12ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should handle multiple ETags in If-None-Match [0.18ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 200 when If-None-Match does not match [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-if-none-match.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ee0894bf0)

test/js/bun/http/serve-if-none-match.test.ts:
(pass) If-None-Match Support > ETag Generation > should automatically generate ETag for static responses [17.95ms]
(pass) If-None-Match Support > ETag Generation > should preserve existing ETag headers [7.73ms]
(pass) If-None-Match Support > ETag Generation > should preserve weak ETag headers [15.79ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches ETag [16.78ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 when If-None-Match matches custom ETag [12.65ms]
(pass) If-None-Match Support > If-None-Match Evaluation > should return 304 for weak ETag comparison [8.16ms]
(pass) If-None-M
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 856ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/jsc_hooks.rs                     |   6 +-
 src/runtime/server/StaticRoute.rs            |  45 ++++++++----
 test/js/bun/http/serve-if-none-match.test.ts | 103 +++++++++++++++++++++++++++
 3 files changed, 137 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/jsc_hooks.rs                          1      1      0
src/runtime/server/StaticRoute.rs                 1      2      0
test/js/bun/http/serve-if-none-match.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->