### PR TITLE
node:http: match body framing to Transfer-Encoding on HTTP/1.0 responses

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1604,7 +1604,15 @@ function renderNativeHeaders(res) {
       closeDelimited = true;
       res[kMustCloseConnection] = true;
     } else if (res._removedContLen) {
-      forceChunked = true;
+      // Node's _storeHeader takes the `!useChunkedEncodingByDefault` branch
+      // (HTTP/1.0, or the user cleared the flag) before it ever auto-adds
+      // Transfer-Encoding, so the response is close-delimited there too.
+      if (res.useChunkedEncodingByDefault === false) {
+        closeDelimited = true;
+        res[kMustCloseConnection] = true;
+      } else {
+        forceChunked = true;
+      }
     }
   }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -612,6 +612,23 @@ static bool connectionValueHasClose(const WTF::String& value)
     return false;
 }
 
+// Transfer-Encoding is `1#transfer-coding` (RFC 9112 §6.1): look for the
+// "chunked" token anywhere in a comma-separated list. Mirrors node:http's
+// /(?:^|\W)chunked(?:$|\W)/i chunkExpression.
+static bool transferEncodingHasChunked(const WTF::String& value)
+{
+    size_t pos = 0;
+    while ((pos = value.findIgnoringASCIICase("chunked"_s, pos)) != WTF::notFound) {
+        bool leftOk = pos == 0 || !isASCIIAlphanumeric(value[pos - 1]);
+        size_t end = pos + 7;
+        bool rightOk = end >= value.length() || !isASCIIAlphanumeric(value[end]);
+        if (leftOk && rightOk)
+            return true;
+        pos = end;
+    }
+    return false;
+}
+
 template<bool isSSL>
 static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL>* res)
 {
@@ -668,6 +685,12 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         // Prevent automatic Transfer-Encoding: chunked insertion when user provides one
         if (header.key == WebCore::HTTPHeaderName::TransferEncoding) {
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
+            // The uWS writer never chunk-frames an HTTP/1.0 (fromAncientRequest)
+            // response on its own, but once Transfer-Encoding: chunked is on the
+            // wire the body MUST be chunk-framed to match it (Node does the same).
+            if (data->fromAncientRequest && transferEncodingHasChunked(value)) {
+                data->fromAncientRequest = false;
+            }
         }
 
         // RFC 9112 §9.6: a server that sends the "close" connection option MUST
@@ -766,6 +789,9 @@ static void NodeHTTPServer__writeHead(
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
                     } else if (headerName == WebCore::HTTPHeaderName::TransferEncoding) {
                         httpResponseData->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
+                        if (httpResponseData->fromAncientRequest && transferEncodingHasChunked(value)) {
+                            httpResponseData->fromAncientRequest = false;
+                        }
                     }
                 }
 

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -1,7 +1,23 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "events";
 import { createServer, request } from "http";
 import { AddressInfo, connect, Server } from "net";
