### PR TITLE
terminal: keep parent slave fd open until subprocess exit on POSIX

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -176,8 +176,8 @@ bitflags::bitflags! {
         /// Set when an inline-created terminal has been attached to a subprocess
         /// via spawn; prevents reusing the same inline terminal for a second
         /// spawn. On Windows the first exit's ClosePseudoConsole would silently
-        /// kill the second; on Linux `slave_fd` is already closed; on macOS
-        /// `slave_fd` is held until the first exit (see `close_slave_fd`).
+        /// kill the second; on POSIX slave_fd is held until the first exit
+        /// (see `drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
     }
 }
@@ -663,30 +663,34 @@ impl Terminal {
         self.hpcon.get()
     }
 
-    /// Close the parent's copy of slave_fd after spawn. The child holds its
-    /// own; closing ours lets the master observe EOF when the child exits.
-    ///
-    /// On macOS this is deferred: xnu's `ptsclose` → `ttyclose` → `ttyflush`
-    /// flushes the pty output queue when the last slave closes, so if a short
-    /// lived child writes and exits before we poll kqueue, closing our slave
-    /// here would drop that output. Subprocess::on_process_exit closes it via
-    /// `drain_and_close_slave_fd` instead.
-    pub(crate) fn close_slave_fd(&self) {
+    /// Mark a terminal created inline by `Bun.spawn` so it cannot be reused
+    /// for a later spawn. See the `INLINE_SPAWNED` flag docs.
+    pub(crate) fn mark_inline_spawned(&self) {
         self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
-        #[cfg(not(target_os = "macos"))]
-        {
-            let fd = self.slave_fd.get();
-            if fd != Fd::INVALID {
-                fd.close();
-                self.slave_fd.set(Fd::INVALID);
-            }
+    }
+
+    /// Close the parent's copy of slave_fd. The child holds its own; once
+    /// every slave fd is gone the master reader observes EOF.
+    pub(crate) fn close_slave_fd(&self) {
+        self.mark_inline_spawned();
+        let fd = self.slave_fd.get();
+        if fd != Fd::INVALID {
+            fd.close();
+            self.slave_fd.set(Fd::INVALID);
         }
     }
 
-    /// macOS: synchronously drain the master (delivering any buffered output
+    /// POSIX: synchronously drain the master (delivering any buffered output
     /// via the data callback) and then release our slave_fd so the next read
     /// observes EOF. Called from Subprocess::on_process_exit on the JS thread.
-    #[cfg(target_os = "macos")]
+    ///
+    /// BSD-derived tty layers flush the pty output queue when the last slave
+    /// closes (xnu `ptsclose` → `ttyclose` → `ttyflush`; FreeBSD `ttydev_leave`
+    /// → `ttydisc_close` → `tty_flush` after a 1s drain window). We keep our
+    /// slave open until the child exits so that window cannot race us, then
+    /// drain here before releasing the last reference. Linux preserves the
+    /// queue, so this only changes when EOF arrives there.
+    #[cfg(unix)]
     pub(crate) fn drain_and_close_slave_fd(&self) {
         let flags = self.flags.get();
         if flags.contains(Flags::CLOSED) {
@@ -699,11 +703,7 @@ impl Terminal {
                 return;
             }
         }
-        let fd = self.slave_fd.get();
-        if fd != Fd::INVALID {
-            fd.close();
-            self.slave_fd.set(Fd::INVALID);
-        }
+        self.close_slave_fd();
     }
 
     /// Windows: close only the ConPTY handle so conhost releases its pipe ends and

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -173,11 +173,9 @@ bitflags::bitflags! {
         const CONNECTED      = 1 << 4;
         const READER_DONE    = 1 << 5;
         const WRITER_DONE    = 1 << 6;
-        /// Set when an inline-created terminal has been attached to a subprocess
-        /// via spawn; prevents reusing the same inline terminal for a second
-        /// spawn. On Windows the first exit's ClosePseudoConsole would silently
-        /// kill the second; on POSIX slave_fd is held until the first exit
-        /// (see `drain_and_close_slave_fd`).
+        /// Set once an inline-created terminal is attached to a spawn; blocks
+        /// reuse. Windows: first exit's ClosePseudoConsole would kill a second
+        /// child. POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
     }
 }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -669,8 +669,9 @@ impl Terminal {
         self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
     }
 
-    /// Close the parent's copy of slave_fd. The child holds its own; once
-    /// every slave fd is gone the master reader observes EOF.
+    /// Close the parent's copy of slave_fd and mark the terminal inline
+    /// spawned (cannot be reused). The child holds its own slave; once every
+    /// slave fd is gone the master reader observes EOF.
     pub(crate) fn close_slave_fd(&self) {
         self.mark_inline_spawned();
         let fd = self.slave_fd.get();
@@ -690,8 +691,10 @@ impl Terminal {
             return;
         }
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
-            self.reader.with_mut(|r| r.read());
-            // The data callback runs user JS, which may have closed us.
+            // SAFETY: single JS thread; re-entrant user JS (data callback may
+            // call `terminal.close()`) is handled via the raw-pointer dispatch
+            // convention used by `__bun_run_file_poll` for BUFFERED_READER.
+            unsafe { (*self.reader.as_ptr()).read() };
             if self.flags.get().contains(Flags::CLOSED) {
                 return;
             }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -680,16 +680,9 @@ impl Terminal {
         }
     }
 
-    /// POSIX: synchronously drain the master (delivering any buffered output
-    /// via the data callback) and then release our slave_fd so the next read
-    /// observes EOF. Called from Subprocess::on_process_exit on the JS thread.
-    ///
-    /// BSD-derived tty layers flush the pty output queue when the last slave
-    /// closes (xnu `ptsclose` → `ttyclose` → `ttyflush`; FreeBSD `ttydev_leave`
-    /// → `ttydisc_close` → `tty_flush` after a 1s drain window). We keep our
-    /// slave open until the child exits so that window cannot race us, then
-    /// drain here before releasing the last reference. Linux preserves the
-    /// queue, so this only changes when EOF arrives there.
+    /// Drain buffered pty output, then close our slave_fd so the reader sees
+    /// EOF. BSD kernels flush the output queue on last slave close; holding
+    /// ours until Subprocess::on_process_exit keeps a fast child's writes.
     #[cfg(unix)]
     pub(crate) fn drain_and_close_slave_fd(&self) {
         let flags = self.flags.get();

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -175,8 +175,9 @@ bitflags::bitflags! {
         const WRITER_DONE    = 1 << 6;
         /// Set when an inline-created terminal has been attached to a subprocess
         /// via spawn; prevents reusing the same inline terminal for a second
-        /// spawn (which on Windows would be silently killed by ClosePseudoConsole
-        /// when the first subprocess exits, and on POSIX has no slave_fd left).
+        /// spawn. On Windows the first exit's ClosePseudoConsole would silently
+        /// kill the second; on Linux `slave_fd` is already closed; on macOS
+        /// `slave_fd` is held until the first exit (see `close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
     }
 }
@@ -662,11 +663,35 @@ impl Terminal {
         self.hpcon.get()
     }
 
-    /// Close the parent's copy of slave_fd after fork
-    /// The child process has its own copy - closing the parent's ensures
-    /// EOF is received on the master side when the child exits
+    /// Close the parent's copy of slave_fd after spawn. The child holds its
+    /// own; closing ours lets the master observe EOF when the child exits.
+    ///
+    /// On macOS this is deferred: xnu's `ptsclose` → `ttyclose` → `ttyflush`
+    /// flushes the pty output queue when the last slave closes, so if a short
+    /// lived child writes and exits before we poll kqueue, closing our slave
+    /// here would drop that output. Subprocess::on_process_exit closes it via
+    /// `drain_and_close_slave_fd` instead.
     pub(crate) fn close_slave_fd(&self) {
         self.update_flags(|f| f.insert(Flags::INLINE_SPAWNED));
+        #[cfg(not(target_os = "macos"))]
+        {
+            let fd = self.slave_fd.get();
+            if fd != Fd::INVALID {
+                fd.close();
+                self.slave_fd.set(Fd::INVALID);
+            }
+        }
+    }
+
+    /// macOS: synchronously drain the master (delivering any buffered output
+    /// via the data callback) and then release our slave_fd so the next read
+    /// observes EOF. Called from Subprocess::on_process_exit on the JS thread.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn drain_and_close_slave_fd(&self) {
+        let flags = self.flags.get();
+        if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
+            self.reader.with_mut(|r| r.read());
+        }
         let fd = self.slave_fd.get();
         if fd != Fd::INVALID {
             fd.close();

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -689,8 +689,15 @@ impl Terminal {
     #[cfg(target_os = "macos")]
     pub(crate) fn drain_and_close_slave_fd(&self) {
         let flags = self.flags.get();
+        if flags.contains(Flags::CLOSED) {
+            return;
+        }
         if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
             self.reader.with_mut(|r| r.read());
+            // The data callback runs user JS, which may have closed us.
+            if self.flags.get().contains(Flags::CLOSED) {
+                return;
+            }
         }
         let fd = self.slave_fd.get();
         if fd != Fd::INVALID {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1413,12 +1413,18 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         IS_SYNC,
     ));
 
-    // For inline terminal options: release parent's slave_fd so EOF reaches the
-    // master when the child exits (deferred to on_process_exit on macOS; see
-    // Terminal::close_slave_fd). Existing terminals keep slave_fd for reuse.
+    // For inline terminal options: keep the parent's slave_fd open until the
+    // subprocess exits. BSD/macOS flush the pty output queue on last slave
+    // close, so closing here races the child's final writes; on_process_exit
+    // drains the master then closes it (Terminal::drain_and_close_slave_fd).
+    // Existing terminals keep slave_fd for reuse.
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;
-        // Spawn succeeded so the child holds its own copy of the slave fd.
+        #[cfg(unix)]
+        info.term().mark_inline_spawned();
+        // Windows: ConPTY's conhost buffers output, so the client handle can go
+        // now; EOF is delivered via close_pseudoconsole on exit.
+        #[cfg(windows)]
         info.term().close_slave_fd();
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1413,8 +1413,9 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         IS_SYNC,
     ));
 
