### PR TITLE
net: set SO_REUSEADDR on localPort bind for outgoing connections

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1734,6 +1734,14 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr,
      * `localAddress`/`localPort` connect options). A failure here - typically
      * EADDRINUSE or EADDRNOTAVAIL - fails the connect with that errno. */
     if (local_addr) {
+#ifndef _WIN32
+        /* Match libuv's uv__tcp_bind: set SO_REUSEADDR so binding the local
+         * port succeeds when earlier connections on that port are still in
+         * TIME_WAIT. Not set on Windows, where SO_REUSEADDR would allow
+         * stealing a port that is actively in use (see libuv win/tcp.c). */
+        int on = 1;
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+#endif
         socklen_t local_len = local_addr->ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
         if (bind(fd, (struct sockaddr *) local_addr, local_len)) {
 #ifdef _WIN32

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -758,12 +758,14 @@ async function runTests() {
           NO_COLOR: "1",
           BUN_DEBUG_QUIET_LOGS: "1",
         };
-        if (!isWindows) {
-          // Node-compat tests spawn workers/children (cluster, child_process)
-          // and then kill/exit; a child that outlives its parent can keep a
-          // common.PORT socket bound and flake the next sequential test.
-          // --no-orphans wires PR_SET_PDEATHSIG / kqueue parent watch so the
-          // whole tree dies with the test process.
+        if (!isWindows && title.includes("/sequential/")) {
+          // Sequential node tests share common.PORT (12346); a cluster worker
+          // or child_process subprocess that outlives its test can keep that
+          // port bound and flake the next file. --no-orphans wires
+          // PR_SET_PDEATHSIG / kqueue parent watch so the whole tree dies with
+          // the test process. Scoped to sequential/ because parallel/ has
+          // tests that assert a detached grandchild survives its parent
+          // (test-child-process-*-detached.js), which this flag defeats.
           env.BUN_FEATURE_FLAG_NO_ORPHANS = "1";
         }
         if ((basename(execPath).includes("asan") || !isCI) && shouldValidateExceptions(testPath)) {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -758,6 +758,14 @@ async function runTests() {
           NO_COLOR: "1",
           BUN_DEBUG_QUIET_LOGS: "1",
         };
+        if (!isWindows) {
+          // Node-compat tests spawn workers/children (cluster, child_process)
+          // and then kill/exit; a child that outlives its parent can keep a
+          // common.PORT socket bound and flake the next sequential test.
+          // --no-orphans wires PR_SET_PDEATHSIG / kqueue parent watch so the
+          // whole tree dies with the test process.
+          env.BUN_FEATURE_FLAG_NO_ORPHANS = "1";
+        }
         if ((basename(execPath).includes("asan") || !isCI) && shouldValidateExceptions(testPath)) {
           env.BUN_JSC_validateExceptionChecks = "1";
           env.BUN_JSC_dumpSimulatedThrows = "1";

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -999,3 +999,66 @@ describe("paused socket whose peer sends RST", () => {
     expect(errors.map(e => e.code)).not.toContain("ENOEXEC");
   });
 });
+
+// libuv's uv__tcp_bind always sets SO_REUSEADDR on Unix, so Node can bind a
+// client localPort that still has earlier connections in TIME_WAIT. Bun used
+// to call bind() bare here and fail with EADDRINUSE, which made
+// sequential/test-net-localport.js order-dependent in CI. Windows is skipped
+// because libuv intentionally does not set SO_REUSEADDR there.
+it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TIME_WAIT sockets", async () => {
+  // Reserve a port and release it so nothing else is listening on it.
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+  const localPort = (probe.address() as import("node:net").AddressInfo).port;
+  await new Promise<void>(r => probe.close(() => r()));
+
+  // Leave a few server-side TIME_WAIT sockets on localPort: the server sends
+  // and then active-closes each connection, which is what puts its local end
+  // (localPort) into TIME_WAIT.
+  {
+    const { promise: drained, resolve: onDrained } = Promise.withResolvers<void>();
+    let accepted = 0;
+    let closed = 0;
+    const waitServer = createServer(c => {
+      if (++accepted === 4) waitServer.close();
+      c.end("x");
+      c.on("close", () => {
+        if (++closed === 4) onDrained();
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      waitServer.on("error", reject);
+      waitServer.listen(localPort, "127.0.0.1", resolve);
+    });
+    for (let i = 0; i < 4; i++) {
+      const c = connect(localPort, "127.0.0.1");
+      c.on("error", () => {});
+      c.resume();
+    }
+    await drained;
+  }
+
+  // Now bind an outgoing connection's local port to localPort. Without
+  // SO_REUSEADDR the kernel rejects this with EADDRINUSE while the TIME_WAIT
+  // entries exist.
+  const target = createServer(c => c.end());
+  try {
+    await new Promise<void>((resolve, reject) => {
+      target.on("error", reject);
+      target.listen(0, "127.0.0.1", resolve);
+    });
+    const targetPort = (target.address() as import("node:net").AddressInfo).port;
+    const { promise, resolve, reject } = Promise.withResolvers<Socket>();
+    const c = connect({ host: "127.0.0.1", port: targetPort, localPort });
+    c.on("connect", () => resolve(c));
+    c.on("error", reject);
+    const sock = await promise;
+    expect(sock.localPort).toBe(localPort);
+    sock.destroy();
+  } finally {
+    target.close();
+  }
+});


### PR DESCRIPTION
`net.connect({ localPort })` fails with `EADDRINUSE` in Bun whenever the requested local port still has sockets in `TIME_WAIT` from a recently closed connection. Node.js succeeds in the same situation because libuv's [`uv__tcp_bind`](https://github.com/libuv/libuv/blob/v1.x/src/unix/tcp.c) sets `SO_REUSEADDR` before `bind()` on Unix; `bsd_create_connect_socket` was calling `bind()` without it.

### Repro

```js
// 1. leave TIME_WAIT sockets on :12346
// 2. net.connect({ host: '127.0.0.1', port: <any>, localPort: 12346 })
//    Node: OK localPort=12346
//    Bun:  connect EADDRINUSE 127.0.0.1:<any>
```

This surfaced in CI as `test/js/node/test/sequential/test-net-localport.js` flaking with

```
error: connect EADDRINUSE 127.0.0.1:39943
 syscall: "connect",
    code: "EADDRINUSE"
```

whenever the shard assignment placed it immediately after `test-http-econnrefused.js` (builds [71279](https://buildkite.com/bun/bun/builds/71279), [71283](https://buildkite.com/bun/bun/builds/71283)). Both tests use `common.PORT` (12346); the first leaves 4 server-side TIME_WAIT sockets on that port for ~60s, and the second's `localPort: common.PORT` bind then fails every retry.

### Fix

- `packages/bun-usockets/src/bsd.c`: set `SO_REUSEADDR` on the connect socket before the `local_addr` bind on non-Windows platforms, matching libuv. Windows is excluded because libuv deliberately does not set it there (on Windows `SO_REUSEADDR` allows stealing an actively bound port).
- `scripts/runner.node.mjs`: also set `BUN_FEATURE_FLAG_NO_ORPHANS=1` for the Node-compat test spawn path on Linux/macOS, so a cluster worker or child_process subprocess that outlives its test file cannot hold a socket into the next sequential test. The flag was previously only applied to `.test.ts` files on ASAN lanes and never reached this spawn path.

### Verification

New test in `test/js/node/net/node-net.test.ts` creates TIME_WAIT sockets on an ephemeral port and then asserts `connect({ localPort })` to a fresh server succeeds with the expected `localPort`. Fails on the released binary with `EADDRINUSE`, passes with this change. The original CI sequence (`test-http-econnrefused.js` then `test-net-localport.js`) now passes back to back.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->