+
+async function rawHTTP10(port: number, path: string): Promise<{ head: string; body: string }> {
+  const { promise, resolve, reject } = Promise.withResolvers<{ head: string; body: string }>();
+  const chunks: Buffer[] = [];
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(`GET ${path} HTTP/1.0\r\nHost: localhost\r\n\r\n`);
+  });
+  socket.on("data", d => chunks.push(d));
+  socket.on("error", reject);
+  socket.on("close", () => {
+    const raw = Buffer.concat(chunks).toString("latin1");
+    const i = raw.indexOf("\r\n\r\n");
+    resolve({ head: raw.slice(0, i), body: raw.slice(i + 4) });
+  });
+  return promise;
+}
 
 const fixture = "node-http-transfer-encoding-fixture.ts";
 test(`should not duplicate transfer-encoding header in request`, async () => {
@@ -93,4 +109,73 @@ test("should not duplicate transfer-encoding header in response when explicitly 
   const bodySection = response.split("\r\n\r\n").slice(1).join("\r\n\r\n");
   expect(bodySection).toContain("Hello, World!");
   expect(bodySection).toContain("Goodbye, World!");
+});
+
+// The declared Transfer-Encoding and the emitted body framing must agree for
+// HTTP/1.0 requests; a mismatch made curl --http1.0 die with
+// "curl: (56) chunk hex-length char not a hex digit".
+describe("HTTP/1.0 response framing matches the advertised headers", () => {
+  test("removing Content-Length does not invent Transfer-Encoding: chunked", async () => {
+    await using server = createServer((req, res) => {
+      res.setHeader("Content-Length", 5);
+      res.removeHeader("Content-Length");
+      res.end("hello");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { head, body } = await rawHTTP10(port, "/");
+    // Node.js never auto-adds Transfer-Encoding here (useChunkedEncodingByDefault
+    // is false for HTTP/1.0); the response is close-delimited instead.
+    expect(head.toLowerCase()).not.toContain("transfer-encoding");
+    expect(head.toLowerCase()).not.toContain("content-length");
+    expect(head).toContain("Connection: close");
+    expect(body).toBe("hello");
+  });
+
+  test.each([
+    ["writeHead", (res: any) => res.writeHead(200, { "Transfer-Encoding": "chunked" })],
+    ["setHeader", (res: any) => res.setHeader("Transfer-Encoding", "chunked")],
+  ])("an explicit Transfer-Encoding: chunked via %s chunk-frames the one-shot body", async (_, setup) => {
+    await using server = createServer((req, res) => {
+      setup(res);
+      res.end("hello");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { head, body } = await rawHTTP10(port, "/");
+    expect(head).toContain("Transfer-Encoding: chunked");
+    // Node.js chunk-frames the body to match the header it committed to.
+    expect(body).toBe("5\r\nhello\r\n0\r\n\r\n");
+  });
+
+  test("an explicit Transfer-Encoding: chunked chunk-frames streaming writes", async () => {
+    await using server = createServer((req, res) => {
+      res.writeHead(200, { "Transfer-Encoding": "chunked" });
+      res.write("hel");
+      res.end("lo");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { head, body } = await rawHTTP10(port, "/");
+    expect(head).toContain("Transfer-Encoding: chunked");
+    expect(body).toBe("3\r\nhel\r\n2\r\nlo\r\n0\r\n\r\n");
+  });
+
+  test("a Transfer-Encoding value without 'chunked' does not chunk-frame the body", async () => {
+    // Node.js only sets chunkedEncoding when the TE value contains the
+    // 'chunked' token; other codings pass through with identity body bytes.
+    await using server = createServer((req, res) => {
+      res.setHeader("Transfer-Encoding", "gzip");
+      res.end("hello");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { head, body } = await rawHTTP10(port, "/");
+    expect(head).toContain("Transfer-Encoding: gzip");
+    expect(body).toBe("hello");
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #19789

Fixes `node:http` server responses to HTTP/1.0 clients where the head advertised `Transfer-Encoding: chunked` but the body bytes were written as identity, desyncing any client that honours the header.

#### Reproduction

```js
import http from "node:http";
import net from "node:net";

const raw10 = (port, path) => new Promise((res) => {
  const c = [];
  const s = net.connect(port, "127.0.0.1", () => s.write(`GET ${path} HTTP/1.0\r\nHost: h\r\n\r\n`));
  s.on("data", (d) => c.push(d));
  s.on("close", () => {
    const a = Buffer.concat(c).toString("latin1"), i = a.indexOf("\r\n\r\n");
    res({ head: a.slice(0, i), body: a.slice(i + 4) });
  });
});

const srv = http.createServer((q, r) => {
  if (q.url === "/rmcl") { r.setHeader("Content-Length", 5); r.removeHeader("Content-Length"); r.end("hello"); }
  else { r.writeHead(200, { "Transfer-Encoding": "chunked" }); r.end("hello"); }
});
srv.listen(0, "127.0.0.1", async () => {
  const p = srv.address().port;
  console.log(await raw10(p, "/rmcl"));
  console.log(await raw10(p, "/whte"));
  srv.close();
});
```

Before this PR, `/rmcl` carried `Transfer-Encoding: chunked` in the head (Bun invented it) with identity body bytes `"hello"`, and `/whte` carried the user's `Transfer-Encoding: chunked` header with identity body bytes `"hello"`. A real HTTP/1.0 client fails hard:

```
$ curl --http1.0 http://127.0.0.1:<port>/whte
curl: (56) chunk hex-length char not a hex digit: 0x68
```

Node.js close-delimits `/rmcl` (no `Transfer-Encoding`) and chunk-frames `/whte` as `5\r\nhello\r\n0\r\n\r\n`.

#### Cause

Two owners decide head and body independently and never look at each other:

- `renderNativeHeaders` in `src/js/node/_http_server.ts` falls through to `forceChunked` when only `Content-Length` was removed, without checking `useChunkedEncodingByDefault` (set to `false` for HTTP/1.0 in the `ServerResponse` constructor). Node's `_storeHeader` takes the `!useChunkedEncodingByDefault` close-delimited branch before it ever reaches the auto-chunked path.
- `NodeHTTPServer__writeHead` forwards a user-set `Transfer-Encoding: chunked` header to the wire, but the uWS body writer gates every chunk-framing path on `!fromAncientRequest`, so the body is written as identity while the head says chunked.

#### Fix

- `renderNativeHeaders`: when the user removed `Content-Length` and `useChunkedEncodingByDefault` is `false`, close-delimit the response instead of forcing chunked.
- `NodeHTTP.cpp`: when a `Transfer-Encoding` header whose value contains the `chunked` token is written, clear `fromAncientRequest` so the uWS writer chunk-frames the body to match the head (like Node). Other TE values (`gzip`, `identity`) leave the gate intact and the body stays raw.

#### Verification

`test/js/node/http/node-http-transfer-encoding.test.ts` adds five HTTP/1.0 cases asserting the exact raw head and body bytes against Node: `removeHeader('Content-Length')`, explicit `Transfer-Encoding: chunked` via `setHeader` / `writeHead` / streaming `write`, and a `Transfer-Encoding: gzip` regression guard. Four fail on the released binary and all pass after; the first two vendored `test-http-1.0*.js` tests and `test-http-remove-header-stays-removed.js` are unchanged.

This is the HTTP/1.0 counterpart to #33871 (HTTP/1.1 TE value vs body framing); different code path (`fromAncientRequest` gate vs `Content-Length`/TE-value conflict).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (677db270c)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [742.17ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [421.95ms]
125 |     const { port } = server.address() as AddressInfo;
126 | 
127 |     const { head, body } = await rawHTTP10(port, "/");
128 |     // Node.js never auto-adds Transfer-Encoding here (useChunkedEncodingByDefault
129 |     // is false for HTTP/1.0); the response is close-delimited instead.
130 |     expect(head.toLowerCase()).not.toContain("transfer-encoding");
                                         ^
error: expect(received).not.toContain(expected)

Expected to not contain:
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (81fa5debf)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [13.33ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [8.80ms]
(pass) HTTP/1.0 response framing matches the advertised headers > removing Content-Length does not invent Transfer-Encoding: chunked [15.37ms]
(pass) HTTP/1.0 response framing matches the advertised headers > an explicit Transfer-Encoding: chunked via writeHead chunk-frames the one-shot body [15.93ms]
(pass) HTTP/1.0 response framing matches the advertised headers > an explicit Transfer-Encoding: chunked via setHeader chunk-frames the one-shot body [16.05ms]
(pass) HTTP/1.0 response framing matches the advertised headers > an explicit Transfer-Encoding: chunked chunk-frames streaming writes [17.74ms]
(pass) HTTP/1.0 response framing matches the advertised headers > a Transfer-Encoding value without 'chunked' does not chunk-frame the body [17.13ms]

 7 pass
 0 fail
 15 expect() calls
Ran 7 tests across 1 file. [260.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (677db270c)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [739.73ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [431.13ms]
(pass) HTTP/1.0 response framing matches the advertised headers > removing Content-Length does not invent Transfer-Encoding: chunked [126.01ms]
(pass) HTTP/1.0 response framing matches the advertised headers > an explicit Transfer-Encoding: chunked via writeHead chunk-frames the one-shot body [109.50ms]
(pass) HTTP/1.0 response framing matches the advertised headers > an explicit Transfer-Encoding: chunked via setHeader chunk-frames the one-shot body [69.51ms]
(pass) HTTP/1.0 res
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 718ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6263ms)
Bundle modules (42ms)
Postprocesss modules (21ms)
Bundle Functions (569ms)
Generate Code (72ms)

[6.98s] Bundled "src/js" for production
  1889 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        | 10 ++-
 src/jsc/bindings/NodeHTTP.cpp                      | 26 +++++++
 .../node/http/node-http-transfer-encoding.test.ts  | 87 +++++++++++++++++++++-
 3 files changed, 121 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/js/node/_http_server.ts                                3      1      0
src/jsc/bindings/NodeHTTP.cpp                              3      3      0
test/js/node/http/node-http-transfer-encoding.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->