-    // For inline terminal options: close parent's slave_fd so EOF is received when child exits
-    // For existing terminal: keep slave_fd open so terminal can be reused for more spawns
+    // For inline terminal options: release parent's slave_fd so EOF reaches the
+    // master when the child exits (deferred to on_process_exit on macOS; see
+    // Terminal::close_slave_fd). Existing terminals keep slave_fd for reuse.
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;
         // Spawn succeeded so the child holds its own copy of the slave fd.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1413,10 +1413,8 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         IS_SYNC,
     ));
 
-    // For inline terminal options: keep the parent's slave_fd open until the
-    // subprocess exits. BSD/macOS flush the pty output queue on last slave
-    // close, so closing here races the child's final writes; on_process_exit
-    // drains the master then closes it (Terminal::drain_and_close_slave_fd).
+    // Inline terminals keep slave_fd until on_process_exit (BSD kernels flush
+    // pty output on last slave close; see Terminal::drain_and_close_slave_fd).
     // Existing terminals keep slave_fd for reuse.
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -908,12 +908,9 @@ impl Subprocess<'_> {
         unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
 
         if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // POSIX: we still hold slave_fd (BSD/macOS flush the pty output
-            // queue on last slave close), so drain the master now and release
-            // our slave so the reader observes EOF.
-            // Windows: ConPTY's conhost stays alive after the child exits, so
-            // close the pseudoconsole to deliver EOF.
-            // Both paths leave the Terminal itself open (closed=false).
+            // Deliver EOF to the terminal reader without closing the Terminal:
+            // POSIX drains then releases slave_fd (BSD kernels flush on last
+            // slave close); Windows closes the ConPTY pseudoconsole.
             if let Some(terminal) = self.terminal.get() {
                 // `BackRef` invariant holds: the terminal is owned by (or
                 // borrowed from a JS wrapper kept live by) this subprocess and

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -907,17 +907,24 @@ impl Subprocess<'_> {
         // provenance (no `&Process → *mut` round-trip).
         unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
 
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "macos"))]
         if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // POSIX gets EOF on the master when the child (last slave_fd holder)
