### PR TITLE
http: reject compression Transfer-Encoding response headers in fetch()

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4750,6 +4750,7 @@ impl<'a> HTTPClient<'a> {
         let mut location: &[u8] = b"";
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
+        let mut unsupported_transfer_coding = false;
         let mut content_codings: u32 = 0;
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
@@ -4836,7 +4837,11 @@ impl<'a> HTTPClient<'a> {
                             Some(Encoding::Chunked) => {
                                 self.state.transfer_encoding = Encoding::Chunked;
                             }
-                            Some(_) => {}
+                            Some(Encoding::Identity) => {}
+                            // We never send a TE request header, so any other coding
+                            // has no decoder here. Defer the error: RFC 9112 §6.1
+                            // allows this header on HEAD/304 where there is no body.
+                            Some(_) => unsupported_transfer_coding = true,
                             None => return Err(crate::Error::UnsupportedTransferEncoding),
                         }
                     }
@@ -5228,6 +5233,9 @@ impl<'a> HTTPClient<'a> {
                 // undrained body bytes so it must be closed, not pooled.
                 self.state.flags.allow_keepalive = false;
                 return Ok(ShouldContinue::Finished);
+            }
+            if unsupported_transfer_coding && self.state.transfer_encoding != Encoding::Chunked {
+                return Err(crate::Error::UnsupportedTransferEncoding);
             }
             Ok(ShouldContinue::ContinueStreaming)
         } else {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4838,8 +4838,7 @@ impl<'a> HTTPClient<'a> {
                                 self.state.transfer_encoding = Encoding::Chunked;
                             }
                             Some(Encoding::Identity) => {}
-                            Some(_) => unsupported_transfer_coding = true,
-                            None => return Err(crate::Error::UnsupportedTransferEncoding),
+                            Some(_) | None => unsupported_transfer_coding = true,
                         }
                     }
                 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4838,9 +4838,6 @@ impl<'a> HTTPClient<'a> {
                                 self.state.transfer_encoding = Encoding::Chunked;
                             }
                             Some(Encoding::Identity) => {}
