### PR TITLE
Preserve non-ASCII source text in TemplateStringsArray.raw and RegExp.source

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3136,53 +3136,10 @@ pub mod __gated_printer {
         }
 
         fn print_raw_template_literal(&mut self, bytes: &[u8]) {
-            if IS_JSON || !ASCII_ONLY {
-                self.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            let mut ascii_start: usize = 0;
-            let mut is_ascii = false;
-            let iter = CodepointIterator::init(bytes);
-            let mut cursor = strings::Cursor::default();
-
-            while iter.next(&mut cursor) {
-                match cursor.c as u32 {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0..=LAST_ASCII => {
-                        if !is_ascii {
-                            ascii_start = cursor.i as usize;
-                            is_ascii = true;
-                        }
-                    }
-                    _ => {
-                        if is_ascii {
-                            self.print(&bytes[ascii_start..(cursor.i as usize)]);
-                            is_ascii = false;
-                        }
-
-                        match cursor.c as u32 {
-                            c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                            _ => {
-                                self.print(b"\\u{");
-                                let _ = self.fmt(format_args!("{:x}", cursor.c));
-                                self.print(b"}");
-                            }
-                        }
-                    }
-                }
-            }
-
-            if is_ascii {
-                self.print(&bytes[ascii_start..]);
-            }
+            // `TemplateStringsArray.raw` exposes these bytes verbatim at
+            // runtime, so re-encoding non-ASCII as `\uXXXX` would change the
+            // observed string value. esbuild exempts template contents too.
+            self.print(bytes);
         }
 
         pub fn check_stack_overflow(&self) -> Result<(), bun_core::Error> {
@@ -4598,41 +4555,10 @@ pub mod __gated_printer {
                 self.print(b" ");
             }
 
-            if IS_BUN_PLATFORM {
-                // Translate any non-ASCII to unicode escape sequences
-                let mut ascii_start: usize = 0;
-                let mut is_ascii = false;
-                let iter = CodepointIterator::init(&e.value);
-                let mut cursor = strings::Cursor::default();
-                while iter.next(&mut cursor) {
-                    match cursor.c as u32 {
-                        FIRST_ASCII..=LAST_ASCII => {
-                            if !is_ascii {
-                                ascii_start = cursor.i as usize;
-                                is_ascii = true;
-                            }
-                        }
-                        _ => {
-                            if is_ascii {
-                                self.print(&e.value[ascii_start..(cursor.i as usize)]);
-                                is_ascii = false;
-                            }
-
-                            match cursor.c as u32 {
-                                c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                                c => self.print(&surrogate_pair_escape(c)[..]),
-                            }
-                        }
-                    }
-                }
-
-                if is_ascii {
-                    self.print(&e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                self.print(&e.value[..]);
-            }
+            // `RegExp.prototype.source` is observable at runtime and must
+            // round-trip the source bytes verbatim; re-encoding non-ASCII as
+            // `\uXXXX` changes what `.source` returns.
+            self.print(&e.value[..]);
 
             // Need a space before the next identifier to avoid it turning into flags
             self.prev_reg_exp_end = self.writer.written();

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3137,8 +3137,8 @@ pub mod __gated_printer {
 
         fn print_raw_template_literal(&mut self, bytes: &[u8]) {
             // `TemplateStringsArray.raw` exposes these bytes verbatim at
-            // runtime, so re-encoding non-ASCII as `\uXXXX` would change the
-            // observed string value. esbuild exempts template contents too.
+            // runtime, so re-encoding non-ASCII as escape sequences would
+            // change the observed string value. esbuild exempts these too.
             self.print(bytes);
         }
 
@@ -4557,7 +4557,7 @@ pub mod __gated_printer {
 
             // `RegExp.prototype.source` is observable at runtime and must
             // round-trip the source bytes verbatim; re-encoding non-ASCII as
-            // `\uXXXX` changes what `.source` returns.
+            // escape sequences changes what `.source` returns.
             self.print(&e.value[..]);
 
             // Need a space before the next identifier to avoid it turning into flags

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1328,16 +1328,6 @@ impl AsyncModule {
 
         // SAFETY: per-thread VM.
         if unsafe { (*jsc_vm).is_watcher_enabled() } {
-            // SAFETY: per-thread VM.
-            let mut resolved_source = unsafe {
-                (*jsc_vm).ref_counted_resolved_source::<false>(
-                    printer.ctx.get_written(),
-                    BunString::init(specifier),
-                    path.text,
-                    None,
-                )
-            };
-
             if let Some(fd_) = input_fd {
                 if bun_paths::is_absolute(path.text)
                     && !strings::contains(path.text, b"node_modules")
@@ -1369,13 +1359,26 @@ impl AsyncModule {
                 }
             }
 
-            resolved_source.is_commonjs_module = is_commonjs_module;
-
-            return Ok(resolved_source);
+            // The ref-counted watcher source creates an external Latin-1
+            // WTFString; fall through to `clone_utf8` when the printer output
+            // contains multi-byte UTF-8 (raw tagged-template / regex literals).
+            if strings::first_non_ascii(printer.ctx.get_written()).is_none() {
+                // SAFETY: per-thread VM.
+                let mut resolved_source = unsafe {
+                    (*jsc_vm).ref_counted_resolved_source::<false>(
+                        printer.ctx.get_written(),
+                        BunString::init(specifier),
+                        path.text,
+                        None,
+                    )
+                };
+                resolved_source.is_commonjs_module = is_commonjs_module;
+                return Ok(resolved_source);
+            }
         }
 
         Ok(ResolvedSource {
-            source_code: BunString::clone_latin1(printer.ctx.get_written()),
+            source_code: BunString::clone_utf8(printer.ctx.get_written()),
             specifier: BunString::init(specifier),
             source_url: BunString::init(path.text),
             is_commonjs_module,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -41,7 +41,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
 /// written before #30888 carried `has_tla=false` for every module; the cache-HIT
 /// path reinstates the bug for any previously-cached TLA module (#30887).
-const EXPECTED_VERSION: u32 = 22;
+/// Version 23: Non-ASCII bytes in tagged-template raw contents and regex
+/// literals are preserved verbatim (#18115); entries from earlier builds
+/// contain `\uXXXX` escape sequences in their place.
+const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -1014,7 +1017,7 @@ impl RuntimeTranspilerCache {
             return;
         }
         debug_assert!(self.entry.is_none());
-        let output_code = BunString::clone_latin1(output_code_bytes);
+        let output_code = BunString::clone_utf8(output_code_bytes);
         // Refcount stays at 1, sole owner.
         // BunString is Copy with no Drop, so an extra dupe_ref here would leak.
         self.output_code = Some(output_code);
@@ -1033,7 +1036,7 @@ impl RuntimeTranspilerCache {
         }
         #[cfg(debug_assertions)]
         {
-            bun_core::scoped_log!(cache, "put() = {} bytes", output_code.latin1().len());
+            bun_core::scoped_log!(cache, "put() = {} bytes", output_code_bytes.len());
         }
     }
 }
@@ -1083,10 +1086,13 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             }
             debug_assert!(this.entry.is_none());
 
-            // Borrowed Latin-1 view: `to_file` only reads `byte_slice()` + the encoding
-            // tag (unmarked 8-bit ZigString -> Encoding::LATIN1, same as clone_latin1),
-            // and `output_code_bytes` outlives the synchronous `to_file` call.
-            let output_code = BunString::ascii(output_code_bytes);
+            // Borrowed UTF-8 view: `to_file` only reads `byte_slice()` + the
+            // encoding tag, and `output_code_bytes` outlives the synchronous
+            // `to_file` call. Printer output may contain multi-byte UTF-8
+            // (raw tagged-template / regex literals) so tag it UTF-8; the
+            // `Encoding::UTF8` load path takes a Latin-1 fast path when the
+            // bytes are pure ASCII.
+            let output_code = BunString::borrow_utf8(output_code_bytes);
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,7 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: Non-ASCII bytes in tagged-template raw contents and regex
 /// literals are preserved verbatim (#18115); entries from earlier builds
-/// contain `\uXXXX` escape sequences in their place.
+/// contain unicode escape sequences in their place.
 const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1034,7 +1034,7 @@ impl TranspilerJob {
                 _ => (ptr::null_mut(), 0),
             };
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache,
                 bytecode_cache_size,
@@ -1181,7 +1181,7 @@ impl TranspilerJob {
             // `cache.output_code` (only the `r#impl == None` fallback does,
             // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
             debug_assert!(cache.output_code.is_none());
-            let result = String::clone_latin1(written);
+            let result = String::clone_utf8(written);
 
             // SAFETY: leaf scalar field read on `*vm`; see `vm` note above.
             if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2645,7 +2645,7 @@ fn transpile_source_code_inner(
                         _ => (core::ptr::null_mut(), 0),
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         already_bundled: true,
@@ -2981,19 +2981,27 @@ fn transpile_source_code_inner(
                     // (Stacked Borrows — see the matching note below).
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread
-                    // VM; `printer.ctx.get_written()` borrows thread-local data.
-                    let mut resolved_source = unsafe {
-                        (*jsc_vm).ref_counted_resolved_source::<false>(
-                            printer.ctx.get_written(),
-                            input_specifier.dupe_ref(),
-                            path.text,
-                            None,
-                        )
-                    };
-                    resolved_source.is_commonjs_module = is_commonjs_module;
-                    resolved_source.module_info = module_info;
-                    return Ok(OwnedResolvedSource::from(resolved_source));
+                    let written = printer.ctx.get_written();
+                    // The ref-counted watcher source creates an external
+                    // Latin-1 WTFString, which mis-decodes any multi-byte
+                    // UTF-8 (raw tagged-template contents / regex literals are
+                    // printed verbatim). Fall through to the encoding-aware
+                    // clone below when the output is not pure ASCII.
+                    if bun_core::strings::first_non_ascii(written).is_none() {
+                        // SAFETY: per fn contract — `jsc_vm` is the live
+                        // per-thread VM; `written` borrows thread-local data.
+                        let mut resolved_source = unsafe {
+                            (*jsc_vm).ref_counted_resolved_source::<false>(
+                                written,
+                                input_specifier.dupe_ref(),
+                                path.text,
+                                None,
+                            )
+                        };
+                        resolved_source.is_commonjs_module = is_commonjs_module;
+                        resolved_source.module_info = module_info;
+                        return Ok(OwnedResolvedSource::from(resolved_source));
+                    }
                 }
 
                 // Final ResolvedSource.
@@ -3059,7 +3067,7 @@ fn transpile_source_code_inner(
                 // `None`.
                 debug_assert!(cache.output_code.is_none());
                 let written_len = written.len();
-                let source_code = bun_core::String::clone_latin1(written);
+                let source_code = bun_core::String::clone_utf8(written);
                 // `printer.ctx.buffer.deinit()`: release the
                 // large/--smol print buffer now instead of holding it until the
                 // next transpile. Replacing the printer drops the old buffer

--- a/test/regression/issue/14976/14976.test.ts
+++ b/test/regression/issue/14976/14976.test.ts
@@ -70,7 +70,7 @@ test("constant-folded equals doesn't lie", async () => {
   console.log("\"" === '"');
 });
 
-test.skip("template literal raw property with unicode in an ascii-only build", async () => {
+test("template literal raw property with unicode in an ascii-only build", async () => {
   expect(String.raw`你好𐃘\\`).toBe("你好𐃘\\\\");
   expect((await $`echo 你好𐃘`.text()).trim()).toBe("你好𐃘");
 });

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -114,7 +114,7 @@ describe("tagged-template .raw and RegExp.source preserve non-ASCII source text"
       cwd: String(dir),
     });
     expect(build.exitCode).toBe(0);
-    // The built output should keep the raw bytes verbatim (no `\uXXXX`).
+    // The built output should keep the raw bytes verbatim (no unicode escapes).
     expect(build.stdout).not.toContain("\\u00E9");
     expect(build.stdout).toContain("café");
 

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -1,0 +1,140 @@
+// https://github.com/oven-sh/bun/issues/18115
+// Bun's transpiler escaped non-ASCII bytes inside tagged-template raw
+// contents and RegExp literals, so the values observed via
+// `TemplateStringsArray.raw` / `RegExp.prototype.source` diverged from
+// the spec and from every other engine. Twin of #26785 (regex) and #8745.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+const fixture = /* js */ `
+const tag = (s, ...v) => ({ raw: s.raw.slice(), cooked: [...s], vals: v });
+const out = {
+  latin1Len: String.raw\`é\`.length,
+  latin1: String.raw\`café\`,
+  cjk: String.raw\`日本語\`,
+  astral: String.raw\`🎉\`,
+  astralLen: String.raw\`🎉\`.length,
+  multiPart: tag\`héllo \${1} wörld 🎉\`,
+  regexSource: /café日本語🎉/u.source,
+  regexLen: /café/.source.length,
+  regexFlagsMatch: /日本語/u.test("日本語"),
+};
+process.stdout.write(JSON.stringify(out));
+`;
+
+const expected = {
+  latin1Len: 1,
+  latin1: "café",
+  cjk: "日本語",
+  astral: "🎉",
+  astralLen: 2,
+  multiPart: {
+    raw: ["héllo ", " wörld 🎉"],
+    cooked: ["héllo ", " wörld 🎉"],
+    vals: [1],
+  },
+  regexSource: "café日本語🎉",
+  regexLen: 4,
+  regexFlagsMatch: true,
+};
+
+async function run(cmd: string[], opts: { cwd?: string; env?: Record<string, string | undefined> } = {}) {
+  await using proc = Bun.spawn({
+    cmd,
+    env: { ...bunEnv, ...opts.env },
+    cwd: opts.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("tagged-template .raw and RegExp.source preserve non-ASCII source text", () => {
+  test.concurrent("runtime (sync module load)", async () => {
+    using dir = tempDir("18115-run", { "entry.mjs": fixture });
+    const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "entry.mjs")]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+
+  test.concurrent("runtime (via require, async transpiler store)", async () => {
+    using dir = tempDir("18115-async", {
+      "mod.js": fixture,
+      "entry.js": `require("./mod.js");`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "entry.js")]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+
+  test.concurrent("pre-bundled (// @bun) source", async () => {
+    using dir = tempDir("18115-atbun", { "entry.js": "// @bun\n" + fixture });
+    const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "entry.js")]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+
+  test.concurrent("watcher path", async () => {
+    using dir = tempDir("18115-watch", {
+      "entry.mjs": fixture + `\nprocess.exit(0);\n`,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "--watch", join(String(dir), "entry.mjs")]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+
+  test.concurrent("runtime transpiler cache round-trips non-ASCII", async () => {
+    // The cache only writes when the source is at least MINIMUM_CACHE_SIZE
+    // bytes; pad with a comment so the entry is actually persisted.
+    const padding = "/*" + Buffer.alloc(64 * 1024, "*").toString() + "*/\n";
+    using dir = tempDir("18115-cache", { "entry.js": padding + fixture, "cache/.keep": "" });
+    const env = { BUN_RUNTIME_TRANSPILER_CACHE_PATH: join(String(dir), "cache") };
+
+    // First run writes the cache entry.
+    {
+      const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "entry.js")], { env });
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      expect(JSON.parse(stdout)).toEqual(expected);
+    }
+
+    // Second run serves the cached entry (regresses if the on-disk encoding
+    // tag and the written bytes disagree).
+    {
+      const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "entry.js")], { env });
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      expect(JSON.parse(stdout)).toEqual(expected);
+    }
+  });
+
+  test.concurrent("bun build --target=bun output runs correctly", async () => {
+    using dir = tempDir("18115-build", { "entry.mjs": fixture });
+    const build = await run([bunExe(), "build", "--target=bun", join(String(dir), "entry.mjs")], {
+      cwd: String(dir),
+    });
+    expect(build.exitCode).toBe(0);
+    // The built output should keep the raw bytes verbatim (no `\uXXXX`).
+    expect(build.stdout).not.toContain("\\u00E9");
+    expect(build.stdout).toContain("café");
+
+    await Bun.write(join(String(dir), "out.js"), build.stdout);
+    const { stdout, stderr, exitCode } = await run([bunExe(), join(String(dir), "out.js")]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+
+  // The `--target=node` / `browser` paths were already correct; guard that
+  // they stay that way.
+  for (const target of ["node", "browser"] as const) {
+    test.concurrent(`bun build --target=${target} output is unchanged`, async () => {
+      using dir = tempDir(`18115-build-${target}`, { "entry.mjs": fixture });
+      const build = await run([bunExe(), "build", `--target=${target}`, join(String(dir), "entry.mjs")], {
+        cwd: String(dir),
+      });
+      expect(build.exitCode).toBe(0);
+      expect(build.stdout).not.toContain("\\u00E9");
+      expect(build.stdout).toContain("café");
+    });
+  }
+});


### PR DESCRIPTION
Fixes #18115
Fixes #8745
Fixes #16763
Fixes #26785
Fixes #18859

### Repro

```console
$ cat repro.mjs
console.log(String.raw`é`.length);
const tag = (s) => s.raw[0];
console.log(JSON.stringify(tag`café`));
console.log(/café/.source.length);

$ node repro.mjs
1
"café"
4

$ bun repro.mjs   # before
6
"caf\\u00E9"
9
```

Every file `bun` executes goes through the printer, so any tagged-template DSL that reads `.raw` (SQL / GraphQL / CSS-in-JS / HTML / `String.dedent`) received ASCII escape sequences the moment an accent, `©`, or emoji appeared in a template. The same escape sequences were baked into `bun build --target=bun` output while `--target=node`/`browser` kept the raw text, so identical source computed different strings per target.

### Cause

Two layers cooperated to mangle the bytes.

**Printer.** `print_raw_template_literal` and `print_reg_exp_literal` in `src/js_printer/lib.rs` re-encoded codepoints > 0x7F as `\uXXXX` when printing for the bun runtime target. Both `TemplateStringsArray.raw` and `RegExp.prototype.source` expose the source bytes verbatim by spec, so escape sequences replaced the author's characters at runtime.

**JSC handoff.** Six Rust sites cloned the printer output (or raw `// @bun` source contents) as Latin-1 unconditionally: `jsc_hooks.rs` (sync load + already-bundled), `RuntimeTranspilerStore.rs` (async transpile + already-bundled), `AsyncModule.rs` (async load), and the `RuntimeTranspilerCache` write path. Plus two watcher branches that routed through `ref_counted_resolved_source`, which creates an external Latin-1 `WTFString`. The Latin-1 clone was only correct because the printer had historically guaranteed ASCII output.

### Fix

- `print_raw_template_literal` / `print_reg_exp_literal` now write the source bytes verbatim. esbuild exempts template contents from `--charset=ascii` for the same reason.
- The six clone sites use `clone_utf8` instead of `clone_latin1`. `BunString__fromBytes` already takes the Latin-1 fast path for pure-ASCII input, so the common case pays nothing new.
- The two watcher branches check `first_non_ascii` and keep the zero-copy external-Latin-1 path for pure-ASCII output, falling through to the encoding-aware clone otherwise. In `AsyncModule.rs` the watcher's `add_file` registration now runs regardless of encoding.
- The `RuntimeTranspilerCache` vtable `put()` tags the on-disk entry as UTF-8 (whose load path already has an ASCII fast path) instead of Latin-1. Cache version bumped 22 → 23.
- Un-skips the existing test at `test/regression/issue/14976/14976.test.ts` that covered this exact property.

### Verification

`test/regression/issue/18115.test.ts` runs the same fixture (Latin-1, CJK, astral codepoints, multi-part tagged template, regex `.source`) through the sync load path, the async transpiler store (`require`), the `// @bun` already-bundled path, `--watch`, the runtime transpiler cache round-trip, and `bun build --target=bun` → run. The `--target=node`/`browser` arms guard that the previously-correct paths stay correct.

Before: 6 of 8 fail (`.raw` is `\uXXXX` sequences, `.source` lengths wrong). After: 8 pass.

`bun bd test test/bundler/transpiler/template-literal.test.ts test/regression/issue/14976/ test/cli/run/transpiler-cache.test.ts test/bundler/bundler_string.test.ts test/bundler/bundler_bun.test.ts test/bundler/transpiler/transpiler.test.js test/cli/hot/hot.test.ts`: all pass.