-            // exits. ConPTY's conhost stays alive after the child exits, so close
-            // the pseudoconsole now to deliver EOF and fire the terminal's exit
-            // callback. Leaves the Terminal itself open to match POSIX.
+            // Linux: EOF on the master arrives when the child (last slave_fd
+            // holder) exits; nothing to do.
+            // macOS: we still hold slave_fd (xnu flushes the pty output queue on
+            // last slave close), so drain the master now and release our slave.
+            // Windows: ConPTY's conhost stays alive after the child exits, so
+            // close the pseudoconsole to deliver EOF. Both paths leave the
+            // Terminal itself open (closed=false).
             if let Some(terminal) = self.terminal.get() {
                 // `BackRef` invariant holds: the terminal is owned by (or
                 // borrowed from a JS wrapper kept live by) this subprocess and
                 // outlives this scope; single JS thread.
-                bun_ptr::BackRef::from(terminal).close_pseudoconsole();
+                let term = bun_ptr::BackRef::from(terminal);
+                #[cfg(target_os = "macos")]
+                term.drain_and_close_slave_fd();
+                #[cfg(windows)]
+                term.close_pseudoconsole();
             }
         }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -907,21 +907,19 @@ impl Subprocess<'_> {
         // provenance (no `&Process → *mut` round-trip).
         unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
 
