### PR TITLE
sourcemap: advance shift cursor past every crossed boundary in finalize

### DIFF
--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -829,8 +829,11 @@ impl SourceMapPieces {
                 current += 1;
             }
 
+            // A single mapping can cross multiple shift boundaries when two
+            // placeholder substitutions have no mapping between them, so
+            // advance to the latest applicable shift before re-encoding.
             let mut did_cross_boundary = false;
-            if shifts.len() > 1 && LineColumnOffset::comes_before(shifts[1].before, generated) {
+            while shifts.len() > 1 && LineColumnOffset::comes_before(shifts[1].before, generated) {
                 shifts = &shifts[1..];
                 did_cross_boundary = true;
             }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2,45 +2,12 @@ import { describe, expect } from "bun:test";
 import { isBroken, isWindows } from "harness";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { itBundled } from "./expectBundled";
+import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
 
 // A public path composes with the referenced file's path relative to the output
 // directory, never relative to the importing chunk (esbuild's semantics).
 const CDN_PUBLIC_PATH = "https://cdn.example/app/";
 const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.example\/[^"]+)"/g)].map(match => match[1]);
-
-function decodeSourceMappingsLine(line: string) {
-  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  const segs: { gen: number; src: number; ol: number; oc: number }[] = [];
-  let gen = 0;
-  let src = 0;
-  let ol = 0;
-  let oc = 0;
-  for (const raw of line ? line.split(",") : []) {
-    const f: number[] = [];
-    let v = 0;
-    let sh = 0;
-    for (const c of raw) {
-      const d = B64.indexOf(c);
-      v |= (d & 31) << sh;
-      if (d & 32) {
-        sh += 5;
-        continue;
-      }
-      f.push(v & 1 ? -(v >>> 1) : v >>> 1);
-      v = 0;
-      sh = 0;
-    }
-    gen += f[0];
-    if (f.length > 1) {
-      src += f[1];
-      ol += f[2];
-      oc += f[3];
-    }
-    segs.push({ gen, src, ol, oc });
-  }
-  return segs;
-}
 
 describe("bundler", () => {
   itBundled("edgecase/EmptyFile", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -9,6 +9,39 @@ import { itBundled } from "./expectBundled";
 const CDN_PUBLIC_PATH = "https://cdn.example/app/";
 const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.example\/[^"]+)"/g)].map(match => match[1]);
 
+function decodeSourceMappingsLine(line: string) {
+  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const segs: { gen: number; src: number; ol: number; oc: number }[] = [];
+  let gen = 0;
+  let src = 0;
+  let ol = 0;
+  let oc = 0;
+  for (const raw of line ? line.split(",") : []) {
+    const f: number[] = [];
+    let v = 0;
+    let sh = 0;
+    for (const c of raw) {
+      const d = B64.indexOf(c);
+      v |= (d & 31) << sh;
+      if (d & 32) {
+        sh += 5;
+        continue;
+      }
+      f.push(v & 1 ? -(v >>> 1) : v >>> 1);
+      v = 0;
+      sh = 0;
+    }
+    gen += f[0];
+    if (f.length > 1) {
+      src += f[1];
+      ol += f[2];
+      oc += f[3];
+    }
+    segs.push({ gen, src, ol, oc });
+  }
+  return segs;
+}
+
 describe("bundler", () => {
   itBundled("edgecase/EmptyFile", {
     files: {
@@ -1288,6 +1321,48 @@ describe("bundler", () => {
         mappingsExactMatch:
           "AACQ,QAAQ,IAAI,MAAM,EAOlB,QAAQ,IAAI,MAAM,EAClB,QAAQ,IAAI,MAAM,EAClB,QAAQ,IAAI,MAAM,EAClB,QAAQ,IAAI,MAAM",
       },
+    },
+  });
+  // SourceMapPieces.finalize advanced the shift cursor at most once per
+  // mapping, so a mapping crossing >=2 placeholder substitutions on one
+  // minified line was re-encoded against a stale shift and landed out of order.
+  itBundled("edgecase/EmitInvalidSourceMapMultipleShifts", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import a from "./a.bin";
+        import b from "./b.bin";
+        import c from "./c.bin";
+        const keep: string[] = [a, b, c];
+        console.log(keep);
+      `,
+      "/a.bin": "AAAA",
+      "/b.bin": "BBBB",
+      "/c.bin": "CCCC",
+    },
+    outdir: "/out",
+    loader: { ".bin": "file" },
+    sourceMap: "external",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const js = api.readFile("/out/entry.js");
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../entry.ts"]);
+      const line1 = decodeSourceMappingsLine(map.mappings.split(";")[0]);
+      for (let i = 1; i < line1.length; i++) {
+        if (line1[i].gen < line1[i - 1].gen) {
+          throw new Error(
+            `out-of-order mappings on line 1: generated column ` +
+              `${line1[i - 1].gen} -> ${line1[i].gen}\n` +
+              line1.map(s => `  col ${s.gen} -> entry.ts:${s.ol + 1}:${s.oc}`).join("\n"),
+          );
+        }
+      }
+      // The first mapping after all three substituted asset paths is for
+      // `keep` in `const keep`. It must point at the `keep` identifier in
+      // the generated output, not at a stale pre-shift column.
+      const keepCol = js.split("\n")[0].indexOf("keep=[");
+      expect(keepCol).toBeGreaterThan(0);
+      expect(line1).toContainEqual({ gen: keepCol, src: 0, ol: 3, oc: 6 });
     },
   });
   itBundled("edgecase/NoUselessConstructorTS", {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -53,6 +53,39 @@ export function dedent(str: string | TemplateStringsArray, ...args: any[]) {
   );
 }
 
+export function decodeSourceMappingsLine(line: string) {
+  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const segs: { gen: number; src: number; ol: number; oc: number }[] = [];
+  let gen = 0;
+  let src = 0;
+  let ol = 0;
+  let oc = 0;
+  for (const raw of line ? line.split(",") : []) {
+    const f: number[] = [];
+    let v = 0;
+    let sh = 0;
+    for (const c of raw) {
+      const d = B64.indexOf(c);
+      v |= (d & 31) << sh;
+      if (d & 32) {
+        sh += 5;
+        continue;
+      }
+      f.push(v & 1 ? -(v >>> 1) : v >>> 1);
+      v = 0;
+      sh = 0;
+    }
+    gen += f[0];
+    if (f.length > 1) {
+      src += f[1];
+      ol += f[2];
+      oc += f[3];
+    }
+    segs.push({ gen, src, ol, oc });
+  }
+  return segs;
+}
+
 let currentFile: string | undefined;
 
 function errorOrWarnParser(isError = true) {
@@ -1593,34 +1626,17 @@ for (const [key, blob] of build.outputs) {
           // decode the raw VLQ first to catch out-of-order segments (a
           // source-map spec violation).
           {
-            const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
             let ln = 0;
             for (const line of String(parsed.mappings).split(";")) {
               ln++;
-              let gen = 0;
-              let prev = -1;
-              for (const seg of line ? line.split(",") : []) {
-                let v = 0;
-                let sh = 0;
-                let delta: number | undefined;
-                for (const c of seg) {
-                  const d = B64.indexOf(c);
-                  v |= (d & 31) << sh;
-                  if (d & 32) {
-                    sh += 5;
-                    continue;
-                  }
-                  delta = v & 1 ? -(v >>> 1) : v >>> 1;
-                  break;
-                }
-                gen += delta!;
-                if (gen < prev) {
+              const segs = decodeSourceMappingsLine(line);
+              for (let i = 1; i < segs.length; i++) {
+                if (segs[i].gen < segs[i - 1].gen) {
                   throw new Error(
                     `${file}: out-of-order segments on generated line ${ln}: ` +
-                      `column ${prev} -> ${gen}\n  mappings line: ${line}`,
+                      `column ${segs[i - 1].gen} -> ${segs[i].gen}\n  mappings line: ${line}`,
                   );
                 }
-                prev = gen;
               }
             }
           }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1589,6 +1589,41 @@ for (const [key, blob] of build.outputs) {
         const file = file_input.toString("utf8"); // type bug? `file_input` is `Buffer|string`
         if (file.endsWith(".map")) {
           const parsed = await Bun.file(path.join(outdir, file)).json();
+          // SourceMapConsumer re-sorts segments by generated position, so
+          // decode the raw VLQ first to catch out-of-order segments (a
+          // source-map spec violation).
+          {
+            const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            let ln = 0;
+            for (const line of String(parsed.mappings).split(";")) {
+              ln++;
+              let gen = 0;
+              let prev = -1;
+              for (const seg of line ? line.split(",") : []) {
+                let v = 0;
+                let sh = 0;
+                let delta: number | undefined;
+                for (const c of seg) {
+                  const d = B64.indexOf(c);
+                  v |= (d & 31) << sh;
+                  if (d & 32) {
+                    sh += 5;
+                    continue;
+                  }
+                  delta = v & 1 ? -(v >>> 1) : v >>> 1;
+                  break;
+                }
+                gen += delta!;
+                if (gen < prev) {
+                  throw new Error(
+                    `${file}: out-of-order segments on generated line ${ln}: ` +
+                      `column ${prev} -> ${gen}\n  mappings line: ${line}`,
+                  );
+                }
+                prev = gen;
+              }
+            }
+          }
           const mappedLocations = new Map();
           await SourceMapConsumer.with(parsed, null, async map => {
             map.eachMapping(m => {


### PR DESCRIPTION
## Problem

With `--minify --sourcemap`, a generated line containing two or more placeholder substitutions (two file-loader asset imports, or an entry chunk importing from two shared chunks under `--splitting`) produces a `mappings` line whose segments are not sorted by generated column, violating the source-map spec. The first mapping after the substitutions also carries the wrong generated column (only the first placeholder's shift is applied), so consumers that binary-search resolve the wrong original, and consumers that silently re-sort end up with two originals claiming one generated column.

```ts
// a.bin, b.bin, c.bin exist
import a from "./a.bin";
import b from "./b.bin";
import c from "./c.bin";
const keep: string[] = [a, b, c];
console.log(keep);
```

Built with `loader: { ".bin": "file" }, minify: { whitespace: true }, sourcemap: "linked"`, decoding the emitted map's first line:

```
col 117 -> entry.ts:4:0    // 'const'  (correct column is 99)
col 112 -> entry.ts:4:6    // 'keep'   (correct column is 103; OUT OF ORDER vs 117)
col 108 -> entry.ts:4:23   // '['      (OUT OF ORDER vs 112)
col 109 -> entry.ts:4:24
...
```

## Cause

`SourceMapPieces::finalize` (src/sourcemap/lib.rs) walks the recorded `SourceMapShifts` alongside the decoded mappings and re-encodes the generated-column delta of any mapping that crossed a shift boundary. It advanced the shift cursor with an `if`:

```rust
if shifts.len() > 1 && LineColumnOffset::comes_before(shifts[1].before, generated) {
    shifts = &shifts[1..];
    did_cross_boundary = true;
}
```

so a mapping that crosses two or more boundaries at once (two placeholder substitutions with no mapping between them) is re-encoded against the stale `shifts[0]`.

## Fix

Change the `if` to a `while` so the cursor advances to the latest applicable shift before the delta is re-encoded.

## Tests

- `edgecase/EmitInvalidSourceMapMultipleShifts`: three file-loader asset imports on one minified line. Decodes the raw VLQ and asserts generated columns are monotone, and that the first mapping after the three substitutions (`keep`) points at the `keep` identifier in the generated output.
- The generic `sourceMap: "external"` validation in `expectBundled.ts` now decodes the raw VLQ and rejects out-of-order segments before handing the map to `SourceMapConsumer` (which silently re-sorts). With this check, the existing `edgecase/EmitInvalidSourceMap1` (`--splitting --minify`) also fails without the fix.

Fails on 1.4.0, passes with this change:

```
error: out-of-order mappings on line 1: generated column 117 -> 112
  col 117 -> entry.ts:4:0
  col 112 -> entry.ts:4:6
  col 108 -> entry.ts:4:23
  ...
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->