### PR TITLE
node:http: frame the response body from the user's Transfer-Encoding value

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -37,9 +37,10 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
         const name = headers[i];
         const value = headers[i + 1];
         if (name.length === 1 && name.charCodeAt(0) === 0) {
-          // node:http's NUL-named framing sentinel pair (see NodeHTTP.cpp):
-          // value "2" = no body (HEAD), anything else = close-delimited.
+          // node:http's NUL-named framing sentinel pair (see NodeHTTP.cpp).
           if (value === "2") noBody = true;
+          else if (value === "3") chunked = true;
+          else if (value === "4") chunked = false;
           else closeDelimited = true;
           continue;
         }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2002,7 +2002,10 @@ function willBeChunked(response) {
   const outHeaders = response[kOutHeaders];
   const te = outHeaders !== null ? outHeaders["transfer-encoding"] : undefined;
   if (te !== undefined) {
-    return chunkExpression.test(String(te[1]));
+    const teValue = te[1];
+    if (!($isArray(teValue) && teValue.length === 0)) {
+      return chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
+    }
   }
   if (outHeaders !== null && outHeaders["content-length"] !== undefined) return false;
   if (response._hasBody === false) return false;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1992,6 +1992,12 @@ function getNodeHTTPServerSocket() {
   return NodeHTTPServerSocket;
 }
 
+// Node.js's matchHeader: undefined = no TE line reaches the wire (empty array), else chunkExpression on the value.
+function teValueSelectsChunked(teValue) {
+  if ($isArray(teValue) && teValue.length === 0) return undefined;
+  return chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
+}
+
 // Node validates the `Trailer` header inside _storeHeader, after the body framing has
 // been decided, so `this.chunkedEncoding` is already set. Bun frames the body in uWS
 // and never sets `response.chunkedEncoding`, so reproduce Node's decision here.
@@ -2002,10 +2008,8 @@ function willBeChunked(response) {
   const outHeaders = response[kOutHeaders];
   const te = outHeaders !== null ? outHeaders["transfer-encoding"] : undefined;
   if (te !== undefined) {
-    const teValue = te[1];
-    if (!($isArray(teValue) && teValue.length === 0)) {
-      return chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
-    }
+    const c = teValueSelectsChunked(te[1]);
+    if (c !== undefined) return c;
   }
   if (outHeaders !== null && outHeaders["content-length"] !== undefined) return false;
   if (response._hasBody === false) return false;
@@ -2262,7 +2266,6 @@ function renderNativeHeaders(res) {
     const storedTransferEncoding = headersMap === null ? undefined : headersMap["transfer-encoding"];
     const storedContentLength = headersMap === null ? undefined : headersMap["content-length"];
     let defectiveNoBodyResponse = false;
-    // undefined: no TE header line; true/false: chunkExpression result
     let userTEChunked;
     if (storedTransferEncoding !== undefined) {
       const statusCode = res[kSnapshotStatusCode] ?? res.statusCode;
@@ -2270,11 +2273,7 @@ function renderNativeHeaders(res) {
         defectiveNoBodyResponse = true;
         res[kMustCloseConnection] = true;
       }
-      const teValue = storedTransferEncoding[1];
-      if (!($isArray(teValue) && teValue.length === 0)) {
-        // Node.js's matchHeader: chunkExpression on the value picks the framing.
-        userTEChunked = chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
-      }
+      userTEChunked = teValueSelectsChunked(storedTransferEncoding[1]);
     }
 
     // Like Node.js's _storeHeader: with no framing headers on the wire, removing

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2267,14 +2267,9 @@ function renderNativeHeaders(res) {
         defectiveNoBodyResponse = true;
         res[kMustCloseConnection] = true;
       }
-      // Like Node.js's matchHeader: the body is chunk-framed iff the user's
-      // Transfer-Encoding value names `chunked`. The native writer otherwise
-      // decides framing from Content-Length alone, so a `TE: chunked` + CL
-      // response would ship a chunked head with an unframed body. An empty
-      // array renders no header line; treat it as no TE (Node's matchHeader
-      // never runs for it), or sentinel "4" would strip the auto-framing.
       const teValue = storedTransferEncoding[1];
       if (!($isArray(teValue) && teValue.length === 0)) {
+        // Node.js's matchHeader: chunkExpression on the value picks the framing.
         userTEChunked = chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
       }
     }
@@ -2357,14 +2352,11 @@ function renderNativeHeaders(res) {
       // it carries (RFC 9112 6.3).
       flat.push("\u0000", "2");
     } else if (userTEChunked === true) {
-      // Sentinel "3": chunk-frame the body even when a Content-Length header
-      // line was written (Node.js's write_() obeys chunkedEncoding alone).
+      // Sentinel "3": chunk-frame even with a Content-Length line on the wire.
       flat.push("\u0000", "3");
       res.chunkedEncoding = true;
     } else if (userTEChunked === false && !defectiveNoBodyResponse) {
-      // Sentinel "4": a non-chunked Transfer-Encoding (identity, gzip, ...)
-      // means the body bytes are written raw, like Node.js. Without this the
-      // native writer auto-chunks because it sees no Content-Length.
+      // Sentinel "4": non-chunked TE (identity, gzip, ...) writes the body raw.
       flat.push("\u0000", "4");
     }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3122,7 +3122,7 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   if (
     trailer &&
     this._hasBody &&
-    !this.hasHeader("content-length") &&
+    willBeChunked(this) &&
     this.req?.httpVersionMajor === 1 &&
     this.req?.httpVersionMinor >= 1
   ) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2259,11 +2259,23 @@ function renderNativeHeaders(res) {
     const storedTransferEncoding = headersMap === null ? undefined : headersMap["transfer-encoding"];
     const storedContentLength = headersMap === null ? undefined : headersMap["content-length"];
     let defectiveNoBodyResponse = false;
+    // undefined: no TE header line; true/false: chunkExpression result
+    let userTEChunked;
     if (storedTransferEncoding !== undefined) {
       const statusCode = res[kSnapshotStatusCode] ?? res.statusCode;
       if (statusCode === 204 || statusCode === 304) {
         defectiveNoBodyResponse = true;
         res[kMustCloseConnection] = true;
+      }
+      // Like Node.js's matchHeader: the body is chunk-framed iff the user's
+      // Transfer-Encoding value names `chunked`. The native writer otherwise
+      // decides framing from Content-Length alone, so a `TE: chunked` + CL
+      // response would ship a chunked head with an unframed body. An empty
+      // array renders no header line; treat it as no TE (Node's matchHeader
+      // never runs for it), or sentinel "4" would strip the auto-framing.
+      const teValue = storedTransferEncoding[1];
+      if (!($isArray(teValue) && teValue.length === 0)) {
+        userTEChunked = chunkExpression.test($isArray(teValue) ? teValue.join(", ") : String(teValue));
       }
     }
 
@@ -2344,6 +2356,16 @@ function renderNativeHeaders(res) {
       // gate - a HEAD response ends at the first empty line whatever headers
       // it carries (RFC 9112 6.3).
       flat.push("\u0000", "2");
+    } else if (userTEChunked === true) {
+      // Sentinel "3": chunk-frame the body even when a Content-Length header
+      // line was written (Node.js's write_() obeys chunkedEncoding alone).
+      flat.push("\u0000", "3");
+      res.chunkedEncoding = true;
+    } else if (userTEChunked === false && !defectiveNoBodyResponse) {
+      // Sentinel "4": a non-chunked Transfer-Encoding (identity, gzip, ...)
+      // means the body bytes are written raw, like Node.js. Without this the
+      // native writer auto-chunks because it sees no Content-Length.
+      flat.push("\u0000", "4");
     }
 
     if (closeDelimited) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -603,18 +603,17 @@ static void NodeHTTPServer__writeHead(
                 RETURN_IF_EXCEPTION(scope, void());
 
                 // node:http marks framing decisions with a NUL-named sentinel
-                // pair instead of a real header: "1" = close-delimited (user
-                // removed the framing headers), "2" = no body (HEAD), "3"/"4"
-                // = the user's Transfer-Encoding value requires chunked / raw
-                // body framing regardless of Content-Length. uWS's chunked
-                // predicate is !HTTP_WROTE_CONTENT_LENGTH_HEADER, so toggle
-                // that bit; the header line itself was already written above.
+                // pair instead of a real header: value "1" = close-delimited
+                // (the user removed the framing headers), value "2" = no body
+                // (HEAD - suppress all body framing like 204/304).
                 if (name.length() == 1 && name[0] == 0) {
                     if (value == "2"_s) {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_NO_BODY_STATUS;
                     } else if (value == "3"_s) {
+                        // TE value is chunked: toggle uWS's !CL predicate so the body chunk-frames.
                         httpResponseData->state &= ~uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                     } else if (value == "4"_s) {
+                        // TE value is non-chunked: toggle uWS's !CL predicate so the body is raw.
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                     } else {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_CLOSE_DELIMITED;

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -603,12 +603,19 @@ static void NodeHTTPServer__writeHead(
                 RETURN_IF_EXCEPTION(scope, void());
 
                 // node:http marks framing decisions with a NUL-named sentinel
-                // pair instead of a real header: value "1" = close-delimited
-                // (the user removed the framing headers), value "2" = no body
-                // (HEAD - suppress all body framing like 204/304).
+                // pair instead of a real header: "1" = close-delimited (user
+                // removed the framing headers), "2" = no body (HEAD), "3"/"4"
+                // = the user's Transfer-Encoding value requires chunked / raw
+                // body framing regardless of Content-Length. uWS's chunked
+                // predicate is !HTTP_WROTE_CONTENT_LENGTH_HEADER, so toggle
+                // that bit; the header line itself was already written above.
                 if (name.length() == 1 && name[0] == 0) {
                     if (value == "2"_s) {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_NO_BODY_STATUS;
+                    } else if (value == "3"_s) {
+                        httpResponseData->state &= ~uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+                    } else if (value == "4"_s) {
+                        httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                     } else {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_CLOSE_DELIMITED;
                     }

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -1031,6 +1031,18 @@ describe("response body framing matches the user's Transfer-Encoding header", ()
       const { body } = await rawGet((server.address() as AddressInfo).port, "/");
       expect(body).toBe("2\r\nok\r\n0\r\n\r\n");
     });
+
+    test.concurrent("addTrailers are emitted (the trailer gate keys on the TE value, not CL)", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Content-Length", "2");
+        res.setHeader("Transfer-Encoding", "chunked");
+        res.addTrailers({ "X-Foo": "bar" });
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("2\r\nok\r\n0\r\nX-Foo: bar\r\n\r\n");
+    });
   });
 
   test.concurrent("Content-Length + Transfer-Encoding: identity stays identity", async () => {

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -1098,5 +1098,17 @@ describe("response body framing matches the user's Transfer-Encoding header", ()
       expect(normalizeHead(head)).toBe("HTTP/1.1 200 OK\r\nConnection: close\r\nTransfer-Encoding: chunked");
       expect(body).toBe("2\r\nab\r\n2\r\ncd\r\n0\r\n\r\n");
     });
+
+    test.concurrent("addTrailers (willBeChunked falls through to auto-framing)", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", []);
+        res.write("ab");
+        res.addTrailers({ "X-Foo": "bar" });
+        res.end("cd");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("2\r\nab\r\n2\r\ncd\r\n0\r\nX-Foo: bar\r\n\r\n");
+    });
   });
 });

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -893,3 +893,198 @@ describe("tearing down a response with its headers on the wire adds no bytes", (
     expect(exitCode).toBe(0);
   });
 });
