### PR TITLE
bundler: gate @bun pragma and @bun-cjs wrapper on build target, not entry hashbang

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -515,11 +515,13 @@ pub fn post_process_js_chunk(
     }
 
     // Add @bun comments and CJS wrapper start for each chunk when targeting Bun.
-    // Gate on the build target, not the entry file's per-file target: a
-    // `#!/usr/bin/env bun` hashbang forces only the entry to print ASCII-only,
-    // while bundled dependencies follow the build target and may contain raw
-    // UTF-8 identifiers that the `// @bun` Latin-1 fast path cannot read.
-    let is_bun = c.options.target.is_bun();
+    // The pragma promises Latin-1-safe bytes for the whole chunk, so gate on
+    // every signal that any part was printed without ASCII-only escaping.
+    let is_bun = c.options.target.is_bun()
+        && c.graph.ast.items_target()[chunk.entry_point.source_index() as usize].is_bun()
+        && !chunk
+            .flags
+            .contains(crate::chunk::Flags::IS_BROWSER_CHUNK_FROM_SERVER_BUILD);
     if is_bun {
         if c.options.generate_bytecode_cache && output_format == options::OutputFormat::Cjs {
             const INPUT: &[u8] =

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -515,7 +515,11 @@ pub fn post_process_js_chunk(
     }
 
     // Add @bun comments and CJS wrapper start for each chunk when targeting Bun.
-    let is_bun = c.graph.ast.items_target()[chunk.entry_point.source_index() as usize].is_bun();
+    // Gate on the build target, not the entry file's per-file target: a
+    // `#!/usr/bin/env bun` hashbang forces only the entry to print ASCII-only,
+    // while bundled dependencies follow the build target and may contain raw
+    // UTF-8 identifiers that the `// @bun` Latin-1 fast path cannot read.
+    let is_bun = c.options.target.is_bun();
     if is_bun {
         if c.options.generate_bytecode_cache && output_format == options::OutputFormat::Cjs {
             const INPUT: &[u8] =

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -137,6 +137,34 @@ error: Hello World`,
     },
     run: { stdout: "" },
   });
+  for (const target of ["node", "browser"] as const) {
+    itBundled(`bun/HashbangBunNoPragmaFor_${target}`, {
+      target,
+      files: {
+        "/entry.ts": `#!/usr/bin/env bun\nimport { Café } from "./lib.ts";\nconsole.log(new Café().méth());\n`,
+        "/lib.ts": `export class Café { méth() { return 7 } }\n`,
+      },
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toStartWith("#!/usr/bin/env bun\n");
+        expect(out).not.toContain("// @bun");
+      },
+      run: { stdout: "7" },
+    });
+  }
+  itBundled("bun/HashbangBunPragmaForBunTarget", {
+    target: "bun",
+    files: {
+      "/entry.ts": `#!/usr/bin/env bun\nimport { Café } from "./lib.ts";\nconsole.log(new Café().méth());\n`,
+      "/lib.ts": `export class Café { méth() { return 7 } }\n`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith("#!/usr/bin/env bun\n// @bun\n");
+      expect(out).not.toContain("méth");
+    },
+    run: { stdout: "7" },
+  });
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {
       itBundled("bun/ExportsConditionsDevelopment" + backend.toUpperCase(), {

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -165,6 +165,36 @@ error: Hello World`,
     },
     run: { stdout: "7" },
   });
+  for (const target of ["node", "browser"] as const) {
+    itBundled(`bun/HashbangBunNoCjsWrapperFor_${target}`, {
+      target,
+      format: "cjs",
+      files: {
+        "/entry.ts": `#!/usr/bin/env bun\nconsole.log("ALIVE", 42);\n`,
+      },
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toStartWith("#!/usr/bin/env bun\n");
+        expect(out).not.toContain("@bun");
+        expect(out).not.toContain("(function(exports, require, module, __filename, __dirname)");
+      },
+      run: target === "node" ? { runtime: "node", stdout: "ALIVE 42" } : undefined,
+    });
+  }
+  itBundled("bun/HashbangBunCjsWrapperForBunTarget", {
+    target: "bun",
+    format: "cjs",
+    files: {
+      "/entry.ts": `#!/usr/bin/env bun\nconsole.log("ALIVE", 42);\n`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith(
+        "#!/usr/bin/env bun\n// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {",
+      );
+    },
+    run: { stdout: "ALIVE 42" },
+  });
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {
       itBundled("bun/ExportsConditionsDevelopment" + backend.toUpperCase(), {


### PR DESCRIPTION
Fixes #25767

### What does this PR do?

A `#!/usr/bin/env bun` hashbang on an entry file sets that one file's per-file target to `Target::Bun` (via `target_from_hashbang`), regardless of `--target`. The linker then emitted the `// @bun` pragma, and under `--format=cjs` the `// @bun @bun-cjs` function-expression wrapper, whenever the entry's per-file target was Bun.

#### `--format=cjs`: silent no-op under node

```
$ printf '#!/usr/bin/env bun\nconsole.log("ALIVE", 42);\n' > cli.ts
$ bun build cli.ts --format=cjs --target=node --outfile=out.cjs
$ head -3 out.cjs
#!/usr/bin/env bun
// @bun @bun-cjs
(function(exports, require, module, __filename, __dirname) {

$ node out.cjs      # exit 0, no output
```

The wrapper is a function expression statement that only Bun's own module loader (via the `@bun-cjs` pragma) ever invokes. Under node and every other CommonJS host the module body is parsed and discarded with no build-time or run-time error. Removing the hashbang produces flat CJS that runs correctly.

#### `--format=esm`: mojibake / `SyntaxError` under bun

The printer's ASCII-only escaping policy is decided per file from `ast.target`: the entry (target=Bun) escapes non-ASCII identifiers, but every bundled dependency follows the build target (node/browser) and keeps them as raw UTF-8. The pragma tells Bun's loader the whole file is safe to read as Latin-1, so it mis-decodes the UTF-8 bytes from dependencies and rejects the bundle it just produced.

```
SyntaxError: Invalid character '©'
```

The same mismatch produces mojibake for string literals from dependencies (#25767):

```
$ bun out.js
Symbols: â â â        # expected: ✓ ✗ ⚠
```

Node runs the same output file without error.

Repro:

```js
import fs from "node:fs";
const dir = fs.mkdtempSync("/tmp/atbun-");
fs.writeFileSync(`${dir}/lib.ts`, `export class Café { méth(): number { return 7 } }\n`);
fs.writeFileSync(`${dir}/cli.ts`, `#!/usr/bin/env bun\nimport { Café } from "./lib.ts";\nconsole.log(new Café().méth());\n`);
await Bun.build({ entrypoints: [`${dir}/cli.ts`], outdir: `${dir}/out`, target: "node" });
Bun.spawnSync({ cmd: [process.execPath, `${dir}/out/cli.js`] });
// before: SyntaxError: Invalid character '©'
// after:  7
```

### Fix

Gate `is_bun` in `postProcessJSChunk.rs` on three conditions so the pragma and the `@bun-cjs` wrapper are only emitted when the whole chunk was printed for Bun:

- `c.options.target.is_bun()`: the build target determines what every non-entry dependency is printed with, and it is the target the output must run under. Fixes both hashbang cases above.
- `ast_targets[entry].is_bun()` (the original check): a `--target=bun` HTML entry produces a browser-printed JS chunk whose entry target is `Browser`; the flag below is not set on that path.
- `!IS_BROWSER_CHUNK_FROM_SERVER_BUILD`: a server build importing HTML produces browser chunks, and a code-split chunk may have a Bun-targeted entry while later files are browser-targeted.

The `@bun-cjs` wrapper open and close both key off the same `is_bun` local, so they stay balanced.

`--target=bun` with a plain JS entry is unchanged: pragma and wrapper are still emitted, identifiers are still escaped, output still runs.

### How did you verify your code works?

Added six `itBundled` cases in `test/bundler/bundler_bun.test.ts`:

- `bun/HashbangBunNoPragmaFor_node` and `bun/HashbangBunNoPragmaFor_browser`: a `#!/usr/bin/env bun` entry importing a dependency with a non-ASCII method name, built for node/browser. Assert no `// @bun` in the output and that the bundle runs in Bun and prints `7`. Both fail on the released binary (pragma present, bundle throws `SyntaxError`).
- `bun/HashbangBunNoCjsWrapperFor_node` and `bun/HashbangBunNoCjsWrapperFor_browser`: a `#!/usr/bin/env bun` entry built with `--format=cjs` for node/browser. Assert no `@bun-cjs` pragma and no function-expression wrapper. The node case additionally runs the output under node and asserts `ALIVE 42` on stdout. Both fail on the released binary (wrapper present, node emits nothing).
- `bun/HashbangBunPragmaForBunTarget` and `bun/HashbangBunCjsWrapperForBunTarget`: same inputs with `--target=bun`. Assert the pragma / wrapper are still present and the bundle runs. Pass before and after (positive controls).

`test/bundler/html-import-manifest.test.ts` covers the browser-chunk regression (an earlier iteration of this PR that gated only on the build target broke its etag snapshots).

`bun bd test test/bundler/bundler_bun.test.ts test/bundler/bundler_banner.test.ts test/bundler/bundler_cjs.test.ts test/bundler/html-import-manifest.test.ts test/bundler/bundler_html.test.ts test/bundler/bundler_html_server.test.ts`: pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (efb476566)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [1096.02ms]
(pass) bundler > bun/embedded-sqlite-file [687.29ms]
(pass) bundler > bun/sqlite-file [642.78ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [1011.79ms]
(pass) bundler > bun/TargetBunSourcemapInline [756.91ms]
(pass) bundler > bun/unicode comment [515.02ms]
145 |         "/lib.ts": `export class Café { méth() { return 7 } }\n`,
146 |       },
147 |       onAfterBundle(api) {
148 |         const out = api.readFile("/out.js");
149 |         expect(out).toStartWith("#!/usr/bin/env bun\n");
150 |         expect(out).not.toContain("// @bun");
                              ^
error: expect(received).not.toContain(expected)

Expected t
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (550273c18)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [27.75ms]
(pass) bundler > bun/embedded-sqlite-file [17.26ms]
(pass) bundler > bun/sqlite-file [16.61ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [17.87ms]
(pass) bundler > bun/TargetBunSourcemapInline [17.40ms]
(pass) bundler > bun/unicode comment [17.42ms]
(pass) bundler > bun/HashbangBunNoPragmaFor_node [16.16ms]
(pass) bundler > bun/HashbangBunNoPragmaFor_browser [16.97ms]
(pass) bundler > bun/HashbangBunPragmaForBunTarget [17.31ms]
(pass) bundler > bun/HashbangBunNoCjsWrapperFor_node [31.42ms]
(pass) bundler > bun/HashbangBunNoCjsWrapperFor_browser [3.68ms]
(pass) bundler > bun/HashbangBunCjsWrapperForBunTarget [17.16ms]
(pass) bundler > bun/ExportsConditionsDevelopmentAPI [15.74ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionAPI [15.65ms]
(pass) bundler > bun/ExportsConditionsDevelopmentCLI [16.60ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionCLI [16.82ms]

 16 pass
 0 fail
 32 expect() calls
Ran 16 tests across 1 file. [464.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (efb476566)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [1115.22ms]
(pass) bundler > bun/embedded-sqlite-file [617.56ms]
(pass) bundler > bun/sqlite-file [609.55ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [730.13ms]
(pass) bundler > bun/TargetBunSourcemapInline [753.02ms]
(pass) bundler > bun/unicode comment [663.72ms]
(pass) bundler > bun/HashbangBunNoPragmaFor_node [547.30ms]
(pass) bundler > bun/HashbangBunNoPragmaFor_browser [554.00ms]
(pass) bundler > bun/HashbangBunPragmaForBunTarget [963.28ms]
(pass) bundler > bun/HashbangBunNoCjsWrapperFor_node [124.27ms]
(pass) bundler > bun/HashbangBunNoCjsWrapperFor_browser [83.55ms]
(pass) bundler > bun/HashbangBunCjsWrapperForBunTarget [574.44ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 791ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/linker_context/postProcessJSChunk.rs |  8 +++-
 test/bundler/bundler_bun.test.ts                 | 58 ++++++++++++++++++++++++
 2 files changed, 65 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/bundler/linker_context/postProcessJSChunk.rs      6      3      0
test/bundler/bundler_bun.test.ts                      2      2      0
```

</details>

<!-- robobun:evidence:end -->