### PR TITLE
Bun.spawn: reject argv0 and cwd containing null bytes

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -463,6 +463,18 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 let argv0_str = argv0_.get_zig_string(global_this)?;
                 if argv0_str.len > 0 {
                     let owned = argv0_str.to_owned_slice_z();
+                    // Check for null bytes in argv0 (security: prevent null byte injection)
+                    if strings::index_of_char(owned.as_bytes(), 0).is_some() {
+                        return Err(global_this
+                            .err(
+                                jsc::ErrorCode::INVALID_ARG_VALUE,
+                                format_args!(
+                                    "The property 'options.argv0' must be a string without null bytes. Received {}",
+                                    bun_fmt::quote(owned.as_bytes())
+                                ),
+                            )
+                            .throw());
+                    }
                     argv0 = Some(owned.as_ptr());
                     cstr_storage.push(owned);
                 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -485,6 +485,18 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                 let cwd_str = cwd_.get_zig_string(global_this)?;
                 if cwd_str.len > 0 {
                     cwd_owned = cwd_str.to_owned_slice_z();
+                    // Check for null bytes in cwd (security: prevent null byte injection)
+                    if strings::index_of_char(cwd_owned.as_bytes(), 0).is_some() {
+                        return Err(global_this
+                            .err(
+                                jsc::ErrorCode::INVALID_ARG_VALUE,
+                                format_args!(
+                                    "The property 'options.cwd' must be a string without null bytes. Received {}",
+                                    bun_fmt::quote(cwd_owned.as_bytes())
+                                ),
+                            )
+                            .throw());
+                    }
                     // `cwd_owned` is never mutated again, so this borrow is valid
                     // for every read of `cwd` below.
                     cwd = cwd_owned.as_bytes();

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -127,7 +127,8 @@ describe("null byte injection protection", () => {
     });
 
     test("works normally with valid argv0", () => {
-      const result = Bun.spawnSync({ cmd: ["echo", "hello"], argv0: "myecho" });
+      // argv0 kept as "echo": busybox dispatches applets by argv[0].
+      const result = Bun.spawnSync({ cmd: ["echo", "hello"], argv0: "echo" });
       expect(result.stdout.toString().trim()).toBe("hello");
       expect(result.exitCode).toBe(0);
     });

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -49,6 +49,17 @@ describe("null byte injection protection", () => {
       }).toThrow(/must be a string without null bytes/);
     });
 
