### PR TITLE
Bun.serve: do not dispatch a pipelined request on a non-persistent connection

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -297,6 +297,17 @@ private:
                 return nullptr;
             }
 
+            /* A previous request on this connection marked it for close (HTTP/1.0
+             * or Connection: close, set below). RFC 9112 9.3/9.6: the connection
+             * is non-persistent; do not dispatch a pipelined follow-up. */
+            if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) {
+                if (((AsyncSocket<SSL> *) s)->getBufferedAmount() == 0) {
+                    ((AsyncSocket<SSL> *) s)->shutdown();
+                    ((AsyncSocket<SSL> *) s)->close();
+                }
+                return nullptr;
+            }
+
             /* Mark pending request and emit it */
             httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -295,11 +295,15 @@ private:
              * or Connection: close, set below). RFC 9112 9.3/9.6: the connection
              * is non-persistent; do not dispatch a pipelined follow-up. Runs
              * before the per-request timeout/offset resets so a backpressured
-             * prior response keeps its armed idle timeout. */
+             * prior response keeps its armed idle timeout. Uncork first:
+             * uws_res_end_without_body / uws_res_end_sendfile markDone without
+             * uncorking, and getBufferedAmount() does not count corked bytes. */
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) {
-                if (((AsyncSocket<SSL> *) s)->getBufferedAmount() == 0) {
-                    ((AsyncSocket<SSL> *) s)->shutdown();
-                    ((AsyncSocket<SSL> *) s)->close();
+                auto *asyncSocket = (AsyncSocket<SSL> *) s;
+                asyncSocket->uncork();
+                if (asyncSocket->getBufferedAmount() == 0) {
+                    asyncSocket->shutdown();
+                    asyncSocket->close();
                 }
                 return nullptr;
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -300,6 +300,9 @@ private:
                 if (asyncSocket->getBufferedAmount() == 0) {
                     asyncSocket->shutdown();
                     asyncSocket->close();
+                } else {
+                    /* Balance onData's us_socket_ref: the nullptr tail skips it. */
+                    us_socket_unref((us_socket_t *) s);
                 }
                 return nullptr;
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -281,13 +281,7 @@ private:
         auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
-            /* For every request we reset the timeout and hang until user makes action */
-            /* Warning: if we are in shutdown state, resetting the timer is a security issue! */
-            us_socket_timeout((us_socket_t *) s, 0);
-
-            /* Reset httpResponse */
             HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
-            httpResponseData->offset = 0;
 
             /* Are we not ready for another request yet? Terminate the connection.
              * Important for denying async pipelining until, if ever, we want to support it.
@@ -299,7 +293,9 @@ private:
 
             /* A previous request on this connection marked it for close (HTTP/1.0
              * or Connection: close, set below). RFC 9112 9.3/9.6: the connection
-             * is non-persistent; do not dispatch a pipelined follow-up. */
+             * is non-persistent; do not dispatch a pipelined follow-up. Runs
+             * before the per-request timeout/offset resets so a backpressured
+             * prior response keeps its armed idle timeout. */
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) {
                 if (((AsyncSocket<SSL> *) s)->getBufferedAmount() == 0) {
                     ((AsyncSocket<SSL> *) s)->shutdown();
@@ -307,6 +303,13 @@ private:
                 }
                 return nullptr;
             }
+
+            /* For every request we reset the timeout and hang until user makes action */
+            /* Warning: if we are in shutdown state, resetting the timer is a security issue! */
+            us_socket_timeout((us_socket_t *) s, 0);
+
+            /* Reset httpResponse */
+            httpResponseData->offset = 0;
 
             /* Mark pending request and emit it */
             httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -291,13 +291,9 @@ private:
                 return nullptr;
             }
 