-        #[cfg(any(windows, target_os = "macos"))]
         if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // Linux: EOF on the master arrives when the child (last slave_fd
-            // holder) exits; nothing to do.
-            // macOS: we still hold slave_fd (xnu flushes the pty output queue on
-            // last slave close), so drain the master now and release our slave.
+            // POSIX: we still hold slave_fd (BSD/macOS flush the pty output
+            // queue on last slave close), so drain the master now and release
+            // our slave so the reader observes EOF.
             // Windows: ConPTY's conhost stays alive after the child exits, so
-            // close the pseudoconsole to deliver EOF. Both paths leave the
-            // Terminal itself open (closed=false).
+            // close the pseudoconsole to deliver EOF.
+            // Both paths leave the Terminal itself open (closed=false).
             if let Some(terminal) = self.terminal.get() {
                 // `BackRef` invariant holds: the terminal is owned by (or
                 // borrowed from a JS wrapper kept live by) this subprocess and
                 // outlives this scope; single JS thread.
                 let term = bun_ptr::BackRef::from(terminal);
-                #[cfg(target_os = "macos")]
+                #[cfg(unix)]
                 term.drain_and_close_slave_fd();
                 #[cfg(windows)]
                 term.close_pseudoconsole();

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1228,13 +1228,9 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     expect(output).toContain("hello");
   });
 
-  // On macOS, xnu flushes the pty output queue when the last slave fd closes
-  // (ptsclose -> ttyclose -> ttyflush). If a short-lived child writes and
-  // exits before the parent's event loop reads the master, the output is
-  // dropped and only the exit callback fires. Spawning many terminals back to
-  // back keeps the parent busy long enough to hit that window on slow hosts.
-  // Not `test.concurrent`: these run concurrently inside the test body, and we
-  // want the serial `Bun.spawn` loop to be the only contention.
+  // https://github.com/oven-sh/bun/issues/33187
+  // Not `test.concurrent`: spawns run concurrently inside the body; the serial
+  // `Bun.spawn` loop must be the only contention to reproduce the race.
   test("many fast-exiting subprocesses all deliver pty output", async () => {
     const N = isWindows ? 8 : 20;
     const outcomes: string[] = [];

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1227,4 +1227,35 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     const output = Buffer.concat(dataChunks).toString();
     expect(output).toContain("hello");
   });