+    test("throws error for null byte in argv0", async () => {
+      try {
+        Bun.spawn({ cmd: ["echo", "hello"], argv0: "AAA\0BBB" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/options\.argv0/);
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
     test("works normally with valid arguments", async () => {
       await using proc = Bun.spawn(["echo", "hello"], { stdout: "pipe" });
       const stdout = await new Response(proc.stdout).text();
@@ -80,6 +91,23 @@ describe("null byte injection protection", () => {
       expect(() => {
         Bun.spawnSync(["echo", arg]);
       }).toThrow(/must be a string without null bytes/);
+    });
+
+    test("throws error for null byte in argv0", () => {
+      try {
+        Bun.spawnSync({ cmd: ["echo", "hello"], argv0: "AAA\0BBB" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/options\.argv0/);
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
+    test("works normally with valid argv0", () => {
+      const result = Bun.spawnSync({ cmd: ["echo", "hello"], argv0: "myecho" });
+      expect(result.stdout.toString().trim()).toBe("hello");
+      expect(result.exitCode).toBe(0);
     });
 
     test("works normally with valid arguments", () => {

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -60,6 +60,17 @@ describe("null byte injection protection", () => {
       }
     });
 
+    test("throws error for null byte in cwd", async () => {
+      try {
+        Bun.spawn({ cmd: ["echo", "hello"], cwd: "/tmp\0/etc" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/options\.cwd/);
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
     test("works normally with valid arguments", async () => {
       await using proc = Bun.spawn(["echo", "hello"], { stdout: "pipe" });
       const stdout = await new Response(proc.stdout).text();
@@ -100,6 +111,17 @@ describe("null byte injection protection", () => {
       } catch (e: any) {
         expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
         expect(e.message).toMatch(/options\.argv0/);
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
+    test("throws error for null byte in cwd", () => {
+      try {
+        Bun.spawnSync({ cmd: ["echo", "hello"], cwd: "/tmp\0/etc" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/options\.cwd/);
         expect(e.message).toMatch(/must be a string without null bytes/);
       }
     });


### PR DESCRIPTION
## Repro

```js
const r = Bun.spawnSync({
  cmd:   ["/bin/sh", "-c", "tr '\\0' '|' < /proc/$$/cmdline; echo"],
  argv0: "AAA\0BBB",
  stdout: "pipe",
});
console.log(r.stdout.toString());
// AAA|-c|tr '\0' '|' < /proc/$$/cmdline; echo|
// ^^^ kernel argv[0] is "AAA": silently truncated at the NUL
```

Every sibling string that reaches `execve` (cmd[0], cmd[i], env keys, env values) is already validated and throws `ERR_INVALID_ARG_VALUE`, and `node:child_process` (both Node.js and Bun's own shim) rejects `options.argv0` with an interior NUL the same way. `Bun.spawn`'s native `argv0` read was unchecked.

## Cause

In `src/runtime/api/bun/js_bun_spawn_bindings.rs`, the `argv0` option is read via `get_zig_string(..).to_owned_slice_z()` and handed straight to `get_argv0(..., pretend_argv0)` as the child's argv[0]. The neighbouring reads of cmd[0], every args[i], and every env key/value in the same file each carry the explicit "Check for null bytes ... (security: prevent null byte injection)" block; the `argv0` read did not.

Since `to_owned_slice_z` NUL-terminates the UTF-8 bytes, an interior NUL ends the C string early, so the child process sees a truncated argv[0] while the JS caller's string still contains the full value. argv[0] is what procfs/ps report, what a script sees as $0, and what multi-call binaries dispatch on.

The `cwd` option read immediately below uses the identical pattern and had the same gap. On current main it surfaces as a generic "failed to spawn process" with no `.code`; Node.js and Bun's `node:child_process` both throw `ERR_INVALID_ARG_VALUE` for it.

## Fix

Add the same null-byte check at the `argv0` and `cwd` read sites, matching the error code and message format of Node.js and `node:child_process`:

```
TypeError [ERR_INVALID_ARG_VALUE]: The property 'options.argv0' must be a string without null bytes. Received "AAA\^@BBB"
```

Applies to both `Bun.spawn` and `Bun.spawnSync` (shared read site).

## Verification

`test/js/bun/spawn/null-byte-injection.test.ts` (5 new tests alongside the existing cmd[]/env checks):

- `USE_SYSTEM_BUN=1 bun test ...`: **4 fail** (argv0 and cwd cases don't throw `ERR_INVALID_ARG_VALUE`)
- `bun bd test ...`: **20 pass / 0 fail**
- `bun bd test test/js/bun/spawn/spawn.test.ts -t argv0`: **4 pass** (existing argv0 tests unaffected)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/null-byte-injection.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e03ab4a7e)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [6.23ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [3.41ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [6.11ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [3.63ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [4.14ms]
52 |     test("throws error for null byte in argv0", async () => {
53 |       try {
54 |         Bun.spawn({ cmd: ["echo", "hell
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e03ab4a7e)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [0.13ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [0.11ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [0.10ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [0.05ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [0.04ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in argv0 [0.08ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in cwd [0.07ms]
(pass) null byte injection protection > Bun.spawn > works normally with valid arguments [1.28ms]
(pass) null byte injection protection > Bun.spawn > works with spread process.env [1.44ms]
(pass) null byte injection protection > Bun.spawnSync > throws error when command contains null byte [0.05ms]
(pass) null byte injection protection > Bun.spawnSync > throws err
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/null-byte-injection.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e03ab4a7e)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [5.95ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [3.49ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [4.96ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [3.69ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [3.83ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in argv0 [5.57ms]
(pass) null byte injection prot
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 728ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/55] cxx obj/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp.o
[2/55] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/55] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[4/55] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[5/55] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[6/55] cxx obj/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp.o
[7/55] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[8/55] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[9/55] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[10/55] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[11/55] cxx obj/unified/UnifiedSource-packages_bun_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/js_bun_spawn_bindings.rs  | 24 +++++++++++++
 test/js/bun/spawn/null-byte-injection.test.ts | 51 +++++++++++++++++++++++++++
 2 files changed, 75 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/api/bun/js_bun_spawn_bindings.rs       5      3      0
test/js/bun/spawn/null-byte-injection.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->