-                            // We never send a TE request header, so any other coding
-                            // has no decoder here. Defer the error: RFC 9112 §6.1
-                            // allows this header on HEAD/304 where there is no body.
                             Some(_) => unsupported_transfer_coding = true,
                             None => return Err(crate::Error::UnsupportedTransferEncoding),
                         }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -363,14 +363,15 @@ describe("fetch() decodes Content-Encoding case-insensitively", () => {
   // indicate what would have been applied. There is no body to decode, so the
   // header is informational and the fetch must resolve like Node/undici.
   it.concurrent.each([
-    ["HEAD", "200 OK"],
-    ["GET", "304 Not Modified"],
-    ["GET", "204 No Content"],
-  ])("%s -> %s with Transfer-Encoding: gzip resolves", async (method, status) => {
+    ["HEAD", "200 OK", "gzip"],
+    ["GET", "304 Not Modified", "gzip"],
+    ["GET", "204 No Content", "gzip"],
+    ["HEAD", "200 OK", "compress"],
+  ])("%s -> %s with Transfer-Encoding: %s resolves", async (method, status, te) => {
     const server = createNetServer(socket => {
       socket.on("error", () => {});
       socket.once("data", () => {
-        socket.end(`HTTP/1.1 ${status}\r\nTransfer-Encoding: gzip\r\nConnection: close\r\n\r\n`);
+        socket.end(`HTTP/1.1 ${status}\r\nTransfer-Encoding: ${te}\r\nConnection: close\r\n\r\n`);
       });
     });
     await once(server.listen(0, "127.0.0.1"), "listening");

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -311,6 +311,80 @@ describe("fetch() decodes Content-Encoding case-insensitively", () => {
       server.close();
     }
   });
+
+  // Bun never sends a TE request header, so per RFC 9112 §5 a server may only
+  // apply chunked. A response carrying one of the compression transfer codings
+  // without chunked has no decoder here and must fail the fetch instead of
+  // handing raw wire bytes (framed by Content-Length) to the caller.
+  it.concurrent.each(["gzip", "x-gzip", "deflate", "br", "zstd"])(
+    "Transfer-Encoding: %s without chunked is rejected",
+    async te => {
+      const server = createNetServer(socket => {
+        socket.on("error", () => {});
+        socket.once("data", () => {
+          socket.end(
+            "HTTP/1.1 200 OK\r\n" +
+              `Transfer-Encoding: ${te}\r\n` +
+              "Content-Length: 4\r\n" +
+              "Connection: close\r\n\r\n" +
+              "abcd",
+          );
+        });
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { port } = server.address() as import("node:net").AddressInfo;
+      try {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `fetch(process.argv[1]).then(
+             async r => console.log(JSON.stringify({ resolved: true, body: await r.text() })),
+             e => console.log(JSON.stringify({ resolved: false, code: e?.code ?? null })),
+           );`,
+            `http://127.0.0.1:${port}/`,
+          ],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+          stdout: JSON.stringify({ resolved: false, code: "UnsupportedTransferEncoding" }),
+          stderr: expect.any(String),
+          exitCode: 0,
+        });
+      } finally {
+        server.close();
+      }
+    },
+  );
+
+  // RFC 9112 §6.1: Transfer-Encoding MAY be sent on a HEAD or 304 response to
+  // indicate what would have been applied. There is no body to decode, so the
+  // header is informational and the fetch must resolve like Node/undici.
+  it.concurrent.each([
+    ["HEAD", "200 OK"],
+    ["GET", "304 Not Modified"],
+    ["GET", "204 No Content"],
+  ])("%s -> %s with Transfer-Encoding: gzip resolves", async (method, status) => {
+    const server = createNetServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        socket.end(`HTTP/1.1 ${status}\r\nTransfer-Encoding: gzip\r\nConnection: close\r\n\r\n`);
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`, { method });
+      expect({ status: res.status, body: await res.text() }).toEqual({
+        status: Number(status.split(" ")[0]),
+        body: "",
+      });
+    } finally {
+      server.close();
+    }
+  });
 });
 
 it("fetch() with a gzip response works (multiple chunks, TCP server)", async done => {


### PR DESCRIPTION
### What does this PR do?

A response header `Transfer-Encoding: gzip` (or `x-gzip` / `deflate` / `br` / `zstd`) without `chunked` resolves the fetch with the still-transfer-coded raw wire bytes framed by `Content-Length` (which RFC 9112 section 6.3 rule 3 says must be ignored when `Transfer-Encoding` is present). Node/undici rejects with `fetch failed`.

Before #36777 this same input aborted debug/ASan builds on the `debug_assert!(transfer_encoding == Identity)` in `handle_response_body`; the token-list parser from that PR no longer stores the compression coding in `state.transfer_encoding`, so the assert is gone and both debug and release now resolve with the raw bytes.

#### Reproduction

```js
import net from "node:net";
const srv = net.createServer(s => {
  s.on("data", () =>
    s.end("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\nContent-Length: 4\r\n\r\nabcd"),
  );
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
await fetch(`http://127.0.0.1:${srv.address().port}/`)
  .then(r => r.text())
  .then(t => console.log("resolved:", t), e => console.log("rejected:", e.code));
srv.close();
// node:        rejected: undefined (TypeError: fetch failed)
// bun (main):  resolved: abcd
// bun (PR):    rejected: UnsupportedTransferEncoding
```

#### Cause

The token-list loop in `handleResponseMetadata` matches the compression codings via `Encoding::from_token` but the `Some(_)` arm is a no-op, so `state.transfer_encoding` stays `Identity` and the body is framed by `Content-Length` (or close-delimited) and handed to the caller undecoded.

#### Fix

Bun's HTTP client never sends a `TE` request header, so per RFC 9112 section 5 a server is only permitted to apply `chunked`. The `Some(_)` arm (compression codings) now records `unsupported_transfer_coding`, and `UnsupportedTransferEncoding` is raised at the body-presence decision only when the response would otherwise `ContinueStreaming` and `chunked` was not the final coding. That keeps the following resolving unchanged, matching Node:

- `Transfer-Encoding: gzip, chunked` (chunked-framed; de-chunked bytes returned, covered by the existing test from #36777)
- HEAD and 1xx/204/304 responses (RFC 9112 section 6.1 allows the header there as informational metadata; no body to decode)
- followed redirects (body is discarded, not awaited)

#### Verification

Added to `test/js/web/fetch/fetch-gzip.test.ts` alongside the existing Transfer-Encoding token-list tests:

- five spawned cases (one per coding, against a raw `node:net` server) assert the fetch rejects with `code === "UnsupportedTransferEncoding"`
- three in-process cases (HEAD 200, GET 304, GET 204 with `Transfer-Encoding: gzip`) assert the fetch resolves with an empty body

```
bun bd test test/js/web/fetch/fetch-gzip.test.ts
  # 88 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
bun test v1.4.0 (27365cc01)

test/js/web/fetch/fetch-gzip.test.ts:
 HTTP/1.1 GET http://localhost:40051/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:40051
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 03 Aug 2026 09:04:33 GMT
< Content-Length: 16139

(pass) fetch() with a buffered gzip response works (one chunk) [253.29ms]
 HTTP/1.1 GET http://localhost:41689/hey
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:41689
 Accept-Encoding: gzip, deflate, br, zstd
< 302 Found
< Location: /redirect
< content-type: application/octet-stream
< Date: Mon, 03 Aug 2026 09:04:33 GMT
< Content-Length: 0

 HTTP/1.1 GET http://localhost:41689/redirect
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:41689
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (80a48794c)

test/js/web/fetch/fetch-gzip.test.ts:
 HTTP/1.1 GET http://localhost:36437/
 Connection: keep-alive
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:36437
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 03 Aug 2026 09:04:53 GMT
< Content-Length: 16139

(pass) fetch() with a buffered gzip response works (one chunk) [11.95ms]
 HTTP/1.1 GET http://localhost:42307/hey
 Connection: keep-alive
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:42307
 Accept-Encoding: gzip, deflate, br, zstd
< 302 Found
< Location: /redirect
< Date: Mon, 03 Aug 2026 09:04:53 GMT
< Content-Length: 0

 HTTP/1.1 GET http://localhost:42307/redirect
 Connection: keep-alive
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:42307
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 03 Aug 2026 09:04:53 GMT
< Content-Length: 16139

(pass) fetch() with a redirect that returns a buffered gzip response works (one chunk) [1.46ms]
 HTTP/1.1 GET http://localhost:39075/hey
 Connection: keep-alive
 User
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
bun test v1.4.0 (27365cc01)

test/js/web/fetch/fetch-gzip.test.ts:
 HTTP/1.1 GET http://localhost:36645/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:36645
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Mon, 03 Aug 2026 09:05:26 GMT
< Content-Length: 16139

(pass) fetch() with a buffered gzip response works (one chunk) [253.77ms]
 HTTP/1.1 GET http://localhost:41711/hey
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:41711
 Accept-Encoding: gzip, deflate, br, zstd
< 302 Found
< Location: /redirect
< content-type: application/octet-stream
< Date: Mon, 03 Aug 2026 09:05:26 GMT
< Content-Length: 0

 HTTP/1.1 GET http://localhost:41711/redirect
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:41711
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                      |  8 +++-
 test/js/web/fetch/fetch-gzip.test.ts | 75 ++++++++++++++++++++++++++++++++++++
 2 files changed, 81 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/http/lib.rs                          12     15      0
test/js/web/fetch/fetch-gzip.test.ts      5      5      0
```

</details>

<!-- robobun:evidence:end -->