### PR TITLE
bundler: allocate wrapper_ref for CommonJS modules with no non-hoistable statements

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2329,6 +2329,14 @@ impl<'a> LinkerContext<'a> {
         was_unwrapped_require: bool,
     ) -> js_printer::RequireOrImportMeta {
         let flags = self.graph.meta.items_flags()[source_index as usize];
+        let wrapper_ref = self.graph.ast.items_wrapper_ref()[source_index as usize];
+        // The printer's require()/import() path gates on wrapper_ref.is_valid()
+        // and emits nothing when it is empty, so an empty wrapper_ref for a
+        // CJS-wrapped module silently produces invalid JavaScript with exit 0.
+        debug_assert!(
+            flags.wrap != WrapKind::Cjs || !wrapper_ref.is_empty(),
+            "js_parser must allocate wrapper_ref for every CJS-wrapped module"
+        );
         js_printer::RequireOrImportMeta {
             exports_ref: if flags.wrap == WrapKind::Esm
                 || (was_unwrapped_require
@@ -2340,7 +2348,7 @@ impl<'a> LinkerContext<'a> {
                 Ref::NONE
             },
             is_wrapper_async: flags.is_async_or_has_async_dependency,
-            wrapper_ref: self.graph.ast.items_wrapper_ref()[source_index as usize],
+            wrapper_ref,
 
             was_unwrapped_require: was_unwrapped_require
                 && self.graph.ast.items_flags()[source_index as usize]

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -608,6 +608,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
                 // "var require_foo = __commonJS(...);"
                 {
+                    debug_assert!(!ast.wrapper_ref.is_empty()); // js_parser must allocate wrapper_ref for ExportsKind::Cjs
                     let decls = G::DeclList::from_slice(&[G::Decl {
                         binding: Binding::alloc(
                             temp_arena,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8667,9 +8667,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             // When code splitting is enabled, always create wrapper_ref to match esbuild behavior.
-            // Otherwise, use needsWrapperRef() to optimize away unnecessary wrappers.
+            // CommonJS files are wrapped unconditionally in the linker (nothing is hoisted out
+            // of the __commonJS closure), so they always need the symbol. Otherwise, use
+            // needsWrapperRef() to optimize away unnecessary ESM wrappers.
             if self.options.bundle
-                && (self.options.code_splitting || self.needs_wrapper_ref(parts.as_slice()))
+                && (self.options.code_splitting
+                    || exports_kind == js_ast::ExportsKind::Cjs
+                    || self.needs_wrapper_ref(parts.as_slice()))
             {
                 use core::fmt::Write as _;
                 let mut buf = bun_alloc::ArenaString::new_in(arena);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8661,18 +8661,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .push(js_ast::NAMESPACE_EXPORT_PART_INDEX);
         }
 
+        let force_cjs_to_esm = self.unwrap_all_requires
+            || exports_kind == js_ast::ExportsKind::EsmWithDynamicFallbackFromCjs;
+
         let wrapper_ref: Ref = 'brk: {
             if self.options.features.hot_module_reloading {
                 break 'brk self.hmr_api_ref;
             }
 
             // When code splitting is enabled, always create wrapper_ref to match esbuild behavior.
-            // CommonJS files are wrapped unconditionally in the linker (nothing is hoisted out
-            // of the __commonJS closure), so they always need the symbol. Otherwise, use
-            // needsWrapperRef() to optimize away unnecessary ESM wrappers.
+            // CommonJS files (including FORCE_CJS_TO_ESM files the linker may later CJS-wrap) are
+            // wrapped unconditionally in the linker and nothing is hoisted out of the __commonJS
+            // closure, so they always need the symbol. Otherwise, use needsWrapperRef() to
+            // optimize away unnecessary ESM wrappers.
             if self.options.bundle
                 && (self.options.code_splitting
                     || exports_kind == js_ast::ExportsKind::Cjs
+                    || force_cjs_to_esm
                     || self.needs_wrapper_ref(parts.as_slice()))
             {
                 use core::fmt::Write as _;
@@ -8777,8 +8782,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             require_ref,
 
-            force_cjs_to_esm: self.unwrap_all_requires
-                || exports_kind == js_ast::ExportsKind::EsmWithDynamicFallbackFromCjs,
+            force_cjs_to_esm,
             uses_module_ref,
             uses_exports_ref,
             uses_require_ref,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -80,6 +80,37 @@ describe("bundler", () => {
       stdout: "object",
     },
   });
+  itBundled("edgecase/StatementlessCommonJSModuleDynamicImport", {
+    files: {
+      "/entry.ts": /* js */ `
+        import('./b.cjs').then(m => console.log(typeof m));
+      `,
+      "/b.cjs": `;`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "object",
+    },
+  });
+  itBundled("edgecase/DirectiveOnlyCommonJSModule", {
+    files: {
+      "/entry.ts": /* js */ `
+        import * as b from './b.cjs';
+        console.log(typeof b);
+      `,
+      "/b.cjs": `"use strict";\n`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "object",
+    },
+  });
   itBundled("edgecase/HoistableOnlyCommonJSModule", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -73,7 +73,10 @@ describe("bundler", () => {
       "/b.cjs": `;`,
     },
     onAfterBundle(api) {
+      // Before the fix the printer emitted `var b = ;` here (no initializer)
+      // with exit 0 and no debug assertion.
       api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").not.toMatch(/\bvar b = ;/);
       api.expectFile("/out.js").toContain("require_b");
     },
     run: {
@@ -83,16 +86,20 @@ describe("bundler", () => {
   itBundled("edgecase/StatementlessCommonJSModuleDynamicImport", {
     files: {
       "/entry.ts": /* js */ `
-        import('./b.cjs').then(m => console.log(typeof m));
+        const ns = await import('./b.cjs');
+        console.log(typeof ns, typeof ns.default);
       `,
-      "/b.cjs": `;`,
+      "/b.cjs": `// comment only\n`,
     },
     onAfterBundle(api) {
+      // Before the fix this emitted `Promise.resolve()__toESM(, 1)` which is a
+      // SyntaxError, with exit 0 and no debug assertion.
       api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").not.toContain("__toESM(,");
       api.expectFile("/out.js").toContain("require_b");
     },
     run: {
-      stdout: "object",
+      stdout: "object object",
     },
   });
   itBundled("edgecase/DirectiveOnlyCommonJSModule", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -27,6 +27,75 @@ describe("bundler", () => {
       stdout: "object",
     },
   });
+  // A CommonJS module whose body parses to zero statements (or whose statements
+  // are all hoistable) must still get a valid `require_*` wrapper symbol. The
+  // parser previously skipped allocating one here, and the linker then printed
+  // `__INVALID__REF__` / `__toESM(, 1)` which is not valid JavaScript.
+  itBundled("edgecase/StatementlessCommonJSModuleNamedImport", {
+    files: {
+      "/entry.ts": /* js */ `
+        import { B } from './b';
+        console.log(typeof B);
+      `,
+      "/b.tsx": `;`,
+      "/package.json": `{"name":"proj","type":"commonjs"}`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "undefined",
+    },
+  });
+  itBundled("edgecase/StatementlessCommonJSModuleStarImport", {
+    files: {
+      "/entry.ts": /* js */ `
+        import * as b from './b.cjs';
+        console.log(typeof b);
+      `,
+      "/b.cjs": `// comment only\n`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "object",
+    },
+  });
+  itBundled("edgecase/StatementlessCommonJSModuleRequire", {
+    files: {
+      "/entry.ts": /* js */ `
+        const b = require('./b.cjs');
+        console.log(typeof b);
+      `,
+      "/b.cjs": `;`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "object",
+    },
+  });
+  itBundled("edgecase/HoistableOnlyCommonJSModule", {
+    files: {
+      "/entry.ts": /* js */ `
+        import { B } from './b.cjs';
+        console.log(typeof B);
+      `,
+      "/b.cjs": `function foo() {}\n`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_b");
+    },
+    run: {
+      stdout: "undefined",
+    },
+  });
   itBundled("edgecase/NestedRedirectToABuiltin", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -96,6 +96,27 @@ describe("bundler", () => {
       stdout: "undefined",
     },
   });
+  // Packages in DEFAULT_UNWRAP_COMMONJS_PACKAGES set FORCE_CJS_TO_ESM at parse
+  // time with exports_kind = Esm; a default import then makes the linker
+  // CJS-wrap them. Same symptom as above if wrapper_ref was never allocated.
+  itBundled("edgecase/HoistableOnlyUnwrapCommonJSPackage", {
+    files: {
+      "/entry.js": /* js */ `
+        import Def from 'scheduler/empty.js';
+        console.log(typeof Def);
+      `,
+      "/node_modules/scheduler/empty.js": `function foo() {}\n`,
+      "/node_modules/scheduler/package.json": `{"name":"scheduler","version":"1.0.0"}`,
+    },
+    target: "browser",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+      api.expectFile("/out.js").toContain("require_empty");
+    },
+    run: {
+      stdout: "object",
+    },
+  });
   itBundled("edgecase/NestedRedirectToABuiltin", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- `bun build` leaves the wrapper symbol empty for a CommonJS file with only hoistable statements (`;`, a comment, `function f(){}`). A release build exits 0 and prints `var __INVALID__REF__ = __commonJS(...)`, `var b = ;` or `Promise.resolve()__toESM()`. A debug build stops at `panic: assertion failed: !ref_.is_empty()` in `print_symbol`.
- Where the output still parses, the value is wrong: `show(require("./b.cjs"))` becomes `show()`. Node passes `{}`.
- The cause is `P::to_ast` (`src/js_parser/p.rs:9360`). It makes `wrapper_ref` only if `needs_wrapper_ref()` finds a statement that cannot be hoisted. That test is correct only for ES module wrappers.

### Fix
- `to_ast` also makes `wrapper_ref` when `exports_kind` is `Cjs` or `force_cjs_to_esm` is set.
- Correct because the linker never hoists out of a `__commonJS` closure: it always declares and calls the symbol. Notes trace each `WrapKind::Cjs` assignment to a file that gets the symbol.
- Two `debug_assert!`s hold the invariant, at the `__commonJS` declaration and in `require_or_import_meta_for_source`.
- Verified: `test/bundler/bundler_edgecase.test.ts`. The 7 new tests fail on 1.4.3 and pass on this branch.

### Background
- The bundler puts a CommonJS file in a closure, `var require_b = __commonJS(...)`, and an importer calls `require_b()`. `wrapper_ref` is the symbol `require_b`.
- The parser makes the symbol, because the linker cannot add one while it prints.
- `needs_wrapper_ref()` skips the symbol when every statement can move out of an `__esm` closure.
- `Ref::NONE` is the empty symbol reference. A release build prints it as `__INVALID__REF__`.
- `force_cjs_to_esm` marks files of packages such as `react`. They parse as ES modules, but the linker can wrap them as CommonJS.

<details><summary>Notes</summary>

**Repro**

```sh
printf ';' > b.cjs
printf 'const b = require("./b.cjs");\nconsole.log(typeof b);\n' > entry.ts
bun build ./entry.ts --outfile=out.js   # exit 0
bun out.js                              # SyntaxError, out.js has `var b = ;`
```

A `.cjs` file needs no `package.json`. A `.js`, `.ts` or `.tsx` file needs `"type": "commonjs"`. A plain `.js` file also becomes CommonJS when a function body refers to `module` or `exports`, for example `function f() { module.exports = 1; }` as an ESM-format entry point. A 0-byte or whitespace-only file does not show the bug. `ParseTask` gives it a lazy-export AST, which already gets the symbol.

**Output shapes on Bun 1.4.3, for a `b.cjs` that holds only `;`**

| source in the importer | output before | result |
|---|---|---|
| `import d from "./b.cjs"` | `var __INVALID__REF__ = __commonJS(function() {});` and `__toESM()` | runs, `d` is `undefined` |
| `const b = require("./b.cjs")` | `var b = ;` | SyntaxError |
| `await import("./b.cjs")` | `await Promise.resolve()__toESM()` | SyntaxError |
| `show(require("./b.cjs"))` | `show()` | runs, passes `undefined` |

Bun 1.4.0 printed `__toESM(, 1)` in the first row, which is a SyntaxError.

The `require()` and `import()` shapes do not reach `print_symbol`. The printer tests `meta.wrapper_ref.is_valid()` and prints nothing when it is false. Thus no build showed an assertion for them.

**After, on a debug build of fede4ae445 (the importer is a `.ts` file)**

| source in the importer | output | result |
|---|---|---|
| `import d from "./b.cjs"` | `var require_b = __commonJS(function() {});` and `__toESM(require_b())` | `d` is `{}` |
| `const b = require("./b.cjs")` | `var b = require_b();` | `b` is `{}` |
| `await import("./b.cjs")` | `await Promise.resolve().then(() => __toESM(require_b()))` | the namespace has `default: {}` |
| `show(require("./b.cjs"))` | `show(require_b())` | passes `{}` |

Node gives the same values for the files when they are not bundled. For a bundle that ran before, the change is `{}` where there was `undefined`. I found no other change in behavior.

**Why each route to `WrapKind::Cjs` is covered**

All assignments are in `src/bundler/linker_context/scanImportsAndExports.rs`.

- A star or default import of a file with `ExportsKind::None`. `_parse` never gives that kind. `to_lazy_export_ast` does (JSON, text, an empty file), and its `SLazyExport` statement makes `needs_wrapper_ref()` return true.
- A default import of a `FORCE_CJS_TO_ESM` file, and the two `COMMONJS_LIFTED_TO_ESM` promotions. `commonjs_lifted_to_esm` is `force_cjs_to_esm && !has_es_module_syntax`, so `force_cjs_to_esm` covers both.
- `require()` or a non-split `import()` of a file that is not `ExportsKind::Esm`. Such a file is `Cjs` or `EsmWithDynamicFallbackFromCjs` from the parser, or a lazy-export file. `force_cjs_to_esm` includes `EsmWithDynamicFallbackFromCjs`.
- A file whose linker kind is `Cjs` (the step 1 rule for non-entry files and for ESM or IIFE output, and `DependencyWrapper::wrap`). The kind is `Cjs` from the parser or from one of the promotions above.

**Tests**

`test/bundler/bundler_edgecase.test.ts` adds 7 cases: a named import (`"type": "commonjs"` and a `.tsx` file), a star import, `require()`, `await import()`, a file with only a directive, a file with only a function, and a `node_modules/scheduler` file for the `force_cjs_to_esm` route. Each case checks the output text and runs the bundle.

Debug build of the merged head fede4ae445:

- `bundler_edgecase`: 189 pass, 11 todo, 0 fail.
- `bundler_cjs`, `bundler_cjs2esm`, `bundler_regressions`, `bundler_splitting`: 306 pass, 1 skip, 3 todo, 0 fail.

Before the merge of main, `bundler_npm`, `bundler_browser` and `bundler_loader` also passed on a debug build of this branch.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (b52d51348)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [651.76ms]
(pass) bundler > edgecase/EmptyCommonJSModule [436.05ms]
============================================================
Bun Debug v1.4.3 (b52d51348) Linux x64
Linux Kernel v7.0.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "/workspace/bun/build/debug/bun-debug" "test" "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_edgecase.test.ts"
Features: Bun.stderr(2) bunfig jsc spawn transpiler_cache(10) tsconfig(3) tsconfig_paths 
Builtins: "bun:internal-for-testing" "bun:jsc" "bun:test" "node:child_process" "node:crypto" "node:fs" "node:fs/promises" "node:os" "node:path" "node:tty" "node:worker_threads" 


panic: assertion failed: !ref_.is_empty()
Crashed while printing /tmp/bun-build-tests/bun-mjRFN7/edgecase/StatementlessCommonJSModuleNamedImport/b.tsx
<bun_crash_handler::draft::rust_panic_hook as core::ops::function::Fn<(&std::panic::PanicHookInfo,)>>::c
... (truncated)

release without fix: 7 failed, 11 skipped
bun test v1.4.3-canary.1 (b52d51348)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [23.24ms]
(pass) bundler > edgecase/EmptyCommonJSModule [21.07ms]
36 |       `,
37 |       "/b.tsx": `;`,
38 |       "/package.json": `{"name":"proj","type":"commonjs"}`,
39 |     },
40 |     onAfterBundle(api) {
41 |       api.expectFile("/out.js").not.toContain("__INVALID__REF__");
                                         ^
error: expect(received).not.toContain(expected)

Expected to not contain: "__INVALID__REF__"
Received: "var __create = Object.create;\nvar __getProtoOf = Object.getPrototypeOf;\nvar __defProp = Object.defineProperty;\nvar __getOwnPropNames = Object.getOwnPropertyNames;\nvar __hasOwnProp = Object.prototype.hasOwnProperty;\nfunction __accessProp(key) {\n  return this[key];\n}\nvar __toESMCache_node;\nvar __toESMCache_esm;\nvar __toESM = (mod, isNodeMode, target) => {\n  var canCache = mod != null && typeof mod === \"object\";\n  if (canCache) {\n    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;\n    var cached = cache.get(mod);\n    if (cached)\n      return cached;\n  }\n  target = mod 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (b52d51348)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [488.20ms]
(pass) bundler > edgecase/EmptyCommonJSModule [384.80ms]
(pass) bundler > edgecase/StatementlessCommonJSModuleNamedImport [478.33ms]
(pass) bundler > edgecase/StatementlessCommonJSModuleStarImport [366.88ms]
(pass) bundler > edgecase/StatementlessCommonJSModuleRequire [391.82ms]
(pass) bundler > edgecase/StatementlessCommonJSModuleDynamicImport [493.45ms]
(pass) bundler > edgecase/DirectiveOnlyCommonJSModule [398.87ms]
(pass) bundler > edgecase/HoistableOnlyCommonJSModule [390.75ms]
(pass) bundler > edgecase/HoistableOnlyUnwrapCommonJSPackage [395.31ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [406.85ms]
(pass) bundler > edgecase/ImportStarFunction [358.26ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [515.63ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [97.54ms]
(pass) bundler > edgecase/ImportNamedFromExportSt
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 944ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_runtime → libbun_runtime.a
^[[1m^[[33mwarning^[[0m^[[1m: binary `bun_shim_impl` should have a kebab-case name^[[0m
   ^[[1m^[[94m|^[[0m
^[[1m^[[94m 1^[[0m ^[[1m^[[94m|^[[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   ^[[1m^[[94m|^[[0m                                              ^[[1m^[[33m^^^^^^^^^^^^^^[[0m
   ^[[1m^[[94m|^[[0m
   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `cargo::non_kebab_case_bins` is set to `warn` by default
^[[1m^[[96mhelp^[[0m: to change the binary name to `bun-shim-impl`, convert `bin.name`
  ^[[1m^[[94m--> ^[[0msrc/install/windows-shim/Cargo.toml:41:8
   ^[[1m^[[94m|^[[0m
^[[1m^[[94m41^[[0m ^[[91m- ^[[0mname = ^[[91m"bun_shim_impl"^[[0m
^[[1m^[[94m41^[[0m ^[[92m+ ^[[0mname = ^[[92m"bun-shim-impl"^[[0m
   ^[[1m^[[94m|^[[0m
^[[1m^[[33mwarning^[[0m: `bun_shim_impl` (manifest) generated 1 warning
^[[1m^[[33mwarning^[[0m^[[1m: `feature(generic_const_exprs)` is not supported with the next-generation trait solver^[[0m
 ^[[1m^[[94m--> ^[[0msrc/shell_parser/lib.rs:1:30
  ^[[1m^[[94m|^[[0m
^[[1m^[[94m1^[[0m ^[[1m^[[94m|^[[0m #![feature(
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |   5 +
 .../linker_context/generateCodeForFileInChunkJS.rs |   1 +
 src/js_parser/p.rs                                 |  12 ++-
 test/bundler/bundler_edgecase.test.ts              | 119 +++++++++++++++++++++
 4 files changed, 133 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                  0      0      2
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      0      0      2
src/js_parser/p.rs                                            0      0      4
test/bundler/bundler_edgecase.test.ts                         1      4      2
```

</details>

**root cause** · written by the author bot

The parser only allocated a CommonJS wrapper symbol when the module body contained at least one non-hoistable statement, so a CommonJS module that was empty, directive-only, or made up solely of hoistable declarations reached the linker with no wrapper reference, and the linker then emitted an invalid wrapper when it later chose WrapKind::Cjs for that file. The fix allocates the wrapper symbol unconditionally whenever the parsed exports kind is CommonJS or the module may be forced from CommonJS to ESM, and it records that decision in the AST so every linker path that assigns a CommonJS wrap…

<!-- robobun:evidence:end -->