+
+  // On macOS, xnu flushes the pty output queue when the last slave fd closes
+  // (ptsclose -> ttyclose -> ttyflush). If a short-lived child writes and
+  // exits before the parent's event loop reads the master, the output is
+  // dropped and only the exit callback fires. Spawning many terminals back to
+  // back keeps the parent busy long enough to hit that window on slow hosts.
+  // Not `test.concurrent`: these run concurrently inside the test body, and we
+  // want the serial `Bun.spawn` loop to be the only contention.
+  test("many fast-exiting subprocesses all deliver pty output", async () => {
+    const N = isWindows ? 8 : 20;
+    const outcomes: string[] = [];
+    const one = async () => {
+      const { promise, resolve } = Promise.withResolvers<string>();
+      let got = "";
+      const proc = Bun.spawn([bunExe(), "-e", "console.log('hello from terminal')"], {
+        env: bunEnv,
+        terminal: {
+          data: (_t, d) => {
+            got += Buffer.from(d).toString();
+            if (got.includes("hello from terminal")) resolve("data");
+          },
+          exit: () => resolve(got.includes("hello from terminal") ? "data" : "exit-no-data"),
+        },
+      });
+      outcomes.push(await promise);
+      proc.terminal?.close();
+      await proc.exited;
+    };
+    await Promise.all(Array.from({ length: N }, one));
+    expect(outcomes).toEqual(Array.from({ length: N }, () => "data"));
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `Bun.spawn({ terminal })` losing a fast-exiting child's output on macOS and FreeBSD, which shows up in CI as `terminal.test.ts > Bun.spawn with terminal option > creates subprocess with terminal attached` timing out after 90s on the x64 mac agents (`macOS-14-x64-1`, `darwin-x64-mini-1-1`).

Same diagnosis and fix shape as #33165 (draft); this version adds the xnu/FreeBSD source citations and drops the watchdog instrumentation.

### Root cause

On BSD-derived kernels, closing the last slave fd of a pty flushes the master's output queue.

- xnu: [`ptsclose`](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/tty_dev.c#L325) calls `ttyclose(tp)` + `ptsstop(tp, FREAD|FWRITE)`; [`ttyclose`](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/tty.c#L418) calls `ttyflush(tp, FREAD | FWRITE)`, clearing `t_outq`. `ptcread` then sees `t_outq.c_cc == 0 && !TS_CONNECTED` and returns EOF.
- FreeBSD: [`ttydev_leave`](https://github.com/freebsd/freebsd-src/blob/main/sys/kern/tty.c) calls `tty_drain(tp, 1)` (waits up to ~1s for the master to read, waking its kqueue via `ptsdrv_outwakeup`), then [`ttydisc_close`](https://github.com/freebsd/freebsd-src/blob/main/sys/kern/tty_ttydisc.c) calls `tty_flush(tp, FREAD | FWRITE)` and `ttyoutq_free`.
- Linux: no flush; the pty buffer persists until drained.

`Bun.spawn` with an inline `terminal:` option closed the parent's slave fd immediately after `spawn_process()` returns. Under `describe.concurrent` the parent does ~11 serial `openpty`+`fork` calls before the event loop polls kqueue. On the slower Intel macs the first few children have already written and exited by then; with our slave already closed, the child's exit releases the last slave reference, the kernel flushes the queue, and the reader sees EOF with zero bytes. `Terminal::on_reader_done` fires the exit callback only, so the test's `await gotMarker.promise` (resolved from the data callback) never resolves.

### Fix

On POSIX, `spawn` now only marks the terminal `INLINE_SPAWNED` and keeps our slave fd open. `Subprocess::on_process_exit` calls a new `Terminal::drain_and_close_slave_fd()` that performs a synchronous nonblocking drain of the master (delivering any buffered output via the data callback) and then closes our slave so the reader observes EOF. Windows is unchanged (ConPTY buffers in conhost; EOF via `ClosePseudoConsole`). Linux does not need the deferral but it only changes when EOF arrives there; the full `terminal.test.ts` suite passes on Linux with it active.

### How did you verify your code works?

Kernel-level C probe (single pty, child writes then exits, parent reads master after `waitpid`):

```
macOS 14.5 x64:   close_slave_early=1 -> read=0  data=[]
macOS 26.4 arm64: close_slave_early=1 -> read=0  data=[]
Linux x64:        close_slave_early=1 -> read=21 data=[hello from terminal]
```

Bun-level repro on `darwin-test-x64-4` against a current `bun-profile` build (200 iterations, batches of `concurrency`):

```
concurrency=5  ok=60  exitNoData=0
concurrency=6  ok=59  exitNoData=1
concurrency=11 ok=129 exitNoData=71
```

arm64 needs `concurrency>=60` to hit the same window, which is why only the x64 lanes flake at the test file's concurrency of 11.

Added `many fast-exiting subprocesses all deliver pty output` to `terminal.test.ts` (N=20 concurrent short-lived spawns, asserts every one delivers data). `cargo check` is clean for `aarch64-apple-darwin`, `x86_64-unknown-freebsd`, and `x86_64-pc-windows-msvc`; `bun bd test test/js/bun/terminal/terminal.test.ts` passes on Linux.

Fixes #33187

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->