### PR TITLE
node:tls: reject invalid ALPNProtocols/session/servername types synchronously in tls.connect()

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -786,9 +786,9 @@ var InternalSecureContext = class SecureContext {
       const ca = options.ca;
       if (ca) throwOnInvalidTLSArray("options.ca", ca);
       if (options.servername != null && typeof options.servername !== "string")
-        throw new TypeError("servername argument must be an string");
+        throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
       if (options.secureOptions != null && typeof options.secureOptions !== "number")
-        throw new TypeError("secureOptions argument must be an number");
+        throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
       const privateKeyIdentifier = options.privateKeyIdentifier;
       if (!$isUndefinedOrNull(privateKeyIdentifier)) {
         const privateKeyEngine = options.privateKeyEngine;
@@ -913,6 +913,13 @@ function TLSSocket(socket?, options?) {
     const { ALPNProtocols } = options;
     if (ALPNProtocols) {
       convertALPNProtocols(ALPNProtocols, this);
+      // Node's native ssl.setALPNProtocols rejects anything that
+      // convertALPNProtocols did not turn into a Buffer; a string or other
+      // truthy non-Array/non-ArrayBufferView value must throw synchronously
+      // rather than silently dropping the ALPN extension.
+      if (this.ALPNProtocols === undefined) {
+        throw new TypeError("Must give a Buffer as first argument");
+      }
     }
 
     if (isNetSocketOrDuplex && !this.isServer) {
@@ -936,7 +943,17 @@ function TLSSocket(socket?, options?) {
     validateFunction(checkServerIdentityOption, "options.checkServerIdentity");
   }
   this[kcheckServerIdentity] = checkServerIdentityOption || checkServerIdentity;
-  this[ksession] = options.session || null;
+  // Node's native ssl.setSession (called from the client _init path) rejects a
+  // non-ArrayBufferView session with ERR_INVALID_ARG_TYPE before the handshake
+  // starts; without this check a bad value would surface asynchronously on the
+  // socket (or be ignored entirely), escaping a try/catch around tls.connect().
+  const session = options.session;
+  if (session && !isServer && !isArrayBufferView(session)) {
+    const error = new TypeError("Session must be a buffer");
+    error.code = "ERR_INVALID_ARG_TYPE";
+    throw error;
+  }
+  this[ksession] = session || null;
 
   // `new tls.TLSSocket(socket, { isServer: true })`: drive the server-side TLS
   // handshake over the provided socket via net.ts's native upgrade path (reaches

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -785,10 +785,11 @@ var InternalSecureContext = class SecureContext {
       if (key) throwOnInvalidTLSArray("options.key", key);
       const ca = options.ca;
       if (ca) throwOnInvalidTLSArray("options.ca", ca);
-      if (options.servername != null && typeof options.servername !== "string")
-        throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
-      if (options.secureOptions != null && typeof options.secureOptions !== "number")
-        throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
+      const { servername, secureOptions } = options;
+      if (servername != null && typeof servername !== "string")
+        throw $ERR_INVALID_ARG_TYPE("options.servername", "string", servername);
+      if (secureOptions != null && typeof secureOptions !== "number")
+        throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
       const privateKeyIdentifier = options.privateKeyIdentifier;
       if (!$isUndefinedOrNull(privateKeyIdentifier)) {
         const privateKeyEngine = options.privateKeyEngine;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -141,6 +141,123 @@ it("should have checkServerIdentity", async () => {
   expect(tls.checkServerIdentity).toBeFunction();
 });
 
+// Node rejects invalid ALPNProtocols / session / servername types synchronously
+// from inside tls.connect() / the TLSSocket constructor. A value that is
+// silently dropped (instead of throwing) means the application believes it
+// enabled ALPN or session resumption and got neither.
+describe("tls.connect() option type validation", () => {
+  const base = { host: "127.0.0.1", port: 1 };
+
+  describe.each([
+    ["string", "h2"],
+    ["wire-format string", "\x02h2\x08http/1.1"],
+    ["number", 42],
+    ["object", { foo: 1 }],
+    ["true", true],
+  ])("ALPNProtocols: %s", (_, value) => {
+    it("throws synchronously from tls.connect()", () => {
+      expect(() => tlsConnect({ ...base, ALPNProtocols: value as never })).toThrow(
+        expect.objectContaining({ name: "TypeError", message: "Must give a Buffer as first argument" }),
+      );
+    });
+    it("throws synchronously from new TLSSocket()", () => {
+      expect(() => new TLSSocket(undefined, { ALPNProtocols: value as never })).toThrow(
+        expect.objectContaining({ name: "TypeError", message: "Must give a Buffer as first argument" }),
+      );
+    });
+  });
+
+  it.each([
+    ["array", ["h2", "http/1.1"]],
+    ["Buffer", Buffer.from("\x02h2")],
+    ["Uint8Array", new Uint8Array([2, 0x68, 0x32])],
+    ["DataView", new DataView(new Uint8Array([2, 0x68, 0x32]).buffer)],
+  ])("ALPNProtocols: %s is accepted", (_, value) => {
+    const sock = new TLSSocket(undefined, { ALPNProtocols: value as never });
+    // convertALPNProtocols normalized the input into the wire-format Buffer.
+    expect(Buffer.isBuffer((sock as unknown as { ALPNProtocols: Buffer }).ALPNProtocols)).toBe(true);
+    sock.destroy();
+  });
+
+  describe.each([
+    ["string", "this is not a tls session"],
+    ["number", 42],
+    ["object", {}],
+  ])("session: %s", (_, value) => {
+    const expected = expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: "Session must be a buffer",
+    });
+    it("throws synchronously from tls.connect()", () => {
+      expect(() => tlsConnect({ ...base, session: value as never })).toThrow(expected);
+    });
+    it("throws synchronously from new TLSSocket()", () => {
+      expect(() => new TLSSocket(undefined, { session: value as never })).toThrow(expected);
+    });
+  });
+
+  it.each([
+    ["Buffer", Buffer.from([1, 2, 3, 4])],
+    ["Uint8Array", new Uint8Array([1, 2, 3, 4])],
+    ["DataView", new DataView(new ArrayBuffer(4))],
+  ])("session: %s is accepted", (_, value) => {
+    expect(() => new TLSSocket(undefined, { session: value as never }).destroy()).not.toThrow();
+  });
+
+  it("session is not validated for a server-side TLSSocket", () => {
+    // Node's ssl.setSession is only called from the client _init path.
+    expect(() => new TLSSocket(undefined, { isServer: true, session: "ignored" as never }).destroy()).not.toThrow();
+  });
+
+  it("servername: non-string throws ERR_INVALID_ARG_TYPE synchronously", () => {
+    expect(() => tlsConnect({ ...base, servername: 123 as never })).toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+
+  it("invalid ALPNProtocols / session never reach the socket 'error' event", async () => {
+    // An argument-type error must be catchable by try/catch around the call,
+    // not delivered asynchronously on the socket. A real server proves no
+    // handshake is ever started for the rejected options.
+    await using server = tls.createServer({ ...COMMON_CERT_, ALPNProtocols: ["h2", "http/1.1"] }, c => {
+      c.end(JSON.stringify({ alpn: c.alpnProtocol || null }));
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as AddressInfo).port;
+    const ok = { host: "127.0.0.1", port, ca: COMMON_CERT_.cert, servername: "localhost" };
+
+    for (const bad of [{ ALPNProtocols: "h2" }, { session: 42 }, { session: "nope" }]) {
+      let asyncError: unknown;
+      let thrown: unknown;
+      try {
+        const s = tlsConnect({ ...ok, ...bad } as never);
+        s.on("error", e => (asyncError = e));
+        await once(s, "close");
+      } catch (e) {
+        thrown = e;
+      }
+      expect({ bad, thrown: thrown && (thrown as Error).name, asyncError }).toEqual({
+        bad,
+        thrown: "TypeError",
+        asyncError: undefined,
+      });
+    }
+
+    // Control: a valid ALPN array is offered on the wire and negotiated.
+    const client = tlsConnect({ ...ok, ALPNProtocols: ["h2"] });
+    let body = "";
+    client.on("data", d => (body += d));
+    await once(client, "secureConnect");
+    await once(client, "end");
+    expect({ clientAlpn: client.alpnProtocol, serverSaw: JSON.parse(body) }).toEqual({
+      clientAlpn: "h2",
+      serverSaw: { alpn: "h2" },
+    });
+    client.destroy();
+  });
+});
+
 it("should thow ECONNRESET if FIN is received before handshake", async () => {
   await using server = net.createServer(c => {
     c.end();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -146,7 +146,7 @@ it("should have checkServerIdentity", async () => {
 // silently dropped (instead of throwing) means the application believes it
 // enabled ALPN or session resumption and got neither.
 describe("tls.connect() option type validation", () => {
-  const base = { host: "127.0.0.1", port: 1 };
+  const base = { host: "127.0.0.1", port: 0 };
 
   describe.each([
     ["string", "h2"],
@@ -168,15 +168,20 @@ describe("tls.connect() option type validation", () => {
   });
 
   it.each([
-    ["array", ["h2", "http/1.1"]],
-    ["Buffer", Buffer.from("\x02h2")],
-    ["Uint8Array", new Uint8Array([2, 0x68, 0x32])],
-    ["DataView", new DataView(new Uint8Array([2, 0x68, 0x32]).buffer)],
-  ])("ALPNProtocols: %s is accepted", (_, value) => {
+    ["array", ["h2", "http/1.1"], Buffer.from("\x02h2\x08http/1.1")],
+    ["Buffer", Buffer.from("\x02h2"), Buffer.from("\x02h2")],
+    ["Uint8Array", new Uint8Array([2, 0x68, 0x32]), Buffer.from("\x02h2")],
+    ["DataView", new DataView(new Uint8Array([2, 0x68, 0x32]).buffer), Buffer.from("\x02h2")],
+  ])("ALPNProtocols: %s is accepted", (_, value, expected) => {
     const sock = new TLSSocket(undefined, { ALPNProtocols: value as never });
-    // convertALPNProtocols normalized the input into the wire-format Buffer.
-    expect(Buffer.isBuffer((sock as unknown as { ALPNProtocols: Buffer }).ALPNProtocols)).toBe(true);
-    sock.destroy();
+    try {
+      // convertALPNProtocols normalized the input into the wire-format Buffer.
+      const got = (sock as unknown as { ALPNProtocols: Buffer }).ALPNProtocols;
+      expect(Buffer.isBuffer(got)).toBe(true);
+      expect(got.equals(expected)).toBe(true);
+    } finally {
+      sock.destroy();
+    }
   });
 
   describe.each([
@@ -210,10 +215,13 @@ describe("tls.connect() option type validation", () => {
     expect(() => new TLSSocket(undefined, { isServer: true, session: "ignored" as never }).destroy()).not.toThrow();
   });
 
-  it("servername: non-string throws ERR_INVALID_ARG_TYPE synchronously", () => {
-    expect(() => tlsConnect({ ...base, servername: 123 as never })).toThrow(
-      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
-    );
+  it.each([
+    ["servername", 123],
+    ["secureOptions", "nope"],
+  ])("%s: wrong type throws ERR_INVALID_ARG_TYPE synchronously", (key, value) => {
+    const expected = expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" });
+    expect(() => tlsConnect({ ...base, [key]: value } as never)).toThrow(expected);
+    expect(() => new TLSSocket(undefined, { [key]: value } as never)).toThrow(expected);
   });
 
   it("invalid ALPNProtocols / session never reach the socket 'error' event", async () => {
@@ -246,15 +254,18 @@ describe("tls.connect() option type validation", () => {
 
     // Control: a valid ALPN array is offered on the wire and negotiated.
     const client = tlsConnect({ ...ok, ALPNProtocols: ["h2"] });
-    let body = "";
-    client.on("data", d => (body += d));
-    await once(client, "secureConnect");
-    await once(client, "end");
-    expect({ clientAlpn: client.alpnProtocol, serverSaw: JSON.parse(body) }).toEqual({
-      clientAlpn: "h2",
-      serverSaw: { alpn: "h2" },
-    });
-    client.destroy();
+    try {
+      let body = "";
+      client.on("data", d => (body += d));
+      await once(client, "secureConnect");
+      await once(client, "end");
+      expect({ clientAlpn: client.alpnProtocol, serverSaw: JSON.parse(body) }).toEqual({
+        clientAlpn: "h2",
+        serverSaw: { alpn: "h2" },
+      });
+    } finally {
+      client.destroy();
+    }
   });
 });
 


### PR DESCRIPTION
## Reproduction

```js
import tls from "node:tls";

// Node v26.3.0 throws synchronously for each of these; Bun accepted them.
tls.connect({ port: 1, ALPNProtocols: "h2" });           // bun: connected, NO ALPN extension offered
tls.connect({ port: 1, session: "not a tls session" });  // bun: connected, session silently ignored
tls.connect({ port: 1, session: 42 });                   // bun: async 'error' event, escapes try/catch
tls.connect({ port: 1, servername: 123 });               // bun: threw uncoded TypeError (no .code)
```

Against a real TLS server with `ALPNProtocols: ["h2","http/1.1"]`, the string form `ALPNProtocols: "h2"` produced a connection that offered no ALPN extension at all (`alpnProtocol === false`, server saw `alpn: null`), so an application that believed it had enabled ALPN pinning got neither the protocol nor an error.

## Cause

Node validates these in `TLSSocket.prototype._init`: the native `ssl.setALPNProtocols(buf)` rejects any non-Buffer with `TypeError: Must give a Buffer as first argument`, and `ssl.setSession(buf)` (client path only) rejects any non-ArrayBufferView with `TypeError[ERR_INVALID_ARG_TYPE]: Session must be a buffer`. `tls.convertALPNProtocols` only normalizes arrays and ArrayBufferViews, so a string passes through untouched and the native call throws.

Bun's `convertALPNProtocols` has the same pass-through behavior, but there is no equivalent native check afterward: `this.ALPNProtocols` stayed `undefined` and no ALPN was offered. The `session` option was stored without validation and only rejected (if at all) by the native connect path, surfacing as an async `'error'` event. The `servername` type check threw a plain `new TypeError("servername argument must be an string")` with no `.code`.

## Fix

In the `TLSSocket` constructor (`src/js/node/tls.ts`):

* After `convertALPNProtocols(ALPNProtocols, this)`, throw `TypeError: Must give a Buffer as first argument` when `this.ALPNProtocols` is still `undefined` (truthy input that was neither an array nor an ArrayBufferView). Matches Node's native `setALPNProtocols`.
* Before storing `options.session`, throw `TypeError[ERR_INVALID_ARG_TYPE]: Session must be a buffer` when the value is truthy, the socket is not server-side, and it is not an ArrayBufferView. Matches Node's native `setSession` on the client `_init` path.
* In `InternalSecureContext`, the `servername` and `secureOptions` type checks now throw via `$ERR_INVALID_ARG_TYPE` so the error carries the standard code.

## Verification

Added a `tls.connect() option type validation` block to `test/js/node/tls/node-tls-connect.test.ts` covering the rejected types (string/number/object/true for `ALPNProtocols`, string/number/object for `session`, number for `servername`) for both `tls.connect()` and `new TLSSocket()`, plus positive controls (array/Buffer/Uint8Array/DataView accepted; server-side `session` not validated) and an end-to-end check against a local TLS server that proves the rejected options never reach the `'error'` event while a valid `["h2"]` array still negotiates ALPN.

```
bun bd test test/js/node/tls/node-tls-connect.test.ts -t "option type validation"
# 26 pass, 0 fail
```

On the released bun, 18 of the 26 tests fail (the 8 positive controls pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 23 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4d5867b9d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.42ms]
154 |     ["number", 42],
155 |     ["object", { foo: 1 }],
156 |     ["true", true],
157 |   ])("ALPNProtocols: %s", (_, value) => {
158 |     it("throws synchronously from tls.connect()", () => {
159 |       expect(() => tlsConnect({ ...base, ALPNProtocols: value as never })).toThrow(
                                                                                 ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: TLSSocket {
  [Symbol(ksecureContext)]: SecureContext {
    context: SecureContext {
      addCACert: [Function: addCACert]
... (truncated)

release without fix: 18 skipped
bun test v1.4.0-canary.1 (f9ac54aea)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.04ms]
(pass) tls.connect() option type validation > ALPNProtocols: string > throws synchronously from tls.connect() [0.22ms]
(pass) tls.connect() option type validation > ALPNProtocols: string > throws synchronously from new TLSSocket() [0.08ms]
(pass) tls.connect() option type validation > ALPNProtocols: wire-format string > throws synchronously from tls.connect() [0.03ms]
(pass) tls.connect() option type validation > ALPNProtocols: wire-format string > throws synchronously from new TLSSocket() [0.03ms]
(pass) tls.connect() option type validation > ALPNProtocols: number > throws synchronously from tls.connect() [0.03ms]
(pass) tls.connect() option type validation > ALPNProtocols: number > throws synchronously from new TLSSocket() [0.03ms]
(pass) tls.connect() option type validation > ALPNProtocols: object > throws synchronously from tls.connect() [0.02ms]
(pass) tls.connect() option type validation > ALPNProtocols: object > throws synchronously from new TLSSocket() [0.02ms]
(pass) tls.connect() option type validation > ALPNProtocols: true > thr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4d5867b9d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.66ms]
(pass) tls.connect() option type validation > ALPNProtocols: string > throws synchronously from tls.connect() [11.02ms]
(pass) tls.connect() option type validation > ALPNProtocols: string > throws synchronously from new TLSSocket() [5.98ms]
(pass) tls.connect() option type validation > ALPNProtocols: wire-format string > throws synchronously from tls.connect() [3.51ms]
(pass) tls.connect() option type validation > ALPNProtocols: wire-format string > throws synchronously from new TLSSocket() [3.16ms]
(pass) tls.connect() option type validation > ALPNProtocols: number > throws synchronously from tls.connect() [3.30ms]
(pass) 
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 672ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 248 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6328ms)
Bundle modules (25ms)
Postprocesss modules (20ms)
Bundle Functions (652ms)
Generate Code (71ms)

[7.11s] Bundled "src/js" for production
  1889 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/tls.ts                        |  28 +++++--
 test/js/node/tls/node-tls-connect.test.ts | 128 ++++++++++++++++++++++++++++++
 2 files changed, 151 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/tls.ts                             3      5      0
test/js/node/tls/node-tls-connect.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->