### PR TITLE
resolver: record enclosing package.json regardless of "name" field

### DIFF
--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -111,10 +111,9 @@ pub struct DirInfo {
     pub(crate) package_json_for_browser_field: Option<&'static PackageJSON>,
     pub(crate) enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
 
-    /// package.json used for bundling
-    /// it's the deepest one in the hierarchy with a "name" field
-    /// or, if using `bun run`, the name field is optional
-    /// https://github.com/oven-sh/bun/issues/229
+    /// Nearest enclosing package.json; governs `"type"` / sideEffects for
+    /// bundling. Not gated on a `"name"` field: Node's module-format rule
+    /// looks only at the nearest package.json's `"type"`.
     // No write site exists in any caller — kept `Option<&'static>` for
     // ergonomics. If a write is ever added, retype to `Option<NonNull<_>>`.
     pub enclosing_package_json: Option<&'static PackageJSON>,

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -111,9 +111,7 @@ pub struct DirInfo {
     pub(crate) package_json_for_browser_field: Option<&'static PackageJSON>,
     pub(crate) enclosing_tsconfig_json: Option<&'static TSConfigJSON>,
 
-    /// Nearest enclosing package.json; governs `"type"` / sideEffects for
-    /// bundling. Not gated on a `"name"` field: Node's module-format rule
-    /// looks only at the nearest package.json's `"type"`.
+    /// Nearest enclosing package.json; governs `"type"` / sideEffects for bundling.
     // No write site exists in any caller — kept `Option<&'static>` for
     // ergonomics. If a write is ever added, retype to `Option<NonNull<_>>`.
     pub enclosing_package_json: Option<&'static PackageJSON>,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1554,13 +1554,21 @@ impl<'a> Resolver<'a> {
 
         let mut iter = result.path_pair.iter();
         let mut module_type = result.module_type;
+        // `primary_side_effects_data` describes `path_pair.primary` (the path the
+        // bundler actually parses); the secondary is only carried for the
+        // dual-package-hazard rewrite and gets its own resolve result when it is
+        // reached via `require()`. Evaluating the sideEffects map against the
+        // secondary path here would overwrite the primary's classification.
+        let mut side_effects_done = false;
         while let Some(path) = iter.next() {
             let name = path.name();
             let Ok(Some(dir)) = self.read_dir_info(name.dir) else {
                 continue;
             };
-            let mut needs_side_effects = true;
-            if let Some(existing) = Result::deref_package_json(result.package_json) {
+            let mut needs_side_effects = !side_effects_done;
+            if let Some(existing) = Result::deref_package_json(result.package_json)
+                && !side_effects_done
+            {
                 // if we don't have it here, they might put it in a sideEfffects
                 // map of the parent package.json
                 // TODO: check if webpack also does this parent lookup
@@ -1639,6 +1647,7 @@ impl<'a> Resolver<'a> {
                     };
                 }
             }
+            side_effects_done = true;
 
             if let Some(tsconfig) = dir.enclosing_tsconfig_json {
                 result.jsx = tsconfig.merge_jsx(core::mem::take(&mut result.jsx));

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1554,11 +1554,6 @@ impl<'a> Resolver<'a> {
 
         let mut iter = result.path_pair.iter();
         let mut module_type = result.module_type;
-        // `primary_side_effects_data` describes `path_pair.primary` (the path the
-        // bundler actually parses); the secondary is only carried for the
-        // dual-package-hazard rewrite and gets its own resolve result when it is
-        // reached via `require()`. Evaluating the sideEffects map against the
-        // secondary path here would overwrite the primary's classification.
         let mut is_primary = true;
         while let Some(path) = iter.next() {
             let compute_side_effects = is_primary;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1559,15 +1559,17 @@ impl<'a> Resolver<'a> {
         // dual-package-hazard rewrite and gets its own resolve result when it is
         // reached via `require()`. Evaluating the sideEffects map against the
         // secondary path here would overwrite the primary's classification.
-        let mut side_effects_done = false;
+        let mut is_primary = true;
         while let Some(path) = iter.next() {
+            let compute_side_effects = is_primary;
+            is_primary = false;
             let name = path.name();
             let Ok(Some(dir)) = self.read_dir_info(name.dir) else {
                 continue;
             };
-            let mut needs_side_effects = !side_effects_done;
+            let mut needs_side_effects = compute_side_effects;
             if let Some(existing) = Result::deref_package_json(result.package_json)
-                && !side_effects_done
+                && compute_side_effects
             {
                 // if we don't have it here, they might put it in a sideEfffects
                 // map of the parent package.json
@@ -1647,7 +1649,6 @@ impl<'a> Resolver<'a> {
                     };
                 }
             }
-            side_effects_done = true;
 
             if let Some(tsconfig) = dir.enclosing_tsconfig_json {
                 result.jsx = tsconfig.merge_jsx(core::mem::take(&mut result.jsx));

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6101,10 +6101,7 @@ impl<'a> Resolver<'a> {
             info.enclosing_tsconfig_json = parent_.enclosing_tsconfig_json;
 
             if let Some(parent_package_json) = parent_.package_json() {
-                // https://github.com/oven-sh/bun/issues/229
-                if !parent_package_json.name.is_empty() || self.care_about_bin_folder {
-                    info.enclosing_package_json = Some(parent_package_json);
-                }
+                info.enclosing_package_json = Some(parent_package_json);
 
                 if parent_package_json.dependencies.map.count() > 0
                     || parent_package_json.package_manager_package_id != Install::INVALID_PACKAGE_ID
@@ -6247,9 +6244,7 @@ impl<'a> Resolver<'a> {
                             info.package_json_for_browser_field = Some(pkg);
                         }
 
-                        if !pkg.name.is_empty() || self.care_about_bin_folder {
-                            info.enclosing_package_json = Some(pkg);
-                        }
+                        info.enclosing_package_json = Some(pkg);
 
                         if pkg.dependencies.map.count() > 0
                             || pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -561,6 +561,39 @@ describe("bundler", () => {
       stdout: "this should be kept\nunused import",
     },
   });
+  // Same as PackageJsonSideEffectsArrayKeepModuleImplicitModule but with a "name" field,
+  // which previously routed finalize_result through a branch that re-evaluated the
+  // sideEffects array against the secondary ("main") path and overwrote the primary's
+  // classification.
+  itBundled("dce/PackageJsonSideEffectsArrayKeepModuleNamedPackage", {
+    todo: isWindows,
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import {foo} from "demo-pkg"
+        console.log('unused import')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/index-main.js": /* js */ `
+        export const foo = 123
+        console.log('TEST FAILED')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/index-module.js": /* js */ `
+        export const foo = 123
+        console.log('this should be kept')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "name": "demo-pkg",
+          "main": "index-main.js",
+          "module": "index-module.js",
+          "sideEffects": ["./index-module.js"]
+        }
+      `,
+    },
+    dce: true,
+    run: {
+      stdout: "this should be kept\nunused import",
+    },
+  });
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleImplicitMain", {
     todo: true,
     files: {

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -561,10 +561,6 @@ describe("bundler", () => {
       stdout: "this should be kept\nunused import",
     },
   });
-  // Same as PackageJsonSideEffectsArrayKeepModuleImplicitModule but with a "name" field,
-  // which previously routed finalize_result through a branch that re-evaluated the
-  // sideEffects array against the secondary ("main") path and overwrote the primary's
-  // classification.
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleNamedPackage", {
     todo: isWindows,
     files: {
@@ -592,6 +588,92 @@ describe("bundler", () => {
     dce: true,
     run: {
       stdout: "this should be kept\nunused import",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/8993
+  itBundled("dce/PackageJsonSideEffectsArrayModuleMainBareImport", {
+    todo: isWindows,
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg"
+        console.log('after import')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/index-module.js": /* js */ `
+        import "./register.js"
+        export const foo = 1
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/register.js": /* js */ `
+        console.log('this should be kept')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/index-main.js": /* js */ `
+        console.log('TEST FAILED')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "name": "demo-pkg",
+          "main": "dist/index-main.js",
+          "module": "dist/index-module.js",
+          "sideEffects": ["./dist/index-module.js", "./dist/register.js"]
+        }
+      `,
+    },
+    dce: true,
+    run: {
+      stdout: "this should be kept\nafter import",
+    },
+  });
+  itBundled("dce/PackageJsonSideEffectsGlobModuleMainBareImport", {
+    todo: isWindows,
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg"
+        console.log('after import')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/index-module.js": /* js */ `
+        console.log('this should be kept')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/bundle.node.js": /* js */ `
+        console.log('TEST FAILED')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "name": "demo-pkg",
+          "main": "dist/bundle.node.js",
+          "module": "dist/index-module.js",
+          "sideEffects": ["./dist/index-*.js"]
+        }
+      `,
+    },
+    dce: true,
+    run: {
+      stdout: "this should be kept\nafter import",
+    },
+  });
+  itBundled("dce/PackageJsonSideEffectsArrayModuleMainBareImportRemove", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg"
+        console.log('unused import')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/index-module.js": /* js */ `
+        export const foo = 'TEST FAILED'
+        console.log('TEST FAILED')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/index-main.js": /* js */ `
+        console.log('TEST FAILED')
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "name": "demo-pkg",
+          "main": "dist/index-main.js",
+          "module": "dist/index-module.js",
+          "sideEffects": ["./dist/index-main.js"]
+        }
+      `,
+    },
+    dce: true,
+    run: {
+      stdout: "unused import",
     },
   });
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleImplicitMain", {

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2051,6 +2051,51 @@ describe("bundler", () => {
       "/package.json": `{ "type": "module" }`,
     },
   });
+  // Node resolves `.js` module format from the nearest package.json's `"type"` field
+  // alone; a missing `"name"` must not cause the bundler to drop that package.json and
+  // treat the file as ESM (which would leave the namespace empty / `default` undefined).
+  itBundled("packagejson/TypeCommonJSWithoutName", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import * as ns from "./c.js";
+        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default));
+      `,
+      "/c.js": `globalThis.__x = 1;`,
+      "/package.json": `{ "type": "commonjs" }`,
+    },
+    target: "node",
+    run: {
+      stdout: `["default"] {}`,
+    },
+  });
+  itBundled("packagejson/TypeCommonJSWithoutNameInSubdir", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import * as ns from "./pkg/c.js";
+        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default));
+      `,
+      "/pkg/c.js": `globalThis.__x = 1;`,
+      "/pkg/package.json": `{ "type": "commonjs" }`,
+    },
+    target: "node",
+    run: {
+      stdout: `["default"] {}`,
+    },
+  });
+  itBundled("packagejson/TypeCommonJSWithName", {
+    files: {
+      "/entry.mjs": /* js */ `
+        import * as ns from "./c.js";
+        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default));
+      `,
+      "/c.js": `globalThis.__x = 1;`,
+      "/package.json": `{ "name": "p", "type": "commonjs" }`,
+    },
+    target: "node",
+    run: {
+      stdout: `["default"] {}`,
+    },
+  });
   itBundled("packagejson/NodePathsESBuildIssue2752", {
     files: {
       "/src/entry.js": /* js */ `

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -38,16 +38,15 @@ describe.concurrent("run-cjs", () => {
       return { stdout, stderr, exitCode };
     }
 
+    const ok = { stdout: "cjs ok\n", stderr: "", exitCode: 0 };
+
     test('subdir: nameless {"type":"commonjs"} overrides outer named {"type":"module"}', async () => {
       using dir = tempDir("nameless-cjs-subdir", {
         "package.json": `{"name":"outer","type":"module"}`,
         "pkg/package.json": `{"type":"commonjs"}`,
         "pkg/sub/t.js": cjsBody,
       });
-      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
-      expect(stderr).toBe("");
-      expect(stdout).toBe("cjs ok\n");
-      expect(exitCode).toBe(0);
+      expect(await run(join(String(dir), "pkg", "sub"), "t.js")).toEqual(ok);
     });
 
     test('subdir: nameless {"type":"commonjs"} with no named ancestor', async () => {
@@ -55,10 +54,7 @@ describe.concurrent("run-cjs", () => {
         "pkg/package.json": `{"type":"commonjs"}`,
         "pkg/sub/t.js": cjsBody,
       });
-      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
-      expect(stderr).toBe("");
-      expect(stdout).toBe("cjs ok\n");
-      expect(exitCode).toBe(0);
+      expect(await run(join(String(dir), "pkg", "sub"), "t.js")).toEqual(ok);
     });
 
     test('adjacent: nameless {"type":"commonjs"} overrides outer named {"type":"module"}', async () => {
@@ -67,10 +63,7 @@ describe.concurrent("run-cjs", () => {
         "pkg/package.json": `{"type":"commonjs"}`,
         "pkg/t.js": cjsBody,
       });
-      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg"), "t.js");
-      expect(stderr).toBe("");
-      expect(stdout).toBe("cjs ok\n");
-      expect(exitCode).toBe(0);
+      expect(await run(join(String(dir), "pkg"), "t.js")).toEqual(ok);
     });
 
     test('subdir: adding "name" to inner package.json (control)', async () => {
@@ -79,10 +72,7 @@ describe.concurrent("run-cjs", () => {
         "pkg/package.json": `{"name":"inner","type":"commonjs"}`,
         "pkg/sub/t.js": cjsBody,
       });
-      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
-      expect(stderr).toBe("");
-      expect(stdout).toBe("cjs ok\n");
-      expect(exitCode).toBe(0);
+      expect(await run(join(String(dir), "pkg", "sub"), "t.js")).toEqual(ok);
     });
   });
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe.concurrent("run-cjs", () => {
@@ -16,5 +16,73 @@ describe.concurrent("run-cjs", () => {
     });
     const stdout = await proc.stdout.text();
     expect(stdout).toEqual("hello world\n");
+  });
+
+  // Node resolves a .js file's module format from the nearest ancestor package.json's
+  // "type" field; the presence of a "name" field is irrelevant. Previously the resolver
+  // only recorded an enclosing package.json when it had a non-empty "name", so a nameless
+  // {"type":"commonjs"} scope was skipped for files in a *subdirectory* of that scope and
+  // the next-higher named ancestor's "type" was used instead.
+  describe('nameless package.json "type" governs module format', () => {
+    const cjsBody = `let x = 1;\nif (x === 2) return;\nconsole.log("cjs ok");\n`;
+
+    async function run(cwd: string, entry: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entry],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test('subdir: nameless {"type":"commonjs"} overrides outer named {"type":"module"}', async () => {
+      using dir = tempDir("nameless-cjs-subdir", {
+        "package.json": `{"name":"outer","type":"module"}`,
+        "pkg/package.json": `{"type":"commonjs"}`,
+        "pkg/sub/t.js": cjsBody,
+      });
+      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("cjs ok\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test('subdir: nameless {"type":"commonjs"} with no named ancestor', async () => {
+      using dir = tempDir("nameless-cjs-no-ancestor", {
+        "pkg/package.json": `{"type":"commonjs"}`,
+        "pkg/sub/t.js": cjsBody,
+      });
+      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("cjs ok\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test('adjacent: nameless {"type":"commonjs"} overrides outer named {"type":"module"}', async () => {
+      using dir = tempDir("nameless-cjs-adjacent", {
+        "package.json": `{"name":"outer","type":"module"}`,
+        "pkg/package.json": `{"type":"commonjs"}`,
+        "pkg/t.js": cjsBody,
+      });
+      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg"), "t.js");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("cjs ok\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test('subdir: adding "name" to inner package.json (control)', async () => {
+      using dir = tempDir("named-cjs-subdir", {
+        "package.json": `{"name":"outer","type":"module"}`,
+        "pkg/package.json": `{"name":"inner","type":"commonjs"}`,
+        "pkg/sub/t.js": cjsBody,
+      });
+      const { stdout, stderr, exitCode } = await run(join(String(dir), "pkg", "sub"), "t.js");
+      expect(stderr).toBe("");
+      expect(stdout).toBe("cjs ok\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Fixes #8993

### Repro

```sh
mkdir repro && cd repro
printf '{"type":"commonjs"}' > package.json
printf 'globalThis.__x = 1;' > c.js
printf 'import * as N from "./c.js";\nconsole.log(Object.keys(N), N.default);\n' > index.mjs
```

Unbundled, Node and Bun agree that `c.js` is CommonJS (namespace has a `default`):

```
$ node index.mjs
[ 'default' ] {}
$ bun index.mjs
[ "default" ] {}
```

Bundled, `bun build` classifies the same `c.js` as ESM:

```
$ bun build ./index.mjs --target=node > b.js
warn: Import "default" will always be undefined because there is
      no matching export in "c.js"
$ node b.js
[] undefined
```

Adding an unrelated `"name":"p"` to the same package.json makes the bundle correct:

```
$ printf '{"name":"p","type":"commonjs"}' > package.json
$ bun build ./index.mjs --target=node > b2.js && node b2.js
[ 'default' ] {}
```

### Cause

`dir_info_uncached` only stored a directory's `enclosing_package_json` when the package.json had a non-empty `name` (or `care_about_bin_folder` was set, which is the `bun run` path). That guard existed for `bun run` script discovery (#229), but `enclosing_package_json` is also what `finalize_result` reads the `"type"` and `sideEffects` fields from, so a nameless package.json lost its `type` in the bundler. Node's module-format rule looks only at the nearest package.json's `"type"`; `"name"` is irrelevant. A nameless `{"type":"commonjs"}` is common in app-root and monorepo-internal package.json files.

Removing that guard exposed a second, latent bug in `finalize_result`: the `path_pair` loop evaluates the sideEffects classification for both the primary (`"module"`) and secondary (`"main"`) paths of a main/module resolution, with the secondary's result overwriting the primary's. `primary_side_effects_data` is paired with `path_pair.primary` everywhere it is consumed (`ParseTask::init`, `enqueue_entry_item`, `resolve_import_records`); the secondary path gets its own resolve result when it is reached via `require()`. The name guard had been accidentally masking this for nameless package.jsons by clearing `result.package_json` before the second iteration, and every `dce/PackageJsonSideEffectsArrayKeep*` test happens to use a nameless one. A named package.json already took the same broken path on `main` (new `dce/PackageJsonSideEffectsArrayKeepModuleNamedPackage` test).

(#22211 attempted the same guard removal and was closed; this is presumably why.)

### Fix

- Always record the nearest package.json as `enclosing_package_json` at both `dir_info_uncached` sites.
- In `finalize_result`, compute `primary_side_effects_data` on the first `path_pair` iteration only.

### Tests

`test/bundler/esbuild/packagejson.test.ts`:

- `TypeCommonJSWithoutName` / `TypeCommonJSWithoutNameInSubdir`: `{"type":"commonjs"}` with no `name`, at the root and inherited from a subdirectory; both fail before, pass after.
- `TypeCommonJSWithName`: `{"name":"p","type":"commonjs"}` control; passes before and after.

`test/bundler/esbuild/dce.test.ts`:

- `PackageJsonSideEffectsArrayKeepModuleNamedPackage`: the existing `...KeepModuleImplicitModule` fixture with a `"name"` added; fails on `main`, passes after.
- The four existing `PackageJsonSideEffectsArrayKeep{Main,Module}*` tests continue to pass.

`test/cli/run/run-cjs.test.ts` (runtime):

- `nameless package.json "type" governs module format`: direct-run `.js` in a subdirectory of a nameless `{"type":"commonjs"}` scope, with top-level `return` as the observable (JSC rejects it when the file is misclassified as ESM). Two cases (with and without a named `{"type":"module"}` ancestor) fail before and pass after; adjacent-file and named-inner controls pass on both.

Also adds bare-import variants (`dce/PackageJsonSideEffectsArrayModuleMainBareImport`, `GlobModuleMainBareImport`, `ArrayModuleMainBareImportRemove`) covering the `@tensorflow/tfjs-backend-cpu` shape from #8993 (folded in from #36652).

`dce.test.ts` (74 pass), `packagejson.test.ts` (77 pass), `default.test.ts` (151 pass), `bundler_cjs.test.ts`, `bundler_cjs2esm.test.ts`, `bundler_browser.test.ts` and `test/js/bun/resolve/` pass with no new failures.

Related: #33807 works around the nameless-package.json skip for the runtime path by walking `DirInfo` parents in `jsc_hooks.rs`; this PR fixes the resolver field it was working around.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/esbuild/dce.test.ts

<!-- robobun:evidence:end -->