-            /* A previous request on this connection marked it for close (HTTP/1.0
-             * or Connection: close, set below). RFC 9112 9.3/9.6: the connection
-             * is non-persistent; do not dispatch a pipelined follow-up. Runs
-             * before the per-request timeout/offset resets so a backpressured
-             * prior response keeps its armed idle timeout. Uncork first:
-             * uws_res_end_without_body / uws_res_end_sendfile markDone without
-             * uncorking, and getBufferedAmount() does not count corked bytes. */
+            /* Non-persistent (HTTP/1.0 or Connection: close, RFC 9112 9.3/9.6):
+             * drop pipelined follow-ups. Uncork first (end_without_body/sendfile
+             * don't) so corked bytes flush; placed before the per-request resets. */
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) {
                 auto *asyncSocket = (AsyncSocket<SSL> *) s;
                 asyncSocket->uncork();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -655,10 +655,11 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
   }
 
   it.each([
-    ["HTTP/1.0, no Connection header", "GET / HTTP/1.0\r\nHost: a\r\n\r\n"],
-    ["HTTP/1.0, client offered keep-alive", "GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n"],
-    ["HTTP/1.1, Connection: close", "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n"],
-  ])("%s", async (_label, payload) => {
+    ["HTTP/1.0, no Connection header", "GET / HTTP/1.0\r\nHost: a\r\n\r\n", "one-response-only"],
+    ["HTTP/1.0, client offered keep-alive", "GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n", "one-response-only"],
+    ["HTTP/1.1, Connection: close", "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n", "one-response-only"],
+    ["HTTP/1.0, HEAD (end-without-body path)", "HEAD / HTTP/1.0\r\nHost: a\r\n\r\n", ""],
+  ])("%s", async (_label, payload, body) => {
     let handled = 0;
     using server = Bun.serve({
       port: 0,
@@ -670,10 +671,10 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
     });
 
     const pipelined = await send(server.port, payload, false);
-    expect(pipelined).toEqual({ responses: 1, advertisedKeepAlive: false, body: "one-response-only" });
+    expect(pipelined).toEqual({ responses: 1, advertisedKeepAlive: false, body });
 
     const sequential = await send(server.port, payload, true);
-    expect(sequential).toEqual({ responses: 1, advertisedKeepAlive: false, body: "one-response-only" });
+    expect(sequential).toEqual({ responses: 1, advertisedKeepAlive: false, body });
 
     expect(handled).toBe(2);
   });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -628,12 +628,18 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
       chunks.push(chunk);
       onData();
     });
-    socket.on("error", () => {});
     socket.on("close", () => onClose());
-    await new Promise<void>(resolve => socket.on("connect", resolve));
+    // The sequential second write goes into a socket the server has already
+    // closed, so EPIPE/ECONNRESET there is expected; `close` always follows
+    // `error`, so the awaits below still settle.
+    socket.on("error", () => {});
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("close", () => reject(new Error("socket closed before connect")));
+    });
     if (secondWriteAfterFirstResponse) {
       socket.write(payload);
-      await gotData;
+      await Promise.race([gotData, closed]);
       socket.write(payload);
     } else {
       socket.write(payload + payload);
@@ -682,29 +688,23 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
     });
     const payload = "GET / HTTP/1.1\r\nHost: a\r\n\r\n";
     const chunks: Buffer[] = [];
-    const { promise, resolve } = Promise.withResolvers<void>();
-    const socket = net.connect(server.port, "127.0.0.1", () => socket.write(payload + payload));
-    socket.on("data", chunk => {
-      chunks.push(chunk);
-      if (
-        (
-          Buffer.concat(chunks)
-            .toString("latin1")
-            .match(/HTTP\/1\.1 200/g) ?? []
-        ).length === 2
-      )
-        resolve();
-    });
-    socket.on("error", () => {});
-    await promise;
-    socket.destroy();
-    expect(
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const responses = () =>
       (
         Buffer.concat(chunks)
           .toString("latin1")
           .match(/HTTP\/1\.1 200/g) ?? []
-      ).length,
-    ).toBe(2);
+      ).length;
+    const socket = net.connect(server.port, "127.0.0.1", () => socket.write(payload + payload));
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      if (responses() === 2) resolve();
+    });
+    socket.on("error", reject);
+    socket.on("close", resolve);
+    await promise;
+    socket.destroy();
+    expect(responses()).toBe(2);
   });
 });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -613,6 +613,88 @@ it.each([
   expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/helloooo");
 });
 
