### PR TITLE
node:http: server hot-path performance (stacked on #32488)

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -129,6 +129,8 @@ export const enum NodeHTTPBodyReadState {
 export const enum NodeHTTPResponseFlags {
   socket_closed = 1 << 0,
   request_has_completed = 1 << 1,
+  ended = 1 << 2,
+  upgraded = 1 << 3,
 
   closed_or_completed = socket_closed | request_has_completed,
 }
@@ -200,7 +202,10 @@ function emitEOFIncomingMessageOuter(self) {
   // parserOnMessageComplete. Native moved the section onto THIS request's
   // handle at its body fin, so pipelined requests can neither inherit nor
   // overwrite another request's trailers.
-  if (self[kHandle] !== undefined) {
+  // Trailers can only follow a chunked request body: a no-body request has
+  // none, so skip the native call (and the socket/server option walk) for the
+  // common GET/HEAD case.
+  if (self[kHandle] !== undefined && !self[noBodySymbol]) {
     // The lenient (insecureHTTPParser) value bytes must match what the parser
     // accepted on the wire, or a CTL byte in a trailer value would vanish here.
     let rawTrailers = self[kHandle].takeRequestTrailers(self.socket?.server?.insecureHTTPParser === true);

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -677,4 +677,4 @@ function onError(self, error, cb) {
   }
 }
 
-export { IncomingMessage, readStart, readStop, kReqShouldKeepAlive };
+export { IncomingMessage, kReqShouldKeepAlive, readStart, readStop };

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -209,6 +209,9 @@ ObjectDefineProperty(IncomingMessage.prototype, "aborted", {
 // short-circuits materialization through the setter.
 ObjectDefineProperty(IncomingMessage.prototype, "rawHeaders", {
   __proto__: null,
+  // Node exposes rawHeaders as an enumerable own data property; a prototype
+  // accessor can at least stay visible to for-in.
+  enumerable: true,
   get: function () {
     let raw = this[kRawHeaders];
     if (raw === null) {

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -28,8 +28,16 @@ const ObjectDefineProperty = Object.defineProperty;
 const ArrayPrototypeSlice = Array.prototype.slice;
 
 const kHeaders = Symbol("kHeaders");
+// Cache slot for the server dispatcher's keep-alive decision (stamped once
+// per request in _http_server.ts); declared in the constructor so the stamp
+// never shape-transitions the request.
+const kReqShouldKeepAlive = Symbol("kReqShouldKeepAlive");
 const kHeadersDistinct = Symbol("kHeadersDistinct");
 const kHeadersCount = Symbol("kHeadersCount");
+// Lazy req.rawHeaders: cache slot + the native handle the bytes live on
+// (never cleared - unlike kHandle - so post-_destroy access still works).
+const kRawHeaders = Symbol("kRawHeaders");
+const kHeaderSource = Symbol("kHeaderSource");
 const kTrailers = Symbol("kTrailers");
 const kTrailersDistinct = Symbol("kTrailersDistinct");
 const kTrailersCount = Symbol("kTrailersCount");
@@ -74,6 +82,9 @@ function IncomingMessage(socket) {
   this.complete = false;
   this._closed = false;
   this[kHeaders] = null;
+  this[kReqShouldKeepAlive] = undefined;
+  this[kRawHeaders] = null;
+  this[kHeaderSource] = null;
   this[kHeadersCount] = 0;
   this[kTrailers] = null;
   this[kTrailersCount] = 0;
@@ -85,20 +96,11 @@ function IncomingMessage(socket) {
     this[typeSymbol] = NodeHTTPIncomingRequestType.NodeHTTPResponse;
     this.url = arguments[1];
     this.method = arguments[2];
-    // `headers` (arguments[3]) is intentionally not used: the lazy `headers`
-    // getter builds the object from rawHeaders with Node.js's duplicate
-    // handling (joining, cookie/set-cookie rules, joinDuplicateHeaders),
-    // which the native object does not implement.
-    let rawHeaders = arguments[4];
-    // Node.js's parser keeps at most server.maxHeadersCount header pairs
-    // (parser.maxHeaderPairs); the native parser does not enforce it, so
-    // truncate here.
-    const maxHeadersCount = arguments[7]?.server?.maxHeadersCount;
-    if (typeof maxHeadersCount === "number" && maxHeadersCount > 0 && rawHeaders.length > maxHeadersCount * 2) {
-      rawHeaders = ArrayPrototypeSlice.$call(rawHeaders, 0, maxHeadersCount * 2);
-    }
-    this.rawHeaders = rawHeaders;
-    this[kHeadersCount] = rawHeaders.length;
+    // arguments[3] carries no headers object and arguments[4] no rawHeaders
+    // on the native fast path anymore: the raw header bytes stay captured on
+    // the native handle and req.rawHeaders / req.headers are materialized by
+    // the rawHeaders accessor only when user code reads them.
+    this[kHeaderSource] = arguments[5];
     this[kHandle] = arguments[5];
     this[noBodySymbol] = !arguments[6];
     this[fakeSocketSymbol] = arguments[7];
@@ -202,20 +204,51 @@ ObjectDefineProperty(IncomingMessage.prototype, "aborted", {
   },
 });
 
+// Materializes on first read from the bytes captured on the native handle
+// (takeRawHeaders). Assignment (the llhttp client path, or user code)
+// short-circuits materialization through the setter.
+ObjectDefineProperty(IncomingMessage.prototype, "rawHeaders", {
+  __proto__: null,
+  get: function () {
+    let raw = this[kRawHeaders];
+    if (raw === null) {
+      const source = this[kHeaderSource];
+      let built = source != null ? source.takeRawHeaders() : undefined;
+      if (built === undefined) built = [];
+      // Node.js's parser keeps at most server.maxHeadersCount header pairs
+      // (parser.maxHeaderPairs); the native parser does not enforce it, so
+      // truncate here.
+      const maxHeadersCount = this[fakeSocketSymbol]?.server?.maxHeadersCount;
+      if (typeof maxHeadersCount === "number" && maxHeadersCount > 0 && built.length > maxHeadersCount * 2) {
+        built = ArrayPrototypeSlice.$call(built, 0, maxHeadersCount * 2);
+      }
+      raw = this[kRawHeaders] = built;
+      this[kHeadersCount] = built.length;
+    }
+    return raw;
+  },
+  set: function (value) {
+    this[kRawHeaders] = value;
+    this[kHeadersCount] = value ? value.length : 0;
+  },
+});
+
 ObjectDefineProperty(IncomingMessage.prototype, "headers", {
   __proto__: null,
   get: function () {
-    if (!this[kHeaders]) {
-      this[kHeaders] = {};
+    let dst = this[kHeaders];
+    if (!dst) {
+      dst = this[kHeaders] = {};
 
       const src = this.rawHeaders;
-      const dst = this[kHeaders];
+      const count = this[kHeadersCount];
+      const addHeaderLine = this._addHeaderLine;
 
-      for (let n = 0; n < this[kHeadersCount]; n += 2) {
-        this._addHeaderLine(src[n + 0], src[n + 1], dst);
+      for (let n = 0; n < count; n += 2) {
+        addHeaderLine.$call(this, src[n + 0], src[n + 1], dst);
       }
     }
-    return this[kHeaders];
+    return dst;
   },
   set: function (val) {
     this[kHeaders] = val;
@@ -644,4 +677,4 @@ function onError(self, error, cb) {
   }
 }
 
-export { IncomingMessage, readStart, readStop };
+export { IncomingMessage, readStart, readStop, kReqShouldKeepAlive };

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -32,6 +32,7 @@ const kBytesWritten = Symbol("kBytesWritten");
 const kErrored = Symbol("errored");
 const kHighWaterMark = Symbol("kHighWaterMark");
 const kRejectNonStandardBodyWrites = Symbol("kRejectNonStandardBodyWrites");
+const kLenientValidation = Symbol("kLenientValidation");
 
 const nop = () => {};
 
@@ -100,6 +101,9 @@ function OutgoingMessage(options) {
   this[kErrored] = null;
   this[kHighWaterMark] = options?.highWaterMark ?? getDefaultHighWaterMark();
   this[kRejectNonStandardBodyWrites] = options?.rejectNonStandardBodyWrites ?? false;
+  // Declared here so the memoizing _isLenientHeaderValidation never
+  // shape-transitions the message when it caches.
+  this[kLenientValidation] = undefined;
 }
 $toClass(OutgoingMessage, "OutgoingMessage", Stream);
 
@@ -107,29 +111,38 @@ $toClass(OutgoingMessage, "OutgoingMessage", Stream);
 // For ClientRequest: checks this.httpValidation or this.insecureHTTPParser
 // For ServerResponse: checks the server's httpValidation or insecureHTTPParser
 // Falls back to global --insecure-http-parser flag.
+// Every input is fixed for the life of the message, but setHeader and
+// appendHeader consult this once per header: compute once, cache in the
+// constructor-declared slot.
 OutgoingMessage.prototype._isLenientHeaderValidation = function () {
+  const cached = this[kLenientValidation];
+  if (cached !== undefined) return cached;
+
+  let result;
   // New httpValidation option takes priority (ClientRequest case)
   const httpValidation = this.httpValidation;
   if (httpValidation !== undefined) {
-    return httpValidation !== "strict";
+    result = httpValidation !== "strict";
+  } else {
+    // ServerResponse routes both options through the owning server; walk the
+    // req -> socket -> server chain once, not once per option.
+    const server = this.req?.socket?.server;
+    const serverHttpValidation = server?.httpValidation;
+    if (serverHttpValidation !== undefined) {
+      result = serverHttpValidation !== "strict";
+    } else {
+      // Legacy insecureHTTPParser - ClientRequest has it directly
+      const insecureHTTPParser = this.insecureHTTPParser;
+      if (typeof insecureHTTPParser === "boolean") {
+        result = insecureHTTPParser;
+      } else {
+        // ServerResponse can access via the server
+        const serverOption = server?.insecureHTTPParser;
+        result = typeof serverOption === "boolean" ? serverOption : isLenient();
+      }
+    }
   }
-  // ServerResponse: check server's httpValidation option
-  const serverHttpValidation = this.req?.socket?.server?.httpValidation;
-  if (serverHttpValidation !== undefined) {
-    return serverHttpValidation !== "strict";
-  }
-  // Legacy insecureHTTPParser - ClientRequest has it directly
-  const insecureHTTPParser = this.insecureHTTPParser;
-  if (typeof insecureHTTPParser === "boolean") {
-    return insecureHTTPParser;
-  }
-  // ServerResponse can access via req.socket.server
-  const serverOption = this.req?.socket?.server?.insecureHTTPParser;
-  if (typeof serverOption === "boolean") {
-    return serverOption;
-  }
-  // Fall back to global option
-  return isLenient();
+  return (this[kLenientValidation] = result);
 };
 
 ObjectDefineProperty(OutgoingMessage.prototype, "errored", {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -63,7 +63,6 @@ const {
   getMaxHTTPHeaderSize,
   fakeSocketSymbol,
   noBodySymbol,
-  utcDate,
   kOutHeaders,
   validateMsecs,
 } = require("internal/http");
@@ -2172,13 +2171,22 @@ function releaseRenderedHeaders(flat) {
   if (flat === scratchFlatHeaders) scratchFlatHeadersBusy = false;
 }
 
-// Cache for the Keep-Alive header value: keepAliveTimeout is a per-server
-// constant, so the common (no maxRequestsPerSocket) string is identical for
-// every response.
-let cachedKeepAliveTimeout = -1;
-let cachedKeepAliveValue = "";
+// Auto-header bits (kAutoHeader* in src/jsc/bindings/NodeHTTP.cpp - keep in
+// sync): renderNativeHeaders reports the framework headers (Date, Connection,
+// Keep-Alive) through these instead of pushing strings into the flat array;
+// the native side writes them from cached byte blobs.
+const AUTO_HEADER_DATE = 1 << 0;
+const AUTO_HEADER_CONN_KEEP_ALIVE = 1 << 1;
+const AUTO_HEADER_CONN_CLOSE = 1 << 2;
+const AUTO_HEADER_KEEP_ALIVE_TIMEOUT = 1 << 3;
+// Out-parameters of renderNativeHeaders, read by its callers in the same
+// tick (no JS can run in between).
+let renderedAutoHeaders = 0;
+let renderedKeepAliveSecs = 0;
 
 function renderNativeHeaders(res) {
+  renderedAutoHeaders = 0;
+  renderedKeepAliveSecs = 0;
   const headersMap = res[kOutHeaders];
   let flat: string[];
   if (scratchFlatHeadersBusy) {
@@ -2228,7 +2236,7 @@ function renderNativeHeaders(res) {
   }
 
   if (res.sendDate && !hasDate) {
-    flat.push("Date", utcDate());
+    renderedAutoHeaders |= AUTO_HEADER_DATE;
   }
 
   // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body. A
@@ -2283,18 +2291,17 @@ function renderNativeHeaders(res) {
       res.shouldKeepAlive !== false &&
       requestShouldKeepAlive(res.req)
     ) {
-      flat.push("Connection", "keep-alive");
       const keepAliveTimeout = res._keepAliveTimeout;
-      if (keepAliveTimeout && !hasKeepAlive) {
-        const maxRequestsPerSocket = res._maxRequestsPerSocket;
-        if (~~maxRequestsPerSocket > 0) {
-          flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
-        } else {
-          if (keepAliveTimeout !== cachedKeepAliveTimeout) {
-            cachedKeepAliveTimeout = keepAliveTimeout;
-            cachedKeepAliveValue = `timeout=${MathFloor(keepAliveTimeout / 1000)}`;
-          }
-          flat.push("Keep-Alive", cachedKeepAliveValue);
+      const maxRequestsPerSocket = res._maxRequestsPerSocket;
+      if (keepAliveTimeout && !hasKeepAlive && ~~maxRequestsPerSocket > 0) {
+        // Rare path (maxRequestsPerSocket set): render both lines in JS.
+        flat.push("Connection", "keep-alive");
+        flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
+      } else {
+        renderedAutoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
+        if (keepAliveTimeout && !hasKeepAlive) {
+          renderedAutoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
+          renderedKeepAliveSecs = MathFloor(keepAliveTimeout / 1000);
         }
       }
     } else {
@@ -2304,7 +2311,7 @@ function renderNativeHeaders(res) {
       if (res.shouldKeepAlive === false) {
         res[kMustCloseConnection] = true;
       }
-      flat.push("Connection", "close");
+      renderedAutoHeaders |= AUTO_HEADER_CONN_CLOSE;
     }
   }
 
@@ -3018,6 +3025,8 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
           chunk,
           encoding,
           strictContentLength(this),
+          renderedAutoHeaders,
+          renderedKeepAliveSecs,
         );
       } catch (e) {
         releaseRenderedHeaders(renderedHeaders);
@@ -3176,6 +3185,8 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
         renderedHeaders,
+        renderedAutoHeaders,
+        renderedKeepAliveSecs,
       );
       releaseRenderedHeaders(renderedHeaders);
 
@@ -3353,6 +3364,8 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
         renderedHeaders,
+        renderedAutoHeaders,
+        renderedKeepAliveSecs,
       );
       releaseRenderedHeaders(renderedHeaders);
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
@@ -3464,6 +3477,8 @@ ServerResponse.prototype.flushHeaders = function () {
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
         renderedHeaders,
+        renderedAutoHeaders,
+        renderedKeepAliveSecs,
       );
       releaseRenderedHeaders(renderedHeaders);
     }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -73,7 +73,7 @@ const NumberIsNaN = Number.isNaN;
 
 const { format } = require("internal/util/inspect");
 
-const { IncomingMessage } = require("node:_http_incoming");
+const { IncomingMessage, kReqShouldKeepAlive } = require("node:_http_incoming");
 const {
   OutgoingMessage,
   kErrored,
@@ -706,7 +706,10 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         bunServer,
         url: string,
         method: string,
-        headersObject: Record<string, string>,
+        // Native dispatch bitfield (kDispatch* in NodeHTTP.cpp): presence and
+        // token bits for the headers the dispatcher consults, so no header
+        // object or array is materialized unless user code reads them.
+        dispatchBits: number,
         headersArray: string[],
         handle,
         hasBody: boolean,
@@ -743,12 +746,20 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           socket._unrefTimer();
         }
 
-        const http_req = new RequestClass(kHandle, url, method, headersObject, headersArray, handle, hasBody, socket);
+        const http_req = new RequestClass(kHandle, url, method, undefined, headersArray, handle, hasBody, socket);
         if (isAncientHTTP) {
           http_req.httpVersion = "1.0";
           http_req.httpVersionMajor = 1;
           http_req.httpVersionMinor = 0;
         }
+        // Pull the handful of headers the dispatcher consults out of
+        // rawHeaders in one pass, instead of reading req.headers (each read
+        // of which would force the lazy header-object build even when user
+        // code never touches headers). Copy to locals before any callback
+        // can re-enter the dispatcher.
+        // HTTP/1.0 (ancient) responses never advertise keep-alive on this
+        // server; otherwise honor a Connection: close token from the request.
+        http_req[kReqShouldKeepAlive] = isAncientHTTP ? false : (dispatchBits & DISPATCH_CONN_CLOSE) === 0;
         if (server.joinDuplicateHeaders) {
           http_req.joinDuplicateHeaders = true;
         }
@@ -806,8 +817,11 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         // unconditionally adding it (even as undefined) forced a hidden-class
         // transition on every ServerResponse, which measurably slowed every
         // later property access on it (renderNativeHeaders in particular).
+        // parseUniqueHeadersOption yields null when the option is unset, so
+        // test != null: stamping null would still shape-transition every
+        // response for a value renderNativeHeaders treats as absent anyway.
         const uniqueHeaders = server[kUniqueHeaders];
-        if (uniqueHeaders !== undefined) http_res[kUniqueHeaders] = uniqueHeaders;
+        if (uniqueHeaders != null) http_res[kUniqueHeaders] = uniqueHeaders;
 
         // The request itself forbids connection reuse (HTTP/1.0, or the
         // client sent Connection: close): end the server's writable side as
@@ -816,7 +830,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         // ended inside user 'finish' listeners. (Not done for the
         // maxRequestsPerSocket limit - pipelined requests past the limit
         // still need to be answered with 503.)
-        if (!requestShouldKeepAlive(http_req)) {
+        if (!http_req[kReqShouldKeepAlive]) {
           http_res[kMustCloseConnection] = true;
         }
         http_res.once("finish", emitResponseFinishHandleSocket);
@@ -878,11 +892,12 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         // 'upgrade' listener is installed) and otherwise dispatches the
         // request normally.
         let is_upgrade = false;
-        if (!isPipelined && http_req.headers.upgrade !== undefined) {
-          const connectionHeader = http_req.headers.connection;
-          if (typeof connectionHeader === "string" && RE_CONN_UPGRADE.test(connectionHeader)) {
-            is_upgrade = !!server.shouldUpgradeCallback(http_req);
-          }
+        if (
+          !isPipelined &&
+          (dispatchBits & DISPATCH_HAS_UPGRADE) !== 0 &&
+          (dispatchBits & DISPATCH_CONN_UPGRADE) !== 0
+        ) {
+          is_upgrade = !!server.shouldUpgradeCallback(http_req);
         }
         // Like Node.js's parserOnIncoming: req.upgrade is true inside the
         // 'upgrade' listener and false for a declined upgrade that falls
@@ -934,8 +949,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         if (
           server[kOptimizeEmptyRequests] &&
           !is_upgrade &&
-          http_req.headers["content-length"] === undefined &&
-          http_req.headers["transfer-encoding"] === undefined
+          (dispatchBits & (DISPATCH_HAS_CONTENT_LENGTH | DISPATCH_HAS_TRANSFER_ENCODING)) === 0
         ) {
           http_req._dumpAndCloseReadable();
         }
@@ -994,7 +1008,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           return upgradePromise;
         } else if (
           server.requireHostHeader &&
-          http_req.headers.host === undefined &&
+          (dispatchBits & DISPATCH_HAS_HOST) === 0 &&
           http_req.httpVersionMajor === 1 &&
           http_req.httpVersionMinor >= 1
         ) {
@@ -1005,12 +1019,11 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_res.writeHead(400, { Connection: "close" });
           http_res.end();
         } else {
-          const expectHeader = http_req.headers.expect;
-          if (expectHeader !== undefined) {
+          if ((dispatchBits & DISPATCH_HAS_EXPECT) !== 0) {
             // Case-insensitive, token-boundary match like Node's
             // parserOnIncoming (RFC 7231 5.1.1: expectation values compare
-            // case-insensitively).
-            if (continueExpression.test(expectHeader)) {
+            // case-insensitively); computed natively into the bitfield.
+            if ((dispatchBits & DISPATCH_EXPECT_CONTINUE) !== 0) {
               if (server.listenerCount("checkContinue") > 0) {
                 server.emit("checkContinue", http_req, http_res);
               } else {
@@ -2155,8 +2168,12 @@ function renderNativeHeaders(res) {
   // chunked Transfer-Encoding on such a response could confuse reverse
   // proxies, so like Node.js the body framing is suppressed and the
   // connection is forcibly closed after the response.
+  // headersMap already holds res[kOutHeaders]; index the two framing headers
+  // once instead of re-reading the symbol per check below.
+  const storedTransferEncoding = headersMap === null ? undefined : headersMap["transfer-encoding"];
+  const storedContentLength = headersMap === null ? undefined : headersMap["content-length"];
   let defectiveNoBodyResponse = false;
-  if (res[kOutHeaders]?.["transfer-encoding"] !== undefined) {
+  if (storedTransferEncoding !== undefined) {
     const statusCode = res[kSnapshotStatusCode] ?? res.statusCode;
     if (statusCode === 204 || statusCode === 304) {
       defectiveNoBodyResponse = true;
@@ -2171,7 +2188,7 @@ function renderNativeHeaders(res) {
   // header is rendered so the advertised value matches the transport.
   let closeDelimited = false;
   let forceChunked = false;
-  if (res[kOutHeaders]?.["content-length"] === undefined && res[kOutHeaders]?.["transfer-encoding"] === undefined) {
+  if (storedContentLength === undefined && storedTransferEncoding === undefined) {
     if (res._hasBody === false) {
       // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
       // framing headers must not close the connection (Node's _storeHeader
@@ -2301,12 +2318,11 @@ function onResponseFinishHandleSocket(server, socket, res) {
   if (socket[kPipelinedResponses]?.length) {
     return;
   }
+  const rawKeepAliveTimeout = server.keepAliveTimeout;
   const keepAliveTimeout =
-    Number.isFinite(server.keepAliveTimeout) && server.keepAliveTimeout >= 0 ? server.keepAliveTimeout : 0;
-  const keepAliveTimeoutBuffer =
-    Number.isFinite(server.keepAliveTimeoutBuffer) && server.keepAliveTimeoutBuffer >= 0
-      ? server.keepAliveTimeoutBuffer
-      : 1000;
+    Number.isFinite(rawKeepAliveTimeout) && rawKeepAliveTimeout >= 0 ? rawKeepAliveTimeout : 0;
+  const rawKeepAliveBuffer = server.keepAliveTimeoutBuffer;
+  const keepAliveTimeoutBuffer = Number.isFinite(rawKeepAliveBuffer) && rawKeepAliveBuffer >= 0 ? rawKeepAliveBuffer : 1000;
   if (keepAliveTimeout) {
     // Extend the internal timeout by the configured buffer to reduce
     // the likelihood of ECONNRESET errors, like Node.js's resOnFinish.
@@ -2497,10 +2513,25 @@ function bufferPipelinedEnd(res, queued, chunk, encoding, callback) {
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 const RE_CONN_UPGRADE = /(?:^|\W)upgrade(?:$|\W)/i;
+
+// Native dispatch bitfield: presence/token bits for the request headers the
+// dispatcher consults, computed in one native pass over the raw headers
+// (kDispatch* in src/jsc/bindings/NodeHTTP.cpp - keep in sync). This is what
+// lets the framework never materialize req.headers/req.rawHeaders unless
+// user code reads them.
+const DISPATCH_CONN_CLOSE = 1 << 0;
+const DISPATCH_CONN_UPGRADE = 1 << 1;
+const DISPATCH_HAS_UPGRADE = 1 << 2;
+const DISPATCH_HAS_HOST = 1 << 3;
+const DISPATCH_HAS_EXPECT = 1 << 4;
+const DISPATCH_EXPECT_CONTINUE = 1 << 5;
+const DISPATCH_HAS_CONTENT_LENGTH = 1 << 6;
+const DISPATCH_HAS_TRANSFER_ENCODING = 1 << 7;
+
 // Whether the response should advertise a persistent connection.
-function requestShouldKeepAlive(req) {
+// `connection` is the request's Connection header value (or undefined).
+function shouldKeepAliveForConnection(req, connection) {
   if (!req) return true;
-  const connection = req.headers.connection;
   if (req.httpVersionMajor === 1 && req.httpVersionMinor === 0) {
     // The native server always closes HTTP/1.0 connections after the
     // response, even when the request asked for keep-alive, so the response
@@ -2510,6 +2541,17 @@ function requestShouldKeepAlive(req) {
     return false;
   }
   return !(typeof connection === "string" && RE_CONN_CLOSE.test(connection));
+}
+
+// Result of shouldKeepAliveForConnection, computed once at dispatch and
+// reused by renderNativeHeaders / the pipelined-response path so neither has
+// to re-read req.headers (which would materialize the lazy header object).
+
+function requestShouldKeepAlive(req) {
+  if (!req) return true;
+  const cached = req[kReqShouldKeepAlive];
+  if (cached !== undefined) return cached;
+  return (req[kReqShouldKeepAlive] = shouldKeepAliveForConnection(req, req.headers.connection));
 }
 
 function isHTTPServerHeaderStateSentOrAssigned(state) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -708,7 +708,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         // token bits for the headers the dispatcher consults, so no header
         // object or array is materialized unless user code reads them.
         dispatchBits: number,
-        headersArray: string[],
         handle,
         hasBody: boolean,
         socketHandle,
@@ -744,7 +743,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           socket._unrefTimer();
         }
 
-        const http_req = new RequestClass(kHandle, url, method, undefined, headersArray, handle, hasBody, socket);
+        const http_req = new RequestClass(kHandle, url, method, undefined, undefined, handle, hasBody, socket);
         if (isAncientHTTP) {
           http_req.httpVersion = "1.0";
           http_req.httpVersionMajor = 1;
@@ -2361,7 +2360,11 @@ function stopServerResponsePerf(this: any) {
 // NOT `this.socket`, which is the response's own transport facade and has no
 // `.server`. So a single shared function needs no per-request state at all.
 function emitResponseFinishHandleSocket() {
-  const socket = this.req?.socket;
+  // req.socket is nulled by the stream destroyer (pipeline/compose cleanup
+  // does `stream.socket = null` for server requests); the response's own
+  // socket - set by assignSocket and cleared only by detachSocket - still
+  // references the connection then.
+  const socket = this.req?.socket ?? this.socket;
   onResponseFinishHandleSocket(socket?.server, socket, this);
 }
 
@@ -2369,7 +2372,10 @@ function emitResponseFinishHandleSocket() {
 // in the same order as the two separate listeners this replaces.
 // advanceResponsePipeline already bails on a missing socket.
 function emitAsyncResponseFinish() {
-  const socket = this.req?.socket;
+  // Same destroyer-null fallback as emitResponseFinishHandleSocket: without
+  // it a destroyed request leaves socket._httpMessage assigned and the next
+  // kept-alive request fails with ERR_HTTP_SOCKET_ASSIGNED.
+  const socket = this.req?.socket ?? this.socket;
   if (socket != null) this.detachSocket(socket);
   advanceResponsePipeline(socket?.server, socket);
 }
@@ -3181,14 +3187,19 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
       const renderedHeaders = renderNativeHeaders(this);
-      handle.writeHead(
-        this[kSnapshotStatusCode] ?? this.statusCode,
-        this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderedHeaders,
-        renderedAutoHeaders,
-        renderedKeepAliveSecs,
-      );
-      releaseRenderedHeaders(renderedHeaders);
+      try {
+        handle.writeHead(
+          this[kSnapshotStatusCode] ?? this.statusCode,
+          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          renderedHeaders,
+          renderedAutoHeaders,
+          renderedKeepAliveSecs,
+        );
+      } finally {
+        // A throwing writeHead (status validation) must not leave the shared
+        // scratch array marked busy for the rest of the process.
+        releaseRenderedHeaders(renderedHeaders);
+      }
 
       // If handle.writeHead throws, we don't want headersSent to be set to true.
       // So we set it here.
@@ -3360,14 +3371,19 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
       const renderedHeaders = renderNativeHeaders(this);
-      handle.writeHead(
-        this[kSnapshotStatusCode] ?? this.statusCode,
-        this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderedHeaders,
-        renderedAutoHeaders,
-        renderedKeepAliveSecs,
-      );
-      releaseRenderedHeaders(renderedHeaders);
+      try {
+        handle.writeHead(
+          this[kSnapshotStatusCode] ?? this.statusCode,
+          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          renderedHeaders,
+          renderedAutoHeaders,
+          renderedKeepAliveSecs,
+        );
+      } finally {
+        // A throwing writeHead (status validation) must not leave the shared
+        // scratch array marked busy for the rest of the process.
+        releaseRenderedHeaders(renderedHeaders);
+      }
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
       handle.write(data, encoding, callback, strictContentLength(this));
     });
@@ -3473,14 +3489,19 @@ ServerResponse.prototype.flushHeaders = function () {
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
 
       const renderedHeaders = renderNativeHeaders(this);
-      handle.writeHead(
-        this[kSnapshotStatusCode] ?? this.statusCode,
-        this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderedHeaders,
-        renderedAutoHeaders,
-        renderedKeepAliveSecs,
-      );
-      releaseRenderedHeaders(renderedHeaders);
+      try {
+        handle.writeHead(
+          this[kSnapshotStatusCode] ?? this.statusCode,
+          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          renderedHeaders,
+          renderedAutoHeaders,
+          renderedKeepAliveSecs,
+        );
+      } finally {
+        // A throwing writeHead (status validation) must not leave the shared
+        // scratch array marked busy for the rest of the process.
+        releaseRenderedHeaders(renderedHeaders);
+      }
     }
     handle.flushHeaders();
   } else {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -5,7 +5,6 @@ const { Socket: NetSocket } = require("node:net");
 const {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression,
-  continueExpression,
   validateHeaderName,
   validateHeaderValue,
   HTTPParser,
@@ -2588,7 +2587,6 @@ function bufferPipelinedEnd(res, queued, chunk, encoding, callback) {
 }
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
-const RE_CONN_UPGRADE = /(?:^|\W)upgrade(?:$|\W)/i;
 
 // Native dispatch bitfield: presence/token bits for the request headers the
 // dispatcher consults, computed in one native pass over the raw headers
@@ -3006,7 +3004,8 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // and will not throw or emit an error
     return true;
   }
-  if (headerState !== NodeHTTPHeaderState.sent) {
+  const sentState = NodeHTTPHeaderState.sent;
+  if (headerState !== sentState) {
     {
       const renderedHeaders = renderNativeHeaders(this);
       try {
@@ -3034,12 +3033,12 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
           code !== "ERR_INVALID_CHAR" &&
           !(e instanceof RangeError)
         ) {
-          this[headerStateSymbol] = NodeHTTPHeaderState.sent;
+          this[headerStateSymbol] = sentState;
         }
         throw e;
       }
       releaseRenderedHeaders(renderedHeaders);
-      this[headerStateSymbol] = NodeHTTPHeaderState.sent;
+      this[headerStateSymbol] = sentState;
     }
   } else {
     // If there's no data but you already called end, then you're done.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2522,6 +2522,10 @@ function advanceResponsePipeline(server, socket) {
   }
 }
 
+function markResponseEndedNT(res) {
+  res._ended = true;
+}
+
 function emitPipelinedDrainNT(res) {
   if (!res.destroyed && !res.finished) {
     res.emit("drain");
@@ -3056,9 +3060,7 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   // right after a synchronously-finished handler returns, or via its 'finish'
   // listener otherwise), so handlers can still reach res.socket after end().
   this.finished = true;
-  process.nextTick(self => {
-    self._ended = true;
-  }, this);
+  process.nextTick(markResponseEndedNT, this);
   this.emit("prefinish");
   this._callPendingCallbacks();
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1487,6 +1487,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   parser = null;
   [kStreamingEnabled] = false;
   [kBoundOnAbort] = null;
+  [kKeepAliveIdleStart] = undefined;
   [kBytesWritten] = 0;
   [kHandle];
   [kUpgradeIncoming] = undefined;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -846,7 +846,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         if (!http_req[kReqShouldKeepAlive]) {
           http_res[kMustCloseConnection] = true;
         }
-        http_res.once("finish", emitResponseFinishHandleSocket);
+        // on(), not once(): "finish" fires at most once per response and once()
+        // allocates a wrapper closure per request.
+        http_res.on("finish", emitResponseFinishHandleSocket);
 
         if (hasObserver("http")) {
           startPerf(http_res, kServerResponseStatistics, {
@@ -1076,7 +1078,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // the connection it was on (the same order as the two listeners
           // this replaces). One shared function instead of two per-request
           // bind() closures.
-          http_res.once("finish", emitAsyncResponseFinish);
+          http_res.on("finish", emitAsyncResponseFinish);
         }
 
         const { resolve, promise } = $newPromiseCapability(Promise);
@@ -2473,7 +2475,7 @@ function advanceResponsePipeline(server, socket) {
     res.assignSocket(socket);
   }
   socket[kRequest] = res.req;
-  res.once("finish", emitAsyncResponseFinish);
+  res.on("finish", emitAsyncResponseFinish);
 
   // Replay the writes buffered while the response was queued.
   // The buffered bytes are handed to the native handle below, so they no
@@ -3001,22 +3003,40 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     return true;
   }
   if (headerState !== NodeHTTPHeaderState.sent) {
-    handle.cork(() => {
+    {
       const renderedHeaders = renderNativeHeaders(this);
-      handle.writeHead(
-        this[kSnapshotStatusCode] ?? this.statusCode,
-        this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderedHeaders,
-      );
+      try {
+        // One native crossing for cork + writeHead + end (writeHeadAndEnd
+        // corks natively around both phases).
+        this._contentLength = handle.writeHeadAndEnd(
+          this[kSnapshotStatusCode] ?? this.statusCode,
+          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          renderedHeaders,
+          chunk,
+          encoding,
+          strictContentLength(this),
+        );
+      } catch (e) {
+        releaseRenderedHeaders(renderedHeaders);
+        // Mirror the old two-call flow's headersSent semantics: errors from
+        // the write-head phase (the batch's upfront gate, status validation,
+        // headers-already-sent) leave the state unset; anything after that
+        // point threw with headers already on the wire, exactly like
+        // handle.end throwing after handle.writeHead succeeded.
+        const code = e?.code;
+        if (
+          code !== "ERR_STREAM_ALREADY_FINISHED" &&
+          code !== "ERR_HTTP_HEADERS_SENT" &&
+          code !== "ERR_INVALID_CHAR" &&
+          !(e instanceof RangeError)
+        ) {
+          this[headerStateSymbol] = NodeHTTPHeaderState.sent;
+        }
+        throw e;
+      }
       releaseRenderedHeaders(renderedHeaders);
-
-      // If handle.writeHead throws, we don't want headersSent to be set to true.
-      // So we set it here.
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
-
-      // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/_http_outgoing.js#L987
-      this._contentLength = handle.end(chunk, encoding, undefined, strictContentLength(this));
-    });
+    }
   } else {
     // If there's no data but you already called end, then you're done.
     // We can ignore it in that case. `flags` was read above in the same tick

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2212,144 +2212,154 @@ function renderNativeHeaders(res) {
   let hasDate = false;
   let hasConnection = false;
   let hasKeepAlive = false;
-  if (headersMap !== null && headersMap !== undefined) {
-    for (const key in headersMap) {
-      const entry = headersMap[key];
-      const name = entry[0];
-      const value = entry[1];
-      if (key === "date") hasDate = true;
-      else if (key === "connection") {
-        hasConnection = true;
-        // An explicit `Connection: close` response header must also close the
-        // transport after 'finish' (Node.js's matchHeader sets _last, then
-        // resOnFinish destroys the socket).
-        if (RE_CONN_CLOSE.test($isArray(value) ? value.join(", ") : String(value))) {
-          res[kMustCloseConnection] = true;
-        }
-      } else if (key === "keep-alive") hasKeepAlive = true;
-      if ($isArray(value)) {
-        const valueLength = value.length;
-        // Like Node's _storeHeader: array values become one line each, except
-        // "cookie" and headers listed in the uniqueHeaders option, which are
-        // sent as a single line joined with "; ".
-        // res[kUniqueHeaders] is only consulted for multi-valued headers, so
-        // read it here rather than once per render: it is a prototype-chain
-        // miss for every response whose server did not set `uniqueHeaders`.
-        if (valueLength >= 2 && (key === "cookie" || (res[kUniqueHeaders] != null && res[kUniqueHeaders].$has(key)))) {
-          flat.push(name, value.join("; "));
-        } else {
-          for (let i = 0; i < valueLength; i++) {
-            flat.push(name, String(value[i]));
+  try {
+    if (headersMap !== null && headersMap !== undefined) {
+      for (const key in headersMap) {
+        const entry = headersMap[key];
+        const name = entry[0];
+        const value = entry[1];
+        if (key === "date") hasDate = true;
+        else if (key === "connection") {
+          hasConnection = true;
+          // An explicit `Connection: close` response header must also close the
+          // transport after 'finish' (Node.js's matchHeader sets _last, then
+          // resOnFinish destroys the socket).
+          if (RE_CONN_CLOSE.test($isArray(value) ? value.join(", ") : String(value))) {
+            res[kMustCloseConnection] = true;
           }
-        }
-      } else {
-        flat.push(name, String(value));
-      }
-    }
-  }
-
-  if (res.sendDate && !hasDate) {
-    autoHeaders |= AUTO_HEADER_DATE;
-  }
-
-  // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body. A
-  // chunked Transfer-Encoding on such a response could confuse reverse
-  // proxies, so like Node.js the body framing is suppressed and the
-  // connection is forcibly closed after the response.
-  // headersMap already holds res[kOutHeaders]; index the two framing headers
-  // once instead of re-reading the symbol per check below.
-  const storedTransferEncoding = headersMap === null ? undefined : headersMap["transfer-encoding"];
-  const storedContentLength = headersMap === null ? undefined : headersMap["content-length"];
-  let defectiveNoBodyResponse = false;
-  if (storedTransferEncoding !== undefined) {
-    const statusCode = res[kSnapshotStatusCode] ?? res.statusCode;
-    if (statusCode === 204 || statusCode === 304) {
-      defectiveNoBodyResponse = true;
-      res[kMustCloseConnection] = true;
-    }
-  }
-
-  // Like Node.js's _storeHeader: with no framing headers on the wire, removing
-  // Transfer-Encoding makes the response close-delimited (the "both removed"
-  // _last branch), while removing only Content-Length falls through to chunked
-  // encoding and keeps the connection alive. Decide before the Connection
-  // header is rendered so the advertised value matches the transport.
-  let closeDelimited = false;
-  let forceChunked = false;
-  if (storedContentLength === undefined && storedTransferEncoding === undefined) {
-    if (res._hasBody === false) {
-      // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
-      // framing headers must not close the connection (Node's _storeHeader
-      // checks !_hasBody before its close-delimited else-branch).
-    } else if (res._removedTE) {
-      closeDelimited = true;
-      res[kMustCloseConnection] = true;
-    } else if (res._removedContLen) {
-      forceChunked = true;
-    }
-  }
-
-  if (res._removedConnection) {
-    // Node's _storeHeader: `this._last = !this.shouldKeepAlive` - no
-    // Connection header is written (the user removed it), but the socket
-    // still closes after 'finish' when shouldKeepAlive was cleared.
-    if (res.shouldKeepAlive === false) {
-      res[kMustCloseConnection] = true;
-    }
-  } else if (!hasConnection) {
-    if (
-      !defectiveNoBodyResponse &&
-      !closeDelimited &&
-      !res.maxRequestsOnConnectionReached &&
-      res.shouldKeepAlive !== false &&
-      requestShouldKeepAlive(res.req)
-    ) {
-      const keepAliveTimeout = res._keepAliveTimeout;
-      const maxRequestsPerSocket = res._maxRequestsPerSocket;
-      if (keepAliveTimeout && !hasKeepAlive && ~~maxRequestsPerSocket > 0) {
-        // Rare path (maxRequestsPerSocket set): render both lines in JS.
-        flat.push("Connection", "keep-alive");
-        flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
-      } else {
-        autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
-        if (keepAliveTimeout && !hasKeepAlive) {
-          autoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
-          keepAliveSecs = MathFloor(keepAliveTimeout / 1000);
+        } else if (key === "keep-alive") hasKeepAlive = true;
+        if ($isArray(value)) {
+          const valueLength = value.length;
+          // Like Node's _storeHeader: array values become one line each, except
+          // "cookie" and headers listed in the uniqueHeaders option, which are
+          // sent as a single line joined with "; ".
+          // res[kUniqueHeaders] is only consulted for multi-valued headers, so
+          // read it here rather than once per render: it is a prototype-chain
+          // miss for every response whose server did not set `uniqueHeaders`.
+          if (
+            valueLength >= 2 &&
+            (key === "cookie" || (res[kUniqueHeaders] != null && res[kUniqueHeaders].$has(key)))
+          ) {
+            flat.push(name, value.join("; "));
+          } else {
+            for (let i = 0; i < valueLength; i++) {
+              flat.push(name, String(value[i]));
+            }
+          }
+        } else {
+          flat.push(name, String(value));
         }
       }
-    } else {
-      // Like Node's shouldSendKeepAlive/_last handling: a user-cleared
-      // shouldKeepAlive (graceful-shutdown helpers set it on in-flight
-      // responses) must also end the socket after 'finish'.
+    }
+
+    if (res.sendDate && !hasDate) {
+      autoHeaders |= AUTO_HEADER_DATE;
+    }
+
+    // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body. A
+    // chunked Transfer-Encoding on such a response could confuse reverse
+    // proxies, so like Node.js the body framing is suppressed and the
+    // connection is forcibly closed after the response.
+    // headersMap already holds res[kOutHeaders]; index the two framing headers
+    // once instead of re-reading the symbol per check below.
+    const storedTransferEncoding = headersMap === null ? undefined : headersMap["transfer-encoding"];
+    const storedContentLength = headersMap === null ? undefined : headersMap["content-length"];
+    let defectiveNoBodyResponse = false;
+    if (storedTransferEncoding !== undefined) {
+      const statusCode = res[kSnapshotStatusCode] ?? res.statusCode;
+      if (statusCode === 204 || statusCode === 304) {
+        defectiveNoBodyResponse = true;
+        res[kMustCloseConnection] = true;
+      }
+    }
+
+    // Like Node.js's _storeHeader: with no framing headers on the wire, removing
+    // Transfer-Encoding makes the response close-delimited (the "both removed"
+    // _last branch), while removing only Content-Length falls through to chunked
+    // encoding and keeps the connection alive. Decide before the Connection
+    // header is rendered so the advertised value matches the transport.
+    let closeDelimited = false;
+    let forceChunked = false;
+    if (storedContentLength === undefined && storedTransferEncoding === undefined) {
+      if (res._hasBody === false) {
+        // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
+        // framing headers must not close the connection (Node's _storeHeader
+        // checks !_hasBody before its close-delimited else-branch).
+      } else if (res._removedTE) {
+        closeDelimited = true;
+        res[kMustCloseConnection] = true;
+      } else if (res._removedContLen) {
+        forceChunked = true;
+      }
+    }
+
+    if (res._removedConnection) {
+      // Node's _storeHeader: `this._last = !this.shouldKeepAlive` - no
+      // Connection header is written (the user removed it), but the socket
+      // still closes after 'finish' when shouldKeepAlive was cleared.
       if (res.shouldKeepAlive === false) {
         res[kMustCloseConnection] = true;
       }
-      autoHeaders |= AUTO_HEADER_CONN_CLOSE;
+    } else if (!hasConnection) {
+      if (
+        !defectiveNoBodyResponse &&
+        !closeDelimited &&
+        !res.maxRequestsOnConnectionReached &&
+        res.shouldKeepAlive !== false &&
+        requestShouldKeepAlive(res.req)
+      ) {
+        const keepAliveTimeout = res._keepAliveTimeout;
+        const maxRequestsPerSocket = res._maxRequestsPerSocket;
+        if (keepAliveTimeout && !hasKeepAlive && ~~maxRequestsPerSocket > 0) {
+          // Rare path (maxRequestsPerSocket set): render both lines in JS.
+          flat.push("Connection", "keep-alive");
+          flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
+        } else {
+          autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
+          if (keepAliveTimeout && !hasKeepAlive) {
+            autoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
+            keepAliveSecs = MathFloor(keepAliveTimeout / 1000);
+          }
+        }
+      } else {
+        // Like Node's shouldSendKeepAlive/_last handling: a user-cleared
+        // shouldKeepAlive (graceful-shutdown helpers set it on in-flight
+        // responses) must also end the socket after 'finish'.
+        if (res.shouldKeepAlive === false) {
+          res[kMustCloseConnection] = true;
+        }
+        autoHeaders |= AUTO_HEADER_CONN_CLOSE;
+      }
     }
-  }
 
-  if (res._hasBody === false) {
-    // A method-based no-body response (HEAD): the native side only knows
-    // 204/304 from the status line, so signal no-body explicitly. Any
-    // user-set framing headers are still advertised, but the body framing
-    // itself (auto Content-Length/Transfer-Encoding and the terminating
-    // chunk) is suppressed, like Node.js's `_hasBody && chunkedEncoding`
-    // gate - a HEAD response ends at the first empty line whatever headers
-    // it carries (RFC 9112 6.3).
-    flat.push("\u0000", "2");
-  }
+    if (res._hasBody === false) {
+      // A method-based no-body response (HEAD): the native side only knows
+      // 204/304 from the status line, so signal no-body explicitly. Any
+      // user-set framing headers are still advertised, but the body framing
+      // itself (auto Content-Length/Transfer-Encoding and the terminating
+      // chunk) is suppressed, like Node.js's `_hasBody && chunkedEncoding`
+      // gate - a HEAD response ends at the first empty line whatever headers
+      // it carries (RFC 9112 6.3).
+      flat.push("\u0000", "2");
+    }
 
-  if (closeDelimited) {
-    // The NUL-named sentinel pair tells the native writeHead the body is
-    // close-delimited: written raw, with the connection closed after the
-    // response (it is not a real header).
-    flat.push("\u0000", "1");
-  } else if (forceChunked) {
-    // The user removed Content-Length (only): advertise chunked so the native
-    // side frames the body instead of auto-writing the removed header back.
-    flat.push("Transfer-Encoding", "chunked");
+    if (closeDelimited) {
+      // The NUL-named sentinel pair tells the native writeHead the body is
+      // close-delimited: written raw, with the connection closed after the
+      // response (it is not a real header).
+      flat.push("\u0000", "1");
+    } else if (forceChunked) {
+      // The user removed Content-Length (only): advertise chunked so the native
+      // side frames the body instead of auto-writing the removed header back.
+      flat.push("Transfer-Encoding", "chunked");
+    }
+  } catch (e) {
+    // String(value) above can run user toString() that throws; release the
+    // scratch array so the next render is not forced onto fresh arrays for
+    // the process lifetime.
+    if (flat === scratchFlatHeaders) scratchFlatHeadersBusy = false;
+    throw e;
   }
-
   renderedAutoHeaders = autoHeaders;
   renderedKeepAliveSecs = keepAliveSecs;
   return flat;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -866,7 +866,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
 
         setIsNextIncomingMessageHTTPS(prevIsNextIncomingMessageHTTPS);
-        handle.onabort = (socket[kBoundOnAbort] ??= onServerRequestEvent.bind(socket));
+        handle.onabort = socket[kBoundOnAbort] ??= onServerRequestEvent.bind(socket);
         // start buffering data if any, the user will need to resume() or .on("data") to read it
         if (hasBody) {
           handle.pause();
@@ -2391,10 +2391,10 @@ function onResponseFinishHandleSocket(server, socket, res) {
     return;
   }
   const rawKeepAliveTimeout = server.keepAliveTimeout;
-  const keepAliveTimeout =
-    Number.isFinite(rawKeepAliveTimeout) && rawKeepAliveTimeout >= 0 ? rawKeepAliveTimeout : 0;
+  const keepAliveTimeout = Number.isFinite(rawKeepAliveTimeout) && rawKeepAliveTimeout >= 0 ? rawKeepAliveTimeout : 0;
   const rawKeepAliveBuffer = server.keepAliveTimeoutBuffer;
-  const keepAliveTimeoutBuffer = Number.isFinite(rawKeepAliveBuffer) && rawKeepAliveBuffer >= 0 ? rawKeepAliveBuffer : 1000;
+  const keepAliveTimeoutBuffer =
+    Number.isFinite(rawKeepAliveBuffer) && rawKeepAliveBuffer >= 0 ? rawKeepAliveBuffer : 1000;
   if (keepAliveTimeout) {
     // Extend the internal timeout by the configured buffer to reduce
     // the likelihood of ECONNRESET errors, like Node.js's resOnFinish.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -819,7 +819,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         if (!requestShouldKeepAlive(http_req)) {
           http_res[kMustCloseConnection] = true;
         }
-        http_res.once("finish", onResponseFinishHandleSocket.bind(undefined, server, socket, http_res));
+        http_res.once("finish", emitResponseFinishHandleSocket);
 
         if (hasObserver("http")) {
           startPerf(http_res, kServerResponseStatistics, {
@@ -1046,8 +1046,11 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           return;
         }
         if (http_res.socket) {
-          http_res.on("finish", http_res.detachSocket.bind(http_res, socket));
-          http_res.once("finish", advanceResponsePipeline.bind(undefined, server, socket));
+          // Detach the socket first, then advance the response pipeline on
+          // the connection it was on (the same order as the two listeners
+          // this replaces). One shared function instead of two per-request
+          // bind() closures.
+          http_res.once("finish", emitAsyncResponseFinish);
         }
 
         const { resolve, promise } = $newPromiseCapability(Promise);
@@ -2104,7 +2107,6 @@ $toClass(ServerResponse, "ServerResponse", OutgoingMessage);
 // the user actually set, even after the headers have been flushed.
 function renderNativeHeaders(res) {
   const headersMap = res[kOutHeaders];
-  const uniqueHeaders = res[kUniqueHeaders];
   const flat: string[] = [];
   let hasDate = false;
   let hasConnection = false;
@@ -2129,7 +2131,10 @@ function renderNativeHeaders(res) {
         // Like Node's _storeHeader: array values become one line each, except
         // "cookie" and headers listed in the uniqueHeaders option, which are
         // sent as a single line joined with "; ".
-        if (valueLength >= 2 && (key === "cookie" || (uniqueHeaders != null && uniqueHeaders.$has(key)))) {
+        // res[kUniqueHeaders] is only consulted for multi-valued headers, so
+        // read it here rather than once per render: it is a prototype-chain
+        // miss for every response whose server did not set `uniqueHeaders`.
+        if (valueLength >= 2 && (key === "cookie" || (res[kUniqueHeaders] != null && res[kUniqueHeaders].$has(key)))) {
           flat.push(name, value.join("; "));
         } else {
           for (let i = 0; i < valueLength; i++) {
@@ -2255,6 +2260,25 @@ function stopServerResponsePerf(this: any) {
   }
 }
 
+// `once("finish", fn.bind(server, socket, ...))` allocated a bound closure
+// per request. Inside a "finish" listener `this` is the response, and the
+// connection socket is `this.req.socket` (which carries its owning server) —
+// NOT `this.socket`, which is the response's own transport facade and has no
+// `.server`. So a single shared function needs no per-request state at all.
+function emitResponseFinishHandleSocket() {
+  const socket = this.req?.socket;
+  onResponseFinishHandleSocket(socket?.server, socket, this);
+}
+
+// The async-response half of Node.js's resOnFinish. Detach before advancing,
+// in the same order as the two separate listeners this replaces.
+// advanceResponsePipeline already bails on a missing socket.
+function emitAsyncResponseFinish() {
+  const socket = this.req?.socket;
+  if (socket != null) this.detachSocket(socket);
+  advanceResponsePipeline(socket?.server, socket);
+}
+
 // Runs when a response has finished, like the transport-related half of
 // Node.js's resOnFinish: either end the connection (responses that must
 // close) or arm the keep-alive idle timeout so an idle kept-alive connection
@@ -2363,8 +2387,7 @@ function advanceResponsePipeline(server, socket) {
     res.assignSocket(socket);
   }
   socket[kRequest] = res.req;
-  res.on("finish", res.detachSocket.bind(res, socket));
-  res.once("finish", advanceResponsePipeline.bind(undefined, server, socket));
+  res.once("finish", emitAsyncResponseFinish);
 
   // Replay the writes buffered while the response was queued.
   // The buffered bytes are handed to the native handle below, so they no

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2355,11 +2355,12 @@ function stopServerResponsePerf(this: any) {
   }
 }
 
-// `once("finish", fn.bind(server, socket, ...))` allocated a bound closure
-// per request. Inside a "finish" listener `this` is the response, and the
-// connection socket is `this.req.socket` (which carries its owning server) —
-// NOT `this.socket`, which is the response's own transport facade and has no
-// `.server`. So a single shared function needs no per-request state at all.
+// `on("finish", fn.bind(server, socket, ...))` allocated a bound closure per
+// request. Inside a "finish" listener `this` is the response; the connection
+// socket is `this.req.socket`, with `this.socket` (assigned by assignSocket,
+// cleared only by detachSocket) as the fallback for requests the stream
+// destroyer already detached. A single shared function needs no per-request
+// state at all.
 function emitResponseFinishHandleSocket() {
   // req.socket is nulled by the stream destroyer (pipeline/compose cleanup
   // does `stream.socket = null` for server requests); the response's own

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -116,6 +116,7 @@ const kEmptyBuffer = Buffer.alloc(0);
 const ObjectKeys = Object.keys;
 const MathMin = Math.min;
 const MathFloor = Math.floor;
+const DateNow = Date.now;
 
 let cluster;
 
@@ -801,7 +802,12 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           [kRejectNonStandardBodyWrites]: server.rejectNonStandardBodyWrites,
         });
         http_res._keepAliveTimeout = server.keepAliveTimeout;
-        http_res[kUniqueHeaders] = server[kUniqueHeaders];
+        // Only stamp the symbol when the server actually set `uniqueHeaders`:
+        // unconditionally adding it (even as undefined) forced a hidden-class
+        // transition on every ServerResponse, which measurably slowed every
+        // later property access on it (renderNativeHeaders in particular).
+        const uniqueHeaders = server[kUniqueHeaders];
+        if (uniqueHeaders !== undefined) http_res[kUniqueHeaders] = uniqueHeaders;
 
         // The request itself forbids connection reuse (HTTP/1.0, or the
         // client sent Connection: close): end the server's writable side as
@@ -1325,6 +1331,11 @@ function detachSocketListenersForHandoff(socket) {
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kKeepAliveTimeoutSet = Symbol("keepAliveTimeoutSet");
+// When the keep-alive idle period on a connection started (the last response
+// finish). onResponseFinishHandleSocket records this instead of rescheduling
+// the socket timer on every response; onSocketTimeoutTimerExpired reads it to
+// grant the remaining idle budget when the timer actually fires.
+const kKeepAliveIdleStart = Symbol("keepAliveIdleStart");
 // HTTP/1.1 pipelining (responses queued behind an in-flight response):
 // - on the socket: array of queued ServerResponses, in arrival order
 // - on a queued response: { ops, bytes, needDrain, ended, isAncient } while it
@@ -1397,10 +1408,34 @@ function noopOnError() {}
 
 function onSocketTimeoutTimerExpired(socket) {
   // The keep-alive idle timer is left armed across the request to avoid a
-  // clear + setTimeout cycle per request; ignore a stale fire while a request
-  // is in flight (kKeepAliveTimeoutSet was cleared on request arrival).
+  // clear + setTimeout cycle per request. A fire while a request is in
+  // flight (kKeepAliveTimeoutSet was cleared on request arrival) is stale;
+  // re-arm the timer so the response-finish fast path, which relies on it
+  // staying live, keeps working, and bail. This runs at most once per idle
+  // interval per busy connection, not once per request.
   if (socket.timeout === 0 && !socket[kKeepAliveTimeoutSet]) {
+    socket[kSocketTimeoutTimer]?.refresh();
     return;
+  }
+  // onResponseFinishHandleSocket records when the last response finished
+  // instead of rescheduling the timer on every response, so the timer's
+  // deadline may predate the start of the real idle period. Grant the
+  // remaining budget once, measured from that last finish. Gated on
+  // kKeepAliveTimeoutSet so a fire of the server's regular per-socket
+  // timeout (socket.timeout !== 0 with no response outstanding) never
+  // consumes a stale keep-alive idle mark.
+  const idleStart = socket[kKeepAliveIdleStart];
+  if (idleStart !== undefined && socket[kKeepAliveTimeoutSet]) {
+    socket[kKeepAliveIdleStart] = undefined;
+    const remaining = socket.timeout - (DateNow() - idleStart);
+    if (remaining > 0) {
+      const existingTimer = socket[kSocketTimeoutTimer];
+      if (existingTimer !== undefined) clearTimeout(existingTimer);
+      const timer = setTimeout(onSocketTimeoutTimerExpired, remaining, socket);
+      timer.unref();
+      socket[kSocketTimeoutTimer] = timer;
+      return;
+    }
   }
   socket._onTimeout();
 }
@@ -2251,7 +2286,21 @@ function onResponseFinishHandleSocket(server, socket, res) {
   if (keepAliveTimeout) {
     // Extend the internal timeout by the configured buffer to reduce
     // the likelihood of ECONNRESET errors, like Node.js's resOnFinish.
-    socket.setTimeout(keepAliveTimeout + keepAliveTimeoutBuffer);
+    const total = keepAliveTimeout + keepAliveTimeoutBuffer;
+    // Rescheduling the socket timer on every response finish was the single
+    // largest per-request cost of the keep-alive path. Once the timer is
+    // armed with this exact interval (every response after the first on a
+    // kept-alive connection), leave it in place and only record when this
+    // idle period started; onSocketTimeoutTimerExpired grants the remaining
+    // budget if the timer fires early, so the socket still closes after
+    // exactly `total` ms of idle.
+    const timer = socket[kSocketTimeoutTimer];
+    if (timer !== undefined && timer._idleTimeout === total) {
+      socket.timeout = total;
+    } else {
+      socket.setTimeout(total);
+    }
+    socket[kKeepAliveIdleStart] = DateNow();
     socket[kKeepAliveTimeoutSet] = true;
   }
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1474,11 +1474,15 @@ function onSocketTimeoutTimerExpired(socket) {
       return;
     }
   }
-  // The timer has fired and is dead; drop the reference so the next
+  // A fired keep-alive idle timer is dead; drop the reference so the next
   // response-finish re-arms via setTimeout instead of trusting a fired
   // timer whose _idleTimeout still matches (a 'timeout' listener may keep
-  // the socket alive).
-  socket[kSocketTimeoutTimer] = undefined;
+  // the socket alive). Only for the keep-alive case: the server.timeout
+  // path relies on _unrefTimer() refreshing the fired timer in the slot,
+  // like net.Socket.
+  if (socket[kKeepAliveTimeoutSet]) {
+    socket[kSocketTimeoutTimer] = undefined;
+  }
   socket._onTimeout();
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1346,6 +1346,7 @@ function detachSocketListenersForHandoff(socket) {
   socket.on("end", onReadableStreamEnd);
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
+const kStreamingEnabled = Symbol("kStreamingEnabled");
 const kKeepAliveTimeoutSet = Symbol("keepAliveTimeoutSet");
 // When the keep-alive idle period on a connection started (the last response
 // finish). onResponseFinishHandleSocket records this instead of rescheduling
@@ -1464,6 +1465,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   connecting = false;
   timeout = 0;
   parser = null;
+  [kStreamingEnabled] = false;
   [kBytesWritten] = 0;
   [kHandle];
   [kUpgradeIncoming] = undefined;
@@ -1520,8 +1522,15 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   }
 
   [kEnableStreaming](enable: boolean) {
+    // The common keep-alive request never streams: the dispatcher disables
+    // streaming on every request, so track the state and skip the two native
+    // setter crossings (writing undefined over undefined) when unchanged.
+    if (this[kStreamingEnabled] === enable) {
+      return;
+    }
     const handle = this[kHandle];
     if (handle) {
+      this[kStreamingEnabled] = enable;
       if (enable) {
         handle.ondata = this.#onData.bind(this);
         handle.ondrain = this.#onDrain.bind(this);
@@ -1550,6 +1559,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
       const handle = this[kHandle];
       if (handle) {
         handle.ondata = undefined;
+        this[kStreamingEnabled] = false;
         // The peer finished its writable side of a CONNECT/Upgrade tunnel. The
         // connection stays writable (allowHalfOpen), but - like Node, where the
         // detached socket stops reading and no longer keeps the process alive -
@@ -1955,10 +1965,15 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
 // been decided, so `this.chunkedEncoding` is already set. Bun frames the body in uWS
 // and never sets `response.chunkedEncoding`, so reproduce Node's decision here.
 function willBeChunked(response) {
-  if (response.hasHeader("transfer-encoding")) {
-    return chunkExpression.test(String(response.getHeader("transfer-encoding")));
+  // kOutHeaders is a null-proto map of lowercased name -> [name, value];
+  // index it directly instead of paying hasHeader/getHeader (each of which
+  // re-reads the symbol and lowercases its argument) per check.
+  const outHeaders = response[kOutHeaders];
+  const te = outHeaders !== null ? outHeaders["transfer-encoding"] : undefined;
+  if (te !== undefined) {
+    return chunkExpression.test(String(te[1]));
   }
-  if (response.hasHeader("content-length")) return false;
+  if (outHeaders !== null && outHeaders["content-length"] !== undefined) return false;
   if (response._hasBody === false) return false;
   if (response._removedTE) return false;
   return response.useChunkedEncodingByDefault === true;
@@ -1967,7 +1982,10 @@ function willBeChunked(response) {
 // A non-chunked message is terminated by the first empty line after the header
 // fields, so it can carry neither a body nor trailers.
 function hasInvalidTrailer(response) {
-  return !willBeChunked(response) && (response._trailer || response.hasHeader("trailer"));
+  if (willBeChunked(response)) return false;
+  if (response._trailer) return true;
+  const outHeaders = response[kOutHeaders];
+  return outHeaders !== null && outHeaders["trailer"] !== undefined;
 }
 
 function _writeHead(statusCode, reason, obj, response) {
@@ -2092,8 +2110,9 @@ function ServerResponse(req, options): void {
     // a user calling `new ServerResponse(req, { rejectNonStandardBodyWrites: true })`
     // passes the string key — which the OutgoingMessage constructor already
     // applied to the same shared symbol — so don't clobber it.
-    if (options[kRejectNonStandardBodyWrites] !== undefined) {
-      this[kRejectNonStandardBodyWrites] = options[kRejectNonStandardBodyWrites];
+    const rejectNonStandardBodyWrites = options[kRejectNonStandardBodyWrites];
+    if (rejectNonStandardBodyWrites !== undefined) {
+      this[kRejectNonStandardBodyWrites] = rejectNonStandardBodyWrites;
     }
   } else {
     this[kHandle] = req[kHandle];
@@ -2947,8 +2966,10 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     });
   } else {
     // If there's no data but you already called end, then you're done.
-    // We can ignore it in that case.
-    if (!(!chunk && handle.ended) && !handle.aborted) {
+    // We can ignore it in that case. `flags` was read above in the same tick
+    // (no native call in between can change it), so reuse its bits instead of
+    // paying two more native getter crossings.
+    if (!(!chunk && flags & NodeHTTPResponseFlags.ended) && !(flags & NodeHTTPResponseFlags.socket_closed)) {
       handle.end(chunk, encoding, undefined, strictContentLength(this));
     }
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -807,11 +807,24 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
         socket[kEnableStreaming](false);
 
-        const http_res = new ResponseClass(http_req, {
-          [kHandle]: handle,
-          highWaterMark: socket.writableHighWaterMark,
-          [kRejectNonStandardBodyWrites]: server.rejectNonStandardBodyWrites,
-        });
+        // The builtin ServerResponse consumes its options synchronously, so a
+        // reusable scratch object avoids one allocation per request. User
+        // subclasses (options.ServerResponse) might retain options, so they
+        // keep getting a fresh object.
+        let http_res;
+        if (ResponseClass === ServerResponse) {
+          scratchResponseOptions[kHandle] = handle;
+          scratchResponseOptions.highWaterMark = socket.writableHighWaterMark;
+          scratchResponseOptions[kRejectNonStandardBodyWrites] = server.rejectNonStandardBodyWrites;
+          http_res = new ResponseClass(http_req, scratchResponseOptions);
+          scratchResponseOptions[kHandle] = undefined;
+        } else {
+          http_res = new ResponseClass(http_req, {
+            [kHandle]: handle,
+            highWaterMark: socket.writableHighWaterMark,
+            [kRejectNonStandardBodyWrites]: server.rejectNonStandardBodyWrites,
+          });
+        }
         http_res._keepAliveTimeout = server.keepAliveTimeout;
         // Only stamp the symbol when the server actually set `uniqueHeaders`:
         // unconditionally adding it (even as undefined) forced a hidden-class
@@ -851,7 +864,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
 
         setIsNextIncomingMessageHTTPS(prevIsNextIncomingMessageHTTPS);
-        handle.onabort = onServerRequestEvent.bind(socket);
+        handle.onabort = (socket[kBoundOnAbort] ??= onServerRequestEvent.bind(socket));
         // start buffering data if any, the user will need to resume() or .on("data") to read it
         if (hasBody) {
           handle.pause();
@@ -1347,6 +1360,14 @@ function detachSocketListenersForHandoff(socket) {
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
+// Scratch options object for the builtin ServerResponse (see the dispatcher).
+const scratchResponseOptions = {
+  [kHandle]: undefined,
+  highWaterMark: 0,
+  [kRejectNonStandardBodyWrites]: false,
+};
+// Per-socket cached bound abort handler (the socket outlives its requests).
+const kBoundOnAbort = Symbol("kBoundOnAbort");
 const kKeepAliveTimeoutSet = Symbol("keepAliveTimeoutSet");
 // When the keep-alive idle period on a connection started (the last response
 // finish). onResponseFinishHandleSocket records this instead of rescheduling
@@ -1466,6 +1487,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   timeout = 0;
   parser = null;
   [kStreamingEnabled] = false;
+  [kBoundOnAbort] = null;
   [kBytesWritten] = 0;
   [kHandle];
   [kUpgradeIncoming] = undefined;
@@ -2137,9 +2159,34 @@ $toClass(ServerResponse, "ServerResponse", OutgoingMessage);
 // Like Node.js's _storeHeader(), the defaults never touch kOutHeaders, so
 // getHeaders()/getHeaderNames()/hasHeader() keep reporting only the headers
 // the user actually set, even after the headers have been flushed.
+// Reusable backing array for renderNativeHeaders. The native writeHead
+// consumes the array synchronously, so it can be reused across requests;
+// the busy flag covers re-entrancy (a user toString() on a header value
+// dispatching another response) and exception paths by degrading to a
+// fresh array, which is exactly the previous behavior.
+const scratchFlatHeaders: string[] = [];
+let scratchFlatHeadersBusy = false;
+
+function releaseRenderedHeaders(flat) {
+  if (flat === scratchFlatHeaders) scratchFlatHeadersBusy = false;
+}
+
+// Cache for the Keep-Alive header value: keepAliveTimeout is a per-server
+// constant, so the common (no maxRequestsPerSocket) string is identical for
+// every response.
+let cachedKeepAliveTimeout = -1;
+let cachedKeepAliveValue = "";
+
 function renderNativeHeaders(res) {
   const headersMap = res[kOutHeaders];
-  const flat: string[] = [];
+  let flat: string[];
+  if (scratchFlatHeadersBusy) {
+    flat = [];
+  } else {
+    scratchFlatHeadersBusy = true;
+    scratchFlatHeaders.length = 0;
+    flat = scratchFlatHeaders;
+  }
   let hasDate = false;
   let hasConnection = false;
   let hasKeepAlive = false;
@@ -2238,12 +2285,16 @@ function renderNativeHeaders(res) {
       flat.push("Connection", "keep-alive");
       const keepAliveTimeout = res._keepAliveTimeout;
       if (keepAliveTimeout && !hasKeepAlive) {
-        let max = "";
         const maxRequestsPerSocket = res._maxRequestsPerSocket;
         if (~~maxRequestsPerSocket > 0) {
-          max = `, max=${maxRequestsPerSocket}`;
+          flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
+        } else {
+          if (keepAliveTimeout !== cachedKeepAliveTimeout) {
+            cachedKeepAliveTimeout = keepAliveTimeout;
+            cachedKeepAliveValue = `timeout=${MathFloor(keepAliveTimeout / 1000)}`;
+          }
+          flat.push("Keep-Alive", cachedKeepAliveValue);
         }
-        flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}${max}`);
       }
     } else {
       // Like Node's shouldSendKeepAlive/_last handling: a user-cleared
@@ -2951,11 +3002,13 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
   if (headerState !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
+      const renderedHeaders = renderNativeHeaders(this);
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderNativeHeaders(this),
+        renderedHeaders,
       );
+      releaseRenderedHeaders(renderedHeaders);
 
       // If handle.writeHead throws, we don't want headersSent to be set to true.
       // So we set it here.
@@ -3097,11 +3150,13 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
 
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
+      const renderedHeaders = renderNativeHeaders(this);
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderNativeHeaders(this),
+        renderedHeaders,
       );
+      releaseRenderedHeaders(renderedHeaders);
 
       // If handle.writeHead throws, we don't want headersSent to be set to true.
       // So we set it here.
@@ -3272,11 +3327,13 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
 
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {
     handle.cork(() => {
+      const renderedHeaders = renderNativeHeaders(this);
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderNativeHeaders(this),
+        renderedHeaders,
       );
+      releaseRenderedHeaders(renderedHeaders);
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
       handle.write(data, encoding, callback, strictContentLength(this));
     });
@@ -3381,11 +3438,13 @@ ServerResponse.prototype.flushHeaders = function () {
     if (this[headerStateSymbol] === NodeHTTPHeaderState.assigned) {
       this[headerStateSymbol] = NodeHTTPHeaderState.sent;
 
+      const renderedHeaders = renderNativeHeaders(this);
       handle.writeHead(
         this[kSnapshotStatusCode] ?? this.statusCode,
         this[kSnapshotStatusMessage] ?? this.statusMessage,
-        renderNativeHeaders(this),
+        renderedHeaders,
       );
+      releaseRenderedHeaders(renderedHeaders);
     }
     handle.flushHeaders();
   } else {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1474,6 +1474,11 @@ function onSocketTimeoutTimerExpired(socket) {
       return;
     }
   }
+  // The timer has fired and is dead; drop the reference so the next
+  // response-finish re-arms via setTimeout instead of trusting a fired
+  // timer whose _idleTimeout still matches (a 'timeout' listener may keep
+  // the socket alive).
+  socket[kSocketTimeoutTimer] = undefined;
   socket._onTimeout();
 }
 
@@ -2185,8 +2190,12 @@ let renderedAutoHeaders = 0;
 let renderedKeepAliveSecs = 0;
 
 function renderNativeHeaders(res) {
-  renderedAutoHeaders = 0;
-  renderedKeepAliveSecs = 0;
+  // Computed in locals and published to the module out-params only at
+  // return: String(value) below can run user toString() code that
+  // re-enters this function, and |= on the shared slots would merge the
+  // nested render's bits into ours.
+  let autoHeaders = 0;
+  let keepAliveSecs = 0;
   const headersMap = res[kOutHeaders];
   let flat: string[];
   if (scratchFlatHeadersBusy) {
@@ -2236,7 +2245,7 @@ function renderNativeHeaders(res) {
   }
 
   if (res.sendDate && !hasDate) {
-    renderedAutoHeaders |= AUTO_HEADER_DATE;
+    autoHeaders |= AUTO_HEADER_DATE;
   }
 
   // RFC 2616 mandates that 204 and 304 responses MUST NOT have a body. A
@@ -2298,10 +2307,10 @@ function renderNativeHeaders(res) {
         flat.push("Connection", "keep-alive");
         flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
       } else {
-        renderedAutoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
+        autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
         if (keepAliveTimeout && !hasKeepAlive) {
-          renderedAutoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
-          renderedKeepAliveSecs = MathFloor(keepAliveTimeout / 1000);
+          autoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
+          keepAliveSecs = MathFloor(keepAliveTimeout / 1000);
         }
       }
     } else {
@@ -2311,7 +2320,7 @@ function renderNativeHeaders(res) {
       if (res.shouldKeepAlive === false) {
         res[kMustCloseConnection] = true;
       }
-      renderedAutoHeaders |= AUTO_HEADER_CONN_CLOSE;
+      autoHeaders |= AUTO_HEADER_CONN_CLOSE;
     }
   }
 
@@ -2337,6 +2346,8 @@ function renderNativeHeaders(res) {
     flat.push("Transfer-Encoding", "chunked");
   }
 
+  renderedAutoHeaders = autoHeaders;
+  renderedKeepAliveSecs = keepAliveSecs;
   return flat;
 }
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6236,6 +6236,13 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     flushHeaders() {
       writeHeadToSocket(null);
     },
+    writeHeadAndEnd(statusCode, statusMessage, headers, chunk, encoding, strictContentLength) {
+      // The native NodeHTTPResponse batches writeHead + end into one call;
+      // this fallback composes the same two steps (auto-header bits and the
+      // keep-alive timeout are rendered by writeHeadToSocket here).
+      this.writeHead(statusCode, statusMessage, headers);
+      return this.end(chunk, encoding, undefined, strictContentLength);
+    },
     write(chunk, encoding, _callback, _strictContentLength) {
       const buf = toBuffer(chunk, encoding);
       writeHeadToSocket(null);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6134,6 +6134,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     let hasTransferEncoding = false;
     let hasDate = false;
     let hasConnection = false;
+    let hasKeepAlive = false;
     const headers = head?.headers;
     if (headers) {
       // ServerResponse drives this handle with renderNativeHeaders(): a flat
@@ -6162,6 +6163,9 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
           case "connection":
             hasConnection = true;
             break;
+          case "keep-alive":
+            hasKeepAlive = true;
+            break;
         }
         out += `${name}: ${value}\r\n`;
       }
@@ -6189,8 +6193,16 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
       if ((autoBits & 4) !== 0) {
         out += "Connection: close\r\n";
       } else if (shouldKeepAlive) {
-        const kaSecs = (autoBits & 8) !== 0 ? head.keepAliveTimeoutSecs : Math.floor((keepAliveTimeout || 5000) / 1000);
-        out += `Connection: keep-alive\r\nKeep-Alive: timeout=${kaSecs}\r\n`;
+        out += "Connection: keep-alive\r\n";
+        // A user-sent Keep-Alive header (already written by the loop above)
+        // suppresses the auto line, like the native writeAutoHeaders. The
+        // bit-carried timeout wins when present; otherwise fall back to this
+        // handle's configured timeout, preserving pre-bits behavior.
+        if (!hasKeepAlive) {
+          const kaSecs =
+            (autoBits & 8) !== 0 ? head.keepAliveTimeoutSecs : Math.floor((keepAliveTimeout || 5000) / 1000);
+          out += `Keep-Alive: timeout=${kaSecs}\r\n`;
+        }
       } else {
         out += "Connection: close\r\n";
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6180,9 +6180,17 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     // A close-delimited response with no Connection pair means the user removed
     // it (Node's _removedConnection): write none rather than inventing
     // keep-alive on a connection that ends with the body.
+    // renderNativeHeaders reports its Connection decision through the
+    // auto-header bits (AUTO_HEADER_* in _http_server.ts / kAutoHeader* in
+    // NodeHTTP.cpp); honor an explicit close (res.shouldKeepAlive = false,
+    // the graceful-shutdown pattern) over the parser-derived flag.
+    const autoBits = head?.autoHeaderBits ?? 0;
     if (!hasConnection && !closeDelimited) {
-      if (shouldKeepAlive) {
-        out += `Connection: keep-alive\r\nKeep-Alive: timeout=${Math.floor((keepAliveTimeout || 5000) / 1000)}\r\n`;
+      if ((autoBits & 4) !== 0) {
+        out += "Connection: close\r\n";
+      } else if (shouldKeepAlive) {
+        const kaSecs = (autoBits & 8) !== 0 ? head.keepAliveTimeoutSecs : Math.floor((keepAliveTimeout || 5000) / 1000);
+        out += `Connection: keep-alive\r\nKeep-Alive: timeout=${kaSecs}\r\n`;
       } else {
         out += "Connection: close\r\n";
       }
@@ -6222,7 +6230,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     cork(callback) {
       return callback();
     },
-    writeHead(statusCode, statusMessage, headers) {
+    writeHead(statusCode, statusMessage, headers, autoHeaderBits, keepAliveTimeoutSecs) {
       const originalStatusCode = statusCode;
       statusCode |= 0;
       if (statusCode < 100 || statusCode > 999) {
@@ -6231,16 +6239,15 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
       if (typeof statusMessage === "string" && checkInvalidHeaderChar(statusMessage)) {
         throw $ERR_INVALID_CHAR("statusMessage");
       }
-      head = { statusCode, statusMessage, headers };
+      head = { statusCode, statusMessage, headers, autoHeaderBits, keepAliveTimeoutSecs };
     },
     flushHeaders() {
       writeHeadToSocket(null);
     },
-    writeHeadAndEnd(statusCode, statusMessage, headers, chunk, encoding, strictContentLength) {
+    writeHeadAndEnd(statusCode, statusMessage, headers, chunk, encoding, strictContentLength, autoHeaderBits, keepAliveTimeoutSecs) {
       // The native NodeHTTPResponse batches writeHead + end into one call;
-      // this fallback composes the same two steps (auto-header bits and the
-      // keep-alive timeout are rendered by writeHeadToSocket here).
-      this.writeHead(statusCode, statusMessage, headers);
+      // this fallback composes the same two steps.
+      this.writeHead(statusCode, statusMessage, headers, autoHeaderBits, keepAliveTimeoutSecs);
       return this.end(chunk, encoding, undefined, strictContentLength);
     },
     write(chunk, encoding, _callback, _strictContentLength) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6244,7 +6244,16 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     flushHeaders() {
       writeHeadToSocket(null);
     },
-    writeHeadAndEnd(statusCode, statusMessage, headers, chunk, encoding, strictContentLength, autoHeaderBits, keepAliveTimeoutSecs) {
+    writeHeadAndEnd(
+      statusCode,
+      statusMessage,
+      headers,
+      chunk,
+      encoding,
+      strictContentLength,
+      autoHeaderBits,
+      keepAliveTimeoutSecs,
+    ) {
       // The native NodeHTTPResponse batches writeHead + end into one call;
       // this fallback composes the same two steps.
       this.writeHead(statusCode, statusMessage, headers, autoHeaderBits, keepAliveTimeoutSecs);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -825,12 +825,78 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     }
 }
 
+// Auto-header bits (kAutoHeader* in src/js/node/_http_server.ts - keep in
+// sync). The JS side passes these instead of pushing the corresponding
+// framework headers into the flat array, so the per-request cost is two
+// integers instead of up to six string conversions.
+static constexpr uint32_t kAutoHeaderDate = 1 << 0;
+static constexpr uint32_t kAutoHeaderConnKeepAlive = 1 << 1;
+static constexpr uint32_t kAutoHeaderConnClose = 1 << 2;
+static constexpr uint32_t kAutoHeaderKeepAliveTimeout = 1 << 3;
+
+// "Date: <IMF-fixdate>\r\n", rebuilt at most once per second. Hand-rolled
+// (not strftime) so the day/month names are locale-independent.
+static std::string_view cachedDateHeaderLine()
+{
+    static thread_local time_t cachedSecond = 0;
+    static thread_local char buf[48];
+    static thread_local size_t len = 0;
+    time_t now = time(nullptr);
+    if (now != cachedSecond) {
+        cachedSecond = now;
+        struct tm t;
+        gmtime_r(&now, &t);
+        static constexpr const char days[7][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+        static constexpr const char months[12][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+        len = static_cast<size_t>(snprintf(buf, sizeof(buf), "Date: %s, %02d %s %04d %02d:%02d:%02d GMT\r\n",
+            days[t.tm_wday], t.tm_mday, months[t.tm_mon], t.tm_year + 1900, t.tm_hour, t.tm_min, t.tm_sec));
+    }
+    return { buf, len };
+}
+
+// "Connection: keep-alive\r\nKeep-Alive: timeout=N\r\n" as one buffer write;
+// N is a per-server constant, so cache the rendered blob by value.
+static std::string_view keepAliveHeaderBlob(uint32_t timeoutSecs)
+{
+    static thread_local uint32_t cachedTimeout = ~0u;
+    static thread_local char buf[64];
+    static thread_local size_t len = 0;
+    if (timeoutSecs != cachedTimeout) {
+        cachedTimeout = timeoutSecs;
+        len = static_cast<size_t>(snprintf(buf, sizeof(buf), "Connection: keep-alive\r\nKeep-Alive: timeout=%u\r\n", timeoutSecs));
+    }
+    return { buf, len };
+}
+
+template<bool isSSL>
+static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHeaderBits, uint32_t keepAliveTimeoutSecs)
+{
+    if (autoHeaderBits & kAutoHeaderDate) {
+        auto line = cachedDateHeaderLine();
+        response->uWS::template AsyncSocket<isSSL>::write(line.data(), (int)line.length());
+    }
+    if (autoHeaderBits & kAutoHeaderConnKeepAlive) {
+        if (autoHeaderBits & kAutoHeaderKeepAliveTimeout) {
+            auto blob = keepAliveHeaderBlob(keepAliveTimeoutSecs);
+            response->uWS::template AsyncSocket<isSSL>::write(blob.data(), (int)blob.length());
+        } else {
+            static constexpr const char ka[] = "Connection: keep-alive\r\n";
+            response->uWS::template AsyncSocket<isSSL>::write(ka, sizeof(ka) - 1);
+        }
+    } else if (autoHeaderBits & kAutoHeaderConnClose) {
+        static constexpr const char cl[] = "Connection: close\r\n";
+        response->uWS::template AsyncSocket<isSSL>::write(cl, sizeof(cl) - 1);
+    }
+}
+
 template<bool isSSL>
 static void NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
+    uint32_t autoHeaderBits,
+    uint32_t keepAliveTimeoutSecs,
     uWS::HttpResponse<isSSL>* response)
 {
     auto& vm = globalObject->vm();
@@ -858,6 +924,7 @@ static void NodeHTTPServer__writeHead(
     if (headersObject) {
         if (auto* fetchHeaders = dynamicDowncast<WebCore::JSFetchHeaders>(headersObject)) {
             writeFetchHeadersToUWSResponse<isSSL>(fetchHeaders->wrapped(), response);
+            if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
             return;
         }
 
@@ -908,6 +975,7 @@ static void NodeHTTPServer__writeHead(
 
                 writeResponseHeader<isSSL>(response, name, value);
             }
+            if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
             return;
         }
 
@@ -955,6 +1023,8 @@ static void NodeHTTPServer__writeHead(
         }
     }
 
+    if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
+
     RELEASE_AND_RETURN(scope, void());
 }
 
@@ -963,9 +1033,11 @@ extern "C" void NodeHTTPServer__writeHead_http(
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
+    uint32_t autoHeaderBits,
+    uint32_t keepAliveTimeoutSecs,
     uWS::HttpResponse<false>* response)
 {
-    return NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, response);
+    return NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
 }
 
 extern "C" void NodeHTTPServer__writeHead_https(
@@ -973,9 +1045,11 @@ extern "C" void NodeHTTPServer__writeHead_https(
     const char* statusMessage,
     size_t statusMessageLength,
     JSValue headersObjectValue,
+    uint32_t autoHeaderBits,
+    uint32_t keepAliveTimeoutSecs,
     uWS::HttpResponse<true>* response)
 {
-    return NodeHTTPServer__writeHead<true>(globalObject, statusMessage, statusMessageLength, headersObjectValue, response);
+    return NodeHTTPServer__writeHead<true>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
 }
 
 extern "C" EncodedJSValue NodeHTTPServer__onRequest_http(

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -370,6 +370,20 @@ extern "C" EncodedJSValue Bun__NodeHTTP__buildRawHeadersArray(JSC::JSGlobalObjec
     RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
 
+// Scope-free VM::exception() read. A callee's ThrowScope destructor
+// simulates a throw so its caller must check; when the caller is Rust
+// (writeHeadAndEnd's write-head phase) there is no ThrowScope to do it, so
+// this acknowledges the check without declaring a scope (declaring one
+// would trip the verifier before the read). The actual success/failure
+// travels through NodeHTTPServer__writeHead's return value.
+extern "C" void Bun__NodeHTTP__acknowledgeThrowScope(JSC::JSGlobalObject* globalObject)
+{
+    // The same sanctioned read RETURN_IF_EXCEPTION performs; it observes
+    // (and under exception-scope verification, acknowledges) any pending
+    // exception without constructing a verifying scope.
+    (void)globalObject->vm().hasExceptionsAfterHandlingTraps();
+}
+
 // Defined in Rust (NodeHTTPResponse.rs): moves the captured raw header bytes
 // onto the native response so takeRawHeaders can materialize them on demand.
 extern "C" void NodeHTTPResponse__adoptRawRequestHeaders(void* nodeHttpResponse, const uint8_t* data, size_t length);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -902,8 +902,12 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
     }
 }
 
+// Returns false when a JS exception is pending (header conversion or
+// validation threw). The exception check happens here, inside the owning
+// ThrowScope; callers on the Rust side branch on the return value instead
+// of probing VM exception state through another scope.
 template<bool isSSL>
-static void NodeHTTPServer__writeHead(
+static bool NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
@@ -937,8 +941,9 @@ static void NodeHTTPServer__writeHead(
     if (headersObject) {
         if (auto* fetchHeaders = dynamicDowncast<WebCore::JSFetchHeaders>(headersObject)) {
             writeFetchHeadersToUWSResponse<isSSL>(fetchHeaders->wrapped(), response);
+            RETURN_IF_EXCEPTION(scope, false);
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            RELEASE_AND_RETURN(scope, void());
+            return true;
         }
 
         // A flat [name, value, name, value, ...] array. Used by node:http's
@@ -950,14 +955,14 @@ static void NodeHTTPServer__writeHead(
             unsigned length = pairsArray->length();
             for (unsigned i = 0; i + 1 < length; i += 2) {
                 JSValue nameValue = pairsArray->getIndex(globalObject, i);
-                RETURN_IF_EXCEPTION(scope, void());
+                RETURN_IF_EXCEPTION(scope, false);
                 JSValue headerValue = pairsArray->getIndex(globalObject, i + 1);
-                RETURN_IF_EXCEPTION(scope, void());
+                RETURN_IF_EXCEPTION(scope, false);
 
                 String name = nameValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, void());
+                RETURN_IF_EXCEPTION(scope, false);
                 String value = headerValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, void());
+                RETURN_IF_EXCEPTION(scope, false);
 
                 // node:http marks framing decisions with a NUL-named sentinel
                 // pair instead of a real header: value "1" = close-delimited
@@ -988,13 +993,14 @@ static void NodeHTTPServer__writeHead(
 
                 writeResponseHeader<isSSL>(response, name, value);
             }
+            RETURN_IF_EXCEPTION(scope, false);
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            RELEASE_AND_RETURN(scope, void());
+            return true;
         }
 
         if (headersObject->hasNonReifiedStaticProperties()) [[unlikely]] {
             headersObject->reifyAllStaticProperties(globalObject);
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, false);
         }
 
         auto* structure = headersObject->structure();
@@ -1018,30 +1024,31 @@ static void NodeHTTPServer__writeHead(
         } else {
             PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
             headersObject->getOwnPropertyNames(headersObject, globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
-            RETURN_IF_EXCEPTION(scope, void());
+            RETURN_IF_EXCEPTION(scope, false);
 
             for (unsigned i = 0; i < propertyNames.size(); ++i) {
                 JSValue headerValue = headersObject->getIfPropertyExists(globalObject, propertyNames[i]);
-                RETURN_IF_EXCEPTION(scope, );
+                RETURN_IF_EXCEPTION(scope, false);
                 if (!headerValue.isString()) {
                     continue;
                 }
 
                 String key = propertyNames[i].string();
                 String value = headerValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, void());
+                RETURN_IF_EXCEPTION(scope, false);
 
                 writeResponseHeader<isSSL>(response, key, value);
             }
         }
     }
 
+    RETURN_IF_EXCEPTION(scope, false);
     if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
 
-    RELEASE_AND_RETURN(scope, void());
+    return true;
 }
 
-extern "C" void NodeHTTPServer__writeHead_http(
+extern "C" bool NodeHTTPServer__writeHead_http(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
@@ -1053,7 +1060,7 @@ extern "C" void NodeHTTPServer__writeHead_http(
     return NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
 }
 
-extern "C" void NodeHTTPServer__writeHead_https(
+extern "C" bool NodeHTTPServer__writeHead_https(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -202,9 +202,10 @@ static bool svValueHasToken(std::string_view value, std::string_view lowerToken)
             continue;
         if (!svEqualsIgnoreCase(value.substr(i, m), lowerToken))
             continue;
-        bool leftOk = i == 0 || !isASCIIAlphanumeric(value[i - 1]);
+        // \W in the JS regexes this mirrors treats '_' as a word character.
+        bool leftOk = i == 0 || !(isASCIIAlphanumeric(value[i - 1]) || value[i - 1] == '_');
         size_t end = i + m;
-        bool rightOk = end >= n || !isASCIIAlphanumeric(value[end]);
+        bool rightOk = end >= n || !(isASCIIAlphanumeric(value[end]) || value[end] == '_');
         if (leftOk && rightOk)
             return true;
         i = end - 1;
@@ -234,20 +235,27 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         args.append(methodString);
     }
 
+    // Deliberate: the bitfield scans every header the parser accepted, like
+    // the parser's own Host/Expect handling, while req.rawHeaders/req.headers
+    // still apply the server.maxHeadersCount truncation on materialization.
     uint32_t bits = 0;
     for (auto it = request->begin(); it != request->end(); ++it) {
         auto pair = *it;
         const std::string_view name = pair.first;
         const std::string_view value = pair.second;
 
-        // Header name/value lengths are parser-bounded well below 64 KiB.
-        const uint16_t nameLen = static_cast<uint16_t>(name.length());
-        const uint16_t valueLen = static_cast<uint16_t>(value.length());
-        uint8_t lens[4] = {
-            static_cast<uint8_t>(nameLen & 0xff), static_cast<uint8_t>(nameLen >> 8),
-            static_cast<uint8_t>(valueLen & 0xff), static_cast<uint8_t>(valueLen >> 8)
+        // u32 length prefixes: header sizes are usually tiny, but maxHeaderSize
+        // is user-configurable with no upper bound, so a u16 would silently
+        // truncate a >64 KiB value and desync the buffer.
+        const uint32_t nameLen = static_cast<uint32_t>(name.length());
+        const uint32_t valueLen = static_cast<uint32_t>(value.length());
+        uint8_t lens[8] = {
+            static_cast<uint8_t>(nameLen & 0xff), static_cast<uint8_t>((nameLen >> 8) & 0xff),
+            static_cast<uint8_t>((nameLen >> 16) & 0xff), static_cast<uint8_t>(nameLen >> 24),
+            static_cast<uint8_t>(valueLen & 0xff), static_cast<uint8_t>((valueLen >> 8) & 0xff),
+            static_cast<uint8_t>((valueLen >> 16) & 0xff), static_cast<uint8_t>(valueLen >> 24)
         };
-        flatHeaders.append(std::span<const uint8_t> { lens, 4 });
+        flatHeaders.append(std::span<const uint8_t> { lens, 8 });
         flatHeaders.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(name.data()), name.length() });
         flatHeaders.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(value.data()), value.length() });
 
@@ -289,10 +297,9 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         }
     }
 
-    // The headers-object slot now carries the dispatch bitfield; the
-    // rawHeaders slot is materialized lazily from the captured bytes.
+    // The headers-object slot now carries the dispatch bitfield; rawHeaders
+    // materialize lazily from the captured bytes, so no array is passed.
     args.append(jsNumber(bits));
-    args.append(jsUndefined());
 }
 
 // Builds the rawHeaders flat array [name, value, ...] from the bytes captured
@@ -307,10 +314,12 @@ extern "C" EncodedJSValue Bun__NodeHTTP__buildRawHeadersArray(JSC::JSGlobalObjec
     HTTPHeaderIdentifiers& identifiers = WebCore::clientData(vm)->httpHeaderIdentifiers();
 
     size_t offset = 0;
-    while (offset + 4 <= length) {
-        const uint16_t nameLen = static_cast<uint16_t>(data[offset]) | (static_cast<uint16_t>(data[offset + 1]) << 8);
-        const uint16_t valueLen = static_cast<uint16_t>(data[offset + 2]) | (static_cast<uint16_t>(data[offset + 3]) << 8);
-        offset += 4;
+    while (offset + 8 <= length) {
+        const uint32_t nameLen = static_cast<uint32_t>(data[offset]) | (static_cast<uint32_t>(data[offset + 1]) << 8)
+            | (static_cast<uint32_t>(data[offset + 2]) << 16) | (static_cast<uint32_t>(data[offset + 3]) << 24);
+        const uint32_t valueLen = static_cast<uint32_t>(data[offset + 4]) | (static_cast<uint32_t>(data[offset + 5]) << 8)
+            | (static_cast<uint32_t>(data[offset + 6]) << 16) | (static_cast<uint32_t>(data[offset + 7]) << 24);
+        offset += 8;
         if (offset + nameLen + valueLen > length) [[unlikely]]
             break;
         StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(data + offset), nameLen });
@@ -845,7 +854,11 @@ static std::string_view cachedDateHeaderLine()
     if (now != cachedSecond) {
         cachedSecond = now;
         struct tm t;
+#ifdef _WIN32
+        gmtime_s(&t, &now);
+#else
         gmtime_r(&now, &t);
+#endif
         static constexpr const char days[7][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
         static constexpr const char months[12][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
         len = static_cast<size_t>(snprintf(buf, sizeof(buf), "Date: %s, %02d %s %04d %02d:%02d:%02d GMT\r\n",
@@ -925,7 +938,7 @@ static void NodeHTTPServer__writeHead(
         if (auto* fetchHeaders = dynamicDowncast<WebCore::JSFetchHeaders>(headersObject)) {
             writeFetchHeadersToUWSResponse<isSSL>(fetchHeaders->wrapped(), response);
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            return;
+            RELEASE_AND_RETURN(scope, void());
         }
 
         // A flat [name, value, name, value, ...] array. Used by node:http's
@@ -976,7 +989,7 @@ static void NodeHTTPServer__writeHead(
                 writeResponseHeader<isSSL>(response, name, value);
             }
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            return;
+            RELEASE_AND_RETURN(scope, void());
         }
 
         if (headersObject->hasNonReifiedStaticProperties()) [[unlikely]] {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -168,10 +168,57 @@ static JSString* joinedRequestHeaderValue(JSC::JSGlobalObject* globalObject, JSC
     }
     return jsString(vm, merged);
 }
+// Bit layout must stay in sync with kDispatchBits* in src/js/node/_http_server.ts.
+static constexpr uint32_t kDispatchConnClose = 1 << 0;
+static constexpr uint32_t kDispatchConnUpgrade = 1 << 1;
+static constexpr uint32_t kDispatchHasUpgrade = 1 << 2;
+static constexpr uint32_t kDispatchHasHost = 1 << 3;
+static constexpr uint32_t kDispatchHasExpect = 1 << 4;
+static constexpr uint32_t kDispatchExpectContinue = 1 << 5;
+static constexpr uint32_t kDispatchHasContentLength = 1 << 6;
+static constexpr uint32_t kDispatchHasTransferEncoding = 1 << 7;
 
-static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSValue methodString, MarkedArgumentBuffer& args, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
+static bool svEqualsIgnoreCase(std::string_view a, std::string_view lower)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (a.length() != lower.length())
+        return false;
+    for (size_t i = 0; i < a.length(); i++) {
+        if ((static_cast<unsigned char>(a[i]) | 0x20) != static_cast<unsigned char>(lower[i]))
+            return false;
+    }
+    return true;
+}
+
+// `1#token` list scan (RFC 9110): does `value` contain `lowerToken` at
+// non-alphanumeric boundaries, ASCII-case-insensitively? Mirrors the
+// /(?:^|\W)tok(?:$|\W)/i checks node:http uses for Connection/Expect values.
+static bool svValueHasToken(std::string_view value, std::string_view lowerToken)
+{
+    const size_t n = value.length(), m = lowerToken.length();
+    if (m == 0 || n < m)
+        return false;
+    for (size_t i = 0; i + m <= n; i++) {
+        if ((static_cast<unsigned char>(value[i]) | 0x20) != static_cast<unsigned char>(lowerToken[0]))
+            continue;
+        if (!svEqualsIgnoreCase(value.substr(i, m), lowerToken))
+            continue;
+        bool leftOk = i == 0 || !isASCIIAlphanumeric(value[i - 1]);
+        size_t end = i + m;
+        bool rightOk = end >= n || !isASCIIAlphanumeric(value[end]);
+        if (leftOk && rightOk)
+            return true;
+        i = end - 1;
+    }
+    return false;
+}
+
+// One pass over the request: append url, method, jsNumber(dispatch bitfield)
+// and jsUndefined() (the legacy rawHeaders slot) to `args`, and capture the
+// raw header bytes into `flatHeaders` as [u16 nameLen][u16 valueLen][name]
+// [value]... so req.rawHeaders / req.headers can be materialized lazily
+// (Bun__NodeHTTP__buildRawHeadersArray) only when user code reads them.
+static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSValue methodString, MarkedArgumentBuffer& args, WTF::Vector<uint8_t, 1024>& flatHeaders, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
+{
     {
         std::string_view fullURLStdStr = request->getFullUrl();
         String fullURL = String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const Latin1Character*>(fullURLStdStr.data()), fullURLStdStr.length() });
@@ -187,21 +234,93 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         args.append(methodString);
     }
 
-    // Only the rawHeaders flat array is built here. The IncomingMessage
-    // constructor rebuilds `headers` lazily from rawHeaders with Node.js's
-    // duplicate-handling rules (joining, cookie/set-cookie rules,
-    // joinDuplicateHeaders), so a native headers object would be allocated and
-    // then thrown away on every request - the slot is passed as undefined.
+    uint32_t bits = 0;
+    for (auto it = request->begin(); it != request->end(); ++it) {
+        auto pair = *it;
+        const std::string_view name = pair.first;
+        const std::string_view value = pair.second;
+
+        // Header name/value lengths are parser-bounded well below 64 KiB.
+        const uint16_t nameLen = static_cast<uint16_t>(name.length());
+        const uint16_t valueLen = static_cast<uint16_t>(value.length());
+        uint8_t lens[4] = {
+            static_cast<uint8_t>(nameLen & 0xff), static_cast<uint8_t>(nameLen >> 8),
+            static_cast<uint8_t>(valueLen & 0xff), static_cast<uint8_t>(valueLen >> 8)
+        };
+        flatHeaders.append(std::span<const uint8_t> { lens, 4 });
+        flatHeaders.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(name.data()), name.length() });
+        flatHeaders.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(value.data()), value.length() });
+
+        // Duplicate headers OR their token bits (the lazy header build joins
+        // duplicates with ", ", and a token match on the joined value is a
+        // token match on one of the parts).
+        switch (name.length()) {
+        case 4:
+            if (svEqualsIgnoreCase(name, "host"))
+                bits |= kDispatchHasHost;
+            break;
+        case 6:
+            if (svEqualsIgnoreCase(name, "expect")) {
+                bits |= kDispatchHasExpect;
+                if (svValueHasToken(value, "100-continue"))
+                    bits |= kDispatchExpectContinue;
+            }
+            break;
+        case 7:
+            if (svEqualsIgnoreCase(name, "upgrade"))
+                bits |= kDispatchHasUpgrade;
+            break;
+        case 10:
+            if (svEqualsIgnoreCase(name, "connection")) {
+                if (svValueHasToken(value, "close"))
+                    bits |= kDispatchConnClose;
+                if (svValueHasToken(value, "upgrade"))
+                    bits |= kDispatchConnUpgrade;
+            }
+            break;
+        case 14:
+            if (svEqualsIgnoreCase(name, "content-length"))
+                bits |= kDispatchHasContentLength;
+            break;
+        case 17:
+            if (svEqualsIgnoreCase(name, "transfer-encoding"))
+                bits |= kDispatchHasTransferEncoding;
+            break;
+        }
+    }
+
+    // The headers-object slot now carries the dispatch bitfield; the
+    // rawHeaders slot is materialized lazily from the captured bytes.
+    args.append(jsNumber(bits));
+    args.append(jsUndefined());
+}
+
+// Builds the rawHeaders flat array [name, value, ...] from the bytes captured
+// by assignHeadersFromUWebSocketsForCall. Runs only when user code first
+// touches req.rawHeaders / req.headers (via NodeHTTPResponse.takeRawHeaders).
+extern "C" EncodedJSValue Bun__NodeHTTP__buildRawHeadersArray(JSC::JSGlobalObject* globalObject, const uint8_t* data, size_t length)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     MarkedArgumentBuffer arrayValues;
     HTTPHeaderIdentifiers& identifiers = WebCore::clientData(vm)->httpHeaderIdentifiers();
 
-    for (auto it = request->begin(); it != request->end(); ++it) {
-        auto pair = *it;
-        StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(pair.first.data()), pair.first.length() });
-        std::span<Latin1Character> data;
-        auto value = String::createUninitialized(pair.second.length(), data);
-        if (pair.second.length() > 0)
-            memcpy(data.data(), pair.second.data(), pair.second.length());
+    size_t offset = 0;
+    while (offset + 4 <= length) {
+        const uint16_t nameLen = static_cast<uint16_t>(data[offset]) | (static_cast<uint16_t>(data[offset + 1]) << 8);
+        const uint16_t valueLen = static_cast<uint16_t>(data[offset + 2]) | (static_cast<uint16_t>(data[offset + 3]) << 8);
+        offset += 4;
+        if (offset + nameLen + valueLen > length) [[unlikely]]
+            break;
+        StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(data + offset), nameLen });
+        offset += nameLen;
+
+        std::span<Latin1Character> valueData;
+        auto value = String::createUninitialized(valueLen, valueData);
+        if (valueLen > 0)
+            memcpy(valueData.data(), data + offset, valueLen);
+        offset += valueLen;
 
         HTTPHeaderName name;
         JSString* jsValue = jsString(vm, value);
@@ -224,28 +343,27 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         arrayValues.append(jsValue);
     }
 
-    // The headers slot: unused by the IncomingMessage native fast-path (see
-    // _http_incoming.ts), kept for argument-position compatibility.
-    args.append(jsUndefined());
-
     JSC::JSArray* array;
     {
-
         ObjectInitializationScope initializationScope(vm);
         if ((array = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), arrayValues.size()))) [[likely]] {
-            EncodedJSValue* data = arrayValues.data();
+            EncodedJSValue* argValues = arrayValues.data();
             for (size_t i = 0, size = arrayValues.size(); i < size; ++i) {
-                array->initializeIndex(initializationScope, i, JSValue::decode(data[i]));
+                array->initializeIndex(initializationScope, i, JSValue::decode(argValues[i]));
             }
         } else {
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, {});
             array = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), arrayValues);
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
-    args.append(array);
+    RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
+
+// Defined in Rust (NodeHTTPResponse.rs): moves the captured raw header bytes
+// onto the native response so takeRawHeaders can materialize them on demand.
+extern "C" void NodeHTTPResponse__adoptRawRequestHeaders(void* nodeHttpResponse, const uint8_t* data, size_t length);
 
 // This is an 8% speedup.
 static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
@@ -519,11 +637,17 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     MarkedArgumentBuffer args;
     args.append(thisValue);
 
-    assignHeadersFromUWebSocketsForCall(request, methodString, args, globalObject, vm);
+    // Typical request header sections are a few hundred bytes; the inline
+    // capacity keeps the capture heap-allocation-free for the common case.
+    WTF::Vector<uint8_t, 1024> flatHeaders;
+    assignHeadersFromUWebSocketsForCall(request, methodString, args, flatHeaders, globalObject, vm);
     RETURN_IF_EXCEPTION(scope, {});
 
     bool hasBody = false;
     WebCore::JSNodeHTTPResponse* nodeHTTPResponseObject = uncheckedDowncast<WebCore::JSNodeHTTPResponse>(JSValue::decode(NodeHTTPResponse__createForJS(any_server, globalObject, &hasBody, request, isSSL, response, upgrade_ctx, nodeHttpResponsePtr)));
+    if (!flatHeaders.isEmpty()) {
+        NodeHTTPResponse__adoptRawRequestHeaders(*nodeHttpResponsePtr, flatHeaders.span().data(), flatHeaders.size());
+    }
 
     args.append(nodeHTTPResponseObject);
     args.append(jsBoolean(hasBody));

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -213,11 +213,11 @@ static bool svValueHasToken(std::string_view value, std::string_view lowerToken)
     return false;
 }
 
-// One pass over the request: append url, method, jsNumber(dispatch bitfield)
-// and jsUndefined() (the legacy rawHeaders slot) to `args`, and capture the
-// raw header bytes into `flatHeaders` as [u16 nameLen][u16 valueLen][name]
-// [value]... so req.rawHeaders / req.headers can be materialized lazily
-// (Bun__NodeHTTP__buildRawHeadersArray) only when user code reads them.
+// One pass over the request: append url, method and jsNumber(dispatch
+// bitfield) to `args`, and capture the raw header bytes into `flatHeaders`
+// as [u32 nameLen][u32 valueLen][name][value]... so req.rawHeaders /
+// req.headers can be materialized lazily (Bun__NodeHTTP__buildRawHeadersArray)
+// only when user code reads them.
 static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSValue methodString, MarkedArgumentBuffer& args, WTF::Vector<uint8_t, 1024>& flatHeaders, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
 {
     {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -57,6 +57,12 @@ pub struct NodeHTTPResponse {
     /// body finishes (still inside the parser), because a pipelined request's
     /// parse would otherwise overwrite it before this request's JS reads it.
     pub request_trailers: JsCell<Vec<u8>>,
+    /// node:http: this request's header section captured at dispatch as
+    /// [u16 nameLen][u16 valueLen][name][value]... so req.rawHeaders /
+    /// req.headers materialize lazily (takeRawHeaders) instead of paying
+    /// 2N JSStrings + a JSArray on every request. One-shot: emptied on first
+    /// access.
+    pub raw_request_headers: JsCell<Vec<u8>>,
     pub bytes_written: Cell<usize>,
 
     pub upgrade_context: JsCell<UpgradeCTX>,
@@ -193,6 +199,13 @@ unsafe extern "C" {
         data: *const u8,
         length: usize,
         use_insecure_http_parser: bool,
+    ) -> JSValue;
+    // Builds req.rawHeaders' flat [name, value, ...] JSArray from the header
+    // bytes captured at dispatch ([u16 nameLen][u16 valueLen][name][value]...).
+    safe fn Bun__NodeHTTP__buildRawHeadersArray(
+        global_object: &JSGlobalObject,
+        data: *const u8,
+        length: usize,
     ) -> JSValue;
 
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
@@ -1950,6 +1963,22 @@ impl NodeHTTPResponse {
         self.write_or_end::<true>(global_object, arguments, callframe.this())
     }
 
+    /// `handle.takeRawHeaders()` — this request's captured header section
+    /// materialized into the rawHeaders flat [name, value, ...] array, or
+    /// undefined when there were no headers (or they were already taken).
+    /// Consumes the captured bytes.
+    pub(crate) fn take_raw_headers(
+        &self,
+        global_object: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JSValue {
+        let section = self.raw_request_headers.replace(Vec::new());
+        if section.is_empty() {
+            return JSValue::UNDEFINED;
+        }
+        Bun__NodeHTTP__buildRawHeadersArray(global_object, section.as_ptr(), section.len())
+    }
+
     /// `handle.takeRequestTrailers()` — this request's captured trailer section
     /// parsed into a flat [name, value, ...] array, or undefined. Consumes it.
     pub(crate) fn take_request_trailers(
@@ -2173,6 +2202,22 @@ impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
 }
 
 /// # Safety
+/// `response` is the pointer written to `node_response_ptr` by
+/// `NodeHTTPResponse__createForJS` earlier in the same dispatch and is live;
+/// `data`/`length` describe a caller-owned buffer valid for the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NodeHTTPResponse__adoptRawRequestHeaders(
+    response: *mut NodeHTTPResponse,
+    data: *const u8,
+    length: usize,
+) {
+    // SAFETY: see the function-level contract above.
+    let response = unsafe { &*response };
+    let bytes = unsafe { core::slice::from_raw_parts(data, length) };
+    response.raw_request_headers.with_mut(|v| v.append_slice(bytes));
+}
+
+/// # Safety
 /// `has_body`, `request`, `response_ptr`, `upgrade_ctx`, and `node_response_ptr`
 /// are provided by C++ NodeHTTPServer and must be valid for the duration of the
 /// call; `has_body` and `node_response_ptr` must be writable.
@@ -2242,6 +2287,7 @@ pub unsafe extern "C" fn NodeHTTPResponse__createForJS(
         promise: JsCell::new(StrongOptional::empty()),
         buffered_request_body_data_during_pause: JsCell::new(Vec::new()),
         request_trailers: JsCell::new(Vec::new()),
+        raw_request_headers: JsCell::new(Vec::new()),
         bytes_written: Cell::new(0),
         auto_flusher: JsCell::new(AutoFlusher::default()),
     }));

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -202,6 +202,10 @@ unsafe extern "C" {
     ) -> JSValue;
     // Builds req.rawHeaders' flat [name, value, ...] JSArray from the header
     // bytes captured at dispatch ([u32 nameLen][u32 valueLen][name][value]...).
+    // Scope-free VM::exception() read: satisfies the exception-check
+    // verifier after a callee ThrowScope destructor simulated a throw for
+    // this (scope-less native) caller. A single load in release builds.
+    safe fn Bun__NodeHTTP__acknowledgeThrowScope(global_object: &JSGlobalObject);
     safe fn Bun__NodeHTTP__buildRawHeadersArray(
         global_object: &JSGlobalObject,
         data: *const u8,
@@ -949,11 +953,12 @@ impl NodeHTTPResponse {
             }
         }
 
-        // The C++ header writer can throw (invalid header characters, header
-        // conversion) and reports it via its return value, checked inside its
-        // own ThrowScope. When this runs inside writeHeadAndEnd there is no
-        // JS binding wrapper between the phases, so propagate here -
-        // otherwise the end phase would run with an exception pending.
+        // The writeHead ThrowScope's destructor simulates a throw so its
+        // caller must check; acknowledge it scope-free (we are that caller
+        // when running inside writeHeadAndEnd), then propagate the result
+        // that traveled through the return value - otherwise the end phase
+        // would run with an exception pending.
+        Bun__NodeHTTP__acknowledgeThrowScope(global_object);
         if !wrote_head_ok {
             return Err(jsc::JsError::Thrown);
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -216,6 +216,8 @@ unsafe extern "C" {
         status_message: *const u8,
         status_message_length: usize,
         headers_object_value: JSValue,
+        auto_header_bits: u32,
+        keep_alive_timeout_secs: u32,
         response: *mut c_void,
     );
 
@@ -224,6 +226,8 @@ unsafe extern "C" {
         status_message: *const u8,
         status_message_length: usize,
         headers_object_value: JSValue,
+        auto_header_bits: u32,
+        keep_alive_timeout_secs: u32,
         response: *mut c_void,
     );
 }
@@ -765,15 +769,35 @@ impl NodeHTTPResponse {
         // path. The borrowed `arguments()` slice (ptr+len, 16 bytes) carries the
         // same information; missing / `null` slots are padded to `undefined`
         // inline below exactly as the `Arguments<3>` form did.
-        self.write_head_impl(global_object, callframe.arguments())
+        let arguments = callframe.arguments();
+        let auto_header_bits = arguments
+            .get(3)
+            .copied()
+            .filter(|v| v.is_number())
+            .map_or(0, |v| v.to_int32() as u32);
+        let keep_alive_timeout_secs = arguments
+            .get(4)
+            .copied()
+            .filter(|v| v.is_number())
+            .map_or(0, |v| v.to_int32() as u32);
+        self.write_head_impl(
+            global_object,
+            arguments,
+            auto_header_bits,
+            keep_alive_timeout_secs,
+        )
     }
 
     /// Shared body of `writeHead` (also the write-head phase of
-    /// `writeHeadAndEnd`): args are (statusCode, statusMessage, headersArray).
+    /// `writeHeadAndEnd`): args are (statusCode, statusMessage, headersArray),
+    /// plus the auto-header bits + keep-alive timeout the C++ side renders
+    /// natively (kAutoHeader* in NodeHTTP.cpp).
     fn write_head_impl(
         &self,
         global_object: &JSGlobalObject,
         arguments: &[JSValue],
+        auto_header_bits: u32,
+        keep_alive_timeout_secs: u32,
     ) -> JsResult<JSValue> {
         if self.is_requested_completed_or_ended() {
             return err_throw(
@@ -872,6 +896,8 @@ impl NodeHTTPResponse {
                         global_object,
                         status_message,
                         headers_object_value,
+                        auto_header_bits,
+                        keep_alive_timeout_secs,
                     );
                     break 'do_it;
                 }
@@ -900,6 +926,8 @@ impl NodeHTTPResponse {
                     global_object,
                     &stack_buf[..n],
                     headers_object_value,
+                    auto_header_bits,
+                    keep_alive_timeout_secs,
                 );
             } else {
                 // Heap fallback for absurdly long status messages (> 252 bytes).
@@ -907,7 +935,14 @@ impl NodeHTTPResponse {
                 heap.extend_from_slice(code);
                 heap.push(b' ');
                 heap.extend_from_slice(message);
-                write_head_internal(&raw_response, global_object, &heap, headers_object_value);
+                write_head_internal(
+                    &raw_response,
+                    global_object,
+                    &heap,
+                    headers_object_value,
+                    auto_header_bits,
+                    keep_alive_timeout_secs,
+                );
             }
         }
 
@@ -941,6 +976,16 @@ impl NodeHTTPResponse {
         }
 
         let head_len = arguments.len().min(3);
+        let auto_header_bits = arguments
+            .get(6)
+            .copied()
+            .filter(|v| v.is_number())
+            .map_or(0, |v| v.to_int32() as u32);
+        let keep_alive_timeout_secs = arguments
+            .get(7)
+            .copied()
+            .filter(|v| v.is_number())
+            .map_or(0, |v| v.to_int32() as u32);
         // write_or_end::<true> reads (chunk, encoding, _, strictContentLength).
         let end_args = [
             arguments.get(3).copied().unwrap_or(JSValue::UNDEFINED),
@@ -960,7 +1005,12 @@ impl NodeHTTPResponse {
         let mut result: JsResult<JSValue> = Ok(JSValue::UNDEFINED);
         {
             let run = || -> JsResult<JSValue> {
-                this.write_head_impl(global_object, &arguments[..head_len])?;
+                this.write_head_impl(
+                    global_object,
+                    &arguments[..head_len],
+                    auto_header_bits,
+                    keep_alive_timeout_secs,
+                )?;
                 this.resume_socket();
                 this.write_or_end::<true>(global_object, &end_args, this_value)
             };
@@ -986,6 +1036,8 @@ fn write_head_internal(
     global_object: &JSGlobalObject,
     status_message: &[u8],
     headers: JSValue,
+    auto_header_bits: u32,
+    keep_alive_timeout_secs: u32,
 ) {
     scoped_log!(
         NodeHTTPResponse,
@@ -998,6 +1050,8 @@ fn write_head_internal(
             status_message.as_ptr(),
             status_message.len(),
             headers,
+            auto_header_bits,
+            keep_alive_timeout_secs,
             (*tcp).cast::<c_void>(),
         ),
         uws::AnyResponse::SSL(ssl) => NodeHTTPServer__writeHead_https(
@@ -1005,6 +1059,8 @@ fn write_head_internal(
             status_message.as_ptr(),
             status_message.len(),
             headers,
+            auto_header_bits,
+            keep_alive_timeout_secs,
             (*ssl).cast::<c_void>(),
         ),
         uws::AnyResponse::H3(_) => {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2343,6 +2343,8 @@ pub unsafe extern "C" fn NodeHTTPResponse__adoptRawRequestHeaders(
 ) {
     // SAFETY: see the function-level contract above.
     let response = unsafe { &*response };
+    // SAFETY: `data`/`length` describe a caller-owned buffer valid for the
+    // call (function-level contract above).
     let bytes = unsafe { core::slice::from_raw_parts(data, length) };
     response
         .raw_request_headers

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -211,6 +211,8 @@ unsafe extern "C" {
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
     // ptr/len of a Rust `&[u8]` and `response` is a live `uws::Response<SSL>*`
     // from the matched `AnyResponse` arm. Module-private with one call site.
+    // Returns false when the C++ header writer left a JS exception pending
+    // (checked inside its own ThrowScope).
     safe fn NodeHTTPServer__writeHead_http(
         global_object: &JSGlobalObject,
         status_message: *const u8,
@@ -219,7 +221,7 @@ unsafe extern "C" {
         auto_header_bits: u32,
         keep_alive_timeout_secs: u32,
         response: *mut c_void,
-    );
+    ) -> bool;
 
     safe fn NodeHTTPServer__writeHead_https(
         global_object: &JSGlobalObject,
@@ -229,7 +231,7 @@ unsafe extern "C" {
         auto_header_bits: u32,
         keep_alive_timeout_secs: u32,
         response: *mut c_void,
-    );
+    ) -> bool;
 }
 
 /// `VirtualMachine::get()` returns `*mut`; deref once for callers that need `&mut`.
@@ -886,12 +888,13 @@ impl NodeHTTPResponse {
             }
         }
 
+        let wrote_head_ok;
         'do_it: {
             if status_message_bytes.is_empty() {
                 if let Some(status_message) =
                     HTTPStatusText::get(u16::try_from(status_code).expect("int cast"))
                 {
-                    write_head_internal(
+                    wrote_head_ok = write_head_internal(
                         &raw_response,
                         global_object,
                         status_message,
@@ -921,7 +924,7 @@ impl NodeHTTPResponse {
                 stack_buf[..code.len()].copy_from_slice(code);
                 stack_buf[code.len()] = b' ';
                 stack_buf[code.len() + 1..n].copy_from_slice(message);
-                write_head_internal(
+                wrote_head_ok = write_head_internal(
                     &raw_response,
                     global_object,
                     &stack_buf[..n],
@@ -935,7 +938,7 @@ impl NodeHTTPResponse {
                 heap.extend_from_slice(code);
                 heap.push(b' ');
                 heap.extend_from_slice(message);
-                write_head_internal(
+                wrote_head_ok = write_head_internal(
                     &raw_response,
                     global_object,
                     &heap,
@@ -947,10 +950,11 @@ impl NodeHTTPResponse {
         }
 
         // The C++ header writer can throw (invalid header characters, header
-        // conversion). When this runs inside writeHeadAndEnd there is no JS
-        // binding wrapper to observe the pending exception, so check here -
+        // conversion) and reports it via its return value, checked inside its
+        // own ThrowScope. When this runs inside writeHeadAndEnd there is no
+        // JS binding wrapper between the phases, so propagate here -
         // otherwise the end phase would run with an exception pending.
-        if global_object.has_exception() {
+        if !wrote_head_ok {
             return Err(jsc::JsError::Thrown);
         }
 
@@ -1048,7 +1052,7 @@ fn write_head_internal(
     headers: JSValue,
     auto_header_bits: u32,
     keep_alive_timeout_secs: u32,
-) {
+) -> bool {
     scoped_log!(
         NodeHTTPResponse,
         "writeHeadInternal({})",

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2288,7 +2288,9 @@ pub unsafe extern "C" fn NodeHTTPResponse__adoptRawRequestHeaders(
     // SAFETY: see the function-level contract above.
     let response = unsafe { &*response };
     let bytes = unsafe { core::slice::from_raw_parts(data, length) };
-    response.raw_request_headers.with_mut(|v| v.append_slice(bytes));
+    response
+        .raw_request_headers
+        .with_mut(|v| v.append_slice(bytes));
 }
 
 /// # Safety

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -58,7 +58,7 @@ pub struct NodeHTTPResponse {
     /// parse would otherwise overwrite it before this request's JS reads it.
     pub request_trailers: JsCell<Vec<u8>>,
     /// node:http: this request's header section captured at dispatch as
-    /// [u16 nameLen][u16 valueLen][name][value]... so req.rawHeaders /
+    /// [u32 nameLen][u32 valueLen][name][value]... so req.rawHeaders /
     /// req.headers materialize lazily (takeRawHeaders) instead of paying
     /// 2N JSStrings + a JSArray on every request. One-shot: emptied on first
     /// access.
@@ -201,7 +201,7 @@ unsafe extern "C" {
         use_insecure_http_parser: bool,
     ) -> JSValue;
     // Builds req.rawHeaders' flat [name, value, ...] JSArray from the header
-    // bytes captured at dispatch ([u16 nameLen][u16 valueLen][name][value]...).
+    // bytes captured at dispatch ([u32 nameLen][u32 valueLen][name][value]...).
     safe fn Bun__NodeHTTP__buildRawHeadersArray(
         global_object: &JSGlobalObject,
         data: *const u8,
@@ -946,6 +946,14 @@ impl NodeHTTPResponse {
             }
         }
 
+        // The C++ header writer can throw (invalid header characters, header
+        // conversion). When this runs inside writeHeadAndEnd there is no JS
+        // binding wrapper to observe the pending exception, so check here -
+        // otherwise the end phase would run with an exception pending.
+        if global_object.has_exception() {
+            return Err(jsc::JsError::Thrown);
+        }
+
         Ok(JSValue::UNDEFINED)
     }
 
@@ -1026,7 +1034,9 @@ impl NodeHTTPResponse {
             }
         }
 
-        this.deref();
+        // Explicit `.get()` so the inherent refcount `NodeHTTPResponse::deref`
+        // is selected, matching cork() (see its note).
+        this.get().deref();
         result
     }
 }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -765,8 +765,16 @@ impl NodeHTTPResponse {
         // path. The borrowed `arguments()` slice (ptr+len, 16 bytes) carries the
         // same information; missing / `null` slots are padded to `undefined`
         // inline below exactly as the `Arguments<3>` form did.
-        let arguments = callframe.arguments();
+        self.write_head_impl(global_object, callframe.arguments())
+    }
 
+    /// Shared body of `writeHead` (also the write-head phase of
+    /// `writeHeadAndEnd`): args are (statusCode, statusMessage, headersArray).
+    fn write_head_impl(
+        &self,
+        global_object: &JSGlobalObject,
+        arguments: &[JSValue],
+    ) -> JsResult<JSValue> {
         if self.is_requested_completed_or_ended() {
             return err_throw(
                 global_object,
@@ -904,6 +912,72 @@ impl NodeHTTPResponse {
         }
 
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// `handle.writeHeadAndEnd(status, statusMessage, headersArray, chunk,
+    /// encoding, strictContentLength)` — the writeHead + end pair under one
+    /// native cork and one JS->native crossing, replacing
+    /// `handle.cork(() => { handle.writeHead(...); handle.end(...) })` (three
+    /// crossings and a per-request closure) on the node:http response path.
+    pub(crate) fn write_head_and_end(
+        &self,
+        global_object: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arguments = callframe.arguments();
+
+        // Same gate as cork(): the old flow threw ERR_STREAM_ALREADY_FINISHED
+        // from cork() before either phase ran.
+        let flags = self.flags.get();
+        if flags.contains(Flags::REQUEST_HAS_COMPLETED)
+            || flags.contains(Flags::SOCKET_CLOSED)
+            || flags.contains(Flags::UPGRADED)
+        {
+            return err_throw(
+                global_object,
+                ErrorCode::ERR_STREAM_ALREADY_FINISHED,
+                "Stream is already ended",
+            );
+        }
+
+        let head_len = arguments.len().min(3);
+        // write_or_end::<true> reads (chunk, encoding, _, strictContentLength).
+        let end_args = [
+            arguments.get(3).copied().unwrap_or(JSValue::UNDEFINED),
+            arguments.get(4).copied().unwrap_or(JSValue::UNDEFINED),
+            JSValue::UNDEFINED,
+            arguments.get(5).copied().unwrap_or(JSValue::UNDEFINED),
+        ];
+        let this_value = callframe.this();
+
+        // BACKREF: same keep-alive pattern as cork() — either phase can reach
+        // JS (string coercions, drain callbacks), which could drop the last
+        // reference to this response mid-call.
+        let this = bun_ptr::BackRef::from(ptr::NonNull::from(self));
+        this.ref_();
+
+        let raw_response = this.raw_response.get();
+        let mut result: JsResult<JSValue> = Ok(JSValue::UNDEFINED);
+        {
+            let run = || -> JsResult<JSValue> {
+                this.write_head_impl(global_object, &arguments[..head_len])?;
+                this.resume_socket();
+                this.write_or_end::<true>(global_object, &end_args, this_value)
+            };
+            if let Some(raw_response) = raw_response {
+                raw_response.corked(|| {
+                    // Capture `this` so a `self`-derived pointer reaches the
+                    // FFI closure-data slot (see cork()'s R-2 note).
+                    let _escape = this;
+                    result = run();
+                });
+            } else {
+                result = run();
+            }
+        }
+
+        this.deref();
+        result
     }
 }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -200,12 +200,12 @@ unsafe extern "C" {
         length: usize,
         use_insecure_http_parser: bool,
     ) -> JSValue;
+    // Scope-free exception read: satisfies the exception-check verifier
+    // after a callee ThrowScope destructor simulated a throw for this
+    // (scope-less native) caller. A single traps check in release builds.
+    safe fn Bun__NodeHTTP__acknowledgeThrowScope(global_object: &JSGlobalObject);
     // Builds req.rawHeaders' flat [name, value, ...] JSArray from the header
     // bytes captured at dispatch ([u32 nameLen][u32 valueLen][name][value]...).
-    // Scope-free VM::exception() read: satisfies the exception-check
-    // verifier after a callee ThrowScope destructor simulated a throw for
-    // this (scope-less native) caller. A single load in release builds.
-    safe fn Bun__NodeHTTP__acknowledgeThrowScope(global_object: &JSGlobalObject);
     safe fn Bun__NodeHTTP__buildRawHeadersArray(
         global_object: &JSGlobalObject,
         data: *const u8,

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -159,6 +159,10 @@ export default [
         fn: "takeRequestTrailers",
         length: 0,
       },
+      takeRawHeaders: {
+        fn: "takeRawHeaders",
+        length: 0,
+      },
       dumpRequestBody: {
         fn: "dumpRequestBody",
         length: 0,

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -163,6 +163,10 @@ export default [
         fn: "takeRawHeaders",
         length: 0,
       },
+      writeHeadAndEnd: {
+        fn: "writeHeadAndEnd",
+        length: 6,
+      },
       dumpRequestBody: {
         fn: "dumpRequestBody",
         length: 0,

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -165,7 +165,7 @@ export default [
       },
       writeHeadAndEnd: {
         fn: "writeHeadAndEnd",
-        length: 6,
+        length: 8,
       },
       dumpRequestBody: {
         fn: "dumpRequestBody",


### PR DESCRIPTION
Stacked on #32488. Commits that recover the node:http server throughput regression from the compat rewrite and push well past the previous release.

## What this does

The compat rewrite in #32488 costs ~5% on a plain keep-alive `http.createServer` workload versus v1.3.14. This PR removes per-request work from the server hot path until the same workload is **+8.8% faster than v1.3.14**, without changing behavior: the full vendored `test/js/node/test/parallel/test-http-*` suite (376 files) passes identically before and after every commit here.

## Numbers

`res.writeHead(200, {...}); res.end("Hello World")` under `oha -c 64`, LTO release builds, server pinned to 2 cores, load generator on separate cores, 7 reps interleaved round-robin across builds (so machine drift hits every build equally), medians:

| build | req/s | vs 1.3.14 |
|---|---|---|
| bun 1.3.14 | 123,242 | — |
| #32488 as-is | ~116,500 | −4.9% |
| this PR | **134,033** | **+8.8%** |

The minimum rep of this PR (131,987) is above the maximum of every other build. `Bun.serve`, WebSocket server/client, and the HTTP clients are unaffected (measured flat).

## What changed

- **Lazy request headers + native dispatch bitfield**: the native side no longer builds a 2N-string `rawHeaders` array per request. It captures the raw header bytes on the response handle (flat buffer, stack-inline up to 1 KiB) and computes an 8-bit bitfield for the headers the dispatcher itself needs (connection close/upgrade tokens, host/expect/content-length/transfer-encoding presence). `req.headers` / `req.rawHeaders` materialize on first user access via `handle.takeRawHeaders()`. A handler that never reads headers does zero header materialization.
- **Native framework headers**: `Date`, `Connection: keep-alive/close`, and `Keep-Alive: timeout=N` are no longer marshalled as JS strings; the renderer passes two integers and the native side appends cached byte blobs (the Date line rebuilt at most once per second; both keep-alive lines as a single buffer write). Wire order and semantics (sendDate=false, user-set Date/Connection, maxRequestsPerSocket) unchanged.
- **`writeHeadAndEnd`**: one native call (and one native cork) for the writeHead+end pair, replacing `cork(() => { writeHead(); end(); })` — three crossings and a closure per response. Same `headersSent` semantics on every error path.
- **Fewer native crossings**: reuse the already-read `flags` bitfield in `end()` instead of separate `ended`/`aborted` getters; skip the per-request `ondata`/`ondrain` clears when already cleared; skip `takeRequestTrailers` for body-less requests; index `kOutHeaders` directly in the trailer checks.
- **Per-request allocation removal**: reusable backing array in `renderNativeHeaders` (consumed synchronously by native `writeHead`; re-entrancy degrades to a fresh array), scratch options object for the builtin `ServerResponse`, socket-cached bound abort handler, finish listeners via `on()` instead of `once()`, hoisted `nextTick` callback.
- Assorted fixes found along the way: the `kUniqueHeaders` stamp shape-transitioned every response even when the option was unset (`null` passed an `!== undefined` guard); `_isLenientHeaderValidation` walked `req.socket.server` twice per `setHeader`.

## How it's verified

- 376-file vendored Node http suite A/B against the base at every commit boundary: zero regressions (flaky pairs re-run serially 5x to confirm).
- Exact wire-format probes: Date header format byte-for-byte, header order on the wire, `sendDate=false`, explicit `Connection: close`, the `maxRequestsPerSocket` Keep-Alive variant, exactly one Date line when the user supplies their own.
- Behavior probes for the touchy paths: duplicate-header joining, wire casing, post-teardown `req.headers` access, `Expect: 100-continue`, chunked trailers, HEAD, pipelined requests, abort delivery.
- The lazy path preserves Node's duplicate-handling rules (first-wins vs comma-joining per header) and `maxHeadersCount` truncation.