+
+// The body framing (chunked vs raw) must match the Transfer-Encoding header the
+// handler set, like Node.js: chunkedEncoding is derived from the header value,
+// not from Content-Length presence. With a mismatch, a `Transfer-Encoding:
+// identity` response carries a chunk-framed body that the client receives as
+// content, and a `Content-Length` + `Transfer-Encoding: chunked` response
+// desyncs any RFC 9112 §6.3-conforming receiver.
+describe("response body framing matches the user's Transfer-Encoding header", () => {
+  async function rawGet(port: number, path: string): Promise<{ head: string; body: string }> {
+    const { promise, resolve, reject } = Promise.withResolvers<{ head: string; body: string }>();
+    const chunks: Buffer[] = [];
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+    });
+    socket.on("data", d => chunks.push(d));
+    socket.on("error", reject);
+    socket.on("close", () => {
+      const all = Buffer.concat(chunks).toString("latin1");
+      const i = all.indexOf("\r\n\r\n");
+      resolve({ head: all.slice(0, i), body: all.slice(i + 4) });
+    });
+    return promise;
+  }
+
+  function normalizeHead(head: string): string {
+    return head
+      .split("\r\n")
+      .filter(line => !/^(date|keep-alive):/i.test(line))
+      .join("\r\n");
+  }
+
+  const identityCases: { name: string; te: string | string[] }[] = [
+    { name: "identity", te: "identity" },
+    { name: "gzip, identity", te: "gzip, identity" },
+    { name: "[gzip, identity]", te: ["gzip", "identity"] },
+  ];
+  describe.each(identityCases)("Transfer-Encoding: $name writes the body raw", ({ te }) => {
+    test.concurrent("res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", te);
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      // Node.js does not chunk-frame, does not add Content-Length, and keeps
+      // the connection alive (state.te suppresses _storeHeader's framing).
+      expect(head.toLowerCase()).toContain("transfer-encoding:");
+      expect(head.toLowerCase()).not.toContain("content-length:");
+      expect(head.toLowerCase()).not.toMatch(/transfer-encoding:.*chunked/);
+      expect(body).toBe("ok");
+    });
+
+    test.concurrent("res.write + res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", te);
+        res.write("ab");
+        res.end("cd");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("abcd");
+    });
+
+    test.concurrent("writeHead", async () => {
+      await using server = createServer((req, res) => {
+        res.writeHead(200, { "Transfer-Encoding": te });
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("ok");
+    });
+  });
+
+  describe("Transfer-Encoding: chunked chunk-frames the body even with Content-Length", () => {
+    test.concurrent("res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Content-Length", "2");
+        res.setHeader("Transfer-Encoding", "chunked");
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(normalizeHead(head)).toBe(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nTransfer-Encoding: chunked\r\nConnection: close",
+      );
+      expect(body).toBe("2\r\nok\r\n0\r\n\r\n");
+    });
+
+    test.concurrent("res.write + res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Content-Length", "4");
+        res.setHeader("Transfer-Encoding", "chunked");
+        res.write("ab");
+        res.end("cd");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("2\r\nab\r\n2\r\ncd\r\n0\r\n\r\n");
+    });
+
+    test.concurrent("TE set first", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", "chunked");
+        res.setHeader("Content-Length", "5");
+        res.write("abc");
+        res.end("de");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(normalizeHead(head)).toBe(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\nConnection: close",
+      );
+      expect(body).toBe("3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n");
+    });
+
+    test.concurrent("writeHead", async () => {
+      await using server = createServer((req, res) => {
+        res.writeHead(200, { "Content-Length": "2", "Transfer-Encoding": "chunked" });
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(head.toLowerCase()).toContain("content-length: 2");
+      expect(head.toLowerCase()).toContain("transfer-encoding: chunked");
+      expect(body).toBe("2\r\nok\r\n0\r\n\r\n");
+    });
+
+    test.concurrent("array value [gzip, chunked]", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Content-Length", "2");
+        res.setHeader("Transfer-Encoding", ["gzip", "chunked"]);
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(body).toBe("2\r\nok\r\n0\r\n\r\n");
+    });
+  });
+
+  test.concurrent("Content-Length + Transfer-Encoding: identity stays identity", async () => {
+    await using server = createServer((req, res) => {
+      res.setHeader("Content-Length", "2");
+      res.setHeader("Transfer-Encoding", "identity");
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+    expect(normalizeHead(head)).toBe(
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nTransfer-Encoding: identity\r\nConnection: close",
+    );
+    expect(body).toBe("ok");
+  });
+
+  test.concurrent("Transfer-Encoding: chunked alone is chunked (unchanged)", async () => {
+    await using server = createServer((req, res) => {
+      res.setHeader("Transfer-Encoding", "chunked");
+      res.write("ab");
+      res.end("cd");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+    expect(normalizeHead(head)).toBe("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close");
+    expect(body).toBe("2\r\nab\r\n2\r\ncd\r\n0\r\n\r\n");
+  });
+
+  // An empty array emits no Transfer-Encoding header line; Node.js's
+  // matchHeader never runs, so the response falls through to auto-framing.
+  // Guard against deriving `userTEChunked = false` from it, which would
+  // push sentinel "4" and strip the auto Content-Length.
+  describe("empty-array Transfer-Encoding keeps auto-framing", () => {
+    test.concurrent("res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", []);
+        res.end("ok");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(normalizeHead(head)).toBe("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2");
+      expect(body).toBe("ok");
+    });
+
+    test.concurrent("res.write + res.end", async () => {
+      await using server = createServer((req, res) => {
+        res.setHeader("Transfer-Encoding", []);
+        res.write("ab");
+        res.end("cd");
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { head, body } = await rawGet((server.address() as AddressInfo).port, "/");
+      expect(normalizeHead(head)).toBe("HTTP/1.1 200 OK\r\nConnection: close\r\nTransfer-Encoding: chunked");
+      expect(body).toBe("2\r\nab\r\n2\r\ncd\r\n0\r\n\r\n");
+    });
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5001,6 +5001,73 @@ it("http2 allowHTTP1 fallback writes no terminating chunk after a keep-alive HEA
   }
 });
 
+it("http2 allowHTTP1 fallback keeps the connection alive after a response with a user-set Transfer-Encoding: chunked", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    if (req.url === "/a") {
+      res.setHeader("Transfer-Encoding", "chunked");
+      res.end("one");
+      return;
+    }
+    res.end("two");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () => socket.write("GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+    );
+    const chunks = [];
+    let sentSecond = false;
+    socket.on("error", reject);
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      if (!sentSecond && Buffer.concat(chunks).includes("0\r\n\r\n")) {
+        sentSecond = true;
+        socket.write("GET /b HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      }
+    });
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    const raw = await promise;
+    const head = raw.slice(0, raw.indexOf("\r\n\r\n")).toLowerCase();
+    // renderNativeHeaders pushes sentinel "3" for this response; the fallback
+    // decoder must not misread it as close-delimited (dropping Connection and
+    // ending the socket).
+    expect(head).toContain("connection: keep-alive");
+    const after = raw.slice(raw.indexOf("0\r\n\r\n") + 5);
+    expect(after).toStartWith("HTTP/1.1 200 ");
+    expect(after.slice(after.indexOf("\r\n\r\n") + 4)).toBe("two");
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback writes a Transfer-Encoding: identity body raw and keeps the connection alive", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    res.setHeader("Transfer-Encoding", "identity");
+    res.end("ok");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    );
+    const chunks = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    const raw = await promise;
+    const head = raw.slice(0, raw.indexOf("\r\n\r\n")).toLowerCase();
+    expect(head).toContain("transfer-encoding: identity");
+    expect(head).not.toContain("content-length");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("ok");
+  } finally {
+    server.close();
+  }
+});
+
 it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited response when the user removed it", async () => {
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
     res.removeHeader("content-length");

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5044,25 +5044,41 @@ it("http2 allowHTTP1 fallback keeps the connection alive after a response with a
 
 it("http2 allowHTTP1 fallback writes a Transfer-Encoding: identity body raw and keeps the connection alive", async () => {
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
-    res.setHeader("Transfer-Encoding", "identity");
-    res.end("ok");
+    if (req.url === "/a") {
+      res.setHeader("Transfer-Encoding", "identity");
+      res.end("ok");
+      return;
+    }
+    res.end("two");
   });
   await new Promise(resolve => server.listen(0, resolve));
   try {
     const { promise, resolve, reject } = Promise.withResolvers();
     const socket = tls.connect(
       { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
-      () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+      () => socket.write("GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n"),
     );
     const chunks = [];
+    let sentSecond = false;
     socket.on("error", reject);
-    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      const so = Buffer.concat(chunks).toString();
+      if (!sentSecond && so.includes("\r\n\r\nok")) {
+        sentSecond = true;
+        socket.write("GET /b HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      }
+    });
     socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
     const raw = await promise;
     const head = raw.slice(0, raw.indexOf("\r\n\r\n")).toLowerCase();
+    // Sentinel "4" must not be misread as close-delimited.
+    expect(head).toContain("connection: keep-alive");
     expect(head).toContain("transfer-encoding: identity");
     expect(head).not.toContain("content-length");
-    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("ok");
+    const after = raw.slice(raw.indexOf("\r\n\r\nok") + 6);
+    expect(after).toStartWith("HTTP/1.1 200 ");
+    expect(after.slice(after.indexOf("\r\n\r\n") + 4)).toBe("two");
   } finally {
     server.close();
   }


### PR DESCRIPTION
### What does this PR do?

Fixes `node:http` server response body framing when the handler sets a `Transfer-Encoding` header: the body bytes now use the framing the header value declares, like Node.js.

#### Reproduction

```js
import http from "node:http";
import net from "node:net";
const raw = (port, path) => new Promise((res) => {
  const c = [], s = net.connect(port, "127.0.0.1", () =>
    s.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`));
  s.on("data", d => c.push(d));
  s.on("close", () => { const a = Buffer.concat(c).toString("latin1"), i = a.indexOf("\r\n\r\n");
    res({ head: a.slice(0, i), body: a.slice(i + 4) }); });
});
const srv = http.createServer((q, r) => {
  if (q.url === "/ident") { r.setHeader("Transfer-Encoding", "identity"); r.end("ok"); }
  else { r.setHeader("Content-Length", "2"); r.setHeader("Transfer-Encoding", "chunked"); r.end("ok"); }
});
srv.listen(0, "127.0.0.1", async () => {
  const p = srv.address().port;
  console.log(await raw(p, "/ident"), await raw(p, "/clte"));
  process.exit(0);
});
```

Before this PR (Bun), `/ident` sends `Transfer-Encoding: identity` with a chunk-framed body `2\r\nok\r\n0\r\n\r\n` (an RFC-conforming client receives the chunk framing as content), and `/clte` sends `Content-Length: 2` plus `Transfer-Encoding: chunked` with an identity body `ok` (RFC 9112 6.3 resolves that conflict as chunked, so a conforming receiver/intermediary desyncs). Node.js writes the body raw for `/ident` and chunk-framed for `/clte`.

#### Cause

`renderNativeHeaders` in `src/js/node/_http_server.ts` forwarded the user's `Transfer-Encoding` header to the native uWS writer as an ordinary header line; the writer's chunked-vs-raw predicate looked only at whether a `Content-Length` header was present. The declared coding and the emitted framing were decided by two owners that never looked at each other.

Node.js decides framing in JS from `res.chunkedEncoding`, which `_storeHeader`/`matchHeader` derive from the user's `Transfer-Encoding` *value* (`chunkExpression` matches → chunked; anything else → not), and the writer obeys it.

#### Fix

`renderNativeHeaders` now tests the `Transfer-Encoding` value against `chunkExpression` (matching Node's `matchHeader`) and tells the native writer which framing to use via the existing NUL-sentinel channel. `NodeHTTPServer__writeHead` reads two new sentinel values: `"3"` forces chunked framing (clears `HTTP_WROTE_CONTENT_LENGTH_HEADER` so uWS's chunked predicate holds even with a `Content-Length` line already written), `"4"` forces raw framing (sets the bit so the predicate fails and no auto-chunking happens). HEAD/204/304 keep taking the existing no-body path.

#### Verification

`test/js/node/http/node-http-transfer-encoding.test.ts` adds 15 cases (identity / `gzip, identity` / array variants, `res.end` / `res.write`+`res.end` / `writeHead`, and the `Content-Length` + `Transfer-Encoding: chunked` direction) that assert the exact raw head and body bytes against Node.js's. 13 fail before this change and all pass after; the Node.js-parallel `test-http-chunked*`, `test-http-content-length*`, `test-http-remove-header-stays-removed` and `test-http-write-head*` tests are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (eb8e40383)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [751.73ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [498.30ms]
(pass) chunked request trailers parse at every field-value scan boundary [522.66ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [115.38ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [104.79ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [102.81ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [131.63ms]
(pass) Content-Length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [112.49ms]
(pass) content-length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [100.95ms]
(pass) Transfer-Encoding: chunked in trailer section fires clientError HPE_INV
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (f6dd0d94d)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [13.26ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [10.22ms]
(pass) chunked request trailers parse at every field-value scan boundary [7.36ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [3.95ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [3.79ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [2.85ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [3.70ms]
(pass) Content-Length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [3.47ms]
(pass) content-length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [2.01ms]
(pass) Transfer-Encoding: chunked in trailer section fires clientError HPE_INVALID_TRANSFER_ENCODING [3.34ms]
(pass) Transfer-Encoding: gzip in trailer section fires clientError HPE_INVALID_TRANSFER_ENCODING [2.34ms]
(pass) transfer-encoding: chunked in trailer section fires clientError HPE_INVALID_TRANSFER_ENC
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (eb8e40383)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [738.70ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [495.65ms]
(pass) chunked request trailers parse at every field-value scan boundary [450.84ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [105.34ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [106.82ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [97.57ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [146.90ms]
(pass) Content-Length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [106.68ms]
(pass) content-length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH [76.62ms]
(pass) Transfer-Encoding: chunked in trailer section fires clientError HPE_INVAL
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 732ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9034ms)
Bundle modules (117ms)
Postprocesss modules (176ms)
Bundle Functions (677ms)
Generate Code (28ms)

[10.05s] Bundled "src/js" for production
  2571 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[2/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  20 +-
 src/js/node/http2.ts                               |   5 +-
 src/jsc/bindings/NodeHTTP.cpp                      |   6 +
 .../node/http/node-http-transfer-encoding.test.ts  | 221 ++++++++++++++++++++-
 test/js/node/http2/node-http2.test.js              |  83 ++++++++
 5 files changed, 330 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/js/node/_http_server.ts                               16     11      0
src/js/node/http2.ts                                       2      1      0
src/jsc/bindings/NodeHTTP.cpp                              4      3      0
test/js/node/http/node-http-transfer-encoding.test.ts      4      5      0
test/js/node/http2/node-http2.test.js                      3      2      0
```

</details>

<!-- robobun:evidence:end -->