+describe("non-persistent connection never dispatches a pipelined follow-up", () => {
+  // RFC 9112 9.3/9.6: an HTTP/1.0 request (absent an advertised keep-alive),
+  // or any request carrying Connection: close, makes the connection
+  // non-persistent. The server sends exactly one response and closes,
+  // regardless of whether a second request arrived in the same TCP segment.
+  async function send(port: number, payload: string, secondWriteAfterFirstResponse: boolean) {
+    const chunks: Buffer[] = [];
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    const { promise: gotData, resolve: onData } = Promise.withResolvers<void>();
+    const socket = net.connect(port, "127.0.0.1");
+    socket.setNoDelay(true);
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      onData();
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => onClose());
+    await new Promise<void>(resolve => socket.on("connect", resolve));
+    if (secondWriteAfterFirstResponse) {
+      socket.write(payload);
+      await gotData;
+      socket.write(payload);
+    } else {
+      socket.write(payload + payload);
+    }
+    await closed;
+    socket.destroy();
+    const raw = Buffer.concat(chunks).toString("latin1");
+    return {
+      responses: (raw.match(/HTTP\/1\.[01] \d{3} /g) ?? []).length,
+      advertisedKeepAlive: /^connection:\s*keep-alive\s*$/im.test(raw.split("\r\n\r\n")[0] ?? ""),
+      body: raw.slice(raw.indexOf("\r\n\r\n") + 4),
+    };
+  }
+
+  it.each([
+    ["HTTP/1.0, no Connection header", "GET / HTTP/1.0\r\nHost: a\r\n\r\n"],
+    ["HTTP/1.0, client offered keep-alive", "GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n"],
+    ["HTTP/1.1, Connection: close", "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n"],
+  ])("%s", async (_label, payload) => {
+    let handled = 0;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        handled++;
+        return new Response("one-response-only");
+      },
+    });
+
+    const pipelined = await send(server.port, payload, false);
+    expect(pipelined).toEqual({ responses: 1, advertisedKeepAlive: false, body: "one-response-only" });
+
+    const sequential = await send(server.port, payload, true);
+    expect(sequential).toEqual({ responses: 1, advertisedKeepAlive: false, body: "one-response-only" });
+
+    expect(handled).toBe(2);
+  });
+
+  it("HTTP/1.1 keep-alive still pipelines", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    const payload = "GET / HTTP/1.1\r\nHost: a\r\n\r\n";
+    const chunks: Buffer[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const socket = net.connect(server.port, "127.0.0.1", () => socket.write(payload + payload));
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      if ((Buffer.concat(chunks).toString("latin1").match(/HTTP\/1\.1 200/g) ?? []).length === 2) resolve();
+    });
+    socket.on("error", () => {});
+    await promise;
+    socket.destroy();
+    expect((Buffer.concat(chunks).toString("latin1").match(/HTTP\/1\.1 200/g) ?? []).length).toBe(2);
+  });
+});
+
 describe("streaming", () => {
   describe("error handler", () => {
     it("throw on pull renders headers, does not call error handler", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -686,12 +686,25 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
     const socket = net.connect(server.port, "127.0.0.1", () => socket.write(payload + payload));
     socket.on("data", chunk => {
       chunks.push(chunk);
-      if ((Buffer.concat(chunks).toString("latin1").match(/HTTP\/1\.1 200/g) ?? []).length === 2) resolve();
+      if (
+        (
+          Buffer.concat(chunks)
+            .toString("latin1")
+            .match(/HTTP\/1\.1 200/g) ?? []
+        ).length === 2
+      )
+        resolve();
     });
     socket.on("error", () => {});
     await promise;
     socket.destroy();
-    expect((Buffer.concat(chunks).toString("latin1").match(/HTTP\/1\.1 200/g) ?? []).length).toBe(2);
+    expect(
+      (
+        Buffer.concat(chunks)
+          .toString("latin1")
+          .match(/HTTP\/1\.1 200/g) ?? []
+      ).length,
+    ).toBe(2);
   });
 });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -656,7 +656,11 @@ describe("non-persistent connection never dispatches a pipelined follow-up", () 
 
   it.each([
     ["HTTP/1.0, no Connection header", "GET / HTTP/1.0\r\nHost: a\r\n\r\n", "one-response-only"],
-    ["HTTP/1.0, client offered keep-alive", "GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n", "one-response-only"],
+    [
+      "HTTP/1.0, client offered keep-alive",
+      "GET / HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n",
+      "one-response-only",
+    ],
     ["HTTP/1.1, Connection: close", "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n", "one-response-only"],
     ["HTTP/1.0, HEAD (end-without-body path)", "HEAD / HTTP/1.0\r\nHost: a\r\n\r\n", ""],
   ])("%s", async (_label, payload, body) => {


### PR DESCRIPTION
## Problem

`Bun.serve` answers a second response on an HTTP/1.0 connection when the two requests arrive in the same TCP read, even though its response head never advertises `Connection: keep-alive`. The same second request arriving a tick later is dropped. The persistence decision depends on packet timing, not on what was negotiated on the wire.

```js
import * as net from 'node:net';
const srv = Bun.serve({ port: 0, fetch: () => new Response('hello') });
const line = 'GET / HTTP/1.0\\r\\nHost: a\\r\\n\\r\\n';
const s = net.connect(srv.port, '127.0.0.1', () => s.write(line + line));  // one write = one recv
// -> two 'HTTP/1.1 200 OK' responses; sequential writes produce one
```

Per RFC 9112 §9.3 an HTTP/1.0 connection is non-persistent unless the response advertises keep-alive (which Bun never does), and §9.6 says a server that is closing sends its final response and initiates close. A conforming 1.0 client treats everything after response 1's declared length as garbage; for a close-delimited body it would be body corruption.

The same applies to `HTTP/1.1` with `Connection: close` (RFC 9112 §9.6: the server MUST NOT process any further requests received on that connection). Node's HTTP server serves exactly one response in both cases.

## Cause

`HttpContext.h` sets `HTTP_CONNECTION_CLOSE` when the request is HTTP/1.0 or carries `Connection: close`, but the close only runs after `fenceAndConsumePostPadded` returns, and that loop dispatches every request it finds in the recv buffer. The per-request lambda's `state = HTTP_RESPONSE_PENDING` assignment wipes the previous request's close flag before re-deriving it, so nothing stops the second dispatch.

## Fix

Check `HTTP_CONNECTION_CLOSE` at the top of the per-request lambda, before the state is reset. If a previous request on this socket already marked it for close, drop the pipelined follow-up and shut the connection (deferring to `onWritable` when the prior response has not yet drained). The bit persists across recv buffers on the per-socket `HttpResponseData`, so this also covers a follow-up that arrives in a later read before the close completes.

## Verification

New tests in `test/js/bun/http/serve.test.ts` cover pipelined and sequential requests for:
- HTTP/1.0 with no `Connection` header
- HTTP/1.0 with client-offered `Connection: keep-alive`
- HTTP/1.1 with `Connection: close`

and a control that HTTP/1.1 keep-alive still pipelines two responses.

Related: #33005 takes a broader approach (parser-level `sawConnectionClose` latch plus response-header changes across 14 files); this PR is the minimal guard for the dispatch loop.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->