### PR TITLE
Preserve non-ASCII in regex .source and tagged template .raw

### DIFF
--- a/src/ast/transpiler_cache.rs
+++ b/src/ast/transpiler_cache.rs
@@ -11,6 +11,7 @@
 //! `bun_bundler::cache` and are stored here type-erased as `*mut ()`).
 
 use crate::{ExportsKind, Source};
+use bun_core::strings::EncodingNonAscii;
 use core::ptr::NonNull;
 
 pub struct RuntimeTranspilerCache {
@@ -52,7 +53,7 @@ impl Default for RuntimeTranspilerCache {
 bun_dispatch::link_interface! {
     pub TranspilerCacheImpl[Jsc] {
         fn get(source: &Source, parser_options: NonNull<()>, used_jsx: bool) -> bool;
-        fn put(output_code: &[u8], sourcemap: &[u8], esm_record: &[u8]);
+        fn put(output_code: &[u8], output_encoding: EncodingNonAscii, sourcemap: &[u8], esm_record: &[u8]);
         fn is_disabled() -> bool;
     }
 }
@@ -83,10 +84,21 @@ impl RuntimeTranspilerCache {
         }
     }
 
+    /// `output_code` is the printer's buffer in the width it ended up in
+    /// (`Latin1` bytes or native-endian `Utf16` units); the entry is stored and
+    /// later loaded in that same width.
     #[inline]
-    pub fn put(&mut self, output_code: &[u8], sourcemap: &[u8], esm_record: &[u8]) {
+    pub fn put(
+        &mut self,
+        output_code: &[u8],
+        output_encoding: EncodingNonAscii,
+        sourcemap: &[u8],
+        esm_record: &[u8],
+    ) {
         match self.r#impl {
-            Some(k) => Self::handle(k, self).put(output_code, sourcemap, esm_record),
+            Some(k) => {
+                Self::handle(k, self).put(output_code, output_encoding, sourcemap, esm_record)
+            }
             None => {
                 if self.input_hash.is_none() {
                     return;

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -246,6 +246,16 @@ impl String {
             }
         }
     }
+    /// [`clone_utf16`](Self::clone_utf16) for text the caller already knows
+    /// contains a character outside Latin-1; skips the narrowing scan.
+    pub fn clone_utf16_wide(s: &[u16]) -> Self {
+        if s.is_empty() {
+            return Self::EMPTY;
+        }
+        debug_assert!(s.iter().any(|&u| u > 0xFF));
+        // SAFETY: s.as_ptr()/len describe a valid u16 slice.
+        unsafe { BunString__fromUTF16(s.as_ptr(), s.len()) }
+    }
     pub fn create_atom(s: &[u8]) -> Self {
         // SAFETY: s.as_ptr()/len describe a valid byte slice.
         unsafe { BunString__createAtom(s.as_ptr(), s.len()) }
@@ -288,6 +298,35 @@ impl String {
         ctx: Ctx,
         callback: ExternalStringImplFreeFunction<Ctx>,
     ) -> Self {
+        // The length handed to WTF is a character count, so a byte slice can
+        // only describe a Latin-1 string; see `create_external_utf16`.
+        debug_assert!(is_latin1);
+        Self::create_external_impl(bytes.as_ptr(), bytes.len(), is_latin1, ctx, callback)
+    }
+
+    /// [`create_external`](Self::create_external) for UTF-16 code units:
+    /// `callback` receives `units.len()` (code units, not bytes).
+    pub fn create_external_utf16<Ctx>(
+        units: &[u16],
+        ctx: Ctx,
+        callback: ExternalStringImplFreeFunction<Ctx>,
+    ) -> Self {
+        Self::create_external_impl(
+            units.as_ptr().cast::<u8>(),
+            units.len(),
+            false,
+            ctx,
+            callback,
+        )
+    }
+
+    fn create_external_impl<Ctx>(
+        ptr: *const u8,
+        len: usize,
+        is_latin1: bool,
+        ctx: Ctx,
+        callback: ExternalStringImplFreeFunction<Ctx>,
+    ) -> Self {
         use core::ffi::c_void;
         // `Ctx` must be a pointer-sized, pointer-aligned handle.
         struct AssertPtrSized<C>(core::marker::PhantomData<C>);
@@ -301,9 +340,9 @@ impl String {
             };
         }
         let () = AssertPtrSized::<Ctx>::OK;
-        debug_assert!(!bytes.is_empty());
-        if bytes.len() > Self::max_length() {
-            callback(ctx, bytes.as_ptr().cast_mut().cast::<c_void>(), bytes.len());
+        debug_assert!(len != 0);
+        if len > Self::max_length() {
+            callback(ctx, ptr.cast_mut().cast::<c_void>(), len);
             return Self::DEAD;
         }
         // The const-assert above only checks size/alignment, so an owning
@@ -325,16 +364,9 @@ impl String {
                 ExternalStringImplFreeFunction<Ctx>,
                 extern "C" fn(*mut c_void, *mut c_void, usize),
             >(callback) });
-        // SAFETY: bytes describes a valid slice; len <= max_length checked.
-        let s = unsafe {
-            BunString__createExternal(
-                bytes.as_ptr(),
-                bytes.len(),
-                is_latin1,
-                ctx_erased,
-                cb_erased,
-            )
-        };
+        // SAFETY: `ptr`/`len` came from a live slice of the matching width in
+        // the callers above; len <= max_length checked.
+        let s = unsafe { BunString__createExternal(ptr, len, is_latin1, ctx_erased, cb_erased) };
         debug_assert!(s.tag != Tag::WTFStringImpl || s.as_wtf().ref_count() == 1);
         s
     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1411,6 +1411,7 @@ pub mod bv2_impl {
             safe fn __bun_jsc_generate_cached_bytecode(
                 format: crate::options_impl::Format,
                 source: &[u8],
+                source_encoding: bun_core::strings::EncodingNonAscii,
                 source_provider_url: &bun_core::String,
                 external_strings: Option<core::ptr::NonNull<EncoderStringTable>>,
             ) -> Option<Box<[u8]>>;
@@ -1459,6 +1460,7 @@ pub mod bv2_impl {
 
         /// Bytecode generation entry point for the linker: marks the calling
         /// thread as bundler-for-bytecode-cache, initializes JSC, and generates.
+        /// `source` is the chunk as written to disk, i.e. UTF-8.
         #[inline]
         pub(crate) fn generate_cached_bytecode(
             format: crate::options_impl::Format,
@@ -1469,6 +1471,7 @@ pub mod bv2_impl {
             __bun_jsc_generate_cached_bytecode(
                 format,
                 source,
+                bun_core::strings::EncodingNonAscii::Utf8,
                 source_provider_url,
                 external_strings,
             )

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
-import { argParse, writeIfNotChanged } from "./helpers";
+import { argParse, checkAscii, writeIfNotChanged } from "./helpers";
 
 // arg parsing
 let { "codegen-root": codegenRoot, debug, ...rest } = argParse(["codegen-root", "debug"]);
@@ -144,6 +144,9 @@ async function run() {
           code = `let ${outName("unloadedModuleRegistry")}={},${outName("config")}={separateSSRGraph:${outName("$separateSSRGraph")}},${outName("server_exports")};${code}`;
 
           code = debug ? `((${params}) => {${code}})\n` : `((${params})=>{${code}})\n`;
+          // DevServer::init_server_runtime loads this as a Latin-1 string, and
+          // regex literals / tagged template raw text are no longer escaped.
+          checkAscii(code);
         } else {
           code = debug ? `(async (${names}) => {${code}})({\n` : `(async(${names})=>{${code}})({`;
         }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2867,54 +2867,30 @@ pub(crate) mod __gated_printer {
             }
         }
 
-        fn print_raw_template_literal(&mut self, bytes: &[u8]) {
-            if IS_JSON || !ASCII_ONLY {
-                self.print(bytes);
+        /// Source text the program can observe (tagged template `.raw`,
+        /// `RegExp#source`, preserved comments via `Function#toString`), so it
+        /// is never escaped. It is the only text that can take the writer's
+        /// Latin-1 buffer to UTF-16 (see [`WriterContext`]); the source map
+        /// builder reads that buffer, so settle its position while the bytes
+        /// are still Latin-1 and tell it afterwards if they no longer are.
+        fn print_verbatim(&mut self, text: &[u8]) {
+            let before = self.writer.output_encoding();
+            if before != OutputEncoding::Latin1 {
+                self.writer.print_verbatim_utf8(text);
                 return;
             }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            let mut ascii_start: usize = 0;
-            let mut is_ascii = false;
-            let iter = CodepointIterator::init(bytes);
-            let mut cursor = strings::Cursor::default();
-
-            while iter.next(&mut cursor) {
-                match cursor.c as u32 {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0..=LAST_ASCII => {
-                        if !is_ascii {
-                            ascii_start = cursor.i as usize;
-                            is_ascii = true;
-                        }
-                    }
-                    _ => {
-                        if is_ascii {
-                            self.print(&bytes[ascii_start..(cursor.i as usize)]);
-                            is_ascii = false;
-                        }
-
-                        match cursor.c as u32 {
-                            c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                            _ => {
-                                self.print(b"\\u{");
-                                let _ = self.fmt(format_args!("{:x}", cursor.c));
-                                self.print(b"}");
-                            }
-                        }
-                    }
-                }
+            if GENERATE_SOURCE_MAP {
+                self.source_map_builder
+                    .update_generated(self.writer.slice());
             }
-
-            if is_ascii {
-                self.print(&bytes[ascii_start..]);
+            self.writer.print_verbatim_utf8(text);
+            if GENERATE_SOURCE_MAP && self.writer.output_encoding() == OutputEncoding::Utf16 {
+                self.source_map_builder.output_widened_to_utf16();
             }
+        }
+
+        fn print_raw_template_literal(&mut self, bytes: &[u8]) {
+            self.print_verbatim(bytes);
         }
 
         pub(crate) fn check_stack_overflow(&self) -> crate::Result<()> {
@@ -4234,7 +4210,7 @@ pub(crate) mod __gated_printer {
                     self.print_expr(e.value, level, flags);
                     if !self.options.minify_whitespace && !self.options.minify_identifiers {
                         self.print(b" /* ");
-                        self.print(&e.comment[..]);
+                        self.print_verbatim(&e.comment[..]);
                         self.print(b" */");
                     }
                 }
@@ -4338,41 +4314,7 @@ pub(crate) mod __gated_printer {
                 self.print(b" ");
             }
 
-            if IS_BUN_PLATFORM {
-                // Translate any non-ASCII to unicode escape sequences
-                let mut ascii_start: usize = 0;
-                let mut is_ascii = false;
-                let iter = CodepointIterator::init(&e.value);
-                let mut cursor = strings::Cursor::default();
-                while iter.next(&mut cursor) {
-                    match cursor.c as u32 {
-                        FIRST_ASCII..=LAST_ASCII => {
-                            if !is_ascii {
-                                ascii_start = cursor.i as usize;
-                                is_ascii = true;
-                            }
-                        }
-                        _ => {
-                            if is_ascii {
-                                self.print(&e.value[ascii_start..(cursor.i as usize)]);
-                                is_ascii = false;
-                            }
-
-                            match cursor.c as u32 {
-                                c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                                c => self.print(&surrogate_pair_escape(c)[..]),
-                            }
-                        }
-                    }
-                }
-
-                if is_ascii {
-                    self.print(&e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                self.print(&e.value[..]);
-            }
+            self.print_verbatim(&e.value[..]);
 
             // Need a space before the next identifier to avoid it turning into flags
             self.prev_reg_exp_end = self.writer.written();
@@ -6361,7 +6303,7 @@ pub(crate) mod __gated_printer {
                 // TODO: rewrite this to handle </script>
                 if !strings::contains(comment, b"*/") {
                     self.print(b" /* ");
-                    self.print(comment);
+                    self.print_verbatim(comment);
                     self.print(b" */");
                 }
             }
@@ -6537,22 +6479,22 @@ pub(crate) mod __gated_printer {
                     let newline_index = newline_index as usize;
                     // Skip over \r if it precedes \n
                     if newline_index > 0 && text[newline_index - 1] == b'\r' {
-                        self.print(&text[..newline_index - 1]);
+                        self.print_verbatim(&text[..newline_index - 1]);
                         self.print(b"\n");
                     } else {
-                        self.print(&text[..newline_index + 1]);
+                        self.print_verbatim(&text[..newline_index + 1]);
                     }
                     self.print_indent();
                     text = &text[newline_index + 1..];
                 }
-                self.print(text);
+                self.print_verbatim(text);
                 self.print_newline();
             } else {
                 // Print a mandatory newline after single-line comments
                 if !text.is_empty() && text[text.len() - 1] == b'\r' {
                     text = &text[..text.len() - 1];
                 }
-                self.print(text);
+                self.print_verbatim(text);
                 self.print(b"\n");
             }
         }
@@ -6817,11 +6759,27 @@ impl HasDefaultValue for js_ast::ArrayBinding {
 // ───────────────────────────────────────────────────────────────────────────
 
 /// Backend operations a `Writer` context provides.
+///
+/// Everything the printer emits is ASCII except the text it copies out of the
+/// source verbatim (regex literals, tagged template raw text, preserved
+/// comments), which goes through [`WriterContext::write_verbatim_utf8`]. A
+/// context therefore either stores UTF-8 bytes, or stores one Latin-1 byte per
+/// character and widens itself to UTF-16 code units the first time a character
+/// above U+00FF is written ([`OutputEncoding`]); the lengths reported and
+/// consumed by every method are always character counts (code units), so the
+/// printer's offsets stay valid across the widening, which maps 1:1.
 pub trait WriterContext {
     fn write_byte(&mut self, char: u8) -> crate::Result<usize>;
     fn write_all(&mut self, buf: &[u8]) -> crate::Result<usize>;
+    /// Write source text, decoding it as WTF-8 when the buffer is not UTF-8.
+    /// Returns the number of code units written.
+    fn write_verbatim_utf8(&mut self, text: &[u8]) -> crate::Result<usize>;
+    fn output_encoding(&self) -> OutputEncoding;
     fn get_last_byte(&self) -> u8;
     fn get_last_last_byte(&self) -> u8;
+    /// Reserve room for `count` characters of ASCII, to be written as bytes at
+    /// the returned pointer and committed with one [`WriterContext::advance_by`]
+    /// (a widened buffer converts them on commit, so the region is single-use).
     fn reserve_next(&mut self, count: u64) -> crate::Result<*mut u8>;
     fn advance_by(&mut self, count: u64);
     fn slice(&self) -> &[u8];
@@ -6841,6 +6799,9 @@ pub trait WriterTrait {
     fn prev_prev_char(&self) -> u8;
     fn print_byte(&mut self, b: u8);
     fn print_slice(&mut self, s: &[u8]);
+    /// See [`WriterContext::write_verbatim_utf8`].
+    fn print_verbatim_utf8(&mut self, text: &[u8]);
+    fn output_encoding(&self) -> OutputEncoding;
     fn reserve(&mut self, count: u64) -> crate::Result<*mut u8>;
     fn advance(&mut self, count: u64);
     /// Reserve `bytes.len()`, memcpy `bytes` into the reserved region, then advance.
@@ -6968,6 +6929,20 @@ impl<C: WriterContext> Writer<C> {
         }
     }
 
+    #[inline]
+    pub(crate) fn print_verbatim_utf8(&mut self, text: &[u8]) {
+        match self.ctx.write_verbatim_utf8(text) {
+            Ok(n) => {
+                debug_assert!(n <= i32::MAX as usize);
+                self.written = self.written.wrapping_add(n as i32);
+            }
+            Err(err) => {
+                self.orig_err = Some(err);
+                self.err = Some(crate::Error::WriteFailed);
+            }
+        }
+    }
+
     pub fn flush(&mut self) -> crate::Result<()> {
         self.ctx.flush()
     }
@@ -6977,6 +6952,14 @@ impl<C: WriterContext> Writer<C> {
 }
 
 impl<C: WriterContext> WriterTrait for Writer<C> {
+    #[inline]
+    fn print_verbatim_utf8(&mut self, text: &[u8]) {
+        self.print_verbatim_utf8(text)
+    }
+    #[inline]
+    fn output_encoding(&self) -> OutputEncoding {
+        self.ctx.output_encoding()
+    }
     #[inline]
     fn written(&self) -> i32 {
         self.written
@@ -7030,6 +7013,14 @@ impl<W: WriterTrait> WriterTrait for &mut W {
         (**self).written()
     }
     #[inline]
+    fn print_verbatim_utf8(&mut self, text: &[u8]) {
+        (**self).print_verbatim_utf8(text)
+    }
+    #[inline]
+    fn output_encoding(&self) -> OutputEncoding {
+        (**self).output_encoding()
+    }
+    #[inline]
     fn prev_char(&self) -> u8 {
         (**self).prev_char()
     }
@@ -7075,7 +7066,16 @@ impl<W: WriterTrait> WriterTrait for &mut W {
 // DirectWriter / BufferWriter
 // ───────────────────────────────────────────────────────────────────────────
 
+/// How the bytes in a [`BufferWriter`] are to be read. See [`WriterContext`].
+pub type OutputEncoding = strings::EncodingNonAscii;
+
 pub struct BufferWriter {
+    /// `Utf8`: the text as bytes. `Latin1`: one character per byte. `Utf16`:
+    /// native-endian code units, two bytes each (see [`Self::written_utf16`]).
+    encoding: OutputEncoding,
+    /// What [`Self::reset`] returns `encoding` to: `Latin1` for a writer that
+    /// feeds JSC directly ([`Self::init_latin1`]), otherwise `Utf8`.
+    initial_encoding: OutputEncoding,
     pub buffer: MutableString,
     /// Watermark into `buffer.list` set by `done()`. Rust can't keep a
     /// self-borrowing slice in a field, so store the length and
@@ -7102,12 +7102,15 @@ impl BufferWriter {
     }
 
     pub fn init() -> BufferWriter {
-        BufferWriter {
-            buffer: MutableString::init_empty(),
-            written_len: 0,
-            append_null_byte: false,
-            append_newline: false,
-        }
+        Self::with_capacity_and_encoding(0, OutputEncoding::Utf8)
+    }
+
+    /// A writer whose output is handed to JSC as-is: Latin-1 until the text
+    /// needs more, then UTF-16 (see [`WriterContext`]). Read the result with
+    /// [`Self::output_encoding`] plus [`Self::get_written`] /
+    /// [`Self::written_utf16`], or [`Self::clone_written_as_string`].
+    pub fn init_latin1() -> BufferWriter {
+        Self::with_capacity_and_encoding(0, OutputEncoding::Latin1)
     }
 
     /// Like [`init`], but pre-sizes the output buffer. The transpiled output is
@@ -7116,7 +7119,14 @@ impl BufferWriter {
     /// otherwise do as the printer appends token-by-token. (`MutableString::init`
     /// is a no-op when `capacity == 0`.)
     pub(crate) fn with_capacity(capacity: usize) -> BufferWriter {
+        Self::with_capacity_and_encoding(capacity, OutputEncoding::Utf8)
+    }
+
+    fn with_capacity_and_encoding(capacity: usize, encoding: OutputEncoding) -> BufferWriter {
+        debug_assert!(encoding != OutputEncoding::Utf16);
         BufferWriter {
+            encoding,
+            initial_encoding: encoding,
             buffer: MutableString::init(capacity).unwrap_or_else(|_| MutableString::init_empty()),
             written_len: 0,
             append_null_byte: false,
@@ -7125,15 +7135,147 @@ impl BufferWriter {
     }
 
     #[inline]
-    pub(crate) fn write_byte(&mut self, byte: u8) -> crate::Result<usize> {
-        self.buffer.append_char(byte)?;
+    pub fn output_encoding(&self) -> OutputEncoding {
+        self.encoding
+    }
+
+    /// The buffer as code units; only valid once [`Self::output_encoding`] is
+    /// `Utf16`. Borrowed unless the allocation happens to be odd-aligned.
+    pub fn written_utf16(&self) -> std::borrow::Cow<'_, [u16]> {
+        debug_assert!(self.encoding == OutputEncoding::Utf16);
+        let bytes = self.buffer.list.as_slice();
+        match bytemuck::try_cast_slice::<u8, u16>(bytes) {
+            Ok(units) => std::borrow::Cow::Borrowed(units),
+            Err(_) => std::borrow::Cow::Owned(
+                bytes
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|&pair| u16::from_ne_bytes(pair))
+                    .collect(),
+            ),
+        }
+    }
+
+    /// The finished text as a JSC string, in the width it was printed in.
+    pub fn clone_written_as_string(&self) -> bun_core::String {
+        match self.encoding {
+            OutputEncoding::Utf8 => bun_core::String::clone_utf8(self.get_written()),
+            OutputEncoding::Latin1 => bun_core::String::clone_latin1(self.get_written()),
+            OutputEncoding::Utf16 => bun_core::String::clone_utf16_wide(&self.written_utf16()),
+        }
+    }
+
+    #[inline]
+    pub fn write_byte(&mut self, byte: u8) -> crate::Result<usize> {
+        if self.encoding != OutputEncoding::Utf16 {
+            debug_assert!(self.encoding == OutputEncoding::Utf8 || byte.is_ascii());
+            self.buffer.append_char(byte)?;
+        } else {
+            self.buffer.append(&u16::from(byte).to_ne_bytes())?;
+        }
         Ok(1)
     }
 
     #[inline]
-    pub(crate) fn write_all(&mut self, bytes: &[u8]) -> crate::Result<usize> {
-        self.buffer.append(bytes)?;
+    pub fn write_all(&mut self, bytes: &[u8]) -> crate::Result<usize> {
+        if self.encoding != OutputEncoding::Utf16 {
+            // Only `write_verbatim_utf8` may store non-ASCII characters into a
+            // Latin-1 buffer; everything else the printer emits is ASCII.
+            debug_assert!(
+                self.encoding == OutputEncoding::Utf8 || strings::is_all_ascii(bytes),
+                "non-ASCII printed into a Latin-1 buffer: {:?}",
+                bstr::BStr::new(bytes)
+            );
+            self.buffer.append(bytes)?;
+        } else {
+            let ptr = self.reserve_next(bytes.len() as u64)?;
+            // SAFETY: `reserve_next` reserved room for `bytes.len()` characters
+            // and `advance_by` widens exactly the bytes written at `ptr`.
+            unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len()) };
+            self.advance_by(bytes.len() as u64);
+        }
         Ok(bytes.len())
+    }
+
+    pub fn write_verbatim_utf8(&mut self, text: &[u8]) -> crate::Result<usize> {
+        if self.encoding == OutputEncoding::Utf8 {
+            return self.write_all(text);
+        }
+        let mut units = 0usize;
+        // Start of the pending run of ASCII bytes, copied in one go.
+        let mut run_start = 0usize;
+        let iter = CodepointIterator::init(text);
+        let mut cursor = strings::Cursor::default();
+        while iter.next(&mut cursor) {
+            let c = cursor.c as u32;
+            if c < 0x80 {
+                continue;
+            }
+            let start = cursor.i as usize;
+            if start > run_start {
+                units += self.write_all(&text[run_start..start])?;
+            }
+            run_start = start + cursor.width as usize;
+            units += if c <= 0xFF {
+                self.write_latin1_char(c as u8)?
+            } else {
+                self.write_wide_char(c)?
+            };
+        }
+        if text.len() > run_start {
+            units += self.write_all(&text[run_start..])?;
+        }
+        Ok(units)
+    }
+
+    fn write_latin1_char(&mut self, c: u8) -> crate::Result<usize> {
+        if self.encoding == OutputEncoding::Utf16 {
+            self.buffer.append(&u16::from(c).to_ne_bytes())?;
+        } else {
+            self.buffer.append_char(c)?;
+        }
+        Ok(1)
+    }
+
+    /// `c` is above U+00FF (a lone surrogate decoded from WTF-8 stays a single
+    /// unit, like the `\uD800` escape it used to be printed as).
+    fn write_wide_char(&mut self, c: u32) -> crate::Result<usize> {
+        if self.encoding == OutputEncoding::Latin1 {
+            self.widen_to_utf16()?;
+        }
+        if c <= 0xFFFF {
+            self.buffer.append(&(c as u16).to_ne_bytes())?;
+            return Ok(1);
+        }
+        let [lead, trail] = strings::encode_surrogate_pair(c);
+        self.buffer.append(&lead.to_ne_bytes())?;
+        self.buffer.append(&trail.to_ne_bytes())?;
+        Ok(2)
+    }
+
+    /// Rewrite the Latin-1 buffer in place as UTF-16 code units. Walking from
+    /// the end, the two bytes unit `i` is written to (`2i`, `2i + 1`) never
+    /// overlap a byte `j < i` that is still to be read.
+    fn widen_to_utf16(&mut self) -> crate::Result<()> {
+        debug_assert!(self.encoding == OutputEncoding::Latin1);
+        let list = &mut self.buffer.list;
+        let len = list.len();
+        list.try_reserve(len).map_err(|_| bun_alloc::AllocError)?;
+        let ptr = list.as_mut_ptr();
+        for i in (0..len).rev() {
+            // SAFETY: `i < len` is initialized; `2i + 1 < 2 * len <= capacity`
+            // after the reservation above, and `write_unaligned` needs no
+            // alignment from the byte buffer.
+            unsafe {
+                let unit = u16::from(*ptr.add(i));
+                ptr.add(2 * i).cast::<u16>().write_unaligned(unit);
+            }
+        }
+        // SAFETY: every byte in `0..2 * len` was written by the loop.
+        unsafe { list.set_len(2 * len) };
+        self.encoding = OutputEncoding::Utf16;
+        Ok(())
     }
 
     #[inline]
@@ -7141,37 +7283,85 @@ impl BufferWriter {
         self.buffer.list.as_slice()
     }
 
-    /// `prev_char` for the printer. The 2-byte window the printer queries is
-    /// derived lazily from the tail of `buffer` here (a rare query site) rather
-    /// than maintained after every `write_byte`/`write_all` (the hot path).
+    /// The character most recently written, for the printer's "what did I just
+    /// print" checks, which all compare against ASCII; anything wider reports
+    /// as U+00FF, a letter, which errs towards inserting a separator.
     #[inline]
-    pub(crate) fn get_last_byte(&self) -> u8 {
+    fn last_chars(&self) -> (u8, u8) {
         let list = &self.buffer.list;
         let len = list.len();
-        if len >= 1 { list[len - 1] } else { 0 }
+        if self.encoding != OutputEncoding::Utf16 {
+            let last = if len >= 1 { list[len - 1] } else { 0 };
+            let last_last = if len >= 2 { list[len - 2] } else { 0 };
+            return (last, last_last);
+        }
+        let unit_at = |end: usize| -> u8 {
+            if end < 2 {
+                return 0;
+            }
+            let unit = u16::from_ne_bytes([list[end - 2], list[end - 1]]);
+            u8::try_from(unit).unwrap_or(0xFF)
+        };
+        (unit_at(len), unit_at(len.saturating_sub(2)))
+    }
+
+    /// `prev_char` for the printer. The 2-character window the printer queries
+    /// is derived lazily from the tail of `buffer` here (a rare query site)
+    /// rather than maintained after every `write_byte`/`write_all` (the hot path).
+    #[inline]
+    pub(crate) fn get_last_byte(&self) -> u8 {
+        self.last_chars().0
     }
     #[inline]
     pub(crate) fn get_last_last_byte(&self) -> u8 {
-        let list = &self.buffer.list;
-        let len = list.len();
-        if len >= 2 { list[len - 2] } else { 0 }
+        self.last_chars().1
     }
 
-    pub(crate) fn reserve_next(&mut self, count: u64) -> crate::Result<*mut u8> {
+    pub fn reserve_next(&mut self, count: u64) -> crate::Result<*mut u8> {
         let n = usize::try_from(count).expect("int cast");
+        // A widened buffer needs two bytes per character; the caller still
+        // writes `count` bytes at the start of the region (see `advance_by`).
+        let n_bytes = if self.encoding == OutputEncoding::Utf16 {
+            n * 2
+        } else {
+            n
+        };
         // SAFETY: caller treats as write-only; advance_by() commits via commit_spare.
-        Ok(unsafe { bun_core::vec::reserve_spare_bytes(&mut self.buffer.list, n) }.as_mut_ptr())
+        Ok(
+            unsafe { bun_core::vec::reserve_spare_bytes(&mut self.buffer.list, n_bytes) }
+                .as_mut_ptr(),
+        )
     }
 
-    pub(crate) fn advance_by(&mut self, count: u64) {
-        let count_usize = usize::try_from(count).expect("int cast");
+    pub fn advance_by(&mut self, count: u64) {
+        let n = usize::try_from(count).expect("int cast");
+        if self.encoding == OutputEncoding::Utf16 {
+            // SAFETY: only the first `n` bytes of the spare region, which the
+            // caller initialized, are read; the rest is written.
+            let spare = unsafe { bun_core::vec::spare_bytes_mut(&mut self.buffer.list) };
+            debug_assert!(spare.len() >= 2 * n);
+            let ptr = spare.as_mut_ptr();
+            for i in (0..n).rev() {
+                // SAFETY: the caller initialized the first `n` bytes of the
+                // region reserved by `reserve_next`, which holds `2n`; same
+                // back-to-front argument as `widen_to_utf16`.
+                unsafe {
+                    let unit = u16::from(*ptr.add(i));
+                    ptr.add(2 * i).cast::<u16>().write_unaligned(unit);
+                }
+            }
+            // SAFETY: the loop initialized `2n` bytes of spare capacity.
+            unsafe { bun_core::vec::commit_spare(&mut self.buffer.list, 2 * n) };
+            return;
+        }
         // SAFETY: reserve_next reserved and the caller initialized [len..len+count).
-        unsafe { bun_core::vec::commit_spare(&mut self.buffer.list, count_usize) };
+        unsafe { bun_core::vec::commit_spare(&mut self.buffer.list, n) };
     }
 
     pub fn reset(&mut self) {
         self.buffer.reset();
         self.written_len = 0;
+        self.encoding = self.initial_encoding;
     }
 
     pub fn written_without_trailing_zero(&self) -> &[u8] {
@@ -7185,7 +7375,7 @@ impl BufferWriter {
     pub(crate) fn done(&mut self) -> crate::Result<()> {
         if self.append_newline {
             self.append_newline = false;
-            self.buffer.append_char(b'\n')?;
+            self.write_byte(b'\n')?;
         }
         if self.append_null_byte {
             // Append a NUL unless the buffer already ends with one; the NUL is
@@ -7193,8 +7383,8 @@ impl BufferWriter {
             // `written_without_trailing_zero`).
             //
             // For an *empty* buffer we still append the NUL.
-            if self.buffer.list.last().copied() != Some(0) {
-                self.buffer.append_char(0)?;
+            if self.buffer.list.is_empty() || self.get_last_byte() != 0 {
+                self.write_byte(0)?;
             }
         }
         self.written_len = self.buffer.list.len();
@@ -7214,6 +7404,13 @@ impl WriterContext for BufferWriter {
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> crate::Result<usize> {
         self.write_all(buf)
+    }
+    fn write_verbatim_utf8(&mut self, text: &[u8]) -> crate::Result<usize> {
+        self.write_verbatim_utf8(text)
+    }
+    #[inline]
+    fn output_encoding(&self) -> OutputEncoding {
+        self.output_encoding()
     }
     #[inline]
     fn get_last_byte(&self) -> u8 {
@@ -7258,11 +7455,11 @@ pub type BufferPrinter = Writer<BufferWriter>;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Format {
     Esm,
-    // bun.js must escape non-latin1 identifiers in the output This is because
-    // we load JavaScript as a UTF-8 buffer instead of a UTF-16 buffer
-    // JavaScriptCore does not support UTF-8 identifiers when the source code
-    // string is loaded as const char* We don't want to double the size of code
-    // in memory...
+    // The runtime hands the output to JSC as an 8-bit string, so identifiers
+    // and string literals are escaped to ASCII rather than doubling the size
+    // of every module that contains one non-ASCII character; only the text the
+    // program can observe verbatim widens the output to UTF-16 (see
+    // `WriterContext`).
     EsmAscii,
 }
 
@@ -7471,12 +7668,13 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     let _ = writer.reserve(source.contents().len() as u64);
 
     let mut opts = opts;
-    let source_map_builder = get_source_map_builder::<ASCII_ONLY>(
+    let mut source_map_builder = get_source_map_builder::<ASCII_ONLY>(
         GenerateSourceMap::lazy_if(GENERATE_SOURCE_MAP),
         &mut opts,
         source,
         tree,
     );
+    source_map_builder.output_encoding = writer.output_encoding();
     let mut printer = PrinterType::<W, ASCII_ONLY, GENERATE_SOURCE_MAP>::init(
         writer,
         bump,
@@ -7565,6 +7763,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         // SAFETY: caller guarantees the cache outlives the print call.
         unsafe { &mut *cache.as_ptr() }.put(
             printer.writer.slice(),
+            printer.writer.output_encoding(),
             source_maps_chunk
                 .as_ref()
                 .map(|c| c.buffer.list.as_slice())
@@ -7715,12 +7914,13 @@ pub(crate) fn print_with_writer_and_platform<
         Printer<'a, W, /*ASCII_ONLY=*/ B, B, false, G>;
     let module_type = opts.module_type;
     let mut opts = opts;
-    let source_map_builder = get_source_map_builder::<IS_BUN_PLATFORM>(
+    let mut source_map_builder = get_source_map_builder::<IS_BUN_PLATFORM>(
         GenerateSourceMap::eager_if(GENERATE_SOURCE_MAPS),
         &mut opts,
         source,
         ast,
     );
+    source_map_builder.output_encoding = writer.output_encoding();
     let mut printer = PrinterType::<W, IS_BUN_PLATFORM, GENERATE_SOURCE_MAPS>::init(
         writer,
         bump,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7198,6 +7198,13 @@ impl BufferWriter {
         Ok(bytes.len())
     }
 
+    /// Ill-formed bytes are decoded by the same `CodepointIterator` the lexer
+    /// builds string literal values with, so verbatim text comes out exactly as
+    /// a string literal written with the same bytes would (#38262 changes that
+    /// shared decode to U+FFFD replacement and this path follows it). A UTF-8
+    /// writer copies the bytes instead, and whoever later reads that file
+    /// decodes them with replacement, so a WTF-8 encoded lone surrogate
+    /// survives only in this path.
     pub fn write_verbatim_utf8(&mut self, text: &[u8]) -> crate::Result<usize> {
         if self.encoding == OutputEncoding::Utf8 {
             return self.write_all(text);
@@ -7238,8 +7245,8 @@ impl BufferWriter {
         Ok(1)
     }
 
-    /// `c` is above U+00FF (a lone surrogate decoded from WTF-8 stays a single
-    /// unit, like the `\uD800` escape it used to be printed as).
+    /// `c` is above U+00FF; a lone surrogate is written as the single unit it
+    /// decoded to (see [`Self::write_verbatim_utf8`]).
     fn write_wide_char(&mut self, c: u32) -> crate::Result<usize> {
         if self.encoding == OutputEncoding::Latin1 {
             self.widen_to_utf16()?;

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1130,7 +1130,7 @@ impl AsyncModule {
         // SAFETY: thread-local owns the leaked Box; only this thread touches it.
         let mut printer = core::mem::replace(
             unsafe { printer_ptr.as_mut() },
-            bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init()),
+            bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init_latin1()),
         );
         printer.ctx.reset();
         // The writeback must fire at fn exit,
@@ -1146,7 +1146,9 @@ impl AsyncModule {
                 unsafe {
                     *dst = core::mem::replace(
                         &mut *src,
-                        bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init()),
+                        bun_js_printer::BufferPrinter::init(
+                            bun_js_printer::BufferWriter::init_latin1(),
+                        ),
                     )
                 };
             });
@@ -1178,11 +1180,11 @@ impl AsyncModule {
         // `cfg(feature = "dump_source")` gate referenced a feature that doesn't
         // exist, which silently compiled this call out everywhere.
         if bun_core::env::DUMP_SOURCE {
-            crate::runtime_transpiler_store::dump_source_string(
+            crate::runtime_transpiler_store::dump_source(
                 // SAFETY: `jsc_vm` is the live per-thread `VirtualMachine` (BACKREF, non-null).
                 unsafe { core::ptr::NonNull::new_unchecked(jsc_vm) },
                 specifier,
-                printer.ctx.get_written(),
+                &printer,
             );
         }
 
@@ -1196,6 +1198,7 @@ impl AsyncModule {
             let mut resolved_source = unsafe {
                 (*jsc_vm).ref_counted_resolved_source(
                     printer.ctx.get_written(),
+                    printer.ctx.output_encoding(),
                     &BunString::from_bytes(specifier),
                     path.text,
                     None,
@@ -1208,7 +1211,7 @@ impl AsyncModule {
         }
 
         Ok(ResolvedSource {
-            source_code: BunString::clone_latin1(printer.ctx.get_written()),
+            source_code: printer.ctx.clone_written_as_string(),
             source_url: BunString::from_bytes(path.text),
             is_commonjs_module,
             ..Default::default()

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -1,6 +1,7 @@
 use core::ptr::NonNull;
 
 use bun_core::String as BunString;
+use bun_core::strings::EncodingNonAscii;
 use bun_options_types::Format;
 
 bun_opaque::opaque_ffi! {
@@ -36,6 +37,31 @@ impl EncoderStringTable {
     }
 }
 
+/// How the generators read `input_code`; the C++ side of the enum is in
+/// ZigSourceProvider.cpp and the two must stay in step. JSC only accepts
+/// bytecode generated from a string equal to the one the module loader builds,
+/// so the generator has to decode the bytes the same way the load path for
+/// that kind of source does: bundler output on disk is UTF-8, while the
+/// runtime printer's buffer is already in its final width (see
+/// `bun_js_printer::BufferWriter::init_latin1`).
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum BytecodeSourceEncoding {
+    Utf8 = 0,
+    Latin1 = 1,
+    Utf16 = 2,
+}
+
+impl From<EncodingNonAscii> for BytecodeSourceEncoding {
+    fn from(encoding: EncodingNonAscii) -> Self {
+        match encoding {
+            EncodingNonAscii::Utf8 => Self::Utf8,
+            EncodingNonAscii::Latin1 => Self::Latin1,
+            EncodingNonAscii::Utf16 => Self::Utf16,
+        }
+    }
+}
+
 unsafe extern "C" {
     fn Bun__EncoderStringTable__create() -> *mut EncoderStringTable;
     fn Bun__EncoderStringTable__destroy(this: *mut EncoderStringTable);
@@ -49,6 +75,7 @@ unsafe extern "C" {
         source_provider_url: &BunString,
         input_code: *const u8,
         input_source_code_size: usize,
+        input_encoding: BytecodeSourceEncoding,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
         cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
@@ -59,6 +86,7 @@ unsafe extern "C" {
         source_provider_url: &BunString,
         input_code: *const u8,
         input_source_code_size: usize,
+        input_encoding: BytecodeSourceEncoding,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
         cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
@@ -90,6 +118,7 @@ impl CachedBytecode {
     pub(crate) fn generate(
         format: Format,
         input: &[u8],
+        input_encoding: EncodingNonAscii,
         source_provider_url: &BunString,
         external_strings: Option<NonNull<EncoderStringTable>>,
     ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
@@ -107,6 +136,7 @@ impl CachedBytecode {
                 source_provider_url,
                 input.as_ptr(),
                 input.len(),
+                BytecodeSourceEncoding::from(input_encoding),
                 &raw mut out_ptr,
                 &raw mut out_size,
                 &raw mut this,
@@ -145,13 +175,19 @@ impl bun_alloc::Allocator for CachedBytecode {}
 pub(crate) fn __bun_jsc_generate_cached_bytecode(
     format: Format,
     source: &[u8],
+    source_encoding: EncodingNonAscii,
     source_provider_url: &BunString,
     external_strings: Option<NonNull<EncoderStringTable>>,
 ) -> Option<Box<[u8]>> {
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(crate::InitializeOptions::default());
-    let (bytes, handle) =
-        CachedBytecode::generate(format, source, source_provider_url, external_strings)?;
+    let (bytes, handle) = CachedBytecode::generate(
+        format,
+        source,
+        source_encoding,
+        source_provider_url,
+        external_strings,
+    )?;
     let owned = Box::<[u8]>::from(bytes);
     // `handle` was just produced by C++ and is valid until deref;
     // `CachedBytecode` is an opaque ZST handle so `opaque_mut` is the

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -8,6 +8,7 @@ use bstr::ByteSlice;
 use bun_boringssl::c as boring;
 use bun_collections::{HashMap, IdentityContext};
 use bun_core::String as BunString;
+use bun_core::strings::EncodingNonAscii;
 use bun_core::{Mutex, ZStr, env_var};
 use bun_options_types::Format;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
@@ -53,6 +54,9 @@ struct Entry {
     /// Post-transpile text; `None` when the module never transpiled
     /// successfully (parse error) — mirrors Node's "not initialized" state.
     code: Option<Box<[u8]>>,
+    /// Width of `code` (the printer's buffer, Latin-1 or UTF-16), which the
+    /// bytecode generator must decode the same way the loader did.
+    code_encoding: EncodingNonAscii,
     /// Deserialized bytecode blob handed to JSC (the cache was accepted).
     /// Kept alive for the process — `ZigSourceProvider` wraps it, no copy.
     blob: Option<AlignedBlob>,
@@ -546,11 +550,14 @@ pub fn get_dir() -> Option<Vec<u8>> {
 
 /// Module-fetch hook: register/refresh the entry for `filename`; returns the
 /// validated bytecode blob when the on-disk cache matches `code` (post-
-/// transpile text). The pointer stays valid for the process (entry map owns it).
+/// transpile text, in the width given by `code_encoding`; a transpiler cache
+/// hit hands over the same bytes the print path did, so both hash alike). The
+/// pointer stays valid for the process (entry map owns it).
 pub fn fetch(
     filename: &[u8],
     is_cjs: bool,
     code: &[u8],
+    code_encoding: EncodingNonAscii,
 ) -> Option<crate::resolved_source::Bytecode> {
     if !is_enabled() || filename.is_empty() || !bun_paths::is_absolute(filename) {
         return None;
@@ -580,6 +587,7 @@ pub fn fetch(
         code_hash,
         code_size,
         code: None,
+        code_encoding,
         blob: None,
         persisted: false,
     };
@@ -633,6 +641,7 @@ pub fn note_parse_failure(filename: &[u8], is_cjs: bool) {
         code_hash: [0u8; HASH_SIZE],
         code_size: 0,
         code: None,
+        code_encoding: EncodingNonAscii::Latin1,
         blob: None,
         persisted: false,
     };
@@ -886,11 +895,17 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
 struct GenJob {
     format: Format,
     code: Box<[u8]>,
+    code_encoding: EncodingNonAscii,
     url: Box<[u8]>,
     resp: std::sync::mpsc::SyncSender<Option<Box<[u8]>>>,
 }
 
-fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]>> {
+fn generate_bytecode(
+    format: Format,
+    code: &[u8],
+    code_encoding: EncodingNonAscii,
+    url: &[u8],
+) -> Option<Box<[u8]>> {
     use std::sync::mpsc;
     static WORKER: Mutex<Option<mpsc::Sender<GenJob>>> = Mutex::new(None);
 
@@ -907,7 +922,11 @@ fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]
                     for job in rx {
                         let url = BunString::clone_utf8(&job.url);
                         let result = crate::cached_bytecode::__bun_jsc_generate_cached_bytecode(
-                            job.format, &job.code, &url, None,
+                            job.format,
+                            &job.code,
+                            job.code_encoding,
+                            &url,
+                            None,
                         );
                         let _ = job.resp.send(result);
                     }
@@ -922,6 +941,7 @@ fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]
             .send(GenJob {
                 format,
                 code: code.into(),
+                code_encoding,
                 url: url.into(),
                 resp: resp_tx,
             })
@@ -940,6 +960,7 @@ struct PersistJob {
     key: u64,
     format: Format,
     code: Box<[u8]>,
+    code_encoding: EncodingNonAscii,
     filename: Box<[u8]>,
     is_cjs: bool,
     code_size: u32,
@@ -983,6 +1004,7 @@ fn collect_persist_jobs(state: &mut CacheState) -> Vec<PersistJob> {
                 Format::Esm
             },
             code,
+            code_encoding: entry.code_encoding,
             filename: entry.filename.clone(),
             is_cjs: entry.is_cjs,
             code_size: entry.code_size,
@@ -1108,7 +1130,7 @@ fn persist_pass() {
     // Phase 2: generate bytecode, unlocked.
     let mut generated: Vec<(PersistJob, Option<Box<[u8]>>)> = Vec::with_capacity(jobs.len());
     for job in jobs {
-        let blob = generate_bytecode(job.format, &job.code, &job.filename);
+        let blob = generate_bytecode(job.format, &job.code, job.code_encoding, &job.filename);
         if blob.is_none() {
             cclog!(
                 "[compile cache] generating cache for {} {} failed, skipping\n",

--- a/src/jsc/RefString.rs
+++ b/src/jsc/RefString.rs
@@ -19,9 +19,16 @@ pub type Map =
 
 pub type Callback = unsafe fn(ctx: *mut c_void, str: *mut RefString);
 
+/// The interned text, owned, in the width the external string reads it in.
+pub(crate) enum Buffer {
+    /// 8-bit characters; a `Box<[u8]>` of `len`.
+    Latin1 { ptr: *const u8, len: usize },
+    /// Native-endian code units; a `Box<[u16]>` of `len`, so they are aligned.
+    Utf16 { ptr: *const u16, len: usize },
+}
+
 pub struct RefString {
-    pub ptr: *const u8,
-    pub(crate) len: usize,
+    pub(crate) buffer: Buffer,
     pub(crate) hash: Hash,
     // `impl` is a Rust keyword — renamed to `impl_`.
     pub(crate) impl_: WTFStringImpl,
@@ -34,8 +41,11 @@ pub struct RefString {
 }
 
 impl RefString {
-    pub(crate) fn compute_hash(input: &[u8]) -> u32 {
-        bun_hash::XxHash32::hash(0, input)
+    /// The map is keyed by this hash alone, so the width goes into the seed:
+    /// the same bytes read as 8-bit characters and as UTF-16 units are
+    /// different strings.
+    pub(crate) fn compute_hash(input: &[u8], utf16: bool) -> u32 {
+        bun_hash::XxHash32::hash(u32::from(utf16), input)
     }
 
     /// Single audited deref of the set-once `impl_` backref so `ref_` /
@@ -53,10 +63,19 @@ impl RefString {
         self.wtf_impl().r#ref();
     }
 
+    /// The text as bytes; the callers that read it as text only ever intern
+    /// 8-bit strings (UTF-16 text comes back as its raw unit bytes).
     pub fn leak(&self) -> &[u8] {
-        // SAFETY: `ptr` points to a live allocation of `len` bytes for the
-        // lifetime of `self` (freed only in `destroy`).
-        unsafe { bun_core::ffi::slice(self.ptr, self.len) }
+        // SAFETY: `buffer` points to a live allocation of `len` elements for
+        // the lifetime of `self` (freed only in `destroy`).
+        unsafe {
+            match self.buffer {
+                Buffer::Latin1 { ptr, len } => bun_core::ffi::slice(ptr, len),
+                Buffer::Utf16 { ptr, len } => {
+                    bun_core::slice_as_bytes(bun_core::ffi::slice(ptr, len))
+                }
+            }
+        }
     }
 
     pub fn deref(&self) {
@@ -75,9 +94,9 @@ impl RefString {
     /// call `this` is dangling.
     pub(crate) unsafe fn destroy(this: *mut RefString) {
         // SAFETY: caller contract — `this` is the unique live pointer to a
-        // `Box<RefString>`-allocated value whose `ptr`/`len` describe a
-        // `Box<[u8]>`-allocated buffer. All raw derefs and `from_raw` calls
-        // below operate on those owned allocations.
+        // `Box<RefString>`-allocated value whose `buffer` describes a boxed
+        // slice of the matching element type. All raw derefs and `from_raw`
+        // calls below operate on those owned allocations.
         unsafe {
             if let Some(on_before_deinit) = (*this).on_before_deinit {
                 // Caller guarantees `ctx` is set
@@ -85,15 +104,20 @@ impl RefString {
                 on_before_deinit((*this).ctx.unwrap().as_ptr(), this);
             }
 
-            // `allocator.free(this.leak())` — reconstitute the owned byte slice
-            // and drop it. Build the fat `*mut [u8]` as a raw pointer (no `&mut`
-            // materialized — the WTF::StringImpl finalizer may still hold a
-            // shared view at this instant, so forming `&mut [u8]` would assert
-            // exclusivity we cannot prove).
-            drop(bun_core::heap::take(core::ptr::slice_from_raw_parts_mut(
-                (*this).ptr.cast_mut(),
-                (*this).len,
-            )));
+            // `allocator.free(this.leak())` — reconstitute the owned slice, in
+            // the element type it was allocated with, and drop it. Build the
+            // fat pointer as a raw pointer (no `&mut` materialized — the
+            // WTF::StringImpl finalizer may still hold a shared view at this
+            // instant, so forming `&mut [_]` would assert exclusivity we cannot
+            // prove).
+            match (*this).buffer {
+                Buffer::Latin1 { ptr, len } => drop(bun_core::heap::take(
+                    core::ptr::slice_from_raw_parts_mut(ptr.cast_mut(), len),
+                )),
+                Buffer::Utf16 { ptr, len } => drop(bun_core::heap::take(
+                    core::ptr::slice_from_raw_parts_mut(ptr.cast_mut(), len),
+                )),
+            }
             // `allocator.destroy(this)`
             drop(bun_core::heap::take(this));
         }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_ast::ExportsKind;
 use bun_ast::Source;
+use bun_core::strings::EncodingNonAscii;
 use bun_core::{FeatureFlags, env_var};
 use bun_core::{String as BunString, ZStr};
 use bun_js_parser::ParserOptions;
@@ -51,7 +52,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: Regex literals, raw template text and preserved comments are no
+/// longer escaped; output is stored in the width the printer produced (LATIN1
+/// with characters above 0x7F, or UTF16), and the UTF8 tag is no longer read.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -86,7 +90,8 @@ pub struct Encoding(u8);
 
 impl Encoding {
     pub(crate) const NONE: Encoding = Encoding(0);
-    pub(crate) const UTF8: Encoding = Encoding(1);
+    // 1 tagged UTF-8 output before version 26; output is now stored in the
+    // width the printer produced, which is one of the two below.
     pub(crate) const UTF16: Encoding = Encoding(2);
     pub(crate) const LATIN1: Encoding = Encoding(3);
 }
@@ -140,6 +145,17 @@ impl Default for Metadata {
 }
 
 impl Metadata {
+    /// The width the entry's output is stored and loaded in (`decode` rejects
+    /// every tag other than these two).
+    pub fn output_width(&self) -> EncodingNonAscii {
+        if self.output_encoding == Encoding::UTF16 {
+            EncodingNonAscii::Utf16
+        } else {
+            debug_assert!(self.output_encoding == Encoding::LATIN1);
+            EncodingNonAscii::Latin1
+        }
+    }
+
     // 1×u32 + 2×u8 (enum reprs) + 12×u64 = 4 + 2 + 96 = 102
     pub(crate) const SIZE: usize = 4 + 1 + 1 + 12 * 8;
 
@@ -210,7 +226,7 @@ impl Metadata {
 
         self.output_encoding = Encoding(output_encoding_raw);
         match self.output_encoding {
-            Encoding::UTF8 | Encoding::UTF16 | Encoding::LATIN1 => {}
+            Encoding::UTF16 | Encoding::LATIN1 => {}
             // Invalid encoding
             _ => return Err(crate::CrateError::UnknownEncoding),
         }
@@ -226,6 +242,9 @@ const _: () = assert!(Metadata::SIZE == 4 + 1 + 1 + 12 * 8);
 #[derive(Default)]
 pub struct Entry {
     pub metadata: Metadata,
+    /// The transpiled module in the width the printer produced it: an 8-bit
+    /// string for a `LATIN1` entry, a 16-bit one for a `UTF16` entry. Empty
+    /// until `load` fills it in.
     pub output_code: BunString,
     pub sourcemap: Box<[u8]>,
     pub esm_record: Box<[u8]>,
@@ -240,7 +259,8 @@ impl Entry {
         features_hash: u64,
         sourcemap: &[u8],
         esm_record: &[u8],
-        output_code: &BunString,
+        output_bytes: &[u8],
+        output_encoding: Encoding,
         exports_kind: ExportsKind,
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.save");
@@ -255,8 +275,6 @@ impl Entry {
         // Reborrow shared: `Tmpfile::create` wants `&ZStr`, and we still need
         // it for the errdefer `unlinkat` below.
         let tmpfilename: &ZStr = &*tmpfilename;
-
-        let output_bytes = output_code.byte_slice();
 
         // First we open the tmpfile, to avoid any other work in the event of failure.
         let mut tmpfile = sys::Tmpfile::create(destination_dir, tmpfilename)?;
@@ -278,13 +296,7 @@ impl Entry {
                         ExportsKind::Cjs => ModuleType::Cjs,
                         _ => ModuleType::Esm,
                     },
-                    output_encoding: if output_code.is_utf16() {
-                        Encoding::UTF16
-                    } else if output_code.is_utf8() {
-                        Encoding::UTF8
-                    } else {
-                        Encoding::LATIN1
-                    },
+                    output_encoding,
                     sourcemap_byte_length: sourcemap.len() as u64,
                     output_byte_offset: Metadata::SIZE as u64,
                     output_byte_length: output_bytes.len() as u64,
@@ -400,51 +412,6 @@ impl Entry {
             BunString::EMPTY
         } else {
             match self.metadata.output_encoding {
-                Encoding::UTF8 => {
-                    // PERF: a per-call arena (`output_code_allocator`) here
-                    // would let the ~1.2 MB scratch buffer
-                    // be bump-freed with the parse arena. Instead this
-                    // `pread_box`'s into a `Box<[u8]>`
-                    // on the worker thread's mimalloc heap, which — even after
-                    // the consumer's `String::clone_utf8` + drop — leaves the
-                    // segment resident in that thread heap (build/create-vue
-                    // bench regression).
-                    //
-                    // Instead, pread straight into a WTF-allocated Latin-1
-                    // buffer (`WTF::StringImpl::tryCreateUninitialized` →
-                    // bmalloc, not the worker mimalloc heap). Transpiler
-                    // output is overwhelmingly pure ASCII, in which case the
-                    // buffer *is* the final `BunString` and we skip the
-                    // 1.2 MB `clone_utf8` memcpy the consumer used to do at
-                    // RuntimeTranspilerStore.rs / jsc_hooks.rs. Only if the
-                    // bytes contain non-ASCII UTF-8 do we fall back to
-                    // `clone_utf8` (transcode → UTF-16) and deref the scratch.
-                    let len = self.metadata.output_byte_length as usize;
-                    let (scratch, bytes) = BunString::create_uninitialized_latin1(len);
-                    // `(dead, &mut [])` on WTF allocation failure; `len > 0`
-                    // (handled above), so an empty slice means OOM.
-                    if bytes.is_empty() {
-                        return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
-                    }
-                    let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
-                    if read_bytes as u64 != self.metadata.output_byte_length {
-                        return Err(crate::CrateError::MissingData);
-                    }
-
-                    if self.metadata.output_hash != 0 && hash(bytes) != self.metadata.output_hash {
-                        return Err(crate::CrateError::InvalidHash);
-                    }
-
-                    if bun_core::strings::is_all_ascii(bytes) {
-                        // Fast path: ASCII ⊂ Latin-1, so `scratch` is already
-                        // the correct `BunString`.
-                        scratch
-                    } else {
-                        // Rare path: real multi-byte UTF-8. Transcode into a
-                        // fresh WTF string; the Latin-1 scratch drops.
-                        BunString::clone_utf8(bytes)
-                    }
-                }
                 Encoding::LATIN1 => {
                     let len = self.metadata.output_byte_length as usize;
                     let (latin1, bytes) = BunString::create_uninitialized_latin1(len);
@@ -772,7 +739,8 @@ impl RuntimeTranspilerCache {
         features_hash: u64,
         sourcemap: &[u8],
         esm_record: &[u8],
-        source_code: &BunString,
+        output_bytes: &[u8],
+        output_encoding: Encoding,
         exports_kind: ExportsKind,
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.toFile");
@@ -820,7 +788,8 @@ impl RuntimeTranspilerCache {
             features_hash,
             sourcemap,
             esm_record,
-            source_code,
+            output_bytes,
+            output_encoding,
             exports_kind,
         )
     }
@@ -950,24 +919,32 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             }
             hit
         },
-        put(output_code_bytes, sourcemap, esm_record) => {
+        put(output_code_bytes, output_encoding, sourcemap, esm_record) => {
             let this = &mut *this;
             if this.input_hash.is_none() || IS_DISABLED.load(Ordering::Relaxed) {
                 return;
             }
             debug_assert!(this.entry.is_none());
 
-            // Borrowed Latin-1 view: `to_file` only reads `byte_slice()` + the encoding
-            // tag (unmarked 8-bit EncodedSlice -> Encoding::LATIN1, same as clone_latin1),
-            // and `output_code_bytes` outlives the synchronous `to_file` call.
-            let output_code = BunString::ascii(output_code_bytes);
+            // The entry is tagged with the width the printer produced, which
+            // is the width `Entry::load` reads it back in.
+            let tag = match output_encoding {
+                EncodingNonAscii::Latin1 => Encoding::LATIN1,
+                EncodingNonAscii::Utf16 => Encoding::UTF16,
+                // Only the runtime's Latin-1/UTF-16 printers carry a cache.
+                EncodingNonAscii::Utf8 => {
+                    debug_assert!(false, "transpiler cache fed UTF-8 printer output");
+                    return;
+                }
+            };
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),
                 this.features_hash.unwrap(),
                 sourcemap,
                 esm_record,
-                &output_code,
+                output_code_bytes,
+                tag,
                 this.exports_kind,
             );
             if let Err(err) = result {

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -61,11 +61,21 @@ bun_core::declare_scope!(RuntimeTranspilerStore, hidden);
 // the caller's `&mut TranspilerJob` (which is stored inside
 // `vm.transpiler_store`). Only the `source_mappings` leaf field is touched,
 // under its own internal lock.
-fn dump_source(vm: NonNull<VirtualMachine>, specifier: &[u8], printer: &BufferPrinter) {
-    dump_source_string(vm, specifier, printer.ctx.get_written());
+pub(crate) fn dump_source(vm: NonNull<VirtualMachine>, specifier: &[u8], printer: &BufferPrinter) {
+    dump_source_code(vm, specifier, &printer.ctx.clone_written_as_string());
 }
 
-pub(crate) fn dump_source_string(vm: NonNull<VirtualMachine>, specifier: &[u8], written: &[u8]) {
+/// The dump is meant to be read, so the module's Latin-1 or UTF-16 text is
+/// written out as UTF-8.
+pub(crate) fn dump_source_code(
+    vm: NonNull<VirtualMachine>,
+    specifier: &[u8],
+    source_code: &String,
+) {
+    dump_source_string(vm, specifier, source_code.to_utf8().slice());
+}
+
+fn dump_source_string(vm: NonNull<VirtualMachine>, specifier: &[u8], written: &[u8]) {
     if let Err(e) = dump_source_string_failiable(vm, specifier, written) {
         bun_core::debug_warn!("Failed to dump source string: {}", e.name());
     }
@@ -951,7 +961,7 @@ impl TranspilerJob {
             if bun_core::env::DUMP_SOURCE {
                 // SAFETY: `vm` is the live owning VM (BACKREF — see `vm` note above).
                 let vm = unsafe { NonNull::new_unchecked(vm) };
-                dump_source_string(vm, specifier, entry.output_code.byte_slice());
+                dump_source_code(vm, specifier, &entry.output_code);
             }
 
             let module_info = if use_isolation_source_provider_cache
@@ -966,6 +976,7 @@ impl TranspilerJob {
             };
 
             self.resolved_source = ResolvedSource {
+                // Takes over the entry's ref.
                 source_code: core::mem::take(&mut entry.output_code),
                 is_commonjs_module: entry.metadata.module_type == CacheModuleType::Cjs,
                 module_info,
@@ -1022,7 +1033,7 @@ impl TranspilerJob {
         }
 
         let source_code_printer = tls_get_or_leak(&SOURCE_CODE_PRINTER, || {
-            let writer = BufferWriter::init();
+            let writer = BufferWriter::init_latin1();
             let mut bp = Box::new(BufferPrinter::init(writer));
             bp.ctx.append_null_byte = false;
             bp
@@ -1032,7 +1043,7 @@ impl TranspilerJob {
         // _writeback guard (the thread-local's buffer is reused).
         let mut printer = core::mem::replace(
             source_code_printer,
-            BufferPrinter::init(BufferWriter::init()),
+            BufferPrinter::init(BufferWriter::init_latin1()),
         );
         printer.ctx.reset();
 
@@ -1040,12 +1051,12 @@ impl TranspilerJob {
         const MAX_BUFFER_CAP: usize = 512 * 1024;
         if printer.ctx.buffer.list.capacity() > MAX_BUFFER_CAP {
             // printer.ctx.buffer.deinit() → Drop
-            let writer = BufferWriter::init();
+            let writer = BufferWriter::init_latin1();
             *source_code_printer = BufferPrinter::init(writer);
             source_code_printer.ctx.append_null_byte = false;
             printer = core::mem::replace(
                 source_code_printer,
-                BufferPrinter::init(BufferWriter::init()),
+                BufferPrinter::init(BufferWriter::init_latin1()),
             );
         }
 
@@ -1091,8 +1102,10 @@ impl TranspilerJob {
                 |(dst, src)| {
                     // SAFETY: both pointees outlive this scope; no aliases at drop.
                     unsafe {
-                        *dst =
-                            core::mem::replace(&mut *src, BufferPrinter::init(BufferWriter::init()))
+                        *dst = core::mem::replace(
+                            &mut *src,
+                            BufferPrinter::init(BufferWriter::init_latin1()),
+                        )
                     };
                 },
             );
@@ -1126,12 +1139,17 @@ impl TranspilerJob {
             // `cache.output_code` (only the `r#impl == None` fallback does,
             // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
             debug_assert!(cache.output_code.is_none());
-            let result = String::clone_latin1(written);
+            // Already in the width JSC wants (Latin-1, or UTF-16 if the text
+            // needed it); this is a copy, not a transcode.
+            debug_assert!(
+                source_code_printer.ctx.output_encoding() != strings::EncodingNonAscii::Utf8
+            );
+            let result = source_code_printer.ctx.clone_written_as_string();
 
             // SAFETY: leaf scalar field read on `*vm`; see `vm` note above.
             if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {
                 // printer.ctx.buffer.deinit() → Drop
-                let writer = BufferWriter::init();
+                let writer = BufferWriter::init_latin1();
                 *source_code_printer = BufferPrinter::init(writer);
                 source_code_printer.ctx.append_null_byte = false;
             }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -8,6 +8,7 @@ use core::ffi::{c_int, c_void};
 use core::ptr::NonNull;
 
 use bun_bundler::Transpiler;
+use bun_core::strings::EncodingNonAscii;
 use bun_io as Async;
 use bun_uws as uws;
 
@@ -3183,39 +3184,33 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
         // `SourceMapHandlerGetter` doc for why `printer` is not stored as `&'a mut`.
         let printer = unsafe { &mut *self.printer };
 
+        // Everything goes through the writer rather than straight into its
+        // byte buffer: the buffer may be holding UTF-16 by now, and the path is
+        // source text that may not be ASCII.
         let encode_len = bun_base64::encode_len(temp_json_buffer.list.as_slice());
         printer
             .ctx
             .buffer
             .grow_if_needed(encode_len + prefix_len + 2)?;
-        printer.ctx.buffer.append_assume_capacity(b"\n");
-        printer
-            .ctx
-            .buffer
-            .append_assume_capacity(SOURCE_MAP_URL_PREFIX_START);
+        printer.ctx.write_all(b"\n")?;
+        printer.ctx.write_all(SOURCE_MAP_URL_PREFIX_START)?;
         {
-            // `MutableString::list` is a `Vec<u8>`; write into spare capacity,
-            // then commit the written length.
-            let buf = &mut printer.ctx.buffer.list;
-            // SAFETY: `grow_if_needed` reserved ≥encode_len spare; encode writes
-            // `wrote<=encode_len` bytes.
+            let region = printer.ctx.reserve_next(encode_len as u64)?;
+            // SAFETY: `reserve_next` returned room for `encode_len` bytes, which
+            // `encode` fills (`wrote <= encode_len`) before `advance_by` commits
+            // exactly that many.
             let wrote = unsafe {
                 bun_base64::encode(
-                    &mut bun_core::vec::spare_bytes_mut(buf)[..encode_len],
+                    core::slice::from_raw_parts_mut(region, encode_len),
                     temp_json_buffer.list.as_slice(),
                 )
             };
-            // SAFETY: `wrote <= encode_len` bytes were just initialized in the
-            // spare capacity reserved by `grow_if_needed` above.
-            unsafe { bun_core::vec::commit_spare(buf, wrote) };
+            printer.ctx.advance_by(wrote as u64);
         }
-        printer
-            .ctx
-            .buffer
-            .append_assume_capacity(SOURCE_MAPPING_URL);
+        printer.ctx.write_all(SOURCE_MAPPING_URL)?;
         // TODO: do we need to %-encode the path?
-        printer.ctx.buffer.append_assume_capacity(source.path.text);
-        printer.ctx.buffer.append(b"\n")?;
+        printer.ctx.write_verbatim_utf8(source.path.text)?;
+        printer.ctx.write_all(b"\n")?;
         Ok(())
     }
 }
@@ -3357,7 +3352,7 @@ fn specifier_cache_resolver_buf() -> *mut bun_paths::PathBuffer {
 
 fn ensure_source_code_printer() {
     if SOURCE_CODE_PRINTER.get().is_none() {
-        let writer = bun_js_printer::BufferWriter::init();
+        let writer = bun_js_printer::BufferWriter::init_latin1();
         let mut printer = Box::new(bun_js_printer::BufferPrinter::init(writer));
         printer.ctx.append_null_byte = false;
         SOURCE_CODE_PRINTER.set(NonNull::new(bun_core::heap::into_raw(printer)));
@@ -4128,9 +4123,13 @@ impl VirtualMachine {
     }
 
     /// Builds a `ResolvedSource` backed by a ref-counted copy of `code` interned in the VM's ref-string map.
+    ///
+    /// `code` is the printer's buffer and `encoding` the width it ended up in;
+    /// the interned copy keeps that width, so JSC reads it in place.
     pub fn ref_counted_resolved_source(
         &mut self,
         code: &[u8],
+        encoding: EncodingNonAscii,
         specifier: &bun_core::String,
         source_url: &[u8],
         hash_: Option<u32>,
@@ -4142,7 +4141,7 @@ impl VirtualMachine {
                 ..Default::default()
             };
         }
-        let source = self.ref_counted_string::<true>(code, hash_);
+        let source = self.ref_counted_string_with_encoding::<true>(code, encoding, hash_);
         // SAFETY: `ref_counted_string` returns a live `*mut RefString` held in
         // `self.ref_strings` until JSC calls the external-string finalizer.
         let source_ref = unsafe { &*source };
@@ -4154,17 +4153,25 @@ impl VirtualMachine {
         }
     }
 
+    /// `input_` holds native-endian code units when `encoding` is `Utf16` and
+    /// 8-bit characters when it is `Latin1`.
     fn ref_counted_string_with_was_new<const DUPE: bool>(
         &mut self,
         new: &mut bool,
         input_: &[u8],
+        encoding: EncodingNonAscii,
         hash_: Option<u32>,
     ) -> *mut crate::ref_string::RefString {
-        use crate::ref_string::RefString;
+        use crate::ref_string::{Buffer, RefString};
         use bun_collections::zig_hash_map::MapEntry as Entry;
         jsc::mark_binding();
         debug_assert!(!input_.is_empty());
-        let hash = hash_.unwrap_or_else(|| RefString::compute_hash(input_));
+        debug_assert!(encoding != EncodingNonAscii::Utf8);
+        let utf16 = encoding == EncodingNonAscii::Utf16;
+        // A UTF-16 buffer is re-allocated as `[u16]` below, so it cannot adopt
+        // the caller's bytes.
+        debug_assert!(DUPE || !utf16);
+        let hash = hash_.unwrap_or_else(|| RefString::compute_hash(input_, utf16));
         // RAII guard releases on every
         // exit (including the early-return `Occupied` arm).
         let _unlock = self.ref_strings_mutex.lock_guard();
@@ -4178,18 +4185,39 @@ impl VirtualMachine {
                 *o.get()
             }
             Entry::Vacant(v) => {
-                // Dupe the input bytes when `DUPE`, otherwise
-                // adopt the caller's allocation (caller transferred ownership).
-                let (ptr, len) = if DUPE {
+                // Dupe the input when `DUPE` (as `[u16]` for a UTF-16 buffer,
+                // so the units are aligned), otherwise adopt the caller's
+                // allocation (caller transferred ownership).
+                let buffer = if utf16 {
+                    let units: Box<[u16]> = match bytemuck::try_cast_slice::<u8, u16>(input_) {
+                        Ok(units) => Box::from(units),
+                        Err(_) => input_
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|&pair| u16::from_ne_bytes(pair))
+                            .collect(),
+                    };
+                    let len = units.len();
+                    Buffer::Utf16 {
+                        ptr: bun_core::heap::into_raw(units).cast::<u16>().cast_const(),
+                        len,
+                    }
+                } else if DUPE {
                     let buf = Box::<[u8]>::from(input_);
                     let len = buf.len();
-                    (bun_core::heap::into_raw(buf).cast::<u8>().cast_const(), len)
+                    Buffer::Latin1 {
+                        ptr: bun_core::heap::into_raw(buf).cast::<u8>().cast_const(),
+                        len,
+                    }
                 } else {
-                    (input_.as_ptr(), input_.len())
+                    Buffer::Latin1 {
+                        ptr: input_.as_ptr(),
+                        len: input_.len(),
+                    }
                 };
                 let ref_ = bun_core::heap::into_raw(Box::new(RefString {
-                    ptr,
-                    len,
+                    buffer,
                     hash,
                     // Filled in just below — `create_external` needs the
                     // `*mut RefString` ctx pointer first.
@@ -4198,16 +4226,30 @@ impl VirtualMachine {
                     on_before_deinit: Some(VirtualMachine::clear_ref_string),
                 }));
                 // SAFETY: `ref_` is the unique live `*mut RefString` (just
-                // boxed); `(ptr, len)` is its owned latin-1 buffer. The
+                // boxed) and `buffer` is its owned, live allocation, so the
+                // slices below are valid for the duration of the call. The
                 // external-string finalizer (`free_ref_string`) is called by
                 // WTF on the JS thread when the impl refcount hits zero, with
                 // `ref_` as ctx.
-                let s = bun_core::String::create_external::<*mut RefString>(
-                    unsafe { bun_core::ffi::slice(ptr, len) },
-                    true,
-                    ref_,
-                    free_ref_string,
-                );
+                let s = unsafe {
+                    match (*ref_).buffer {
+                        Buffer::Utf16 { ptr, len } => {
+                            bun_core::String::create_external_utf16::<*mut RefString>(
+                                bun_core::ffi::slice(ptr, len),
+                                ref_,
+                                free_ref_string,
+                            )
+                        }
+                        Buffer::Latin1 { ptr, len } => {
+                            bun_core::String::create_external::<*mut RefString>(
+                                bun_core::ffi::slice(ptr, len),
+                                true,
+                                ref_,
+                                free_ref_string,
+                            )
+                        }
+                    }
+                };
                 // SAFETY: see above.
                 unsafe { (*ref_).impl_ = s.leak_wtf_impl() };
                 v.insert(ref_);
@@ -4217,15 +4259,27 @@ impl VirtualMachine {
         }
     }
 
-    /// Interns `input_` in the VM's ref-string map and returns the ref-counted entry.
+    /// Interns the 8-bit string `input_` in the VM's ref-string map and returns
+    /// the ref-counted entry.
     pub fn ref_counted_string<const DUPE: bool>(
         &mut self,
         input_: &[u8],
         hash_: Option<u32>,
     ) -> *mut crate::ref_string::RefString {
+        self.ref_counted_string_with_encoding::<DUPE>(input_, EncodingNonAscii::Latin1, hash_)
+    }
+
+    /// [`Self::ref_counted_string`] for a buffer of either width (see
+    /// [`Self::ref_counted_string_with_was_new`]).
+    fn ref_counted_string_with_encoding<const DUPE: bool>(
+        &mut self,
+        input_: &[u8],
+        encoding: EncodingNonAscii,
+        hash_: Option<u32>,
+    ) -> *mut crate::ref_string::RefString {
         debug_assert!(!input_.is_empty());
         let mut was_new = false;
-        self.ref_counted_string_with_was_new::<DUPE>(&mut was_new, input_, hash_)
+        self.ref_counted_string_with_was_new::<DUPE>(&mut was_new, input_, encoding, hash_)
     }
 
     // Note: `flags` is a runtime arg —

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3162,11 +3162,6 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
             .map_err(|_| bun_js_printer::Error::WriteFailed)?;
         const SOURCE_MAP_URL_PREFIX_START: &[u8] =
             b"//# sourceMappingURL=data:application/json;base64,";
-        // TODO: do we need to %-encode the path?
-        let source_url_len = source.path.text.len();
-        const SOURCE_MAPPING_URL: &[u8] = b"\n//# sourceURL=";
-        let prefix_len =
-            SOURCE_MAP_URL_PREFIX_START.len() + SOURCE_MAPPING_URL.len() + source_url_len;
 
         self.vm_source_mappings_mut()
             .put_mappings(source, chunk.buffer)
@@ -3184,14 +3179,10 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
         // `SourceMapHandlerGetter` doc for why `printer` is not stored as `&'a mut`.
         let printer = unsafe { &mut *self.printer };
 
-        // Everything goes through the writer rather than straight into its
-        // byte buffer: the buffer may be holding UTF-16 by now, and the path is
-        // source text that may not be ASCII.
+        // Appended through the writer rather than straight into its byte
+        // buffer, since the buffer may be holding UTF-16 by now. The module's
+        // URL is the provider's; no `//# sourceURL=` directive is needed.
         let encode_len = bun_base64::encode_len(temp_json_buffer.list.as_slice());
-        printer
-            .ctx
-            .buffer
-            .grow_if_needed(encode_len + prefix_len + 2)?;
         printer.ctx.write_all(b"\n")?;
         printer.ctx.write_all(SOURCE_MAP_URL_PREFIX_START)?;
         {
@@ -3207,9 +3198,6 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
             };
             printer.ctx.advance_by(wrote as u64);
         }
-        printer.ctx.write_all(SOURCE_MAPPING_URL)?;
-        // TODO: do we need to %-encode the path?
-        printer.ctx.write_verbatim_utf8(source.path.text)?;
         printer.ctx.write_all(b"\n")?;
         Ok(())
     }

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -205,10 +205,49 @@ extern "C" void Bun__DecoderStringTable__install(JSC::VM* vm, const uint8_t* byt
     static_cast<WebCore::JSVMClientData*>(vm->clientData)->setDecoderStringTable(std::span<const uint8_t>(bytes, len));
 }
 
-extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+// Mirrors `BytecodeSourceEncoding` in CachedBytecode.rs.
+enum class BytecodeSourceEncoding : uint8_t {
+    // Bytes written to disk by the bundler (`--bytecode`, `--compile`); the
+    // loader reads them back with `String::clone_utf8` -> `BunString__fromBytes`.
+    Utf8 = 0,
+    // The runtime printer's buffer, which the loader hands to JSC as-is
+    // (NODE_COMPILE_CACHE): one Latin-1 character per byte ...
+    Latin1 = 1,
+    // ... or native-endian UTF-16 code units, two bytes each.
+    Utf16 = 2,
+};
+
+// JSC accepts the bytecode only if the string it was generated from equals the
+// string the module loader later creates, so each encoding is decoded exactly the
+// way the corresponding load path decodes it.
+static WTF::String sourceCodeStringForBytecode(const uint8_t* inputSourceCode, size_t inputSourceCodeSize, BytecodeSourceEncoding encoding)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    if (inputSourceCodeSize == 0)
+        return WTF::emptyString();
+    switch (encoding) {
+    case BytecodeSourceEncoding::Utf8:
+        return Zig::convertUTF8ToString(std::span { inputSourceCode, inputSourceCodeSize });
+    case BytecodeSourceEncoding::Latin1:
+        return WTF::String(std::span { reinterpret_cast<const Latin1Character*>(inputSourceCode), inputSourceCodeSize });
+    case BytecodeSourceEncoding::Utf16: {
+        // The bytes arrive in a byte buffer, so copy rather than alias them as char16_t.
+        std::span<char16_t> units;
+        auto impl = WTF::StringImpl::tryCreateUninitialized(inputSourceCodeSize / 2, units);
+        if (!impl)
+            return WTF::String();
+        memcpy(units.data(), inputSourceCode, units.size_bytes());
+        return WTF::String(WTF::move(impl));
+    }
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sourceProviderURL, const uint8_t* inputSourceCode, size_t inputSourceCodeSize, BytecodeSourceEncoding inputEncoding, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+{
+    WTF::String source = sourceCodeStringForBytecode(inputSourceCode, inputSourceCodeSize, inputEncoding);
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
     JSC::VM& vm = vmForBytecodeCache();
 
@@ -240,11 +279,12 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(const BunString* sour
     return true;
 }
 
-extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(const BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
+extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(const BunString* sourceProviderURL, const uint8_t* inputSourceCode, size_t inputSourceCodeSize, BytecodeSourceEncoding inputEncoding, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr, JSC::EncoderStringTable* externalStrings)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    WTF::String source = sourceCodeStringForBytecode(inputSourceCode, inputSourceCodeSize, inputEncoding);
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
     JSC::VM& vm = vmForBytecodeCache();
 
     JSC::JSLockHolder locker(vm);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -17,6 +17,7 @@
 //!      `__bun_http_sync_download_*` — low-tier extern impls.
 
 use bun_core::WTFStringImplExt as _;
+use bun_core::strings::EncodingNonAscii;
 use bun_options_types::LoaderExt as _;
 use core::cell::Cell;
 use core::ffi::c_void;
@@ -2928,18 +2929,18 @@ fn transpile_source_code_inner(
                         None
                     };
                     let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
-                    // Node compile cache hook (transpiler-cache-hit path); must
-                    // read `output_code` before it is consumed below. UTF-16
-                    // output would hash differently than the print path — skip.
+                    // Node compile cache hook (transpiler-cache-hit path). The
+                    // entry holds the printer's buffer in its original width,
+                    // so its bytes hash exactly as they did on the print path.
                     let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
                         && source.path.is_file()
                         && loader.is_java_script_like()
-                        && !entry.output_code.is_utf16()
                     {
                         bun_jsc::node_compile_cache::fetch(
                             source.path.text,
                             is_commonjs_module,
                             entry.output_code.byte_slice(),
+                            entry.metadata.output_width(),
                         )
                     } else {
                         None
@@ -3171,11 +3172,17 @@ fn transpile_source_code_inner(
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
                     let written = printer.ctx.get_written();
+                    let encoding = printer.ctx.output_encoding();
                     let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
                         && path.is_file()
                         && loader.is_java_script_like()
                     {
-                        bun_jsc::node_compile_cache::fetch(path.text, is_commonjs_module, written)
+                        bun_jsc::node_compile_cache::fetch(
+                            path.text,
+                            is_commonjs_module,
+                            written,
+                            encoding,
+                        )
                     } else {
                         None
                     };
@@ -3184,6 +3191,7 @@ fn transpile_source_code_inner(
                     let mut resolved_source = unsafe {
                         (*jsc_vm).ref_counted_resolved_source(
                             written,
+                            encoding,
                             input_specifier,
                             path.text,
                             None,
@@ -3252,13 +3260,19 @@ fn transpile_source_code_inner(
                 let printer: &mut bun_js_printer::BufferPrinter =
                     unsafe { &mut *(*extra).source_code_printer };
                 let written = printer.ctx.get_written();
+                let encoding = printer.ctx.output_encoding();
                 // Node compile cache hook (sync transpile path). `fetch` copies
                 // `written`; the printer may be replaced below.
                 let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
                     && path.is_file()
                     && loader.is_java_script_like()
                 {
-                    bun_jsc::node_compile_cache::fetch(path.text, is_commonjs_module, written)
+                    bun_jsc::node_compile_cache::fetch(
+                        path.text,
+                        is_commonjs_module,
+                        written,
+                        encoding,
+                    )
                 } else {
                     None
                 };
@@ -3268,15 +3282,18 @@ fn transpile_source_code_inner(
                 // `None`.
                 debug_assert!(cache.output_code.is_none());
                 let written_len = written.len();
-                let source_code = bun_core::String::clone_latin1(written);
+                // Already in the width JSC wants; a copy, not a transcode.
+                debug_assert!(encoding != EncodingNonAscii::Utf8);
+                let source_code = printer.ctx.clone_written_as_string();
                 // `printer.ctx.buffer.deinit()`: release the
                 // large/--smol print buffer now instead of holding it until the
                 // next transpile. Replacing the printer drops the old buffer
                 // (same shape as RuntimeTranspilerStore).
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
                 if written_len > 1024 * 1024 * 2 || unsafe { &*jsc_vm }.smol {
-                    *printer =
-                        bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init());
+                    *printer = bun_js_printer::BufferPrinter::init(
+                        bun_js_printer::BufferWriter::init_latin1(),
+                    );
                     printer.ctx.append_null_byte = false;
                 }
 
@@ -4414,7 +4431,7 @@ pub unsafe extern "C" fn Bun__transpileFile(
     let printer_ptr: *mut bun_js_printer::BufferPrinter = TRANSPILE_PRINTER.with(|cell| {
         let mut p = cell.get();
         if p.is_null() {
-            let writer = bun_js_printer::BufferWriter::init();
+            let writer = bun_js_printer::BufferWriter::init_latin1();
             let mut bp = Box::new(bun_js_printer::BufferPrinter::init(writer));
             bp.ctx.append_null_byte = false;
             p = bun_core::heap::into_raw(bp);
@@ -4565,7 +4582,7 @@ pub extern "C" fn Bun__transpileVirtualModule(
     let printer_ptr: *mut bun_js_printer::BufferPrinter = TRANSPILE_PRINTER.with(|cell| {
         let mut p = cell.get();
         if p.is_null() {
-            let writer = bun_js_printer::BufferWriter::init();
+            let writer = bun_js_printer::BufferWriter::init_latin1();
             let mut bp = Box::new(bun_js_printer::BufferPrinter::init(writer));
             bp.ctx.append_null_byte = false;
             p = bun_core::heap::into_raw(bp);

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -1,4 +1,5 @@
 use bun_ast::{Loc, Source};
+use bun_core::strings::EncodingNonAscii;
 use bun_core::{MutableString, strings};
 use bun_paths::{PathBuffer, fs::FileSystem};
 use bun_ptr::RawSlice;
@@ -384,6 +385,11 @@ pub struct NewBuilder<'a, T: SourceMapFormatCtx> {
 
     /// When generating sourcemappings for bun, we store a count of how many mappings there were
     pub prepend_count: bool,
+
+    /// How the printer's output buffer (the `output` passed to every method
+    /// here) is encoded. `last_generated_update` is a byte offset into it in
+    /// every case; generated columns are UTF-16 code units in every case.
+    pub output_encoding: EncodingNonAscii,
 }
 
 impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<'_, T> {
@@ -404,6 +410,7 @@ impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<'_, T> {
             cover_lines_without_mappings: false,
             approximate_input_line_count: 0,
             prepend_count: false,
+            output_encoding: EncodingNonAscii::Utf8,
         }
     }
 }
@@ -456,9 +463,33 @@ impl Drop for OwnedLineOffsetTables {
 // and lives once in this crate, adjacent to `flush_window`. The concrete
 // (non-generic) impl is what pins one copy per CGU.
 impl NewBuilder<'_, VLQSourceMap> {
+    /// The printer's buffer, which held one Latin-1 character per byte so far,
+    /// has just been widened in place to UTF-16 code units (two bytes each).
+    /// The caller consumed everything written before the widening with
+    /// [`Self::update_generated`] first, so the only thing to carry over is the
+    /// byte offset of that point.
+    pub fn output_widened_to_utf16(&mut self) {
+        debug_assert!(self.output_encoding == EncodingNonAscii::Latin1);
+        self.output_encoding = EncodingNonAscii::Utf16;
+        self.last_generated_update *= 2;
+    }
+
+    /// Consume the output written since the previous call, advancing the
+    /// generated line and column. `Utf8` and `Latin1` buffers share the byte
+    /// version (whose ASCII window fast path still inlines here); a widened
+    /// buffer takes the code unit version.
+    #[inline]
+    pub fn update_generated(&mut self, output: &[u8]) {
+        if self.output_encoding == EncodingNonAscii::Utf16 {
+            self.update_generated_utf16_slow(output);
+        } else {
+            self.update_generated_line_and_column(output);
+        }
+    }
+
     #[inline(never)]
     pub fn generate_chunk(&mut self, output: &[u8]) -> Chunk {
-        self.update_generated_line_and_column(output);
+        self.update_generated(output);
         // Capture scalars before borrowing `source_map` mutably via
         // `get_buffer`, to satisfy the borrow checker.
         if self.prepend_count {
@@ -525,20 +556,27 @@ impl NewBuilder<'_, VLQSourceMap> {
             && !self.line_starts_with_mapping
             && self.has_prev_state;
 
+        let latin1 = self.output_encoding == EncodingNonAscii::Latin1;
         let mut i: usize = 0;
         let n: usize = slice.len();
         let mut c: i32;
         while i < n {
-            let len = strings::wtf8_byte_sequence_length_with_invalid(slice[i]);
-            let mut cp_bytes = [0u8; 4];
-            let take = (len as usize).min(n - i);
-            cp_bytes[..take].copy_from_slice(&slice[i..i + take]);
-            c = strings::decode_wtf8_rune_t::<i32>(
-                cp_bytes,
-                len,
-                strings::UNICODE_REPLACEMENT as i32,
-            );
-            i += len as usize;
+            if latin1 {
+                // One character per byte; nothing above U+00FF can be present.
+                c = slice[i] as i32;
+                i += 1;
+            } else {
+                let len = strings::wtf8_byte_sequence_length_with_invalid(slice[i]);
+                let mut cp_bytes = [0u8; 4];
+                let take = (len as usize).min(n - i);
+                cp_bytes[..take].copy_from_slice(&slice[i..i + take]);
+                c = strings::decode_wtf8_rune_t::<i32>(
+                    cp_bytes,
+                    len,
+                    strings::UNICODE_REPLACEMENT as i32,
+                );
+                i += len as usize;
+            }
 
             match c {
                 14..=127 => {
@@ -570,31 +608,7 @@ impl NewBuilder<'_, VLQSourceMap> {
                         }
                     }
 
-                    // If we're about to move to the next line and the previous line didn't have
-                    // any mappings, add a mapping at the start of the previous line.
-                    if needs_mapping {
-                        self.append_mapping_without_remapping(SourceMapState {
-                            generated_line: self.prev_state.generated_line,
-                            generated_column: 0,
-                            source_index: self.prev_state.source_index,
-                            original_line: self.prev_state.original_line,
-                            original_column: self.prev_state.original_column,
-                        });
-                    }
-
-                    self.prev_state.generated_line += 1;
-                    self.prev_state.generated_column = 0;
-                    self.generated_column = 0;
-                    self.source_map
-                        .append_line_separator()
-                        .expect("unreachable");
-
-                    // This new line doesn't have a mapping yet
-                    self.line_starts_with_mapping = false;
-
-                    needs_mapping = self.cover_lines_without_mappings
-                        && !self.line_starts_with_mapping
-                        && self.has_prev_state;
+                    self.begin_generated_line(&mut needs_mapping);
                 }
 
                 _ => {
@@ -605,6 +619,71 @@ impl NewBuilder<'_, VLQSourceMap> {
         }
 
         self.last_generated_update = output.len() as u32;
+    }
+
+    /// [`Self::update_generated_line_and_column`] for a buffer of native-endian
+    /// UTF-16 code units. Every unit, surrogates included, is one column, which
+    /// is what the byte version arrives at too. Only modules whose text did
+    /// not fit in Latin-1 get here, so there is no fast path.
+    #[inline(never)]
+    #[cold]
+    fn update_generated_utf16_slow(&mut self, output: &[u8]) {
+        let slice = &output[self.last_generated_update as usize..];
+        debug_assert!(slice.len().is_multiple_of(2));
+
+        let mut needs_mapping = self.cover_lines_without_mappings
+            && !self.line_starts_with_mapping
+            && self.has_prev_state;
+
+        let mut units = slice
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|&pair| u16::from_ne_bytes(pair))
+            .peekable();
+        while let Some(unit) = units.next() {
+            match unit {
+                0x0D | 0x0A | 0x2028 | 0x2029 => {
+                    // windows newline
+                    if unit == 0x0D && units.peek() == Some(&0x0A) {
+                        continue;
+                    }
+                    self.begin_generated_line(&mut needs_mapping);
+                }
+                _ => self.generated_column += 1,
+            }
+        }
+
+        self.last_generated_update = output.len() as u32;
+    }
+
+    /// The output just crossed a line break.
+    fn begin_generated_line(&mut self, needs_mapping: &mut bool) {
+        // If we're about to move to the next line and the previous line didn't have
+        // any mappings, add a mapping at the start of the previous line.
+        if *needs_mapping {
+            self.append_mapping_without_remapping(SourceMapState {
+                generated_line: self.prev_state.generated_line,
+                generated_column: 0,
+                source_index: self.prev_state.source_index,
+                original_line: self.prev_state.original_line,
+                original_column: self.prev_state.original_column,
+            });
+        }
+
+        self.prev_state.generated_line += 1;
+        self.prev_state.generated_column = 0;
+        self.generated_column = 0;
+        self.source_map
+            .append_line_separator()
+            .expect("unreachable");
+
+        // This new line doesn't have a mapping yet
+        self.line_starts_with_mapping = false;
+
+        *needs_mapping = self.cover_lines_without_mappings
+            && !self.line_starts_with_mapping
+            && self.has_prev_state;
     }
 
     #[inline(always)]
@@ -698,7 +777,7 @@ impl NewBuilder<'_, VLQSourceMap> {
             }
         }
 
-        self.update_generated_line_and_column(output);
+        self.update_generated(output);
 
         // If this line doesn't start with a mapping and we're about to add a mapping
         // that's not at the start, insert a mapping first so the line starts with one.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1321,10 +1321,12 @@ pub(crate) fn to_bytes(
             loader: output_file.loader,
             contents: StringPointer::default(),
             // Latin1 lets the runtime wrap the mmapped section bytes in a
-            // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
-            // server-side JS, but `--banner`/`--footer`/hashbang and
-            // client-side (target=browser) chunks are concatenated verbatim
-            // as UTF-8, so verify the final bytes before committing to Latin1.
+            // zero-copy ExternalStringImpl. The printer escapes identifiers and
+            // string literals for server-side JS, but regex and raw template
+            // text, preserved comments, `--banner`/`--footer`/hashbang and
+            // client-side (target=browser) chunks are written as UTF-8, so
+            // verify the final bytes before committing to Latin1 (#38771 is
+            // about storing the rest in their final width too).
             encoding: match output_file.loader {
                 Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx
                     if strings::first_non_ascii(buf_bytes).is_none() =>

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -166,6 +166,33 @@ export default function IndexPage() {
     expect(indexHtml).toContain(`<div id="probe">© café-中-🐰|11</div>`);
   });
 
+  // Same handoff, for the text the printer used to escape: the server chunks
+  // are printed for the Bun target, so this pins that regex and raw template
+  // text reach the prerendered page as written.
+  test("non-ASCII regex and tagged template text survives prerendering", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-non-ascii-verbatim", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `
+const re = /café-中-🐰/u;
+const raw = String.raw\`é中🐰\\n\`;
+
+export default function IndexPage() {
+  return <div id="probe">{[re.source, re.source.length, raw, raw.length].join("|")}</div>;
+}
+`,
+    });
+
+    const build = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(build.stderr.toString()).not.toContain("error");
+    expect(build.exitCode).toBe(0);
+
+    const indexHtml = await Bun.file(path.join(dir, "dist", "index.html")).text();
+    expect(indexHtml).toContain(`<div id="probe">café-中-🐰|9|é中🐰\\n|6</div>`);
+  });
+
   test("import.meta properties are inlined in catch-all routes during production build", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-catch-all", {
       "src/index.tsx": `export default { 

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -38,6 +38,32 @@ describe("bundler", () => {
     },
     run: { stdout: "RedisClient\nRedisClient\nRedisClient\n" },
   });
+  // Regex literals and tagged template raw text are printed verbatim (UTF-8), so
+  // the .jsc sidecar's SourceCodeKey has to be computed from the same decoding
+  // the loader uses; otherwise JSC silently ignores the bytecode. (ESM bytecode
+  // only exists with --compile; see bundler_compile.test.ts for both formats.)
+  itBundled("bun/BytecodeSidecarNonAsciiRegexAndRawTemplate", {
+    target: "bun",
+    format: "cjs",
+    bytecode: true,
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        const r = /café-中-🐰/u;
+        const raw = String.raw\`é中🐰\`;
+        console.log(JSON.stringify([r.source, r.source.length, raw, raw.length]));
+      `,
+    },
+    run: {
+      stdout: JSON.stringify(["café-中-🐰", "café-中-🐰".length, "é中🐰", "é中🐰".length]),
+      env: {
+        BUN_JSC_verboseDiskCache: "1",
+      },
+      validate({ stderr }) {
+        expect(stderr).toContain("[Disk Cache] Cache hit for sourceCode");
+      },
+    },
+  });
   itBundled("bun/embedded-sqlite-file", {
     target: "bun",
     outfile: "",
@@ -125,6 +151,71 @@ describe("bundler", () => {
 error: Hello World`,
         );
         expect(stderr).toInclude("entry.ts:6:19");
+      },
+    },
+  });
+  // The regex and raw template text make the bundle non-ASCII, so the runtime
+  // holds it as a 16-bit string: the error preview is rendered from that
+  // string and, with --sourcemap=inline, the sourceMappingURL comment is
+  // located in it. Apart from the text itself, the output below is identical
+  // to what the ASCII version of this file produces.
+  const nonAsciiThrowFixture = /* js */ `
+    // this file has comments and weird whitespace, intentionally
+    // to make it obvious if sourcemaps were generated and mapped properly
+    const marker = /café-中-🐰/u;
+    if           (marker.test("café-中-🐰")) code();
+    function code() {
+      // hello world
+      throw new class Boom extends Error {
+        constructor() {
+          super(String.raw\`Hello 🐰\`);
+        }
+      }();
+    }
+  `;
+  itBundled("bun/TargetBunNoSourcemapNonAsciiPreview", {
+    target: "bun",
+    files: { "/entry.ts": nonAsciiThrowFixture },
+    run: {
+      exitCode: 1,
+      validate({ stderr }) {
+        // The regex text is shown as written while the string literal next to
+        // it is still escaped. Context-line labels are not asserted: they are
+        // off by one for bundled modules today, independently of this change.
+        expect(stderr).toInclude("| var marker = /café-中-🐰/u;\n");
+        expect(stderr).toInclude('| if (marker.test("caf\\xE9-\\u4E2D-\\uD83D\\uDC30"))\n');
+        expect(stderr).toInclude(
+          `7 |   throw new class Boom extends Error {
+            ^
+error: Hello 🐰
+`,
+        );
+        expect(stderr).toMatch(/at code \(.*out\.js:7:9\)\n/);
+        expect(stderr).toInclude("\nnote: missing sourcemaps for ");
+      },
+    },
+  });
+  itBundled("bun/TargetBunSourcemapInlineNonAscii", {
+    target: "bun",
+    files: { "/entry.ts": nonAsciiThrowFixture },
+    sourceMap: "inline",
+    run: {
+      exitCode: 1,
+      validate({ stderr }) {
+        expect(stderr).toStartWith(
+          `2 | // to make it obvious if sourcemaps were generated and mapped properly
+3 | const marker = /café-中-🐰/u;
+4 | if           (marker.test("café-中-🐰")) code();
+5 | function code() {
+6 |   // hello world
+7 |   throw new class Boom extends Error {
+            ^
+error: Hello 🐰
+`,
+        );
+        expect(stderr).toInclude("entry.ts:7:9");
+        expect(stderr).toInclude("entry.ts:4:41");
+        expect(stderr).not.toInclude("missing sourcemaps");
       },
     },
   });

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -138,6 +138,33 @@ describe("bundler", () => {
     },
   });
 
+  // Non-ASCII regex and tagged template text is printed as written, so the
+  // bytecode has to be generated from the same decoding of the output the
+  // loader uses, or JSC silently ignores it.
+  for (const format of ["cjs", "esm"] as const) {
+    itBundled(`compile/BytecodeNonAsciiRegexAndRawTemplate+${format}`, {
+      compile: true,
+      bytecode: true,
+      format,
+      files: {
+        "/entry.ts": /* js */ `
+          const r = /café-中-🐰/u;
+          const raw = String.raw\`é中🐰\`;
+          console.log(JSON.stringify([r.source, r.source.length, raw, raw.length]));
+        `,
+      },
+      run: {
+        stdout: JSON.stringify(["café-中-🐰", "café-中-🐰".length, "é中🐰", "é中🐰".length]),
+        env: {
+          BUN_JSC_verboseDiskCache: "1",
+        },
+        validate({ stderr }) {
+          expect(stderr).toContain("[Disk Cache] Cache hit for sourceCode");
+        },
+      },
+    });
+  }
+
   // `import defer * as ns from "..."` must not break bytecode generation.
   // The bundler inlines the deferred module into the entry chunk (documented
   // out-of-scope limitation — same as esbuild), so the defer semantics are

--- a/test/bundler/transpiler/template-literal.test.ts
+++ b/test/bundler/transpiler/template-literal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { readdirSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "path";
 
 // Tagged template cooked strings round-trip through the runtime transpiler.
@@ -156,6 +156,47 @@ describe.concurrent("tagged template .raw preserves non-ASCII", () => {
   });
 });
 
+// Ill-formed UTF-8 in verbatim text is decoded by the same routine the lexer
+// decodes string literals with, so whatever policy the lexer has for a byte
+// sequence (#38262 is making it U+FFFD per maximal subpart, like node), the
+// regex source and the raw text built from the same bytes must come out equal
+// to a string literal built from them. This pins the two paths to each other
+// rather than to a particular policy. (Files written by `bun build` keep the
+// bytes and are decoded with replacement by whoever loads them, which only
+// differs for WTF-8 encoded surrogates; that path is not covered here.)
+describe.concurrent("ill-formed bytes in verbatim text decode like a string literal", () => {
+  test.each([
+    ["stray continuation byte", [0xa9]],
+    ["truncated sequence followed by ASCII", [0xe4, 0xb8, 0x78]],
+    ["overlong encoding", [0xc0, 0x80]],
+    ["encoded surrogate", [0xed, 0xa0, 0x80]],
+    ["byte that cannot start a sequence", [0xff]],
+  ])("%s", async (_name, bytes) => {
+    const bad = Buffer.from(bytes);
+    const wrap = (before: string, after: string) => Buffer.concat([Buffer.from(before), bad, Buffer.from(after)]);
+    using dir = tempDir("ill-formed-verbatim", {
+      "entry.js": Buffer.concat([
+        wrap("const literal = 'a", "b';\n"),
+        wrap("const source = /a", "b/.source;\n"),
+        wrap("const raw = ((s) => s.raw[0])`a", "b`;\n"),
+        Buffer.from(
+          "const units = (s) => [...s].map(c => c.codePointAt(0));\n" +
+            "process.stdout.write(JSON.stringify([units(literal), source === literal, raw === literal]));\n",
+        ),
+      ]),
+    });
+    const { stdout, stderr, exitCode } = await runIn(String(dir), ["entry.js"]);
+    expect(stderr).toBe("");
+    const [literal, sourceMatches, rawMatches] = JSON.parse(stdout);
+    // The literal itself is the lexer's reading of the bytes; only its shape
+    // is asserted, the policy belongs to the lexer.
+    expect(literal[0]).toBe(0x61);
+    expect(literal.at(-1)).toBe(0x62);
+    expect({ sourceMatches, rawMatches, literal }).toEqual({ sourceMatches: true, rawMatches: true, literal });
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("bun build --target=bun preserves non-ASCII in regex/raw templates", async () => {
   using dir = tempDir("nonascii-regex-template", {
     "index.ts": [
@@ -231,6 +272,8 @@ const raw = String.raw\`${text}\\n\`;
 const values = [re.source, re.source.length, String(re), raw, raw.length];
 `;
   return {
+    text,
+    body,
     expected: JSON.stringify([text, text.length, `/${text}/u`, `${text}\\n`, text.length + "\\n".length]),
     files: probeFiles(body),
   };
@@ -247,7 +290,7 @@ function tagged() {
 }
 const values = [tagged.toString().split("/*! ")[1].split(" */")[0]];
 `;
-  return { expected: JSON.stringify([text]), files: probeFiles(body) };
+  return { text, body, expected: JSON.stringify([text]), files: probeFiles(body) };
 }
 
 type Probe = ReturnType<typeof probe>;
@@ -298,6 +341,27 @@ function cacheEntries(dir: string) {
   });
 }
 
+// Entry header, see `Metadata::encode` in src/jsc/RuntimeTranspilerCache.rs:
+// u32 version, u8 module type, u8 encoding tag, then u64 fields starting with
+// features_hash, input_byte_length, input_hash, output_byte_offset and
+// output_byte_length. UTF-16 output is stored in native byte order; CI is
+// little-endian everywhere.
+const CACHE_TAG_UTF16 = 2;
+const CACHE_TAG_LATIN1 = 3;
+function cacheEntryOutputs(dir: string) {
+  const cacheDir = join(dir, "transpiler-cache");
+  return readdirSync(cacheDir)
+    .map(name => {
+      const entry = readFileSync(join(cacheDir, name));
+      const tag = entry[5];
+      const offset = Number(entry.readBigUInt64LE(30));
+      const length = Number(entry.readBigUInt64LE(38));
+      const output = entry.subarray(offset, offset + length);
+      return { tag, output: output.toString(tag === CACHE_TAG_UTF16 ? "utf16le" : "latin1") };
+    })
+    .sort((a, b) => a.tag - b.tag);
+}
+
 describe.concurrent("every module loading path preserves non-ASCII regex/raw text", () => {
   describe.each(kinds)("%s", (_kind, { files, expected }) => {
     test.each([
@@ -316,15 +380,18 @@ describe.concurrent("every module loading path preserves non-ASCII regex/raw tex
   });
 
   // The on-disk transpiler cache stores the output in the width the printer
-  // ended up with, tagged so that it is read back in that width. The first run
-  // writes the entry and the second run must serve it: an entry read back in
-  // the wrong width is garbage, and an entry that fails to load is rewritten.
+  // ended up with, and the entry's tag is the one place that width can be
+  // observed from outside: 8-bit text must leave the module 8-bit, and text
+  // above U+00FF must have widened it. The first run writes the entry and the
+  // second run must serve it: an entry read back in the wrong width is
+  // garbage, and an entry that fails to load is rewritten.
   test.each([
-    ["8-bit", "entry point (sync transpiler)", "padded-main.js", latin1],
-    ["8-bit", "import (async transpiler)", "import-padded.mjs", latin1],
-    ["UTF-16", "entry point (sync transpiler)", "padded-main.js", nonAscii],
-    ["UTF-16", "import (async transpiler)", "import-padded.mjs", nonAscii],
-  ])("transpiler cache round trip of %s output through the %s", async (_width, _name, entry, { files, expected }) => {
+    ["8-bit", "entry point (sync transpiler)", "padded-main.js", latin1, CACHE_TAG_LATIN1],
+    ["8-bit", "import (async transpiler)", "import-padded.mjs", latin1, CACHE_TAG_LATIN1],
+    ["UTF-16", "entry point (sync transpiler)", "padded-main.js", nonAscii, CACHE_TAG_UTF16],
+    ["UTF-16", "import (async transpiler)", "import-padded.mjs", nonAscii, CACHE_TAG_UTF16],
+  ])("transpiler cache round trip of %s output through the %s", async (_width, _name, entry, probe, tag) => {
+    const { files, expected, text } = probe;
     using dir = tempDir("nonascii-transpiler-cache", files);
     const env = transpilerCacheEnv(String(dir));
 
@@ -334,11 +401,33 @@ describe.concurrent("every module loading path preserves non-ASCII regex/raw tex
     // Only the padded module is large enough to be cached.
     const written = cacheEntries(String(dir));
     expect(written).toHaveLength(1);
+    const [stored] = cacheEntryOutputs(String(dir));
+    expect(stored.tag).toBe(tag);
+    expect(stored.output).toContain(`/${text}/u`);
 
     const second = await runIn(String(dir), [entry], env);
     expect({ stdout: second.stdout, stderr: second.stderr }).toEqual({ stdout: expected, stderr: "" });
     expect(second.exitCode).toBe(0);
     expect(cacheEntries(String(dir))).toEqual(written);
+  });
+
+  // `require()` reuses one printer for every module of the process, so after
+  // a module has widened it, the next module must start out 8-bit again.
+  // Nothing else in this file loads a widening module before an 8-bit one in
+  // the same process.
+  test("a module printed after a widened one is 8-bit again", async () => {
+    using dir = tempDir("nonascii-printer-reset", {
+      "wide.cjs": padding + nonAscii.body + "module.exports = values;\n",
+      "narrow.cjs": padding + latin1.body + "module.exports = values;\n",
+      "main.cjs": `process.stdout.write(JSON.stringify([require("./wide.cjs"), require("./narrow.cjs")]));\n`,
+    });
+    const { stdout, stderr, exitCode } = await runIn(String(dir), ["main.cjs"], transpilerCacheEnv(String(dir)));
+    expect({ stdout, stderr }).toEqual({ stdout: `[${nonAscii.expected},${latin1.expected}]`, stderr: "" });
+    expect(exitCode).toBe(0);
+    const [wide, narrow] = cacheEntryOutputs(String(dir));
+    expect([wide.tag, narrow.tag]).toEqual([CACHE_TAG_UTF16, CACHE_TAG_LATIN1]);
+    expect(wide.output).toContain(`/${nonAscii.text}/u`);
+    expect(narrow.output).toContain(`/${latin1.text}/u`);
   });
 });
 
@@ -352,59 +441,94 @@ describe.concurrent("every module loading path preserves non-ASCII regex/raw tex
 // bytes). Before this change a cached module with a non-ASCII legal comment
 // still reached the compile cache, so that combination must keep working.
 //
-// Each of these runs three probes through two rounds of processes, the first
-// of which also generates and persists the bytecode, so they stay out of the
-// concurrent group above rather than racing the timeout while it saturates
-// the machine.
+// The modes differ in which path populates the compile cache: "transpiled
+// again" and "served from the transpiler cache" generate the bytecode from the
+// print path on the first run, while "warmed" writes the transpiler cache
+// entry first (as a machine that has run the program before would have) so
+// that the bytecode is generated from the entry's bytes and stored width, and
+// the last run's acceptance is the match between the two.
+//
+// Each mode runs three probes through two or three rounds of processes, the
+// first of which also generates and persists the bytecode, so these stay out
+// of the concurrent groups and get an explicit timeout: three rounds of a
+// debug build take about as long as the default allows.
+type CompileCacheMode = "transpiled again" | "served from the transpiler cache" | "warmed";
 describe("NODE_COMPILE_CACHE bytecode is accepted", () => {
-  test.each([
-    ["regex and raw template text, module transpiled again", "import-empty.mjs", false, asciiTwin, [latin1, nonAscii]],
+  test.each<[string, CompileCacheMode, string, Probe, Probe[]]>([
+    [
+      "regex and raw template text, module transpiled again",
+      "transpiled again",
+      "import-empty.mjs",
+      asciiTwin,
+      [latin1, nonAscii],
+    ],
     [
       "regex and raw template text, module served from the transpiler cache",
+      "served from the transpiler cache",
       "import-padded.mjs",
-      true,
+      asciiTwin,
+      [latin1, nonAscii],
+    ],
+    [
+      "regex and raw template text, bytecode generated from a warm transpiler cache",
+      "warmed",
+      "import-padded.mjs",
       asciiTwin,
       [latin1, nonAscii],
     ],
     [
       "legal comment text, module served from the transpiler cache",
+      "served from the transpiler cache",
       "import-padded.mjs",
-      true,
       asciiCommentTwin,
       [latin1Comment, nonAsciiComment],
     ],
-  ])("%s", async (_name, entry, useTranspilerCache, twin, probes) => {
-    async function cacheHits({ files, expected }: Probe) {
-      using dir = tempDir("nonascii-compile-cache", files);
-      const env = {
-        NODE_COMPILE_CACHE: join(String(dir), "compile-cache"),
-        ...(useTranspilerCache ? transpilerCacheEnv(String(dir)) : {}),
-      };
+  ])(
+    "%s",
+    async (_name, mode, entry, twin, probes) => {
+      async function cacheHits({ files, expected }: Probe) {
+        using dir = tempDir("nonascii-compile-cache", files);
+        const compileCache = { NODE_COMPILE_CACHE: join(String(dir), "compile-cache") };
+        const transpilerCache = transpilerCacheEnv(String(dir));
+        const runs =
+          mode === "transpiled again"
+            ? [compileCache, compileCache]
+            : mode === "served from the transpiler cache"
+              ? [
+                  { ...compileCache, ...transpilerCache },
+                  { ...compileCache, ...transpilerCache },
+                ]
+              : [transpilerCache, { ...compileCache, ...transpilerCache }, { ...compileCache, ...transpilerCache }];
 
-      const first = await runIn(String(dir), [entry], env);
-      expect({ stdout: first.stdout, stderr: first.stderr }).toEqual({ stdout: expected, stderr: "" });
-      expect(first.exitCode).toBe(0);
-      if (useTranspilerCache) expect(cacheEntries(String(dir))).toHaveLength(1);
+        let stderr = "";
+        for (const [i, env] of runs.entries()) {
+          const last = i === runs.length - 1;
+          const result = await runIn(String(dir), [entry], last ? { ...env, BUN_JSC_verboseDiskCache: "1" } : env);
+          if (!last) expect({ stdout: result.stdout, stderr: result.stderr }).toEqual({ stdout: expected, stderr: "" });
+          else expect(result.stdout).toBe(expected);
+          expect(result.exitCode).toBe(0);
+          if (i === 0 && mode !== "transpiled again") expect(cacheEntries(String(dir))).toHaveLength(1);
+          stderr = result.stderr;
+        }
+        return stderr.split("[Disk Cache] Cache hit for sourceCode").length - 1;
+      }
 
-      const second = await runIn(String(dir), [entry], { ...env, BUN_JSC_verboseDiskCache: "1" });
-      expect(second.stdout).toBe(expected);
-      expect(second.exitCode).toBe(0);
-      return second.stderr.split("[Disk Cache] Cache hit for sourceCode").length - 1;
-    }
-
-    const [twinHits, ...hits] = await Promise.all([twin, ...probes].map(cacheHits));
-    expect(twinHits).toBeGreaterThanOrEqual(3);
-    // One entry per probe: 8-bit output, then output widened to UTF-16.
-    expect(hits).toEqual([twinHits, twinHits]);
-  });
+      const [twinHits, ...hits] = await Promise.all([twin, ...probes].map(cacheHits));
+      expect(twinHits).toBeGreaterThanOrEqual(3);
+      // One entry per probe: 8-bit output, then output widened to UTF-16.
+      expect(hits).toEqual([twinHits, twinHits]);
+    },
+    20_000,
+  );
 });
 
-// The runtime source map counts generated columns in bytes while the output is
-// 8-bit and in UTF-16 code units once it has widened, switching over at the
-// point where the widening happened. Stack positions must map back to the
-// original source wherever the widening happens relative to the construct
-// being located. Columns are 1-based UTF-16 offsets of the callee in the
-// original line, which `indexOf` gives directly.
+// Error positions must still map back to the original source when a module
+// widens partway through. These layouts pin the line accounting on both sides
+// of the switch (the runtime printer puts each statement on its own generated
+// line, so they say nothing about columns within a line; the column arithmetic
+// of both builder modes is pinned by test/cli/inspect/inspect-inline-sourcemap.test.ts).
+// Columns below are 1-based UTF-16 offsets of the callee in the original
+// line, which `indexOf` gives directly.
 describe.concurrent("stack positions are remapped around non-ASCII regex/raw text", () => {
   const layouts = {
     "text before the error sites": (text: string) => [

--- a/test/bundler/transpiler/template-literal.test.ts
+++ b/test/bundler/transpiler/template-literal.test.ts
@@ -449,9 +449,8 @@ describe.concurrent("every module loading path preserves non-ASCII regex/raw tex
 // the last run's acceptance is the match between the two.
 //
 // Each mode runs three probes through two or three rounds of processes, the
-// first of which also generates and persists the bytecode, so these stay out
-// of the concurrent groups and get an explicit timeout: three rounds of a
-// debug build take about as long as the default allows.
+// first of which also generates and persists the bytecode, so these run on
+// their own after the concurrent groups instead of competing with them.
 type CompileCacheMode = "transpiled again" | "served from the transpiler cache" | "warmed";
 describe("NODE_COMPILE_CACHE bytecode is accepted", () => {
   test.each<[string, CompileCacheMode, string, Probe, Probe[]]>([
@@ -483,43 +482,39 @@ describe("NODE_COMPILE_CACHE bytecode is accepted", () => {
       asciiCommentTwin,
       [latin1Comment, nonAsciiComment],
     ],
-  ])(
-    "%s",
-    async (_name, mode, entry, twin, probes) => {
-      async function cacheHits({ files, expected }: Probe) {
-        using dir = tempDir("nonascii-compile-cache", files);
-        const compileCache = { NODE_COMPILE_CACHE: join(String(dir), "compile-cache") };
-        const transpilerCache = transpilerCacheEnv(String(dir));
-        const runs =
-          mode === "transpiled again"
-            ? [compileCache, compileCache]
-            : mode === "served from the transpiler cache"
-              ? [
-                  { ...compileCache, ...transpilerCache },
-                  { ...compileCache, ...transpilerCache },
-                ]
-              : [transpilerCache, { ...compileCache, ...transpilerCache }, { ...compileCache, ...transpilerCache }];
+  ])("%s", async (_name, mode, entry, twin, probes) => {
+    async function cacheHits({ files, expected }: Probe) {
+      using dir = tempDir("nonascii-compile-cache", files);
+      const compileCache = { NODE_COMPILE_CACHE: join(String(dir), "compile-cache") };
+      const transpilerCache = transpilerCacheEnv(String(dir));
+      const runs =
+        mode === "transpiled again"
+          ? [compileCache, compileCache]
+          : mode === "served from the transpiler cache"
+            ? [
+                { ...compileCache, ...transpilerCache },
+                { ...compileCache, ...transpilerCache },
+              ]
+            : [transpilerCache, { ...compileCache, ...transpilerCache }, { ...compileCache, ...transpilerCache }];
 
-        let stderr = "";
-        for (const [i, env] of runs.entries()) {
-          const last = i === runs.length - 1;
-          const result = await runIn(String(dir), [entry], last ? { ...env, BUN_JSC_verboseDiskCache: "1" } : env);
-          if (!last) expect({ stdout: result.stdout, stderr: result.stderr }).toEqual({ stdout: expected, stderr: "" });
-          else expect(result.stdout).toBe(expected);
-          expect(result.exitCode).toBe(0);
-          if (i === 0 && mode !== "transpiled again") expect(cacheEntries(String(dir))).toHaveLength(1);
-          stderr = result.stderr;
-        }
-        return stderr.split("[Disk Cache] Cache hit for sourceCode").length - 1;
+      let stderr = "";
+      for (const [i, env] of runs.entries()) {
+        const last = i === runs.length - 1;
+        const result = await runIn(String(dir), [entry], last ? { ...env, BUN_JSC_verboseDiskCache: "1" } : env);
+        if (!last) expect({ stdout: result.stdout, stderr: result.stderr }).toEqual({ stdout: expected, stderr: "" });
+        else expect(result.stdout).toBe(expected);
+        expect(result.exitCode).toBe(0);
+        if (i === 0 && mode !== "transpiled again") expect(cacheEntries(String(dir))).toHaveLength(1);
+        stderr = result.stderr;
       }
+      return stderr.split("[Disk Cache] Cache hit for sourceCode").length - 1;
+    }
 
-      const [twinHits, ...hits] = await Promise.all([twin, ...probes].map(cacheHits));
-      expect(twinHits).toBeGreaterThanOrEqual(3);
-      // One entry per probe: 8-bit output, then output widened to UTF-16.
-      expect(hits).toEqual([twinHits, twinHits]);
-    },
-    20_000,
-  );
+    const [twinHits, ...hits] = await Promise.all([twin, ...probes].map(cacheHits));
+    expect(twinHits).toBeGreaterThanOrEqual(3);
+    // One entry per probe: 8-bit output, then output widened to UTF-16.
+    expect(hits).toEqual([twinHits, twinHits]);
+  });
 });
 
 // Error positions must still map back to the original source when a module

--- a/test/bundler/transpiler/template-literal.test.ts
+++ b/test/bundler/transpiler/template-literal.test.ts
@@ -1,10 +1,9 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync, statSync } from "node:fs";
 import { join } from "path";
 
-// When targeting Bun's runtime,
-// We must escape latin1 characters in raw template literals
-// This is somewhat brittle
+// Tagged template cooked strings round-trip through the runtime transpiler.
 test("template literal", () => {
   const { stdout, exitCode } = Bun.spawnSync({
     cmd: [bunExe(), "run", join(import.meta.dir, "template-literal-fixture-test.js")],
@@ -18,5 +17,436 @@ test("template literal", () => {
     // This is base64 encoded contents of the template literal
     // this narrows down the test to the transpiler instead of the runtime
     "8J+QsDEyMzEyM/CfkLDwn5Cw8J+QsPCfkLDwn5Cw8J+QsDEyM/CfkLAxMjPwn5CwMTIzMTIz8J+QsDEyM/CfkLAxMjPwn5CwLPCfkLB0cnVl",
+  );
+});
+
+// The runtime transpiler must not rewrite non-ASCII characters inside tagged
+// template raw contents or regex literal patterns: both are observable at
+// runtime via `.raw` / `.source`.
+// https://github.com/oven-sh/bun/issues/8745
+// https://github.com/oven-sh/bun/issues/18115
+// https://github.com/oven-sh/bun/issues/15492
+// https://github.com/oven-sh/bun/issues/16763
+// https://github.com/oven-sh/bun/issues/8207
+// https://github.com/oven-sh/bun/issues/13853
+// https://github.com/oven-sh/bun/issues/33930
+async function run(code: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("RegExp literal .source preserves non-ASCII", () => {
+  test.each([
+    ["latin1 range", "/café/u", "café"],
+    ["BMP", "/中文/u", "中文"],
+    ["BOM", "/a\uFEFFb/u", "a\uFEFFb"],
+    ["astral", "/a🐰b/u", "a🐰b"],
+  ])("%s", async (_name, literal, source) => {
+    const { stdout, stderr, exitCode } = await run(
+      `const r = ${literal}; process.stdout.write(JSON.stringify([r.source, r.source.length, String(r)]));`,
+    );
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify([source, source.length, `/${source}/u`]),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/13853
+  // parsel-js widens a regex via re.source.replace("(?<argument>¶*)", ...); when
+  // the transpiler escapes ¶ to \u00B6 the replace never matches and puppeteer's
+  // ::-p-* selector arguments come back empty.
+  test("parsel-js .source.replace on literal ¶ (#13853)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const re = /::(?<name>[-\\w\\P{ASCII}]+)(?:\\((?<argument>¶*)\\))?/gu;` +
+        `const widened = re.source.replace("(?<argument>¶*)", "(?<argument>.*)");` +
+        `process.stdout.write(JSON.stringify([re.source.includes("(?<argument>\\xB6*)"), widened.includes(".*"), re.source]));`,
+    );
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify([true, true, "::(?<name>[-\\w\\P{ASCII}]+)(?:\\((?<argument>¶*)\\))?"]),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/33930
+  // Raw control bytes (0x00-0x1F) in a regex literal must come through as one
+  // code point in .source, not the six-character \uNNNN escape text. Uses a
+  // file because argv is NUL-terminated.
+  test("raw NUL and control bytes (#33930)", async () => {
+    using dir = tempDir("regex-source-control", {
+      "entry.js":
+        `const nul = /` +
+        "\x00" +
+        `HFMASK(\\d+)` +
+        "\x00" +
+        `/g;\n` +
+        `const ctrl = /a` +
+        "\x01\x1f" +
+        `b/;\n` +
+        `process.stdout.write(JSON.stringify({\n` +
+        `  nul: [...nul.source].map(c => c.codePointAt(0)),\n` +
+        `  nulLen: nul.source.length,\n` +
+        `  match: nul.test("\\x00HFMASK42\\x00"),\n` +
+        `  ctrl: [...ctrl.source].map(c => c.codePointAt(0)),\n` +
+        `  ctrlLen: ctrl.source.length,\n` +
+        `}));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: JSON.stringify({
+        nul: [0, 72, 70, 77, 65, 83, 75, 40, 92, 100, 43, 41, 0],
+        nulLen: 13,
+        match: true,
+        ctrl: [97, 1, 31, 98],
+        ctrlLen: 4,
+      }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("tagged template .raw preserves non-ASCII", () => {
+  test.each([
+    ["latin1 range", "Redémarrage"],
+    ["BMP", "before中after"],
+    ["astral", "æ™弟気👋"],
+  ])("%s", async (_name, value) => {
+    const { stdout, stderr, exitCode } = await run(
+      `process.stdout.write(JSON.stringify([String.raw\`${value}\`, String.raw\`${value}\`.length]));`,
+    );
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify([value, value.length]), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("String.raw iterates code points (#18115)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const text = String.raw\`a中\`; const chars = []; for (const c of text) chars.push(c); ` +
+        `process.stdout.write(JSON.stringify(chars));`,
+    );
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify(["a", "中"]), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("substitutions between non-ASCII", async () => {
+    const { stdout, stderr, exitCode } = await run(`process.stdout.write(String.raw\`中\${"x"}弟\${"y"}気\`);`);
+    expect({ stdout, stderr }).toEqual({ stdout: "中x弟y気", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test(".raw matches source, cooked is unchanged", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const tag = (s) => JSON.stringify({ raw: s.raw[0], cooked: s[0] }); process.stdout.write(tag\`é\\n中\`);`,
+    );
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify({ raw: "é\\n中", cooked: "é\n中" }), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+});
+
+test("bun build --target=bun preserves non-ASCII in regex/raw templates", async () => {
+  using dir = tempDir("nonascii-regex-template", {
+    "index.ts": [
+      `const r = /café-中-🐰/u;`,
+      `const raw = String.raw\`é中🐰\`;`,
+      `process.stdout.write(JSON.stringify([r.source, r.source.length, raw, raw.length]));`,
+    ].join("\n"),
+  });
+
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "--outfile", String(dir) + "/out.js", String(dir) + "/index.ts"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildErr).not.toContain("error");
+  expect(buildExit).toBe(0);
+
+  const out = await Bun.file(String(dir) + "/out.js").text();
+  expect(out).not.toMatch(/\\u00E9/i);
+  expect(out).not.toMatch(/\\u4E2D/i);
+  expect(out).toContain("café-中-🐰");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), String(dir) + "/out.js"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr }).toEqual({
+    stdout: JSON.stringify(["café-中-🐰", "café-中-🐰".length, "é中🐰", "é中🐰".length]),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
+// When printing for the runtime the printer writes 8-bit (Latin-1) output and
+// widens the whole buffer to UTF-16 at the first code point above U+00FF, so
+// every path that hands transpiler output to JSC has an 8-bit arm and a 16-bit
+// arm; `// @bun` files skip the printer and are decoded from UTF-8. The same
+// module goes through each of those paths here with text of each class; a path
+// that reads the wrong width shows up as mojibake or garbage. `body` must
+// define `values`.
+//
+// The `padded-*` modules are large enough (MINIMUM_CACHE_SIZE is 4 KiB) to be
+// stored in the on-disk transpiler cache.
+const padding = "// " + Buffer.alloc(8 * 1024, "x").toString() + "\n";
+function probeFiles(body: string) {
+  const print = `process.stdout.write(JSON.stringify(values));\nprocess.exit(0);\n`;
+  return {
+    "main.js": body + print,
+    "padded-main.js": padding + body + print,
+    "pragma-main.js": "// @bun\n" + body + print,
+    "probe.mjs": body + "export default values;\n",
+    "padded-probe.mjs": padding + body + "export default values;\n",
+    "pragma-probe.mjs": "// @bun\n" + body + "export default values;\n",
+    "probe.cjs": body + "module.exports = values;\n",
+    "import.mjs": `import values from "./probe.mjs";\n` + print,
+    "import-pragma.mjs": `import values from "./pragma-probe.mjs";\n` + print,
+    "require.cjs": `const values = require("./probe.cjs");\n` + print,
+    "empty.js": "",
+    "import-empty.mjs": `import "./empty.js";\nimport values from "./probe.mjs";\n` + print,
+    "import-padded.mjs": `import "./empty.js";\nimport values from "./padded-probe.mjs";\n` + print,
+  };
+}
+
+function probe(text: string) {
+  const body = `
+const re = /${text}/u;
+const raw = String.raw\`${text}\\n\`;
+const values = [re.source, re.source.length, String(re), raw, raw.length];
+`;
+  return {
+    expected: JSON.stringify([text, text.length, `/${text}/u`, `${text}\\n`, text.length + "\\n".length]),
+    files: probeFiles(body),
+  };
+}
+
+// Legal comments were already printed verbatim before regex and template text
+// was (and came back as mojibake, e.g. "Â©", on every path), so this variant
+// pins the module loading half independently of the regex/template change.
+function legalCommentProbe(text: string) {
+  const body = `
+function tagged() {
+  /*! ${text} */
+  return 1;
+}
+const values = [tagged.toString().split("/*! ")[1].split(" */")[0]];
+`;
+  return { expected: JSON.stringify([text]), files: probeFiles(body) };
+}
+
+type Probe = ReturnType<typeof probe>;
+
+// "café-©-ÿ" stays within Latin-1, so the module's output is still 8-bit;
+// "中" and "🐰" widen it to UTF-16 (the rabbit also checks surrogate pairs).
+const latin1 = probe("café-©-ÿ");
+const nonAscii = probe("café-中-🐰");
+const asciiTwin = probe("cafe-x-y");
+const latin1Comment = legalCommentProbe("© café ÿ");
+const nonAsciiComment = legalCommentProbe("© café-中-🐰");
+const asciiCommentTwin = legalCommentProbe("(c) cafe-x-y");
+const kinds: [string, Probe][] = [
+  ["8-bit regex and raw template text", latin1],
+  ["UTF-16 regex and raw template text", nonAscii],
+  ["8-bit legal comment text (module loading fix alone)", latin1Comment],
+  ["UTF-16 legal comment text (module loading fix alone)", nonAsciiComment],
+];
+
+async function runIn(cwd: string, args: string[], env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function transpilerCacheEnv(dir: string) {
+  return {
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: join(dir, "transpiler-cache"),
+    // Debug builds only read the cache back with this set.
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
+}
+
+// Identity of every entry in the transpiler cache directory. An entry that
+// fails to load is silently deleted and written again by the re-transpile, so
+// a second run that really hit the cache leaves these unchanged.
+function cacheEntries(dir: string) {
+  const cacheDir = join(dir, "transpiler-cache");
+  return readdirSync(cacheDir).map(name => {
+    const { ino, mtimeMs, size } = statSync(join(cacheDir, name));
+    return { name, ino, mtimeMs, size };
+  });
+}
+
+describe.concurrent("every module loading path preserves non-ASCII regex/raw text", () => {
+  describe.each(kinds)("%s", (_kind, { files, expected }) => {
+    test.each([
+      ["entry point", ["main.js"]],
+      ["entry point with --hot (watcher keeps a ref-counted copy of the source)", ["--hot", "main.js"]],
+      ["entry point with the // @bun pragma", ["pragma-main.js"]],
+      ["import (async transpiler)", ["import.mjs"]],
+      ["import of a // @bun module (async transpiler)", ["import-pragma.mjs"]],
+      ["require (sync transpiler)", ["require.cjs"]],
+    ])("%s", async (_name, args) => {
+      using dir = tempDir("nonascii-load-path", files);
+      const { stdout, stderr, exitCode } = await runIn(String(dir), args);
+      expect({ stdout, stderr }).toEqual({ stdout: expected, stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // The on-disk transpiler cache stores the output in the width the printer
+  // ended up with, tagged so that it is read back in that width. The first run
+  // writes the entry and the second run must serve it: an entry read back in
+  // the wrong width is garbage, and an entry that fails to load is rewritten.
+  test.each([
+    ["8-bit", "entry point (sync transpiler)", "padded-main.js", latin1],
+    ["8-bit", "import (async transpiler)", "import-padded.mjs", latin1],
+    ["UTF-16", "entry point (sync transpiler)", "padded-main.js", nonAscii],
+    ["UTF-16", "import (async transpiler)", "import-padded.mjs", nonAscii],
+  ])("transpiler cache round trip of %s output through the %s", async (_width, _name, entry, { files, expected }) => {
+    using dir = tempDir("nonascii-transpiler-cache", files);
+    const env = transpilerCacheEnv(String(dir));
+
+    const first = await runIn(String(dir), [entry], env);
+    expect({ stdout: first.stdout, stderr: first.stderr }).toEqual({ stdout: expected, stderr: "" });
+    expect(first.exitCode).toBe(0);
+    // Only the padded module is large enough to be cached.
+    const written = cacheEntries(String(dir));
+    expect(written).toHaveLength(1);
+
+    const second = await runIn(String(dir), [entry], env);
+    expect({ stdout: second.stdout, stderr: second.stderr }).toEqual({ stdout: expected, stderr: "" });
+    expect(second.exitCode).toBe(0);
+    expect(cacheEntries(String(dir))).toEqual(written);
+  });
+});
+
+// NODE_COMPILE_CACHE persists JSC bytecode generated from the transpiler's
+// output, in whichever width it has, and keyed by a hash of those bytes. On
+// later runs the loader must hand it the same bytes in the same width, whether
+// it transpiled the module again or served it from the transpiler cache, and
+// the bytecode must have been generated from a string of that width too; any
+// mismatch is a silent miss. The ASCII twin gives the expected number of hits
+// (entry point, probe module and the empty module, whose output has zero
+// bytes). Before this change a cached module with a non-ASCII legal comment
+// still reached the compile cache, so that combination must keep working.
+//
+// Each of these runs three probes through two rounds of processes, the first
+// of which also generates and persists the bytecode, so they stay out of the
+// concurrent group above rather than racing the timeout while it saturates
+// the machine.
+describe("NODE_COMPILE_CACHE bytecode is accepted", () => {
+  test.each([
+    ["regex and raw template text, module transpiled again", "import-empty.mjs", false, asciiTwin, [latin1, nonAscii]],
+    [
+      "regex and raw template text, module served from the transpiler cache",
+      "import-padded.mjs",
+      true,
+      asciiTwin,
+      [latin1, nonAscii],
+    ],
+    [
+      "legal comment text, module served from the transpiler cache",
+      "import-padded.mjs",
+      true,
+      asciiCommentTwin,
+      [latin1Comment, nonAsciiComment],
+    ],
+  ])("%s", async (_name, entry, useTranspilerCache, twin, probes) => {
+    async function cacheHits({ files, expected }: Probe) {
+      using dir = tempDir("nonascii-compile-cache", files);
+      const env = {
+        NODE_COMPILE_CACHE: join(String(dir), "compile-cache"),
+        ...(useTranspilerCache ? transpilerCacheEnv(String(dir)) : {}),
+      };
+
+      const first = await runIn(String(dir), [entry], env);
+      expect({ stdout: first.stdout, stderr: first.stderr }).toEqual({ stdout: expected, stderr: "" });
+      expect(first.exitCode).toBe(0);
+      if (useTranspilerCache) expect(cacheEntries(String(dir))).toHaveLength(1);
+
+      const second = await runIn(String(dir), [entry], { ...env, BUN_JSC_verboseDiskCache: "1" });
+      expect(second.stdout).toBe(expected);
+      expect(second.exitCode).toBe(0);
+      return second.stderr.split("[Disk Cache] Cache hit for sourceCode").length - 1;
+    }
+
+    const [twinHits, ...hits] = await Promise.all([twin, ...probes].map(cacheHits));
+    expect(twinHits).toBeGreaterThanOrEqual(3);
+    // One entry per probe: 8-bit output, then output widened to UTF-16.
+    expect(hits).toEqual([twinHits, twinHits]);
+  });
+});
+
+// The runtime source map counts generated columns in bytes while the output is
+// 8-bit and in UTF-16 code units once it has widened, switching over at the
+// point where the widening happened. Stack positions must map back to the
+// original source wherever the widening happens relative to the construct
+// being located. Columns are 1-based UTF-16 offsets of the callee in the
+// original line, which `indexOf` gives directly.
+describe.concurrent("stack positions are remapped around non-ASCII regex/raw text", () => {
+  const layouts = {
+    "text before the error sites": (text: string) => [
+      `const re = /${text}/u;`,
+      `const raw = String.raw\`${text}\`; const a = new Error("a");`,
+      `const b = new Error("b");`,
+      `print(a, b);`,
+    ],
+    "text between the error sites": (text: string) => [
+      `const a = new Error("a");`,
+      `const re = /${text}/u; const b = new Error("b");`,
+      `const raw = String.raw\`${text}\`;`,
+      `const c = new Error("c");`,
+      `print(a, b, c);`,
+    ],
+  };
+  const print = [
+    `function print(...errors) {`,
+    `  process.stdout.write(JSON.stringify(errors.map(e => e.stack.split("\\n")[1].match(/:(\\d+:\\d+)$/)[1])));`,
+    `}`,
+  ];
+
+  function expectedPositions(lines: string[]) {
+    return lines.flatMap((line, row) => {
+      const column = line.indexOf("Error(");
+      return column === -1 ? [] : [`${row + 1}:${column + 1}`];
+    });
+  }
+
+  const texts: [string, string][] = [
+    ["ASCII", "xyz"],
+    ["8-bit", "é©"],
+    ["UTF-16", "中🐰"],
+  ];
+  test.each(texts.flatMap(([width, text]) => Object.keys(layouts).map(layout => [width, layout, text] as const)))(
+    "%s %s",
+    async (_width, layout, text) => {
+      const lines = layouts[layout as keyof typeof layouts](text);
+      using dir = tempDir("nonascii-stack-positions", { "main.js": [...lines, ...print].join("\n") });
+      const { stdout, stderr, exitCode } = await runIn(String(dir), ["main.js"]);
+      expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify(expectedPositions(lines)), stderr: "" });
+      expect(exitCode).toBe(0);
+    },
   );
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4636,6 +4636,22 @@ console.log(foo, array);
       const result = await transpiler.transform(input);
       expect(result).toBe(`let list = [\"\\u2022\", \"-\", \"\\u25E6\", \"\\u25AA\", \"\\u25AB\"];\n`);
     });
+
+    // The bun target still escapes string literals (that is invisible to the
+    // program), but regex literals and tagged template raw text are observable
+    // through RegExp#source and .raw, so they are printed verbatim.
+    // https://github.com/oven-sh/bun/issues/18115
+    it("bun target keeps regex literals and raw template text verbatim", async () => {
+      const transpiler = new Bun.Transpiler({
+        loader: "js",
+        target: "bun",
+      });
+
+      const input = 'const re = /café-中-🐰/u;\nconst raw = String.raw`é中🐰\\n`;\nconst str = "é中🐰";\n';
+      const expected = 'const re = /café-中-🐰/u, raw = String.raw`é中🐰\\n`, str = "\\xE9\\u4E2D\\uD83D\\uDC30";\n';
+      expect(transpiler.transformSync(input)).toBe(expected);
+      expect(await transpiler.transform(input)).toBe(expected);
+    });
   });
 
   describe("edge cases", () => {

--- a/test/cli/inspect/inspect-inline-sourcemap.test.ts
+++ b/test/cli/inspect/inspect-inline-sourcemap.test.ts
@@ -1,21 +1,20 @@
 import { spawn } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
+import { SourceMapConsumer } from "source-map";
 import { WebSocket } from "ws";
 
-test("--inspect inline sourcemap sources[0] is a valid path under cwd", async () => {
-  // VT (0x0B) / BEL (0x07) in the source exercise quote_for_json's RFC 8259
-  // escape handling for sourcesContent.
-  const source = "// comment [\x0b\x07]\nsetInterval(() => {}, 200);\n";
-  using dir = tempDir("inspect-sourcemap", {
-    "sub/target.mjs": source,
-  });
+// Starts `entry` under --inspect-wait, connects, and returns its
+// Debugger.scriptParsed event together with the inline source map the runtime
+// transpiler attached to it.
+async function runtimeSourceMap(files: Record<string, string>, entry: string) {
+  using dir = tempDir("inspect-sourcemap", files);
   const cwd = fs.realpathSync(String(dir));
 
   await using proc = spawn({
-    cmd: [bunExe(), "--inspect-wait=127.0.0.1:0", join("sub", "target.mjs")],
+    cmd: [bunExe(), "--inspect-wait=127.0.0.1:0", entry],
     env: bunEnv,
     cwd,
     stdout: "ignore",
@@ -51,6 +50,7 @@ test("--inspect inline sourcemap sources[0] is a valid path under cwd", async ()
 
     await Promise.race([new Promise<void>(resolve => ws.addEventListener("open", () => resolve())), failed]);
 
+    const entryFile = entry.split(/[\\/]/).pop()!;
     const pending = new Map<number, (v: any) => void>();
     const scriptParsed = new Promise<any>(resolve => {
       ws.addEventListener("message", ({ data }) => {
@@ -58,7 +58,7 @@ test("--inspect inline sourcemap sources[0] is a valid path under cwd", async ()
         if (typeof msg.id === "number" && pending.has(msg.id)) {
           pending.get(msg.id)!(msg);
           pending.delete(msg.id);
-        } else if (msg.method === "Debugger.scriptParsed" && String(msg.params?.url ?? "").endsWith("target.mjs")) {
+        } else if (msg.method === "Debugger.scriptParsed" && String(msg.params?.url ?? "").endsWith(entryFile)) {
           resolve(msg.params);
         }
       });
@@ -81,12 +81,76 @@ test("--inspect inline sourcemap sources[0] is a valid path under cwd", async ()
     const m = String(params.sourceMapURL ?? "").match(/base64,([A-Za-z0-9+/=]+)/);
     expect(m).not.toBeNull();
     const raw = Buffer.from(m![1], "base64").toString();
-    expect(raw).not.toMatch(/\\v|\\x[0-9A-Fa-f]{2}/);
-    const map = JSON.parse(raw);
-
-    expect(map.sources[0]).toBe("/sub/target.mjs");
-    expect(map.sourcesContent[0]).toBe(source);
+    return { cwd, params, raw, map: JSON.parse(raw) };
   } finally {
     ws.close();
   }
+}
+
+type Mapping = { generatedLine: number; generatedColumn: number; originalLine: number; originalColumn: number };
+
+async function mappingsOf(map: any): Promise<Mapping[]> {
+  const found: Mapping[] = [];
+  await SourceMapConsumer.with(map, null, consumer => {
+    consumer.eachMapping(({ generatedLine, generatedColumn, originalLine, originalColumn }) => {
+      found.push({ generatedLine, generatedColumn, originalLine, originalColumn });
+    });
+  });
+  return found;
+}
+
+test("--inspect inline sourcemap sources[0] is a valid path under cwd", async () => {
+  // VT (0x0B) / BEL (0x07) in the source exercise quote_for_json's RFC 8259
+  // escape handling for sourcesContent.
+  const source = "// comment [\x0b\x07]\nsetInterval(() => {}, 200);\n";
+  const { raw, map } = await runtimeSourceMap({ "sub/target.mjs": source }, join("sub", "target.mjs"));
+  expect(raw).not.toMatch(/\\v|\\x[0-9A-Fa-f]{2}/);
+  expect(map.sources[0]).toBe("/sub/target.mjs");
+  expect(map.sourcesContent[0]).toBe(source);
+});
+
+test("--inspect inline sourcemap for a module in a non-ASCII directory", async () => {
+  // The regex makes the module's transpiled text UTF-16, so the source map
+  // comment is appended to, and has to be found in, a 16-bit string. The
+  // script's URL comes from the module loader; no sourceURL comment is added.
+  const source = "const re = /中/u;\nsetInterval(() => {}, 200);\n";
+  const { cwd, params, map } = await runtimeSourceMap(
+    { "sub-é-中/target.mjs": source },
+    join("sub-é-中", "target.mjs"),
+  );
+  expect(params.url).toBe(join(cwd, "sub-é-中", "target.mjs"));
+  expect(map.sources[0]).toBe("/sub-é-中/target.mjs");
+  expect(map.sourcesContent[0]).toBe(source);
+});
+
+// The runtime transpiler prints this line exactly as written, so every mapping
+// on it must have equal generated and original columns, and since each
+// variant's texts occupy the same number of UTF-16 code units, the variants
+// must produce the same mappings as each other. The regex is the first
+// non-ASCII text of its module: the 8-bit variant pins that a Latin-1 buffer is
+// counted one column per byte after it, and the widening variant pins that the
+// buffer is counted in code units from the point where the regex widened it
+// (astral text counting two), including the raw template text written after
+// the switch.
+describe.concurrent("--inspect inline sourcemap columns after verbatim text", () => {
+  test.each([
+    ["ASCII", "xyz", "w"],
+    ["8-bit", "éÿ©", "ü"],
+    ["widening", "中🐰", "é"],
+  ])("%s", async (_name, regexText, rawText) => {
+    const line = `const x = [/${regexText}/u, new Error("b"), String.raw\`${rawText}\`, f()];`;
+    const source = `function f() {}\n${line}\nsetInterval(() => {}, 200);\n`;
+    const { map } = await runtimeSourceMap({ "target.mjs": source }, "target.mjs");
+
+    const onLine = (await mappingsOf(map)).filter(m => m.generatedLine === 2);
+    const columns = onLine.map(m => m.generatedColumn);
+    expect(onLine).toEqual(
+      columns.map(column => ({ generatedLine: 2, generatedColumn: column, originalLine: 2, originalColumn: column })),
+    );
+    // Expressions after the regex (and, for `f()`, after the raw text) are
+    // mapped at their own columns.
+    expect(columns).toContain(line.indexOf("new Error"));
+    expect(columns).toContain(line.indexOf("String.raw"));
+    expect(columns).toContain(line.indexOf("f()"));
+  });
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -676,7 +676,10 @@ test("source text has the expected length", () => {
   expect(covered()).toBe(${2 * coverageTextUnits});
 });
 `;
+// `units` must be a multiple of `piece.length` (in code units), or the result
+// would end in a partial repetition of the piece.
 function repeatUnits(piece: string, units: number) {
+  expect(units % piece.length).toBe(0);
   return Buffer.alloc((Buffer.byteLength(piece) * units) / piece.length, piece).toString();
 }
 

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -725,3 +725,18 @@ test("a non-ASCII preserved comment does not shift coverage lines", async () => 
   expect(ascii).toContain("\nDA:10,0\n");
   expect(legalComment).toBe(ascii);
 });
+
+// Regex and raw template text is transpiled as written, so the module text
+// JSC holds is 8-bit with characters above 0x7F for Latin-1 range text and
+// UTF-16 beyond it; the line table has to agree with it in both cases.
+test("non-ASCII regex and raw template text does not shift coverage lines", async () => {
+  const asciiBanner = repeatUnits("x", coverageBannerUnits);
+  const [ascii, latin1, utf16] = await coverageRecords({
+    ascii: coverageDemo(asciiBanner, repeatUnits("x", coverageTextUnits)),
+    latin1: coverageDemo(asciiBanner, repeatUnits("é", coverageTextUnits)),
+    utf16: coverageDemo(asciiBanner, repeatUnits("é中🐰", coverageTextUnits)),
+  });
+  expect(ascii).toContain("\nDA:7,0\n");
+  expect(ascii).toContain("\nDA:10,0\n");
+  expect({ latin1, utf16 }).toEqual({ latin1: ascii, utf16: ascii });
+});

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -456,6 +456,23 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test(".load of a file with an ill-formed byte inside a regex evaluates it with U+FFFD", async () => {
+      // Regex text now reaches the evaluator as written too (it used to be
+      // escaped to the six characters \\uFFFD), so the same decoding applies.
+      using dir = tempDir("repl-load-ill-formed-regex", {
+        "bad.js": Buffer.concat([Buffer.from("var badRegex = /a"), Buffer.from([0xe9]), Buffer.from("b/;\n")]),
+      });
+      const filePath = path.join(String(dir), "bad.js");
+      const { outputs, stderr, exitCode } = await runRepl([
+        `.load ${filePath}`,
+        "JSON.stringify([badRegex.source.length, badRegex.source.codePointAt(1)])",
+        ".exit",
+      ]);
+      expect(outputs).toEqual([`Loading ${filePath}...\n/a\uFFFDb/`, '"[3,65533]"']);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
     test(".load with a nonexistent file shows the error and keeps running", async () => {
       // A relative path: Windows rejects a forward-slash absolute path with EINVAL.
       const { outputs, stderr, exitCode } = await runRepl([
@@ -900,6 +917,21 @@ describe.concurrent("Bun REPL", () => {
       const { stdout, stderr, exitCode } = await runReplWith(["--print", "2 * 3"]);
       expect(stdout).toBe("6\n");
       expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    // The REPL transpiles its input like the runtime does; regex literals and
+    // tagged template raw text must reach the program unescaped.
+    // https://github.com/oven-sh/bun/issues/18115
+    test("-e keeps non-ASCII regex source and raw template text", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith([
+        "-e",
+        "console.log(JSON.stringify([/é/.source, String.raw`中🐰`, String(/café/u)]))",
+      ]);
+      expect({ stdout, stderr }).toEqual({
+        stdout: JSON.stringify(["é", "中🐰", "/café/u"]) + "\n",
+        stderr: "",
+      });
       expect(exitCode).toBe(0);
     });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -391,10 +391,25 @@ describe("bunshell", () => {
 
     test("escape unicode", async () => {
       const { stdout } = await $`echo \\弟\\気`;
-      // TODO: Uncomment and replace after unicode in template tags is supported
-      // expect(stdout.toString("utf8")).toEqual(`\弟\気\n`);
-      // Set this here for now, because unicode in template tags while using .raw is broken, but should be fixed
-      expect(stdout.toString("utf8")).toEqual("\\u5F1F\\u6C17\n");
+      expect(stdout.toString("utf8")).toEqual(`\\弟\\気\n`);
+    });
+
+    // https://github.com/oven-sh/bun/issues/15929
+    test("literal non-ascii in template raw text", async () => {
+      const { stdout } = await $`echo 日本語 español "rêver" 🐰`;
+      expect(stdout.toString("utf8")).toEqual("日本語 español rêver 🐰\n");
+    });
+
+    test("literal non-ascii path after interpolation", async () => {
+      using dir = tempDir("shell-nonascii", {
+        "日本語/a.txt": "jp\n",
+        "español/a.txt": "es\n",
+      });
+      const base = String(dir);
+      expect((await $`cat ${base}/日本語/a.txt`).text()).toEqual("jp\n");
+      expect((await $`cat ${base}/español/a.txt`).text()).toEqual("es\n");
+      expect((await $`cat ${base}/${"日本語"}/a.txt`).text()).toEqual("jp\n");
+      expect((await $`cat ${base}/${"español"}/a.txt`).text()).toEqual("es\n");
     });
 
     /**

--- a/test/regression/issue/14976/14976.test.ts
+++ b/test/regression/issue/14976/14976.test.ts
@@ -70,7 +70,7 @@ test("constant-folded equals doesn't lie", async () => {
   console.log("\"" === '"');
 });
 
-test.skip("template literal raw property with unicode in an ascii-only build", async () => {
+test("template literal raw property with unicode in an ascii-only build", async () => {
   expect(String.raw`你好𐃘\\`).toBe("你好𐃘\\\\");
   expect((await $`echo 你好𐃘`.text()).trim()).toBe("你好𐃘");
 });


### PR DESCRIPTION
Fixes #8207
Fixes #8745
Fixes #13853
Fixes #15492
Fixes #15929
Fixes #16763
Fixes #18115
Fixes #33930

Last of a four PR stack, based on #38714 (1: #38708 16-bit sources in the error preview, position fix-up and REPL; 2: #38710 coverage line table; 3: #38714 disk and bundler output decoded as UTF-8; 4: this). The diff shown here is against #38714 and contains only this part.

### Problem

- `String.raw`\`日本語\` returns `"\u65E5\u672C\u8A9E"` (18 characters) and `/é/.source` returns `"\u00E9"`; Node returns `"日本語"` and `"é"`. Same for any tag function's `.raw`, `String(regex)`, and the `bun build --target=bun` / `--compile` / `--bytecode` output of such code. `new RegExp(..)` is unaffected, so the same pattern reflects differently depending on how it was written.
- Cause: `print_raw_template_literal` and `print_reg_exp_literal` in `src/js_printer/lib.rs` rewrite every non-ASCII code point (and, for regexes, every control byte, #33930) to an escape when printing for the Bun target. Escaping is invisible for identifiers, string literals and cooked template text, but these two pieces of text are exposed verbatim to the program (ES2026 22.2.6.13.1 only allows `/` and line terminators to be escaped in `.source`; esbuild's `--charset=ascii` exempts both constructs for the same reason).
- The escaping was load-bearing: every consumer of runtime printer output wraps the bytes as an 8-bit string without looking at them, which is only correct while they are ASCII. Preserved `/*! */` comments already broke that assumption (a function containing `/*! © */` reports `Â©` from `Function.prototype.toString()` on every path that goes through the runtime printer today), so simply printing more text verbatim needs the consumers to know what width they are holding.

### Fix

- Printer: regex text, raw template text and preserved comments go through one `print_verbatim` and are never escaped. Everything else is still escaped, so output for code without such text is byte-for-byte what it was (`test/regression/issue/14976` "outputs only ascii" still holds). Writers for files and for `Bun.Transpiler` are UTF-8 and copy the text through.
- This is the design from #28214: when printing for the runtime, `BufferWriter` starts out as Latin-1 (`init_latin1`, one character per byte) and the first verbatim character above U+00FF rewrites the buffer in place as UTF-16 code units, after which printing continues in UTF-16. All printer offsets (`prev_reg_exp_end`, `stmt_start`, ...) count characters and the widening maps 1:1, so they stay valid; `reserve`/`advance` regions are converted on commit. A module whose non-ASCII text fits in Latin-1 (`/café/`) stays 8-bit; a module with `中` costs one O(n) widening and then two bytes per character, which is what JSC needs for it anyway. The ASCII path is one predictable branch per write.
- The source map builder is told the writer's mode: one column per byte while Latin-1, one per code unit after widening (`update_generated_utf16_slow`); `print_verbatim` flushes the pending bytes before widening and doubles the builder's byte cursor afterwards, so positions are right whether the widening happens before, after or in the middle of the line being mapped.
- Every consumer takes the buffer in its final width; nothing scans or transcodes:
  - the three loaders (`jsc_hooks`, `RuntimeTranspilerStore`, `AsyncModule`) copy it with `clone_written_as_string` (`clone_latin1`, or the new `clone_utf16_wide`);
  - the `--hot` / `--watch` intern map (`VirtualMachine::ref_counted_resolved_source`, `RefString`) owns either a `Box<[u8]>` or a `Box<[u16]>`, hands JSC an external string of the matching width (`String::create_external_utf16` is new), and seeds the content hash with the width, since the map is keyed by hash alone;
  - the runtime transpiler cache's `put` passes the printer's bytes and the matching on-disk tag (`LATIN1` or `UTF16`; those arms were dead until now) straight through to the writer, and `load` reads the entry back into a string of that width; the compile cache hook on the cache-hit path takes the width from the entry's header. The `UTF8` tag is no longer written or accepted, `Entry.output_code` is a plain string, and `EXPECTED_VERSION` 25 -> 26 discards entries holding escaped output;
  - `NODE_COMPILE_CACHE` hashes the bytes of either width (a cache hit hands over the same bytes the print path did) and passes the width to the bytecode generators as `BytecodeSourceEncoding` (a `repr(u8)` enum mirrored in C++), and `ZigSourceProvider.cpp` decodes `Utf8` (bundler output on disk), `Latin1` or `Utf16` exactly as the corresponding loader does, so the bytecode's SourceCodeKey matches at load time. This is also what makes `--bytecode` / `--compile --bytecode` work for non-ASCII bundles, which `--compile` already loaded as UTF-8;
  - the debugger's inline `sourceMappingURL` trailer (`on_source_map_chunk`) and the debug source dump write through the width-aware buffer. The trailer no longer appends a `//# sourceURL=` comment: the script's URL comes from the module loader anyway (Bun's debug adapter only reads `url`), on main the comment was mojibake for non-ASCII paths, and it was the only non-source text that could have widened a module;
  - `bake-codegen.ts` asserts the server HMR runtime, which `DevServer` still embeds as a Latin-1 string, stays ASCII now that its regexes are no longer escaped.
- Ill-formed UTF-8 in verbatim text is decoded by the same `CodepointIterator` the lexer builds string literal values with, so under `bun x.js` a regex or raw template containing such bytes evaluates to the same string as a literal written with the same bytes; #38262 changes that shared decoder to U+FFFD replacement and this path follows it automatically. A file written by `bun build` keeps the bytes and is decoded with replacement by whoever loads it, which differs from the in-process result only for WTF-8 encoded lone surrogates (the lexer keeps those for `Bun.Transpiler` string input); that is noted on `write_verbatim_utf8`.
- `StandaloneModuleGraph` still loads any non-ASCII module through `clone_utf8`, i.e. as a 16-bit heap copy; this change makes that case more common, and #38771 is about storing such modules in their final width.
- Compatibility: `bun build --target=bun` output (without `--compile`) that contains a non-ASCII regex or tagged template now carries the raw UTF-8, and Bun versions before #38714 read `// @bun` files as Latin-1, so such a bundle run on an older Bun gets mojibake in those two places (a `/café/` built here does not match `"café"` on 1.3.x, where today's escaped output does). Output for code without those constructs is unchanged, and `--compile` and the runtime transpiler are unaffected because the runtime that reads the output is the one that wrote it. Worth a line in the release notes.
- Verification (fails on #38714, passes here, unless noted):
  - `test/bundler/transpiler/template-literal.test.ts`: `.source` / `.raw` values for Latin-1, BMP, BOM, astral and control characters, the #13853 and #18115 repros, `bun build --target=bun`; a matrix of four modules (regex/template text and preserved-comment text, each in an 8-bit variant `café-©-ÿ` and a widening variant `café-中-🐰`) through entry point, `--hot`, `// @bun` entry point, `import`, `import` of a `// @bun` module and `require` (the `// @bun` rows pass since #38714 and pin it; the other 16 fail before this change); transpiler cache write + read back for both widths through the sync and async paths, asserting the entry's width tag (`LATIN1` for `café-©-ÿ`, `UTF16` for `café-中-🐰`) and the text stored under it, and that the second run serves the entry untouched (inode, mtime and size compared); one process that `require`s a widening module and then an 8-bit one, whose two entries must be tagged `UTF16` and `LATIN1` (the printer is reused, so this pins `reset()` restoring Latin-1); `NODE_COMPILE_CACHE` hit counts for both widths equal to an ASCII twin's, with the module transpiled again, served from the transpiler cache, and with the transpiler cache warmed before the compile cache is enabled (so the bytecode is generated from the cache-served bytes and the header's width, and the final run's hit is the SourceCodeKey match), plus the preserved-comment module; five ill-formed byte sequences (stray continuation byte, truncated sequence, overlong encoding, encoded surrogate, 0xFF) for which `.source` and `.raw` must equal a string literal built from the same bytes; and stack positions of `new Error` sites before and after the widening text (line accounting only; they pass before the change too). 43 of the file's 58 tests fail on the #38714 build.
  - `test/cli/inspect/inspect-inline-sourcemap.test.ts`: decodes the runtime source map the inspector reports for a line that the transpiler prints unchanged, `const x = [/.../u, new Error("b"), String.raw`...`, f()];`, in an ASCII, an 8-bit and a widening variant with the same number of code units, and requires every mapping on the line to have equal generated and original columns, including the ones at `new Error`, `String.raw` and `f()`. That pins the builder's byte mode, its code unit mode and the cursor handoff at the point of widening; the 8-bit and widening variants fail on #38714 (the escaped text shifts the columns). A further case runs a widening module from a non-ASCII directory and checks `scriptParsed.url` and the decoded map.
  - `test/bundler/bundler_bun.test.ts`: the `.jsc` sidecar accepted for a non-ASCII CJS bundle; a non-ASCII `--target=bun` bundle's error preview (regex shown as written next to a still-escaped string literal) and frame positions without source maps, and with `--sourcemap=inline`, where the `sourceMappingURL` comment is located in the now 16-bit `// @bun` source and positions remap to `entry.ts`. `test/bundler/bundler_compile.test.ts`: `--compile --bytecode` hits for ESM and CJS.
  - `test/cli/test/coverage.test.ts`: lcov records for 8-bit and widened regex/template text equal the ASCII twin's (the preserved-comment case is in #38710). `test/bake/dev/production.test.ts`: a prerendered page renders both values as written (the preserved-comment case is in #38714). `test/js/bun/repl/repl.test.ts`: `-e` with non-ASCII `.source` / `.raw`, and `.load` of a file with an ill-formed byte inside a regex evaluating to U+FFFD (the preserved-comment case is in #38708). `transpiler.test.js` (`Bun.Transpiler` keeps both constructs verbatim while still escaping string literals), `bunshell.test.ts` (#15929) and the previously skipped case in `14976`.
  - Also run on this build: `runtime-transpiler`, `transpiler-cache`, `node-module-module` (compile cache), `test/js/bun/sourcemap/`, `hot.test.ts`, the rest of `bundler_bun`, `bundler_compile`'s bytecode and source map cases, `repl`, `coverage`, `bunshell`, the rest of `test/cli/inspect/` (`debugger-buntranspiledmodule` matches scripts on `url`; `inspect.test.ts`'s connection tests cannot bind in this environment with or without the change), clippy and fmt on the touched crates.

### Background

- Bun-target printing: the printer has an ASCII-only mode used whenever Bun itself will execute the output (runtime transpiler, `bun build --target=bun`, `--compile`). Identifiers and string literals are printed as escapes so the common module has no bytes above 0x7F and can be handed to JSC as an 8-bit string without a copy of any kind.
- JSC strings are either 8-bit (one Latin-1 character per byte) or 16-bit (UTF-16 code units); there is no UTF-8 string, so UTF-8 input has to be scanned and, if not ASCII, transcoded. The widening here produces the 16-bit form directly, so the loaders only ever memcpy.
- External strings / intern map: under `--hot` and `--watch` the runtime keeps each module's transpiled text in a refcounted map so reloads of unchanged text share one buffer; JSC is given an external string pointing at that buffer, and the map is keyed by a hash of the content alone.
- Runtime transpiler cache: on-disk cache of transpiler output keyed by source hash. Each entry records the width of the stored output so `load` can read it directly into a string of that width; `EXPECTED_VERSION` invalidates every entry when the format or the output changes.
- SourceCodeKey: JSC bytecode caches (`--bytecode`, `NODE_COMPILE_CACHE`) are validated at load time by comparing a key derived from the source string against the one stored with the bytecode; a mismatch silently falls back to parsing, which is why the generator has to build the same string (same width, same content) the loader will.
- Source maps count generated columns in UTF-16 code units, and the builder derives them by walking the printer's buffer, so it has to know what the bytes in that buffer are.

### Related

- #28214 is where this design was proposed; #27274 (a rebase of #15047), #30558, #30566 and #31394 were earlier attempts that fixed the printer and switched the loaders to UTF-8 decoding. pfgithub and kernoeb are credited as co-authors on the printer commit; the transpiler cache round-trip test is taken from #31394.
- #33868 was an alternative that turned ASCII escaping off for the whole runtime path; closed in favour of this scope. #37162 is folded into #38714.
- Earlier revisions of this PR decoded UTF-8 printer output in every consumer instead, and carried parts 1 to 3; they were split out at review.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts, test/js/bun/repl/repl.test.ts, test/bundler/bundler_compile.test.ts, test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->
